### PR TITLE
Use detected rrdtool_version as fallback

### DIFF
--- a/LibreNMS/Data/Store/Rrd.php
+++ b/LibreNMS/Data/Store/Rrd.php
@@ -60,7 +60,9 @@ class Rrd extends BaseDatastore
             ' RRA:MAX:0.5:1:2016 RRA:MAX:0.5:6:1440     RRA:MAX:0.5:24:1440     RRA:MAX:0.5:288:1440 ' .
             ' RRA:LAST:0.5:1:2016 '
         );
-        $this->version = Config::get('rrdtool_version', '1.4');
+
+        $versions = version_info();
+        $this->version = Config::get('rrdtool_version', $versions['rrdtool_ver']);
     }
 
     public function getName()


### PR DESCRIPTION
Follow-up librenms/docker#166 librenms/docker@ab027d7

Currently [Validation of RRD](https://github.com/librenms/librenms/blob/20b4215204d2494430195e5bac306fc3b2d1fc47/LibreNMS/Validations/Rrd.php#L47-L48) specify that we can comment `rrdtool_version` config so I assume it will use the one installed but it will [fallback to `1.4` instead](https://github.com/librenms/librenms/blob/20b4215204d2494430195e5bac306fc3b2d1fc47/LibreNMS/Data/Store/Rrd.php#L63) which can't handle new features.

This PR allows to use detected rrdtool version as fallback instead of a static value.