### PR TITLE
Fixes incorrect device overlay graph type for poweralert 12 devices

### DIFF
--- a/includes/definitions/poweralert.yaml
+++ b/includes/definitions/poweralert.yaml
@@ -3,8 +3,8 @@ text: 'Tripp Lite PowerAlert'
 type: power
 over:
     - { graph: device_current, text: Current }
-    - { graph: sensor_power, text: Power }
-    - { graph: sensor_load, text: Load}
+    - { graph: device_power, text: Power }
+    - { graph: device_load, text: Load}
 icon: tripplite
 rfc1628_compat: true
 mib_dir: poweralert


### PR DESCRIPTION
I introduced a small bug in the device overlay graphs, which were added in #12445.

Here is an example of what they look like before the fix: 
![Screen Shot 2021-02-02 at 10 29 17 AM](https://user-images.githubusercontent.com/11429076/106630579-914db280-6541-11eb-9f5f-3a041de80bd8.png)



DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
