### PR TITLE
GitHub Actions

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,0 +1,65 @@
+name: doc
+
+on:
+  push:
+    branches:
+      - 'master'
+    tags:
+      - '*'
+    paths:
+      - '.github/workflows/doc.yml'
+      - 'doc/**'
+      - 'mkdocs.yml'
+  pull_request:
+    branches:
+      - 'master'
+    paths:
+      - '.github/workflows/doc.yml'
+      - 'doc/**'
+      - 'mkdocs.yml'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      -
+        name: Prepare
+        id: prep
+        run: |
+          VERSION=edge
+          RELEASE=false
+          if [[ $GITHUB_REF == refs/tags/* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/}
+          fi
+          if [[ $VERSION =~ ^[0-9]{1,3}\.[0-9]{1,3}\. ]]; then
+            RELEASE=true
+          fi
+          echo ::set-output name=release::${RELEASE}
+      -
+        name: Build mkdocs Docker image
+        run: |
+          docker build -t mkdocs -f ./doc/Dockerfile ./
+      -
+        name: Build docs
+        run: |
+          docker run --rm -v "$(pwd):/docs" mkdocs build
+          sudo chown -R $(id -u):$(id -g) ./out
+      -
+        name: Check GitHub Pages status
+        uses: crazy-max/ghaction-github-status@v2
+        with:
+          pages_threshold: major_outage
+      -
+        name: Deploy
+        if: github.event_name != 'pull_request' && (endsWith(github.ref, github.event.repository.default_branch) || steps.prep.outputs.release == 'true')
+        uses: crazy-max/ghaction-github-pages@v2
+        with:
+          target_branch: gh-pages
+          build_dir: out
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/doc/Dockerfile
+++ b/doc/Dockerfile
@@ -1,0 +1,16 @@
+FROM squidfunk/mkdocs-material:6.1.0
+
+RUN \
+  apk add --no-cache \
+    git \
+    git-fast-import \
+    openssh \
+  && apk add --no-cache --virtual .build gcc musl-dev \
+  && pip install --no-cache-dir \
+    'markdown-include' \
+    'mkdocs-awesome-pages-plugin' \
+    'mkdocs-exclude' \
+    'mkdocs-git-revision-date-localized-plugin' \
+    'mkdocs-macros-plugin' \
+  && apk del .build gcc musl-dev \
+  && rm -rf /tmp/*

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,7 +29,9 @@ plugins:
       j2_variable_end_string: '=@'
   - search
   - exclude:
-      glob: General/Changelogs/*
+      glob:
+        - "General/Changelogs/*"
+        - "Dockerfile"
 extra_css:
     - https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css
     - librenms.css


### PR DESCRIPTION
This PR is the beginning of a best-effort to migrate to GitHub Actions as discussed on Discord since travis-ci.org [will be officially closed down completely on December 31st, 2020](https://mailchi.mp/3d439eeb1098/travis-ciorg-is-moving-to-travis-cicom?e=%5BUNIQID%5D). But today [travis-ci.com requires a limited number of credits](https://blog.travis-ci.com/2020-11-02-travis-ci-new-billing).

> ...we will upgrade you to our trial (free) plan with a 10K credit allotment (which allows around 1000 minutes in a Linux environment).

ATM I've added a simple workflow to generate mkdocs documentation without disruption of the actual implementation with the Travis build:

* Doc generated with a simple Dockerfile. In the future we could remove `scripts/deploy-docs.sh`.
* Push generated documentation to `gh-pages` branch on this repo.
* We could remove [librenms-docs/librenms-docs.github.io](https://github.com/librenms-docs/librenms-docs.github.io) and only rely on this repo for a better integration and without sharing a Personal Access Token.

You can generate and test doc locally with the following commands:
  * Create mkdocs Docker image: `docker build -t mkdocs -f ./doc/Dockerfile .`
  * Launch local doc website (http://localhost:8000): `docker run --rm -it -p 8000:8000 -v $(pwd):/docs mkdocs`

Live example of the build process and generated doc available on my fork: https://github.com/crazy-max/librenms/runs/1452595127?check_suite_focus=true

![image](https://user-images.githubusercontent.com/1951866/100209833-3d4f9d80-2f02-11eb-9f37-c87524a2c033.png)

https://crazymax.dev/librenms/