### PR TITLE
Added feature that will replace variables in the body field

### DIFF
--- a/LibreNMS/Alert/Transport/Api.php
+++ b/LibreNMS/Alert/Transport/Api.php
@@ -43,7 +43,7 @@ class Api extends Transport
     {
         $request_opts = [];
         $request_heads = [];
-	    $query = [];
+        $query = [];
 
         $method = strtolower($method);
         $host = explode('?', $api, 2)[0]; //we don't use the parameter part, cause we build it out of options.
@@ -76,9 +76,9 @@ class Api extends Transport
         */
         function iterateVariables($obj, &$subject)
         {
-            foreach( $obj as $key => $value ) {
+            foreach ($obj as $key => $value) {
                 // iterate variables if it is an array recursivly
-                if ( is_array($value)) {
+                if (is_array($value)) {
                     iterateVariables($value,$subject);
                 } else {
                     // replace expected templated markup of {{ $variable }}

--- a/LibreNMS/Alert/Transport/Api.php
+++ b/LibreNMS/Alert/Transport/Api.php
@@ -177,4 +177,5 @@ class Api extends Transport
             ],
         ];
     }
+
 }

--- a/LibreNMS/Alert/Transport/Api.php
+++ b/LibreNMS/Alert/Transport/Api.php
@@ -43,7 +43,7 @@ class Api extends Transport
     {
         $request_opts = [];
         $request_heads = [];
-        $query = [];
+	    $query = [];
 
         $method = strtolower($method);
         $host = explode('?', $api, 2)[0]; //we don't use the parameter part, cause we build it out of options.
@@ -67,6 +67,29 @@ class Api extends Transport
             //store the parameter in the array for HTTP query
             $query[$u_key] = $u_val;
         }
+        
+        /**
+        * Recursivly iterate $obj's variables into $subject
+        * @param mixed $obj - Input object
+        * @param string &$subject - Output variable
+        * @return void
+        */
+        function iterateVariables($obj,&$subject)
+        {
+            foreach( $obj as $key => $value )
+            {
+                // iterate variables if it is an array recursivly
+                if ( is_array($value) ) {
+                    iterateVariables($value,$subject);
+                } else {
+                    // replace expected templated markup of {{ $variable }}
+                    $subject = preg_replace("/\{\{\s*\\\${$key}\s*\}\}/i",$value,$subject);
+                }
+            }
+        }
+        // turn objects into arrays in a newObj
+        $newObj = json_decode(json_encode($obj),true);
+        iterateVariables($newObj, $body);
 
         $client = new \GuzzleHttp\Client();
         $request_opts['proxy'] = get_guzzle_proxy();

--- a/LibreNMS/Alert/Transport/Api.php
+++ b/LibreNMS/Alert/Transport/Api.php
@@ -39,13 +39,13 @@ class Api extends Transport
         return $this->contactAPI($obj, $url, $options, $method, $auth, $headers, $body);
     }
 
-   /**
-    * Recursivly iterate $obj's attributes into $subject for text replacement
-    * as {{ $ value }} format 
-    * @param mixed $obj - Object array to iterate
-    * @param string &$subject - String with text to be replaced
-    * @return void
-    */
+    /**
+     * Recursivly iterate $obj's attributes into $subject for text replacement
+     * as {{ $ value }} format
+     * @param mixed $obj - Object array to iterate
+     * @param string &$subject - String with text to be replaced
+     * @return void
+     */
     private function iterateObjectAttributes($obj, &$subject)
     {
         foreach ($obj as $key => $value) {
@@ -87,7 +87,7 @@ class Api extends Transport
         }
 
         //typecast native array and iterate $obj attributes to process variables for Body;
-        $this->iterateObjectAttributes(json_decode(json_encode($obj),true), $body);
+        $this->iterateObjectAttributes(json_decode(json_encode($obj), true), $body);
 
         $client = new \GuzzleHttp\Client();
         $request_opts['proxy'] = get_guzzle_proxy();

--- a/LibreNMS/Alert/Transport/Api.php
+++ b/LibreNMS/Alert/Transport/Api.php
@@ -68,6 +68,13 @@ class Api extends Transport
             $query[$u_key] = $u_val;
         }
 
+        /**
+        * Recursivly iterate $obj's variables into $subject
+        * @param mixed $obj - Input object
+        * @param string &$subject - Output variable
+        * @return void
+        */
+        
         function iterateVariables($obj, &$subject)
         {
             foreach ($obj as $key => $value) {
@@ -177,5 +184,4 @@ class Api extends Transport
             ],
         ];
     }
