### PR TITLE
Fix alert template variable ping_timestamp

### DIFF
--- a/LibreNMS/Alert/RunAlerts.php
+++ b/LibreNMS/Alert/RunAlerts.php
@@ -77,7 +77,7 @@ class RunAlerts
     /**
      * Describe Alert
      * @param array $alert Alert-Result from DB
-     * @return array|bool
+     * @return array|bool|string
      */
     public function describeAlert($alert)
     {
@@ -112,7 +112,7 @@ class RunAlerts
         $obj['status_reason'] = $device['status_reason'];
         if (can_ping_device($attribs)) {
             $ping_stats = DevicePerf::where('device_id', $alert['device_id'])->latest('timestamp')->first();
-            $obj['ping_timestamp'] = $ping_stats->template;
+            $obj['ping_timestamp'] = $ping_stats->timestamp;
             $obj['ping_loss'] = $ping_stats->loss;
             $obj['ping_min'] = $ping_stats->min;
             $obj['ping_max'] = $ping_stats->max;

--- a/LibreNMS/Alert/Template.php
+++ b/LibreNMS/Alert/Template.php
@@ -34,7 +34,7 @@ class Template
     /**
      * Get the template details
      *
-     * @param null $obj
+     * @param array|null $obj
      * @return mixed
      */
     public function getTemplate($obj = null)

--- a/LibreNMS/Alerting/QueryBuilderFluentParser.php
+++ b/LibreNMS/Alerting/QueryBuilderFluentParser.php
@@ -34,7 +34,7 @@ class QueryBuilderFluentParser extends QueryBuilderParser
     /**
      * Convert the query builder rules to a Laravel Fluent builder
      *
-     * @return Builder
+     * @return Builder|null
      */
     public function toQuery()
     {

--- a/LibreNMS/Alerting/QueryBuilderParser.php
+++ b/LibreNMS/Alerting/QueryBuilderParser.php
@@ -284,7 +284,7 @@ class QueryBuilderParser implements \JsonSerializable
     /**
      * Parse a rule
      *
-     * @param $rule
+     * @param array $rule
      * @param bool $expand Expand macros?
      * @return string
      */
@@ -322,7 +322,7 @@ class QueryBuilderParser implements \JsonSerializable
     /**
      * Expand macro to sql
      *
-     * @param $subject
+     * @param string $subject
      * @param bool $tables_only Used when finding tables in query returns an array instead of sql string
      * @param int $depth_limit
      * @return string|array


### PR DESCRIPTION
`ping_timestamp` in the Alerting Template has never worked due to a typo

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
