### PR TITLE
Fix return value on deleting a Device Group

### DIFF
--- a/app/Http/Controllers/DeviceGroupController.php
+++ b/app/Http/Controllers/DeviceGroupController.php
@@ -177,8 +177,8 @@ class DeviceGroupController extends Controller
     {
         $deviceGroup->delete();
 
-        Toastr::success(__('Device Group :name deleted', ['name' => $deviceGroup->name]));
+        $msg = __('Device Group :name deleted', ['name' => $deviceGroup->name]);
 
-        return redirect()->route('device-groups.index');
+        return response ($msg, 200);
     }
 }

--- a/app/Http/Controllers/DeviceGroupController.php
+++ b/app/Http/Controllers/DeviceGroupController.php
@@ -179,6 +179,6 @@ class DeviceGroupController extends Controller
 
         $msg = __('Device Group :name deleted', ['name' => $deviceGroup->name]);
 
-        return response ($msg, 200);
+        return response($msg, 200);
     }
 }


### PR DESCRIPTION
Device Group will be deleted successfully,

But Return Code was wrong following into this:

before:
![image](https://user-images.githubusercontent.com/7978916/96385729-00bbb400-1196-11eb-8378-0eb058cc03ae.png)

after:
![image](https://user-images.githubusercontent.com/7978916/96385636-74a98c80-1195-11eb-94aa-19d13701f419.png)


#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
