### PR TITLE
don't show gelocation on snmp location string

### DIFF
--- a/includes/html/dev-overview-data.inc.php
+++ b/includes/html/dev-overview-data.inc.php
@@ -129,7 +129,7 @@ if ($device['location_id']) {
     echo '
     <div class="row">
         <div class="col-sm-4">Location</div>
-        <div class="col-sm-8">' . $location->location . '</div>
+        <div class="col-sm-8">' . $location->display() . '</div>
     </div>
     <div class="row" id="coordinates-row" data-toggle="collapse" data-target="#toggle-map">
         <div class="col-sm-4">Lat / Lng</div>


### PR DESCRIPTION
don't show location string in snmp location, if set

before:

![Screenshot from 2020-12-08 12-10-43](https://user-images.githubusercontent.com/7978916/101477428-7bf84580-394f-11eb-96c2-e5218c361c01.png)

after:

![Screenshot from 2020-12-08 12-10-39](https://user-images.githubusercontent.com/7978916/101477454-8581ad80-394f-11eb-99d0-729547ba06ba.png)


#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
