### PR TITLE
Correct check for SNMPv3 SHA-192/256 compability

### DIFF
--- a/doc/Support/FAQ.md
+++ b/doc/Support/FAQ.md
@@ -66,7 +66,7 @@ You have two options for adding a new device into LibreNMS.
    to the directory of your LibreNMS install and typing (be sure to
    put the correct details).
 
-```ssh
+```bash
 ./addhost.php [community] [v1|v2c] [port] [udp|udp6|tcp|tcp6]
 ```
 
@@ -318,7 +318,7 @@ architecture then the following steps should be all that's needed:
 - and import it into your new server (`mysql -u root -p librenms < librenms.sql`).
 - Copy the `rrd/` folder to the new server.
 - Copy the `.env` and `config.php` files to the new server.
-- Check for modified files (eg specific os, ...) with `git status` and 
+- Check for modified files (eg specific os, ...) with `git status` and
   migrate them.
 - Ensure ownership of the copied files and folders (substitute your
   user if necessary) - `chown -R librenms:librenms /opt/librenms`
@@ -369,7 +369,7 @@ adding to /etc/snmp/snmpd.conf :
 ## <a name="faq28"> What does mean \"ignore alert tag\" on device, component, service and port?</a>
 
 Tag device, component, service and port to ignore alerts. Alert checks will still run.
-However, ignore tag can be read in alert rules. For example on device, if `devices.ignore = 0` 
+However, ignore tag can be read in alert rules. For example on device, if `devices.ignore = 0`
 or `macros.device = 1` condition is is set and ignore alert tag is on,
 the alert rule won't match. The alert rule is ignored.
 
@@ -601,17 +601,17 @@ To view a prediction:
 You should now see a linear prediction line on the graph.
 ## <a name='move-db-to-another-server'>How do I move only the DB to another server?</a>
 
-There is already a reference how to move your whole LNMS installation to another server. But the following steps will help you to split up an "All-in-one" installation to one LibreNMS installation with a separate database install. 
+There is already a reference how to move your whole LNMS installation to another server. But the following steps will help you to split up an "All-in-one" installation to one LibreNMS installation with a separate database install.
 *Note: This section assumes you have a MySQL/MariaDB instance
 
 - Stop the apache and mysql service in you LibreNMS installation.
-- Edit out all the cron entries in `/etc/cron.d/librenms`. 
+- Edit out all the cron entries in `/etc/cron.d/librenms`.
 - Dump your `librenms`database on your current install by issuing `mysqldump librenms -u root -p > librenms.sql`.
 - Stop and disable the MySQL server on your current install.
 - On your new server make sure you create a new database with the standard install command, no need to add a user for localhost though.
 - Copy this over to your new database server and import it with `mysql -u root -p librenms < librenms.sql`.
 - Enter to mysql and add permissions with the following two commands:
-```
+```sql
 GRANT ALL PRIVILEGES ON librenms.* TO 'librenms'@'IP_OF_YOUR_LNMS_SERVER' IDENTIFIED BY 'PASSWORD' WITH GRANT OPTION;
 GRANT ALL PRIVILEGES ON librenms.* TO 'librenms'@'FQDN_OF_YOUR_LNMS_SERVER' IDENTIFIED BY 'PASSWORD' WITH GRANT OPTION;
 FLUSH PRIVILEGES;
@@ -619,7 +619,8 @@ exit;
 ```
 - Enable and restart MySQL server.
 - Edit your `config.php` file to point the install to the new database server location.
-- **Very important**: On your LibreNMS server, inside your install directory is a `.env` file, in it you need to edit the `DBHOST` paramater to point to your new server location. 
+- **Very important**: On your LibreNMS server, inside your install directory is a `.env` file, in it you need to edit the `DBHOST` paramater to point to your new server location.
 - After all this is done, enable all the cron entries again and start apache.
 ## <a name='optional-requirements-for-snmpv3-sha2-auth'>What are the "optional requirements message" when I add SNMPv3 devices?</a>
