### PR TITLE
VRP NAC polling optimisation

### DIFF
--- a/LibreNMS/OS/Vrp.php
+++ b/LibreNMS/OS/Vrp.php
@@ -81,7 +81,7 @@ class Vrp extends OS implements
                 $apTable = snmpwalk_group($this->getDeviceArray(), $apTableOid, 'HUAWEI-WLAN-AP-MIB', 2, $apTable);
             }
 
-            $apRadioTableOids = [ // hwWlanRadioInfoTable
+            $apRadioTableOids = [
                 'hwWlanRadioMac',
                 'hwWlanRadioChUtilizationRate',
                 'hwWlanRadioChInterferenceRate',
@@ -298,11 +298,26 @@ class Vrp extends OS implements
     {
         $nac = collect();
         // We collect the first table
-        $portAuthSessionEntry = snmpwalk_cache_oid($this->getDeviceArray(), 'hwAccessTable', [], 'HUAWEI-AAA-MIB');
+        $portAuthSessionEntry = snmpwalk_cache_oid($this->getDeviceArray(), 'hwAccessInterface', [], 'HUAWEI-AAA-MIB');
 
         if (! empty($portAuthSessionEntry)) {
-            // If it is not empty, lets add the Extended table
-            $portAuthSessionEntry = snmpwalk_cache_oid($this->getDeviceArray(), 'hwAccessExtTable', $portAuthSessionEntry, 'HUAWEI-AAA-MIB');
+            // If it is not empty, lets add all the necessary OIDs
+            $hwAccessOids = [
+                'hwAccessMACAddress',
+                'hwAccessDomain',
+                'hwAccessUserName',
+                'hwAccessIPAddress',
+                'hwAccessType',
+                'hwAccessAuthorizetype',
+                'hwAccessSessionTimeout',
+                'hwAccessOnlineTime',
+                'hwAccessCurAuthenPlace',
+                'hwAccessAuthtype',
+                'hwAccessVLANID'
+            ];
+            foreach ($hwAccessOids as $hwAccessOid) {
+                $portAuthSessionEntry = snmpwalk_cache_oid($this->getDeviceArray(), $hwAccessOid, $portAuthSessionEntry, 'HUAWEI-AAA-MIB');
+            }
             // We cache a port_ifName -> port_id map
             $ifName_map = $this->getDevice()->ports()->pluck('port_id', 'ifName');
 

--- a/LibreNMS/OS/Vrp.php
+++ b/LibreNMS/OS/Vrp.php
@@ -81,7 +81,7 @@ class Vrp extends OS implements
                 $apTable = snmpwalk_group($this->getDeviceArray(), $apTableOid, 'HUAWEI-WLAN-AP-MIB', 2, $apTable);
             }
 
-            $apRadioTableOids = [
+            $apRadioTableOids = [ // hwWlanRadioInfoTable
                 'hwWlanRadioMac',
                 'hwWlanRadioChUtilizationRate',
                 'hwWlanRadioChInterferenceRate',
@@ -313,7 +313,7 @@ class Vrp extends OS implements
                 'hwAccessOnlineTime',
                 'hwAccessCurAuthenPlace',
                 'hwAccessAuthtype',
-                'hwAccessVLANID'
+                'hwAccessVLANID',
             ];
             foreach ($hwAccessOids as $hwAccessOid) {
                 $portAuthSessionEntry = snmpwalk_cache_oid($this->getDeviceArray(), $hwAccessOid, $portAuthSessionEntry, 'HUAWEI-AAA-MIB');


### PR DESCRIPTION
Instead of polling a very large table for only a part of the OIDs, we only walk the OIDs we need. 
11 small snmpwalk_cache_oids calls instead of 2 big ones. 

6 seconds instead of 20 seconds on my stacks. 

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
