### PR TITLE
Add feature to capture a full snmprec

### DIFF
--- a/LibreNMS/Util/ModuleTestHelper.php
+++ b/LibreNMS/Util/ModuleTestHelper.php
@@ -140,9 +140,18 @@ class ModuleTestHelper
         $this->json_file = $path;
     }
 
-    public function captureFromDevice($device_id, $write = true, $prefer_new = false)
+    public function captureFromDevice($device_id, $write = true, $prefer_new = false, $full = false)
     {
-        $snmp_oids = $this->collectOids($device_id);
+        if ($full) {
+            $snmp_oids[] = [
+                'oid' => '.',
+                'method' => 'walk',
+                'mib' => null,
+                'mibdir' => null,
+            ];
+        } else {
+            $snmp_oids = $this->collectOids($device_id);
+        }
 
         $device = device_by_id_cache($device_id, true);
         DeviceCache::setPrimary($device_id);

--- a/scripts/collect-snmp-data.php
+++ b/scripts/collect-snmp-data.php
@@ -23,6 +23,7 @@ $options = getopt(
         'file:',
         'debug',
         'snmpsim',
+        'full',
         'help',
     ]
 );
@@ -83,10 +84,14 @@ Optional:
   -f, --file         Save data to file instead of the standard location
   -d, --debug        Enable debug output
       --snmpsim      Run snmpsimd.py using the collected data for manual testing.
+      --full         Walk the whole device (default: only used OIDs)
+                     Useful when adding device support when you don\'t have access to it directly,
+                     or when discovery/poller causes errors when capturing normally.
+                     Do NOT use this to submit test data!
 
-Example:
+Examples:
   ./collect-snmp-data.php -h 192.168.0.1 -v 2960x
-  ./collect-snmp-data.php -h 127.0.0.1 -v freeradius -m freeradius
+  ./collect-snmp-data.php -h 127.0.0.1 -v freeradius -m applications
 ';
     exit;
 }
@@ -125,10 +130,11 @@ try {
     }
 
     $prefer_new_snmprec = isset($options['n']) || isset($options['prefer-new']);
+    $full = isset($options['full']);
 
     echo 'Capturing Data: ';
     \LibreNMS\Util\OS::updateCache(true); // Force update of OS Cache
-    $capture->captureFromDevice($device['device_id'], true, $prefer_new_snmprec);
+    $capture->captureFromDevice($device['device_id'], true, $prefer_new_snmprec, $full);
 } catch (InvalidModuleException $e) {
     echo $e->getMessage() . PHP_EOL;
 }

--- a/scripts/save-test-data.php
+++ b/scripts/save-test-data.php
@@ -57,9 +57,9 @@ Optional:
   -d, --debug        Enable debug output
       --snmpsim      Run snmpsimd.py using the collected data for manual testing.
 
-Example:
+Examples:
   ./save-test-data.php -o ios -v 2960x
-  ./save-test-data.php -o linux -v freeradius -m freeradius
+  ./save-test-data.php -o linux -v freeradius -m applications
 ";
     exit;
 }


### PR DESCRIPTION
Good for adding device support when you don't have access to it directly. 
Or when discovery/poller causes errors when capturing normally

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