-When you add a device via the WebUI you may see a little message stating "Optional requirements are not met so some options are disabled". Do not panic. This simply means your system does not contain **openssl >= 1.1** and **net-snmp >= 5.8**, which are the minimum specifications needed to be able to use AES-192,AES-256 as crypto algorithms and SHA-224|256|384|512 as auth algorithms. 
+When you add a device via the WebUI you may see a little message stating "Optional requirements are not met so some options are disabled". Do not panic. This simply means your system does not contain **openssl >= 1.1** and **net-snmp >= 5.8**, which are the minimum specifications needed to be able to use SHA-224|256|384|512 as auth algorithms.
+For crypto algorithms AES-192, AES-256 you need **net-snmp** compiled with `--enable-blumenthal-aes`.

--- a/includes/common.php
+++ b/includes/common.php
@@ -799,27 +799,20 @@ function version_info($remote = false)
 }//end version_info()
 
 /**
- * checks if System is SNMPv3 SHA2 Capable for Auth Algorithms (SHA-224,SHA-256,SHA-384,SHA-512)
- * @return bool
+ * Checks SNMPv3 capabilities
+ *
+ * SHA2 for Auth Algorithms (SHA-224,SHA-256,SHA-384,SHA-512)
+ * AES-192, AES-256 for Privacy Algorithms
  */
-function snmpv3_sha2_capable()
+function snmpv3_capabilities(): array
 {
     $process = new Process([Config::get('snmpget', 'snmpget'), '--help']);
     $process->run();
 
-    return Str::contains($process->getErrorOutput(), 'SHA-512');
-}
+    $ret['sha2'] = Str::contains($process->getErrorOutput(), 'SHA-512');
+    $ret['aes256'] = Str::contains($process->getErrorOutput(), 'AES-256');
 
