### PR TITLE
Custom_descr Ports - configurable Icons

### DIFF
--- a/app/Http/Controllers/Select/GraphAggregateController.php
+++ b/app/Http/Controllers/Select/GraphAggregateController.php
@@ -48,7 +48,7 @@ class GraphAggregateController extends Controller
         ];
 
         foreach ((array) Config::get('custom_descr', []) as $custom) {
-            $custom = is_array($custom) : $custom[0] : $custom;
+            $custom = is_array($custom) ? $custom[0] : $custom;
             if ($custom) {
                 $types[] = $custom;
             }

--- a/app/Http/Controllers/Select/GraphAggregateController.php
+++ b/app/Http/Controllers/Select/GraphAggregateController.php
@@ -48,6 +48,7 @@ class GraphAggregateController extends Controller
         ];
 
         foreach ((array) Config::get('custom_descr', []) as $custom) {
+            $custom = is_array($custom) : $custom[0] : $custom;
             if ($custom) {
                 $types[] = $custom;
             }

--- a/app/Http/ViewComposers/MenuComposer.php
+++ b/app/Http/ViewComposers/MenuComposer.php
@@ -98,7 +98,7 @@ class MenuComposer
                 continue;
             }
             $custom_descr[] = ['name' => $custom_descr_name,
-                'icon' => is_array($descr) ? $descr[1] : 'fa-connectdevelop'
+                'icon' => is_array($descr) ? $descr[1] : 'fa-connectdevelop',
             ];
         }
         $vars['custom_port_descr'] = collect($custom_descr)->filter();

--- a/app/Http/ViewComposers/MenuComposer.php
+++ b/app/Http/ViewComposers/MenuComposer.php
@@ -90,7 +90,18 @@ class MenuComposer
         $vars['port_counts']['pseudowire'] = Config::get('enable_pseudowires') ? ObjectCache::portCounts(['pseudowire'])['pseudowire'] : 0;
 
         $vars['port_counts']['alerted'] = 0; // not actually supported on old...
-        $vars['custom_port_descr'] = collect(Config::get('custom_descr', []))->filter();
+
+        $custom_descr = [];
+        foreach ((array)Config::get('custom_descr', []) as $descr) {
+            $custom_descr_name = is_array($descr) ? $descr[0] : $descr;
+            if (empty($custom_descr_name)) {
+                continue;
+            }
+            $custom_descr[] = ['name' => $custom_descr_name,
+                               'icon' => is_array($descr) ? $descr[1] : 'fa-connectdevelop'
+                               ];
+        }
+        $vars['custom_port_descr'] = collect($custom_descr)->filter();
         $vars['port_groups_exist'] = Config::get('int_customers') ||
             Config::get('int_transit') ||
             Config::get('int_peering') ||

--- a/app/Http/ViewComposers/MenuComposer.php
+++ b/app/Http/ViewComposers/MenuComposer.php
@@ -92,14 +92,14 @@ class MenuComposer
         $vars['port_counts']['alerted'] = 0; // not actually supported on old...
 
         $custom_descr = [];
-        foreach ((array)Config::get('custom_descr', []) as $descr) {
+        foreach ((array) Config::get('custom_descr', []) as $descr) {
             $custom_descr_name = is_array($descr) ? $descr[0] : $descr;
             if (empty($custom_descr_name)) {
                 continue;
             }
             $custom_descr[] = ['name' => $custom_descr_name,
-                               'icon' => is_array($descr) ? $descr[1] : 'fa-connectdevelop'
-                               ];
+                'icon' => is_array($descr) ? $descr[1] : 'fa-connectdevelop'
+            ];
         }
         $vars['custom_port_descr'] = collect($custom_descr)->filter();
         $vars['port_groups_exist'] = Config::get('int_customers') ||

--- a/resources/views/layouts/menu.blade.php
+++ b/resources/views/layouts/menu.blade.php
@@ -326,7 +326,7 @@
                                 </li>
                                 @endconfig
                                 @foreach($custom_port_descr as $custom_descr)
-                                    <li><a href="{{ url('iftype/type=' . urlencode($custom_descr)) }}"><i class="fa fa-connectdevelop fa-fw fa-lg" aria-hidden="true"></i> {{ ucwords($custom_descr) }}</a></li>
+                                    <li><a href="{{ url('iftype/type=' . urlencode($custom_descr['name'])) }}"><i class="fa {{$custom_descr['icon']}} fa-fw fa-lg" aria-hidden="true"></i> {{ ucwords($custom_descr['name']) }}</a></li>
                                 @endforeach
                             @endif
 


### PR DESCRIPTION
if define Special Ports via 'custom_descr', now they can also have a custom 'font-awesome' icon.
(works only for array definition)

config.php:
```
$config['custom_descr'][] = ['Custom_icon1', 'fa-plus'];
$config['custom_descr'][] = ['Custom_icon2', 'fa-building'];
$config['custom_descr'][] = 'defaulticon';
```

Result:
![image](https://user-images.githubusercontent.com/7978916/99859136-6f25d480-2b8f-11eb-9b94-b361a6484a18.png)




#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
