### PR TITLE
Potential fix for #12427

### DIFF
--- a/LibreNMS/__init__.py
+++ b/LibreNMS/__init__.py
@@ -36,7 +36,7 @@ def call_script(script, args=()):
     cmd = base + ("{}/{}".format(base_dir, script),) + tuple(map(str, args))
     debug("Running {}".format(cmd))
     # preexec_fn=os.setsid here keeps process signals from propagating (close_fds=True is default)
-    return subprocess.check_call(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT, preexec_fn=os.setsid, close_fds=True)
+    return subprocess.check_call(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT, start_new_session=True, close_fds=True)
 
 
 class DB:

--- a/LibreNMS/service.py
+++ b/LibreNMS/service.py
@@ -9,11 +9,6 @@ import threading
 import sys
 import time
 
-try:
-    import psutil
-except ImportError:
-    pass
-
 from datetime import timedelta
 from datetime import datetime
 from logging import debug, info, warning, error, critical, exception
@@ -501,11 +496,7 @@ class Service:
 
         info('Restarting service... ')
 
-        if 'psutil' not in sys.modules:
-            warning("psutil is not available, polling gap possible")
-            self._stop_managers_and_wait()
-        else:
-            self._stop_managers()
+        self._stop_managers()
         self._release_master()
 
         python = sys.executable

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ PyMySQL
 python-dotenv
 redis>=3.0
 setuptools
-psutil


### PR DESCRIPTION
When testing, check that:
* the process restarts overnight with no polling gaps
* the main process does not run at 100% load
* there are no 'defunct' processes

If anyone is running a poller on Windows, macOS or BSD, it'd be interesting to see if this is portable.
#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
