### PR TITLE
Update hpe-ilo.yaml

### DIFF
--- a/includes/definitions/discovery/hpe-ilo.yaml
+++ b/includes/definitions/discovery/hpe-ilo.yaml
@@ -134,3 +134,36 @@ modules:
                         - { descr: ok, graph: 1, value: 2, generic: 0 }
                         - { descr: degraded, graph: 1, value: 3, generic: 1 }
                         - { descr: failed, graph: 1, value: 4, generic: 1 }
+                -
+                    oid: cpqDaLogDrvTable
+                    value: cpqDaLogDrvStatus
+                    num_oid:  '.1.3.6.1.4.1.232.3.2.3.1.1.4.{{ $index }}'
+                    descr: 'Logical Drive Status #{{ $cpqDaLogDrvIndex }}'
+                    index: 'cpqDaLogDrvEntry.{{ $index }}'
+                    state_name: cpqDaLogDrvEntry
+                    states:
+                        - { descr: other, graph: 1, value: 1, generic: 3 }
+                        - { descr: ok, graph: 1, value: 2, generic: 0 }
+                        - { descr: failed, graph: 1, value: 3, generic: 2 }
+                        - { descr: unconfigured, graph: 1, value: 4, generic: 3 }
+                        - { descr: recovering, graph: 1, value: 5, generic: 2 }
+                        - { descr: readyRebuild, graph: 1, value: 6, generic: 1 }
+                        - { descr: rebuilding, graph: 1, value: 7, generic: 2 }
+                        - { descr: wrongDrive, graph: 1, value: 8, generic: 2 }
+                        - { descr: badConnect, graph: 1, value: 9, generic: 1 }
+                        - { descr: overheating, graph: 1, value: 10, generic: 2 }
+                        - { descr: shutdown, graph: 1, value: 11, generic: 2 }
+                        - { descr: expanding, graph: 1, value: 12, generic: 1 }
+                        - { descr: notAvailable, graph: 1, value: 13, generic: 3 }
+                        - { descr: queuedForExpansion, graph: 1, value: 14, generic: 1 }
+                        - { descr: multipathAccessDegraded, graph: 1, value: 15, generic: 1 }
+                        - { descr: erasing, graph: 1, value: 16, generic: 1 }
+                        - { descr: predictiveSpareRebuildReady, graph: 1, value: 17, generic: 1 }
+                        - { descr: rapidParityInitializationInProgress, graph: 1, value: 18, generic: 1 }
+                        - { descr: rapidParityInitializationPending, graph: 1, value: 19, generic: 1 }
+                        - { descr: noAccessEncryptedWithNoControllerKey, graph: 1, value: 20, generic: 0 }
+                        - { descr: unencryptedToEncryptedTransformationInProgress, graph: 1, value: 21, generic: 1 }
+                        - { descr: newLogicalDriveKeyRekeyInProgress, graph: 1, value: 22, generic: 1 }
+                        - { descr: noAccessEncryptedWithControllerEncryptionNotEnabled, graph: 1, value: 23, generic: 1 }
+                        - { descr: unencryptedToEncryptedTransformationNotStarted, graph: 1, value: 24, generic: 1 }
+                        - { descr: newLogicalDriveKeyRekeyRequestReceived, graph: 1, value: 25, generic: 1 }

--- a/includes/definitions/discovery/hpe-ilo.yaml
+++ b/includes/definitions/discovery/hpe-ilo.yaml
@@ -139,8 +139,8 @@ modules:
                     value: cpqDaLogDrvStatus
                     num_oid:  '.1.3.6.1.4.1.232.3.2.3.1.1.4.{{ $index }}'
                     descr: 'Logical Drive Status #{{ $cpqDaLogDrvIndex }}'
-                    index: 'cpqDaLogDrvEntry.{{ $index }}'
-                    state_name: cpqDaLogDrvEntry
+                    index: 'cpqDaLogDrvIndex.{{ $index }}'
+                    state_name: cpqDaLogDrvStatus
                     states:
                         - { descr: other, graph: 1, value: 1, generic: 3 }
                         - { descr: ok, graph: 1, value: 2, generic: 0 }

--- a/tests/data/hpe-ilo_4.json
+++ b/tests/data/hpe-ilo_4.json
@@ -4627,6 +4627,31 @@
                     "sensor_deleted": 0,
                     "sensor_class": "state",
                     "poller_type": "snmp",
