### PR TITLE
Schleifenbauer: enumerate sensors under the Outlet for the entity-physical inventory

### DIFF
--- a/includes/discovery/entity-physical/schleifenbauer.inc.php
+++ b/includes/discovery/entity-physical/schleifenbauer.inc.php
@@ -95,6 +95,13 @@ foreach ($sdbMgmtCtrlDevUnitAddressArray as $sdbMgmtCtrlDevUnitAddress => $sdbDe
                 $entPhysicalName = 'Outlet #' . $sdbDevOutIndex;
 
                 discover_entity_physical($valid, $device, $outletIndex, 'PDU outlet', 'powerSupply', $entPhysicalName, null, null, $outletBackplaneIndex, 'Schleifenbauer Products B.V.', $sdbDevOutIndex, null, null, null, null, 'false', $sdbDevOutName, null, null);
+
+                // Enumerate sensors under the Outlet
+                discover_entity_physical($valid, $device, $outletIndex + 110, $entPhysicalName . ' voltage sensor (V)', 'sensor', 'Voltage Sensor', null, null, $outletIndex, 'Schleifenbauer Products B.V.', 1, null, null, null, null, 'false', null, null, null);
+                discover_entity_physical($valid, $device, $outletIndex + 120, $entPhysicalName . ' RMS current sensor (A)', 'sensor', 'Current Sensor', null, null, $outletIndex, 'Schleifenbauer Products B.V.', 2, null, null, null, null, 'false', null, null, null);
+                discover_entity_physical($valid, $device, $outletIndex + 130, $entPhysicalName . ' apparent power sensor (W)', 'sensor', 'Power Sensor', null, null, $outletIndex, 'Schleifenbauer Products B.V.', 3, null, null, null, null, 'false', null, null, null);
+                discover_entity_physical($valid, $device, $outletIndex + 140, $entPhysicalName . ' lifetime power consumed sensor (kWh)', 'sensor', 'Power Consumed Sensor', null, null, $outletIndex, 'Schleifenbauer Products B.V.', 4, null, null, null, null, 'false', null, null, null);
+                discover_entity_physical($valid, $device, $outletIndex + 150, $entPhysicalName . ' power factor sensor (ratio)', 'sensor', 'Power Factor Sensor', null, null, $outletIndex, 'Schleifenbauer Products B.V.', 5, null, null, null, null, 'false', null, null, null);
             } // end Outlet discovery foreach sdbDevOutNameArray
         } // end of Outlet Backplane detection
     }


### PR DESCRIPTION
In PR #10949 it seems that support for monitoring outlet sensors was added, but the code in `includes/discovery/entity-physical/schleifenbauer.inc.php` to detect the relevant sensors in the entity-physical discovery was missed - this PR resolves that.

There were no changes to the actual sensor discovery by the way, because the calculated `$entPhysicalIndex` values were already present there - as such, the test results haven't changed.


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 12439`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
