### PR TITLE
Added additional function called good_if_regexp to allow whitelist of…

### DIFF
--- a/doc/Developing/os/Settings.md
+++ b/doc/Developing/os/Settings.md
@@ -66,9 +66,12 @@ bad_iftype: # ifType (substring)
     - sonet
 good_if: # ignore all other bad_if settings ifDescr (substring, case insensitive)
     - virtual
-bad_ifoperstatus # IfOperStatus (substring, case insensitive)
+good_if_regexp: # ifDescr (regex, case insensitive). 
+	- "/ens[0-9]+/"
+bad_ifoperstatus: # IfOperStatus (substring, case insensitive)
     - notPresent
 ```
+For Whitelisting on Interface ifDescr see [Whitelisting intefaces](../../Support/Configuration.md#whitelisting-interfaces).
 
 ### Controlling interface labels
 

--- a/doc/Support/Configuration.md
+++ b/doc/Support/Configuration.md
@@ -655,6 +655,10 @@ definitions (includes/definitions/_specific_os_.yaml) can contain
 bad_if\* arrays, but should only be modified via pull-request as 
 manipulation of the definition files will block updating. 
 
+The default filtering mode is to blacklist based on ifDescr. 
+Whitelisting interfaces is also possible. 
+See [Whitelisting intefaces](../Support/Configuration.md#whitelisting-interfaces) later in this section for more information.
+
 Examples:
 
 **Add entries to default arrays**
@@ -704,6 +708,45 @@ $config['os']['ios']['good_if'][] = 'FastEthernet';
 as well which would stop that port from being ignored. I.e If bad_if
 and good_if both contained FastEthernet then ports with this value in
 the ifDescr will be valid.
+
+# Whitelisting interfaces
+By default interfaces are blacklisted. By setting a whitelist you will only 
+allow the interfaces defined. All other intefaces will be ignored. The 
+definition is via a list of strings called good_if_regexp. Whitelisting can 
+only be performed on a per OS basis, and the if_filter_mode setting must be 
+set to 'whitelist'.
+
+Examples;
+
+```php
+
+$config['os']['junos']['if_filter_mode'] = 'whitelist';
+$config['os']['junos']['good_if_regexp'][] = '/^fxp$/';
+$config['os']['junos']['good_if_regexp'][] = '/^ae[0-9]+/';
+$config['os']['junos']['good_if_regexp'][] = '/^ge-/';
+$config['os']['junos']['good_if_regexp'][] = '/^xe-/';
+
+$config['os']['linux']['if_filter_mode'] = 'whitelist';
+$config['os']['linux']['good_if_regexp'][] = '/^ens[0-9]+/';
+```
+The `junos` example here will only match on fxp,ae,ge,xe interfaces. 
+All the other types (which can be many) will be ignored.
+
+The `linux` example will only match ens (typically debian) ethernet interfaces. 
+But will ignore the loopback, or any other interface on the system.
+
+The only limitation is whats in the ifDescr field and your comfort with 
+regular expressions.
+
+More complex example;
+```php
+$config['os']['junos']['if_filter_mode'] = 'whitelist';
+$config['os']['junos']['good_if_regexp'][] = '/^fxp[0-9]+$/';
+$config['os']['junos']['good_if_regexp'][] = '/^(gx)e-[0-9]+/[0-9]+/[0-9]+$/'
+$config['os']['junos']['good_if_regexp'][] = '/^ae[0-9]+$/'
+```
+This is similar to the `junos` example above but will only match major 
+(physical) interfaces and not their respective sub interfaces.
 
 # Interfaces to be rewritten
 
@@ -824,7 +867,6 @@ These options rely on daily.sh running from cron as per the installation instruc
 $config['syslog_purge']                                   = 30;
 $config['eventlog_purge']                                 = 30;
 $config['authlog_purge']                                  = 30;
-$config['perf_times_purge']                               = 30;
 $config['device_perf_purge']                              = 7;
 $config['alert_log_purge']                                = 365;
 $config['port_fdb_purge']                                 = 10;

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -931,7 +931,7 @@ function include_dir($dir, $regex = '')
 
 /**
  * Check if port is valid to poll.
- * Settings: empty_ifdescr, good_if, bad_if, bad_if_regexp, bad_ifname_regexp, bad_ifalias_regexp, bad_iftype, bad_ifoperstatus
+ * Settings: empty_ifdescr, good_if, good_if_regexp, bad_if, bad_if_regexp, bad_ifname_regexp, bad_ifalias_regexp, bad_iftype, bad_ifoperstatus
  *
  * @param array $port
  * @param array $device
@@ -964,6 +964,13 @@ function is_port_valid($port, $device)
 
     if (str_i_contains($ifDescr, Config::getOsSetting($device['os'], 'good_if', Config::get('good_if')))) {
         return true;
+    }
+
+	//Loop through the good_if_regexp interfaces and allow as a whitelist. This should be coupled with bad_if_regexp wildcard match on all interfaces. 
+    foreach (Config::getCombined($device['os'], 'good_if_regexp') as $gir) {
+        if (preg_match($gir . 'i', $ifDescr)) {
+            return true;
+        }
     }
 
     foreach (Config::getCombined($device['os'], 'bad_if') as $bi) {


### PR DESCRIPTION
… intefaces using regular expressions.

This should also be used with a wildcard match on all interfaces using bad_if_regexp.

e.g the following will only allow ens interfaces on linux.
$config['os']['linux']['bad_if_regexp']='/.*/'
$config['os']['linux']['good_if_regexp']='/^ens[0-9]+$/'

e.g the following will only allow physical and aggregated interfaces on IOSXR.
$config['os']['iosxr']['bad_if_regexp']='/.*/'
$config['os']['iosxr']['good_if_regexp']='/^TenGigE[0-9].*/'
$config['os']['iosxr']['good_if_regexp']='/^GigabitEthernet[0-9].*/'
$config['os']['iosxr'']['good_if_regexp']='/^FastEthernet[0-9].*/'
$config['os']['iosxr']['good_if_regexp']='/^Bundle-Ether[0-9].*/'

e.g the following will only allow physical and aggregated major interfaces on JUNOS, but not their sub interfaces
$config['os']['junos']['bad_if_regexp']='/.*/'
$config['os']['junos']['good_if_regexp']='/^(gx)e-[0-9]+\/[0-9]+\/[0-9]+$/'
$config['os']['junos']['good_if_regexp']='/^ae[0-9]+$/'

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
