### PR TITLE
List external commands in help. Allow reload of external commands

### DIFF
--- a/LibreNMS/IRCBot.php
+++ b/LibreNMS/IRCBot.php
@@ -656,10 +656,14 @@ class IRCBot
 
     //end _auth()
 
-    private function _reload()
+    private function _reload($params)
     {
         if ($this->user['level'] == 10) {
-            $new_config = Config::reload();
+            if ($params == 'external') {
+                $this->respond('Reloading external scripts.');
+                return $this->loadExternal();
+            }
+            $new_config = Config::load();
             $this->respond('Reloading configuration & defaults');
             if ($new_config != $this->config) {
                 return $this->__construct();
@@ -697,11 +701,10 @@ class IRCBot
 
     private function _help($params)
     {
-        foreach ($this->commands as $cmd) {
-            $msg .= ', ' . $cmd;
+        $msg = join(', ', $this->commands);
+        if (count($this->external) > 0) {
+            $msg .= ', '. join(', ', array_keys($this->external));
         }
-
-        $msg = substr($msg, 2);
 
         return $this->respond("Available commands: $msg");
     }


### PR DESCRIPTION
Lists alseo external commands in the help-output.
And enables a reload of external commands only, not just the entire bot.  Allows for easier development of external commands.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
