### PR TITLE
Revised Tripp Lite model detection to work with SNMPWEBCARDs

### DIFF
--- a/includes/polling/os/msl.inc.php
+++ b/includes/polling/os/msl.inc.php
@@ -18,7 +18,11 @@ $features_oid     = '.1.3.6.1.4.1.1027.4.1.2.1.1.1.5.10.1.3.6.1.4.1.1027.1.6.1';
 $oids             = array("mitelAppTblProductVersion.10.1.3.6.1.4.1.1027.1.6.1", "mitelAppTblProductDescr.10.1.3.6.1.4.1.1027.1.6.1");
 $mitelapptbl_data = snmp_get_multi_oid($device, $oids, "-OUQnt", "MITEL-APPCMN-MIB");
 
-$hardware = preg_replace('/;VerSw.*$/', '', (preg_replace('/^.*VerHw:/', '', $mslhw)));
+if (strpos($mslhw, 'ppc') !== false) {
+	$hardware = (preg_replace('/^.*VerPl:/', '', $mslhw));
+}else{
+        $hardware = preg_replace('/;VerSw.*$/', '', (preg_replace('/^.*VerHw:/', '', $mslhw)));
+}
 $version  = trim($mitelapptbl_data[$version_oid], '"');
 $features = trim($mitelapptbl_data[$features_oid], '"');
 

--- a/includes/polling/os/poweralert.inc.php
+++ b/includes/polling/os/poweralert.inc.php
@@ -1,13 +1,12 @@
 <?php
 
 // .1.3.6.1.2.1.33.1.1.2.0 = STRING: "TRIPP LITE PDUMH20HVATNET"
+// .1.3.6.1.2.1.33.1.1.2.0 = STRING: "SU1500XL"
 // .1.3.6.1.2.1.33.1.1.4.0 = STRING: "12.04.0052"
 // .1.3.6.1.2.1.33.1.1.5.0 = STRING: "sysname.company.com"
 // .1.3.6.1.4.1.850.100.1.1.4.0 = STRING: "9942AY0AC796000912"
 // .1.3.6.1.4.1.850.10.2.2.1.12.1 = STRING: "This Is My Location"
 $hardware    = snmp_get($device, 'upsIdentModel.0', '-Ovq', 'UPS-MIB');
-$hardware    = preg_split('/TRIPP\ LITE/', $hardware);
-$hardware    = $hardware[1];
 $location    = trim(snmp_get($device, '.1.3.6.1.4.1.850.10.2.2.1.12.1', '-Ovq', 'TRIPPLITE-MIB'), '"');
 $sysName     = trim(snmp_get($device, '.1.3.6.1.2.1.33.1.1.5.0', '-Ovq', 'TRIPPLITE-MIB'), '"');
 $serial      = trim(snmp_get($device, '.1.3.6.1.4.1.850.100.1.1.4.0', '-Ovq', 'TRIPPLITE-MIB'), '"');

--- a/includes/polling/os/poweralert.inc.php
+++ b/includes/polling/os/poweralert.inc.php
@@ -7,6 +7,7 @@
 // .1.3.6.1.4.1.850.100.1.1.4.0 = STRING: "9942AY0AC796000912"
 // .1.3.6.1.4.1.850.10.2.2.1.12.1 = STRING: "This Is My Location"
 $hardware    = snmp_get($device, 'upsIdentModel.0', '-Ovq', 'UPS-MIB');
+$hardware    = trim(str_replace('TRIPP LITE','',$hardware));
 $location    = trim(snmp_get($device, '.1.3.6.1.4.1.850.10.2.2.1.12.1', '-Ovq', 'TRIPPLITE-MIB'), '"');
 $sysName     = trim(snmp_get($device, '.1.3.6.1.2.1.33.1.1.5.0', '-Ovq', 'TRIPPLITE-MIB'), '"');
 $serial      = trim(snmp_get($device, '.1.3.6.1.4.1.850.100.1.1.4.0', '-Ovq', 'TRIPPLITE-MIB'), '"');


### PR DESCRIPTION
Removed code that seeks to remove "Tripp Lite" from model string; this is not present in all Tripp Lite devices.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
