### PR TITLE
Add option to use SNMP for pinging

### DIFF
--- a/LibreNMS/Sping.php
+++ b/LibreNMS/Sping.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * Sping.php
+ *
+ * -Description-
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @package    LibreNMS
+ * @link       http://librenms.org
+ * @copyright  2020 Tony Murray
+ * @author     Tony Murray <murraytony@gmail.com>
+ */
+
+namespace LibreNMS;
+
+use App\Models\Device;
+use Log;
+
+class Sping
+{
+    private $oid;
+    private $timeout;
+    private $retries;
+
+    /**
+     * Create a new SNMP ping instance.
+     */
+    public function __construct()
+    {
+        $this->oid = "1.3.6.1.2.1.1.1.0";
+        $this->timeout = (Config::get('snmp_ping_timeout', 5)) * 1000000;
+        $this->retries = Config::get('snmp_ping_retries', 2);
+    }
+
+    /**
+     * Run sping against a device and collect stats.
+     *
+     * @param object $device
+     * @return object
+     */
+    public function sping($device)
+    {
+        $response = [
+            'result' => (boolean)false,
+            'last_ping_timetaken' => (float)0.0,
+            'db' => [
+                'xmt' => (int)1,
+                'rcv' => (int)0,
+                'loss' => (float)100.0,
+                'min' => (float)0.0,
+                'max' => (float)0.0,
+                'avg' =>(float)0.0
+            ]
+        ];
+
+        $version = $device['snmpver'];
+        $target = Device::pollerTarget($device['hostname']);
+
+        $rtt = (boolean)false;
+        if (strpos($version, '2c') !== false) {
+            $rtt = $this->sping2c($device, $target);
+        } elseif (strpos($version, '3') !== false) {
+            $rtt = $this->sping3($device, $target);
+        } else { // version 1
+            $rtt = $this->sping1($device, $target);
+        }
+
+        if ($rtt !== false) {
+            $rtt = (Config::get('record_snmp_ping_rtt') === true ? (float)$rtt : (float)0.0);
+            $response['result'] = (boolean)true;
+            $response['last_ping_timetaken'] = $rtt;
+            $response['db']['rcv'] = (int)1;
+            $response['db']['loss'] = (float)0.0;
+            $response['db']['min'] = $rtt;
+            $response['db']['max'] = $rtt;
+            $response['db']['avg'] = $rtt;
+        }
+
+        return $response;
+    }
+
+    private function sping1($device, $target)
+    {
+        $rtt = (boolean)false;
+        $community = $device['community'];
+        $before = microtime(true);
+        $sysDescr = snmpget($target, $community, $this->oid, $this->timeout, $this->retries);
+        $after = microtime(true);
+        if ($sysDescr !== false) {
+            $rtt = (float)(($after - $before) * 1000.0);
+        }
+        return $rtt;
+    }
+
+    private function sping2c($device, $target)
+    {
+        $rtt = (boolean)false;
+        $community = $device['community'];
+        $before = microtime(true);
+        $sysDescr = snmp2_get($target, $community, $this->oid, $this->timeout, $this->retries);
+        $after = microtime(true);
+        if ($sysDescr !== false) {
+            $rtt = (float)(($after - $before) * 1000.0);
+        }
+        return $rtt;
+    }
+
+    private function sping3($device, $target)
+    {
+        $rtt = (boolean)false;
+        $authname = $device['authname'];
+        $authlevel = $device['authlevel'];
+        $authalgo = null;
+        $authpass = null;
+        $cryptalgo = null;
+        $cryptpass = null;
+        if ($authlevel === "authPriv") {
+            $authalgo = $device['authalgo'];
+            $authpass = $device['authpass'];
+            $cryptalgo = $device['cryptoalgo'];
+            $cryptpass = $device['cryptopass'];
+        } elseif ($authlevel === "authNoPriv") {
+            $authalgo = $device['authalgo'];
+            $authpass = $device['authpass'];
+        }
+        $before = microtime(true);
+        $sysDescr = snmp3_get($target, $authname, $authlevel, $authalgo, $authpass, $cryptalgo, $cryptpass, $this->oid, $this->timeout, $this->retries);
+        $after = microtime(true);
+        if ($sysDescr !== false) {
+            $rtt = (float)(($after - $before) * 1000.0);
+        }
+        return $rtt;
+    }
+}

