### PR TITLE
Remove legacy password algorithms and move to Laravel standard

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -6,6 +6,7 @@ use App\Events\UserCreated;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Facades\Hash;
 use LibreNMS\Authentication\LegacyAuth;
 use Permissions;
 
@@ -94,7 +95,7 @@ class User extends Authenticatable
      */
     public function setPassword($password)
     {
-        $this->attributes['password'] = $password ? password_hash($password, PASSWORD_DEFAULT) : null;
+        $this->attributes['password'] = $password ? Hash::make($password) : null;
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -62,8 +62,7 @@
         "symfony/yaml": "^4.0",
         "tecnickcom/tcpdf": "~6.2.0",
         "tightenco/ziggy": "^0.8.0",
-        "wpb/string-blade-compiler": "dev-laravel-7-and-autoload-blade-custom-directives",
-        "xjtuwangke/passwordhash": "dev-master"
+        "wpb/string-blade-compiler": "dev-laravel-7-and-autoload-blade-custom-directives"
     },
     "require-dev": {
         "barryvdh/laravel-debugbar": "^3.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4389f49396c63fa97f39a7fb849f9312",
+    "content-hash": "da041241928d2324788ffb2accf1a739",
     "packages": [
         {
             "name": "amenadiel/jpgraph",
@@ -6114,50 +6114,6 @@
                 "source": "https://github.com/librenms/StringBladeCompiler/tree/laravel-7-and-autoload-blade-custom-directives"
             },
             "time": "2020-07-10T19:15:25+00:00"
-        },
-        {
-            "name": "xjtuwangke/passwordhash",
-            "version": "dev-master",
-            "source": {
-                "type": "git",
-                "url": "git@github.com:xjtuwangke/passwordhash.git",
-                "reference": "a7bcd9705add858cd496bdd8cdc9bbed231e8bb3"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/xjtuwangke/passwordhash/zipball/a7bcd9705add858cd496bdd8cdc9bbed231e8bb3",
-                "reference": "a7bcd9705add858cd496bdd8cdc9bbed231e8bb3",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "Phpass": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "Public Domain"
-            ],
-            "authors": [
-                {
-                    "name": "Solar Designer",
-                    "email": "solar@openwall.com",
-                    "homepage": "http://openwall.com/phpass/"
-                }
-            ],
-            "description": "Portable PHP password hashing framework",
-            "homepage": "http://github.com/xjtuwangke/passwordhash/",
-            "keywords": [
-                "blowfish",
-                "crypt",
-                "password",
-                "security"
-            ],
-            "time": "2012-08-31T00:00:00+00:00"
         }
     ],
     "packages-dev": [
@@ -9748,8 +9704,7 @@
     "minimum-stability": "stable",
     "stability-flags": {
         "oriceon/toastr-5-laravel": 20,
-        "wpb/string-blade-compiler": 20,
-        "xjtuwangke/passwordhash": 20
+        "wpb/string-blade-compiler": 20
     },
     "prefer-stable": false,
     "prefer-lowest": false,


### PR DESCRIPTION
Since we already use `password_hash` (which uses bcrypt as default), we're in luck and the `Hash::needsRehash` won't even trigger the first time.

As a bonus we now also support "upgrading" hashes if needed.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
