### PR TITLE
fix empty sensor_classes

### DIFF
--- a/LibreNMS/Util/ObjectCache.php
+++ b/LibreNMS/Util/ObjectCache.php
@@ -74,7 +74,7 @@ class ObjectCache
     public static function sensors()
     {
         return Cache::remember('ObjectCache:sensor_list:' . auth()->id(), self::$cache_time, function () {
-            $sensor_classes = Sensor::hasAccess(auth()->user())->select('sensor_class')->groupBy('sensor_class')->orderBy('sensor_class')->get();
+            $sensor_classes = Sensor::hasAccess(auth()->user())->select('sensor_class')->where('sensor_class','<>','')->groupBy('sensor_class')->orderBy('sensor_class')->get();
 
             $sensor_menu = [];
             foreach ($sensor_classes as $sensor_model) {

--- a/LibreNMS/Util/ObjectCache.php
+++ b/LibreNMS/Util/ObjectCache.php
@@ -74,7 +74,7 @@ class ObjectCache
     public static function sensors()
     {
         return Cache::remember('ObjectCache:sensor_list:' . auth()->id(), self::$cache_time, function () {
-            $sensor_classes = Sensor::hasAccess(auth()->user())->select('sensor_class')->where('sensor_class','<>','')->groupBy('sensor_class')->orderBy('sensor_class')->get();
+            $sensor_classes = Sensor::hasAccess(auth()->user())->select('sensor_class')->where('sensor_class', '<>', '')->groupBy('sensor_class')->orderBy('sensor_class')->get();
 
             $sensor_menu = [];
             foreach ($sensor_classes as $sensor_model) {


### PR DESCRIPTION
fix empty sensor_classes from being shown in menu and headers
this is caused by IPMI inserting blank sensors into DB with no sensor_class for some reason?
so the menu and headers seem to be showing an empty option?

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

**BEFORE:**
![goofed](https://user-images.githubusercontent.com/765314/113488673-72bf5580-94b7-11eb-90da-c8957a0831b9.png)
**AFTER:**
![fixed](https://user-images.githubusercontent.com/765314/113488676-76eb7300-94b7-11eb-89e5-c3a6bc543168.png)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
