### PR TITLE
Change raspberry_pi_sensors state

### DIFF
--- a/includes/discovery/sensors/state/linux.inc.php
+++ b/includes/discovery/sensors/state/linux.inc.php
@@ -31,7 +31,7 @@ if (! empty($pre_cache['raspberry_pi_sensors'])) {
         if (stripos($value, 'abled') !== false) {
             $states = [
                 ['value' => 2, 'generic' => 0, 'graph' => 1, 'descr' => 'enabled'],
-                ['value' => 3, 'generic' => 2, 'graph' => 1, 'descr' => 'disabled'],
+                ['value' => 3, 'generic' => 3, 'graph' => 1, 'descr' => 'disabled'],
             ];
             create_state_index($state_name, $states);
 

--- a/tests/data/linux_raspberrypi.json
+++ b/tests/data/linux_raspberrypi.json
@@ -660,7 +660,7 @@
                     "state_descr": "disabled",
                     "state_draw_graph": 1,
                     "state_value": 3,
-                    "state_generic_value": 2
+                    "state_generic_value": 3
                 }
             ]
         }

--- a/tests/data/linux_raspberrypi.json
+++ b/tests/data/linux_raspberrypi.json
@@ -328,7 +328,7 @@
                     "state_descr": "disabled",
                     "state_draw_graph": 1,
                     "state_value": 3,
-                    "state_generic_value": 2
+                    "state_generic_value": 3
                 }
             ]
         },


### PR DESCRIPTION
I think it is great that the codecs of a Raspberry are queried, but a non-existent codec license is not a critical sensor value. What do you think?

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
