### PR TITLE
OSPF View Open/Close Button

### DIFF
--- a/includes/html/pages/device/routing/ospf.inc.php
+++ b/includes/html/pages/device/routing/ospf.inc.php
@@ -43,7 +43,7 @@ foreach (dbFetchRows('SELECT * FROM `ospf_instances` WHERE `device_id` = ?', [$d
     echo '
         <tbody>
           <tr data-toggle="collapse" data-target="#ospf-panel' . $i . '" class="accordion-toggle">
-            <td><button id="ospf-panel_button'. $i .'" class="btn btn-default btn-xs"><span id="ospf-panel_span'. $i .'" class="fa fa-plus"></span></button></td>
+            <td><button id="ospf-panel_button'. $i .'" class="btn btn-default btn-xs"><span id="ospf-panel_span' . $i . '" class="fa fa-plus"></span></button></td>
             <td>' . $instance['ospfRouterId'] . '</td>
             <td><span class="label label-' . $status_color . '">' . $instance['ospfAdminStat'] . '</span></td>
             <td><span class="label label-' . $abr_status_color . '">' . $instance['ospfAreaBdrRtrStatus'] . '</span></td>
@@ -54,7 +54,7 @@ foreach (dbFetchRows('SELECT * FROM `ospf_instances` WHERE `device_id` = ?', [$d
           </tr>
           <script type="text/javascript">
           $("#ospf-panel_button' . $i . '").click(function(){
-              $("#ospf-panel_span'. $i .'").toggleClass("fa-minus");
+              $("#ospf-panel_span' . $i . '").toggleClass("fa-minus");
           });
           </script>
           <tr>

--- a/includes/html/pages/device/routing/ospf.inc.php
+++ b/includes/html/pages/device/routing/ospf.inc.php
@@ -43,7 +43,7 @@ foreach (dbFetchRows('SELECT * FROM `ospf_instances` WHERE `device_id` = ?', [$d
     echo '
         <tbody>
           <tr data-toggle="collapse" data-target="#ospf-panel' . $i . '" class="accordion-toggle">
-            <td><button id="ospf-panel_button'. $i .'" class="btn btn-default btn-xs"><span id="ospf-panel_span' . $i . '" class="fa fa-plus"></span></button></td>
+            <td><button id="ospf-panel_button' . $i . '" class="btn btn-default btn-xs"><span id="ospf-panel_span' . $i . '" class="fa fa-plus"></span></button></td>
             <td>' . $instance['ospfRouterId'] . '</td>
             <td><span class="label label-' . $status_color . '">' . $instance['ospfAdminStat'] . '</span></td>
             <td><span class="label label-' . $abr_status_color . '">' . $instance['ospfAreaBdrRtrStatus'] . '</span></td>

--- a/includes/html/pages/device/routing/ospf.inc.php
+++ b/includes/html/pages/device/routing/ospf.inc.php
@@ -43,7 +43,7 @@ foreach (dbFetchRows('SELECT * FROM `ospf_instances` WHERE `device_id` = ?', [$d
     echo '
         <tbody>
           <tr data-toggle="collapse" data-target="#ospf-panel' . $i . '" class="accordion-toggle">
-            <td><button class="btn btn-default btn-xs"><span class="fa fa-plus"></span></button></td>
+            <td><button id="ospf-panel_button'. $i .'" class="btn btn-default btn-xs"><span id="ospf-panel_span'. $i .'" class="fa fa-plus"></span></button></td>
             <td>' . $instance['ospfRouterId'] . '</td>
             <td><span class="label label-' . $status_color . '">' . $instance['ospfAdminStat'] . '</span></td>
             <td><span class="label label-' . $abr_status_color . '">' . $instance['ospfAreaBdrRtrStatus'] . '</span></td>
@@ -52,6 +52,11 @@ foreach (dbFetchRows('SELECT * FROM `ospf_instances` WHERE `device_id` = ?', [$d
             <td>' . $port_count . '(' . $port_count_enabled . ')</td>
             <td>' . $nbr_count . '</td>
           </tr>
+          <script type="text/javascript">
+          $("#ospf-panel_button' . $i . '").click(function(){
+              $("#ospf-panel_span'. $i .'").toggleClass("fa-minus");
+          });
+          </script>
           <tr>
             <td colspan="12" class="hiddenRow">
             <div class="accordian-body collapse" id="ospf-panel' . $i . '">


### PR DESCRIPTION
on expanding OSPF View Button stays on a "+"  like it's not expanded

before:

![image](https://user-images.githubusercontent.com/7978916/98601943-02cdea00-22e0-11eb-866b-599faacfd679.png)


after:

![image](https://user-images.githubusercontent.com/7978916/98601979-0eb9ac00-22e0-11eb-8917-ed1243e82fcd.png)



#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
