### PR TITLE
Notifications : display sensor state textual value

### DIFF
--- a/includes/html/functions.inc.php
+++ b/includes/html/functions.inc.php
@@ -963,10 +963,13 @@ function alert_details($details)
         }
 
         if ($tmp_alerts['sensor_id']) {
-            $details = 'Value: ' . $tmp_alerts['sensor_current'] . ' (' . $tmp_alerts['sensor_class'] . ')<br>  ';
             if ($tmp_alerts['sensor_class'] == 'state') {
+                // Give more details for a state (textual form)
                 $details = 'State: ' . $tmp_alerts['state_descr'] . ' (numerical ' . $tmp_alerts['sensor_current'] . ')<br>  ';
-            }
+            } else {
+                // Other sensors
+                $details = 'Value: ' . $tmp_alerts['sensor_current'] . ' (' . $tmp_alerts['sensor_class'] . ')<br>  ';
+            ]
             $details_a = [];
 
             if ($tmp_alerts['sensor_limit_low']) {

--- a/includes/html/functions.inc.php
+++ b/includes/html/functions.inc.php
@@ -965,7 +965,7 @@ function alert_details($details)
         if ($tmp_alerts['sensor_id']) {
             $details = 'Value: ' . $tmp_alerts['sensor_current'] . ' (' . $tmp_alerts['sensor_class'] . ')<br>  ';
             if ($tmp_alerts['sensor_class'] == 'state') {
-                $details = 'State: ' . $tmp_alerts['state_descr'] . ' (value ' . $tmp_alerts['sensor_current'] . ')<br>  ';
+                $details = 'State: ' . $tmp_alerts['state_descr'] . ' (numerical ' . $tmp_alerts['sensor_current'] . ')<br>  ';
             }
             $details_a = [];
 

--- a/includes/html/functions.inc.php
+++ b/includes/html/functions.inc.php
@@ -963,7 +963,10 @@ function alert_details($details)
         }
 
         if ($tmp_alerts['sensor_id']) {
-            $details = 'Current Value: ' . $tmp_alerts['sensor_current'] . ' (' . $tmp_alerts['sensor_class'] . ')<br>  ';
+            $details = 'Value: ' . $tmp_alerts['sensor_current'] . ' (' . $tmp_alerts['sensor_class'] . ')<br>  ';
+            if ($tmp_alerts['sensor_class'] == 'state') {
+                $details = 'State: ' . $tmp_alerts['state_descr'].' (value ' . $tmp_alerts['sensor_current'] . ')<br>  ';
+            }
             $details_a = [];
 
             if ($tmp_alerts['sensor_limit_low']) {

--- a/includes/html/functions.inc.php
+++ b/includes/html/functions.inc.php
@@ -965,7 +965,7 @@ function alert_details($details)
         if ($tmp_alerts['sensor_id']) {
             $details = 'Value: ' . $tmp_alerts['sensor_current'] . ' (' . $tmp_alerts['sensor_class'] . ')<br>  ';
             if ($tmp_alerts['sensor_class'] == 'state') {
-                $details = 'State: ' . $tmp_alerts['state_descr'].' (value ' . $tmp_alerts['sensor_current'] . ')<br>  ';
+                $details = 'State: ' . $tmp_alerts['state_descr'] . ' (value ' . $tmp_alerts['sensor_current'] . ')<br>  ';
             }
             $details_a = [];
 

--- a/includes/html/functions.inc.php
+++ b/includes/html/functions.inc.php
@@ -969,7 +969,7 @@ function alert_details($details)
             } else {
                 // Other sensors
                 $details = 'Value: ' . $tmp_alerts['sensor_current'] . ' (' . $tmp_alerts['sensor_class'] . ')<br>  ';
-            ]
+            }
             $details_a = [];
 
             if ($tmp_alerts['sensor_limit_low']) {


### PR DESCRIPTION
Display state textual value in notification list.
![Capture d’écran 2021-02-23 à 10 40 07](https://user-images.githubusercontent.com/38363551/108825749-b0c97f80-75c3-11eb-8cfa-0ca39f501779.png)

Text was `Current Value: 2 (state)` before patch

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
