### PR TITLE
Handle unknown device_type's.

### DIFF
--- a/includes/html/pages/device/edit/device.inc.php
+++ b/includes/html/pages/device/edit/device.inc.php
@@ -155,7 +155,12 @@ $disable_notify             = get_dev_attrib($device, 'disable_notify');
                     echo(' >' . ucfirst($type['type']) . '</option>');
                 }
                 if ($unknown) {
-                    echo('          <option value="other">Other</option>');
+                    if(!is_null($device_model->type)) {
+                        $device_type = htmlspecialchars($device_model->type);
+                        echo('          <option value="'. $device_type .'" selected="1" >' . ucfirst($device_type) . '</option>');
+                    } else {
+                        echo('          <option value="other">Other</option>');
+                    }
                 }
                 ?>
             </select>

--- a/includes/html/pages/device/edit/device.inc.php
+++ b/includes/html/pages/device/edit/device.inc.php
@@ -155,7 +155,7 @@ $disable_notify             = get_dev_attrib($device, 'disable_notify');
                     echo(' >' . ucfirst($type['type']) . '</option>');
                 }
                 if ($unknown) {
-                    if(!is_null($device_model->type)) {
+                    if (!is_null($device_model->type)) {
                         $device_type = htmlspecialchars($device_model->type);
                         echo('          <option value="'. $device_type .'" selected="1" >' . ucfirst($device_type) . '</option>');
                     } else {


### PR DESCRIPTION
This is the solution as discussed in #12017.

If a device is not one of the default configuration, add its type to the
list and make it selected. Add 'Other' only as a fallback.

Signed-off-by: Marcus van Dam <marcus@marcusvandam.nl>

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
