### PR TITLE
Added metric for MySQL Slave Lag (secs)

### DIFF
--- a/includes/polling/applications/mysql.inc.php
+++ b/includes/polling/applications/mysql.inc.php
@@ -96,6 +96,7 @@ $mapping = [
     'CSt'     => 'c5',
     'CUe'     => 'c3',
     'CUMi'    => 'c9',
+    'SlLa'    => 'br',
 ];
 
 $data = explode("\n", $mysql);
@@ -192,7 +193,8 @@ $rrd_def = RrdDefinition::make()
     ->addDataset('CRSt', 'DERIVE', 0, 125000000000)
     ->addDataset('CSt', 'DERIVE', 0, 125000000000)
     ->addDataset('CUe', 'DERIVE', 0, 125000000000)
-    ->addDataset('CUMi', 'DERIVE', 0, 125000000000);
+    ->addDataset('CUMi', 'DERIVE', 0, 125000000000)
+    ->addDataset('SlLa', 'GAUGE', 0, 125000000000);
 
 $tags = compact('name', 'app_id', 'rrd_name', 'rrd_def');
 data_update($device, 'app', $tags, $fields);

--- a/tests/data/linux_opensips.json
+++ b/tests/data/linux_opensips.json
@@ -1186,6 +1186,12 @@
                     "app_type": "mysql"
                 },
                 {
+                    "metric": "SlLa",
+                    "value": 0,
+                    "value_prev": null,
+                    "app_type": "mysql"
+                },
+                {
                     "metric": "SMPs",
                     "value": 98,
                     "value_prev": null,


### PR DESCRIPTION
Added metric for MySQL Slave Lag (in seconds) to be able to build Alert Rules when slave lag value is greater than 0 (or X). It's possible to add graphs and other metrics as well, but the priority for me is to be able to build alert rules based on the "Slave Lag" metric.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
