### PR TITLE
Rrdcached SNMP: Add poller feature for RRDCached SNMP to query remote agent.

### DIFF
--- a/doc/Extensions/Applications.md
+++ b/doc/Extensions/Applications.md
@@ -128,6 +128,7 @@ by following the steps under the `SNMP Extend` heading.
 1. [PureFTPd](#pureftpd) - SNMP extend
 1. [Raspberry PI](#raspberry-pi) - SNMP extend
 1. [Redis](#redis) - SNMP extend
+1. [RRDCached](#rrdcached) - SNMP extend
 1. [SDFS info](#sdfs-info) - SNMP extend
 1. [Seafile](#seafile) - SNMP extend
 1. [SMART](#smart) - SNMP extend
@@ -1649,6 +1650,24 @@ SNMP extend script to monitor your Redis Server
 
 ```
 extend redis /etc/snmp/redis.py
+```
+
+# RRDCached
+
+SNMP extend script to monitor your RRDCached via snmp
+
+## SNMP Extend
+
+1: Download the script onto the desired host. `wget
+   https://raw.githubusercontent.com/librenms/librenms-agent/master/snmp/rrdcached
+   -O /etc/snmp/rrdcached`
+
+2: Make the script executable: `chmod +x /etc/snmp/rrdcached`
+
+3: Edit your snmpd.conf file (usually `/etc/snmp/snmpd.conf`) and add:
+
+```
+extend rrdcached /etc/snmp/rrdcached
 ```
 
 # Seafile

--- a/doc/Extensions/Applications.md
+++ b/doc/Extensions/Applications.md
@@ -1657,10 +1657,10 @@ extend redis /etc/snmp/redis.py
 Install/Setup:
 For Install/Setup Local Librenms RRDCached: Please see [RRDCached](RRDCached.md)
 
-Capable of collecting stats via:
-1: Local unix socket specified by rrdcached config setting
-1: Local or remote connection to port 42217 specified by rrdcached config setting
-2: Monitor thru snmp with Snmp Extend:
+Will collect stats by:
+1: Connecting directly to the associated device on port 42217
+2: Monitor thru snmp with SNMP extend, as outlined below
+3: Connecting to the rrdcached server specified by the `rrdcached` setting
 
 SNMP extend script to monitor your (remote) RRDCached via snmp
 

--- a/doc/Extensions/Applications.md
+++ b/doc/Extensions/Applications.md
@@ -1658,12 +1658,6 @@ Install/Setup:
 For Install/Setup Local Librenms RRDCached: Please see [RRDCached](RRDCached.md)
 Securing RRCached: Please see [RRDCached Security](RRDCached-Security.md)
 
-Local Polling:
-For local Polling the 'RRDCached' Application (librenms-localhost) the usual is either to:
-
-1: Use unix:socket as described: [RRDCached](RRDCached.md)
-2: or Monitor thru port listen 42217 as described: [RRDCached Security](RRDCached-Security.md)
-
 For Remote Polling the 'RRDCached' Application, you have two options:
 
 1: Monitor thru exposing rrdcached port, listen 42217 as described: [RRDCached Security](RRDCached-Security.md)

--- a/doc/Extensions/Applications.md
+++ b/doc/Extensions/Applications.md
@@ -1658,16 +1658,16 @@ Install/Setup:
 For Install/Setup Local Librenms RRDCached: Please see [RRDCached](RRDCached.md)
 Securing RRCached: Please see [RRDCached Security](RRDCached-Security.md)
 
-Polling:
+Local Polling:
 For local Polling the 'RRDCached' Application (librenms-localhost) the usual is either to:
 
-1. Use unix:socket as described: [RRDCached](RRDCached.md)
-2. or Monitor thru port listen 42217 as described: [RRDCached Security](RRDCached-Security.md)
+1: Use unix:socket as described: [RRDCached](RRDCached.md)
+2: or Monitor thru port listen 42217 as described: [RRDCached Security](RRDCached-Security.md)
 
-For remote Polling the 'RRDCached' Application, you have two options:
+For Remote Polling the 'RRDCached' Application, you have two options:
 
-1. Monitor thru exposing rrdcached port, listen 42217 as described: [RRDCached Security](RRDCached-Security.md)
-2. Monitor thru snmp with Snmp Extend as described, here:
+1: Monitor thru exposing rrdcached port, listen 42217 as described: [RRDCached Security](RRDCached-Security.md)
+2: Monitor thru snmp with Snmp Extend as described, here:
 
 SNMP extend script to monitor your (remote) RRDCached via snmp
 

--- a/doc/Extensions/Applications.md
+++ b/doc/Extensions/Applications.md
@@ -1654,7 +1654,22 @@ extend redis /etc/snmp/redis.py
 
 # RRDCached
 
-SNMP extend script to monitor your RRDCached via snmp
+Install/Setup:
+For Install/Setup Local Librenms RRDCached: Please see [RRDCached](RRDCached.md)
+Securing RRCached: Please see [RRDCached Security](RRDCached-Security.md)
+
+Polling:
+For local Polling the 'RRDCached' Application (librenms-localhost) the usual is either to:
+
+1. Use unix:socket;
+2. or Monitor thru port listen 42217 as described: [RRDCached Security](RRDCached-Security.md)
+
+For remote Polling the 'RRDCached' Application, you have two options:
+
+1. Monitor thru exposing rrdcached port, listen 42217 as described: [RRDCached Security](RRDCached-Security.md)
+2. Monitor thru snmp with Snmp Extend as described, here:
+
+SNMP extend script to monitor your (remote) RRDCached via snmp
 
 ## SNMP Extend
 

--- a/doc/Extensions/Applications.md
+++ b/doc/Extensions/Applications.md
@@ -1656,12 +1656,11 @@ extend redis /etc/snmp/redis.py
 
 Install/Setup:
 For Install/Setup Local Librenms RRDCached: Please see [RRDCached](RRDCached.md)
-Securing RRCached: Please see [RRDCached Security](RRDCached-Security.md)
 
-For Remote Polling the 'RRDCached' Application, you have two options:
-
-1: Monitor thru exposing rrdcached port, listen 42217 as described: [RRDCached Security](RRDCached-Security.md)
-2: Monitor thru snmp with Snmp Extend as described, here:
+Capable of collecting stats via:
+1: Local unix socket specified by rrdcached config setting
+1: Local or remote connection to port 42217 specified by rrdcached config setting
+2: Monitor thru snmp with Snmp Extend:
 
 SNMP extend script to monitor your (remote) RRDCached via snmp
 

--- a/doc/Extensions/Applications.md
+++ b/doc/Extensions/Applications.md
@@ -1661,7 +1661,7 @@ Securing RRCached: Please see [RRDCached Security](RRDCached-Security.md)
 Polling:
 For local Polling the 'RRDCached' Application (librenms-localhost) the usual is either to:
 
-1. Use unix:socket;
+1. Use unix:socket as described: [RRDCached](RRDCached.md)
 2. or Monitor thru port listen 42217 as described: [RRDCached Security](RRDCached-Security.md)
 
 For remote Polling the 'RRDCached' Application, you have two options:

--- a/includes/polling/applications/rrdcached.inc.php
+++ b/includes/polling/applications/rrdcached.inc.php
@@ -40,6 +40,13 @@ if ($agent_data['app'][$name]) {
     $sock = fsockopen($device['hostname'], 42217, $errno, $errstr, 5);
 
     if (! $sock) {
+        d_echo("\nNo Socket to rrdcached server " . $device['hostname'] . ":42217 try to get rrdcached from SNMP\n");
+        $oid = '.1.3.6.1.4.1.8072.1.3.2.3.1.2.9.114.114.100.99.97.99.104.101.100';
+        $result = snmp_get($device, $oid, '-Oqv');
+        $data = trim($result, '"');
+        $data = str_replace("<<<rrdcached>>>\n", '', $data);
+    }
+    if (strlen($data) < 100) {
         $socket = \LibreNMS\Config::get('rrdcached');
         if (substr($socket, 0, 6) == 'unix:/') {
             $socket_file = substr($socket, 5);
@@ -47,6 +54,7 @@ if ($agent_data['app'][$name]) {
                 $sock = fsockopen('unix://' . $socket_file);
             }
         }
+        d_echo("\nNo SnmpData " . $device['hostname'] . ' fallback to local rrdcached unix://' . $socket_file . "\n");
     }
     if ($sock) {
         fwrite($sock, "STATS\n");
@@ -61,7 +69,7 @@ if ($agent_data['app'][$name]) {
             $count++;
         }
         fclose($sock);
-    } else {
+    } elseif (strlen($data) < 100) {
         d_echo("ERROR: $errno - $errstr\n");
     }
 }


### PR DESCRIPTION
Add poller feature for RRDCached SNMP to query remote agent instead of falling back to local unix socket if no connection to agent:42217/tcp is availlable. 
Documentation update is needed to include rrdcached extend snmp agent similar to memcached extend.
Today rrdcached fallback to local unix socket if remote agent is not availlable in port 42217, and in this case, we should try to fetch stats info from SNMP, similar to how memcached works.

       modified:   includes/polling/applications/rrdcached.inc.php

Documentation Update included.