### PR TITLE
Fixes issues with binding and authenticating users in nested groups

### DIFF
--- a/LibreNMS/Authentication/ActiveDirectoryAuthorizer.php
+++ b/LibreNMS/Authentication/ActiveDirectoryAuthorizer.php
@@ -91,10 +91,10 @@ class ActiveDirectoryAuthorizer extends AuthorizerBase
         }
 
         // special character handling
-        $ldap_find_chr = array();
+        $ldap_find_chr = [];
         $ldap_find_chr[] = '(';
         $ldap_find_chr[] = ')';
-        $ldap_replace_chr = array();
+        $ldap_replace_chr = [];
         $ldap_replace_chr[] = '\(';
         $ldap_replace_chr[] = '\)';
 

--- a/LibreNMS/Authentication/ActiveDirectoryAuthorizer.php
+++ b/LibreNMS/Authentication/ActiveDirectoryAuthorizer.php
@@ -119,10 +119,10 @@ class ActiveDirectoryAuthorizer extends AuthorizerBase
         $entries = ldap_get_entries($connection, $search);
 
         if ($entries['count']) {
-            return boolval(1);
+            return true;
         }
 
-        return boolval(0);
+        return false;
     }
 
     public function getUserlevel($username)

--- a/LibreNMS/Authentication/ActiveDirectoryAuthorizer.php
+++ b/LibreNMS/Authentication/ActiveDirectoryAuthorizer.php
@@ -91,8 +91,8 @@ class ActiveDirectoryAuthorizer extends AuthorizerBase
         }
 
         // special character handling
-        $ldap_find_chr[]  = "(";
-        $ldap_find_chr[]  = ")";
+        $ldap_find_chr[] = "(";
+        $ldap_find_chr[] = ")";
         $ldap_replace_chr[] = "\(";
         $ldap_replace_chr[] = "\)";
 

--- a/LibreNMS/Authentication/ActiveDirectoryAuthorizer.php
+++ b/LibreNMS/Authentication/ActiveDirectoryAuthorizer.php
@@ -74,7 +74,6 @@ class ActiveDirectoryAuthorizer extends AuthorizerBase
             ['cn']
         );
         $result = ldap_get_entries($connection, $search);
-
         if ($result == false || $result['count'] !== 1) {
             if (Config::get('auth_ad_debug', false)) {
                 if ($result == false) {
@@ -90,19 +89,7 @@ class ActiveDirectoryAuthorizer extends AuthorizerBase
             throw new AuthenticationException();
         }
 
-        $group_dn = $result[0]['dn'];
-
-        $search = ldap_search(
-            $connection,
-            Config::get('auth_ad_base_dn'),
-            // add 'LDAP_MATCHING_RULE_IN_CHAIN to the user filter to search for $username in nested $group_dn
-            // limiting to "DN" for shorter array
-            '(&' . $this->userFilter($username) . "(memberOf:1.2.840.113556.1.4.1941:=$group_dn))",
-            ['DN']
-        );
-        $entries = ldap_get_entries($connection, $search);
-
-        return $entries['count'] > 0;
+        return $result['count'] > 0;
     }
 
     public function userExists($username, $throw_exception = false)
@@ -226,7 +213,7 @@ class ActiveDirectoryAuthorizer extends AuthorizerBase
         ldap_set_option($this->ldap_connection, LDAP_OPT_NETWORK_TIMEOUT, -1); // restore timeout
 
         if ($bind_result) {
-            return;
+            return $bind_result;
         }
 
         ldap_set_option($this->ldap_connection, LDAP_OPT_NETWORK_TIMEOUT, Config::get('auth_ad_timeout', 5));

--- a/LibreNMS/Authentication/ActiveDirectoryAuthorizer.php
+++ b/LibreNMS/Authentication/ActiveDirectoryAuthorizer.php
@@ -91,15 +91,7 @@ class ActiveDirectoryAuthorizer extends AuthorizerBase
         }
 
         // special character handling
-        $ldap_find_chr = [];
-        $ldap_find_chr[] = '(';
-        $ldap_find_chr[] = ')';
-        $ldap_replace_chr = [];
-        $ldap_replace_chr[] = '\(';
-        $ldap_replace_chr[] = '\)';
-
-        // fix group_dn based on above character handling
-        $group_dn = str_replace($ldap_find_chr, $ldap_replace_chr, $result[0]['dn']);
+        $group_dn = addcslashes($result[0]['dn'], '()');
 
         $search = ldap_search(
             $connection,

--- a/LibreNMS/Authentication/ActiveDirectoryAuthorizer.php
+++ b/LibreNMS/Authentication/ActiveDirectoryAuthorizer.php
@@ -91,10 +91,10 @@ class ActiveDirectoryAuthorizer extends AuthorizerBase
         }
 
         // special character handling
-        $ldap_find_chr[] = "(";
-        $ldap_find_chr[] = ")";
-        $ldap_replace_chr[] = "\(";
-        $ldap_replace_chr[] = "\)";
+        $ldap_find_chr[] = '(';
+        $ldap_find_chr[] = ')';
+        $ldap_replace_chr[] = '\(';
+        $ldap_replace_chr[] = '\)';
 
         // fix group_dn based on above character handling
         $group_dn = str_replace($ldap_find_chr, $ldap_replace_chr, $result[0]['dn']);

--- a/LibreNMS/Authentication/ActiveDirectoryAuthorizer.php
+++ b/LibreNMS/Authentication/ActiveDirectoryAuthorizer.php
@@ -91,8 +91,10 @@ class ActiveDirectoryAuthorizer extends AuthorizerBase
         }
 
         // special character handling
+        $ldap_find_chr = array();
         $ldap_find_chr[] = '(';
         $ldap_find_chr[] = ')';
+        $ldap_replace_chr = array();
         $ldap_replace_chr[] = '\(';
         $ldap_replace_chr[] = '\)';
 
@@ -125,10 +127,10 @@ class ActiveDirectoryAuthorizer extends AuthorizerBase
         $entries = ldap_get_entries($connection, $search);
 
         if ($entries['count']) {
-            return 1;
+            return boolval(1);
         }
 
-        return 0;
+        return boolval(0);
     }
 
     public function getUserlevel($username)


### PR DESCRIPTION
Signed-off-by: Patrik Forsberg <paddy@paddyonline.net>

Please give a short description what your pull request is for

After having a few issues with authenticating users with our Active Directory I created these modifications and they seem to be working as intended.
In the function bind it returns the result from $bind_result to the requesting module if it is true - which returned "null" pre-patch making active directory bind fail.
In the function userInGroup a bit of code that seem obsolete has been cut away and return value is now derived from ldap_get_entries in the initial search - which seems to be doing what the obsolete code was doing and by doing it again it actually broke authentication.

Using PHP 7.3 and not 7.0 might have something to do with it.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
