### PR TITLE
Fix Fast Ping alerts always running

### DIFF
--- a/app/Jobs/PingCheck.php
+++ b/app/Jobs/PingCheck.php
@@ -256,9 +256,11 @@ class PingCheck implements ShouldQueue
 
             $device->save(); // only saves if needed (which is every time because of last_ping)
 
-            echo "Device $device->hostname changed status to $type, running alerts\n";
-            $rules = new AlertRules;
-            $rules->runRules($device->device_id);
+            if (isset($type)) { // only run alert rules if status changed
+                echo "Device $device->hostname changed status to $type, running alerts\n";
+                $rules = new AlertRules;
+                $rules->runRules($device->device_id);
+            }
 
             // add data to rrd
             app('Datastore')->put($device->toArray(), 'ping-perf', $this->rrd_tags, ['ping' => $device->last_ping_timetaken]);


### PR DESCRIPTION
Alerts should only be ran if the status changes.  This should restore some speed.
Was broken by another fix.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
