### PR TITLE
Adding OOB Management to the device type definitions

### DIFF
--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -908,6 +908,11 @@
                     "type": "environment"
                 },
                 {
+                    "icon": "oob-management.png",
+                    "text": "OOB Management",
+                    "type": "OOB Management"
+                },
+                {
                     "icon": "loadbalancer.png",
                     "text": "Load Balancers",
                     "type": "loadbalancer"


### PR DESCRIPTION
Signed-off-by: Marcus van Dam <marcus@marcusvandam.nl>

In #5744 the initial support for Opengear devices was added, introducing the `OOB Management` device type. However this device type is not included in the list of `device_type` definitions, leading to the artefact, that when editing a device of type `OOB Management`, you will always inadvertently change its type to `server` as the type drown-down menu is not populated correctly.

In this commit I am adding the type `OOB Management` to the list of device types.

**note 1:** There seem to be a fair amount more of these cases, where there is a device type defined in the definitions, but not in the default `device_types`. I compiled the following list. **bold** is included right now.
- **appliance**
- camera
- **collaboration**
- encoder
- **environment**
- environmental (single device, could be a typo?)
- **firewall**
- **loadbalancer**
- management
- **network**
- 'OOB Management' (this pr)
- **power**
- **printer**
- proxy
- sensor
- **server**
- **storage**
- timing
- **wireless**
- **workstation**

**note 2:** The `icon` property seems to be populated in all the defaults, however the image cannot be found anywhere in the source. I just went along with it and did the same.

If you'd like, I can extend the PR to fix the other types as well. Possibly merging some which seem to be misclassified.


#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
