### PR TITLE
Reintroduce word wrapping to the custom login message

### DIFF
--- a/resources/views/auth/login-form.blade.php
+++ b/resources/views/auth/login-form.blade.php
@@ -5,7 +5,7 @@
 
     @config('login_message')
     <x-slot name="footer">
-        <pre style="font-family: Helvetica Neue, Helvetica, Arial, sans-serif;border: 0;padding: 0;font-weight: bold;">{{ \LibreNMS\Config::get('login_message') }}</pre>
+        <div style="font-family: Helvetica Neue, Helvetica, Arial, sans-serif;border: 0;padding: 0;font-weight: bold;">{{ \LibreNMS\Config::get('login_message') }}</div>
     </x-slot>
     @endconfig
 


### PR DESCRIPTION
The \<pre\> tag breaks the well formed output of the login messages by introducing scrollbars and wrong background color. Later is most noticeable in the dark theme.

before | after
--- | ---
![grafik](https://user-images.githubusercontent.com/10722552/105613777-0e9c5900-5dc5-11eb-92dd-ae0a44fb3ff8.png) | ![grafik](https://user-images.githubusercontent.com/10722552/105613785-1e1ba200-5dc5-11eb-83de-9627d7f79fd8.png)
![grafik](https://user-images.githubusercontent.com/10722552/105613809-3a1f4380-5dc5-11eb-920d-6786a41d2f75.png) | ![grafik](https://user-images.githubusercontent.com/10722552/105613846-5d49f300-5dc5-11eb-9be1-311a24cff6c2.png)

Just by using div instead of pre fixes the output.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
