### PR TITLE
Update regex for vCenter 7

### DIFF
--- a/includes/definitions/vmware-vcsa.yaml
+++ b/includes/definitions/vmware-vcsa.yaml
@@ -14,4 +14,4 @@ discovery:
     -
         sysDescr_regex:
             - '/^VMware-vCenter-Server-Appliance/'
-            - '/^VMware vCenter Server Appliance/'
+            - '/^VMware vCenter Server/'


### PR DESCRIPTION
Please give a short description what your pull request is for
It looks like VMware dropped the Appliance for vCenter 7 since it only comes as an appliance now. Example: `VMware vCenter Server 7.0.1.00100 embedded build 17004997 VMware, Inc x86_64`

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
