### PR TITLE
remove broken link

### DIFF
--- a/doc/API/index.md
+++ b/doc/API/index.md
@@ -4,8 +4,7 @@ path: blob/master/doc/
 ## Versioning
 
 Versioning an API is a minefield which saw us looking at numerous
-options on how to do this. Paul wrote an excellent blog post which
-touches on this: <https://blog.librenms.org/2014/09/restful-apis/>
+options on how to do this.
 
 We have currently settled on using versioning within the API end point
 itself `/api/v0`. As the API itself is new and still in active


### PR DESCRIPTION
the entire https://blog.librenms.org site seems to be broken, can't find a new location for this blog post, given the age I assume it has been removed.

Please give a short description what your pull request is for

Documentation fix, remove broken link to non-existing API blogpost.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
