### PR TITLE
API - return all port data, not only name and id

### DIFF
--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -894,11 +894,6 @@ function list_available_wireless_graphs(Illuminate\Http\Request $request)
 function get_port_graphs(Illuminate\Http\Request $request)
 {
     $hostname = $request->route('hostname');
-    $columns = $request->get('columns', 'ifName');
-
-    if ($validate = validate_column_list($columns, 'ports') !== true) {
-        return $validate;
-    }
 
     // use hostname as device_id if it's all digits
     $device_id = ctype_digit($hostname) ? $hostname : getidbyname($hostname);
@@ -909,7 +904,7 @@ function get_port_graphs(Illuminate\Http\Request $request)
         array_push($params, Auth::id());
     }
 
-    $ports = dbFetchRows("SELECT $columns FROM `ports` WHERE `device_id` = ? AND `deleted` = '0' $sql ORDER BY `ifIndex`", $params);
+    $ports = dbFetchRows("SELECT * FROM `ports` WHERE `device_id` = ? AND `deleted` = '0' $sql ORDER BY `ifIndex`", $params);
 
     return api_success($ports, 'ports');
 }


### PR DESCRIPTION
instead of only return a list of ifName and Port_id, return all port data when requesting all ports data of a device
(will reduce API calls (for getting port information) to 1 Call instead of n+1 Calls)

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
