### PR TITLE
Make sure 1st admin user creation does not fail with error 500

### DIFF
--- a/app/Http/Controllers/Install/MakeUserController.php
+++ b/app/Http/Controllers/Install/MakeUserController.php
@@ -64,8 +64,7 @@ class MakeUserController extends InstallationController implements InstallerStep
             'password' => 'required',
         ]);
 
-        // $message might never be initialized, resulting in 500 error
-        $message = "";
+        $message = trans('install.user.failure')
         
         try {
             // only allow the first admin to be created
@@ -76,7 +75,6 @@ class MakeUserController extends InstallationController implements InstallerStep
                 $user->setPassword($request->get('password'));
                 $res = $user->save();
 
-                $message = trans('install.user.failure');
                 if ($res) {
                     $message = trans('install.user.success');
                     $this->markStepComplete();

--- a/app/Http/Controllers/Install/MakeUserController.php
+++ b/app/Http/Controllers/Install/MakeUserController.php
@@ -64,6 +64,9 @@ class MakeUserController extends InstallationController implements InstallerStep
             'password' => 'required',
         ]);
 
+        // $message might never be initialized, resulting in 500 error
+        $message = "";
+        
         try {
             // only allow the first admin to be created
             if (!$this->complete()) {

--- a/app/Http/Controllers/Install/MakeUserController.php
+++ b/app/Http/Controllers/Install/MakeUserController.php
@@ -64,7 +64,7 @@ class MakeUserController extends InstallationController implements InstallerStep
             'password' => 'required',
         ]);
 
-        $message = trans('install.user.failure')
+        $message = trans('install.user.failure');
         
         try {
             // only allow the first admin to be created

--- a/app/Http/Controllers/Install/MakeUserController.php
+++ b/app/Http/Controllers/Install/MakeUserController.php
@@ -65,7 +65,7 @@ class MakeUserController extends InstallationController implements InstallerStep
         ]);
 
         $message = trans('install.user.failure');
-        
+
         try {
             // only allow the first admin to be created
             if (!$this->complete()) {


### PR DESCRIPTION
When creating the first admin user while installer is running, the error message variable `$message` might not be initialized, resulting in an HTTP 500 error.

```
 production.ERROR: Undefined variable: message {"exception":"[object] (ErrorException(code: 0): Undefined variable: message at /var/www/librenms.host.local/ftp/www/app/Http/Controllers/Install/MakeUserController.php:86)
```

Not a Laravel developper, so there might actually be a better way to make sure `$message` gets initialized. At least this PR will get attention to the code flaw.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
