### PR TITLE
Switch parsing order of <field>_template and <field>_regex

### DIFF
--- a/LibreNMS/OS/Traits/YamlOSDiscovery.php
+++ b/LibreNMS/OS/Traits/YamlOSDiscovery.php
@@ -67,15 +67,16 @@ trait YamlOSDiscovery
 
         foreach ($oids as $field => $oid_list) {
             if ($value = $this->findFirst($data, $oid_list, $numeric)) {
-                // extract via regex if requested
-                if (isset($os_yaml["{$field}_regex"])) {
-                    $this->parseRegex($os_yaml["{$field}_regex"], $value);
-                    $value = $device->$field;
+                $device->$field = $value;
+
+                if (isset($os_yaml["{$field}_template"])) {
+                    $device->$field = $this->parseTemplate($os_yaml["{$field}_template"], $data);
                 }
 
-                $device->$field = isset($os_yaml["{$field}_template"])
-                    ? $this->parseTemplate($os_yaml["{$field}_template"], $data)
-                    : $value;
+                // extract via regex if requested
+                if (isset($os_yaml["{$field}_regex"])) {
+                    $this->parseRegex($os_yaml["{$field}_regex"], $device->$field);
+                }
             }
         }
     }


### PR DESCRIPTION
This allows for a rudimental "else" in yaml with template support.

For example; This would match the first oid that exists,
either "oid1" or "oid2/oid3":

```yaml
    serial:
        - MIB::oid1
        - MIB::oid2
        - MIB::oid3
    serial_template: '{{ MIB::oid1 }} {{ MIB::oid2 }}/{{ MIB::{{ MIB::oid3 }} }}'
    serial_regex: '/(?<serial>[^ ]+)/'
```

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
