### PR TITLE
Add ID to Device Table List and to Device Dependencies Table List + Shorten ifname in Device: Recent Events.

### DIFF
--- a/app/Http/Controllers/Table/DeviceController.php
+++ b/app/Http/Controllers/Table/DeviceController.php
@@ -53,12 +53,13 @@ class DeviceController extends TableController
             'disable_notify' => 'nullable|in:0,1',
             'group' => 'nullable|int',
             'poller_group' => 'nullable|int',
+            'device_id' => 'nullable|int',
         ];
     }
 
     protected function filterFields($request)
     {
-        return ['os', 'version', 'hardware', 'features', 'type', 'status' => 'state', 'disabled', 'disable_notify', 'ignore', 'location_id' => 'location'];
+        return ['os', 'version', 'hardware', 'features', 'type', 'status' => 'state', 'disabled', 'disable_notify', 'ignore', 'location_id' => 'location', 'device_id' => 'device_id'];
     }
 
     protected function searchFields($request)
@@ -76,6 +77,7 @@ class DeviceController extends TableController
             'os' => 'os',
             'uptime' => \DB::raw('IF(`status` = 1, `uptime`, `last_polled` - NOW())'),
             'location' => 'location',
+            'device_id' => 'device_id',
         ];
     }
 
@@ -149,6 +151,7 @@ class DeviceController extends TableController
             'uptime' => (! $device->status && ! $device->last_polled) ? __('Never polled') : Time::formatInterval($device->status ? $device->uptime : $device->last_polled->diffInSeconds(), 'short'),
             'location' => $this->getLocation($device),
             'actions' => $this->getActions($device),
+            'device_id' => $device->device_id,
         ];
     }
 

--- a/includes/html/pages/device-dependencies.inc.php
+++ b/includes/html/pages/device-dependencies.inc.php
@@ -29,12 +29,12 @@ require_once 'includes/html/modal/manage_host_dependencies.inc.php';
     <table id="hostdeps" class="table table-hover table-condensed table-striped">
         <thead>
             <tr>
-                <th data-column-id="deviceid" data-visible="false" data-css-class="deviceid">No</th>
+                <th data-column-id="id" data-formatter="deviceid" data-type="int" data-sortable="true" data-visible="true">Id</th>
                 <th data-column-id="hostname" data-type="string" data-css-class="childhost" data-formatter="hostname">Hostname</th>
                 <th data-column-id="sysname" data-type="string" data-visible="false">Sysname</th>
                 <th data-column-id="parent" data-type="string" data-css-class="parenthost" data-formatter="parent">Parent Device(s)</th>
                 <th data-column-id="parentid" data-visible="false">Parent ID</th>
-                <th data-column-id="actions" data-searchable="false" data-formatter="actions">Actions</th>
+                <th data-column-id="actions" data-sortable="false" data-searchable="false" data-formatter="actions">Actions</th>
             </tr>
         </thead>
         <tbody>
