### PR TITLE
DynamicDiscovery - Guess num_oid if not provided in YAML file

### DIFF
--- a/LibreNMS/Device/YamlDiscovery.php
+++ b/LibreNMS/Device/YamlDiscovery.php
@@ -83,11 +83,18 @@ class YamlDiscovery
 
                     if (! isset($data['num_oid'])) {
                         try {
-                            $num_oid = static::oidToNumeric($data['value'], $device, $device['dynamic_discovery']['mib'], $device['mib_dir']);
+                            d_echo('Info: Trying to find a numerical OID for ' . $data['value'] . '.');
+                            $search_mib = $device['dynamic_discovery']['mib'];
+                            if (Str::contains($data['oid'], '::') && ! (Str::contains($data['value'], '::'))) {
+                                // We should search this mib first
+                                $exp_oid = explode('::', $data['oid']);
+                                $search_mib = $exp_oid[0] . ':' . $search_mib;
+                            }
+                            $num_oid = static::oidToNumeric($data['value'], $device, $search_mib, $device['mib_dir']);
                             $data['num_oid'] = $num_oid . '.{{ $index }}';
                             d_echo('Info: We found numerical oid for ' . $data['value'] . ': ' . $data['num_oid']);
                         } catch (\Exception $e) {
-                            d_echo('Error: We cannot find a numerical OID for ' . $data['value'] . '.');
+                            d_echo('Error: We cannot find a numerical OID for ' . $data['value'] . '. Skipping this one...');
                             continue;
                         }
                     }

