### PR TITLE
Add Google Chat Transport

### DIFF
--- a/LibreNMS/Alert/Transport/Googlechat.php
+++ b/LibreNMS/Alert/Transport/Googlechat.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * transport-telegram.inc.php
+ *
+ * LibreNMS Google Chat alerting transport
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @package    LibreNMS
+ * @link       http://librenms.org
+ * @copyright  2021 Pablo Baldovi
+ * @author     Pablo Baldovi <pbaldovi@gmail.com>
+ */
+namespace LibreNMS\Alert\Transport;
+
+use LibreNMS\Enum\AlertState;
+use LibreNMS\Alert\Transport;
+use Log;
+
+
+class Googlechat extends Transport
+{
+    public function deliverAlert($obj, $opts)
+    {
+
+        $googlechat_conf['webhookurl'] = $this->config['googlechat-webhook'];
+        return $this->contactGooglechat($obj, $googlechat_conf);
+    }
+
+
+    public static function contactGooglechat($obj, $data)
+    {
+        $payload = '{"text": "' . $obj['msg'] . '"}';
+
+        Log::debug($payload);
+
+        // Create a new cURL resource
+        $ch = curl_init($data['webhookurl']);
+
+
+        // Attach encoded JSON string to the POST fields
+        curl_setopt($ch, CURLOPT_POSTFIELDS, $payload);
+
+        // Set the content type to application/json
+        curl_setopt($ch, CURLOPT_HTTPHEADER, array('Content-Type:application/json'));
+
+        // Return response instead of outputting
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+
+        // Execute the POST request
+        $result = curl_exec($ch);
+
+        // Close cURL resource
+        curl_close($ch);
+        $code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+
+
+
+
+
+        if ($code != 200) {
+
+            Log::error('Google Chat Transport Error');
+            Log::error($result);
+            return 'HTTP Status code ' . $code;
+        }
+
+        return true;
+    }
+
+
+    public static function configTemplate()
+    {
+        return [
+            'config' => [
+                [
+                    'title' => 'Webhook URL',
+                    'name' => 'googlechat-webhook',
+                    'descr' => 'Google Chat Room Webhook',
+                    'type' => 'text',
+                ]
+            ],
+            'validation' => [
+                'googlechat-webhook' => 'required|string',
+            ]
+        ];
+    }
+}


### PR DESCRIPTION
Please give a short description what your pull request is for

Implementation of a transport for Google Chat

Google Chat is the successor of Google Hangout, and allows you to configure webhooks for group chats.
This is a simple implementation using curl that allows to send alerts to a Google Chat group

[https://developers.google.com/hangouts/chat/how-tos/webhooks
](url)


#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
