### PR TITLE
Don't fail on rrd close

### DIFF
--- a/LibreNMS/Proc.php
+++ b/LibreNMS/Proc.php
@@ -176,8 +176,12 @@ class Proc
     public function close($command = null)
     {
         if (isset($command)) {
-            if (is_resource($this->_pipes[0])) {
-                $this->sendInput($this->checkAddEOL($command));
+            try {
+                if (is_resource($this->_pipes[0])) {
+                    $this->sendInput($this->checkAddEOL($command));
+                }
+            } catch (\ErrorException $e) {
+                // might have closed already
             }
         }
 


### PR DESCRIPTION
if process already left

Tries to fix `ErrorException: fwrite(): write of 5 bytes failed with errno=32 Broken pipe`
from tests.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
