### PR TITLE
Cisco AES256 support

### DIFF
--- a/includes/html/pages/addhost.inc.php
+++ b/includes/html/pages/addhost.inc.php
@@ -265,6 +265,7 @@ foreach (get_port_assoc_modes() as $mode) {
                 <option value="AES" selected>AES</option>
                 <option value="AES-192"<?= $snmpv3_aes256 ?: ' disabled'?>>AES-192</option>
                 <option value="AES-256"<?= $snmpv3_aes256 ?: ' disabled'?>>AES-256</option>
+                <option value="AES-256-C"<?= $snmpv3_aes256 ?: ' disabled'?>>AES-256-C</option>
                 <option value="DES">DES</option>
               </select>
               <?php if (! $snmpv3_aes256) {?>

--- a/includes/html/pages/device/edit/snmp.inc.php
+++ b/includes/html/pages/device/edit/snmp.inc.php
@@ -385,6 +385,7 @@ if (! $snmpv3_sha2) {
     <option value='AES' " . ($device['cryptoalgo'] === 'AES' ? 'selected' : '') . ">AES</option>
     <option value='AES-192' " . ($device['cryptoalgo'] === 'AES-192' ? 'selected' : '') . ($snmpv3_aes256 ?: ' disabled') . ">AES-192</option>
     <option value='AES-256' " . ($device['cryptoalgo'] === 'AES-256' ? 'selected' : '') . ($snmpv3_aes256 ?: ' disabled') . ">AES-256</option>
+    <option value='AES-256-C' " . ($device['cryptoalgo'] === 'AES-256-C' ? 'selected' : '') . ($snmpv3_aes256 ?: ' disabled') . ">AES-256 Cisco</option>
     <option value='DES'>DES</option>
     </select>
     ";

--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -5035,7 +5035,7 @@
             ],
             "validate": {
                 "value.*.authalgo": "in:MD5,SHA,SHA-224,SHA-256,SHA-384,SHA-512",
-                "value.*.cryptoalgo": "in:AES,AES-192,AES-256,DES"
+                "value.*.cryptoalgo": "in:AES,AES-192,AES-256,AES-256-C,DES"
             }
         },
         "snmp.version": {

--- a/tests/AddHostCliTest.php
+++ b/tests/AddHostCliTest.php
@@ -114,7 +114,7 @@ class AddHostCliTest extends DBTestCase
 
     public function testSnmpV3PrivacyProtocol()
     {
-        $modes = ['DES', 'AES', 'AES-192', 'AES-256'];
+        $modes = ['DES', 'AES', 'AES-192', 'AES-256', 'AES-256-C'];
         foreach ($modes as $mode) {
             $host = 'hostName' . $mode;
             $result = \Artisan::call('device:add ' . $host . ' -force -x ' . $mode . ' --v3');


### PR DESCRIPTION
Adds support to use the Cisco specific AES-256-C crypto algorithm for net-snmp if it is compiled with AES 256 support. 

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
