### PR TITLE
added expiration for alerts cache::lock()

### DIFF
--- a/alerts.php
+++ b/alerts.php
@@ -38,7 +38,7 @@ if (set_debug(isset($options['d']))) {
     echo "DEBUG!\n";
 }
 
-$alerts_lock = Cache::lock('alerts');
+$alerts_lock = Cache::lock('alerts', \LibreNMS\Config::get('service_alerting_frequency'));
 if ($alerts_lock->get()) {
     $alerts = new RunAlerts();
     if (! defined('TEST') && \LibreNMS\Config::get('alert.disable') != 'true') {


### PR DESCRIPTION
adds (much) shorter expiration to alerts cache lock, defaults to 60 seconds per `service_alerting_frequency`. Laravel cache lock defaults to 24 hours without a given expiration

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
