### PR TITLE
Fix missing 'nets' for autodiscovery

### DIFF
--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -3697,6 +3697,9 @@
             "default": "/usr/lib/nagios/plugins",
             "type": "directory"
         },
+        "nets": {
+            "type": "array"
+        },
         "network_map_items": {
             "default": [
                 "xdp",


### PR DESCRIPTION
Fix missing 'nets' for autodiscovery in misc/config_definitions.json 

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
