### PR TITLE
followUp - FDB table for GS1900-8 as well

### DIFF
--- a/includes/discovery/fdb-table/zynos.inc.php
+++ b/includes/discovery/fdb-table/zynos.inc.php
@@ -13,7 +13,7 @@
  * @author     PipoCanaja <pipocanaja@gmail.com>
  */
 
-if (in_array($device['hardware'], ['GS1900-48', 'GS1900-24'])) {
+if (in_array($device['hardware'], ['GS1900-48', 'GS1900-24', 'GS1900-8'])) {
     echo 'Zyxel GS1900 Q-BRIDGE:' . PHP_EOL;
     // These devices do not provide a proper Q-BRIDGE reply (there is a ".6." index between VLAN and MAC)
     // <vlanid>.6.<mac1>.<mac2>.<mac3>.<mac4>.<mac5>.<mac6>


### PR DESCRIPTION
The 8 ports variant behaves the same as 24 and 48 ports. This is a follow up of #12230 . I don't have the device so I cannot add test-data but we already have the 24 ports variant in tests.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
