### PR TITLE
Fix broken statement on auto discovery

### DIFF
--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -54,8 +54,8 @@ foreach ($cdp_array as $key => $cdp_if_array) {
         $remote_device_id = find_device_id($cdp['cdpCacheDeviceId'], $cdp_ip);
 
         if (! $remote_device_id &&
-            ! can_skip_discovery($cdp['cdpCacheDeviceId'], $cdp['cdpCacheVersion'], $cdp['cdpCachePlatform'] &&
-            Config::get('autodiscovery.xdp') === true)
+            ! can_skip_discovery($cdp['cdpCacheDeviceId'], $cdp['cdpCacheVersion'], $cdp['cdpCachePlatform']) &&
+            Config::get('autodiscovery.xdp') === true
         ) {
             $remote_device_id = discover_new_device($cdp['cdpCacheDeviceId'], $device, 'CDP', $interface);
 


### PR DESCRIPTION
My Cisco IP phones were still being auto discovered even when i had autodiscovery.xdp set to false, and it wasn't ignoring them for the auto discovery regex either. This statement had some misplaced Parenthesis. Working now on my install with this fix.

Basically this statement would never run False for me, now it does. 

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
