### PR TITLE
Python log mysql connection errors and harden config retrieval

### DIFF
--- a/LibreNMS/library.py
+++ b/LibreNMS/library.py
@@ -26,6 +26,8 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 # Logging functions ########################################################
+# The following logging functions are
+# (C) 2019-2020 Orsiris de Jong under BSD 3-Clause license
 
 FORMATTER = logging.Formatter('%(asctime)s :: %(levelname)s :: %(message)s')
 
@@ -103,6 +105,7 @@ def logger_get_logger(log_file=None, temp_log_file=None, debug=False):
                 _logger.warning('Failed to use log file [%s], %s.', log_file, err_output)
     return _logger
 
+# End of Logging functions #################################################
 
 # Generic functions ########################################################
 
@@ -115,6 +118,8 @@ def command_runner(command, valid_exit_codes=None, timeout=300, shell=False, enc
     Whenever we can, we need to avoid shell=True in order to preseve better security
     Runs system command, returns exit code and stdout/stderr output, and logs output on error
     valid_exit_codes is a list of codes that don't trigger an error
+    
+    (C) 2019-2020 Orsiris de Jong under BSD 3-Clause license
     """
 
     # Set default values for kwargs

--- a/LibreNMS/library.py
+++ b/LibreNMS/library.py
@@ -123,9 +123,9 @@ def get_config_data(install_dir):
     try:
         proc = subprocess.Popen(config_cmd, stdout=subprocess.PIPE, stdin=subprocess.PIPE)
         return proc.communicate()[0].decode()
-    except Exception as e:
-        print("ERROR: Could not execute: %s" % config_cmd)
-        print(e)
+    except Exception as exc:
+        logger.error("ERROR: Could not execute: %s" % config_cmd)
+        logger.error('exc'.format(exc))
         sys.exit(2)
 
 # Database functions #######################################################
@@ -140,6 +140,6 @@ def db_open(db_socket, db_server, db_port, db_username, db_password, db_dbname):
 
         return MySQLdb.connect(**options)
     except Exception as dbexc:
-        print('ERROR: Could not connect to MySQL database!')
-        print('ERROR: %s' % dbexc)
+        logger.error('ERROR: Could not connect to MySQL database!')
+        logger.error('exc'.format(exc))
         sys.exit(2)

--- a/LibreNMS/library.py
+++ b/LibreNMS/library.py
@@ -199,7 +199,7 @@ def db_open(db_socket, db_server, db_port, db_username, db_password, db_dbname):
             options['unix_socket'] = db_socket
 
         return MySQLdb.connect(**options)
-    except Exception as dbexc:
+    except Exception as exc:
         logger.error('ERROR: Could not connect to MySQL database!')
         logger.error('{0}'.format(exc))
         sys.exit(2)

--- a/LibreNMS/library.py
+++ b/LibreNMS/library.py
@@ -109,12 +109,12 @@ def logger_get_logger(log_file=None, temp_log_file=None, debug=False):
 def command_runner(command, valid_exit_codes=None, timeout=300, shell=False, encoding='utf-8',
                    windows_no_window=False, **kwargs):
     """
+    Unix & Windows compatible subprocess wrapper that handles encoding, timeout, and
+    various exit codes.
+    Accepts subprocess.check_output and subprocess.popen arguments
     Whenever we can, we need to avoid shell=True in order to preseve better security
     Runs system command, returns exit code and stdout/stderr output, and logs output on error
     valid_exit_codes is a list of codes that don't trigger an error
-    
-    Accepts subprocess.check_output arguments
-        
     """
 
     # Set default values for kwargs
@@ -122,12 +122,17 @@ def command_runner(command, valid_exit_codes=None, timeout=300, shell=False, enc
     universal_newlines = kwargs.pop('universal_newlines', False)
     creationflags = kwargs.pop('creationflags', 0)
     if windows_no_window:
+        # Disable the following pylint error since the code also runs on nt platform, but
+        # triggers and error on Unix
+        # pylint: disable=E1101
         creationflags = creationflags | subprocess.CREATE_NO_WINDOW
 
     try:
         # universal_newlines=True makes netstat command fail under windows
         # timeout does not work under Python 2.7 with subprocess32 < 3.5
         # decoder may be unicode_escape for dos commands or utf-8 for powershell
+        # Disabling pylint error for the same reason as above
+        # pylint: disable=E1123
         output = subprocess.check_output(command, stderr=subprocess.STDOUT, shell=shell,
                                          timeout=timeout, universal_newlines=universal_newlines, encoding=encoding,
                                          errors=errors, creationflags=creationflags, **kwargs)

--- a/LibreNMS/library.py
+++ b/LibreNMS/library.py
@@ -201,5 +201,5 @@ def db_open(db_socket, db_server, db_port, db_username, db_password, db_dbname):
         return MySQLdb.connect(**options)
     except Exception as dbexc:
         logger.error('ERROR: Could not connect to MySQL database!')
-        logger.error('exc'.format(exc))
+        logger.error('{0}'.format(exc))
         sys.exit(2)

--- a/LibreNMS/library.py
+++ b/LibreNMS/library.py
@@ -186,7 +186,6 @@ def get_config_data(install_dir):
     else:
         logger.error("ERROR: Could not execute: %s" % config_cmd)
         logger.error("exit code: {0}. Output:\n{1}".format(exit_code, values))
-        logger.error('exc'.format(exc))
         sys.exit(2)
 
 # Database functions #######################################################


### PR DESCRIPTION
This small patch enables logging of database connection problems.
Also hardenes subprocess execution calls.

It's the beginning of a larger series of patches I initially wrote for librenms python3 compat.
The `command_runner` function will be used later in snmp-scan, poller-wrapper, discovery-wrapper and services-wrapper.py.

Underlying motivation:
I had problems with poller-wrapper.py not working. Nothing in the logs.
I understood that I had mysql connection problems due to the fact that I had an accent `é` in my mysql password (this is another bug, but not librenms related).
So instead of only printing the errors, it's adivsable to log them.

Also when executing php to read the config file, it's better to use a more reliable way to deal with subprocesses.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
