### PR TITLE
Document flattened Inventory API function

### DIFF
--- a/doc/API/Inventory.md
+++ b/doc/API/Inventory.md
@@ -11,7 +11,8 @@ cage, then the sfp itself. The way this API call is designed is to
 enable a recursive lookup. The first call will retrieve the root
 entry, included within this response will be entPhysicalIndex, you can
 then call for entPhysicalContainedIn which will then return the next
-layer of results.
+layer of results.  To retrieve all items together, see 
+[get_inventory_for_device](#get_inventory_for_device).
 
 Route: `/api/v0/inventory/:hostname`
 
@@ -26,6 +27,55 @@ Input:
   inventory assigned to a previous component, for example specifying
   the chassis (entPhysicalIndex) will retrieve all items where the
   chassis is the parent.
+
+Example:
+
+```curl
+curl -H 'X-Auth-Token: YOURAPITOKENHERE' https://librenms.org/api/v0/inventory/localhost?entPhysicalContainedIn=65536
+```
+
+Output:
+
+```json
+{
+    "status": "ok",
+    "message": "",
+    "count": 1,
+    "inventory": [
+        {
+            "entPhysical_id": "2",
+            "device_id": "32",
+            "entPhysicalIndex": "262145",
+            "entPhysicalDescr": "Linux 3.3.5 ehci_hcd RB400 EHCI",
+            "entPhysicalClass": "unknown",
+            "entPhysicalName": "1:1",
+            "entPhysicalHardwareRev": "",
+            "entPhysicalFirmwareRev": "",
+            "entPhysicalSoftwareRev": "",
+            "entPhysicalAlias": "",
+            "entPhysicalAssetID": "",
+            "entPhysicalIsFRU": "false",
+            "entPhysicalModelName": "0x0002",
+            "entPhysicalVendorType": "zeroDotZero",
+            "entPhysicalSerialNum": "rb400_usb",
+            "entPhysicalContainedIn": "65536",
+            "entPhysicalParentRelPos": "-1",
+            "entPhysicalMfgName": "0x1d6b",
+            "ifIndex": "0"
+        }
+    ]
+}
+```
+
+### `get_inventory_for_device`
+
+Retrieve the flattened inventory for a device.  This retrieves all 
+inventory items for a device regardless of their structure, and may be 
+more useful for devices with with nested components.
+
+Route: `/api/v0/inventory/:hostname/all`
+
+- hostname can be either the device hostname or the device id
 
 Example:
 


### PR DESCRIPTION
Added documentation for existing API function to return the inventory in a flattened manner (no need to recursively call API to receive entire inventory).  No code changed.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
