### PR TITLE
Fix location for devices with broken snmp

### DIFF
--- a/LibreNMS/OS/Traits/YamlOSDiscovery.php
+++ b/LibreNMS/OS/Traits/YamlOSDiscovery.php
@@ -83,7 +83,7 @@ trait YamlOSDiscovery
     public function fetchLocation(): Location
     {
         $os_yaml = $this->getDiscovery('os');
-        $name = $os_yaml['location'] ?? 'SNMPv2-MIB::sysLocation.0';
+        $name = $os_yaml['location'] ?? null;
         $lat = $os_yaml['lat'] ?? null;
         $lng = $os_yaml['long'] ?? null;
 
@@ -94,7 +94,7 @@ trait YamlOSDiscovery
         Log::debug('Yaml location data:', $data);
 
         return new Location([
-            'location' => $this->findFirst($data, $name, $numeric),
+            'location' => $this->findFirst($data, $name, $numeric) ?? snmp_get($this->getDeviceArray(), 'SNMPv2-MIB::sysLocation.0', '-Oqv'),
             'lat' => $this->findFirst($data, $lat, $numeric),
             'lng' => $this->findFirst($data, $lng, $numeric),
         ]);


### PR DESCRIPTION
AirOS devices with old firmware did not return SNMP results as they should.  This compromise should minimize extra snmp queries.  (Although there are more)

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
