### PR TITLE
Fixed typo jnxPowerSupplyOK

### DIFF
--- a/config/snmptraps.php
+++ b/config/snmptraps.php
@@ -71,7 +71,7 @@ return [
         'JUNIPER-LDP-MIB::jnxLdpSesDown' => \LibreNMS\Snmptrap\Handlers\JnxLdpSesDown::class,
         'JUNIPER-LDP-MIB::jnxLdpSesUp' => \LibreNMS\Snmptrap\Handlers\JnxLdpSesUp::class,
         'JUNIPER-MIB::jnxPowerSupplyFailure' => \LibreNMS\Snmptrap\Handlers\JnxPowerSupplyFailure::class,
-        'JUNIPER-MIB::jnxPowerSupplyOk' => \LibreNMS\Snmptrap\Handlers\JnxPowerSupplyOk::class,
+        'JUNIPER-MIB::jnxPowerSupplyOK' => \LibreNMS\Snmptrap\Handlers\JnxPowerSupplyOk::class,
         'JUNIPER-VPN-MIB::jnxVpnIfDown' => \LibreNMS\Snmptrap\Handlers\JnxVpnIfDown::class,
         'JUNIPER-VPN-MIB::jnxVpnIfUp' => \LibreNMS\Snmptrap\Handlers\JnxVpnIfUp::class,
         'JUNIPER-VPN-MIB::jnxVpnPwDown' => \LibreNMS\Snmptrap\Handlers\JnxVpnPwDown::class,

--- a/tests/Feature/SnmpTraps/JnxPowerSupplyTest.php
+++ b/tests/Feature/SnmpTraps/JnxPowerSupplyTest.php
@@ -62,7 +62,7 @@ SNMPv2-MIB::snmpTrapEnterprise.0 JUNIPER-CHASSIS-DEFINES-MIB::jnxProductNameMX96
         $trapText = "$device->hostname
 UDP: [$device->ip]:49716->[10.0.0.1]:162
 DISMAN-EVENT-MIB::sysUpTimeInstance 470:23:25:41.21
-SNMPv2-MIB::snmpTrapOID.0 JUNIPER-MIB::jnxPowerSupplyOk
+SNMPv2-MIB::snmpTrapOID.0 JUNIPER-MIB::jnxPowerSupplyOK
 JUNIPER-MIB::jnxContentsContainerIndex.2.4.0.0 2
 JUNIPER-MIB::jnxContentsL1Index.2.4.0.0 4
 JUNIPER-MIB::jnxContentsL2Index.2.4.0.0 0
@@ -75,6 +75,6 @@ SNMPv2-MIB::snmpTrapEnterprise.0 JUNIPER-CHASSIS-DEFINES-MIB::jnxProductNameMX96
         $message = 'Power Supply PEM 4 is OK';
         \Log::shouldReceive('event')->once()->with($message, $device->device_id, 'trap', 1);
 
-        $this->assertTrue(Dispatcher::handle($trap), 'Could not handle JnxPowerSupplyOk');
+        $this->assertTrue(Dispatcher::handle($trap), 'Could not handle JnxPowerSupplyOK');
     }
 }


### PR DESCRIPTION
In config/snmptrap.php, the trap text for jnxPowerSupplyOK has a lower case 'k' causing the trap to not be caught for handling.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
