### PR TITLE
API: Allow logs to be filtered by min/max id

### DIFF
--- a/doc/API/Logs.md
+++ b/doc/API/Logs.md
@@ -12,7 +12,7 @@ Input:
 - start: The page number to request.
 - limit: The limit of results to be returned.
 - from: The date and time or the event id to search from.
-- to: The data and time or th event id to search to.
+- to: The data and time or the event id to search to.
 
 ### `list_eventlog`
 

--- a/doc/API/Logs.md
+++ b/doc/API/Logs.md
@@ -11,8 +11,8 @@ Input:
 
 - start: The page number to request.
 - limit: The limit of results to be returned.
-- from: The date and time to search from.
-- to: The data and time to search to.
+- from: The date and time or the event id to search from.
+- to: The data and time or th event id to search to.
 
 ### `list_eventlog`
 

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -2235,18 +2235,22 @@ function list_logs(Illuminate\Http\Request $request, Router $router)
         $query = ' FROM eventlog LEFT JOIN `devices` ON `eventlog`.`device_id`=`devices`.`device_id` WHERE 1';
         $full_query = 'SELECT `devices`.`hostname`, `devices`.`sysName`, `eventlog`.`device_id` as `host`, `eventlog`.*'; // inject host for backward compat
         $timestamp = 'datetime';
+        $id_field = 'event_id';
     } elseif ($type === 'list_syslog') {
         $query = ' FROM syslog LEFT JOIN `devices` ON `syslog`.`device_id`=`devices`.`device_id` WHERE 1';
         $full_query = 'SELECT `devices`.`hostname`, `devices`.`sysName`, `syslog`.*';
         $timestamp = 'timestamp';
+        $id_field = 'seq';
     } elseif ($type === 'list_alertlog') {
         $query = ' FROM alert_log LEFT JOIN `devices` ON `alert_log`.`device_id`=`devices`.`device_id` WHERE 1';
         $full_query = 'SELECT `devices`.`hostname`, `devices`.`sysName`, `alert_log`.*';
         $timestamp = 'time_logged';
+        $id_field = 'id';
     } elseif ($type === 'list_authlog') {
         $query = ' FROM authlog WHERE 1';
         $full_query = 'SELECT `authlog`.*';
         $timestamp = 'datetime';
+        $id_field = 'id';
     } else {
         $query = ' FROM eventlog LEFT JOIN `devices` ON `eventlog`.`device_id`=`devices`.`device_id` WHERE 1';
         $full_query = 'SELECT `devices`.`hostname`, `devices`.`sysName`, `eventlog`.*';
@@ -2264,12 +2268,20 @@ function list_logs(Illuminate\Http\Request $request, Router $router)
     }
 
     if ($from) {
-        $query .= " AND $timestamp >= ?";
+        if (is_numeric($from)) {
+            $query .= " AND $id_field >= ?";
+        } else {
+            $query .= " AND $timestamp >= ?";
+        }
         $param[] = $from;
     }
 
     if ($to) {
-        $query .= " AND $timestamp <= ?";
+        if (is_numeric($to)) {
+            $query .= " AND $id_field <= ?";
+        } else {
+            $query .= " AND $timestamp <= ?";
+        }
         $param[] = $to;
     }
 


### PR DESCRIPTION
Allow the from/to parameters on the various logs API endpoints to be used to filter by id (get all the logs after/before this event id) instead of datetimes

(I did not tested it yet, I am building my dev environment to do so, this may take some time so feel free to take a look if it looks okay)

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
