### PR TITLE
WIP: Expose raw RRD data to LibreNMS app

### DIFF
--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -101,13 +101,11 @@ function api_get_graph(array $vars)
         $json = json_decode($image);
         if ($json !== null) {
             return api_success($json, 'dataset', null, 200, count($json->data));
-        } else {
-            if ($json_enabled) {
-                return api_error(500, 'Could not load data');
-            } else {
-                return api_error(501, 'JSON output not available for this graph');
-            }
         }
+        if ($json_enabled) {
+            return api_error(500, 'Could not load data');
+        }
+        return api_error(501, 'JSON output not available for this graph');
     }
 
     return response($image, 200, ['Content-Type' => get_image_type()]);

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -97,6 +97,19 @@ function api_get_graph(array $vars)
         return api_success(['image' => $base64_output, 'content-type' => get_image_type()], 'image');
     }
 
+    if ($vars['output'] === 'json') {
+        $json = json_decode($image);
+        if ($json !== null) {
+            return api_success($json, 'dataset', null, 200, count($json->data));
+        } else {
+            if ($json_enabled) {
+                return api_error(500, 'Could not load data');
+            } else {
+                return api_error(501, 'JSON output not available for this graph');
+            }
+        }
+    }
+
     return response($image, 200, ['Content-Type' => get_image_type()]);
 }
 

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -85,6 +85,11 @@ function api_get_graph(array $vars)
         return api_error(400, 'Invalid graph type');
     }
 
+    // if json output, check if graph_type is supported
+    if ($vars['output'] === 'json' && ! graph_type_supports_json($vars['type'])) {
+        return api_error(501, 'JSON output not available for this graph');
+    }
+
     ob_start();
 
     include 'includes/html/graphs/graph.inc.php';
@@ -102,10 +107,7 @@ function api_get_graph(array $vars)
         if ($json !== null) {
             return api_success($json, 'dataset', null, 200, count($json->data));
         }
-        if ($json_enabled) {
-            return api_error(500, 'Could not load data');
-        }
-        return api_error(501, 'JSON output not available for this graph');
+        return api_error(500, 'Could not load data');
     }
 
     return response($image, 200, ['Content-Type' => get_image_type()]);

