### PR TITLE
speedup alertlog widget

### DIFF
--- a/includes/html/table/alertlog.inc.php
+++ b/includes/html/table/alertlog.inc.php
@@ -13,7 +13,7 @@
  * @author     LibreNMS Contributors
 */
 
-$alert_severities = [
+$alert_severities = array(
     // alert_rules.status is enum('ok','warning','critical')
     'ok' => 1,
     'warning' => 2,
@@ -21,7 +21,8 @@ $alert_severities = [
     'ok only' => 4,
     'warning only' => 5,
     'critical only' => 6,
-];
+);
+
 
 $where = 1;
 $param = [];
@@ -36,25 +37,41 @@ if ($vars['state'] >= 0) {
     $param[] = mres($vars['state']);
 }
 
-if (isset($vars['min_severity'])) {
-    $where .= get_sql_filter_min_severity($vars['min_severity'], 'R');
-}
-
-if (! Auth::user()->hasGlobalRead()) {
+if (!Auth::user()->hasGlobalRead()) {
     $device_ids = Permissions::devicesForUser()->toArray() ?: [0];
-    $where .= ' AND `E`.`device_id` IN ' . dbGenPlaceholders(count($device_ids));
+    $where .= " AND `E`.`device_id` IN " .dbGenPlaceholders(count($device_ids));
     $param = array_merge($param, $device_ids);
 }
 
-if (isset($searchPhrase) && ! empty($searchPhrase)) {
-    $where .= ' AND (`D`.`hostname` LIKE ? OR `D`.`sysName` LIKE ? OR `E`.`time_logged` LIKE ? OR `name` LIKE ?)';
+if (isset($searchPhrase) && !empty($searchPhrase)) {
+    $where .= " AND (`D`.`hostname` LIKE ? OR `D`.`sysName` LIKE ? OR `E`.`time_logged` LIKE ? OR `name` LIKE ?)";
     $param[] = "%$searchPhrase%";
     $param[] = "%$searchPhrase%";
     $param[] = "%$searchPhrase%";
     $param[] = "%$searchPhrase%";
 }
 
-$sql = " FROM `alert_log` AS E LEFT JOIN devices AS D ON E.device_id=D.device_id RIGHT JOIN alert_rules AS R ON E.rule_id=R.id WHERE $where";
+$alert_rules = array();
+$sql = "SELECT id, name, severity from alert_rules";
+foreach (dbFetchRows($sql, $param) as $alertlog) {
+    $alert_rules[$alertlog['id']]['alert'] = $alertlog['name'];
+    $alert_rules[$alertlog['id']]['severity'] = $alert_severities[$alertlog['severity']];
+    $alert_rules[$alertlog['id']]['severity_name'] = $alertlog['severity'];
+}
+
+$sql_severity = "";
+if (isset($vars['min_severity'])) {
+    $rules_count = 0;
+    foreach($alert_rules as $id => $ruledat) {
+        if (($vars['min_severity']>3 && $ruledat['severity'] == ($vars['min_severity'] - 3)) || ($vars['min_severity']<=3 && $ruledat['severity'] >= $vars['min_severity'])) {
+            $param[] = $id;
+            $rules_count++;
+        }
+    }
+    $where .= " AND rule_id in ".dbGenPlaceholders($rules_count);
+}
+
+$sql = " FROM `alert_log` AS E LEFT JOIN devices AS D ON E.device_id=D.device_id WHERE $where";
 
 $count_sql = "SELECT COUNT(`E`.`id`) $sql";
 $total = dbFetchCell($count_sql, $param);
@@ -62,7 +79,7 @@ if (empty($total)) {
     $total = 0;
 }
 
-if (! isset($sort) || empty($sort)) {
+if (!isset($sort) || empty($sort)) {
     $sort = 'time_logged DESC';
 }
 
@@ -77,13 +94,13 @@ if ($rowCount != -1) {
     $sql .= " LIMIT $limit_low,$limit_high";
 }
 
-$sql = "SELECT R.severity, D.device_id,name AS alert,rule_id, state,time_logged,DATE_FORMAT(time_logged, '" . \LibreNMS\Config::get('dateformat.mysql.compact') . "') as humandate,details $sql";
+$sql = "SELECT D.device_id,rule_id,state,time_logged,DATE_FORMAT(time_logged, '" . \LibreNMS\Config::get('dateformat.mysql.compact') . "') as humandate,details $sql";
 
 $rulei = 0;
 foreach (dbFetchRows($sql, $param) as $alertlog) {
     $dev = device_by_id_cache($alertlog['device_id']);
     logfile($alertlog['rule_id']);
-    $log = dbFetchCell('SELECT details FROM alert_log WHERE rule_id = ? AND device_id = ? AND `state` = 1 ORDER BY id DESC LIMIT 1', [$alertlog['rule_id'], $alertlog['device_id']]);
+    $log = dbFetchCell('SELECT details FROM alert_log WHERE rule_id = ? AND device_id = ? AND `state` = 1 ORDER BY id DESC LIMIT 1', array($alertlog['rule_id'], $alertlog['device_id']));
     $fault_detail = alert_details($log);
     if (empty($fault_detail)) {
         $fault_detail = 'Rule created, no faults found';
@@ -101,21 +118,21 @@ foreach (dbFetchRows($sql, $param) as $alertlog) {
         $status = 'label-primary';
     }//end if
 
-    $response[] = [
+    $response[] = array(
         'id' => $rulei++,
         'time_logged' => $alertlog['humandate'],
         'details' => '<a class="fa fa-plus incident-toggle" style="display:none" data-toggle="collapse" data-target="#incident' . ($rulei) . '" data-parent="#alerts"></a>',
         'hostname' => '<div class="incident">' . generate_device_link($dev, shorthost($dev['hostname'])) . '<div id="incident' . ($rulei) . '" class="collapse">' . $fault_detail . '</div></div>',
-        'alert' => htmlspecialchars($alertlog['alert']),
-        'status' => "<i class='alert-status " . $status . "' title='" . ($alert_state ? 'active' : 'recovered') . "'></i>",
-        'severity' => $alertlog['severity'],
-    ];
+        'alert' => htmlspecialchars($alert_rules[$alertlog['rule_id']]['alert']),
+        'status' => "<i class='alert-status " . $status . "' title='". ($alert_state ? 'active':'recovered')."'></i>",
+        'severity' => $alert_rules[$alertlog['rule_id']]['severity_name']
+    );
 }//end foreach
 
-$output = [
+$output = array(
     'current' => $current,
     'rowCount' => $rowCount,
     'rows' => $response,
     'total' => $total,
-];
+);
 echo _json_encode($output);

--- a/includes/html/table/alertlog.inc.php
+++ b/includes/html/table/alertlog.inc.php
@@ -13,7 +13,7 @@
  * @author     LibreNMS Contributors
 */
 
-$alert_severities = array(
+$alert_severities = [
     // alert_rules.status is enum('ok','warning','critical')
     'ok' => 1,
     'warning' => 2,
@@ -21,7 +21,7 @@ $alert_severities = array(
     'ok only' => 4,
     'warning only' => 5,
     'critical only' => 6,
-);
+];
 
 
 $where = 1;
@@ -51,7 +51,7 @@ if (isset($searchPhrase) && !empty($searchPhrase)) {
     $param[] = "%$searchPhrase%";
 }
 
-$alert_rules = array();
+$alert_rules = [];
 $sql = "SELECT id, name, severity from alert_rules";
 foreach (dbFetchRows($sql, $param) as $alertlog) {
     $alert_rules[$alertlog['id']]['alert'] = $alertlog['name'];
@@ -119,7 +119,7 @@ foreach (dbFetchRows($sql, $param) as $alertlog) {
         $status = 'label-primary';
     }//end if
 
-    $response[] = array(
+    $response[] = [
         'id' => $rulei++,
         'time_logged' => $alertlog['humandate'],
         'details' => '<a class="fa fa-plus incident-toggle" style="display:none" data-toggle="collapse" data-target="#incident' . ($rulei) . '" data-parent="#alerts"></a>',
@@ -127,13 +127,13 @@ foreach (dbFetchRows($sql, $param) as $alertlog) {
         'alert' => htmlspecialchars($alert_rules[$alertlog['rule_id']]['alert']),
         'status' => "<i class='alert-status " . $status . "' title='". ($alert_state ? 'active':'recovered')."'></i>",
         'severity' => $alert_rules[$alertlog['rule_id']]['severity_name']
-    );
+    ];
 }//end foreach
 
-$output = array(
+$output = [
     'current' => $current,
     'rowCount' => $rowCount,
     'rows' => $response,
     'total' => $total,
-);
+];
 echo _json_encode($output);

--- a/includes/html/table/alertlog.inc.php
+++ b/includes/html/table/alertlog.inc.php
@@ -59,7 +59,6 @@ foreach (dbFetchRows($sql, $param) as $alertlog) {
     $alert_rules[$alertlog['id']]['severity_name'] = $alertlog['severity'];
 }
 
-$sql_severity = "";
 if (isset($vars['min_severity'])) {
     $rules_count = 0;
     foreach($alert_rules as $id => $ruledat) {

--- a/includes/html/table/alertlog.inc.php
+++ b/includes/html/table/alertlog.inc.php
@@ -67,7 +67,9 @@ if (isset($vars['min_severity'])) {
             $rules_count++;
         }
     }
-    $where .= " AND rule_id in ".dbGenPlaceholders($rules_count);
+    if ($rules_count > 0) {
+        $where .= " AND rule_id in ".dbGenPlaceholders($rules_count);
+    }
 }
 
 $sql = " FROM `alert_log` AS E LEFT JOIN devices AS D ON E.device_id=D.device_id WHERE $where";

--- a/resources/views/widgets/settings/alertlog.blade.php
+++ b/resources/views/widgets/settings/alertlog.blade.php
@@ -9,8 +9,8 @@
         <label for="state-{{ $id }}" class="control-label">@lang('State'):</label>
         <select class="form-control" name="state" id="state-{{ $id }}">
             <option value="-1">@lang('not filtered')</option>
-            <option value="0" @if($state === '1') selected @endif>@lang('OK')</option>
-            <option value="1" @if($state === '0') selected @endif>@lang('Alert')</option>
+            <option value="0" @if($state === '0') selected @endif>@lang('OK')</option>
+            <option value="1" @if($state === '1') selected @endif>@lang('Alert')</option>
         </select>
     </div>
     <div class="form-group">


### PR DESCRIPTION
Rework main sql request for widget 'alert history' - the query to the table was placed in a separate query and the processing of the linkage of the main query with this table on the php level, which made it possible to speed up the work of the widget by at least 15 times.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
