### PR TITLE
Enable secure cookies

### DIFF
--- a/config/session.php
+++ b/config/session.php
@@ -174,7 +174,7 @@ return [
     |
     */
 
-    'secure' => env('SESSION_SECURE_COOKIE'),
+    'secure' => env('SESSION_SECURE_COOKIE', true),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
Security analyzers (for example Greenbone) report an issue with LibreNMS:

```
SSL/TLS: Missing `secure` Cookie Attribute:
The host is running a server with SSL/TLS and is prone to information
disclosure vulnerability.
```

This PR attempts to address this issue.

Without this change:
![librenms_secure_cookie_off](https://user-images.githubusercontent.com/414984/104693634-4bec5100-570a-11eb-83c8-39b686a67baf.png)

With this change:
![librenms_secure_cookie_on](https://user-images.githubusercontent.com/414984/104693645-4ee74180-570a-11eb-8959-4261fdfa236a.png)


