### PR TITLE
Add ability to set a custom port on IPMI agents

### DIFF
--- a/includes/html/pages/device/edit/ipmi.inc.php
+++ b/includes/html/pages/device/edit/ipmi.inc.php
@@ -3,7 +3,7 @@
 if ($_POST['editing']) {
     if (Auth::user()->hasGlobalAdmin()) {
         $ipmi_hostname = mres($_POST['ipmi_hostname']);
-        $ipmi_port = mres($_POST['ipmi_port']);
+        $ipmi_port = (int) $_POST['ipmi_port'];
         $ipmi_username = mres($_POST['ipmi_username']);
         $ipmi_password = mres($_POST['ipmi_password']);
 

--- a/includes/html/pages/device/edit/ipmi.inc.php
+++ b/includes/html/pages/device/edit/ipmi.inc.php
@@ -3,6 +3,7 @@
 if ($_POST['editing']) {
     if (Auth::user()->hasGlobalAdmin()) {
         $ipmi_hostname = mres($_POST['ipmi_hostname']);
+        $ipmi_port = mres($_POST['ipmi_port']);
         $ipmi_username = mres($_POST['ipmi_username']);
         $ipmi_password = mres($_POST['ipmi_password']);
 
@@ -10,6 +11,12 @@ if ($_POST['editing']) {
             set_dev_attrib($device, 'ipmi_hostname', $ipmi_hostname);
         } else {
             del_dev_attrib($device, 'ipmi_hostname');
+        }
+
+        if ($ipmi_port != '') {
+            set_dev_attrib($device, 'ipmi_port', $ipmi_port);
+        } else {
+            set_dev_attrib($device, 'ipmi_port', '623'); // Default port
         }
 
         if ($ipmi_username != '') {
@@ -48,6 +55,12 @@ if ($updated && $update_message) {
     <label for="ipmi_hostname" class="col-sm-2 control-label">IPMI/BMC Hostname</label>
     <div class="col-sm-6">
       <input id="ipmi_hostname" name="ipmi_hostname" class="form-control" value="<?php echo get_dev_attrib($device, 'ipmi_hostname'); ?>" />
+    </div>
+  </div>
+  <div class="form-group">
+    <label for="ipmi_port" class="col-sm-2 control-label">IPMI/BMC Port</label>
+    <div class="col-sm-6">
+      <input id="ipmi_port" name="ipmi_port" class="form-control" value="<?php echo get_dev_attrib($device, 'ipmi_port'); ?>" placeholder="623" />
     </div>
   </div>
   <div class="form-group">

--- a/includes/polling/ipmi.inc.php
+++ b/includes/polling/ipmi.inc.php
@@ -9,6 +9,7 @@ if (is_array($ipmi_rows)) {
     d_echo($ipmi_rows);
 
     if ($ipmi['host'] = $attribs['ipmi_hostname']) {
+        $ipmi['port'] = filter_var($attribs['ipmi_port'], FILTER_VALIDATE_INT) ? $attribs['ipmi_port'] : '623';
         $ipmi['user'] = $attribs['ipmi_username'];
         $ipmi['password'] = $attribs['ipmi_password'];
         $ipmi['type'] = $attribs['ipmi_type'];
@@ -17,7 +18,7 @@ if (is_array($ipmi_rows)) {
 
         $cmd = [Config::get('ipmitool', 'ipmitool')];
         if (Config::get('own_hostname') != $device['hostname'] || $ipmi['host'] != 'localhost') {
-            array_push($cmd, '-H', $ipmi['host'], '-U', $ipmi['user'], '-P', $ipmi['password'], '-L', 'USER');
+            array_push($cmd, '-H', $ipmi['host'], '-U', $ipmi['user'], '-P', $ipmi['password'], '-L', 'USER', '-p', $ipmi['port']);
         }
 
         // Check to see if we know which IPMI interface to use


### PR DESCRIPTION
Add an optional "IPMI/BMC" host port setting field. This is useful when you have an IPMI system that is configured on the non-standard port other than 623.

Default is still set to 623 regardless 

![image](https://user-images.githubusercontent.com/76983557/111718000-11479600-88be-11eb-8465-972d8373caeb.png)


#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