--- a/LibreNMS/Device/YamlDiscovery.php
+++ b/LibreNMS/Device/YamlDiscovery.php
@@ -41,6 +41,7 @@ class YamlDiscovery
     public static function discover(OS $os, $class, $yaml_data)
     {
         $pre_cache = $os->preCache();
+        $device = $os->getDeviceArray();
         $items = [];
 
         // convert to class name for static call below
@@ -78,6 +79,17 @@ class YamlDiscovery
 
                     if (! isset($data['value'])) {
                         $data['value'] = $data['oid'];
+                    }
+
+                    if (! isset($data['num_oid'])) {
+                        try {
+                            $num_oid = static::oidToNumeric($data['value'], $device, $device['dynamic_discovery']['mib'], $device['mib_dir']);
+                            $data['num_oid'] = $num_oid . '.{{ $index }}';
+                            d_echo('Info: We found numerical oid for ' . $data['value'] . ': ' . $data['num_oid']);
+                        } catch (\Exception $e) {
+                            d_echo('Error: We cannot find a numerical OID for ' . $data['value'] . '.');
+                            continue;
+                        }
                     }
 
                     foreach ($data as $name => $value) {

--- a/doc/Developing/os/Health-Information.md
+++ b/doc/Developing/os/Health-Information.md
@@ -88,8 +88,8 @@ are as follows:
 - `oid` (required): This is the name of the table you want to do the snmp walk on.
 - `value` (optional): This is the key within the table that contains
   the value. If not provided willuse `oid`
-- `num_oid` (optional): If not provided, this parameter should be found
-  automatically. This is the numerical OID that contains
+- `num_oid` (optional): If not provided, this parameter should be computed
+  automatically by discovery process. This is the numerical OID that contains
   `value`. This should usually include `{{ $index }}`.
   In case the index is a string, `{{ $index_string }}` can be used instead.
 - `divisor` (optional): This is the divisor to use against the returned `value`.

--- a/doc/Developing/os/Health-Information.md
+++ b/doc/Developing/os/Health-Information.md
@@ -88,9 +88,9 @@ are as follows:
 - `oid` (required): This is the name of the table you want to do the snmp walk on.
 - `value` (optional): This is the key within the table that contains
   the value. If not provided willuse `oid`
-- `num_oid` (required): This is the numerical OID that contains
-  `value`. This should always include `{{ $index }}`.  snmptranslate
-  -On can help figure out the number.
+- `num_oid` (optional): If not provided, this parameter should be found
+  automatically. This is the numerical OID that contains
+  `value`. This should usually include `{{ $index }}`.
   In case the index is a string, `{{ $index_string }}` can be used instead.
 - `divisor` (optional): This is the divisor to use against the returned `value`.
 - `multiplier` (optional): This is the multiplier to use against the returned `value`.

--- a/doc/Developing/os/Mem-CPU-Information.md
+++ b/doc/Developing/os/Mem-CPU-Information.md
@@ -115,7 +115,7 @@ Available yaml data keys:
 Key | Default | Description
 ----- | --- | -----
 oid | required | The string based oid to fetch data, could be a table or a single value
-num_oid | required | the numerical oid to fetch data from when polling, usually should be appended by {{ $index }}
+num_oid | optional | The numerical oid to fetch data from when polling, usually should be appended by {{ $index }}. Computed by discovery process if not provided.
 value | optional | Oid to retrieve data from, primarily used for tables
 precision | 1 | The multiplier to multiply the data by. If this is negative, the data will be multiplied then subtracted from 100.
 descr | Processor | Description of this processor, may be an oid or plain string.  Helpful values {{ $index }} and {{$count}}

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -954,8 +954,6 @@ function discovery_process(&$valid, $device, $sensor_class, $pre_cache)
 
                 // Check if we have a "num_oid" value. If not, we'll try to compute it from textual OIDs with snmptranslate.
                 if (empty($data['num_oid'])) {
-                    // Let's guess
-                    d_echo($device);
                     $num_oid = snmp_translate($data_name, $device['dynamic_discovery']['mib'], null, null, $device);
                     if (oid_is_numeric($num_oid)) {
                         $data['num_oid'] = $num_oid . '.{{ $index }}';

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -963,7 +963,7 @@ function discovery_process(&$valid, $device, $sensor_class, $pre_cache)
                     } else {
                         $skippedFromYaml = true;
                         // Cause we still don't have a num_oid
-                        d_echo("Error: We don't have a num_oid defined for " . $data_name . " in YAML file, and cannot guess it out of MIB files (" . $device['dynamic_discovery']['mib'] . ")");
+                        d_echo('Error: We don\'t have a num_oid defined for ' . $data_name . ' in YAML file, and cannot guess it out of MIB files (' . $device['dynamic_discovery']['mib'] . ')');
                     }
                 }
 

--- a/includes/snmp.inc.php
+++ b/includes/snmp.inc.php
@@ -783,10 +783,14 @@ function snmp_translate($oid, $mib = 'ALL', $mibdir = null, $options = null, $de
     if (oid_is_numeric($oid)) {
         $default_options = '-Os';
     } else {
-        if ($mib != 'ALL' && ! Str::contains($oid, '::')) {
+        if ($mib != 'ALL' && ! Str::contains($mib, ':') && ! Str::contains($oid, '::')) {
             $oid = "$mib::$oid";
         }
         $default_options = '-On';
+        if (Str::contains($mib, ':') && ! Str::contains($oid, '::')) {
+            // We have more than one MIB file to load, and no explicit mib in OID, so let's activate random search for OID
+            $cmd = array_merge($cmd, ['-IR']);
+        }
     }
     $options = is_null($options) ? $default_options : $options;
     $cmd = array_merge($cmd, (array) $options);

--- a/includes/snmp.inc.php
+++ b/includes/snmp.inc.php
@@ -781,16 +781,12 @@ function snmp_translate($oid, $mib = 'ALL', $mibdir = null, $options = null, $de
     $cmd = [Config::get('snmptranslate', 'snmptranslate'), '-M', mibdir($mibdir, $device), '-m', $mib];
 
     if (oid_is_numeric($oid)) {
-        $default_options = '-Os';
+        $default_options = ['-Os', '-Pu'];
     } else {
-        if ($mib != 'ALL' && ! Str::contains($mib, ':') && ! Str::contains($oid, '::')) {
+        if ($mib != 'ALL' && ! Str::contains($oid, '::')) {
             $oid = "$mib::$oid";
         }
-        $default_options = '-On';
-        if (Str::contains($mib, ':') && ! Str::contains($oid, '::')) {
-            // We have more than one MIB file to load, and no explicit mib in OID, so let's activate random search for OID
-            $cmd = array_merge($cmd, ['-IR']);
-        }
+        $default_options = ['-On', '-Pu'];
     }
     $options = is_null($options) ? $default_options : $options;
     $cmd = array_merge($cmd, (array) $options);

--- a/misc/discovery_schema.json
+++ b/misc/discovery_schema.json
@@ -170,7 +170,6 @@
                                 },
                                 "additionalProperties": false,
                                 "required": [
-                                    "num_oid",
                                     "oid"
                                 ]
                             }
@@ -279,7 +278,6 @@
                                         "additionalProperties": false,
                                         "required": [
                                             "descr",
-                                            "num_oid",
                                             "oid",
                                             "states"
                                         ]
@@ -446,7 +444,6 @@
                         "additionalProperties": false,
                         "required": [
                             "descr",
-                            "num_oid",
                             "oid"
                         ]
                     }


### PR DESCRIPTION
This PR will try to guess "num_oid" if this value is not provided for sensors or processors in discovery YAML file. 
- If it is not found, then the sensor/processor won't be discovered and a debug information will be written
- If found, a debug info is still written

Should be found most of the time, because if the MIBfile is not OK, then the snmp(bulk)walk probably failed before the snmptranslate. But MIBfiles are sometimes so messy that we may have cornercases. 

Should not have any impact on any existing YAML file (where num_oid is fully defined).

TODO:
- OPTIONAL - evaluate if any optimisation/caching is needed on snmptranslate. It only occurs in discovery, so polling code is anyway not impacted.


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 12570 `
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
