### PR TITLE
Show Device Group on Map

### DIFF
--- a/app/Http/Controllers/Maps/DeviceDependencyController.php
+++ b/app/Http/Controllers/Maps/DeviceDependencyController.php
@@ -161,6 +161,7 @@ class DeviceDependencyController extends MapController
             $group_name = $group_name->name;
         }
 
+
         $data = [
             'showparentdevicepath' => $show_device_path,
             'isolated_device_id' => $this->isolatedDeviceId,

--- a/app/Http/Controllers/Maps/DeviceDependencyController.php
+++ b/app/Http/Controllers/Maps/DeviceDependencyController.php
@@ -25,6 +25,7 @@
 namespace App\Http\Controllers\Maps;
 
 use App\Models\Device;
+use App\Models\DeviceGroup;
 use Illuminate\Http\Request;
 use LibreNMS\Util\Url;
 
@@ -155,6 +156,11 @@ class DeviceDependencyController extends MapController
 
         array_multisort(array_column($device_list, 'label'), SORT_ASC, $device_list);
 
+        $group_name = DeviceGroup::where('id', '=', $group_id)->first('name');
+        if (!empty($group_name)) {
+            $group_name = $group_name->name;
+        }
+
         $data = [
             'showparentdevicepath' => $show_device_path,
             'isolated_device_id' => $this->isolatedDeviceId,
@@ -165,6 +171,7 @@ class DeviceDependencyController extends MapController
             'options' => $this->visOptions(),
             'nodes' => json_encode(array_values($devices_by_id)),
             'edges' => json_encode($dependencies),
+            'group_name' => $group_name,
         ];
 
         return view('map.device-dependency', $data);

--- a/app/Http/Controllers/Maps/DeviceDependencyController.php
+++ b/app/Http/Controllers/Maps/DeviceDependencyController.php
@@ -161,7 +161,6 @@ class DeviceDependencyController extends MapController
             $group_name = $group_name->name;
         }
 
-
         $data = [
             'showparentdevicepath' => $show_device_path,
             'isolated_device_id' => $this->isolatedDeviceId,

--- a/app/Http/Controllers/Maps/DeviceDependencyController.php
+++ b/app/Http/Controllers/Maps/DeviceDependencyController.php
@@ -157,7 +157,7 @@ class DeviceDependencyController extends MapController
         array_multisort(array_column($device_list, 'label'), SORT_ASC, $device_list);
 
         $group_name = DeviceGroup::where('id', '=', $group_id)->first('name');
-        if (!empty($group_name)) {
+        if (! empty($group_name)) {
             $group_name = $group_name->name;
         }
 

--- a/includes/html/print-map.inc.php
+++ b/includes/html/print-map.inc.php
@@ -44,8 +44,10 @@ $device_assoc_seen = [];
 $ports = [];
 $devices = [];
 
+$group_name = '';
 $where = '';
 if (is_numeric($group) && $group) {
+    $group_name = dbFetchCell('SELECT `name` from `device_groups` WHERE `id` = ?' , [$group]);
     $where .= ' AND D1.device_id IN (SELECT `device_id` FROM `device_group_device` WHERE `device_group_id` = ?)';
     $sql_array[] = $group;
     $where .= ' OR D2.device_id IN (SELECT `device_id` FROM `device_group_device` WHERE `device_group_id` = ?)';
@@ -342,6 +344,7 @@ if (count($devices_by_id) > 1 && count($links) > 0) {
 
 <form name="printmapform" method="get" action="" class="form-horizontal" role="form">
     <?php if (empty($device['hostname'])) { ?>
+<big><b><?=$group_name?></b></big>
 <div class="pull-right">
 <select name="highlight_node" id="highlight_node" class="input-sm" onChange="highlightNode()";>
 <option value="0">None</option>

--- a/includes/html/print-map.inc.php
+++ b/includes/html/print-map.inc.php
@@ -47,7 +47,7 @@ $devices = [];
 $group_name = '';
 $where = '';
 if (is_numeric($group) && $group) {
-    $group_name = dbFetchCell('SELECT `name` from `device_groups` WHERE `id` = ?' , [$group]);
+    $group_name = dbFetchCell('SELECT `name` from `device_groups` WHERE `id` = ?', [$group]);
     $where .= ' AND D1.device_id IN (SELECT `device_id` FROM `device_group_device` WHERE `device_group_id` = ?)';
     $sql_array[] = $group;
     $where .= ' OR D2.device_id IN (SELECT `device_id` FROM `device_group_device` WHERE `device_group_id` = ?)';

--- a/resources/views/map/device-dependency.blade.php
+++ b/resources/views/map/device-dependency.blade.php
@@ -5,6 +5,7 @@
 @section('content')
 
 @if($node_count)
+&nbsp;<big><b>{{ $group_name }}</b></big>
 <div class="pull-right">
 <input type="checkbox" class="custom-control-input" id="showparentdevicepath" onChange="highlightNode()" @if($showparentdevicepath) checked @endif>
 <label class="custom-control-label" for="showparentdevicepath">@lang('Highlight Dependencies to Root Device')</label>


### PR DESCRIPTION
if having a Map of a Device Group open for longer time it is nice to have the Name of the Group in it :-)

![image](https://user-images.githubusercontent.com/7978916/101093090-8ff02000-35ba-11eb-86d1-8ff47beebca1.png)

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
