### PR TITLE
Rrdtool array class

### DIFF
--- a/LibreNMS/Util/RrdTool.php
+++ b/LibreNMS/Util/RrdTool.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace LibreNMS\Util;
+
+use App\Models\Device;
+use LibreNMS\Config;
+use LibreNMS\Util\Rewrite;
+use LibreNMS\Data\Store\Rrd;
+
+
+class RrdTool
+{
+    /**
+     * Get array of all rrd files for device
+     *
+     * @param array $device device for which we get the rrd's
+     * @return array $rrdfilearray array of rrd files for this host
+     */
+    public static function getRrdFiles($device)
+    {
+        if (Config::get('rrdcached')) {
+            $rrdcachedcmd = sprintf('%s list /%s --daemon %s', Config::get('rrdtool', 'rrdtool'), $device['hostname'], Config::get('rrdcached'));
+            $rrd_files = shell_exec($rrdcachedcmd);
+            // Split returned files into array
+            $rrdfilearray = preg_split('/\s+/', trim($rrd_files));
+        } else {
+            $rrdclass = new Rrd();
+            $rrddir = $rrdclass->dirFromHost($device['hostname']);
+
+            $pattern = sprintf('%s/*.rrd', $rrddir);
+            $rrdfilearray = glob($pattern);
+        }
+
+        return $rrdfilearray;
+    }
+
+    /**
+     * Get array of rrd files for specific application.
+     *
+     * @param array $device device for which we get the rrd's
+     * @param int   $app_id application id on the device
+     * @param string  $app_name name of app to be searched
+     * @param string  $category which category of graphs are searched
+     * @return array $rrdfilearray array of rrd files for this host
+     */
+    public static function getRrdApplicationArrays($device, $app_id, $app_name, $category = null)
+    {
+        $entries = [];
+        $separator = '-';
+
+        $rrdfilearray = self::getRrdFiles($device);
+        if ($category) {
+            $pattern = sprintf('%s-%s-%s-%s', 'app', $app_name, $app_id, $category);
+        } else {
+            $pattern = sprintf('%s-%s-%s', 'app', $app_name, $app_id);
+        }
+
+        foreach ($rrdfilearray as $rrd) {
+            if (str_contains($rrd, $pattern)) {
+                $filename = basename($rrd, '.rrd');
+                $entry = explode($separator, $filename, 4 + $offset)[3 + $offset];
+                if ($entry) {
+                    array_push($entries, $entry);
+                }
+            }
+        }
+        
+        return $entries;
+    }
+}

--- a/LibreNMS/Util/RrdTool.php
+++ b/LibreNMS/Util/RrdTool.php
@@ -4,7 +4,6 @@ namespace LibreNMS\Util;
 
 use App\Models\Device;
 use LibreNMS\Config;
-use LibreNMS\Util\Rewrite;
 use LibreNMS\Data\Store\Rrd;
 
 

--- a/LibreNMS/Util/RrdTool.php
+++ b/LibreNMS/Util/RrdTool.php
@@ -24,9 +24,7 @@ class RrdTool
             // Split returned files into array
             $rrdfilearray = preg_split('/\s+/', trim($rrd_files));
         } else {
-            $rrdclass = new Rrd();
-            $rrddir = $rrdclass->dirFromHost($device['hostname']);
-
+            $rrddir = \Rrd::dirFromHost($device['hostname']);
             $pattern = sprintf('%s/*.rrd', $rrddir);
             $rrdfilearray = glob($pattern);
         }

--- a/includes/html/graphs/application/docker-common.inc.php
+++ b/includes/html/graphs/application/docker-common.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Util\RrdTool;
+
 $name = 'docker';
 $app_id = $app['app_id'];
 $colours = 'mega';
@@ -15,7 +17,8 @@ $smalldescrlen = 25;
 if (isset($vars['container'])) {
     $containers = [$vars['container']];
 } else {
-    $containers = get_arrays_with_application($device, $app['app_id'], 'docker');
+    $containers = RrdTool::getRrdApplicationArrays($device, $app['app_id'], 'docker');
+
 }
 
 $int = 0;

--- a/includes/html/pages/device/apps/docker.inc.php
+++ b/includes/html/pages/device/apps/docker.inc.php
@@ -1,6 +1,8 @@
 <?php
 
-$domain_list = get_arrays_with_application($device, $app['app_id'], 'docker');
+use LibreNMS\Util\RrdTool;
+
+$domain_list = RrdTool::getRrdApplicationArrays($device, $app['app_id'], 'docker');
 
 print_optionbar_start();
 


### PR DESCRIPTION
Some applications grab an array of rrd filenames to display links on the webgui and display the rrd graph data. This does not work over rrdcached, this pull request is to fix that.. I only have docker fixed in this pull request, but can fix the rest if this looks good. 

Here is the orginal PR that i tried.
https://github.com/librenms/librenms/pull/12689

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