+                    "sensor_oid": ".1.3.6.1.4.1.232.3.2.3.1.1.4.0.1",
+                    "sensor_index": "cpqDaLogDrvIndex.0.1",
+                    "sensor_type": "cpqDaLogDrvStatus",
+                    "sensor_descr": "Logical Drive Status #1",
+                    "group": null,
+                    "sensor_divisor": 1,
+                    "sensor_multiplier": 1,
+                    "sensor_current": 2,
+                    "sensor_limit": null,
+                    "sensor_limit_warn": null,
+                    "sensor_limit_low": null,
+                    "sensor_limit_low_warn": null,
+                    "sensor_alert": 1,
+                    "sensor_custom": "No",
+                    "entPhysicalIndex": null,
+                    "entPhysicalIndex_measured": null,
+                    "sensor_prev": null,
+                    "user_func": null,
+                    "state_name": "cpqDaLogDrvStatus"
+                },
+
+                {
+                    "sensor_deleted": 0,
+                    "sensor_class": "state",
+                    "poller_type": "snmp",
                     "sensor_oid": ".1.3.6.1.4.1.232.3.2.5.1.1.37.0.0",
                     "sensor_index": "cpqDaPhyDrvCondition.0.0",
                     "sensor_type": "cpqDaPhyDrvCondition",
@@ -6431,6 +6456,181 @@
                     "state_descr": "failed",
                     "state_draw_graph": 1,
                     "state_value": 4,
+                    "state_generic_value": 1
+                },
+                {
+                    "state_name": "cpqDaLogDrvStatus",
+                    "state_descr": "other",
+                    "state_draw_graph": 1,
+                    "state_value": 1,
+                    "state_generic_value": 3
+                },
+                {
+                    "state_name": "cpqDaLogDrvStatus",
+                    "state_descr": "ok",
+                    "state_draw_graph": 1,
+                    "state_value": 2,
+                    "state_generic_value": 0
+                },
+                {
+                    "state_name": "cpqDaLogDrvStatus",
+                    "state_descr": "failed",
+                    "state_draw_graph": 1,
+                    "state_value": 3,
+                    "state_generic_value": 2
+                },
+                {
+                    "state_name": "cpqDaLogDrvStatus",
+                    "state_descr": "unconfigured",
+                    "state_draw_graph": 1,
+                    "state_value": 4,
+                    "state_generic_value": 2
+                },
+                {
+                    "state_name": "cpqDaLogDrvStatus",
+                    "state_descr": "recovering",
+                    "state_draw_graph": 1,
+                    "state_value": 5,
+                    "state_generic_value": 2
+                },
+                {
+                    "state_name": "cpqDaLogDrvStatus",
+                    "state_descr": "readyRebuild",
+                    "state_draw_graph": 1,
+                    "state_value": 6,
+                    "state_generic_value": 1
+                },
+                {
+                    "state_name": "cpqDaLogDrvStatus",
+                    "state_descr": "rebuilding",
+                    "state_draw_graph": 1,
+                    "state_value": 7,
+                    "state_generic_value": 2
+                },
+                {
+                    "state_name": "cpqDaLogDrvStatus",
+                    "state_descr": "wrongDrive",
+                    "state_draw_graph": 1,
+                    "state_value": 8,
+                    "state_generic_value": 2
+                },
+                {
+                    "state_name": "cpqDaLogDrvStatus",
+                    "state_descr": "badConnect",
+                    "state_draw_graph": 1,
+                    "state_value": 9,
+                    "state_generic_value": 1
+                },
+                {
+                    "state_name": "cpqDaLogDrvStatus",
+                    "state_descr": "overheating",
+                    "state_draw_graph": 1,
+                    "state_value": 10,
+                    "state_generic_value": 2
+                },
+                {
+                    "state_name": "cpqDaLogDrvStatus",
+                    "state_descr": "shutdown",
+                    "state_draw_graph": 1,
+                    "state_value": 11,
+                    "state_generic_value": 2
+                },
+                {
+                    "state_name": "cpqDaLogDrvStatus",
+                    "state_descr": "expanding",
+                    "state_draw_graph": 1,
+                    "state_value": 12,
+                    "state_generic_value": 1
+                },
+                {
+                    "state_name": "cpqDaLogDrvStatus",
+                    "state_descr": "notAvailable",
+                    "state_draw_graph": 1,
+                    "state_value": 13,
+                    "state_generic_value": 3
+                },
+                {
+                    "state_name": "cpqDaLogDrvStatus",
+                    "state_descr": "queuedForExpansion",
+                    "state_draw_graph": 1,
+                    "state_value": 14,
+                    "state_generic_value": 1
+                },
+                {
+                    "state_name": "cpqDaLogDrvStatus",
+                    "state_descr": "multipathAccessDegraded",
+                    "state_draw_graph": 1,
+                    "state_value": 15,
+                    "state_generic_value": 1
+                },
+                {
+                    "state_name": "cpqDaLogDrvStatus",
+                    "state_descr": "erasing",
+                    "state_draw_graph": 1,
+                    "state_value": 16,
+                    "state_generic_value": 1
+                },
+                {
+                    "state_name": "cpqDaLogDrvStatus",
+                    "state_descr": "predictiveSpareRebuildReady",
+                    "state_draw_graph": 1,
+                    "state_value": 17,
+                    "state_generic_value": 1
+                },
+                {
+                    "state_name": "cpqDaLogDrvStatus",
+                    "state_descr": "rapidParityInitializationInProgress",
+                    "state_draw_graph": 1,
+                    "state_value": 18,
+                    "state_generic_value": 1
+                },
+                {
+                    "state_name": "cpqDaLogDrvStatus",
+                    "state_descr": "rapidParityInitializationPending",
+                    "state_draw_graph": 1,
+                    "state_value": 19,
+                    "state_generic_value": 1
+                },
+                {
+                    "state_name": "cpqDaLogDrvStatus",
+                    "state_descr": "noAccessEncryptedWithNoControllerKey",
+                    "state_draw_graph": 1,
+                    "state_value": 20,
+                    "state_generic_value": 0
+                },
+                {
+                    "state_name": "cpqDaLogDrvStatus",
+                    "state_descr": "unencryptedToEncryptedTransformationInProgress",
+                    "state_draw_graph": 1,
+                    "state_value": 21,
+                    "state_generic_value": 1
+                },
+                {
+                    "state_name": "cpqDaLogDrvStatus",
+                    "state_descr": "newLogicalDriveKeyRekeyInProgress",
+                    "state_draw_graph": 1,
+                    "state_value": 22,
+                    "state_generic_value": 1
+                },
+                {
+                    "state_name": "cpqDaLogDrvStatus",
+                    "state_descr": "noAccessEncryptedWithControllerEncryptionNotEnabled",
+                    "state_draw_graph": 1,
+                    "state_value": 23,
+                    "state_generic_value": 1
+                },
+                {
+                    "state_name": "cpqDaLogDrvStatus",
+                    "state_descr": "unencryptedToEncryptedTransformationNotStarted",
+                    "state_draw_graph": 1,
+                    "state_value": 24,
+                    "state_generic_value": 1
+                },
+                {
+                    "state_name": "cpqDaLogDrvStatus",
+                    "state_descr": "newLogicalDriveKeyRekeyRequestReceived",
+                    "state_draw_graph": 1,
+                    "state_value": 25,
                     "state_generic_value": 1
                 },
                 {

--- a/tests/data/hpe-ilo_4.json
+++ b/tests/data/hpe-ilo_4.json
@@ -6484,7 +6484,7 @@
                     "state_descr": "unconfigured",
                     "state_draw_graph": 1,
                     "state_value": 4,
-                    "state_generic_value": 2
+                    "state_generic_value": 3
                 },
                 {
                     "state_name": "cpqDaLogDrvStatus",


### PR DESCRIPTION
### Please give a short description what your pull request is for

Added support for Logical Drive Status.

When using 3rd party disks with for example P420i, the controller reports the Logical Drive Condition as degraded as the disk is unauthenticated. So to get the actual status of the logical device one has to look at Logical Drive Status instead (which also reports a lot of other states).

The following alert rule can be created to alert for anything that isn't "other" or "OK":

sensors.sensor_current NOT REGEXP "[1-2]" AND sensors.sensor_oid LIKE '.1.3.6.1.4.1.232.3.2.3.1.1.4%'

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
