### PR TITLE
Fix typo cause empty data for NFS Server

### DIFF
--- a/includes/polling/applications/nfs-server.inc.php
+++ b/includes/polling/applications/nfs-server.inc.php
@@ -202,7 +202,7 @@ proc4ops 59 0 0 0 2 0 0 0 0 0 402 3 0 0 0 0 3 0 0 0 0 0 0 403 0 1 0 1 0 0 0 0 0 
 */
 
 $keys_nfs_server = [
-    'rc' => ['th_hits', 'th_misses', 'th_nocache'],
+    'rc' => ['rc_hits', 'rc_misses', 'rc_nocache'],
     'fh' => ['fh_lookup', 'fh_anon', 'fh_ncachedir', 'fh_ncachenondir', 'fh_stale'],
     'io' => ['io_read', 'io_write'],
     'th' => ['th_threads', 'th_fullcnt', 'th_range01', 'th_range02', 'th_range03', 'th_range04', 'th_range05', 'th_range06', 'th_range07', 'th_range08', 'th_range09', 'th_range10'],


### PR DESCRIPTION
Typo causing NFS tab data aren't polling properly

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
