### PR TITLE
Update OPNsense version Regex, for _ releases

### DIFF
--- a/includes/definitions/discovery/opnsense.yaml
+++ b/includes/definitions/discovery/opnsense.yaml
@@ -4,4 +4,4 @@ modules:
             - '/ (?<version>\d+\.\S+)/'
             - '/(?<hardware>\S+)$/'
         version: .1.3.6.1.4.1.8072.1.3.2.3.1.2.7.118.101.114.115.105.111.110
-        version_regex: '/(?<version>[\d.]+) \((?<hardware>[^)]+)\)/'
+        version_regex: '/(?<version>[\d._]+) \((?<hardware>[^)]+)\)/'


### PR DESCRIPTION
Update OPNsense version Regex, for when underscores are used in OPNsense release.

With the latest OPNsense release, they have added a underscore to the version, so the regex doesn't pickup the version currently

Before change it shows "1" after change it shows "20.7.7_1"
![image](https://user-images.githubusercontent.com/3495647/103232382-34ebe780-4932-11eb-8556-b6da3190a43e.png)


https://regex101.com/r/Rm7NkI/1

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
