### PR TITLE
Clean up default alert rules

### DIFF
--- a/misc/alert_rules.json
+++ b/misc/alert_rules.json
@@ -2,7 +2,6 @@
   {
     "rule": "macros.device_down = \"1\"",
     "name": "Devices up/down",
-    "default": false
   },
   {
     "rule": "macros.device_down = \"1\" && devices.status_reason = \"icmp\"",
@@ -24,13 +23,11 @@
     "rule": "bgpPeers.bgpPeerState != \"established\" && macros.device_up = \"1\" && bgpPeers.bgpPeerAdminStatus != \"stop\"",
     "name": "BGP Session down",
     "extra": "{\"count\": 1}",
-    "default": true
   },
   {
     "rule": "bgpPeers.bgpPeerFsmEstablishedTime < \"300\" && bgpPeers.bgpPeerState = \"established\" && macros.device_up = \"1\"",
     "name": "BGP Session established",
     "extra": "{\"count\": 1}",
-    "default": true
   },
   {
     "rule": "macros.port_down = \"1\"",
@@ -77,13 +74,11 @@
     "rule": "wireless_sensors.sensor_type == \"arubaos\" && wireless_sensors.sensor_class == \"ap-count\" && wireless_sensors.sensor_alert = \"1\" && macros.device_up = \"1\" && wireless_sensors.sensor_current <= `wireless_sensors.sensor_limit_low_warn` && wireless_sensors.sensor_current > `wireless_sensors.sensor_limit_low`",
     "name": "Aruba Wireless AP Count Low Warning",
     "severity": "warning",
-    "default": false
   },
   {
     "rule": "wireless_sensors.sensor_type == \"arubaos\" && wireless_sensors.sensor_class == \"ap-count\" && wireless_sensors.sensor_alert = \"1\" && macros.device_up = \"1\" && wireless_sensors.sensor_current <= `wireless_sensors.sensor_limit_low`",
     "name": "Aruba Wireless AP Count Low Critical",
     "severity": "critical",
-    "default": false
   },
   {
     "rule": "macros.state_sensor_critical && sensors.sensor_alert = 1",
@@ -93,7 +88,6 @@
   {
     "rule": "macros.state_sensor_warning && sensors.sensor_alert = 1",
     "name": "State Sensor Warning",
-    "default": false
   },
   {
     "rule": "macros.bill_quota_over_quota >= \"75\"",
@@ -438,24 +432,20 @@
  {
     "rule": "customoids.customoid_current >= `customoids.customoid_limit` && customoids.customoid_alert = \"1\" && macros.device_up = \"1\"",
     "name": "CustomOID over limit",
-    "default": false
   },
   {
     "rule": "customoids.customoid_current <= `customoids.customoid_limit_low` && customoids.customoid_alert = \"1\" && macros.device_up = \"1\"",
     "name": "CustomOID under limit",
-    "default": false
   },
   {
     "rule": "customoids.customoid_current >= `customoids.customoid_limit_warn` && customoids.customoid_alert = \"1\" && macros.device_up = \"1\"",
     "name": "CustomOID over warning limit",
     "severity": "warning",
-    "default": false
   },
   {
     "rule": "customoids.customoid_current <= `customoids.customoid_limit_low_warn` && customoids.customoid_alert = \"1\" && macros.device_up = \"1\"",
     "name": "CustomOID under warning limit",
     "severity": "warning",
-    "default": false
   },
   {
     "rule": "applications.app_type = \"ups-nut\" && state_indexes.state_name = \"UPSOnBattery\" && macros.state_sensor_warning = 1",

--- a/misc/alert_rules.json
+++ b/misc/alert_rules.json
@@ -438,24 +438,24 @@
  {
     "rule": "customoids.customoid_current >= `customoids.customoid_limit` && customoids.customoid_alert = \"1\" && macros.device_up = \"1\"",
     "name": "CustomOID over limit",
-    "default": true
+    "default": false
   },
   {
     "rule": "customoids.customoid_current <= `customoids.customoid_limit_low` && customoids.customoid_alert = \"1\" && macros.device_up = \"1\"",
     "name": "CustomOID under limit",
-    "default": true
+    "default": false
   },
   {
     "rule": "customoids.customoid_current >= `customoids.customoid_limit_warn` && customoids.customoid_alert = \"1\" && macros.device_up = \"1\"",
     "name": "CustomOID over warning limit",
     "severity": "warning",
-    "default": true
+    "default": false
   },
   {
     "rule": "customoids.customoid_current <= `customoids.customoid_limit_low_warn` && customoids.customoid_alert = \"1\" && macros.device_up = \"1\"",
     "name": "CustomOID under warning limit",
     "severity": "warning",
-    "default": true
+    "default": false
   },
   {
     "rule": "applications.app_type = \"ups-nut\" && state_indexes.state_name = \"UPSOnBattery\" && macros.state_sensor_warning = 1",


### PR DESCRIPTION
Too many rules in the default, disabling the customoid rules.
It is easy to add from the collection.  Any other suggestions?

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
