### PR TITLE
Support multiple Alertmanager URLs

### DIFF
--- a/LibreNMS/Alert/Transport/Alertmanager.php
+++ b/LibreNMS/Alert/Transport/Alertmanager.php
@@ -35,7 +35,7 @@ class Alertmanager extends Transport
         return $this->contactAlertmanager($obj, $alertmanager_opts);
     }
 
-    public static function contactAlertmanager($obj, $api)
+    public function contactAlertmanager($obj, $api)
     {
         if ($obj['state'] == AlertState::RECOVERED) {
             $alertmanager_status = 'endsAt';
@@ -43,8 +43,6 @@ class Alertmanager extends Transport
             $alertmanager_status = 'startsAt';
         }
         $gen_url = (Config::get('base_url') . 'device/device=' . $obj['device_id']);
-        $host = ($api['url'] . '/api/v2/alerts');
-        $curl = curl_init();
         $alertmanager_msg = strip_tags($obj['msg']);
         $data = [[
             $alertmanager_status => date('c'),
@@ -61,26 +59,59 @@ class Alertmanager extends Transport
             ],
         ]];
 
+        $url = $api['url'];
         unset($api['url']);
         foreach ($api as $label => $value) {
             $data[0]['labels'][$label] = $value;
         }
 
-        $alert_message = json_encode($data);
-        curl_setopt($curl, CURLOPT_HTTPHEADER, ['Content-Type: application/json']);
+        return $this->postAlerts($url, $data);
+    }
+
+    public static function postAlerts($url, $data)
+    {
+        $curl = curl_init();
         set_curl_proxy($curl);
-        curl_setopt($curl, CURLOPT_URL, $host);
+        curl_setopt($curl, CURLOPT_HTTPHEADER, ['Content-Type: application/json']);
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
+        curl_setopt($curl, CURLOPT_TIMEOUT, 5);
+        curl_setopt($curl, CURLOPT_TIMEOUT_MS, 5000);
+        curl_setopt($curl, CURLOPT_CONNECTTIMEOUT, 5);
+        curl_setopt($curl, CURLOPT_CONNECTTIMEOUT_MS, 5000);
         curl_setopt($curl, CURLOPT_POST, true);
+
+        $alert_message = json_encode($data);
         curl_setopt($curl, CURLOPT_POSTFIELDS, $alert_message);
 
-        $ret = curl_exec($curl);
-        $code = curl_getinfo($curl, CURLINFO_HTTP_CODE);
-        if ($code != 200) {
-            return 'HTTP Status code ' . $code;
+        foreach (explode(',', $url) as $am) {
+            $post_url = ($am . '/api/v2/alerts');
+            curl_setopt($curl, CURLOPT_URL, $post_url);
+            $ret = curl_exec($curl);
+            if ($ret === false || curl_errno($curl)) {
+                logfile("Failed to contact $post_url: " . curl_error($curl));
+                continue;
+            }
+            $code = curl_getinfo($curl, CURLINFO_HTTP_CODE);
+            if ($code == 200) {
+                curl_close($curl);
+
+                return true;
+            }
         }
 
-        return true;
+        $err = "Unable to POST to Alertmanager at $post_url .";
+
+        if ($ret === false || curl_errno($curl)) {
+            $err .= ' cURL error: ' . curl_error($curl);
+        } else {
+            $err .= ' HTTP status: ' . curl_getinfo($curl, CURLINFO_HTTP_CODE);
+        }
+
+        curl_close($curl);
+
+        logfile($err);
+
+        return $err;
     }
 
     public static function configTemplate()
@@ -88,9 +119,9 @@ class Alertmanager extends Transport
         return [
             'config' => [
                 [
-                    'title' => 'Alertmanager URL',
+                    'title' => 'Alertmanager URL(s)',
                     'name' => 'alertmanager-url',
-                    'descr' => 'Alertmanager Webhook URL',
+                    'descr' => 'Alertmanager Webhook URL(s). Can contain comma-separated URLs',
                     'type' => 'text',
                 ],
                 [
@@ -101,7 +132,7 @@ class Alertmanager extends Transport
                 ],
             ],
             'validation' => [
-                'alertmanager-url' => 'required|url',
+                'alertmanager-url' => 'required|string',
             ],
         ];
     }

--- a/doc/Alerting/Transports.md
+++ b/doc/Alerting/Transports.md
@@ -63,9 +63,12 @@ of alerts of similar content for an array of hosts, whereas
 Alertmanager can group them by alert meta, ideally producing one
 single notice in case an issue occurs.
 
-It is possible to configure as much label values as required in
-Alertmanager Options section. Every label and it's value should be
+It is possible to configure as many label values as required in
+Alertmanager Options section. Every label and its value should be
 entered as a new line.
+
+Multiple Alertmanager URLs (comma separated) are supported. Each
+URL will be tried and the search will stop at the first success.
 
 [Alertmanager Docs](https://prometheus.io/docs/alerting/alertmanager/)
 
@@ -73,7 +76,7 @@ entered as a new line.
 
 | Config | Example |
 | ------ | ------- |
-| Alertmanager URL      | http://alertmanager.example.com |
+| Alertmanager URL(s)   | http://alertmanager1.example.com,http://alertmanager2.example.com |
 | Alertmanager Options: | source=librenms <br/> customlabel=value |
 
 ## API


### PR DESCRIPTION
This change implements support for sending alerts to multiple Alertmanager URLs. The feature request has been filed as https://community.librenms.org/t/alertmanager-support-for-multiple-addresses/13930

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
