### PR TITLE
Add attach sysName to Prometheus.

### DIFF
--- a/LibreNMS/Data/Store/Prometheus.php
+++ b/LibreNMS/Data/Store/Prometheus.php
@@ -95,6 +95,9 @@ class Prometheus extends BaseDatastore
             $options['body'] = $vals;
 
             $promurl = $this->base_uri . $device['hostname'] . $promtags;
+            if (Config::get('prometheus.attach_sysname', false)) {
+                $promurl .= '/sysName/' . $device['sysName'];
+            }
             $promurl = str_replace(" ", "-", $promurl); // Prometheus doesn't handle tags with spaces in url
 
             Log::debug("Prometheus put $promurl: ", [

--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -4476,6 +4476,13 @@
             "section": "prometheus",
             "order": 2
         },
+        "prometheus.attach_sysname": {
+            "default": false,
+            "type": "boolean",
+            "group": "poller",
+            "section": "prometheus",
+            "order": 3
+        },
         "public_status": {
             "default": false,
             "group": "auth",

--- a/resources/lang/en/settings.php
+++ b/resources/lang/en/settings.php
@@ -1097,11 +1097,11 @@ return [
                 'description' => 'Enable',
                 'help' => 'Exports metrics to Prometheus Push Gateway'
             ],
-            'host' => [
+            'url' => [
                 'description' => 'Server',
                 'help' => 'The IP or hostname of the Prometheus Push Gateway to send data to'
             ],
-            'port' => [
+            'Job' => [
                 'description' => 'Job',
                 'help' => 'Job label for exported metrics'
             ],

--- a/resources/lang/en/settings.php
+++ b/resources/lang/en/settings.php
@@ -1108,7 +1108,7 @@ return [
             'attach_sysname' => [
                 'description' => 'Attach Device sysName',
                 'help' => 'Attach sysName information put to Prometheus.'
-            ],
+            ]
         ],
         'public_status' => [
             'description' => 'Show status publicly',

--- a/resources/lang/en/settings.php
+++ b/resources/lang/en/settings.php
@@ -1104,7 +1104,7 @@ return [
             'port' => [
                 'description' => 'Job',
                 'help' => 'Job label for exported metrics'
-            ]
+            ],
             'attach_sysname' => [
                 'description' => 'Attach Device sysName',
                 'help' => 'Attach sysName information put to Prometheus.'

--- a/resources/lang/en/settings.php
+++ b/resources/lang/en/settings.php
@@ -1098,8 +1098,8 @@ return [
                 'help' => 'Exports metrics to Prometheus Push Gateway'
             ],
             'url' => [
-                'description' => 'Server',
-                'help' => 'The IP or hostname of the Prometheus Push Gateway to send data to'
+                'description' => 'URL',
+                'help' => 'The URL of the Prometheus Push Gateway to send data to'
             ],
             'Job' => [
                 'description' => 'Job',

--- a/resources/lang/en/settings.php
+++ b/resources/lang/en/settings.php
@@ -1105,6 +1105,10 @@ return [
                 'description' => 'Job',
                 'help' => 'Job label for exported metrics'
             ]
+            'attach_sysname' => [
+                'description' => 'Attach Device sysName',
+                'help' => 'Attach sysName information put to Prometheus.'
+            ],
         ],
         'public_status' => [
             'description' => 'Show status publicly',

--- a/resources/lang/zh-TW.json
+++ b/resources/lang/zh-TW.json
@@ -1,4 +1,7 @@
 {
+    "Ignore tag": "已忽略標記",
+    "Device Groups Dependencies": "裝置群組相依性",
+    "Outages": "中斷",
     "Device Status": "裝置狀態",
     "alert-disabled": "警報已停用",
     "maintenance": "維護",

--- a/resources/lang/zh-TW/settings.php
+++ b/resources/lang/zh-TW/settings.php
@@ -680,6 +680,24 @@ return [
             'description' => '連接埠大於 (天)',
             'help' => 'Cleanup done by daily.sh'
         ],
+        'prometheus' => [
+            'enable' => [
+                'description' => '啟用',
+                'help' => '匯出指標數據至 Prometheus Push Gateway'
+            ],
+            'url' => [
+                'description' => '伺服器位址',
+                'help' => '要傳送資料至 Prometheus Push Gateway 的主機 IP 或網址。'
+            ],
+            'job' => [
+                'description' => 'Job',
+                'help' => '指定匯出指標數據的 Job 標籤'
+            ],
+            'attach_sysname' => [
+                'description' => '附加 sysName',
+                'help' => '附加裝置的 sysName 資訊至 Prometheus Push Gateway。'
+            ]
+        ],
         'public_status' => [
             'description' => '公開狀態顯示',
             'help' => '允許不登入的情況下，顯示裝置的狀態資訊。'

--- a/resources/lang/zh-TW/settings.php
+++ b/resources/lang/zh-TW/settings.php
@@ -686,8 +686,8 @@ return [
                 'help' => '匯出指標數據至 Prometheus Push Gateway'
             ],
             'url' => [
-                'description' => '伺服器位址',
-                'help' => '要傳送資料至 Prometheus Push Gateway 的主機 IP 或網址。'
+                'description' => '網址',
+                'help' => '要傳送資料至 Prometheus Push Gateway 的主機網址。'
             ],
             'job' => [
                 'description' => 'Job',


### PR DESCRIPTION
The value of put to prometheus can be added to sysName by setting the relevant parameter.

This will make the display of LibreNMS Devices on Prometheus and Grafana more user-friendly.

~~config.php adding the setting entry:
`$config['prometheus']['attach_sysname'] = true;`~~

which allows put to Prometheus to add sysName content, for example:
`ping{instance="192.168.1.140",job="librenms",measurement="ping-perf",sysName="metric1"} 0.15`


This option can be enabled via `Global Settings > Poller > Datastore: Prometheus` :
![image](https://user-images.githubusercontent.com/30381035/92343333-0da8aa80-f0f6-11ea-9ff9-755893220850.png)

  
  


Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
