### PR TITLE
Improving readability and layout of dark theme dashboards

### DIFF
--- a/html/css/dark.css
+++ b/html/css/dark.css
@@ -7183,6 +7183,7 @@
   .device-overview>.panel-body>.row:nth-child(odd) { background-color: #4f565d; }
   .device-overview>.panel-body>.row:hover {background-color: #686d73;}
   .gridster .gs-w{
+    color: var(--color-light2);
   	background: #353a41;
   }
   a.list-device{
@@ -7210,4 +7211,7 @@
   }
   .vis-legend-text {
     color: black;
+  }
+  .widget_body {
+    overflow-x: hidden;
   }


### PR DESCRIPTION
- lighten the text color in widget tables such as syslog or eventlog (it was black on grey)

before | after
--- | ---
![image](https://user-images.githubusercontent.com/10722552/105480727-655f4100-5ca6-11eb-926a-8ebbac2bce78.png) | ![image](https://user-images.githubusercontent.com/10722552/105480741-698b5e80-5ca6-11eb-8495-6e07291ebe68.png)

- remove the useless horizontal scroll bars for widgets alert history and alert history stats (always displayed and scrolls only few pixels)

order | image
--- | ---
before | ![image](https://user-images.githubusercontent.com/10722552/105481182-ffbf8480-5ca6-11eb-901d-b0435be9563d.png)
after | ![image](https://user-images.githubusercontent.com/10722552/105481204-064dfc00-5ca7-11eb-9167-453ad36a1ee6.png)

The screenshots are from the additional custom css "kibanafeel" but **tested as well the with default dark theme**.
I tested the changes on the latest firefox and chrome browsers.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
