### PR TITLE
Translate hex sensor values returned from ipmitool

### DIFF
--- a/includes/polling/ipmi.inc.php
+++ b/includes/polling/ipmi.inc.php
@@ -38,8 +38,8 @@ if (is_array($ipmi_rows)) {
 
             // SDR records can include hexadecimal values, identified by an h
             // suffix (like "93h" for 0x93). Convert them to decimal.
-            if (preg_match('/^[0-9A-Fa-f]+h$/', $value)) {
-                $value = hexdec(substr($value, 0, -1));
+            if (preg_match('/^([0-9A-Fa-f]+)h$/', $value, $matches)) {
+                $value = hexdec($matches[1]);
             }
 
             $ipmi_sensor[$desc][$ipmi_unit_type]['value'] = $value;

--- a/includes/polling/ipmi.inc.php
+++ b/includes/polling/ipmi.inc.php
@@ -35,6 +35,13 @@ if (is_array($ipmi_rows)) {
             [$desc, $value, $type, $status] = explode(',', $row);
             $desc = trim($desc, ' ');
             $ipmi_unit_type = Config::get("ipmi_unit.$type");
+
+	    // SDR records can include hexadecimal values, identified by an h
+	    // suffix (like "93h" for 0x93). Convert them to decimal.
+            if (preg_match('/^[0-9A-Fa-f]+h$/', $value)) {
+                $value = hexdec(substr($value, 0, -1));
+            }
+
             $ipmi_sensor[$desc][$ipmi_unit_type]['value'] = $value;
             $ipmi_sensor[$desc][$ipmi_unit_type]['unit'] = $type;
         }

--- a/includes/polling/ipmi.inc.php
+++ b/includes/polling/ipmi.inc.php
@@ -36,8 +36,8 @@ if (is_array($ipmi_rows)) {
             $desc = trim($desc, ' ');
             $ipmi_unit_type = Config::get("ipmi_unit.$type");
 
-	    // SDR records can include hexadecimal values, identified by an h
-	    // suffix (like "93h" for 0x93). Convert them to decimal.
+            // SDR records can include hexadecimal values, identified by an h
+            // suffix (like "93h" for 0x93). Convert them to decimal.
             if (preg_match('/^[0-9A-Fa-f]+h$/', $value)) {
                 $value = hexdec(substr($value, 0, -1));
             }


### PR DESCRIPTION
This PR does two things:
1.  It ensures that hex values returned by `ipmitool` are interpreted correctly (i.e. so `93h` is written as 147 rather than 93).
2. It removes a source of string values from the ipmi poller, making it less likely that the InfluxDB write will fail.

More on the second point: I was seeing errors like this:

```
[2021-03-20 13:33:46] production.ERROR: InfluxDB exception: HTTP Code 400 {"error":"partial write: field type conflict: input field \"sensor\" on measurement \"ipmi\" is type float, already exists as type string dropped=1"}
```

This error occurred because the ipmi poller was writing string values and numeric values. `93h` would be written as a string, while `14.1` would be written as a number. The order of writing was apparently non-deterministic (or perhaps `ipmitool` was using non-deterministic order or who knows why), with the first value written determining the type of the field. If the string value won, the numeric values wouldn't be written, and vice versa. This PR fixes the one source of string values that affected me. I don't know enough about IPMI to know if there are others.

A better fix might be to call `floatval` on all ipmitool-sourced values before passing them to `data_update`, or perhaps to have `data_update` do the casting. I don't know enough about either `ipmitool` or `data_update` to know whether either change would be safe. 

#### Testing

I didn't add any tests for this PR because I couldn't figure out where to put them. There doesn't appear to be an existing test for the IPMI poller?

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
