### PR TITLE
Add TrueNAS temperature

### DIFF
--- a/includes/discovery/sensors/temperature/truenas.inc.php
+++ b/includes/discovery/sensors/temperature/truenas.inc.php
@@ -1,0 +1,5 @@
+<?php
+
+use LibreNMS\Config;
+
+include_once Config::get('install_dir') . '/includes/discovery/sensors/temperature/unix.inc.php';


### PR DESCRIPTION
TrueNAS systems are identified with os=truenas. As of 11.3-BETA1,
TrueNAS exposes CPU temperatures via LM-SENSORS-MIB.
See https://jira.ixsystems.com/browse/NAS-100412

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