--- a/includes/html/functions.inc.php
+++ b/includes/html/functions.inc.php
@@ -1606,8 +1606,9 @@ function nfsen_live_dir($hostname)
  */
 function graph_type_supports_json(string $type)
 {
-    switch($type) {
+    switch ($type) {
         case 'device_uptime':
+        case 'device_bits':
             return true;
         default:
             return false;

--- a/includes/html/functions.inc.php
+++ b/includes/html/functions.inc.php
@@ -1609,6 +1609,9 @@ function graph_type_supports_json(string $type)
     switch ($type) {
         case 'device_uptime':
         case 'device_bits':
+        case 'port_bits':
+        case 'multiport_bits':
+        case 'multiport_bits_separate':
             return true;
         default:
             return false;

--- a/includes/html/functions.inc.php
+++ b/includes/html/functions.inc.php
@@ -1179,9 +1179,13 @@ function eventlog_severity($eventlog_severity)
 /**
  *
  */
-function set_image_type()
+function set_image_type($output = '')
 {
-    return header('Content-type: ' . get_image_type());
+    if (!empty($output) && $output === 'json') {
+        return header('Content-type: ' . 'application/json');
+    } else {
+        return header('Content-type: ' . get_image_type());
+    }
 }
 
 function get_image_type()
@@ -1592,5 +1596,20 @@ function nfsen_live_dir($hostname)
         if (file_exists($base_dir) && is_dir($base_dir)) {
             return $base_dir.'/profiles-data/live/'.$hostname;
         }
+    }
+}
+
+/**
+ * @param string $type
+ * @return bool
+ * Takes $type and returns if JSON output is supported
+ */
+function graph_type_supports_json(string $type)
+{
+    switch($type) {
+        case 'device_uptime':
+            return true;
+        default:
+            return false;
     }
 }

--- a/includes/html/graphs/common.inc.php
+++ b/includes/html/graphs/common.inc.php
@@ -122,5 +122,4 @@ if ($output === 'json') {
     if (isset($_GET['absolute']) && $_GET['absolute'] == "1") {
         $rrd_options .= ' --full-size-mode';
     }
-
 }

--- a/includes/html/graphs/common.inc.php
+++ b/includes/html/graphs/common.inc.php
@@ -86,7 +86,7 @@ if (!isset($float_precision)) {
     $float_precision = 2;
 }
 
-if ($output === 'json') {
+if ($json_output) {
     $rrd_options .= ' --start '.$from.' --end '.$to.' --width '.$width.' ';
 } else {
     $rrd_options .= ' -E --start '.$from.' --end '.$to.' --width '.$width.' --height '.$height.' ';

--- a/includes/html/graphs/common.inc.php
+++ b/includes/html/graphs/common.inc.php
@@ -86,36 +86,41 @@ if (!isset($float_precision)) {
     $float_precision = 2;
 }
 
-$rrd_options .= ' -E --start '.$from.' --end '.$to.' --width '.$width.' --height '.$height.' ';
-
-if (Config::get('applied_site_style') == 'dark') {
-    $rrd_options .= \LibreNMS\Config::get('rrdgraph_def_text_dark') . ' -c FONT#' . ltrim(\LibreNMS\Config::get('rrdgraph_def_text_color_dark'), '#');
+if ($output === 'json') {
+    $rrd_options .= ' --start '.$from.' --end '.$to.' --width '.$width.' ';
 } else {
-    $rrd_options .= \LibreNMS\Config::get('rrdgraph_def_text') . ' -c FONT#' . ltrim(\LibreNMS\Config::get('rrdgraph_def_text_color'), '#');
-}
+    $rrd_options .= ' -E --start '.$from.' --end '.$to.' --width '.$width.' --height '.$height.' ';
+
+    if (Config::get('applied_site_style') == 'dark') {
+        $rrd_options .= \LibreNMS\Config::get('rrdgraph_def_text_dark') . ' -c FONT#' . ltrim(\LibreNMS\Config::get('rrdgraph_def_text_color_dark'), '#');
+    } else {
+        $rrd_options .= \LibreNMS\Config::get('rrdgraph_def_text') . ' -c FONT#' . ltrim(\LibreNMS\Config::get('rrdgraph_def_text_color'), '#');
+    }
 
 
-if ($_GET['bg']) {
-    $rrd_options .= ' -c CANVAS#' . Clean::alphaDash($_GET['bg']) . ' ';
-}
+    if ($_GET['bg']) {
+        $rrd_options .= ' -c CANVAS#' . Clean::alphaDash($_GET['bg']) . ' ';
+    }
 
-if ($_GET['font']) {
-    $rrd_options .= ' -c FONT#' . Clean::alphaDash($_GET['font']) . ' ';
-}
+    if ($_GET['font']) {
+        $rrd_options .= ' -c FONT#' . Clean::alphaDash($_GET['font']) . ' ';
+    }
 
-// $rrd_options .= " -c BACK#FFFFFF";
-if ($height < '99') {
-    $rrd_options .= ' --only-graph';
-}
+    // $rrd_options .= " -c BACK#FFFFFF";
+    if ($height < '99') {
+        $rrd_options .= ' --only-graph';
+    }
 
-if ($width <= '300') {
-    $rrd_options .= ' --font LEGEND:7:' . \LibreNMS\Config::get('mono_font') . ' --font AXIS:6:' . \LibreNMS\Config::get('mono_font');
-} else {
-    $rrd_options .= ' --font LEGEND:8:' . \LibreNMS\Config::get('mono_font') . ' --font AXIS:7:' . \LibreNMS\Config::get('mono_font');
-}
+    if ($width <= '300') {
+        $rrd_options .= ' --font LEGEND:7:' . \LibreNMS\Config::get('mono_font') . ' --font AXIS:6:' . \LibreNMS\Config::get('mono_font');
+    } else {
+        $rrd_options .= ' --font LEGEND:8:' . \LibreNMS\Config::get('mono_font') . ' --font AXIS:7:' . \LibreNMS\Config::get('mono_font');
+    }
 
-$rrd_options .= ' --font-render-mode normal';
+    $rrd_options .= ' --font-render-mode normal';
 
-if (isset($_GET['absolute']) && $_GET['absolute'] == "1") {
-    $rrd_options .= ' --full-size-mode';
+    if (isset($_GET['absolute']) && $_GET['absolute'] == "1") {
+        $rrd_options .= ' --full-size-mode';
+    }
+
 }

--- a/includes/html/graphs/device/uptime.inc.php
+++ b/includes/html/graphs/device/uptime.inc.php
@@ -9,8 +9,7 @@ $rrd_filename = rrd_name($device['hostname'], 'uptime');
 $rrd_options .= ' DEF:uptime='.$rrd_filename.':uptime:AVERAGE';
 $rrd_options .= ' CDEF:cuptime=uptime,86400,/';
 
-if ($output === 'json') {
-    $json_enabled = true;
+if ($json_output) {
     $rrd_options .= ' XPORT:cuptime:Uptime';
 } else {
     $rrd_options .= " 'COMMENT:Days      Current  Minimum  Maximum  Average\\n'";

--- a/includes/html/graphs/device/uptime.inc.php
+++ b/includes/html/graphs/device/uptime.inc.php
@@ -8,8 +8,14 @@ $rrd_filename = rrd_name($device['hostname'], 'uptime');
 
 $rrd_options .= ' DEF:uptime='.$rrd_filename.':uptime:AVERAGE';
 $rrd_options .= ' CDEF:cuptime=uptime,86400,/';
-$rrd_options .= " 'COMMENT:Days      Current  Minimum  Maximum  Average\\n'";
-$rrd_options .= ' AREA:cuptime#00FF0022:Uptime';
-$rrd_options .= ' LINE1.25:cuptime#36393D:';
-$rrd_options .= ' GPRINT:cuptime:LAST:%6.2lf  GPRINT:cuptime:MIN:%6.2lf';
-$rrd_options .= " GPRINT:cuptime:MAX:%6.2lf  'GPRINT:cuptime:AVERAGE:%6.2lf\\n'";
+
+if ($output === 'json') {
+    $json_enabled = true;
+    $rrd_options .= ' XPORT:cuptime:Uptime';
+} else {
+    $rrd_options .= " 'COMMENT:Days      Current  Minimum  Maximum  Average\\n'";
+    $rrd_options .= ' AREA:cuptime#00FF0022:Uptime';
+    $rrd_options .= ' LINE1.25:cuptime#36393D:';
+    $rrd_options .= ' GPRINT:cuptime:LAST:%6.2lf  GPRINT:cuptime:MIN:%6.2lf';
+    $rrd_options .= " GPRINT:cuptime:MAX:%6.2lf  'GPRINT:cuptime:AVERAGE:%6.2lf\\n'";
+}

--- a/includes/html/graphs/generic_multi_data.inc.php
+++ b/includes/html/graphs/generic_multi_data.inc.php
@@ -100,34 +100,44 @@ if ($i) {
         $rrd_options .= ' VDEF:dpercentile_outX=dpercentile_outXn,FIRST';
     }
 
-    if ($legend == 'no' || $legend == '1') {
-        $rrd_options .= ' AREA:in' . $format . '#' . $colour_area_in . $stacked['transparency'] . ':';
-        $rrd_options .= ' AREA:dout' . $format . '#' . $colour_area_out . $stacked['transparency'] . ':';
+    if ($json_output) {
+        $rrd_options .= ' XPORT:in' . $format . ":'In'";
+        $rrd_options .= ' XPORT:dout' . $format . ":'Out'";
     } else {
-        $rrd_options .= " COMMENT:'bps      Now       Ave      Max      " . \LibreNMS\Config::get('percentile_value') . "th %\\n'";
-        $rrd_options .= ' AREA:in' . $format . '#' . $colour_area_in . $stacked['transparency'] . ':In ';
-        $rrd_options .= ' GPRINT:in' . $format . ':LAST:%6.'.$float_precision.'lf%s';
-        $rrd_options .= ' GPRINT:in' . $format . ':AVERAGE:%6.'.$float_precision.'lf%s';
-        $rrd_options .= ' GPRINT:in' . $format . ':MAX:%6.'.$float_precision.'lf%s';
-        $rrd_options .= " GPRINT:percentile_in:%6.".$float_precision."lf%s\\n";
-        $rrd_options .= ' AREA:dout' . $format . '#' . $colour_area_out . $stacked['transparency'] . ':Out';
-        $rrd_options .= ' GPRINT:out' . $format . ':LAST:%6.'.$float_precision.'lf%s';
-        $rrd_options .= ' GPRINT:out' . $format . ':AVERAGE:%6.'.$float_precision.'lf%s';
-        $rrd_options .= ' GPRINT:out' . $format . ':MAX:%6.'.$float_precision.'lf%s';
-        $rrd_options .= " GPRINT:percentile_out:%6.".$float_precision."lf%s\\n";
-        $rrd_options .= " GPRINT:tot:'Total %6.".$float_precision."lf%sB'";
-        $rrd_options .= " GPRINT:totin:'(In %6.".$float_precision."lf%sB'";
-        $rrd_options .= " GPRINT:totout:'Out %6.".$float_precision."lf%sB)\\l'";
-    }
+        if ($legend == 'no' || $legend == '1') {
+            $rrd_options .= ' AREA:in' . $format . '#' . $colour_area_in . $stacked['transparency'] . ':';
+            $rrd_options .= ' AREA:dout' . $format . '#' . $colour_area_out . $stacked['transparency'] . ':';
+        } else {
+            $rrd_options .= " COMMENT:'bps      Now       Ave      Max      " . \LibreNMS\Config::get('percentile_value') . "th %\\n'";
+            $rrd_options .= ' AREA:in' . $format . '#' . $colour_area_in . $stacked['transparency'] . ':In ';
+            $rrd_options .= ' GPRINT:in' . $format . ':LAST:%6.'.$float_precision.'lf%s';
+            $rrd_options .= ' GPRINT:in' . $format . ':AVERAGE:%6.'.$float_precision.'lf%s';
+            $rrd_options .= ' GPRINT:in' . $format . ':MAX:%6.'.$float_precision.'lf%s';
+            $rrd_options .= " GPRINT:percentile_in:%6.".$float_precision."lf%s\\n";
+            $rrd_options .= ' AREA:dout' . $format . '#' . $colour_area_out . $stacked['transparency'] . ':Out';
+            $rrd_options .= ' GPRINT:out' . $format . ':LAST:%6.'.$float_precision.'lf%s';
+            $rrd_options .= ' GPRINT:out' . $format . ':AVERAGE:%6.'.$float_precision.'lf%s';
+            $rrd_options .= ' GPRINT:out' . $format . ':MAX:%6.'.$float_precision.'lf%s';
+            $rrd_options .= " GPRINT:percentile_out:%6.".$float_precision."lf%s\\n";
+            $rrd_options .= " GPRINT:tot:'Total %6.".$float_precision."lf%sB'";
+            $rrd_options .= " GPRINT:totin:'(In %6.".$float_precision."lf%sB'";
+            $rrd_options .= " GPRINT:totout:'Out %6.".$float_precision."lf%sB)\\l'";
+        }
 
-    $rrd_options .= ' LINE1:percentile_in#aa0000';
-    $rrd_options .= ' LINE1:dpercentile_out#aa0000';
+        $rrd_options .= ' LINE1:percentile_in#aa0000';
+        $rrd_options .= ' LINE1:dpercentile_out#aa0000';
 
-    if ($_GET['previous'] == 'yes') {
-        $rrd_options .= ' AREA:in' . $format . 'X#99999999' . $stacked['transparency'] . ':';
-        $rrd_options .= ' AREA:dout' . $format . 'X#99999999' . $stacked['transparency'] . ':';
-        $rrd_options .= ' LINE1:in' . $format . 'X#666666:';
-        $rrd_options .= ' LINE1:dout' . $format . 'X#666666:';
+        if ($_GET['previous'] == 'yes') {
+            if ($json_output) {
+                $rrd_options .= ' XPORT:in' . $format . 'X' . ":'Prev In'";
+                $rrd_options .= ' XPORT:dout' . $format . 'X' . ":'Prev Out'";
+            } else {
+                $rrd_options .= ' AREA:in' . $format . 'X#99999999' . $stacked['transparency'] . ':';
+                $rrd_options .= ' AREA:dout' . $format . 'X#99999999' . $stacked['transparency'] . ':';
+                $rrd_options .= ' LINE1:in' . $format . 'X#666666:';
+                $rrd_options .= ' LINE1:dout' . $format . 'X#666666:';
+            }
+        }
     }
 }
 

--- a/includes/html/graphs/generic_multi_seperated.inc.php
+++ b/includes/html/graphs/generic_multi_seperated.inc.php
@@ -43,32 +43,34 @@ if ($format == 'octets' || $format == 'bytes') {
 
 $i = 0;
 
-if ($width > '500') {
-    $rrd_options .= sprintf(" COMMENT:'%s'", $units_descr);
-    $rrd_options .= sprintf(" COMMENT:'%12s'", "Current");
-    $rrd_options .= sprintf(" COMMENT:'%10s'", "Average");
-    $rrd_options .= sprintf(" COMMENT:'%10s'", "Maximum");
-    if (!$$args['nototal']) {
-        $rrd_options .= sprintf(" COMMENT:'%8s'", "Total");
+if (!$json_output) {
+    if ($width > '500') {
+        $rrd_options .= sprintf(" COMMENT:'%s'", $units_descr);
+        $rrd_options .= sprintf(" COMMENT:'%12s'", "Current");
+        $rrd_options .= sprintf(" COMMENT:'%10s'", "Average");
+        $rrd_options .= sprintf(" COMMENT:'%10s'", "Maximum");
+        if (!$$args['nototal']) {
+            $rrd_options .= sprintf(" COMMENT:'%8s'", "Total");
+        }
+    } else {
+        $nototal = true;
+        $rrd_options .= sprintf(" COMMENT:'%s'", $units_descr);
+        $rrd_options .= sprintf(" COMMENT:'%12s'", "Now");
+        $rrd_options .= sprintf(" COMMENT:'%10s'", "Avg");
+        $rrd_options .= sprintf(" COMMENT:'%10s'", "Max");
     }
-} else {
-    $nototal = true;
-    $rrd_options .= sprintf(" COMMENT:'%s'", $units_descr);
-    $rrd_options .= sprintf(" COMMENT:'%12s'", "Now");
-    $rrd_options .= sprintf(" COMMENT:'%10s'", "Avg");
-    $rrd_options .= sprintf(" COMMENT:'%10s'", "Max");
-}
 
-if ($_GET['previous']) {
-    $rrd_options .= sprintf(" COMMENT:'\t'", "");
-    $rrd_options .= sprintf(" COMMENT:'%10s'", "P Avg");
-    $rrd_options .= sprintf(" COMMENT:'%10s'", "P Max");
-    if (!$args['nototal']) {
-        $rrd_options .= sprintf(" COMMENT:'%8s'", "P Total");
+    if ($_GET['previous']) {
+        $rrd_options .= sprintf(" COMMENT:'\t'", "");
+        $rrd_options .= sprintf(" COMMENT:'%10s'", "P Avg");
+        $rrd_options .= sprintf(" COMMENT:'%10s'", "P Max");
+        if (!$args['nototal']) {
+            $rrd_options .= sprintf(" COMMENT:'%8s'", "P Total");
+        }
     }
-}
 
-$rrd_options .= " COMMENT:'\\n'";
+    $rrd_options .= " COMMENT:'\\n'";
+}
 
 foreach ($rrd_list as $rrd) {
     if (!Config::get("graph_colours.$colours_in.$iter") || !Config::get("graph_colours.$colours_out.$iter")) {
@@ -137,45 +139,50 @@ foreach ($rrd_list as $rrd) {
         $descr_out = rrdtool_escape('', $rrddescr_len) . ' Out';
     }
 
-    $rrd_options .= ' AREA:inbits' . $i . '#' . $colour_in . $stacked['transparency'] . ":'$descr'$stack";
-    $rrd_options .= ' GPRINT:inbits' . $i . ':LAST:%6.'.$float_precision."lf%s$units";
-    $rrd_options .= ' GPRINT:inbits' . $i . ':AVERAGE:%6.'.$float_precision."lf%s$units";
-    $rrd_options .= ' GPRINT:inbits' . $i . ':MAX:%6.'.$float_precision."lf%s$units";
+    if ($json_output) {
+        $rrd_options .= ' XPORT:inbits' . $i . ":'" . $rrd['descr'] . " In'";
+        $rrd_optionsb .= ' XPORT:outbits' . $i . '_neg' . ":'" . $rrd['descr'] . " Out'";
+    } else {
+        $rrd_options .= ' AREA:inbits' . $i . '#' . $colour_in . $stacked['transparency'] . ":'$descr'$stack";
+        $rrd_options .= ' GPRINT:inbits' . $i . ':LAST:%6.'.$float_precision."lf%s$units";
+        $rrd_options .= ' GPRINT:inbits' . $i . ':AVERAGE:%6.'.$float_precision."lf%s$units";
+        $rrd_options .= ' GPRINT:inbits' . $i . ':MAX:%6.'.$float_precision."lf%s$units";
 
-    if (!$args['nototal']) {
-        $rrd_options .= ' GPRINT:totinB' . $i . ":%6.".$float_precision."lf%s$total_units";
-    }
-
-    if ($_GET['previous'] == 'yes') {
-        $rrd_options .= " COMMENT:' \t'";
-        $rrd_options .= ' GPRINT:inbits' . $i . 'X:AVERAGE:%6.'.$float_precision."lf%s$units";
-        $rrd_options .= ' GPRINT:inbits' . $i . 'X:MAX:%6.'.$float_precision."lf%s$units";
         if (!$args['nototal']) {
-            $rrd_options .= ' GPRINT:totinB' . $i . 'X' . ":%6.".$float_precision."lf%s$total_units";
+            $rrd_options .= ' GPRINT:totinB' . $i . ":%6.".$float_precision."lf%s$total_units";
         }
-    }
 
-    $rrd_options .= " COMMENT:'\\n'";
-    $rrd_optionsb .= ' AREA:outbits' . $i . '_neg#' . $colour_out . $stacked['transparency'] . ":$stack";
-    $rrd_options .= ' HRULE:999999999999999#' . $colour_out . ":'$descr_out'";
-    $rrd_options .= ' GPRINT:outbits' . $i . ':LAST:%6.'.$float_precision."lf%s$units";
-    $rrd_options .= ' GPRINT:outbits' . $i . ':AVERAGE:%6.'.$float_precision."lf%s$units";
-    $rrd_options .= ' GPRINT:outbits' . $i . ':MAX:%6.'.$float_precision."lf%s$units";
+        if ($_GET['previous'] == 'yes') {
+            $rrd_options .= " COMMENT:' \t'";
+            $rrd_options .= ' GPRINT:inbits' . $i . 'X:AVERAGE:%6.'.$float_precision."lf%s$units";
+            $rrd_options .= ' GPRINT:inbits' . $i . 'X:MAX:%6.'.$float_precision."lf%s$units";
+            if (!$args['nototal']) {
+                $rrd_options .= ' GPRINT:totinB' . $i . 'X' . ":%6.".$float_precision."lf%s$total_units";
+            }
+        }
 
-    if (!$args['nototal']) {
-        $rrd_options .= ' GPRINT:totoutB' . $i . ":%6.".$float_precision."lf%s$total_units";
-    }
+        $rrd_options .= " COMMENT:'\\n'";
+        $rrd_optionsb .= ' AREA:outbits' . $i . '_neg#' . $colour_out . $stacked['transparency'] . ":$stack";
+        $rrd_options .= ' HRULE:999999999999999#' . $colour_out . ":'$descr_out'";
+        $rrd_options .= ' GPRINT:outbits' . $i . ':LAST:%6.'.$float_precision."lf%s$units";
+        $rrd_options .= ' GPRINT:outbits' . $i . ':AVERAGE:%6.'.$float_precision."lf%s$units";
+        $rrd_options .= ' GPRINT:outbits' . $i . ':MAX:%6.'.$float_precision."lf%s$units";
 
-    if ($_GET['previous'] == 'yes') {
-        $rrd_options .= " COMMENT:' \t'";
-        $rrd_options .= ' GPRINT:outbits' . $i . 'X:AVERAGE:%6.'.$float_precision."lf%s$units";
-        $rrd_options .= ' GPRINT:outbits' . $i . 'X:MAX:%6.'.$float_precision."lf%s$units";
         if (!$args['nototal']) {
-            $rrd_options .= ' GPRINT:totoutB' . $i . 'X' . ":%6.".$float_precision."lf%s$total_units";
+            $rrd_options .= ' GPRINT:totoutB' . $i . ":%6.".$float_precision."lf%s$total_units";
         }
-    }
 
-    $rrd_options .= " COMMENT:'\\n'";
+        if ($_GET['previous'] == 'yes') {
+            $rrd_options .= " COMMENT:' \t'";
+            $rrd_options .= ' GPRINT:outbits' . $i . 'X:AVERAGE:%6.'.$float_precision."lf%s$units";
+            $rrd_options .= ' GPRINT:outbits' . $i . 'X:MAX:%6.'.$float_precision."lf%s$units";
+            if (!$args['nototal']) {
+                $rrd_options .= ' GPRINT:totoutB' . $i . 'X' . ":%6.".$float_precision."lf%s$total_units";
+            }
+        }
+
+        $rrd_options .= " COMMENT:'\\n'";
+    }
     $i++;
     $iter++;
 }
@@ -204,10 +211,15 @@ if ($_GET['previous'] == 'yes') {
 }
 
 if ($_GET['previous'] == 'yes') {
-    $rrd_options .= ' AREA:in' . $format . 'X#99999999' . $stacked['transparency'] . ':';
-    $rrd_optionsb .= ' AREA:dout' . $format . 'X#99999999' . $transparency . ':';
-    $rrd_options .= ' LINE1.25:in' . $format . 'X#666666:';
-    $rrd_optionsb .= ' LINE1.25:dout' . $format . 'X#666666:';
+    if ($json_output) {
+        $rrd_options .= ' XPORT:in' . $format . 'X' . ":'Previous In'";
+        $rrd_optionsb .= ' XPORT:dout' . $format . 'X' . ":'Previous Out'";
+    } else {
+        $rrd_options .= ' AREA:in' . $format . 'X#99999999' . $stacked['transparency'] . ':';
+        $rrd_optionsb .= ' AREA:dout' . $format . 'X#99999999' . $transparency . ':';
+        $rrd_options .= ' LINE1.25:in' . $format . 'X#666666:';
+        $rrd_optionsb .= ' LINE1.25:dout' . $format . 'X#666666:';
+    }
 }
 
 if (!$args['nototal']) {
@@ -231,47 +243,51 @@ if (!$args['nototal']) {
     $rrd_options .= ' VDEF:aveout=outbits,AVERAGE';
     $rrd_options .= ' VDEF:tot=octets,TOTAL';
 
-    $rrd_options .= " COMMENT:' \\n'";
+    if (!$json_output) {
+        $rrd_options .= " COMMENT:' \\n'";
 
-    $rrd_options .= " HRULE:999999999999999#FFFFFF:'" . rrdtool_escape('Total', $rrddescr_len) . "  In'";
-    $rrd_options .= ' GPRINT:inbits:LAST:%6.'.$float_precision."lf%s$units";
-    $rrd_options .= ' GPRINT:inbits:AVERAGE:%6.'.$float_precision."lf%s$units";
-    $rrd_options .= ' GPRINT:inbits:MAX:%6.'.$float_precision."lf%s$units";
-    $rrd_options .= " GPRINT:totin:%6.".$float_precision."lf%s$total_units";
-    if ($_GET['previous'] == 'yes') {
-        $rrd_options .= " COMMENT:' \t'";
-        $rrd_options .= ' GPRINT:inbitsX:AVERAGE:%6.'.$float_precision."lf%s$units";
-        $rrd_options .= ' GPRINT:inbitsX:MAX:%6.'.$float_precision."lf%s$units";
-        $rrd_options .= " GPRINT:totinX:%6.".$float_precision."lf%s$total_units";
-    }
-    $rrd_options .= " COMMENT:'\\n'";
+        $rrd_options .= " HRULE:999999999999999#FFFFFF:'" . rrdtool_escape('Total', $rrddescr_len) . "  In'";
+        $rrd_options .= ' GPRINT:inbits:LAST:%6.'.$float_precision."lf%s$units";
+        $rrd_options .= ' GPRINT:inbits:AVERAGE:%6.'.$float_precision."lf%s$units";
+        $rrd_options .= ' GPRINT:inbits:MAX:%6.'.$float_precision."lf%s$units";
+        $rrd_options .= " GPRINT:totin:%6.".$float_precision."lf%s$total_units";
+        if ($_GET['previous'] == 'yes') {
+            $rrd_options .= " COMMENT:' \t'";
+            $rrd_options .= ' GPRINT:inbitsX:AVERAGE:%6.'.$float_precision."lf%s$units";
+            $rrd_options .= ' GPRINT:inbitsX:MAX:%6.'.$float_precision."lf%s$units";
+            $rrd_options .= " GPRINT:totinX:%6.".$float_precision."lf%s$total_units";
+        }
+        $rrd_options .= " COMMENT:'\\n'";
 
-    $rrd_options .= " HRULE:999999999999990#FFFFFF:'" . rrdtool_escape('', $rrddescr_len) . " Out'";
-    $rrd_options .= ' GPRINT:outbits:LAST:%6.'.$float_precision."lf%s$units";
-    $rrd_options .= ' GPRINT:outbits:AVERAGE:%6.'.$float_precision."lf%s$units";
-    $rrd_options .= ' GPRINT:outbits:MAX:%6.'.$float_precision."lf%s$units";
-    $rrd_options .= " GPRINT:totout:%6.".$float_precision."lf%s$total_units";
-    if ($_GET['previous'] == 'yes') {
-        $rrd_options .= " COMMENT:' \t'";
-        $rrd_options .= ' GPRINT:outbitsX:AVERAGE:%6.'.$float_precision."lf%s$units";
-        $rrd_options .= ' GPRINT:outbitsX:MAX:%6.'.$float_precision."lf%s$units";
-        $rrd_options .= ' GPRINT:totoutX:%6.'.$float_precision."lf%s$total_units";
-    }
-    $rrd_options .= " COMMENT:'\\n'";
+        $rrd_options .= " HRULE:999999999999990#FFFFFF:'" . rrdtool_escape('', $rrddescr_len) . " Out'";
+        $rrd_options .= ' GPRINT:outbits:LAST:%6.'.$float_precision."lf%s$units";
+        $rrd_options .= ' GPRINT:outbits:AVERAGE:%6.'.$float_precision."lf%s$units";
+        $rrd_options .= ' GPRINT:outbits:MAX:%6.'.$float_precision."lf%s$units";
+        $rrd_options .= " GPRINT:totout:%6.".$float_precision."lf%s$total_units";
+        if ($_GET['previous'] == 'yes') {
+            $rrd_options .= " COMMENT:' \t'";
+            $rrd_options .= ' GPRINT:outbitsX:AVERAGE:%6.'.$float_precision."lf%s$units";
+            $rrd_options .= ' GPRINT:outbitsX:MAX:%6.'.$float_precision."lf%s$units";
+            $rrd_options .= ' GPRINT:totoutX:%6.'.$float_precision."lf%s$total_units";
+        }
+        $rrd_options .= " COMMENT:'\\n'";
 
-    $rrd_options .= " HRULE:999999999999990#FFFFFF:'" . rrdtool_escape('', $rrddescr_len) . " Agg'";
-    $rrd_options .= ' GPRINT:bits:LAST:%6.'.$float_precision."lf%s$units";
-    $rrd_options .= ' GPRINT:bits:AVERAGE:%6.'.$float_precision."lf%s$units";
-    $rrd_options .= ' GPRINT:bits:MAX:%6.'.$float_precision."lf%s$units";
-    $rrd_options .= " GPRINT:tot:%6.".$float_precision."lf%s$total_units";
-    if ($_GET['previous'] == 'yes') {
-        $rrd_options .= " COMMENT:' \t'";
-        $rrd_options .= ' GPRINT:bitsX:AVERAGE:%6.'.$float_precision."lf%s$units";
-        $rrd_options .= ' GPRINT:bitsX:MAX:%6.'.$float_precision."lf%s$units";
-        $rrd_options .= " GPRINT:totX:%6.".$float_precision."lf%s$total_units";
+        $rrd_options .= " HRULE:999999999999990#FFFFFF:'" . rrdtool_escape('', $rrddescr_len) . " Agg'";
+        $rrd_options .= ' GPRINT:bits:LAST:%6.'.$float_precision."lf%s$units";
+        $rrd_options .= ' GPRINT:bits:AVERAGE:%6.'.$float_precision."lf%s$units";
+        $rrd_options .= ' GPRINT:bits:MAX:%6.'.$float_precision."lf%s$units";
+        $rrd_options .= " GPRINT:tot:%6.".$float_precision."lf%s$total_units";
+        if ($_GET['previous'] == 'yes') {
+            $rrd_options .= " COMMENT:' \t'";
+            $rrd_options .= ' GPRINT:bitsX:AVERAGE:%6.'.$float_precision."lf%s$units";
+            $rrd_options .= ' GPRINT:bitsX:MAX:%6.'.$float_precision."lf%s$units";
+            $rrd_options .= " GPRINT:totX:%6.".$float_precision."lf%s$total_units";
+        }
+        $rrd_options .= " COMMENT:'\\n'";
     }
-    $rrd_options .= " COMMENT:'\\n'";
 }
 
 $rrd_options .= $rrd_optionsb;
-$rrd_options .= ' HRULE:0#999999';
+if (!$json_output) {
+    $rrd_options .= ' HRULE:0#999999';
+}

--- a/includes/html/graphs/graph.inc.php
+++ b/includes/html/graphs/graph.inc.php
@@ -30,7 +30,9 @@ $period = ($to - $from);
 $base64_output = '';
 $prev_from = ($from - $period);
 
-if ($output === 'json') {
+$json_output = false;
+if ($output === 'json' && graph_type_supports_json($vars['type'])) {
+    $json_output = true;
     $step = Config::get('rrd.step');
     $width = (!empty($width) ? $width : ceil($period/$step) );
     $rrd_options .= " --step $step";
@@ -102,7 +104,7 @@ if ($error_msg) {
     }
 } else {
     // $rrd_options .= " HRULE:0#999999";
-    if ($output === 'json' && $json_enabled) {
+    if ($json_output) {
         $rrd_options .= " --imgformat=JSONTIME";
     } else {
         if ($graph_type === 'svg') {
@@ -138,7 +140,11 @@ if ($error_msg) {
             d_echo($rrd_cmd);
             if (is_file($graphfile)) {
                 if (!$debug) {
-                    set_image_type();
+                    if ($json_output) {
+                        set_image_type('json');
+                    } else {
+                        set_image_type();
+                    }
                     if (Config::get('trim_tobias') && $graph_type !== 'svg') {
                         list($w, $h, $type, $attr) = getimagesize($graphfile);
                         $src_im                    = imagecreatefrompng($graphfile);

--- a/includes/html/graphs/graph.inc.php
+++ b/includes/html/graphs/graph.inc.php
@@ -30,6 +30,12 @@ $period = ($to - $from);
 $base64_output = '';
 $prev_from = ($from - $period);
 
+if ($output === 'json') {
+    $step = Config::get('rrd.step');
+    $width = (!empty($width) ? $width : ceil($period/$step) );
+    $rrd_options .= " --step $step";
+}
+
 $graphfile = Config::get('temp_dir') . '/' . strgen();
 
 require Config::get('install_dir') . "/includes/html/graphs/$type/auth.inc.php";
@@ -96,10 +102,14 @@ if ($error_msg) {
     }
 } else {
     // $rrd_options .= " HRULE:0#999999";
-    if ($graph_type === 'svg') {
-        $rrd_options .= " --imgformat=SVG";
-        if ($width < 350) {
-            $rrd_options .= " -m 0.75 -R light";
+    if ($output === 'json' && $json_enabled) {
+        $rrd_options .= " --imgformat=JSONTIME";
+    } else {
+        if ($graph_type === 'svg') {
+            $rrd_options .= " --imgformat=SVG";
+            if ($width < 350) {
+                $rrd_options .= " -m 0.75 -R light";
+            }
         }
     }
 


### PR DESCRIPTION
This will most likely be a small PR, but hopefully the first of many to allow querying the data stored in RRD. The (over-ambitious) plan is to expose RRD data to LibreNMS internal libraries, which will allow for future improvements, such as a UI graphing replacement and to allow graphing from another supported data source (graphite, influx, etc).

Please share any suggestions, and if this conflicts with other future project plans. I've made a few assumptions on best-practice, such as using the `$json_enabled` variable in graph include files, like `uptime.inc.php`. This seems to be a decent way to only enable JSON results as the include files are updated to support them.

I'm on the discord at `@hayden#8083`

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
