### PR TITLE
Issue with snmpwalk_group string splitting

### DIFF
--- a/includes/discovery/sensors/voltage/rfc1628.inc.php
+++ b/includes/discovery/sensors/voltage/rfc1628.inc.php
@@ -26,7 +26,6 @@ if (is_numeric($battery_volts)) {
 }
 
 $output_volts = snmpwalk_group($device, 'upsOutputVoltage', 'UPS-MIB');
-d_echo($output_volts);
 foreach ($output_volts as $index => $data) {
     $volt_oid = ".1.3.6.1.2.1.33.1.4.4.1.2.$index";
     $divisor = get_device_divisor($device, $pre_cache['poweralert_serial'], 'voltage', $volt_oid);

--- a/includes/discovery/sensors/voltage/rfc1628.inc.php
+++ b/includes/discovery/sensors/voltage/rfc1628.inc.php
@@ -26,6 +26,7 @@ if (is_numeric($battery_volts)) {
 }
 
 $output_volts = snmpwalk_group($device, 'upsOutputVoltage', 'UPS-MIB');
+d_echo($output_volts);
 foreach ($output_volts as $index => $data) {
     $volt_oid = ".1.3.6.1.2.1.33.1.4.4.1.2.$index";
     $divisor = get_device_divisor($device, $pre_cache['poweralert_serial'], 'voltage', $volt_oid);

--- a/includes/snmp.inc.php
+++ b/includes/snmp.inc.php
@@ -675,14 +675,19 @@ function snmpwalk_group($device, $oid, $mib = '', $depth = 1, $array = [], $mibd
         // merge the parts into an array, creating keys if they don't exist
         $tmp = &$array;
         foreach ($parts as $part) {
-            $key = trim($part, '".');
-            if (empty($key)) {
-                continue 2;
-                //Warning: Illegal string offset '' in /opt/librenms/includes/snmp.inc.php on line 678
-                //Cannot create references to/from string offsets
-                //{"exception":"[object] (Error(code: 0): Cannot create references to/from string offsets at /opt/librenms/includes/snmp.inc.php:678)"}
-            }
-            $tmp = &$tmp[$key];
+            $tmp = &$tmp[trim($part, '"')];
+//            $key = strval(trim(strval((string)$part), '"'));
+//            if (empty($key)) {
+//        d_echo("ARRAY");
+//        d_echo($array);
+//        d_echo("KEY");
+//        d_echo($key);
+//        //        continue 2;
+//                //Warning: Illegal string offset '' in /opt/librenms/includes/snmp.inc.php on line 678
+//                //Cannot create references to/from string offsets
+//                //{"exception":"[object] (Error(code: 0): Cannot create references to/from string offsets at /opt/librenms/includes/snmp.inc.php:678)"}
+//            }
+//            $tmp = &$tmp[(string)$key];
         }
         $tmp = trim($value, "\" \n\r"); // assign the value as the leaf
     }

--- a/includes/snmp.inc.php
+++ b/includes/snmp.inc.php
@@ -674,18 +674,17 @@ function snmpwalk_group($device, $oid, $mib = '', $depth = 1, $array = [], $mibd
 
         // merge the parts into an array, creating keys if they don't exist
         $tmp = &$array;
-        try {
-            foreach ($parts as $part) {
-                $tmp = &$tmp[trim($part, '".')];
+        foreach ($parts as $part) {
+            $key = trim($part, '".');
+            if (empty($key)) {
+                continue 2;
+                //Warning: Illegal string offset '' in /opt/librenms/includes/snmp.inc.php on line 678
+                //Cannot create references to/from string offsets
+                //{"exception":"[object] (Error(code: 0): Cannot create references to/from string offsets at /opt/librenms/includes/snmp.inc.php:678)"}
             }
-            $tmp = trim($value, "\" \n\r"); // assign the value as the leaf
-        } catch (Exception $e) {
-            // We probably have invalid data here
-            //Warning: Illegal string offset '' in /opt/librenms/includes/snmp.inc.php on line 678
-            //Cannot create references to/from string offsets
-            //{"exception":"[object] (Error(code: 0): Cannot create references to/from string offsets at /opt/librenms/includes/snmp.inc.php:678)"}
-            continue;
+            $tmp = &$tmp[$key];
         }
+        $tmp = trim($value, "\" \n\r"); // assign the value as the leaf
     }
 
     return $array;

--- a/includes/snmp.inc.php
+++ b/includes/snmp.inc.php
@@ -662,7 +662,6 @@ function snmpwalk_group($device, $oid, $mib = '', $depth = 1, $array = [], $mibd
         }
 
         [$address, $value] = explode(' =', $line, 2);
-//file_put_contents("/tmp/debug", "line: ". $line."\n", FILE_APPEND );
         preg_match_all('/([^[\]]+)/', $address, $parts);
         $parts = $parts[1];
         array_splice($parts, $depth, 0, array_shift($parts)); // move the oid name to the correct depth
@@ -676,12 +675,9 @@ function snmpwalk_group($device, $oid, $mib = '', $depth = 1, $array = [], $mibd
         // merge the parts into an array, creating keys if they don't exist
         $tmp = &$array;
         foreach ($parts as $part) {
-//file_put_contents("/tmp/debug", "--> ". strval($part) . "\n", FILE_APPEND );
-            $key = (trim($part, '.'));
-            $key = (trim($key, '"'));
+            // we don't want to remove dots inside quotes, only outside
+            $key = trim(trim($part, '.'), '"');
             $tmp = &$tmp[$key];
-
-//file_put_contents("/tmp/debug", "-key-> ". $key . "\n", FILE_APPEND );
         }
         $tmp = trim($value, "\" \n\r"); // assign the value as the leaf
     }

--- a/includes/snmp.inc.php
+++ b/includes/snmp.inc.php
@@ -674,10 +674,19 @@ function snmpwalk_group($device, $oid, $mib = '', $depth = 1, $array = [], $mibd
 
         // merge the parts into an array, creating keys if they don't exist
         $tmp = &$array;
-        foreach ($parts as $part) {
-            $tmp = &$tmp[trim($part, '".')];
+        try {
+            foreach ($parts as $part) {
+                $tmp = &$tmp[trim($part, '".')];
+            }
+            $tmp = trim($value, "\" \n\r"); // assign the value as the leaf
         }
-        $tmp = trim($value, "\" \n\r"); // assign the value as the leaf
+        catch (Exception $e) {
+            // We probably have invalid data here
+            //Warning: Illegal string offset '' in /opt/librenms/includes/snmp.inc.php on line 678
+            //Cannot create references to/from string offsets
+            //{"exception":"[object] (Error(code: 0): Cannot create references to/from string offsets at /opt/librenms/includes/snmp.inc.php:678)"}
+            continue;
+        }
     }
 
     return $array;

--- a/includes/snmp.inc.php
+++ b/includes/snmp.inc.php
@@ -679,8 +679,7 @@ function snmpwalk_group($device, $oid, $mib = '', $depth = 1, $array = [], $mibd
                 $tmp = &$tmp[trim($part, '".')];
             }
             $tmp = trim($value, "\" \n\r"); // assign the value as the leaf
-        }
-        catch (Exception $e) {
+        } catch (Exception $e) {
             // We probably have invalid data here
             //Warning: Illegal string offset '' in /opt/librenms/includes/snmp.inc.php on line 678
             //Cannot create references to/from string offsets

--- a/includes/snmp.inc.php
+++ b/includes/snmp.inc.php
@@ -662,6 +662,7 @@ function snmpwalk_group($device, $oid, $mib = '', $depth = 1, $array = [], $mibd
         }
 
         [$address, $value] = explode(' =', $line, 2);
+//file_put_contents("/tmp/debug", "line: ". $line."\n", FILE_APPEND );
         preg_match_all('/([^[\]]+)/', $address, $parts);
         $parts = $parts[1];
         array_splice($parts, $depth, 0, array_shift($parts)); // move the oid name to the correct depth
@@ -675,19 +676,12 @@ function snmpwalk_group($device, $oid, $mib = '', $depth = 1, $array = [], $mibd
         // merge the parts into an array, creating keys if they don't exist
         $tmp = &$array;
         foreach ($parts as $part) {
-            $tmp = &$tmp[trim($part, '"')];
-//            $key = strval(trim(strval((string)$part), '"'));
-//            if (empty($key)) {
-//        d_echo("ARRAY");
-//        d_echo($array);
-//        d_echo("KEY");
-//        d_echo($key);
-//        //        continue 2;
-//                //Warning: Illegal string offset '' in /opt/librenms/includes/snmp.inc.php on line 678
-//                //Cannot create references to/from string offsets
-//                //{"exception":"[object] (Error(code: 0): Cannot create references to/from string offsets at /opt/librenms/includes/snmp.inc.php:678)"}
-//            }
-//            $tmp = &$tmp[(string)$key];
+//file_put_contents("/tmp/debug", "--> ". strval($part) . "\n", FILE_APPEND );
+            $key = (trim($part, '.'));
+            $key = (trim($key, '"'));
+            $tmp = &$tmp[$key];
+
+//file_put_contents("/tmp/debug", "-key-> ". $key . "\n", FILE_APPEND );
         }
         $tmp = trim($value, "\" \n\r"); // assign the value as the leaf
     }


### PR DESCRIPTION
fixes #12688

Trying to handle the replies from ipv6z entries that are not correctly returned by net-snmp. We expect it in hex and receive it raw.

Current string parsing was wrong, removing both quotes and dots. The correct behaviour is to remove dots first, and then remove quotes. The goal is to avoid removing dots inside quoted strings.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
