### PR TITLE
Clarify non-x86 hardware info sources for snmpd

### DIFF
--- a/doc/Support/SNMP-Configuration-Examples.md
+++ b/doc/Support/SNMP-Configuration-Examples.md
@@ -380,6 +380,13 @@ is mode 0400. One solution is to include `@reboot chmod 444
 /sys/devices/virtual/dmi/id/product_serial` in the crontab for root or
 equivalent.
 
+Non-x86 or SMBIOS-based systems, such as ARM-based Raspberry Pi units should
+query device tree locations for this metadata, for example:
+```
+extend hardware '/bin/cat /sys/firmware/devicetree/base/model'
+extend serial '/bin/cat /sys/firmware/devicetree/base/serial-number'
+```
+
 The LibreNMS server include a copy of this example here:
 
 ```

--- a/snmpd.conf.example
+++ b/snmpd.conf.example
@@ -5,12 +5,18 @@ group MyROGroup v2c        readonly
 view all    included  .1                               80
 access MyROGroup ""      any       noauth    exact  all    none   none
 
-syslocation Rack, Room, Building, City, Country [GPSX,Y]
+syslocation Rack, Room, Building, City, Country [Lat, Lon]
 syscontact Your Name <your@email.address>
 
-#Distro Detection
+#OS Distribution Detection
 extend distro /usr/bin/distro
-#Hardware Detection (uncomment to enable)
-#extend hardware '/bin/cat /sys/devices/virtual/dmi/id/product_name'
+
+#Hardware Detection
+# (uncomment for x86 platforms)
 #extend manufacturer '/bin/cat /sys/devices/virtual/dmi/id/sys_vendor'
+#extend hardware '/bin/cat /sys/devices/virtual/dmi/id/product_name'
 #extend serial '/bin/cat /sys/devices/virtual/dmi/id/product_serial'
+
+# (uncomment for ARM platforms)
+#extend hardware '/bin/cat /sys/firmware/devicetree/base/model'
+#extend serial '/bin/cat /sys/firmware/devicetree/base/serial-number'


### PR DESCRIPTION
Follow-up to #12195, this PR gives examples for ARM-based metadata (model, serial number, etc). In particular this is geared for Raspberry Pi 4 hosts.

![image](https://user-images.githubusercontent.com/139549/96800984-7c4a7a80-13bb-11eb-8328-6dc3fbf5bc19.png)


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.

