### PR TITLE
speedup alertlog-stats widget

### DIFF
--- a/includes/html/table/alertlog-stats.inc.php
+++ b/includes/html/table/alertlog-stats.inc.php
@@ -13,7 +13,18 @@
  * @author     LibreNMS Contributors
 */
 
+$alert_severities = array(
+    // alert_rules.status is enum('ok','warning','critical')
+    'ok' => 1,
+    'warning' => 2,
+    'critical' => 3,
+    'ok only' => 4,
+    'warning only' => 5,
+    'critical only' => 6,
+);
+
 $where = 1;
+$params = [];
 
 if (is_numeric($vars['device_id'])) {
     $where .= ' AND E.device_id = ?';
@@ -27,32 +38,49 @@ if (is_numeric($vars['time_interval'])) {
     $param[] = $vars['time_interval'];
 }
 
+$alert_rules = array();
+$sql = "SELECT id, name, severity from alert_rules";
+foreach (dbFetchRows($sql, $param) as $alertlog) {
+    $alert_rules[$alertlog['id']]['alert'] = $alertlog['name'];
+    $alert_rules[$alertlog['id']]['severity'] = $alert_severities[$alertlog['severity']];
+}
+
 if (isset($vars['min_severity'])) {
-    $where .= get_sql_filter_min_severity($vars['min_severity'], 'R');
+    $rules_count = 0;
+    foreach($alert_rules as $id => $ruledat) {
+        if (($vars['min_severity']>3 && $ruledat['severity'] == ($vars['min_severity'] - 3)) || ($vars['min_severity']<=3 && $ruledat['severity'] >= $vars['min_severity'])) {
+            $param[] = $id;
+            $rules_count++;
+        }
+    }
+    if ($rules_count > 0) {
+        $where .= " AND rule_id in " . dbGenPlaceholders($rules_count);
+    }
 }
 
+$sql = " FROM `alert_log` AS E LEFT JOIN devices AS D ON E.device_id=D.device_id ";
 if (Auth::user()->hasGlobalRead()) {
-    $sql = " FROM `alert_log` AS E LEFT JOIN devices AS D ON E.device_id=D.device_id RIGHT JOIN alert_rules AS R ON E.rule_id=R.id WHERE $where";
+    $sql .= "WHERE $where";
 } else {
-    $sql = " FROM `alert_log` AS E LEFT JOIN devices AS D ON E.device_id=D.device_id RIGHT JOIN alert_rules AS R ON E.rule_id=R.id RIGHT JOIN devices_perms AS P ON E.device_id = P.device_id WHERE $where AND P.user_id = ?";
-    $param[] = [Auth::id()];
+    $sql .= "RIGHT JOIN devices_perms AS P ON E.device_id = P.device_id WHERE $where AND P.user_id = ?";
+    $param[] = array(Auth::id());
 }
 
-if (isset($searchPhrase) && ! empty($searchPhrase)) {
-    $sql .= ' AND (`D`.`hostname` LIKE ? OR `D`.`sysName` LIKE ? OR `E`.`time_logged` LIKE ? OR `name` LIKE ?)';
+if (isset($searchPhrase) && !empty($searchPhrase)) {
+    $sql .= " AND (`D`.`hostname` LIKE ? OR `D`.`sysName` LIKE ? OR `E`.`time_logged` LIKE ? OR `name` LIKE ?)";
     $param[] = "%$searchPhrase%";
     $param[] = "%$searchPhrase%";
     $param[] = "%$searchPhrase%";
     $param[] = "%$searchPhrase%";
 }
 
-$count_sql = "SELECT COUNT(DISTINCT D.sysname, R.name) $sql";
+$count_sql = "SELECT COUNT(DISTINCT D.sysname, rule_id) $sql";
 $total = dbFetchCell($count_sql, $param);
 if (empty($total)) {
     $total = 0;
 }
 
-$sql .= ' GROUP BY D.device_id, R.name ORDER BY COUNT(*) DESC';
+$sql .= " GROUP BY D.device_id, rule_id ORDER BY COUNT(*) DESC";
 
 if (isset($current)) {
     $limit_low = (($current * $rowCount) - ($rowCount));
@@ -63,24 +91,24 @@ if ($rowCount != -1) {
     $sql .= " LIMIT $limit_low,$limit_high";
 }
 
-$sql = "SELECT COUNT(*), D.device_id, R.name $sql";
+$sql = "SELECT COUNT(*), D.device_id, rule_id $sql";
 
 $rulei = 0;
 foreach (dbFetchRows($sql, $param) as $alertlog) {
     $dev = device_by_id_cache($alertlog['device_id']);
 
-    $response[] = [
+    $response[] = array(
         'id' => $rulei++,
         'count' => $alertlog['COUNT(*)'],
         'hostname' => '<div class="incident">' . generate_device_link($dev, shorthost($dev['hostname'])),
-        'alert_rule' => $alertlog['name'],
-    ];
+        'alert_rule' => $alert_rules[$alertlog['rule_id']]['alert'],
+    );
 }//end foreach
 
-$output = [
+$output = array(
     'current' => $current,
     'rowCount' => $rowCount,
     'rows' => $response,
     'total' => $total,
-];
+);
 echo _json_encode($output);

--- a/includes/html/table/alertlog-stats.inc.php
+++ b/includes/html/table/alertlog-stats.inc.php
@@ -55,6 +55,8 @@ if (isset($vars['min_severity'])) {
     }
     if ($rules_count > 0) {
         $where .= " AND rule_id in " . dbGenPlaceholders($rules_count);
+    } else {
+        $where .= " AND rule_id = 0";
     }
 }
 

--- a/includes/html/table/alertlog-stats.inc.php
+++ b/includes/html/table/alertlog-stats.inc.php
@@ -13,7 +13,7 @@
  * @author     LibreNMS Contributors
 */
 
-$alert_severities = array(
+$alert_severities = [
     // alert_rules.status is enum('ok','warning','critical')
     'ok' => 1,
     'warning' => 2,
@@ -21,7 +21,7 @@ $alert_severities = array(
     'ok only' => 4,
     'warning only' => 5,
     'critical only' => 6,
-);
+];
 
 $where = 1;
 $params = [];
@@ -38,7 +38,7 @@ if (is_numeric($vars['time_interval'])) {
     $param[] = $vars['time_interval'];
 }
 
-$alert_rules = array();
+$alert_rules = [];
 $sql = "SELECT id, name, severity from alert_rules";
 foreach (dbFetchRows($sql, $param) as $alertlog) {
     $alert_rules[$alertlog['id']]['alert'] = $alertlog['name'];
@@ -99,18 +99,18 @@ $rulei = 0;
 foreach (dbFetchRows($sql, $param) as $alertlog) {
     $dev = device_by_id_cache($alertlog['device_id']);
 
-    $response[] = array(
+    $response[] = [
         'id' => $rulei++,
         'count' => $alertlog['COUNT(*)'],
         'hostname' => '<div class="incident">' . generate_device_link($dev, shorthost($dev['hostname'])),
         'alert_rule' => $alert_rules[$alertlog['rule_id']]['alert'],
-    );
+    ];
 }//end foreach
 
-$output = array(
+$output = [
     'current' => $current,
     'rowCount' => $rowCount,
     'rows' => $response,
     'total' => $total,
-);
+];
 echo _json_encode($output);


### PR DESCRIPTION
Rework main sql request for widget 'Alert history stats' - the query to the table was placed in a separate query and the processing of the linkage of the main query with this table on the php level, which made it possible to speed up the work of the widget.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
