### PR TITLE
Improving readability of tables on dark theme dashboards

### DIFF
--- a/html/css/dark.css
+++ b/html/css/dark.css
@@ -7183,7 +7183,8 @@
   .device-overview>.panel-body>.row:nth-child(odd) { background-color: #4f565d; }
   .device-overview>.panel-body>.row:hover {background-color: #686d73;}
   .gridster .gs-w{
-  	background: #353a41;
+    color: var(--color-light2);
+    background: #353a41;
   }
   a.list-device{
     color: #acb6bf;


### PR DESCRIPTION
lighten the text color in widget tables such as syslog or eventlog (it was black on grey)

before | after
--- | ---
![image](https://user-images.githubusercontent.com/10722552/105480727-655f4100-5ca6-11eb-926a-8ebbac2bce78.png) | ![image](https://user-images.githubusercontent.com/10722552/105480741-698b5e80-5ca6-11eb-8495-6e07291ebe68.png)

The screenshots are from the additional custom css "kibanafeel" but **tested as well with the default dark theme**.
Changes tested on the latest firefox and chrome browsers.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
