### PR TITLE
Fix - only get shortlabel from vlan if it has ports

### DIFF
--- a/resources/views/device/tabs/vlans.blade.php
+++ b/resources/views/device/tabs/vlans.blade.php
@@ -18,10 +18,12 @@
                 <td>
                 @foreach($vlans as $port)
                     @if(!$vars)
+@if($port->port)
 @portLink($port->port, $port->port->getShortLabel())
 @if($port->untagged)
 (U)@endif
 @if(!$loop->last),
+@endif
 @endif
 
                     @else


### PR DESCRIPTION
on some switch configurations a VLAN has no ports - also no short label - , so GUI crashes

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