--- a/LibreNMS/Sping.php
+++ b/LibreNMS/Sping.php
@@ -17,7 +17,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
- * @package    LibreNMS
  * @link       http://librenms.org
  * @copyright  2020 Tony Murray
  * @author     Tony Murray <murraytony@gmail.com>
@@ -26,7 +25,6 @@
 namespace LibreNMS;
 
 use App\Models\Device;
-use Log;
 
 class Sping
 {
@@ -39,7 +37,7 @@ class Sping
      */
     public function __construct()
     {
-        $this->oid = "1.3.6.1.2.1.1.1.0";
+        $this->oid = '1.3.6.1.2.1.1.1.0';
         $this->timeout = (Config::get('snmp_ping_timeout', 5)) * 1000000;
         $this->retries = Config::get('snmp_ping_retries', 2);
     }
@@ -53,22 +51,22 @@ class Sping
     public function sping($device)
     {
         $response = [
-            'result' => (boolean)false,
-            'last_ping_timetaken' => (float)0.0,
+            'result' => (bool) false,
+            'last_ping_timetaken' => (float) 0.0,
             'db' => [
-                'xmt' => (int)1,
-                'rcv' => (int)0,
-                'loss' => (float)100.0,
-                'min' => (float)0.0,
-                'max' => (float)0.0,
-                'avg' =>(float)0.0
-            ]
+                'xmt' => (int) 1,
+                'rcv' => (int) 0,
+                'loss' => (float) 100.0,
+                'min' => (float) 0.0,
+                'max' => (float) 0.0,
+                'avg' =>(float) 0.0,
+            ],
         ];
 
         $version = $device['snmpver'];
         $target = Device::pollerTarget($device['hostname']);
 
-        $rtt = (boolean)false;
+        $rtt = (bool) false;
         if (strpos($version, '2c') !== false) {
             $rtt = $this->sping2c($device, $target);
         } elseif (strpos($version, '3') !== false) {
@@ -78,11 +76,11 @@ class Sping
         }
 
         if ($rtt !== false) {
-            $rtt = (Config::get('record_snmp_ping_rtt') === true ? (float)$rtt : (float)0.0);
-            $response['result'] = (boolean)true;
+            $rtt = (Config::get('record_snmp_ping_rtt') === true ? (float) $rtt : (float) 0.0);
+            $response['result'] = (bool) true;
             $response['last_ping_timetaken'] = $rtt;
-            $response['db']['rcv'] = (int)1;
-            $response['db']['loss'] = (float)0.0;
+            $response['db']['rcv'] = (int) 1;
+            $response['db']['loss'] = (float) 0.0;
             $response['db']['min'] = $rtt;
             $response['db']['max'] = $rtt;
             $response['db']['avg'] = $rtt;
@@ -93,45 +91,47 @@ class Sping
 
     private function sping1($device, $target)
     {
-        $rtt = (boolean)false;
+        $rtt = (bool) false;
         $community = $device['community'];
         $before = microtime(true);
         $sysDescr = snmpget($target, $community, $this->oid, $this->timeout, $this->retries);
         $after = microtime(true);
         if ($sysDescr !== false) {
-            $rtt = (float)(($after - $before) * 1000.0);
+            $rtt = (float) (($after - $before) * 1000.0);
         }
+
         return $rtt;
     }
 
     private function sping2c($device, $target)
     {
-        $rtt = (boolean)false;
+        $rtt = (bool) false;
         $community = $device['community'];
         $before = microtime(true);
         $sysDescr = snmp2_get($target, $community, $this->oid, $this->timeout, $this->retries);
         $after = microtime(true);
         if ($sysDescr !== false) {
-            $rtt = (float)(($after - $before) * 1000.0);
+            $rtt = (float) (($after - $before) * 1000.0);
         }
+
         return $rtt;
     }
 
     private function sping3($device, $target)
     {
-        $rtt = (boolean)false;
+        $rtt = (bool) false;
         $authname = $device['authname'];
         $authlevel = $device['authlevel'];
         $authalgo = null;
         $authpass = null;
         $cryptalgo = null;
         $cryptpass = null;
-        if ($authlevel === "authPriv") {
+        if ($authlevel === 'authPriv') {
             $authalgo = $device['authalgo'];
             $authpass = $device['authpass'];
             $cryptalgo = $device['cryptoalgo'];
             $cryptpass = $device['cryptopass'];
-        } elseif ($authlevel === "authNoPriv") {
+        } elseif ($authlevel === 'authNoPriv') {
             $authalgo = $device['authalgo'];
             $authpass = $device['authpass'];
         }
@@ -139,8 +139,9 @@ class Sping
         $sysDescr = snmp3_get($target, $authname, $authlevel, $authalgo, $authpass, $cryptalgo, $cryptpass, $this->oid, $this->timeout, $this->retries);
         $after = microtime(true);
         if ($sysDescr !== false) {
-            $rtt = (float)(($after - $before) * 1000.0);
+            $rtt = (float) (($after - $before) * 1000.0);
         }
+
         return $rtt;
     }
 }

--- a/LibreNMS/Validations/Programs.php
+++ b/LibreNMS/Validations/Programs.php
@@ -39,9 +39,9 @@ class Programs extends BaseValidation
     public function validate(Validator $validator)
     {
         // Check programs
-        $bins = array('rrdtool', 'snmpwalk', 'snmpget', 'snmpgetnext', 'snmpbulkwalk');
+        $bins = ['rrdtool', 'snmpwalk', 'snmpget', 'snmpgetnext', 'snmpbulkwalk'];
         $use_snmp_ping = Config::get('use_snmp_ping') === true ? true : false;
-        if (!$use_snmp_ping) {
+        if (! $use_snmp_ping) {
             array_push($bins, 'fping');
         }
         foreach ($bins as $bin) {

--- a/LibreNMS/Validations/Programs.php
+++ b/LibreNMS/Validations/Programs.php
@@ -39,7 +39,11 @@ class Programs extends BaseValidation
     public function validate(Validator $validator)
     {
         // Check programs
-        $bins = ['fping', 'rrdtool', 'snmpwalk', 'snmpget', 'snmpgetnext', 'snmpbulkwalk'];
+        $bins = array('rrdtool', 'snmpwalk', 'snmpget', 'snmpgetnext', 'snmpbulkwalk');
+        $use_snmp_ping = Config::get('use_snmp_ping') === true ? true : false;
+        if (!$use_snmp_ping) {
+            array_push($bins, 'fping');
+        }
         foreach ($bins as $bin) {
             if (! ($cmd = $this->findExecutable($bin))) {
                 $validator->fail(

--- a/app/Jobs/PingCheck.php
+++ b/app/Jobs/PingCheck.php
@@ -35,8 +35,8 @@ use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Collection;
 use LibreNMS\Alert\AlertRules;
 use LibreNMS\Config;
-use LibreNMS\Sping;
 use LibreNMS\RRD\RrdDefinition;
+use LibreNMS\Sping;
 use Log;
 use Symfony\Component\Process\Process;
 
@@ -82,7 +82,7 @@ class PingCheck implements ShouldQueue
         $this->rrd_tags = ['rrd_def' => $rrd_def, 'rrd_step' => $rrd_step];
 
         $this->use_snmp_ping = Config::get('use_snmp_ping') === true ? true : false;
-        $this->use_icmp_ping = !$this->use_snmp_ping;
+        $this->use_icmp_ping = ! $this->use_snmp_ping;
 
         if ($this->use_icmp_ping) {
             // set up fping process
@@ -122,7 +122,7 @@ class PingCheck implements ShouldQueue
         // check for any left over devices
         if ($this->deferred->isNotEmpty()) {
             d_echo("Leftover devices, this shouldn't happen: " . $this->deferred->flatten(1)->implode('hostname', ', ') . PHP_EOL);
-            d_echo("Devices left in tier: " . collect($this->current)->implode('hostname', ', ') . PHP_EOL);
+            d_echo('Devices left in tier: ' . collect($this->current)->implode('hostname', ', ') . PHP_EOL);
         }
 
         if (\App::runningInConsole()) {
@@ -174,7 +174,7 @@ class PingCheck implements ShouldQueue
                 $this->recordData(['hostname' => $t['hostname'], 'status' => 'alive', 'rtt' => $response['last_ping_timetaken']]);
                 $this->processTier();
             } else {
-                $this->recordData(['hostname' => $t['hostname'], 'status' => 'unreachable', 'rtt' => (float)0.0]);
+                $this->recordData(['hostname' => $t['hostname'], 'status' => 'unreachable', 'rtt' => (float) 0.0]);
             }
         }
     }
@@ -281,7 +281,7 @@ class PingCheck implements ShouldQueue
             // mark up only if snmp is not down too
             $device->status = ($data['status'] == 'alive' && $device->status_reason != 'snmp');
             $device->last_ping = Carbon::now();
-            $device->last_ping_timetaken = (float)0.0;
+            $device->last_ping_timetaken = (float) 0.0;
             if (isset($data['rtt'])) {
                 if ($this->use_icmp_ping || ($this->use_snmp_ping && $this->record_snmp_ping_rtt)) {
                     $device->last_ping_timetaken = floatval($data['rtt']);

--- a/includes/common.php
+++ b/includes/common.php
@@ -727,7 +727,9 @@ function object_is_cached($section, $obj)
  **/
 function can_ping_device($attribs)
 {
-    if (Config::get('icmp_check') && ! (isset($attribs['override_icmp_disable']) && $attribs['override_icmp_disable'] == 'true')) {
+    if (Config::get('use_snmp_ping') === true) {
+        return true;
+    } elseif (Config::get('icmp_check') && ! (isset($attribs['override_icmp_disable']) && $attribs['override_icmp_disable'] == 'true')) {
         return true;
     } else {
         return false;

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -617,7 +617,7 @@ function addHost($host, $snmp_version = '', $port = '161', $transport = 'udp', $
     }
 
     // Allow ping fallback, unless SNMP check for reachability is mandated
-    if (isset($additional['ping_fallback']) && $additional['ping_fallback'] == 1 && !$use_snmp_ping) {
+    if (isset($additional['ping_fallback']) && $additional['ping_fallback'] == 1 && ! $use_snmp_ping) {
         $additional['snmp_disable'] = 1;
         $additional['os'] = 'ping';
 


### PR DESCRIPTION

This contribution adds an option to perform all device pings using SNMP rather than ICMP (fping).  This can be desirable when LibreNMS is deployed in a Kubernetes cluster that disallows executables from escalating their privilege via the setuid bit on ping/fping, or from having the required Linux capabilities enabled on the ping/fping executable.

The option is enabled for an installation by setting the new boolean configuration value 'use_snmp_ping' to 'true'.  When enabled, all pinging (discovery, polling, etc) is simulated using the snmpstatus tool.  A second new boolean configuration value, 'record_snmp_ping_rtt', controls whether or not the round trip time for snmpstatus pings are recorded for the device.  The number of retry attempts and timeout parameter are set through the new 'snmp_ping_retries' and 'snmp_ping_timeout' configuration settings.

(I'm in the process of developing some tests, so this is WIP for now.)

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