-
 }

--- a/LibreNMS/Alert/Transport/Api.php
+++ b/LibreNMS/Alert/Transport/Api.php
@@ -67,28 +67,27 @@ class Api extends Transport
             //store the parameter in the array for HTTP query
             $query[$u_key] = $u_val;
         }
-        
+
         /**
         * Recursivly iterate $obj's variables into $subject
         * @param mixed $obj - Input object
         * @param string &$subject - Output variable
         * @return void
         */
-        function iterateVariables($obj,&$subject)
+        function iterateVariables($obj, &$subject)
         {
-            foreach( $obj as $key => $value )
-            {
+            foreach( $obj as $key => $value ) {
                 // iterate variables if it is an array recursivly
-                if ( is_array($value) ) {
+                if ( is_array($value)) {
                     iterateVariables($value,$subject);
                 } else {
                     // replace expected templated markup of {{ $variable }}
-                    $subject = preg_replace("/\{\{\s*\\\${$key}\s*\}\}/i",$value,$subject);
+                    $subject = preg_replace("/\{\{\s*\\\${$key}\s*\}\}/i", $value, $subject);
                 }
             }
         }
         // turn objects into arrays in a newObj
-        $newObj = json_decode(json_encode($obj),true);
+        $newObj = json_decode(json_encode($obj), true);
         iterateVariables($newObj, $body);
 
         $client = new \GuzzleHttp\Client();

--- a/LibreNMS/Alert/Transport/Api.php
+++ b/LibreNMS/Alert/Transport/Api.php
@@ -69,12 +69,11 @@ class Api extends Transport
         }
 
         /**
-        * Recursivly iterate $obj's variables into $subject
-        * @param mixed $obj - Input object
-        * @param string &$subject - Output variable
-        * @return void
-        */
-        
+         * Recursivly iterate $obj's variables into $subject
+         * @param mixed $obj - Input object
+         * @param string &$subject - Output variable
+         * @return void
+         */
         function iterateVariables($obj, &$subject)
         {
             foreach ($obj as $key => $value) {

--- a/LibreNMS/Alert/Transport/Api.php
+++ b/LibreNMS/Alert/Transport/Api.php
@@ -68,12 +68,6 @@ class Api extends Transport
             $query[$u_key] = $u_val;
         }
 
-        /**
-        * Recursivly iterate $obj's variables into $subject
-        * @param mixed $obj - Input object
-        * @param string &$subject - Output variable
-        * @return void
-        */
         function iterateVariables($obj, &$subject)
         {
             foreach ($obj as $key => $value) {

--- a/LibreNMS/Alert/Transport/Api.php
+++ b/LibreNMS/Alert/Transport/Api.php
@@ -79,7 +79,7 @@ class Api extends Transport
             foreach ($obj as $key => $value) {
                 // iterate variables if it is an array recursivly
                 if (is_array($value)) {
-                    iterateVariables($value,$subject);
+                    iterateVariables($value, $subject);
                 } else {
                     // replace expected templated markup of {{ $variable }}
                     $subject = preg_replace("/\{\{\s*\\\${$key}\s*\}\}/i", $value, $subject);


### PR DESCRIPTION
Added feature that will replace variables in the body field of the Transport Api.php

This adds the ability to markup variables similar to the header and options fields via the {{ $variable }} syntax that walks the whole object. It is useful for crafting the body as json or whatever format your endpoint it but also passing the lookup of results of the object, alert, and fault information.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
