### PR TITLE
Update syslog.php

### DIFF
--- a/includes/syslog.php
+++ b/includes/syslog.php
@@ -53,9 +53,16 @@ function process_syslog($entry, $update)
     }
 
     $entry['host'] = preg_replace('/^::ffff:/', '', $entry['host']);
-    if ($new_host = Config::get("syslog_xlate.{$entry['host']}")) {
-        $entry['host'] = $new_host;
+
+    $axlate = Config::get('syslog_xlate');
+    if(true == is_array($axlate)){
+      foreach ($axlate as $xname => $xlate) {
+        if ( $xname == $entry['host']){
+           $entry['host'] = $xlate;
+        }
+      }
     }
+    
     $entry['device_id'] = get_cache($entry['host'], 'device_id');
     if ($entry['device_id']) {
         $os = get_cache($entry['host'], 'os');
@@ -166,6 +173,13 @@ function process_syslog($entry, $update)
 
         unset($os);
     }//end if
+    elseif(true == Config::get("syslog_debug"))
+    {
+        // For finding unknowen Hosts
+        $fd = fopen('/opt/librenms/logs/Debug.log', 'a');
+        fputs($fd, "Can't process host: " . $entry['host'] . "\n");
+        fclose($fd);
+    }
 
     return $entry;
 }//end process_syslog()


### PR DESCRIPTION
Some syslog-sendes use their FQDN as sender. If you put the whole FQDN in your config.php you can not access this entry. The Function Config::get uses dots as an array seperator.

This pull request fixes the problem described above.
Allready checked an have this running on my own site.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