@@ -80,6 +80,9 @@ var grid = $("#hostdeps").bootgrid({
         },
         "hostname": function(column, row) {
             return '<a href="device/device='+row.deviceid+'/" class="list-device">'+row.hostname+'</a><br />'+row.sysname;
+        },
+        "deviceid": function(column, row) {
+            return row.deviceid;
         },
         "parent": function(column, row) {
             if (row.parent == 'None') {

--- a/includes/html/pages/device-dependencies.inc.php
+++ b/includes/html/pages/device-dependencies.inc.php
@@ -29,7 +29,7 @@ require_once 'includes/html/modal/manage_host_dependencies.inc.php';
     <table id="hostdeps" class="table table-hover table-condensed table-striped">
         <thead>
             <tr>
-                <th data-column-id="id" data-formatter="deviceid" data-type="int" data-sortable="true" data-visible="true">Id</th>
+                <th data-column-id="id" data-type="int" data-sortable="true" data-visible="true">Id</th>
                 <th data-column-id="hostname" data-type="string" data-css-class="childhost" data-formatter="hostname">Hostname</th>
                 <th data-column-id="sysname" data-type="string" data-visible="false">Sysname</th>
                 <th data-column-id="parent" data-type="string" data-css-class="parenthost" data-formatter="parent">Parent Device(s)</th>
@@ -80,9 +80,6 @@ var grid = $("#hostdeps").bootgrid({
         },
         "hostname": function(column, row) {
             return '<a href="device/device='+row.deviceid+'/" class="list-device">'+row.hostname+'</a><br />'+row.sysname;
-        },
-        "deviceid": function(column, row) {
-            return row.deviceid;
         },
         "parent": function(column, row) {
             if (row.parent == 'None') {

--- a/includes/html/pages/devices.inc.php
+++ b/includes/html/pages/devices.inc.php
@@ -291,9 +291,10 @@ if ($format == 'graph') {
         <table id="devices" class="table table-hover table-condensed table-striped">
             <thead>
                 <tr>
-                    <th data-column-id="status" data-formatter="status" data-width="7px" data-searchable="false">&nbsp;</th>
+                    <th data-column-id="status" data-formatter="status" data-width="7px" data-searchable="false"><?php echo $detailed ? 'S.' : 'Status'; ?></th>
+                    <th data-column-id="device_id" data-width="5px" data-visible="<?php echo $detailed ? 'true' : 'false'; ?>">Id</th>
+                    <th data-column-id="maintenance" data-width="5px" data-searchable="false" data-formatter="maintenance" data-visible="<?php echo $detailed ? 'true' : 'false'; ?>"><?php echo $detailed ? 'M.' : 'Maintenance'; ?></th>
                     <th data-column-id="icon" data-width="70px" data-searchable="false" data-formatter="icon" data-visible="<?php echo $detailed ? 'true' : 'false'; ?>">Vendor</th>
-                    <th data-column-id="maintenance" data-width="5px" data-searchable="false" data-formatter="maintenance" data-visible="<?php echo $detailed ? 'true' : 'false'; ?>"></th>
                     <th data-column-id="hostname" data-order="asc" <?php echo $detailed ? 'data-formatter="device"' : ''; ?>>Device</th>
                     <th data-column-id="metrics" data-width="<?php echo $detailed ? '100px' : '150px'; ?>" data-sortable="false" data-searchable="false" data-visible="<?php echo $detailed ? 'true' : 'false'; ?>">Metrics</th>
                     <th data-column-id="hardware">Platform</th>
@@ -313,7 +314,7 @@ if ($format == 'graph') {
             columnSelection: true,
             formatters: {
                 "status": function (column, row) {
-                    return "<span class=\"<?php echo $detailed ? 'alert-status' : 'alert-status-small' ?> " + row.extra + "\"></span>";
+                    return "<span title=\"Status: " + row.status + " : " + row.extra.replace(/^label-/,'') + "\" class=\"<?php echo $detailed ? 'alert-status' : 'alert-status-small' ?> " + row.extra + "\"></span>";
                 },
                 "icon": function (column, row) {
                     return "<span class=\"device-table-icon\">" + row.icon + "</span>";
@@ -339,7 +340,6 @@ if ($format == 'graph') {
             },
             templates: {
                 header: "<div class=\"devices-headers-table-menu\" style=\"padding:6px 6px 0px 0px;\"><p class=\"{{css.actions}}\"></p></div><div class=\"row\"></div>"
-
             },
             post: function () {
                 return {
@@ -357,6 +357,7 @@ if ($format == 'graph') {
                     disable_notify: '<?php echo mres($vars['disable_notify']); ?>',
                     group: '<?php echo mres($vars['group']); ?>',
                     poller_group: '<?php echo mres($vars['poller_group']); ?>',
+                    device_id: '<?php echo mres($vars['device_id']); ?>',
                 };
             },
             url: "<?php echo url('/ajax/table/device') ?>"

--- a/includes/html/print-event-short.inc.php
+++ b/includes/html/print-event-short.inc.php
@@ -27,7 +27,7 @@ if ($entry['type'] == 'interface') {
     $entry['link'] = '<b>' . generate_port_link(cleanPort(getifbyid($entry['reference']))) . '</b>';
 }
 
-echo '<td style="white-space: nowrap;">' . $entry['link'] . '</td>';
+echo '<td style="white-space: nowrap;max-width: 100px;overflow: hidden;text-overflow: ellipsis;">' . $entry['link'] . '</td>';
 echo '<td>' . htmlspecialchars($entry['message']) . '</td>';
 
 echo '</tr>';


### PR DESCRIPTION
3d1eebf:
Add 'device_id' information to Device Table List and to Device Dependencies Table List. This is usefull because sometimes we need to know what device is the last device added do the db.

       modified:   app/Http/Controllers/Table/DeviceController.php
       modified:   includes/html/pages/device-dependencies.inc.php
       modified:   includes/html/pages/devices.inc.php

d6660bc:
Shorten interface name inside device page, inside event-short list, on some devices this interface text is huge, i.e.: teldat (ex. interface name: 'Switch Port interface: Group 1, Port 4; Associated interface: ethernet0/0')

       modified:   includes/html/print-event-short.inc.php
