### PR TITLE
Hide horizontal scrollbars for widget bodys

### DIFF
--- a/html/css/styles.css
+++ b/html/css/styles.css
@@ -1962,6 +1962,7 @@ label {
 .widget_body {
     padding: 0.8em;
     overflow-y: auto;
+    overflow-x: hidden;
     width: 100%;
     height: calc(100% - 38px);
     cursor: auto;


### PR DESCRIPTION
Due to margin errors in widget content it was possible that the horizontal scroll bar got visible although the width is set to 100% (e.g. Alert widgets #12454).

order | image
--- | ---
before | ![image](https://user-images.githubusercontent.com/10722552/105481182-ffbf8480-5ca6-11eb-901d-b0435be9563d.png)
after | ![image](https://user-images.githubusercontent.com/10722552/105481204-064dfc00-5ca7-11eb-9167-453ad36a1ee6.png)

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
