### PR TITLE
Add no-db-cleanup argument in daily.sh

### DIFF
--- a/daily.sh
+++ b/daily.sh
@@ -342,7 +342,7 @@ main () {
                 status_run 'Updating SQL-Schema' 'php includes/sql-schema/update.php'
                 status_run 'Cleaning up DB' "$DAILY_SCRIPT cleanup"
             ;;
-            post-pull)
+            post-pull|no-db-cleanup)
                 # re-check dependencies after pull with the new code
                 check_dependencies
 
@@ -366,7 +366,9 @@ main () {
                 # List all tasks to do after pull in the order of execution
                 status_run 'Updating SQL-Schema' 'php includes/sql-schema/update.php'
                 status_run 'Updating submodules' "$DAILY_SCRIPT submodules"
-                status_run 'Cleaning up DB' "$DAILY_SCRIPT cleanup"
+                if [ "$arg" != "no-db-cleanup" ] ; then
+                    status_run 'Cleaning up DB' "$DAILY_SCRIPT cleanup"
+                fi
                 status_run 'Fetching notifications' "$DAILY_SCRIPT notifications"
                 status_run 'Caching PeeringDB data' "$DAILY_SCRIPT peeringdb"
             ;;


### PR DESCRIPTION
I am using distributed pollers. and one database. each poller maintains the current librenms code and cleans the database after each update. if many pollers are updated, everyone will clean up the database. running the daily update script with this key will avoid such situations. but we must remember that the database should still be cleaned with a daily update, but now it will be possible to do it only from one place. 