### PR TITLE
UBNT switch discovery issue-12133

### DIFF
--- a/includes/definitions/edgeswitch.yaml
+++ b/includes/definitions/edgeswitch.yaml
@@ -18,6 +18,7 @@ discovery:
             - '/^EdgePoint/'
             - '/^USW[ -]/'
             - '/^UBNT US/'
+            - '/^US[ -]'
     -
         sysObjectID:
             - .1.3.6.1.4.1.8072.3.2.10


### PR DESCRIPTION
To be able to detect Ubiquiti switch that report model name starting with US  eg. US-16-150W
Some Ubiquiti switches answer snmp query just the model number such as:

```
librenms@librenms:~$ snmpbulkwalk -v2c -c kenny 192.168.1.2|more
iso.3.6.1.2.1.1.1.0 = STRING: "US-16-150W, 5.37.2.12269, Linux 3.6.5"
iso.3.6.1.2.1.1.2.0 = OID: iso.3.6.1.4.1.4413
```


Which is not defined in edgeswitch.yaml     While Inteno GW which has the same OID and not specified sysDescr_regex.  That is the reason why Ubiquiti switch was detected as Inteno GW.

```
librenms@librenms:~/includes/definitions$ cat inteno.yaml
os: inteno
text: 'Inteno GW'
type: network
over:
    - { graph: device_bits, text: Traffic }
mib_dir: inteno
icon: inteno
discovery:
    -
        sysObjectID:
            - .1.3.6.1.4.1.4413
        sysDescr_regex_except:
            - '/VxWorks/'
            - '/quanta/i'
            - '/FASTPATH (Switching|Routing)/'
```



Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
