### PR TITLE
schema: add missing primary keys

### DIFF
--- a/database/migrations/2018_07_03_091314_create_bill_perms_table.php
+++ b/database/migrations/2018_07_03_091314_create_bill_perms_table.php
@@ -13,6 +13,7 @@ class CreateBillPermsTable extends Migration
     public function up()
     {
         Schema::create('bill_perms', function (Blueprint $table) {
+            $table->bigIncrements(id);
             $table->unsignedInteger('user_id');
             $table->unsignedInteger('bill_id');
         });

--- a/database/migrations/2018_07_03_091314_create_bill_perms_table.php
+++ b/database/migrations/2018_07_03_091314_create_bill_perms_table.php
@@ -13,7 +13,7 @@ class CreateBillPermsTable extends Migration
     public function up()
     {
         Schema::create('bill_perms', function (Blueprint $table) {
-            $table->bigIncrements(id);
+            $table->id();
             $table->unsignedInteger('user_id');
             $table->unsignedInteger('bill_id');
         });

--- a/database/migrations/2018_07_03_091314_create_bill_ports_table.php
+++ b/database/migrations/2018_07_03_091314_create_bill_ports_table.php
@@ -13,7 +13,7 @@ class CreateBillPortsTable extends Migration
     public function up()
     {
         Schema::create('bill_ports', function (Blueprint $table) {
-            $table->bigIncrements(id);
+            $table->id();
             $table->unsignedInteger('bill_id');
             $table->unsignedInteger('port_id');
             $table->boolean('bill_port_autoadded')->default(0);

--- a/database/migrations/2018_07_03_091314_create_bill_ports_table.php
+++ b/database/migrations/2018_07_03_091314_create_bill_ports_table.php
@@ -13,6 +13,7 @@ class CreateBillPortsTable extends Migration
     public function up()
     {
         Schema::create('bill_ports', function (Blueprint $table) {
+            $table->bigIncrements(id);
             $table->unsignedInteger('bill_id');
             $table->unsignedInteger('port_id');
             $table->boolean('bill_port_autoadded')->default(0);

--- a/database/migrations/2018_07_03_091314_create_devices_perms_table.php
+++ b/database/migrations/2018_07_03_091314_create_devices_perms_table.php
@@ -13,6 +13,7 @@ class CreateDevicesPermsTable extends Migration
     public function up()
     {
         Schema::create('devices_perms', function (Blueprint $table) {
+            $table->bigIncrements(id);
             $table->unsignedInteger('user_id')->index();
             $table->unsignedInteger('device_id');
         });

--- a/database/migrations/2018_07_03_091314_create_devices_perms_table.php
+++ b/database/migrations/2018_07_03_091314_create_devices_perms_table.php
@@ -13,7 +13,7 @@ class CreateDevicesPermsTable extends Migration
     public function up()
     {
         Schema::create('devices_perms', function (Blueprint $table) {
-            $table->bigIncrements(id);
+            $table->id();
             $table->unsignedInteger('user_id')->index();
             $table->unsignedInteger('device_id');
         });

--- a/database/migrations/2018_07_03_091314_create_entPhysical_state_table.php
+++ b/database/migrations/2018_07_03_091314_create_entPhysical_state_table.php
@@ -13,7 +13,7 @@ class CreateEntPhysicalStateTable extends Migration
     public function up()
     {
         Schema::create('entPhysical_state', function (Blueprint $table) {
-            $table->bigIncrements(id);
+            $table->id();
             $table->unsignedInteger('device_id');
             $table->string('entPhysicalIndex', 64);
             $table->string('subindex', 64)->nullable();

--- a/database/migrations/2018_07_03_091314_create_entPhysical_state_table.php
+++ b/database/migrations/2018_07_03_091314_create_entPhysical_state_table.php
@@ -13,6 +13,7 @@ class CreateEntPhysicalStateTable extends Migration
     public function up()
     {
         Schema::create('entPhysical_state', function (Blueprint $table) {
+            $table->bigIncrements(id);
             $table->unsignedInteger('device_id');
             $table->string('entPhysicalIndex', 64);
             $table->string('subindex', 64)->nullable();

--- a/database/migrations/2018_07_03_091314_create_ipv4_mac_table.php
+++ b/database/migrations/2018_07_03_091314_create_ipv4_mac_table.php
@@ -13,7 +13,7 @@ class CreateIpv4MacTable extends Migration
     public function up()
     {
         Schema::create('ipv4_mac', function (Blueprint $table) {
-            $table->bigIncrements(id);
+            $table->id();
             $table->unsignedInteger('port_id')->index();
             $table->unsignedInteger('device_id')->nullable();
             $table->string('mac_address', 32)->index();

--- a/database/migrations/2018_07_03_091314_create_ipv4_mac_table.php
+++ b/database/migrations/2018_07_03_091314_create_ipv4_mac_table.php
@@ -13,6 +13,7 @@ class CreateIpv4MacTable extends Migration
     public function up()
     {
         Schema::create('ipv4_mac', function (Blueprint $table) {
+            $table->bigIncrements(id);
             $table->unsignedInteger('port_id')->index();
             $table->unsignedInteger('device_id')->nullable();
             $table->string('mac_address', 32)->index();

--- a/database/migrations/2018_07_03_091314_create_juniAtmVp_table.php
+++ b/database/migrations/2018_07_03_091314_create_juniAtmVp_table.php
@@ -13,7 +13,7 @@ class CreateJuniAtmVpTable extends Migration
     public function up()
     {
         Schema::create('juniAtmVp', function (Blueprint $table) {
-            $table->bigIncrements(id);
+            $table->id();
             $table->unsignedInteger('juniAtmVp_id');
             $table->unsignedInteger('port_id')->index();
             $table->unsignedInteger('vp_id');

--- a/database/migrations/2018_07_03_091314_create_juniAtmVp_table.php
+++ b/database/migrations/2018_07_03_091314_create_juniAtmVp_table.php
@@ -13,6 +13,7 @@ class CreateJuniAtmVpTable extends Migration
     public function up()
     {
         Schema::create('juniAtmVp', function (Blueprint $table) {
+            $table->bigIncrements(id);
             $table->unsignedInteger('juniAtmVp_id');
             $table->unsignedInteger('port_id')->index();
             $table->unsignedInteger('vp_id');

--- a/database/migrations/2018_07_03_091314_create_loadbalancer_vservers_table.php
+++ b/database/migrations/2018_07_03_091314_create_loadbalancer_vservers_table.php
@@ -13,6 +13,7 @@ class CreateLoadbalancerVserversTable extends Migration
     public function up()
     {
         Schema::create('loadbalancer_vservers', function (Blueprint $table) {
+            $table->bigIncrements(id);
             $table->unsignedInteger('classmap_id');
             $table->string('classmap', 128);
             $table->string('serverstate', 64);

--- a/database/migrations/2018_07_03_091314_create_loadbalancer_vservers_table.php
+++ b/database/migrations/2018_07_03_091314_create_loadbalancer_vservers_table.php
@@ -13,7 +13,7 @@ class CreateLoadbalancerVserversTable extends Migration
     public function up()
     {
         Schema::create('loadbalancer_vservers', function (Blueprint $table) {
-            $table->bigIncrements(id);
+            $table->id();
             $table->unsignedInteger('classmap_id');
             $table->string('classmap', 128);
             $table->string('serverstate', 64);

--- a/database/migrations/2018_07_03_091314_create_ports_perms_table.php
+++ b/database/migrations/2018_07_03_091314_create_ports_perms_table.php
@@ -13,7 +13,7 @@ class CreatePortsPermsTable extends Migration
     public function up()
     {
         Schema::create('ports_perms', function (Blueprint $table) {
-            $table->bigIncrements(id);
+            $table->id();
             $table->unsignedInteger('user_id');
             $table->unsignedInteger('port_id');
         });

--- a/database/migrations/2018_07_03_091314_create_ports_perms_table.php
+++ b/database/migrations/2018_07_03_091314_create_ports_perms_table.php
@@ -13,6 +13,7 @@ class CreatePortsPermsTable extends Migration
     public function up()
     {
         Schema::create('ports_perms', function (Blueprint $table) {
+            $table->bigIncrements(id);
             $table->unsignedInteger('user_id');
             $table->unsignedInteger('port_id');
         });

--- a/database/migrations/2018_07_03_091314_create_processes_table.php
+++ b/database/migrations/2018_07_03_091314_create_processes_table.php
@@ -13,7 +13,7 @@ class CreateProcessesTable extends Migration
     public function up()
     {
         Schema::create('processes', function (Blueprint $table) {
-            $table->bigIncrements(id);
+            $table->id();
             $table->unsignedInteger('device_id')->index();
             $table->integer('pid');
             $table->integer('vsz');

--- a/database/migrations/2018_07_03_091314_create_processes_table.php
+++ b/database/migrations/2018_07_03_091314_create_processes_table.php
@@ -13,6 +13,7 @@ class CreateProcessesTable extends Migration
     public function up()
     {
         Schema::create('processes', function (Blueprint $table) {
+            $table->bigIncrements(id);
             $table->unsignedInteger('device_id')->index();
             $table->integer('pid');
             $table->integer('vsz');

--- a/database/migrations/2018_07_03_091314_create_transport_group_transport_table.php
+++ b/database/migrations/2018_07_03_091314_create_transport_group_transport_table.php
@@ -35,7 +35,7 @@ class CreateTransportGroupTransportTable extends Migration
     public function up()
     {
         Schema::create('transport_group_transport', function (Blueprint $table) {
-            $table->bigIncrements(id);
+            $table->id();
             $table->unsignedInteger('transport_group_id');
             $table->unsignedInteger('transport_id');
         });

--- a/database/migrations/2018_07_03_091314_create_transport_group_transport_table.php
+++ b/database/migrations/2018_07_03_091314_create_transport_group_transport_table.php
@@ -35,6 +35,7 @@ class CreateTransportGroupTransportTable extends Migration
     public function up()
     {
         Schema::create('transport_group_transport', function (Blueprint $table) {
+            $table->bigIncrements(id);
             $table->unsignedInteger('transport_group_id');
             $table->unsignedInteger('transport_id');
         });

--- a/database/migrations/2020_10_03_1000_add_primary_key_bill_perms.php
+++ b/database/migrations/2020_10_03_1000_add_primary_key_bill_perms.php
@@ -21,7 +21,7 @@ class AddPrimaryKeyBillPerms extends Migration
     {
         if (! Schema::hasColumn('bill_perms', 'id')) {
             Schema::table('bill_perms', function (Blueprint $table) {
-                $table->bigIncrements('id')->first();
+                $table->id()->first();
             });
         }
     }

--- a/database/migrations/2020_10_03_1000_add_primary_key_bill_perms.php
+++ b/database/migrations/2020_10_03_1000_add_primary_key_bill_perms.php
@@ -19,9 +19,11 @@ class AddPrimaryKeyBillPerms extends Migration
      */
     public function up()
     {
-        Schema::table('bill_perms', function (Blueprint $table) {
-            $table->bigIncrements('id')->first();
-        });
+        if (! Schema::hasColumn('bill_perms', 'id')) {
+            Schema::table('bill_perms', function (Blueprint $table) {
+                $table->bigIncrements('id')->first();
+            });
+        }
     }
 
     /**

--- a/database/migrations/2020_10_03_1000_add_primary_key_bill_perms.php
+++ b/database/migrations/2020_10_03_1000_add_primary_key_bill_perms.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+    This migration adds primary key for table bill_perms.
+
+    Percona Xtradb refuses to modify a table
+    without a primary key.
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+
+class AddPrimaryKeyBillPerms extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('bill_perms', function (Blueprint $table) {
+            $table->bigIncrements('id')->first();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+    }
+}

--- a/database/migrations/2020_10_03_1000_add_primary_key_bill_ports.php
+++ b/database/migrations/2020_10_03_1000_add_primary_key_bill_ports.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+    This migration adds primary key for table bill_ports.
+
+    Percona Xtradb refuses to modify a table
+    without a primary key.
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+
+class AddPrimaryKeyBillPorts extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('bill_ports', function (Blueprint $table) {
+            $table->bigIncrements('id')->first();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+    }
+}

--- a/database/migrations/2020_10_03_1000_add_primary_key_bill_ports.php
+++ b/database/migrations/2020_10_03_1000_add_primary_key_bill_ports.php
@@ -19,9 +19,11 @@ class AddPrimaryKeyBillPorts extends Migration
      */
     public function up()
     {
-        Schema::table('bill_ports', function (Blueprint $table) {
-            $table->bigIncrements('id')->first();
-        });
+        if (! Schema::hasColumn('bill_ports', 'id')) {
+            Schema::table('bill_ports', function (Blueprint $table) {
+                $table->bigIncrements('id')->first();
+            });
+        }
     }
 
     /**

--- a/database/migrations/2020_10_03_1000_add_primary_key_bill_ports.php
+++ b/database/migrations/2020_10_03_1000_add_primary_key_bill_ports.php
@@ -21,7 +21,7 @@ class AddPrimaryKeyBillPorts extends Migration
     {
         if (! Schema::hasColumn('bill_ports', 'id')) {
             Schema::table('bill_ports', function (Blueprint $table) {
-                $table->bigIncrements('id')->first();
+                $table->id()->first();
             });
         }
     }

--- a/database/migrations/2020_10_03_1000_add_primary_key_devices_perms.php
+++ b/database/migrations/2020_10_03_1000_add_primary_key_devices_perms.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+    This migration adds primary key for table devices_perms.
+
+    Percona Xtradb refuses to modify a table
+    without a primary key.
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+
+class AddPrimaryKeyDevicesPerms extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('devices_perms', function (Blueprint $table) {
+            $table->bigIncrements('id')->first();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+    }
+}

--- a/database/migrations/2020_10_03_1000_add_primary_key_devices_perms.php
+++ b/database/migrations/2020_10_03_1000_add_primary_key_devices_perms.php
@@ -21,7 +21,7 @@ class AddPrimaryKeyDevicesPerms extends Migration
     {
         if (! Schema::hasColumn('devices_perms', 'id')) {
             Schema::table('devices_perms', function (Blueprint $table) {
-                $table->bigIncrements('id')->first();
+                $table->id()->first();
             });
         }
     }

--- a/database/migrations/2020_10_03_1000_add_primary_key_devices_perms.php
+++ b/database/migrations/2020_10_03_1000_add_primary_key_devices_perms.php
@@ -19,9 +19,11 @@ class AddPrimaryKeyDevicesPerms extends Migration
      */
     public function up()
     {
-        Schema::table('devices_perms', function (Blueprint $table) {
-            $table->bigIncrements('id')->first();
-        });
+        if (! Schema::hasColumn('devices_perms', 'id')) {
+            Schema::table('devices_perms', function (Blueprint $table) {
+                $table->bigIncrements('id')->first();
+            });
+        }
     }
 
     /**

--- a/database/migrations/2020_10_03_1000_add_primary_key_entPhysical_state.php
+++ b/database/migrations/2020_10_03_1000_add_primary_key_entPhysical_state.php
@@ -19,9 +19,11 @@ class AddPrimaryKeyEntphysicalState extends Migration
      */
     public function up()
     {
-        Schema::table('entPhysical_state', function (Blueprint $table) {
-            $table->bigIncrements('id')->first();
-        });
+        if (! Schema::hasColumn('entPhysical_state', 'id')) {
+            Schema::table('entPhysical_state', function (Blueprint $table) {
+                $table->bigIncrements('id')->first();
+            });
+        }
     }
 
     /**

--- a/database/migrations/2020_10_03_1000_add_primary_key_entPhysical_state.php
+++ b/database/migrations/2020_10_03_1000_add_primary_key_entPhysical_state.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+    This migration adds primary key for table entPhysical_state.
+
+    Percona Xtradb refuses to modify a table
+    without a primary key.
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+
+class AddPrimaryKeyEntphysicalState extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('entPhysical_state', function (Blueprint $table) {
+            $table->bigIncrements('id')->first();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+    }
+}

--- a/database/migrations/2020_10_03_1000_add_primary_key_entPhysical_state.php
+++ b/database/migrations/2020_10_03_1000_add_primary_key_entPhysical_state.php
@@ -21,7 +21,7 @@ class AddPrimaryKeyEntphysicalState extends Migration
     {
         if (! Schema::hasColumn('entPhysical_state', 'id')) {
             Schema::table('entPhysical_state', function (Blueprint $table) {
-                $table->bigIncrements('id')->first();
+                $table->id()->first();
             });
         }
     }

--- a/database/migrations/2020_10_03_1000_add_primary_key_ipv4_mac.php
+++ b/database/migrations/2020_10_03_1000_add_primary_key_ipv4_mac.php
@@ -21,7 +21,7 @@ class AddPrimaryKeyIpv4Mac extends Migration
     {
         if (! Schema::hasColumn('ipv4_mac', 'id')) {
             Schema::table('ipv4_mac', function (Blueprint $table) {
-                $table->bigIncrements('id')->first();
+                $table->id()->first();
             });
         }
     }

--- a/database/migrations/2020_10_03_1000_add_primary_key_ipv4_mac.php
+++ b/database/migrations/2020_10_03_1000_add_primary_key_ipv4_mac.php
@@ -19,9 +19,11 @@ class AddPrimaryKeyIpv4Mac extends Migration
      */
     public function up()
     {
-        Schema::table('ipv4_mac', function (Blueprint $table) {
-            $table->bigIncrements('id')->first();
-        });
+        if (! Schema::hasColumn('ipv4_mac', 'id')) {
+            Schema::table('ipv4_mac', function (Blueprint $table) {
+                $table->bigIncrements('id')->first();
+            });
+        }
     }
 
     /**

--- a/database/migrations/2020_10_03_1000_add_primary_key_ipv4_mac.php
+++ b/database/migrations/2020_10_03_1000_add_primary_key_ipv4_mac.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+    This migration adds primary key for table ipv4_mac.
+
+    Percona Xtradb refuses to modify a table
+    without a primary key.
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+
+class AddPrimaryKeyIpv4Mac extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('ipv4_mac', function (Blueprint $table) {
+            $table->bigIncrements('id')->first();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+    }
+}

--- a/database/migrations/2020_10_03_1000_add_primary_key_juniAtmVp.php
+++ b/database/migrations/2020_10_03_1000_add_primary_key_juniAtmVp.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+    This migration adds primary key for table juniAtmVp.
+
+    Percona Xtradb refuses to modify a table
+    without a primary key.
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+
+class AddPrimaryKeyJuniatmvp extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('juniAtmVp', function (Blueprint $table) {
+            $table->bigIncrements('id')->first();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+    }
+}

--- a/database/migrations/2020_10_03_1000_add_primary_key_juniAtmVp.php
+++ b/database/migrations/2020_10_03_1000_add_primary_key_juniAtmVp.php
@@ -21,7 +21,7 @@ class AddPrimaryKeyJuniatmvp extends Migration
     {
         if (! Schema::hasColumn('juniAtmVp', 'id')) {
             Schema::table('juniAtmVp', function (Blueprint $table) {
-                $table->bigIncrements('id')->first();
+                $table->id()->first();
             });
         }
     }

--- a/database/migrations/2020_10_03_1000_add_primary_key_juniAtmVp.php
+++ b/database/migrations/2020_10_03_1000_add_primary_key_juniAtmVp.php
@@ -19,9 +19,11 @@ class AddPrimaryKeyJuniatmvp extends Migration
      */
     public function up()
     {
-        Schema::table('juniAtmVp', function (Blueprint $table) {
-            $table->bigIncrements('id')->first();
-        });
+        if (! Schema::hasColumn('juniAtmVp', 'id')) {
+            Schema::table('juniAtmVp', function (Blueprint $table) {
+                $table->bigIncrements('id')->first();
+            });
+        }
     }
 
     /**

--- a/database/migrations/2020_10_03_1000_add_primary_key_loadbalancer_vservers.php
+++ b/database/migrations/2020_10_03_1000_add_primary_key_loadbalancer_vservers.php
@@ -19,9 +19,11 @@ class AddPrimaryKeyLoadbalancerVservers extends Migration
      */
     public function up()
     {
-        Schema::table('loadbalancer_vservers', function (Blueprint $table) {
-            $table->bigIncrements('id')->first();
-        });
+        if (! Schema::hasColumn('loadbalancer_vservers', 'id')) {
+            Schema::table('loadbalancer_vservers', function (Blueprint $table) {
+                $table->bigIncrements('id')->first();
+            });
+        }
     }
 
     /**

--- a/database/migrations/2020_10_03_1000_add_primary_key_loadbalancer_vservers.php
+++ b/database/migrations/2020_10_03_1000_add_primary_key_loadbalancer_vservers.php
@@ -21,7 +21,7 @@ class AddPrimaryKeyLoadbalancerVservers extends Migration
     {
         if (! Schema::hasColumn('loadbalancer_vservers', 'id')) {
             Schema::table('loadbalancer_vservers', function (Blueprint $table) {
-                $table->bigIncrements('id')->first();
+                $table->id()->first();
             });
         }
     }

--- a/database/migrations/2020_10_03_1000_add_primary_key_loadbalancer_vservers.php
+++ b/database/migrations/2020_10_03_1000_add_primary_key_loadbalancer_vservers.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+    This migration adds primary key for table loadbalancer_vservers.
+
+    Percona Xtradb refuses to modify a table
+    without a primary key.
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+
+class AddPrimaryKeyLoadbalancerVservers extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('loadbalancer_vservers', function (Blueprint $table) {
+            $table->bigIncrements('id')->first();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+    }
+}

--- a/database/migrations/2020_10_03_1000_add_primary_key_ports_perms.php
+++ b/database/migrations/2020_10_03_1000_add_primary_key_ports_perms.php
@@ -21,7 +21,7 @@ class AddPrimaryKeyPortsPerms extends Migration
     {
         if (! Schema::hasColumn('ports_perms', 'id')) {
             Schema::table('ports_perms', function (Blueprint $table) {
-                $table->bigIncrements('id')->first();
+                $table->id()->first();
             });
         }
     }

--- a/database/migrations/2020_10_03_1000_add_primary_key_ports_perms.php
+++ b/database/migrations/2020_10_03_1000_add_primary_key_ports_perms.php
@@ -19,9 +19,11 @@ class AddPrimaryKeyPortsPerms extends Migration
      */
     public function up()
     {
-        Schema::table('ports_perms', function (Blueprint $table) {
-            $table->bigIncrements('id')->first();
-        });
+        if (! Schema::hasColumn('ports_perms', 'id')) {
+            Schema::table('ports_perms', function (Blueprint $table) {
+                $table->bigIncrements('id')->first();
+            });
+        }
     }
 
     /**

--- a/database/migrations/2020_10_03_1000_add_primary_key_ports_perms.php
+++ b/database/migrations/2020_10_03_1000_add_primary_key_ports_perms.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+    This migration adds primary key for table ports_perms.
+
+    Percona Xtradb refuses to modify a table
+    without a primary key.
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+
+class AddPrimaryKeyPortsPerms extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('ports_perms', function (Blueprint $table) {
+            $table->bigIncrements('id')->first();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+    }
+}

--- a/database/migrations/2020_10_03_1000_add_primary_key_processes.php
+++ b/database/migrations/2020_10_03_1000_add_primary_key_processes.php
@@ -21,7 +21,7 @@ class AddPrimaryKeyProcesses extends Migration
     {
         if (! Schema::hasColumn('processes', 'id')) {
             Schema::table('processes', function (Blueprint $table) {
-                $table->bigIncrements('id')->first();
+                $table->id()->first();
             });
         }
     }

--- a/database/migrations/2020_10_03_1000_add_primary_key_processes.php
+++ b/database/migrations/2020_10_03_1000_add_primary_key_processes.php
@@ -19,9 +19,11 @@ class AddPrimaryKeyProcesses extends Migration
      */
     public function up()
     {
-        Schema::table('processes', function (Blueprint $table) {
-            $table->bigIncrements('id')->first();
-        });
+        if (! Schema::hasColumn('processes', 'id')) {
+            Schema::table('processes', function (Blueprint $table) {
+                $table->bigIncrements('id')->first();
+            });
+        }
     }
 
     /**

--- a/database/migrations/2020_10_03_1000_add_primary_key_processes.php
+++ b/database/migrations/2020_10_03_1000_add_primary_key_processes.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+    This migration adds primary key for table processes.
+
+    Percona Xtradb refuses to modify a table
+    without a primary key.
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+
+class AddPrimaryKeyProcesses extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('processes', function (Blueprint $table) {
+            $table->bigIncrements('id')->first();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+    }
+}

--- a/database/migrations/2020_10_03_1000_add_primary_key_transport_group_transport.php
+++ b/database/migrations/2020_10_03_1000_add_primary_key_transport_group_transport.php
@@ -21,7 +21,7 @@ class AddPrimaryKeyTransportGroupTransport extends Migration
     {
         if (! Schema::hasColumn('transport_group_transport', 'id')) {
             Schema::table('transport_group_transport', function (Blueprint $table) {
-                $table->bigIncrements('id')->first();
+                $table->id()->first();
             });
         }
     }

--- a/database/migrations/2020_10_03_1000_add_primary_key_transport_group_transport.php
+++ b/database/migrations/2020_10_03_1000_add_primary_key_transport_group_transport.php
@@ -19,9 +19,11 @@ class AddPrimaryKeyTransportGroupTransport extends Migration
      */
     public function up()
     {
-        Schema::table('transport_group_transport', function (Blueprint $table) {
-            $table->bigIncrements('id')->first();
-        });
+        if (! Schema::hasColumn('transport_group_transport', 'id')) {
+            Schema::table('transport_group_transport', function (Blueprint $table) {
+                $table->bigIncrements('id')->first();
+            });
+        }
     }
 
     /**

--- a/database/migrations/2020_10_03_1000_add_primary_key_transport_group_transport.php
+++ b/database/migrations/2020_10_03_1000_add_primary_key_transport_group_transport.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+    This migration adds primary key for table transport_group_transport.
+
+    Percona Xtradb refuses to modify a table
+    without a primary key.
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+
+class AddPrimaryKeyTransportGroupTransport extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('transport_group_transport', function (Blueprint $table) {
+            $table->bigIncrements('id')->first();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+    }
+}

--- a/misc/db_schema.yaml
+++ b/misc/db_schema.yaml
@@ -320,13 +320,19 @@ bill_history:
     bill_history_bill_id_index: { Name: bill_history_bill_id_index, Columns: [bill_id], Unique: false, Type: BTREE }
 bill_perms:
   Columns:
+    - { Field: id, Type: 'bigint unsigned', 'Null': false, Extra: auto_increment }
     - { Field: user_id, Type: 'int unsigned', 'Null': false, Extra: '' }
     - { Field: bill_id, Type: 'int unsigned', 'Null': false, Extra: '' }
+  Indexes:
+    PRIMARY: { Name: PRIMARY, Columns: [id], Unique: true, Type: BTREE }
 bill_ports:
   Columns:
+    - { Field: id, Type: 'bigint unsigned', 'Null': false, Extra: auto_increment }
     - { Field: bill_id, Type: 'int unsigned', 'Null': false, Extra: '' }
     - { Field: port_id, Type: 'int unsigned', 'Null': false, Extra: '' }
     - { Field: bill_port_autoadded, Type: tinyint, 'Null': false, Extra: '', Default: '0' }
+  Indexes:
+    PRIMARY: { Name: PRIMARY, Columns: [id], Unique: true, Type: BTREE }
 bill_port_counters:
   Columns:
     - { Field: port_id, Type: 'int unsigned', 'Null': false, Extra: '' }
@@ -562,9 +568,11 @@ devices_group_perms:
     devices_group_perms_user_id_index: { Name: devices_group_perms_user_id_index, Columns: [user_id], Unique: false, Type: BTREE }
 devices_perms:
   Columns:
+    - { Field: id, Type: 'bigint unsigned', 'Null': false, Extra: auto_increment }
     - { Field: user_id, Type: 'int unsigned', 'Null': false, Extra: '' }
     - { Field: device_id, Type: 'int unsigned', 'Null': false, Extra: '' }
   Indexes:
+    PRIMARY: { Name: PRIMARY, Columns: [id], Unique: true, Type: BTREE }
     devices_perms_user_id_index: { Name: devices_perms_user_id_index, Columns: [user_id], Unique: false, Type: BTREE }
 device_graphs:
   Columns:
@@ -670,6 +678,7 @@ entPhysical:
     entphysical_device_id_index: { Name: entphysical_device_id_index, Columns: [device_id], Unique: false, Type: BTREE }
 entPhysical_state:
   Columns:
+    - { Field: id, Type: 'bigint unsigned', 'Null': false, Extra: auto_increment }
     - { Field: device_id, Type: 'int unsigned', 'Null': false, Extra: '' }
     - { Field: entPhysicalIndex, Type: varchar(64), 'Null': false, Extra: '' }
     - { Field: subindex, Type: varchar(64), 'Null': true, Extra: '' }
@@ -677,6 +686,7 @@ entPhysical_state:
     - { Field: key, Type: varchar(64), 'Null': false, Extra: '' }
     - { Field: value, Type: varchar(255), 'Null': false, Extra: '' }
   Indexes:
+    PRIMARY: { Name: PRIMARY, Columns: [id], Unique: true, Type: BTREE }
     device_id_index: { Name: device_id_index, Columns: [device_id, entPhysicalIndex], Unique: false, Type: BTREE }
 eventlog:
   Columns:
@@ -743,12 +753,14 @@ ipv4_addresses:
     ipv4_addresses_port_id_index: { Name: ipv4_addresses_port_id_index, Columns: [port_id], Unique: false, Type: BTREE }
 ipv4_mac:
   Columns:
+    - { Field: id, Type: 'bigint unsigned', 'Null': false, Extra: auto_increment }
     - { Field: port_id, Type: 'int unsigned', 'Null': false, Extra: '' }
     - { Field: device_id, Type: 'int unsigned', 'Null': true, Extra: '' }
     - { Field: mac_address, Type: varchar(32), 'Null': false, Extra: '' }
     - { Field: ipv4_address, Type: varchar(32), 'Null': false, Extra: '' }
     - { Field: context_name, Type: varchar(128), 'Null': false, Extra: '' }
   Indexes:
+    PRIMARY: { Name: PRIMARY, Columns: [id], Unique: true, Type: BTREE }
     ipv4_mac_mac_address_index: { Name: ipv4_mac_mac_address_index, Columns: [mac_address], Unique: false, Type: BTREE }
     ipv4_mac_port_id_index: { Name: ipv4_mac_port_id_index, Columns: [port_id], Unique: false, Type: BTREE }
 ipv4_networks:
@@ -780,11 +792,13 @@ ipv6_networks:
     PRIMARY: { Name: PRIMARY, Columns: [ipv6_network_id], Unique: true, Type: BTREE }
 juniAtmVp:
   Columns:
+    - { Field: id, Type: 'bigint unsigned', 'Null': false, Extra: auto_increment }
     - { Field: juniAtmVp_id, Type: 'int unsigned', 'Null': false, Extra: '' }
     - { Field: port_id, Type: 'int unsigned', 'Null': false, Extra: '' }
     - { Field: vp_id, Type: 'int unsigned', 'Null': false, Extra: '' }
     - { Field: vp_descr, Type: varchar(32), 'Null': false, Extra: '' }
   Indexes:
+    PRIMARY: { Name: PRIMARY, Columns: [id], Unique: true, Type: BTREE }
     juniatmvp_port_id_index: { Name: juniatmvp_port_id_index, Columns: [port_id], Unique: false, Type: BTREE }
 links:
   Columns:
@@ -814,11 +828,13 @@ loadbalancer_rservers:
     PRIMARY: { Name: PRIMARY, Columns: [rserver_id], Unique: true, Type: BTREE }
 loadbalancer_vservers:
   Columns:
+    - { Field: id, Type: 'bigint unsigned', 'Null': false, Extra: auto_increment }
     - { Field: classmap_id, Type: 'int unsigned', 'Null': false, Extra: '' }
     - { Field: classmap, Type: varchar(128), 'Null': false, Extra: '' }
     - { Field: serverstate, Type: varchar(64), 'Null': false, Extra: '' }
     - { Field: device_id, Type: 'int unsigned', 'Null': false, Extra: '' }
   Indexes:
+    PRIMARY: { Name: PRIMARY, Columns: [id], Unique: true, Type: BTREE }
     loadbalancer_vservers_device_id_index: { Name: loadbalancer_vservers_device_id_index, Columns: [device_id], Unique: false, Type: BTREE }
 locations:
   Columns:
@@ -1510,8 +1526,11 @@ ports_nac:
     ports_nac_port_id_mac_address_index: { Name: ports_nac_port_id_mac_address_index, Columns: [port_id, mac_address], Unique: false, Type: BTREE }
 ports_perms:
   Columns:
+    - { Field: id, Type: 'bigint unsigned', 'Null': false, Extra: auto_increment }
     - { Field: user_id, Type: 'int unsigned', 'Null': false, Extra: '' }
     - { Field: port_id, Type: 'int unsigned', 'Null': false, Extra: '' }
+  Indexes:
+    PRIMARY: { Name: PRIMARY, Columns: [id], Unique: true, Type: BTREE }
 ports_stack:
   Columns:
     - { Field: device_id, Type: 'int unsigned', 'Null': false, Extra: '' }
@@ -1594,6 +1613,7 @@ ports_vlans:
     ports_vlans_device_id_port_id_vlan_unique: { Name: ports_vlans_device_id_port_id_vlan_unique, Columns: [device_id, port_id, vlan], Unique: true, Type: BTREE }
 processes:
   Columns:
+    - { Field: id, Type: 'bigint unsigned', 'Null': false, Extra: auto_increment }
     - { Field: device_id, Type: 'int unsigned', 'Null': false, Extra: '' }
     - { Field: pid, Type: int, 'Null': false, Extra: '' }
     - { Field: vsz, Type: int, 'Null': false, Extra: '' }
@@ -1602,6 +1622,7 @@ processes:
     - { Field: user, Type: varchar(50), 'Null': false, Extra: '' }
     - { Field: command, Type: text, 'Null': false, Extra: '' }
   Indexes:
+    PRIMARY: { Name: PRIMARY, Columns: [id], Unique: true, Type: BTREE }
     processes_device_id_index: { Name: processes_device_id_index, Columns: [device_id], Unique: false, Type: BTREE }
 processors:
   Columns:
@@ -1874,8 +1895,11 @@ toner:
     toner_device_id_index: { Name: toner_device_id_index, Columns: [device_id], Unique: false, Type: BTREE }
 transport_group_transport:
   Columns:
+    - { Field: id, Type: 'bigint unsigned', 'Null': false, Extra: auto_increment }
     - { Field: transport_group_id, Type: 'int unsigned', 'Null': false, Extra: '' }
     - { Field: transport_id, Type: 'int unsigned', 'Null': false, Extra: '' }
+  Indexes:
+    PRIMARY: { Name: PRIMARY, Columns: [id], Unique: true, Type: BTREE }
 ucd_diskio:
   Columns:
     - { Field: diskio_id, Type: 'int unsigned', 'Null': false, Extra: auto_increment }

--- a/tests/module_tables.yaml
+++ b/tests/module_tables.yaml
@@ -9,7 +9,7 @@ applications:
         order_by: metric
 arp-table:
     ipv4_mac:
-        excluded_fields: [device_id, port_id]
+        excluded_fields: [id, device_id, port_id]
         order_by: ipv4_mac.context_name, ipv4_mac.ipv4_address, ipv4_mac.mac_address
 bgp-peers:
     bgpPeers:


### PR DESCRIPTION
Add primary keys to tables where no primary and unique keys were defined. This is needed for Percona Xtradb to accept writes to such tables. Similar PR: https://github.com/librenms/librenms/pull/11331

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

I found that the following tables had no primary and unique keys defined:
```
bill_perms
bill_ports
devices_perms
entPhysical_state
ipv4_mac
juniAtmVp
loadbalancer_vservers
ports_perms
processes
transport_group_transport
```

So all tables have been extended with an `id` field and a primary key.

Can this change break anything? 