### PR TITLE
Schedule maintenance : remove date time picker constraint

### DIFF
--- a/includes/html/modal/alert_schedule.inc.php
+++ b/includes/html/modal/alert_schedule.inc.php
@@ -405,12 +405,12 @@ $(function () {
             close: 'fa fa-close'
         }
     });
-    $("#start_recurring_hr").on("dp.change", function (e) {
-        $("#end_recurring_hr").data("DateTimePicker").minDate(e.date);
-    });
-    $("#end_recurring_hr").on("dp.change", function (e) {
-        $("#start_recurring_hr").data("DateTimePicker").maxDate(e.date);
-    });
+    //$("#start_recurring_hr").on("dp.change", function (e) {
+    //    $("#end_recurring_hr").data("DateTimePicker").minDate(e.date);
+    //});
+    //$("#end_recurring_hr").on("dp.change", function (e) {
+    //    $("#start_recurring_hr").data("DateTimePicker").maxDate(e.date);
+    //});
 });
 
 $("[name='recurring']").bootstrapSwitch();

--- a/includes/html/modal/alert_schedule.inc.php
+++ b/includes/html/modal/alert_schedule.inc.php
@@ -405,12 +405,6 @@ $(function () {
             close: 'fa fa-close'
         }
     });
-    //$("#start_recurring_hr").on("dp.change", function (e) {
-    //    $("#end_recurring_hr").data("DateTimePicker").minDate(e.date);
-    //});
-    //$("#end_recurring_hr").on("dp.change", function (e) {
-    //    $("#start_recurring_hr").data("DateTimePicker").maxDate(e.date);
-    //});
 });
 
 $("[name='recurring']").bootstrapSwitch();


### PR DESCRIPTION
Remove javascript check that disable:

- start hour time > end hour time
- end hour time < start hour time

For example, "00", "01", "02" are in grey and cannot be selected.

![image](https://user-images.githubusercontent.com/47607835/92709368-2368da80-f357-11ea-8b39-810355f06373.png)

Two reasons for that:

-  https://github.com/librenms/librenms/pull/11389 added the possibility to schedule maintenance overnight (i.e. for time before midnight to time after midnight) but the webui does not permit it
- consistent behaviour with https://github.com/librenms/librenms/pull/11622

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
