### PR TITLE
Add poller_group docs on auto-discovered devices

### DIFF
--- a/doc/Extensions/Auto-Discovery.md
+++ b/doc/Extensions/Auto-Discovery.md
@@ -186,5 +186,5 @@ optional arguments:
 
 # Discovered devices
 
-Newly discovered devices will be added to the `default_poller_group`, this value defaults to 0 if unset. 
-When using distributed polling this value can be changed by setting `$config['default_poller_group`]` in config.php.
+Newly discovered devices will be added to the `default_poller_group`, this value defaults to 0 if unset.
+When using distributed polling, this value can be changed locally by setting `$config['default_poller_group`]` in config.php or globally by using `lnms config:set`.

--- a/doc/Extensions/Auto-Discovery.md
+++ b/doc/Extensions/Auto-Discovery.md
@@ -183,3 +183,8 @@ optional arguments:
                  verbosity.
 
 ```
+
+# Discovered devices
+
+Newly discovered devices will be added to the `default_poller_group`, this value defaults to 0 if unset. 
+When using distributed polling this value can be changed by setting `$config['default_poller_group`]` in config.php.


### PR DESCRIPTION
I needed to check the source code to figure to which poller_group auto-discovered devices were assigned. So to avoid people having to figure that out again, let's add it to the docs.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
