### PR TITLE
fix adding discrete ipmi sensors by mistake

### DIFF
--- a/includes/discovery/sensors/ipmi.inc.php
+++ b/includes/discovery/sensors/ipmi.inc.php
@@ -18,9 +18,9 @@ if ($ipmi['host'] = get_dev_attrib($device, 'ipmi_hostname')) {
     foreach (Config::get('ipmi.type', []) as $ipmi_type) {
         $results = explode(PHP_EOL, external_exec(array_merge($cmd, ['-I', $ipmi_type, 'sensor'])));
 
-        array_filter($results, function ($line) {
+        $results = array_values(array_filter($results, function ($line) {
             return ! Str::contains($line, 'discrete');
-        });
+        }));
 
         if (! empty($results)) {
             set_dev_attrib($device, 'ipmi_type', $ipmi_type);


### PR DESCRIPTION
fix adding discrete ipmi sensors by accident

before it was adding the discrete sensors as blank sensor_classes

however this fix returns the array correctly and also renumbers them in order too

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
