### PR TITLE
Pop returned value from snmpwalk_group for lldp on mikrotik routeros

### DIFF
--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -86,6 +86,7 @@ if (($device['os'] == 'routeros')) {
     echo ' LLDP-MIB: ';
     $lldp_array = snmpwalk_group($device, 'lldpRemEntry', 'LLDP-MIB', 3);
     if (! empty($lldp_array)) {
+        // workaround for routeros returning the incorrect index
         if (! empty($lldp_array[0][0])) {
             $lldp_array = $lldp_array[0][0];
         }

--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -84,7 +84,7 @@ echo PHP_EOL;
 
 if (($device['os'] == 'routeros')) {
     echo ' LLDP-MIB: ';
-    $lldp_array = snmpwalk_group($device, 'lldpRemEntry', 'LLDP-MIB', 3);
+    $lldp_array = snmpwalk_group($device, 'lldpRemEntry', 'LLDP-MIB', 3)[0][0];
     if (! empty($lldp_array)) {
         $lldp_ports = snmpwalk_group($device, 'mtxrInterfaceStatsName', 'MIKROTIK-MIB');
         $lldp_ports_num = snmpwalk_group($device, 'mtxrNeighborInterfaceID', 'MIKROTIK-MIB');

--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -84,8 +84,10 @@ echo PHP_EOL;
 
 if (($device['os'] == 'routeros')) {
     echo ' LLDP-MIB: ';
-    $lldp_array = snmpwalk_group($device, 'lldpRemEntry', 'LLDP-MIB', 3)[0][0];
+    $lldp_array = snmpwalk_group($device, 'lldpRemEntry', 'LLDP-MIB', 3);
     if (! empty($lldp_array)) {
+        if(!empty($lldp_array[0][0])) $lldp_array = $lldp_array[0][0];
+
         $lldp_ports = snmpwalk_group($device, 'mtxrInterfaceStatsName', 'MIKROTIK-MIB');
         $lldp_ports_num = snmpwalk_group($device, 'mtxrNeighborInterfaceID', 'MIKROTIK-MIB');
 

--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -86,7 +86,9 @@ if (($device['os'] == 'routeros')) {
     echo ' LLDP-MIB: ';
     $lldp_array = snmpwalk_group($device, 'lldpRemEntry', 'LLDP-MIB', 3);
     if (! empty($lldp_array)) {
-        if(!empty($lldp_array[0][0])) $lldp_array = $lldp_array[0][0];
+        if (! empty($lldp_array[0][0])) {
+            $lldp_array = $lldp_array[0][0];
+        }
 
         $lldp_ports = snmpwalk_group($device, 'mtxrInterfaceStatsName', 'MIKROTIK-MIB');
         $lldp_ports_num = snmpwalk_group($device, 'mtxrNeighborInterfaceID', 'MIKROTIK-MIB');


### PR DESCRIPTION
This seems to be an issue on only one vendor, but since they are already an exception I thought making the fix more complex might be too much.

On mikrotik devices the snmpwalk_group function returns 
`array (
  0 =>
  array (
    0 =>
    array (
      182 =>
      array (
      ....
`
instead of:
`array (
  182 =>
  array (
  ...
`
So the fix is pealing out the array.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
