### PR TITLE
Fix php min version in the Docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,7 +41,7 @@ extra:
     article_nav_top: false
     article_nav_bottom: true
     php:
-        version_min: 7.2.5
+        version_min: 7.3
 site_author: LibreNMS
 site_description: LibreNMS user and developer documentation
 repo_url: https://github.com/librenms/librenms/


### PR DESCRIPTION
Fixed the minimum PHP version to 7.3

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
