### PR TITLE
Add NoBulk Option for Sitemonitor

### DIFF
--- a/includes/definitions/sitemonitor.yaml
+++ b/includes/definitions/sitemonitor.yaml
@@ -4,6 +4,7 @@ type: appliance
 icon: packetflux
 over:
     - { graph: device_poller_perf, text: 'Poller time' }
+nobulk: true
 mib_dir: packetflux
 discovery:
     -


### PR DESCRIPTION
Please give a short description what your pull request is for:

This PR adds the `nobulk` option to the PacketFlux Sitemonitor Definition. The device does not support SNMP GetBulk.

