### PR TITLE
Additional fix for Cisco Crossbar overview missing

### DIFF
--- a/includes/html/pages/device/overview.inc.php
+++ b/includes/html/pages/device/overview.inc.php
@@ -34,7 +34,7 @@ require 'overview/processors.inc.php';
 require 'overview/mempools.inc.php';
 require 'overview/storage.inc.php';
 
-if (!isset($entity_state)) {
+if (! isset($entity_state)) {
     $entity_state = get_dev_entity_state($device['device_id']);
 }
 if (is_array($entity_state['group']['c6kxbar'])) {

--- a/includes/html/pages/device/overview.inc.php
+++ b/includes/html/pages/device/overview.inc.php
@@ -34,6 +34,9 @@ require 'overview/processors.inc.php';
 require 'overview/mempools.inc.php';
 require 'overview/storage.inc.php';
 
+if (!isset($entity_state)) {
+    $entity_state = get_dev_entity_state($device['device_id']);
+}
 if (is_array($entity_state['group']['c6kxbar'])) {
     require 'overview/c6kxbar.inc.php';
 }

--- a/includes/html/pages/device/overview/c6kxbar.inc.php
+++ b/includes/html/pages/device/overview/c6kxbar.inc.php
@@ -10,7 +10,9 @@ echo '<i class="fa fa-arrows fa-lg icon-theme" aria-hidden="true"></i> <strong>C
 echo '          </div>
     <table class="table table-hover table-condensed table-striped">';
 
-$entity_state = get_dev_entity_state($device['device_id']);
+if (!isset($entity_state)) {
+    $entity_state = get_dev_entity_state($device['device_id']);
+}
 foreach ($entity_state['group']['c6kxbar'] as $index => $entry) {
     // FIXME i'm not sure if this is the correct way to decide what entphysical index it is. slotnum+1? :>
     $entity = dbFetchRow('SELECT * FROM entPhysical WHERE device_id = ? AND entPhysicalIndex = ?', [$device['device_id'], $index + 1]);

--- a/includes/html/pages/device/overview/c6kxbar.inc.php
+++ b/includes/html/pages/device/overview/c6kxbar.inc.php
@@ -10,7 +10,7 @@ echo '<i class="fa fa-arrows fa-lg icon-theme" aria-hidden="true"></i> <strong>C
 echo '          </div>
     <table class="table table-hover table-condensed table-striped">';
 
-if (!isset($entity_state)) {
+if (! isset($entity_state)) {
     $entity_state = get_dev_entity_state($device['device_id']);
 }
 foreach ($entity_state['group']['c6kxbar'] as $index => $entry) {


### PR DESCRIPTION
This fixes the non-existing Cisco crossbar in the overview page.
Previous fix in #11839 did not work, since the file was not included in overview.php, using $entity_state before loading it.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
