### PR TITLE
Correct rrdcached.sock location on doc

### DIFF
--- a/doc/Extensions/RRDCached-Security.md
+++ b/doc/Extensions/RRDCached-Security.md
@@ -38,7 +38,7 @@ server {
     allow $LibreNMS_IP;
     deny all;
 
-    proxy_pass unix:/var/run/rrdcached/rrdcached.sock;
+    proxy_pass unix:/run/rrdcached.sock;
 }
 
 ```


### PR DESCRIPTION
According to https://docs.librenms.org/Extensions/RRDCached/ , the `rrdcached.sock` location should be `unix:/run/rrdcached.sock`

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
