### PR TITLE
Do not remove users with API tokens

### DIFF
--- a/daily.php
+++ b/daily.php
@@ -315,12 +315,7 @@ if ($options['f'] === 'purgeusers') {
             }
 
             // Also keep users with a valid API Token
-            foreach (dbFetchRows('SELECT DISTINCT(`username`)
-                                  FROM `api_tokens`
-                                      LEFT JOIN `users` ON api_tokens.user_id=users.user_id
-                                  WHERE `username` IS NOT NULL;') as $token_user) {
-                $users[] = $token_user['username'];
-            }
+            $users = array_merge($users, User::has('apiToken')->pluck('username'));
 
             if (dbDelete('users', 'username NOT IN ' . dbGenPlaceholders(count($users)), $users)) {
                 echo "Removed users that haven't logged in for $purge days";

--- a/daily.php
+++ b/daily.php
@@ -314,6 +314,14 @@ if ($options['f'] === 'purgeusers') {
                 $users[] = $user['user'];
             }
 
+            // Also keep users with a valid API Token
+            foreach (dbFetchRows('SELECT DISTINCT(`username`)
+                                  FROM `api_tokens`
+                                      LEFT JOIN `users` ON api_tokens.user_id=users.user_id
+                                  WHERE `username` IS NOT NULL;') as $token_user) {
+                $users[] = $token_user['username'];
+            }
+
             if (dbDelete('users', 'username NOT IN ' . dbGenPlaceholders(count($users)), $users)) {
                 echo "Removed users that haven't logged in for $purge days";
             }

--- a/daily.php
+++ b/daily.php
@@ -315,7 +315,7 @@ if ($options['f'] === 'purgeusers') {
                 ->merge(\App\Models\User::has('apiToken')->pluck('username')) // don't purge users with api tokens
                 ->unique();
 
-            if (\App\Models\User::whereNotIn('username', $users)->delete()) {
+            if (\App\Models\User::thisAuth()->whereNotIn('username', $users)->delete()) {
                 echo "Removed users that haven't logged in for $purge days\n";
             }
         }


### PR DESCRIPTION
External users are periodically purged unless they appear in the auditlog. Accounts that are only used for API access do not appear in this log. This pull request excludes them from the user-cleanup-process. 

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
