### PR TITLE
Optional availability calculation mode to allow planned maintenance

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2045,7 +2045,7 @@ function device_is_up($device, $record_perf = false)
     }
 
     if ($device['status'] != $response['status'] || $device['status_reason'] != $response['status_reason'] || $state_update_again) {
-        if (!$state_update_again) {
+        if (! $state_update_again) {
             dbUpdate(
                 ['status' => $response['status'], 'status_reason' => $response['status_reason']],
                 'devices',

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2045,12 +2045,14 @@ function device_is_up($device, $record_perf = false)
     }
 
     if ($device['status'] != $response['status'] || $device['status_reason'] != $response['status_reason'] || $state_update_again) {
-        dbUpdate(
-            ['status' => $response['status'], 'status_reason' => $response['status_reason']],
-            'devices',
-            'device_id=?',
-            [$device['device_id']]
-        );
+        if(!$state_update_again) {
+            dbUpdate(
+                ['status' => $response['status'], 'status_reason' => $response['status_reason']],
+                'devices',
+                'device_id=?',
+                [$device['device_id']]
+            );
+        }
 
         if ($response['status']) {
             $type = 'up';

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2039,7 +2039,8 @@ function device_is_up($device, $record_perf = false)
                 $response['status_reason'] = 'snmp';
             }
         }
-    } else {
+    } 
+    else {
         echo 'Unpingable';
         $response['status'] = '0';
         if($maintenance && $mode) {
@@ -2079,7 +2080,8 @@ function device_is_up($device, $record_perf = false)
                     [$device['device_id'], $going_down]
                 );
             }
-        } else {
+        }
+        else {
             $type = 'down';
             $reason = $response['status_reason'];
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2045,7 +2045,7 @@ function device_is_up($device, $record_perf = false)
     }
 
     if ($device['status'] != $response['status'] || $device['status_reason'] != $response['status_reason'] || $state_update_again) {
-        if(!$state_update_again) {
+        if (!$state_update_again) {
             dbUpdate(
                 ['status' => $response['status'], 'status_reason' => $response['status_reason']],
                 'devices',

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2027,15 +2027,13 @@ function device_is_up($device, $record_perf = false)
         if ($device['snmp_disable'] || isSNMPable($device)) {
             $response['status'] = '1';
             $response['status_reason'] = '';
-        }
-        else {
+        } else {
             echo 'SNMP Unreachable';
             $response['status'] = '0';
             if ($maintenance && $consider_maintenance) {
                 // Scheduled maintenance, device not responding to snmp
                 $response['status_reason'] = 'snmp (maintenance)';
-            }
-            else {
+            } else {
                 $response['status_reason'] = 'snmp';
             }
         }
@@ -2046,8 +2044,7 @@ function device_is_up($device, $record_perf = false)
         if($maintenance && $consider_maintenance) {
             // Scheduled maintenance, device not responding to icmp
             $response['status_reason'] = 'icmp (maintenance)';
-        }
-        else {
+        } else {
             $response['status_reason'] = 'icmp';
         }
     }
@@ -2080,8 +2077,7 @@ function device_is_up($device, $record_perf = false)
                     [$device['device_id'], $going_down]
                 );
             }
-        }
-        else {
+        } else {
             $type = 'down';
             $reason = $response['status_reason'];
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2040,7 +2040,7 @@ function device_is_up($device, $record_perf = false)
     }
 
     // Special case where the device is still down, optional mode is on, device not in maintenance mode and has no ongoing outages
-    if (($consider_maintenance && !$maintenance) && ($device['status'] == '0' && $response['status'] == '0')) {
+    if (($consider_maintenance && ! $maintenance) && ($device['status'] == '0' && $response['status'] == '0')) {
         $state_update_again = empty(dbFetchCell('SELECT going_down FROM device_outages WHERE device_id=? AND up_again IS NULL ORDER BY going_down DESC', [$device['device_id']]));
     }
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2041,7 +2041,7 @@ function device_is_up($device, $record_perf = false)
     else {
         echo 'Unpingable';
         $response['status'] = '0';
-        if($maintenance && $consider_maintenance) {
+        if ($maintenance && $consider_maintenance) {
             // Scheduled maintenance, device not responding to icmp
             $response['status_reason'] = 'icmp (maintenance)';
         } else {
@@ -2081,7 +2081,7 @@ function device_is_up($device, $record_perf = false)
             $type = 'down';
             $reason = $response['status_reason'];
 
-            if ( ! $consider_maintenance || (!$maintenance && $consider_maintenance)) {
+            if (! $consider_maintenance || (! $maintenance && $consider_maintenance)) {
                 // use current time as a starting point when an outage starts
                 $data = ['device_id' => $device['device_id'],
                     'going_down' => time(), ];

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2037,8 +2037,7 @@ function device_is_up($device, $record_perf = false)
                 $response['status_reason'] = 'snmp';
             }
         }
-    } 
-    else {
+    } else {
         echo 'Unpingable';
         $response['status'] = '0';
         if ($maintenance && $consider_maintenance) {

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2085,7 +2085,7 @@ function device_is_up($device, $record_perf = false)
             $type = 'down';
             $reason = $response['status_reason'];
 
-            if ( ! $consider_maintenance_mode || (!$maintenance && $consider_maintenance_mode)) {
+            if ( ! $consider_maintenance || (!$maintenance && $consider_maintenance)) {
                 // use current time as a starting point when an outage starts
                 $data = ['device_id' => $device['device_id'],
                     'going_down' => time(), ];

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2040,7 +2040,7 @@ function device_is_up($device, $record_perf = false)
     }
 
     // Special case where the device is still down, optional mode is on, device not in maintenance mode and has no ongoing outages
-    if(($consider_maintenance && !$maintenance) && ($device['status'] == '0' && $response['status'] == '0')) {
+    if (($consider_maintenance && !$maintenance) && ($device['status'] == '0' && $response['status'] == '0')) {
         $state_update_again = empty(dbFetchCell('SELECT going_down FROM device_outages WHERE device_id=? AND up_again IS NULL ORDER BY going_down DESC', [$device['device_id']]));
     }
 

--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -1261,7 +1261,7 @@
         "graphing.availability": {
             "group": "poller",
             "section": "availability",
-            "order": 10,
+            "order": 1,
             "default": [
                 "86400",
                 "604800",
@@ -1269,6 +1269,13 @@
                 "31536000"
             ],
             "type": "array"
+        },
+        "graphing.availability_ignore_maintenance": {
+            "group": "poller",
+            "section": "availability",
+            "order": 2,
+            "default": false,
+            "type": "boolean"
         },
         "dot": {
             "default": "/usr/bin/dot",

--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -1270,7 +1270,7 @@
             ],
             "type": "array"
         },
-        "graphing.availability_ignore_maintenance": {
+        "graphing.availability_consider_maintenance": {
             "group": "poller",
             "section": "availability",
             "order": 2,

--- a/resources/lang/en/settings.php
+++ b/resources/lang/en/settings.php
@@ -688,7 +688,7 @@ return [
                 'description' => 'Duration',
                 'help' => 'Calculate Device Availability for listed durations. (Durations are defined in seconds)',
             ],
-            'availability_ignore_maintenance' => [
+            'availability_consider_maintenance' => [
                 'description' => 'Scheduled maintenance does not affect availability',
                 'help' => 'Disables the creation of outages and decreasing of availability for devices which are in maintenance mode.',
             ],

--- a/resources/lang/en/settings.php
+++ b/resources/lang/en/settings.php
@@ -688,6 +688,10 @@ return [
                 'description' => 'Duration',
                 'help' => 'Calculate Device Availability for listed durations. (Durations are defined in seconds)',
             ],
+            'availability_ignore_maintenance' => [
+                'description' => 'Scheduled maintenance does not affect availability',
+                'help' => 'Disables the creation of outages and decreasing of availability for devices which are in maintenance mode.',
+            ],
         ],
         'graylog' => [
             'base_uri' => [


### PR DESCRIPTION
Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.

Adds an optional availability calculation mode where scheduled maintenance does not affect availability. The option can be enabled from options and is disabled by default.

#### Screenshots

![optional-outage-mode](https://user-images.githubusercontent.com/7031571/96114640-8fa6a300-0eee-11eb-8a4d-9448caacb585.PNG)

#### Additional changes

Do not use device's uptime anymore while calculating availability. If the device is not reachable to the monitoring system, consider it unavailable.

#### WIP status

Needs more testing. Tested with the following cases:

Device not in maintenance mode

1. Device goes down => an outage should start
2. Device come back up => the latest outage ends

Optional mode disabled => PASS
Optional mode enabled => PASS

Device in maintenance mode, outage is shorter than maintenance break

1. Device goes down => no outage should start
2. Device comes back up => no modifications should occur to the outages table

Optional mode disabled => PASS
Optional mode enabled => PASS

Device in maintenance mode but outage lasts longer than maintenance break

1. Device goes down => no outage yet
2. Time passes until maintenance break is over => an outage should start
3. Device comes back up => outage ends

Optional mode disabled => PASS
Optional mode enabled => PASS
