### PR TITLE
Nokia sap improvements

### DIFF
--- a/includes/html/pages/device/routing/mpls.inc.php
+++ b/includes/html/pages/device/routing/mpls.inc.php
@@ -469,10 +469,19 @@ if ($vars['view'] == 'saps') {
             $operstate_status_color = 'danger';
         }
 
+        $outerEncapValue = (($sap['sapEncapValue'] % 65536) == 4095 ? '*' : ($sap['sapEncapValue'] % 65536));
+        $innerEncapValue = (intval($sap['sapEncapValue'] / 65536) == 4095 ? '*' : intval($sap['sapEncapValue'] / 65536));
+        $innerEncapValue = ($innerEncapValue == '0' ? '' : ".$innerEncapValue");
+        $showSapEncapValue = "$outerEncapValue$innerEncapValue";
+
+        if ($showSapEncapValue == 0 AND $showSapEncapValue != '*') {
+            $showSapEncapValue = '';
+        }
+
         echo "<tr bgcolor=$bg_colour>" . '
             <td>' . generate_sap_url($sap, $sap['svc_oid']) . '</td>
             <td>' . generate_port_link($port) . '</td>
-            <td>' . $sap['sapEncapValue'] . '</td>
+            <td>' . $showSapEncapValue . '</td>
             <td>' . $sap['sapType'] . '</td>
             <td>' . $sap['sapDescription'] . '</td>
             <td><span class="label label-' . $adminstate_status_color . '">' . $sap['sapAdminStatus'] . '</td>


### PR DESCRIPTION
This pull request is for Nokia sap improvements.

1, Sum the ingress and egress traffic.
2, Calculate and show the VLAN values when the port is in access without encapsulation or Dot1q or QinQ mode.  

Previous page:
![Screenshot from 2021-02-25 20-40-04](https://user-images.githubusercontent.com/55170590/109122239-29d7fb00-77ad-11eb-99b2-257ede325715.png)

After the changes:
![Screenshot from 2021-02-25 20-35-04](https://user-images.githubusercontent.com/55170590/109122250-32303600-77ad-11eb-8370-590ddafca2a4.png)


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
