### PR TITLE
Accommodate upcoming php 7.3 change

### DIFF
--- a/doc/Installation/Install-LibreNMS.md
+++ b/doc/Installation/Install-LibreNMS.md
@@ -14,7 +14,7 @@ Connect to the server command line and follow the instructions below.
 > at `mysql>` prompts) or temporarily become a user with root
 > privileges with `sudo -s` or `sudo -i`.
 
-**Please note the minimum supported PHP version is 7.2.5**
+**Please note currently the minimum supported PHP version is 7.2.5, but from 1 November 2020 this will be bumped to PHP 7.3**
 
 # Install Required Packages
 
@@ -39,15 +39,32 @@ Connect to the server command line and follow the instructions below.
     === "NGINX"
         ```
         dnf -y install epel-release
-        dnf install bash-completion composer cronie fping git ImageMagick mariadb-server mtr net-snmp net-snmp-utils nginx nmap php-fpm php-cli php-common php-curl php-gd php-json php-mbstring php-process php-snmp php-xml php-zip php-mysqlnd python3 python3-PyMySQL python3-redis python3-memcached python3-pip rrdtool unzip
+        dnf module reset php
+        dnf module list php
+        dnf module enable php:7.3
+        dnf install bash-completion cronie fping git ImageMagick mariadb-server mtr net-snmp net-snmp-utils nginx nmap php-fpm php-cli php-common php-curl php-gd php-json php-mbstring php-process php-snmp php-xml php-zip php-mysqlnd python3 python3-PyMySQL python3-redis python3-memcached python3-pip rrdtool unzip
+        ```
+    Composer does not ship via the `dnf` package manager anymore, so you will have to install it "manually". To install it globally:
+        ```
+        wget https://getcomposer.org/composer-stable.phar
+        mv composer-stable.phar /usr/bin/composer
+        chmod +x /usr/bin/composer
         ```
     
     === "Apache"
         ```
         dnf -y install epel-release
-        dnf install bash-completion composer cronie fping git httpd ImageMagick mariadb-server mtr net-snmp net-snmp-utils nmap php-fpm php-cli php-common php-curl php-gd php-json php-mbstring php-process php-snmp php-xml php-zip php-mysqlnd python3 python3-PyMySQL python3-redis python3-memcached python3-pip rrdtool unzip
+        dnf module reset php
+        dnf module list php
+        dnf module enable php:7.3
+        dnf install bash-completion cronie fping git httpd ImageMagick mariadb-server mtr net-snmp net-snmp-utils nmap php-fpm php-cli php-common php-curl php-gd php-json php-mbstring php-process php-snmp php-xml php-zip php-mysqlnd python3 python3-PyMySQL python3-redis python3-memcached python3-pip rrdtool unzip
         ```
-
+    Composer does not ship via the `dnf` package manager anymore, so you will have to install it "manually". To install it globally:
+        ```
+        wget https://getcomposer.org/composer-stable.phar
+        mv composer-stable.phar /usr/bin/composer
+        chmod +x /usr/bin/composer
+        ```
 === "Debian 10"
     === "NGINX"
         ```

--- a/doc/Installation/Install-LibreNMS.md
+++ b/doc/Installation/Install-LibreNMS.md
@@ -43,12 +43,6 @@ Connect to the server command line and follow the instructions below.
         dnf module enable php:7.3
         dnf install bash-completion cronie fping git ImageMagick mariadb-server mtr net-snmp net-snmp-utils nginx nmap php-fpm php-cli php-common php-curl php-gd php-json php-mbstring php-process php-snmp php-xml php-zip php-mysqlnd python3 python3-PyMySQL python3-redis python3-memcached python3-pip rrdtool unzip
         ```
-    Composer does not ship via the `dnf` package manager anymore, so you will have to install it "manually". To install it globally:
-        ```
-        wget https://getcomposer.org/composer-stable.phar
-        mv composer-stable.phar /usr/bin/composer
-        chmod +x /usr/bin/composer
-        ```
     
     === "Apache"
         ```
@@ -57,12 +51,7 @@ Connect to the server command line and follow the instructions below.
         dnf module enable php:7.3
         dnf install bash-completion cronie fping git httpd ImageMagick mariadb-server mtr net-snmp net-snmp-utils nmap php-fpm php-cli php-common php-curl php-gd php-json php-mbstring php-process php-snmp php-xml php-zip php-mysqlnd python3 python3-PyMySQL python3-redis python3-memcached python3-pip rrdtool unzip
         ```
-    Composer does not ship via the `dnf` package manager anymore, so you will have to install it "manually". To install it globally:
-        ```
-        wget https://getcomposer.org/composer-stable.phar
-        mv composer-stable.phar /usr/bin/composer
-        chmod +x /usr/bin/composer
-        ```
+    
 === "Debian 10"
     === "NGINX"
         ```
@@ -97,6 +86,12 @@ setfacl -R -m g::rwx /opt/librenms/rrd /opt/librenms/logs /opt/librenms/bootstra
 su - librenms
 ./scripts/composer_wrapper.php install --no-dev
 exit
+```
+Sometime when there is a proxy used to gain internet access, the above script may fail. The workaround is to install the `composer` package manually. For a global installation:
+```
+wget https://getcomposer.org/composer-stable.phar
+mv composer-stable.phar /usr/bin/composer
+chmod +x /usr/bin/composer
 ```
 
 # Set timezone

--- a/doc/Installation/Install-LibreNMS.md
+++ b/doc/Installation/Install-LibreNMS.md
@@ -14,7 +14,7 @@ Connect to the server command line and follow the instructions below.
 > at `mysql>` prompts) or temporarily become a user with root
 > privileges with `sudo -s` or `sudo -i`.
 
-**Please note currently the minimum supported PHP version is 7.2.5, but from 1 November 2020 this will be bumped to PHP 7.3**
+**Please note the minimum supported PHP version is 7.3**
 
 # Install Required Packages
 

--- a/doc/Installation/Install-LibreNMS.md
+++ b/doc/Installation/Install-LibreNMS.md
@@ -40,7 +40,6 @@ Connect to the server command line and follow the instructions below.
         ```
         dnf -y install epel-release
         dnf module reset php
-        dnf module list php
         dnf module enable php:7.3
         dnf install bash-completion cronie fping git ImageMagick mariadb-server mtr net-snmp net-snmp-utils nginx nmap php-fpm php-cli php-common php-curl php-gd php-json php-mbstring php-process php-snmp php-xml php-zip php-mysqlnd python3 python3-PyMySQL python3-redis python3-memcached python3-pip rrdtool unzip
         ```
@@ -55,7 +54,6 @@ Connect to the server command line and follow the instructions below.
         ```
         dnf -y install epel-release
         dnf module reset php
-        dnf module list php
         dnf module enable php:7.3
         dnf install bash-completion cronie fping git httpd ImageMagick mariadb-server mtr net-snmp net-snmp-utils nmap php-fpm php-cli php-common php-curl php-gd php-json php-mbstring php-process php-snmp php-xml php-zip php-mysqlnd python3 python3-PyMySQL python3-redis python3-memcached python3-pip rrdtool unzip
         ```


### PR DESCRIPTION
An announcement on Twitter as well as [this](https://github.com/librenms/librenms/pull/12118) says future release will depend on PHP7.3 minimum. CentOS 8 ships with 7.2 by default. Also, the composer package's availability via `dnf` was dropped somewhere by CentOS project, so one needs to install it "manually" nowadays. I have yet to find a different solution than the one showed here. Any inputs welcome.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
