### PR TITLE
Add Blade Submenu component

### DIFF
--- a/app/View/Components/Submenu.php
+++ b/app/View/Components/Submenu.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\View\Components;
+
+use Illuminate\View\Component;
+
+class Submenu extends Component
+{
+    /**
+     * The submenu title.
+     *
+     * @var string
+     */
+    public $title;
+
+    /**
+     * The submenu menu.
+     *
+     * @var string
+     */
+    public $menu;
+
+    /**
+     * The submenu device_id.
+     *
+     * @var string
+     */
+    public $device_id;
+
+    /**
+     * The submenu current_tab.
+     *
+     * @var string
+     */
+    public $current_tab;
+
+    /**
+     * The submenu selected.
+     *
+     * @var string
+     */
+    public $selected;
+
+    /**
+     * Create a new component instance.
+     *
+     * @return void
+     */
+    public function __construct($title, $menu, $deviceId, $currentTab, $selected)
+    {
+        $this->title = $title;
+        $this->menu = $menu;
+        $this->device_id = $deviceId;
+        $this->current_tab = $currentTab;
+        $this->selected = $selected;
+    }
+
+    /**
+     * Determine if the given option is the current selected option.
+     *
+     * @param  string  $option
+     * @return bool
+     */
+    public function isSelected($url)
+    {
+        return $url === $this->selected;
+    }
+
+    /**
+     * Get the view / contents that represent the component.
+     *
+     * @return \Illuminate\View\View|string
+     */
+    public function render()
+    {
+        return view('components.submenu');
+    }
+}

--- a/resources/views/components/submenu.blade.php
+++ b/resources/views/components/submenu.blade.php
@@ -1,0 +1,21 @@
+<div class="panel panel-default">
+    <div class="panel-heading">
+        @foreach ($menu as $header => $m)
+            @if($loop->first)
+                <b>{{ $title }}</b>
+                »
+            @else
+                | {{ $header }}:
+            @endif
+
+            @foreach($m as $sm)
+                @if($isSelected($sm['url']))<span class="pagemenu-selected">@endif
+                <a href="{{ route('device', ['device' => $device_id, 'tab' => $current_tab, 'vars' => $sm['url']]) }}">{{ $sm['name'] }}</a>@if($isSelected($sm['url']))</span>@endif
+
+                @if(!$loop->last)
+                    |
+                @endif
+            @endforeach
+        @endforeach
+    </div>
+</div>

--- a/resources/views/device/submenu.blade.php
+++ b/resources/views/device/submenu.blade.php
@@ -1,0 +1,9 @@
+@extends('device.index')
+
+@section('tab')
+    @isset($data['submenu'])
+        <x-submenu :title="$title" :menu="$data['submenu']" :device-id="$device_id" :current-tab="$current_tab" :selected="$vars" />
+    @endisset
+
+    @yield('tabcontent')
+@endsection


### PR DESCRIPTION
A component used for creating submenus,

Feed it with an array like;
```php
'submenu' => [
    [
        ['name' => 'Basic', 'url' => ''],
    ],
    'Graphs' => [
        ['name' => 'Bits', 'url' => 'bits'],
        ['name' => 'Unicast Packets', 'url' => 'unicast'],
        ...
    ],
]
```
To output:
![image](https://user-images.githubusercontent.com/759887/94417313-3580b080-0180-11eb-97d7-632407b19d34.png)


To discuss:
- [ ] Name
- [ ] Missing features

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
