### PR TITLE
Support new lines in login_message again

### DIFF
--- a/html/css/styles.css
+++ b/html/css/styles.css
@@ -2383,3 +2383,7 @@ label {
 #manage-device-groups-table > thead > tr > th:last-child {
     min-width: 7%;
 }
+
+.logon-message {
+    white-space: pre-wrap;
+}

--- a/resources/views/auth/login-form.blade.php
+++ b/resources/views/auth/login-form.blade.php
@@ -5,7 +5,7 @@
 
     @config('login_message')
     <x-slot name="footer">
-        <div style="font-family: Helvetica Neue, Helvetica, Arial, sans-serif;border: 0;padding: 0;font-weight: bold;">{{ \LibreNMS\Config::get('login_message') }}</div>
+        <div class="logon-message">{{ \LibreNMS\Config::get('login_message') }}</div>
     </x-slot>
     @endconfig
 


### PR DESCRIPTION
* Introducing own css class `logon-message` for customization; Removing previous styles since this is the only text and thus recognizable enough.
* Fix problem introduced with #12460

## Context
New lines can be set in the configuration config.php:
```
$config['login_message']    = "Unauthorised access or use 
shall render the user liable to 
criminal and/or civil prosecution.
Last very long line with random content to trigger the horizontal scrollbar appearing also with wrong background";
```
![image](https://user-images.githubusercontent.com/10722552/105974438-3245f480-608e-11eb-8656-15cf485385be.png)

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
