### PR TITLE
only add new outage entry if Device status changed

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2072,11 +2072,13 @@ function device_is_up($device, $record_perf = false)
             $type = 'down';
             $reason = $response['status_reason'];
 
-            if (! $consider_maintenance || (! $maintenance && $consider_maintenance)) {
-                // use current time as a starting point when an outage starts
-                $data = ['device_id' => $device['device_id'],
-                    'going_down' => time(), ];
-                dbInsert($data, 'device_outages');
+            if ($device['status'] != $response['status'] {
+                if (! $consider_maintenance || (! $maintenance && $consider_maintenance)) {
+                    // use current time as a starting point when an outage starts
+                    $data = ['device_id' => $device['device_id'],
+                        'going_down' => time(), ];
+                    dbInsert($data, 'device_outages');
+                }
             }
         }
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2072,7 +2072,7 @@ function device_is_up($device, $record_perf = false)
             $type = 'down';
             $reason = $response['status_reason'];
 
-            if ($device['status'] != $response['status'] {
+            if ($device['status'] != $response['status']) {
                 if (! $consider_maintenance || (! $maintenance && $consider_maintenance)) {
                     // use current time as a starting point when an outage starts
                     $data = ['device_id' => $device['device_id'],


### PR DESCRIPTION
change of status reason on offline devices causes new outage entry without "recovering" entry before.
Outage is a outage, a change of the reason doesn't care, so a new outage only has to be added if device status has changed

happens e.G. if a problematic device is flapping between 
"Device status changed to Down from snmp check." and "Device status changed to Down from icmp check."

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
