### PR TITLE
Extend Debian instructions with Raspberry Pi OS

### DIFF
--- a/doc/Installation/Install-LibreNMS.md
+++ b/doc/Installation/Install-LibreNMS.md
@@ -61,7 +61,8 @@ Connect to the server command line and follow the instructions below.
 ## Add librenms user
 
 ```
-useradd librenms -d /opt/librenms -M -r -s /usr/bin/bash
+BASHLOCATION=$(which bash)
+useradd librenms -d /opt/librenms -M -r -s $BASHLOCATION
 ```
 
 ## Download LibreNMS

--- a/doc/Installation/Install-LibreNMS.md
+++ b/doc/Installation/Install-LibreNMS.md
@@ -61,8 +61,7 @@ Connect to the server command line and follow the instructions below.
 ## Add librenms user
 
 ```
-BASHLOCATION=$(which bash)
-useradd librenms -d /opt/librenms -M -r -s $BASHLOCATION
+useradd librenms -d /opt/librenms -M -r -s "$(which bash)"
 ```
 
 ## Download LibreNMS


### PR DESCRIPTION
The Debian 10 part of the install instructions for LibreNMS just need a different bash location to be compatible on Raspberry Pi OS, formerly known as Raspbian which is based on Debian 10 Buster.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
