### PR TITLE
Update docs for raspberry.sh

### DIFF
--- a/doc/Extensions/Applications.md
+++ b/doc/Extensions/Applications.md
@@ -1618,13 +1618,13 @@ SNMP extend script to get your PI data into your host.
 3: Edit your snmpd.conf file (usually `/etc/snmp/snmpd.conf`) and add:
 
 ```
-extend raspberry sudo /etc/snmp/raspberry.sh
+extend raspberry /usr/bin/sudo /bin/sh /etc/snmp/raspberry.sh
 ```
 
 4: Edit your sudo users (usually `visudo`) and add at the bottom:
 
 ```
-snmp ALL=(ALL) NOPASSWD: /etc/snmp/raspberry.sh, /usr/bin/vcgencmd
+snmp ALL=(ALL) NOPASSWD: /bin/sh /etc/snmp/raspberry.sh
 ```
 
 **Note:** If you are using Raspian, the default user is


### PR DESCRIPTION
When using the original docs for the raspberry.sh script all I got in the SNMP output was `nsExtendOutLine."raspberry".1 = sudo: No such file or directory`

this can be fixed by using the complete path to the sudo command.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
