### PR TITLE
fix v.1.62 download composer version too new error

### DIFF
--- a/scripts/composer_wrapper.php
+++ b/scripts/composer_wrapper.php
@@ -77,7 +77,7 @@ if (is_file($install_dir . '/composer.phar')) {
             echo "Error: Failed to download $installer_url\n";
         } elseif (@hash_file('SHA384', $dest) === $good_sha) {
             // Installer verified
-            shell_exec("php $dest");
+            shell_exec("php $dest --version=1.10.17");
             $exec = "php $install_dir/composer.phar";
         } else {
             echo "Error: Corrupted download, signature doesn't match for $installer_url\n";


### PR DESCRIPTION
Signed-off-by: ZhengSheng0524 <j13tw@yahoo.com.tw>

When I test the LibreNMS version 1.62 (setting up to use this version in my project running)
Recent days, I try to rebuild my environment use the non-composer env install LibreNMS
When I use the composer to download and install the third-party-module
I use the command ```./script/composer_wrapper.php install --no-dev```
It will tell me something error like this
```
> php artisan package:discover --ansi

In PackageManifest.php line 122:
                         
  Undefined index: name  
                         

Script php artisan package:discover --ansi handling the post-autoload-dump event returned with error code 1
```
and the commposer is in the ./script/composer_wrapper.php step to downlod it
I try to follow the ./script/composer_wrapper.php command to download composer
and the composer will install the newest version (in my test, it will be version v2.0.4)
> follow the composer update version: https://getcomposer.org/download/

```
root@ubuntu:~# php composer.php 
All settings correct for using Composer
Downloading...

Composer (version 2.0.4) successfully installed to: /root/composer.phar
Use it: php composer.phar
```

I find the solution is pre-setup the composer install version (v1.10.17)
and change the composer download version 
then the command ```./script/composer_wrapper.php install --no-dev``` and the Install will pass

tips: 
The another solution is use the command ```./scripts/composer_wrapper.php self-update --1``` berfore  the ```./script/composer_wrapper.php install --no-dev```, the composer will downgrade to the old version.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