-/**
- * Checks if system is SNMPv3 AES-192/256 capable for Privacy Algorithms
- * @return bool
- */
-function snmpv3_aes_strong_capable()
-{
-    $process = new Process([Config::get('snmpget', 'snmpget'), '--help']);
-    $process->run();
-
-    return Str::contains($process->getErrorOutput(), 'AES-256');
+    return $ret;
 }
 
 /**

--- a/includes/common.php
+++ b/includes/common.php
@@ -811,6 +811,18 @@ function snmpv3_sha2_capable()
 }
 
 /**
+ * Checks if system is SNMPv3 AES-192/256 capable for Privacy Algorithms
+ * @return bool
+ */
+function snmpv3_aes_strong_capable()
+{
+    $process = new Process([Config::get('snmpget', 'snmpget'), '--help']);
+    $process->run();
+
+    return Str::contains($process->getErrorOutput(), 'AES-256');
+}
+
+/**
  * Convert a MySQL binary v4 (4-byte) or v6 (16-byte) IP address to a printable string.
  * @param string $ip A binary string containing an IP address, as returned from MySQL's INET6_ATON function
  * @return string Empty if not valid.

--- a/includes/html/pages/addhost.inc.php
+++ b/includes/html/pages/addhost.inc.php
@@ -190,8 +190,7 @@ foreach (get_port_assoc_modes() as $mode) {
     echo "              <option value=\"$mode\" $selected>$mode</option>\n";
 }
 
-$snmpv3_sha2_capable = snmpv3_sha2_capable();
-$snmpv3_aes_strong_capable = snmpv3_aes_strong_capable();
+list('sha2' => $snmpv3_sha2, 'aes256' => $snmpv3_aes256) = snmpv3_capabilities();
 ?>
             </select>
           </div>
@@ -243,12 +242,12 @@ $snmpv3_aes_strong_capable = snmpv3_aes_strong_capable();
               <select name="authalgo" id="authalgo" class="form-control input-sm">
                 <option value="MD5" selected>MD5</option>
                 <option value="SHA">SHA</option>
-                <option value="SHA-224"<?= $snmpv3_sha2_capable ?: ' disabled'?>>SHA-224</option>
-                <option value="SHA-256"<?= $snmpv3_sha2_capable ?: ' disabled'?>>SHA-256</option>
-                <option value="SHA-384"<?= $snmpv3_sha2_capable ?: ' disabled'?>>SHA-384</option>
-                <option value="SHA-512"<?= $snmpv3_sha2_capable ?: ' disabled'?>>SHA-512</option>
+                <option value="SHA-224"<?= $snmpv3_sha2 ?: ' disabled'?>>SHA-224</option>
+                <option value="SHA-256"<?= $snmpv3_sha2 ?: ' disabled'?>>SHA-256</option>
+                <option value="SHA-384"<?= $snmpv3_sha2 ?: ' disabled'?>>SHA-384</option>
+                <option value="SHA-512"<?= $snmpv3_sha2 ?: ' disabled'?>>SHA-512</option>
               </select>
-              <?php if (! $snmpv3_sha2_capable) {?>
+              <?php if (! $snmpv3_sha2) {?>
               <label class="text-left"><small>Some options are disabled. <a href="https://docs.librenms.org/Support/FAQ/#optional-requirements-for-snmpv3-sha2-auth">Read more here</a></small></label>
               <?php } ?>
             </div>
@@ -264,11 +263,11 @@ $snmpv3_aes_strong_capable = snmpv3_aes_strong_capable();
             <div class="col-sm-9">
               <select name="cryptoalgo" id="cryptoalgo" class="form-control input-sm">
                 <option value="AES" selected>AES</option>
-                <option value="AES-192"<?= $snmpv3_aes_strong_capable ?: ' disabled'?>>AES-192</option>
-                <option value="AES-256"<?= $snmpv3_aes_strong_capable ?: ' disabled'?>>AES-256</option>
+                <option value="AES-192"<?= $snmpv3_aes256 ?: ' disabled'?>>AES-192</option>
+                <option value="AES-256"<?= $snmpv3_aes256 ?: ' disabled'?>>AES-256</option>
                 <option value="DES">DES</option>
               </select>
-              <?php if (! $snmpv3_aes_strong_capable) {?>
+              <?php if (! $snmpv3_aes256) {?>
               <label class="text-left"><small>Some options are disabled. <a href="https://docs.librenms.org/Support/FAQ/#optional-requirements-for-snmpv3-sha2-auth">Read more here</a></small></label>
               <?php } ?>
             </div>

--- a/includes/html/pages/addhost.inc.php
+++ b/includes/html/pages/addhost.inc.php
@@ -190,7 +190,7 @@ foreach (get_port_assoc_modes() as $mode) {
     echo "              <option value=\"$mode\" $selected>$mode</option>\n";
 }
 
-list('sha2' => $snmpv3_sha2, 'aes256' => $snmpv3_aes256) = snmpv3_capabilities();
+['sha2' => $snmpv3_sha2, 'aes256' => $snmpv3_aes256] = snmpv3_capabilities();
 ?>
             </select>
           </div>

--- a/includes/html/pages/addhost.inc.php
+++ b/includes/html/pages/addhost.inc.php
@@ -191,6 +191,7 @@ foreach (get_port_assoc_modes() as $mode) {
 }
 
 $snmpv3_sha2_capable = snmpv3_sha2_capable();
+$snmpv3_aes_strong_capable = snmpv3_aes_strong_capable();
 ?>
             </select>
           </div>
@@ -248,7 +249,7 @@ $snmpv3_sha2_capable = snmpv3_sha2_capable();
                 <option value="SHA-512"<?= $snmpv3_sha2_capable ?: ' disabled'?>>SHA-512</option>
               </select>
               <?php if (! $snmpv3_sha2_capable) {?>
-              <label class="text-left"><small>Optional requirements not resolved so some options are disabled</small></label>
+              <label class="text-left"><small>Some options are disabled. <a href="https://docs.librenms.org/Support/FAQ/#optional-requirements-for-snmpv3-sha2-auth">Read more here</a></small></label>
               <?php } ?>
             </div>
           </div>
@@ -263,12 +264,12 @@ $snmpv3_sha2_capable = snmpv3_sha2_capable();
             <div class="col-sm-9">
               <select name="cryptoalgo" id="cryptoalgo" class="form-control input-sm">
                 <option value="AES" selected>AES</option>
-                <option value="AES-192"<?= $snmpv3_sha2_capable ?: ' disabled'?>>AES-192</option>
-                <option value="AES-256"<?= $snmpv3_sha2_capable ?: ' disabled'?>>AES-256</option>
+                <option value="AES-192"<?= $snmpv3_aes_strong_capable ?: ' disabled'?>>AES-192</option>
+                <option value="AES-256"<?= $snmpv3_aes_strong_capable ?: ' disabled'?>>AES-256</option>
                 <option value="DES">DES</option>
               </select>
-              <?php if (! $snmpv3_sha2_capable) {?>
-              <label class="text-left"><small>Optional requirements not resolved so some options are disabled</small></label>
+              <?php if (! $snmpv3_aes_strong_capable) {?>
+              <label class="text-left"><small>Some options are disabled. <a href="https://docs.librenms.org/Support/FAQ/#optional-requirements-for-snmpv3-sha2-auth">Read more here</a></small></label>
               <?php } ?>
             </div>
           </div>

--- a/includes/html/pages/device/edit/snmp.inc.php
+++ b/includes/html/pages/device/edit/snmp.inc.php
@@ -302,6 +302,7 @@ foreach (get_port_assoc_modes() as $pam_id => $pam) {
 }
 
 $snmpv3_sha2_capable = snmpv3_sha2_capable();
+$snmpv3_aes_strong_capable = snmpv3_aes_strong_capable();
 echo "        </select>
       </div>
     </div>
@@ -367,7 +368,7 @@ echo "        </select>
     </select>
     ';
 if (! $snmpv3_sha2_capable) {
-    echo '<label class="text-left"><small>Optional requirements not resolved so some options are disabled</small></label>';
+    echo '<label class="text-left"><small>Some options are disabled. <a href="https://docs.librenms.org/Support/FAQ/#optional-requirements-for-snmpv3-sha2-auth">Read more here</a></small></label>';
 }
     echo "
     </div>
@@ -383,13 +384,13 @@ if (! $snmpv3_sha2_capable) {
     <div class='col-sm-4'>
     <select id='cryptoalgo' name='cryptoalgo' class='form-control'>
     <option value='AES' " . ($device['cryptoalgo'] === 'AES' ? 'selected' : '') . ">AES</option>
-    <option value='AES-192' " . ($device['cryptoalgo'] === 'AES-192' ? 'selected' : '') . ($snmpv3_sha2_capable ?: ' disabled') . ">AES-192</option>
-    <option value='AES-256' " . ($device['cryptoalgo'] === 'AES-256' ? 'selected' : '') . ($snmpv3_sha2_capable ?: ' disabled') . ">AES-256</option>
+    <option value='AES-192' " . ($device['cryptoalgo'] === 'AES-192' ? 'selected' : '') . ($snmpv3_aes_strong_capable ?: ' disabled') . ">AES-192</option>
+    <option value='AES-256' " . ($device['cryptoalgo'] === 'AES-256' ? 'selected' : '') . ($snmpv3_aes_strong_capable ?: ' disabled') . ">AES-256</option>
     <option value='DES'>DES</option>
     </select>
     ";
-if (! $snmpv3_sha2_capable) {
-    echo '<label class="text-left"><small>Optional requirements not resolved so some options are disabled</small></label>';
+if (! $snmpv3_aes_strong_capable) {
+    echo '<label class="text-left"><small>Some options are disabled. <a href="https://docs.librenms.org/Support/FAQ/#optional-requirements-for-snmpv3-sha2-auth">Read more here</a></small></label>';
 }
     echo '
     </div>

--- a/includes/html/pages/device/edit/snmp.inc.php
+++ b/includes/html/pages/device/edit/snmp.inc.php
@@ -301,8 +301,7 @@ foreach (get_port_assoc_modes() as $pam_id => $pam) {
     echo ">$pam</option>\n";
 }
 
-$snmpv3_sha2_capable = snmpv3_sha2_capable();
-$snmpv3_aes_strong_capable = snmpv3_aes_strong_capable();
+list('sha2' => $snmpv3_sha2, 'aes256' => $snmpv3_aes256) = snmpv3_capabilities();
 echo "        </select>
       </div>
     </div>
@@ -361,13 +360,13 @@ echo "        </select>
     <select id='authalgo' name='authalgo' class='form-control'>
     <option value='MD5'>MD5</option>
     <option value='SHA' " . ($device['authalgo'] === 'SHA' ? 'selected' : '') . ">SHA</option>
-    <option value='SHA-224' " . ($device['authalgo'] === 'SHA-224' ? 'selected' : '') . ($snmpv3_sha2_capable ?: ' disabled') . ">SHA-224</option>
-    <option value='SHA-256' " . ($device['authalgo'] === 'SHA-256' ? 'selected' : '') . ($snmpv3_sha2_capable ?: ' disabled') . ">SHA-256</option>
-    <option value='SHA-384' " . ($device['authalgo'] === 'SHA-384' ? 'selected' : '') . ($snmpv3_sha2_capable ?: ' disabled') . ">SHA-384</option>
-    <option value='SHA-512' " . ($device['authalgo'] === 'SHA-512' ? 'selected' : '') . ($snmpv3_sha2_capable ?: ' disabled') . '>SHA-512</option>
+    <option value='SHA-224' " . ($device['authalgo'] === 'SHA-224' ? 'selected' : '') . ($snmpv3_sha2 ?: ' disabled') . ">SHA-224</option>
+    <option value='SHA-256' " . ($device['authalgo'] === 'SHA-256' ? 'selected' : '') . ($snmpv3_sha2 ?: ' disabled') . ">SHA-256</option>
+    <option value='SHA-384' " . ($device['authalgo'] === 'SHA-384' ? 'selected' : '') . ($snmpv3_sha2 ?: ' disabled') . ">SHA-384</option>
+    <option value='SHA-512' " . ($device['authalgo'] === 'SHA-512' ? 'selected' : '') . ($snmpv3_sha2 ?: ' disabled') . '>SHA-512</option>
     </select>
     ';
-if (! $snmpv3_sha2_capable) {
+if (! $snmpv3_sha2) {
     echo '<label class="text-left"><small>Some options are disabled. <a href="https://docs.librenms.org/Support/FAQ/#optional-requirements-for-snmpv3-sha2-auth">Read more here</a></small></label>';
 }
     echo "
@@ -384,12 +383,12 @@ if (! $snmpv3_sha2_capable) {
     <div class='col-sm-4'>
     <select id='cryptoalgo' name='cryptoalgo' class='form-control'>
     <option value='AES' " . ($device['cryptoalgo'] === 'AES' ? 'selected' : '') . ">AES</option>
-    <option value='AES-192' " . ($device['cryptoalgo'] === 'AES-192' ? 'selected' : '') . ($snmpv3_aes_strong_capable ?: ' disabled') . ">AES-192</option>
-    <option value='AES-256' " . ($device['cryptoalgo'] === 'AES-256' ? 'selected' : '') . ($snmpv3_aes_strong_capable ?: ' disabled') . ">AES-256</option>
+    <option value='AES-192' " . ($device['cryptoalgo'] === 'AES-192' ? 'selected' : '') . ($snmpv3_aes256 ?: ' disabled') . ">AES-192</option>
+    <option value='AES-256' " . ($device['cryptoalgo'] === 'AES-256' ? 'selected' : '') . ($snmpv3_aes256 ?: ' disabled') . ">AES-256</option>
     <option value='DES'>DES</option>
     </select>
     ";
-if (! $snmpv3_aes_strong_capable) {
+if (! $snmpv3_aes256) {
     echo '<label class="text-left"><small>Some options are disabled. <a href="https://docs.librenms.org/Support/FAQ/#optional-requirements-for-snmpv3-sha2-auth">Read more here</a></small></label>';
 }
     echo '

--- a/includes/html/pages/device/edit/snmp.inc.php
+++ b/includes/html/pages/device/edit/snmp.inc.php
@@ -301,7 +301,7 @@ foreach (get_port_assoc_modes() as $pam_id => $pam) {
     echo ">$pam</option>\n";
 }
 
-list('sha2' => $snmpv3_sha2, 'aes256' => $snmpv3_aes256) = snmpv3_capabilities();
+['sha2' => $snmpv3_sha2, 'aes256' => $snmpv3_aes256] = snmpv3_capabilities();
 echo "        </select>
       </div>
     </div>


### PR DESCRIPTION
For crypto algorithms AES-192, AES-256 you need **net-snmp** compiled with `--enable-blumenthal-aes`.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
