### PR TITLE
Fix to make vmware port discovery match port polling.

### DIFF
--- a/includes/discovery/ports.inc.php
+++ b/includes/discovery/ports.inc.php
@@ -53,6 +53,10 @@ if ($device['os'] == 'fabos') {
 foreach ($port_stats as $ifIndex => $snmp_data) {
     $snmp_data['ifIndex'] = $ifIndex; // Store ifIndex in port entry
 
+    if ($device['os'] == 'vmware' && preg_match('/Device ([a-z0-9]+) at .*/', $snmp_data['ifDescr'], $matches)) {
+        $snmp_data['ifDescr'] = $matches[1];
+    }
+
     // Get port_id according to port_association_mode used for this device
     $port_id = get_port_id($ports_mapped, $snmp_data, $port_association_mode);
 


### PR DESCRIPTION
Ref. https://community.librenms.org/t/suppress-vmware-nic-change-logs/9888/2

The port polling on vmware got som magic going on, which makes the interface name/description appear 'changed' whenever the port discovery happens every 6 hours. This causes log spam for every esxi host. See above referenced forum post for an explanation.

This fix silenced our logs, but I do find it in bad taste to push an os-specific kludge into generic code like this. 
Is there a better way?



DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
