### PR TITLE
Update DSL stats even if port is down

### DIFF
--- a/includes/html/graphs/port/adsl_attainable.inc.php
+++ b/includes/html/graphs/port/adsl_attainable.inc.php
@@ -3,11 +3,11 @@
 $rrd_filename = get_port_rrdfile_path($device['hostname'], $port['port_id'], 'adsl');
 
 $rrd_list[0]['filename'] = $rrd_filename;
-$rrd_list[0]['descr'] = 'Downstream';
+$rrd_list[0]['descr'] = 'Central to CPE';
 $rrd_list[0]['ds'] = 'AturCurrAttainableR';
 
 $rrd_list[1]['filename'] = $rrd_filename;
-$rrd_list[1]['descr'] = 'Upstream';
+$rrd_list[1]['descr'] = 'CPE to Central';
 $rrd_list[1]['ds'] = 'AtucCurrAttainableR';
 
 $unit_text = 'Bits/sec';

--- a/includes/html/graphs/port/adsl_attainable.inc.php
+++ b/includes/html/graphs/port/adsl_attainable.inc.php
@@ -4,11 +4,11 @@ $rrd_filename = get_port_rrdfile_path($device['hostname'], $port['port_id'], 'ad
 
 $rrd_list[0]['filename'] = $rrd_filename;
 $rrd_list[0]['descr'] = 'Downstream';
-$rrd_list[0]['ds'] = 'AtucCurrAttainableR';
+$rrd_list[0]['ds'] = 'AturCurrAttainableR';
 
 $rrd_list[1]['filename'] = $rrd_filename;
 $rrd_list[1]['descr'] = 'Upstream';
-$rrd_list[1]['ds'] = 'AturCurrAttainableR';
+$rrd_list[1]['ds'] = 'AtucCurrAttainableR';
 
 $unit_text = 'Bits/sec';
 

--- a/includes/html/graphs/port/adsl_attenuation.inc.php
+++ b/includes/html/graphs/port/adsl_attenuation.inc.php
@@ -3,12 +3,12 @@
 $rrd_filename = get_port_rrdfile_path($device['hostname'], $port['port_id'], 'adsl');
 
 $rrd_list[0]['filename'] = $rrd_filename;
-$rrd_list[0]['descr'] = 'Downstream';
-$rrd_list[0]['ds'] = 'AtucCurrAtn';
+$rrd_list[0]['descr'] = 'Central to CPE';
+$rrd_list[0]['ds'] = 'AturCurrAtn';
 
 $rrd_list[1]['filename'] = $rrd_filename;
-$rrd_list[1]['descr'] = 'Upstream';
-$rrd_list[1]['ds'] = 'AturCurrAtn';
+$rrd_list[1]['descr'] = 'CPE to Central';
+$rrd_list[1]['ds'] = 'AtucCurrAtn';
 
 $unit_text = 'dB';
 

--- a/includes/html/graphs/port/adsl_power.inc.php
+++ b/includes/html/graphs/port/adsl_power.inc.php
@@ -3,12 +3,12 @@
 $rrd_filename = get_port_rrdfile_path($device['hostname'], $port['port_id'], 'adsl');
 
 $rrd_list[0]['filename'] = $rrd_filename;
-$rrd_list[0]['descr'] = 'Downstream';
-$rrd_list[0]['ds'] = 'AtucCurrOutputPwr';
+$rrd_list[0]['descr'] = 'Central';
+$rrd_list[0]['ds'] = 'AturCurrOutputPwr';
 
 $rrd_list[1]['filename'] = $rrd_filename;
-$rrd_list[1]['descr'] = 'Upstream';
-$rrd_list[1]['ds'] = 'AturCurrOutputPwr';
+$rrd_list[1]['descr'] = 'CPE';
+$rrd_list[1]['ds'] = 'AtucCurrOutputPwr';
 
 $unit_text = 'dBm';
 

--- a/includes/html/graphs/port/adsl_snr.inc.php
+++ b/includes/html/graphs/port/adsl_snr.inc.php
@@ -3,11 +3,11 @@
 $rrd_filename = get_port_rrdfile_path($device['hostname'], $port['port_id'], 'adsl');
 
 $rrd_list[0]['filename'] = $rrd_filename;
-$rrd_list[0]['descr'] = 'Downstream';
+$rrd_list[0]['descr'] = 'Central to CPE';
 $rrd_list[0]['ds'] = 'AturCurrSnrMgn';
 
 $rrd_list[1]['filename'] = $rrd_filename;
-$rrd_list[1]['descr'] = 'Upstream';
+$rrd_list[1]['descr'] = 'CPE to Central';
 $rrd_list[1]['ds'] = 'AtucCurrSnrMgn';
 
 $unit_text = 'dB';

--- a/includes/html/graphs/port/adsl_snr.inc.php
+++ b/includes/html/graphs/port/adsl_snr.inc.php
@@ -4,11 +4,11 @@ $rrd_filename = get_port_rrdfile_path($device['hostname'], $port['port_id'], 'ad
 
 $rrd_list[0]['filename'] = $rrd_filename;
 $rrd_list[0]['descr'] = 'Downstream';
-$rrd_list[0]['ds'] = 'AtucCurrSnrMgn';
+$rrd_list[0]['ds'] = 'AturCurrSnrMgn';
 
 $rrd_list[1]['filename'] = $rrd_filename;
 $rrd_list[1]['descr'] = 'Upstream';
-$rrd_list[1]['ds'] = 'AturCurrSnrMgn';
+$rrd_list[1]['ds'] = 'AtucCurrSnrMgn';
 
 $unit_text = 'dB';
 

--- a/includes/html/graphs/port/adsl_speed.inc.php
+++ b/includes/html/graphs/port/adsl_speed.inc.php
@@ -3,11 +3,11 @@
 $rrd_filename = get_port_rrdfile_path($device['hostname'], $port['port_id'], 'adsl');
 
 $rrd_list[0]['filename'] = $rrd_filename;
-$rrd_list[0]['descr'] = 'Downstream';
+$rrd_list[0]['descr'] = 'Central to CPE';
 $rrd_list[0]['ds'] = 'AtucChanCurrTxRate';
 
 $rrd_list[1]['filename'] = $rrd_filename;
-$rrd_list[1]['descr'] = 'Upstream';
+$rrd_list[1]['descr'] = 'CPE to Central';
 $rrd_list[1]['ds'] = 'AturChanCurrTxRate';
 
 $unit_text = 'Bits/sec';

--- a/includes/html/pages/device/port/adsl.inc.php
+++ b/includes/html/pages/device/port/adsl.inc.php
@@ -2,8 +2,13 @@
 
 if (file_exists(get_port_rrdfile_path($device['hostname'], $port['port_id'], 'adsl'))) {
     $iid = $id;
-    echo '<div class=graphhead>ADSL Line Speed</div>';
+    echo '<div class=graphhead>ADSL Current Line Speed</div>';
     $graph_type = 'port_adsl_speed';
+
+    include 'includes/html/print-interface-graphs.inc.php';
+
+    echo '<div class=graphhead>ADSL Attainable Speed</div>';
+    $graph_type = 'port_adsl_attainable';
 
     include 'includes/html/print-interface-graphs.inc.php';
 

--- a/includes/html/print-interface.inc.php
+++ b/includes/html/print-interface.inc.php
@@ -146,9 +146,9 @@ if ($port_adsl['adslLineCoding']) {
     //    adslAtucCurrAttainableRate is UploadMaxRate
     echo 'Max:' . formatRates($port_adsl['adslAturCurrAttainableRate']) . '/' . formatRates($port_adsl['adslAtucCurrAttainableRate']);
     echo "</td><td width=150 onclick=\"location.href='" . generate_port_url($port) . "'\" >";
-    echo 'Atten:' . $port_adsl['adslAtucCurrAtn'] . 'dB/' . $port_adsl['adslAturCurrAtn'] . 'dB';
+    echo 'Atten:' . $port_adsl['adslAturCurrAtn'] . 'dB/' . $port_adsl['adslAtucCurrAtn'] . 'dB';
     echo '<br />';
-    echo 'SNR:' . $port_adsl['adslAtucCurrSnrMgn'] . 'dB/' . $port_adsl['adslAturCurrSnrMgn'] . 'dB';
+    echo 'SNR:' . $port_adsl['adslAturCurrSnrMgn'] . 'dB/' . $port_adsl['adslAtucCurrSnrMgn'] . 'dB';
 } else {
     echo "</td><td width=150 onclick=\"location.href='" . generate_port_url($port) . "'\" >";
     if ($port['ifType'] && $port['ifType'] != '') {

--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -734,8 +734,9 @@ foreach ($ports as $port) {
         if (! empty($port['skipped'])) {
             // We don't care about statistics for skipped selective polling ports
             d_echo("$port_id skipped because selective polling ports is set.");
-        } elseif ($port['ifOperStatus'] == 'down' && $port['ifOperStatus_prev'] == 'down' && $this_port['ifOperStatus'] == 'down' && $this_port['ifLastChange'] == $port['ifLastChange']) {
+        } elseif ($port['ifType'] != 'adsl' && $port['ifOperStatus'] == 'down' && $port['ifOperStatus_prev'] == 'down' && $this_port['ifOperStatus'] == 'down' && $this_port['ifLastChange'] == $port['ifLastChange']) {
             // We don't care about statistics for down ports on which states did not change since last polling
+            // We still take into account 'adsl' ports that may update speed/noise even if the interface is status down
             d_echo("$port_id skipped because port is still down since last polling.");
         } else {
             // End parse ifAlias


### PR DESCRIPTION
ADSL stats are interesting even if port is down/admindown (noise on the line is still collected, atteignable linerate etc etc). This PR will allow to RRD and DB write when the data is anyway polled but was skipped because of ifLastChange. Tested successfully on Cisco DSL routers. 

I also finished to correct the Downstream/upstream inconsistancies, and renamed them Central to CPE and CPE to Central. 

This PR only have a minimal impact on DB update during the polling. SNMP is already done today.

![image](https://user-images.githubusercontent.com/38363551/97279079-ccea2980-183a-11eb-80d6-0ffce33d6c29.png)


Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
