### PR TITLE
Remove unnecessary horizontal scroll bars in allert widgets

### DIFF
--- a/html/css/styles.css
+++ b/html/css/styles.css
@@ -1962,6 +1962,7 @@ label {
 .widget_body {
     padding: 0.8em;
     overflow-y: auto;
+    overflow-x: hidden;
     width: 100%;
     height: calc(100% - 38px);
     cursor: auto;

--- a/resources/views/widgets/alertlog.blade.php
+++ b/resources/views/widgets/alertlog.blade.php
@@ -1,8 +1,3 @@
-<div class="row">
-    <div class="col-sm-12">
-        <span id="message"></span>
-    </div>
-</div>
 <div class="table-responsive">
     <table id="alertlog_{{ $id }}" class="table table-hover table-condensed alerts">
         <thead>

--- a/resources/views/widgets/alertlog_stats.blade.php
+++ b/resources/views/widgets/alertlog_stats.blade.php
@@ -1,8 +1,3 @@
-<div class="row">
-    <div class="col-sm-12">
-        <span id="message"></span>
-    </div>
-</div>
 <div class="table-responsive">
     <table id="alertlog-stats_{{ $id }}" class="table table-hover table-condensed table-striped">
         <thead>

--- a/resources/views/widgets/alerts.blade.php
+++ b/resources/views/widgets/alerts.blade.php
@@ -1,8 +1,3 @@
-<div class="row">
-    <div class="col-sm-12">
-        <span id="message"></span>
-    </div>
-</div>
 <div class="table-responsive">
     <table id="alerts_{{ $id }}" class="table table-hover table-condensed alerts">
         <thead>


### PR DESCRIPTION
* First unnecessary \<div\> in the widget bodies extends the content out of the available space with incorrect margins. This makes the PR #12459 obsolete which I will close:

order | image
--- | ---
before | ![image](https://user-images.githubusercontent.com/10722552/105481182-ffbf8480-5ca6-11eb-901d-b0435be9563d.png)
after | ![image](https://user-images.githubusercontent.com/10722552/105481204-064dfc00-5ca7-11eb-9167-453ad36a1ee6.png)

* Hiding horizontal scroll bars in general as requested by @murrant (https://github.com/librenms/librenms/pull/12455#issuecomment-765876037)

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
