### PR TITLE
Fix Linux OS mib_dir usage

### DIFF
--- a/includes/definitions/linux.yaml
+++ b/includes/definitions/linux.yaml
@@ -4,8 +4,6 @@ group: unix
 text: Linux
 ifXmcbc: true
 ifname: true
-mib_dir: supermicro
-    - dell
 over:
     - { graph: device_processor, text: 'Processor Usage' }
     - { graph: device_ucd_memory, text: 'Memory Usage' }

--- a/includes/discovery/sensors/fanspeed/supermicro.inc.php
+++ b/includes/discovery/sensors/fanspeed/supermicro.inc.php
@@ -1,6 +1,6 @@
 <?php
 
-$oids = snmp_walk($device, '.1.3.6.1.4.1.10876.2.1.1.1.1.3', '-OsqnU', 'SUPERMICRO-HEALTH-MIB');
+$oids = snmp_walk($device, '.1.3.6.1.4.1.10876.2.1.1.1.1.3', '-OsqnU', 'SUPERMICRO-HEALTH-MIB', 'supermicro');
 d_echo($oids . "\n");
 
 $oids = trim($oids);
@@ -20,13 +20,13 @@ foreach (explode("\n", $oids) as $data) {
             $limit_oid = ".1.3.6.1.4.1.10876.2.1.1.1.1.6.$index";
             $divisor_oid = ".1.3.6.1.4.1.10876.2.1.1.1.1.9.$index";
             $monitor_oid = ".1.3.6.1.4.1.10876.2.1.1.1.1.10.$index";
-            $descr = snmp_get($device, $descr_oid, '-Oqv', 'SUPERMICRO-HEALTH-MIB');
-            $current = snmp_get($device, $fan_oid, '-Oqv', 'SUPERMICRO-HEALTH-MIB');
-            $low_limit = snmp_get($device, $limit_oid, '-Oqv', 'SUPERMICRO-HEALTH-MIB');
-            // $divisor       = snmp_get($device, $divisor_oid, "-Oqv", "SUPERMICRO-HEALTH-MIB");
+            $descr = snmp_get($device, $descr_oid, '-Oqv', 'SUPERMICRO-HEALTH-MIB', 'supermicro');
+            $current = snmp_get($device, $fan_oid, '-Oqv', 'SUPERMICRO-HEALTH-MIB', 'supermicro');
+            $low_limit = snmp_get($device, $limit_oid, '-Oqv', 'SUPERMICRO-HEALTH-MIB', 'supermicro');
+            // $divisor       = snmp_get($device, $divisor_oid, "-Oqv", "SUPERMICRO-HEALTH-MIB", 'supermicro');
             // ^ This returns an incorrect precision. At least using the raw value... I think. -TL
             $divisor = '1';
-            $monitor = snmp_get($device, $monitor_oid, '-Oqv', 'SUPERMICRO-HEALTH-MIB');
+            $monitor = snmp_get($device, $monitor_oid, '-Oqv', 'SUPERMICRO-HEALTH-MIB', 'supermicro');
             $descr = str_replace(' Fan Speed', '', $descr);
             $descr = str_replace(' Speed', '', $descr);
             if ($monitor == 'true') {

--- a/includes/discovery/sensors/state/dell.inc.php
+++ b/includes/discovery/sensors/state/dell.inc.php
@@ -16,7 +16,7 @@ $tables = [
     ['memoryDeviceTable', '.1.3.6.1.4.1.674.10892.1.1100.50.1.5.', 'memoryDeviceStatus', 'memoryDeviceLocationName', 'MIB-Dell-10892'],
     ['powerSupplyTable', '.1.3.6.1.4.1.674.10892.1.600.12.1.5.', 'powerSupplyStatus', 'powerSupplyLocationName', 'MIB-Dell-10892'],
     ['intrusionTable', '.1.3.6.1.4.1.674.10892.1.300.70.1.5.', 'intrusionStatus', 'Intrusion', 'MIB-Dell-10892'],
-    ['controllerTable', '.1.3.6.1.4.1.674.10893.1.20.130.1.1.5.', 'controllerState', 'controllerName', 'StorageManagement-MIB','dell'],
+    ['controllerTable', '.1.3.6.1.4.1.674.10893.1.20.130.1.1.5.', 'controllerState', 'controllerName', 'StorageManagement-MIB', 'dell'],
     ['arrayDiskTable', '.1.3.6.1.4.1.674.10893.1.20.130.4.1.4.', 'arrayDiskState', 'arrayDiskName', 'StorageManagement-MIB', 'dell'],
     ['virtualDiskTable', '.1.3.6.1.4.1.674.10893.1.20.140.1.1.4.', 'virtualDiskState', 'virtualDiskDeviceName', 'StorageManagement-MIB', 'dell'],
     ['batteryTable', '.1.3.6.1.4.1.674.10893.1.20.130.15.1.4.', 'batteryState', 'batteryName', 'StorageManagement-MIB', 'dell'],

--- a/includes/discovery/sensors/state/dell.inc.php
+++ b/includes/discovery/sensors/state/dell.inc.php
@@ -16,10 +16,10 @@ $tables = [
     ['memoryDeviceTable', '.1.3.6.1.4.1.674.10892.1.1100.50.1.5.', 'memoryDeviceStatus', 'memoryDeviceLocationName', 'MIB-Dell-10892'],
     ['powerSupplyTable', '.1.3.6.1.4.1.674.10892.1.600.12.1.5.', 'powerSupplyStatus', 'powerSupplyLocationName', 'MIB-Dell-10892'],
     ['intrusionTable', '.1.3.6.1.4.1.674.10892.1.300.70.1.5.', 'intrusionStatus', 'Intrusion', 'MIB-Dell-10892'],
-    ['controllerTable', '.1.3.6.1.4.1.674.10893.1.20.130.1.1.5.', 'controllerState', 'controllerName', 'StorageManagement-MIB'],
-    ['arrayDiskTable', '.1.3.6.1.4.1.674.10893.1.20.130.4.1.4.', 'arrayDiskState', 'arrayDiskName', 'StorageManagement-MIB'],
-    ['virtualDiskTable', '.1.3.6.1.4.1.674.10893.1.20.140.1.1.4.', 'virtualDiskState', 'virtualDiskDeviceName', 'StorageManagement-MIB'],
-    ['batteryTable', '.1.3.6.1.4.1.674.10893.1.20.130.15.1.4.', 'batteryState', 'batteryName', 'StorageManagement-MIB'],
+    ['controllerTable', '.1.3.6.1.4.1.674.10893.1.20.130.1.1.5.', 'controllerState', 'controllerName', 'StorageManagement-MIB','dell'],
+    ['arrayDiskTable', '.1.3.6.1.4.1.674.10893.1.20.130.4.1.4.', 'arrayDiskState', 'arrayDiskName', 'StorageManagement-MIB', 'dell'],
+    ['virtualDiskTable', '.1.3.6.1.4.1.674.10893.1.20.140.1.1.4.', 'virtualDiskState', 'virtualDiskDeviceName', 'StorageManagement-MIB', 'dell'],
+    ['batteryTable', '.1.3.6.1.4.1.674.10893.1.20.130.15.1.4.', 'batteryState', 'batteryName', 'StorageManagement-MIB', 'dell'],
 ];
 
 foreach ($tables as $tablevalue) {

--- a/includes/discovery/sensors/state/hp.inc.php
+++ b/includes/discovery/sensors/state/hp.inc.php
@@ -53,7 +53,7 @@ foreach ($tables as $tablevalue) {
         $state_index_id = create_state_index($state_name, $states);
 
         foreach ($temp as $index => $entry) {
-            $drive_bay = snmp_get($device, "cpqDaPhyDrvBay.$index", '-Ovqn', 'CPQIDA-MIB');
+            $drive_bay = snmp_get($device, "cpqDaPhyDrvBay.$index", '-Ovqn', 'CPQIDA-MIB', 'hp');
 
             //Discover Sensors
             discover_sensor(

--- a/includes/discovery/sensors/temperature/supermicro.inc.php
+++ b/includes/discovery/sensors/temperature/supermicro.inc.php
@@ -1,7 +1,7 @@
 <?php
 
 // Supermicro sensors
-$oids = snmp_walk($device, '.1.3.6.1.4.1.10876.2.1.1.1.1.3', '-Osqn', 'SUPERMICRO-HEALTH-MIB');
+$oids = snmp_walk($device, '.1.3.6.1.4.1.10876.2.1.1.1.1.3', '-Osqn', 'SUPERMICRO-HEALTH-MIB', 'supermicro');
 $oids = trim($oids);
 if ($oids) {
     echo 'Supermicro ';
@@ -17,11 +17,11 @@ if ($oids) {
                 $limit_oid = ".1.3.6.1.4.1.10876.2.1.1.1.1.5.$index";
                 $divisor_oid = ".1.3.6.1.4.1.10876.2.1.1.1.1.9.$index";
                 $monitor_oid = ".1.3.6.1.4.1.10876.2.1.1.1.1.10.$index";
-                $descr = snmp_get($device, $descr_oid, '-Oqv', 'SUPERMICRO-HEALTH-MIB');
-                $temperature = snmp_get($device, $temperature_oid, '-Oqv', 'SUPERMICRO-HEALTH-MIB');
-                $limit = snmp_get($device, $limit_oid, '-Oqv', 'SUPERMICRO-HEALTH-MIB');
-                $divisor = snmp_get($device, $divisor_oid, '-Oqv', 'SUPERMICRO-HEALTH-MIB') || 1;
-                $monitor = snmp_get($device, $monitor_oid, '-Oqv', 'SUPERMICRO-HEALTH-MIB');
+                $descr = snmp_get($device, $descr_oid, '-Oqv', 'SUPERMICRO-HEALTH-MIB', 'supermicro');
+                $temperature = snmp_get($device, $temperature_oid, '-Oqv', 'SUPERMICRO-HEALTH-MIB', 'supermicro');
+                $limit = snmp_get($device, $limit_oid, '-Oqv', 'SUPERMICRO-HEALTH-MIB', 'supermicro');
+                $divisor = snmp_get($device, $divisor_oid, '-Oqv', 'SUPERMICRO-HEALTH-MIB', 'supermicro') || 1;
+                $monitor = snmp_get($device, $monitor_oid, '-Oqv', 'SUPERMICRO-HEALTH-MIB', 'supermicro');
                 if ($monitor == 'true') {
                     $descr = trim(str_ireplace('temperature', '', $descr));
                     discover_sensor($valid['sensor'], 'temperature', $device, $temperature_oid, trim($index, '.'), 'supermicro', $descr, (int) $divisor, '1', null, null, null, $limit, $temperature);

--- a/includes/discovery/sensors/voltage/linux.inc.php
+++ b/includes/discovery/sensors/voltage/linux.inc.php
@@ -30,7 +30,7 @@ if (! empty($pre_cache['raspberry_pi_sensors'])) {
     }
 }
 
-$oids = snmp_walk($device, '.1.3.6.1.4.1.10876.2.1.1.1.1.3', '-OsqnU', 'SUPERMICRO-HEALTH-MIB');
+$oids = snmp_walk($device, '.1.3.6.1.4.1.10876.2.1.1.1.1.3', '-OsqnU', 'SUPERMICRO-HEALTH-MIB', 'supermicro');
 d_echo($oids . "\n");
 
 $oids = trim($oids);
@@ -53,11 +53,11 @@ foreach (explode("\n", $oids) as $data) {
             $limit_oid = '.1.3.6.1.4.1.10876.2.1.1.1.1.5.' . $index;
             $lowlimit_oid = '.1.3.6.1.4.1.10876.2.1.1.1.1.6.' . $index;
 
-            $descr = snmp_get($device, $descr_oid, '-Oqv', 'SUPERMICRO-HEALTH-MIB');
-            $current = (snmp_get($device, $volt_oid, '-Oqv', 'SUPERMICRO-HEALTH-MIB') / $divisor);
-            $limit = (snmp_get($device, $limit_oid, '-Oqv', 'SUPERMICRO-HEALTH-MIB') / $divisor);
-            $lowlimit = (snmp_get($device, $lowlimit_oid, '-Oqv', 'SUPERMICRO-HEALTH-MIB') / $divisor);
-            $monitor = snmp_get($device, $monitor_oid, '-Oqv', 'SUPERMICRO-HEALTH-MIB');
+            $descr = snmp_get($device, $descr_oid, '-Oqv', 'SUPERMICRO-HEALTH-MIB', 'supermicro');
+            $current = (snmp_get($device, $volt_oid, '-Oqv', 'SUPERMICRO-HEALTH-MIB', 'supermicro') / $divisor);
+            $limit = (snmp_get($device, $limit_oid, '-Oqv', 'SUPERMICRO-HEALTH-MIB', 'supermicro') / $divisor);
+            $lowlimit = (snmp_get($device, $lowlimit_oid, '-Oqv', 'SUPERMICRO-HEALTH-MIB', 'supermicro') / $divisor);
+            $monitor = snmp_get($device, $monitor_oid, '-Oqv', 'SUPERMICRO-HEALTH-MIB', 'supermicro');
             $descr = trim(str_ireplace('Voltage', '', $descr));
 
             if ($monitor == 'true') {


### PR DESCRIPTION
Removes invalid `mib_dir` usage and hopefully makes a couple of sensors work again

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
