### PR TITLE
Ban legacy dbFacile functions

### DIFF
--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -52,7 +52,7 @@ function poll_sensor($device, $class)
     $misc_sensors = [];
     $all_sensors = [];
 
-    foreach (dbFetchRows('SELECT * FROM `sensors` WHERE `sensor_class` = ? AND `device_id` = ?S', [$class, $device['device_id']]) as $sensor) {
+    foreach (dbFetchRows('SELECT * FROM `sensors` WHERE `sensor_class` = ? AND `device_id` = ?', [$class, $device['device_id']]) as $sensor) {
         if ($sensor['poller_type'] == 'agent') {
             // Agent sensors are polled in the unix-agent
         } elseif ($sensor['poller_type'] == 'ipmi') {
@@ -87,7 +87,7 @@ function poll_sensor($device, $class)
                 }
             } elseif ($class == 'state') {
                 if (! is_numeric($sensor_value)) {
-                    $state_values = dbFetchCell(
+                    $state_value = dbFetchCell(
                         'SELECT `state_value`
                         FROM `state_translations` LEFT JOIN `sensors_to_state_indexes`
                         ON `state_translations`.`state_index_id` = `sensors_to_state_indexes`.`state_index_id`

--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -52,7 +52,7 @@ function poll_sensor($device, $class)
     $misc_sensors = [];
     $all_sensors = [];
 
-    foreach (dbFetchRows('SELECT * FROM `sensors` WHERE `sensor_class` = ? AND `device_id` = ?', [$class, $device['device_id']]) as $sensor) {
+    foreach (dbFetchRows('SELECT * FROM `sensors` WHERE `sensor_class` = ? AND `device_id` = ?S', [$class, $device['device_id']]) as $sensor) {
         if ($sensor['poller_type'] == 'agent') {
             // Agent sensors are polled in the unix-agent
         } elseif ($sensor['poller_type'] == 'ipmi') {
@@ -87,7 +87,7 @@ function poll_sensor($device, $class)
                 }
             } elseif ($class == 'state') {
                 if (! is_numeric($sensor_value)) {
-                    $state_value = dbFetchCell(
+                    $state_values = dbFetchCell(
                         'SELECT `state_value`
                         FROM `state_translations` LEFT JOIN `sensors_to_state_indexes`
                         ON `state_translations`.`state_index_id` = `sensors_to_state_indexes`.`state_index_id`
@@ -209,7 +209,7 @@ function record_sensor_data($device, $all_sensors)
         }
         if ($sensor['sensor_class'] == 'state' && $prev_sensor_value != $sensor_value) {
             $trans = array_column(
-                dbFetchRows(
+                $unneeded = dbFetchRows(
                     'SELECT `state_translations`.`state_value`, `state_translations`.`state_descr` FROM `sensors_to_state_indexes` LEFT JOIN `state_translations` USING (`state_index_id`) WHERE `sensors_to_state_indexes`.`sensor_id`=? AND `state_translations`.`state_value` IN (?,?)',
                     [$sensor['sensor_id'], $sensor_value, $prev_sensor_value]
                 ),

--- a/tests/NoLegacyFunctions.php
+++ b/tests/NoLegacyFunctions.php
@@ -1,0 +1,105 @@
+<?php
+/*
+ * NoLegacyFunctions.php
+ *
+ * -Description-
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @package    LibreNMS
+ * @link       http://librenms.org
+ * @copyright  2021 Tony Murray
+ * @author     Tony Murray <murraytony@gmail.com>
+ */
+
+namespace LibreNMS\Tests;
+
+use Illuminate\Support\Str;
+
+class NoLegacyFunctions extends TestCase
+{
+    private $dbFacile = [
+        'dbArrayToRaw',
+        'dbBeginTransaction',
+        'dbBulkInsert',
+        'dbCommitTransaction',
+        'dbConnect',
+        'dbDelete',
+        'dbDeleteOrphans',
+        'dbFetch',
+        'dbFetchCell',
+        'dbFetchColumn',
+        'dbFetchKeyValue',
+        'dbFetchRow',
+        'dbFetchRows',
+        'dbGenPlaceholders',
+        'dbHandleException',
+        'dbInsert',
+        'dbIsConnected',
+        'dbPlaceHolders',
+        'dbQuery',
+        'dbRollbackTransaction',
+        'dbSyncRelationship',
+        'dbSyncRelationships',
+        'dbUpdate',
+        'recordDbStatistic',
+    ];
+
+    public function testNoLegacyFunctionsAdded()
+    {
+        $diff = `git diff -w origin/master HEAD | grep -E "^\+"`;
+
+        $regex = '/' . implode('|', array_map(function ($f) {
+                return $f . '\s*\(';
+            }, $this->dbFacile)) . '/';
+
+        $invalid_functions = [];
+        $file = 'unknown';
+        if (preg_match($regex, $diff)) { // fast check to save time
+            // split into files and
+            foreach (explode('+++ ', $diff) as $section) {
+                if (! str_contains($section, PHP_EOL)) {
+                    continue;
+                }
+
+                $file = substr($section, 0, strpos($section, PHP_EOL));
+                unset($matches);
+                preg_match_all($regex, $section, $matches);
+                if (! empty($matches[0])) {
+                    dd($section, $file, $matches);
+                }
+            }
+
+            dd($invalid_functions);
+
+            foreach ($this->dbFacile as $function) {
+                if (Str::contains($diff, $function . '(')) {
+                    $invalid_functions[$function] = substr_count($regex,);
+                }
+            }
+        }
+
+        if (! empty($invalid_functions)) {
+            $functions = implode(',', $invalid_functions);
+            $this->fail(<<<MESSAGE
+\e[41;97;1mYour code changes contain use of deprecated dbFacile function(s): $functions\e[0m
+You must use Laravel Eloquent or Fluent to access the database.
+https://laravel.com/docs/eloquent
+https://laravel.com/docs/queries
+MESSAGE
+            );
+
+        }
+    }
+}

--- a/tests/NoLegacyFunctions.php
+++ b/tests/NoLegacyFunctions.php
@@ -56,7 +56,7 @@ class NoLegacyFunctions extends TestCase
         'recordDbStatistic',
     ];
 
-    public function testNoLegacyFunctionsAdded()
+    public function testNoLegacyDbFacileFunctionsAdded()
     {
         $diff = `git diff -w origin/master HEAD | grep -E "^\+"`;
 

--- a/tests/NoLegacyFunctions.php
+++ b/tests/NoLegacyFunctions.php
@@ -59,6 +59,7 @@ class NoLegacyFunctions extends TestCase
     public function testNoLegacyFunctionsAdded()
     {
         $diff = `git diff -w origin/master HEAD | grep -E "^\+"`;
+        dd($diff);
 
         $regex = '/' . implode('|', array_map(function ($f) {
                 return $f . '\s*\(';


### PR DESCRIPTION
Have CI fail when code changes add usage of dbFacile functions.  Users need to be using Eloquent and Fluent so we can add multiple database server capability.

There will likely be changes we don't care about this for... but it is good to tell the contributor early.

Includes changes that will fail, will remove after feedback.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
