### PR TITLE
Enable config:set to set variables inside a nested array of settings

### DIFF
--- a/app/Console/Commands/SetConfigCommand.php
+++ b/app/Console/Commands/SetConfigCommand.php
@@ -78,6 +78,7 @@ class SetConfigCommand extends LnmsCommand
             $sub_data = Config::get($setting, []);
             if (! is_array($sub_data)) {
                 $this->error(trans('commands.config:set.errors.append'));
+
                 return 2;
             }
 
@@ -101,10 +102,6 @@ class SetConfigCommand extends LnmsCommand
             $this->error($message);
 
             return 2;
-        }
-
-        if ($parent) {
-            dd($value);
         }
 
         if (Config::persist($setting, $value)) {

--- a/app/Console/Commands/SetConfigCommand.php
+++ b/app/Console/Commands/SetConfigCommand.php
@@ -4,6 +4,8 @@ namespace App\Console\Commands;
 
 use App\Console\Commands\Traits\CompletesConfigArgument;
 use App\Console\LnmsCommand;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 use LibreNMS\Config;
 use LibreNMS\DB\Eloquent;
 use LibreNMS\Util\DynamicConfig;
@@ -39,11 +41,15 @@ class SetConfigCommand extends LnmsCommand
         $setting = $this->argument('setting');
         $value = $this->argument('value');
         $force = $this->option('ignore-checks');
+        $parent = null;
 
-        if (! $force && ! $definition->isValidSetting($setting)) {
-            $this->error(trans('commands.config:set.errors.invalid'));
+        if (! $definition->isValidSetting($setting)) {
+            $parent = $this->findParentSetting($definition, $setting);
+            if (! $force && ! $parent) {
+                $this->error(trans('commands.config:set.errors.invalid'));
 
-            return 2;
+                return 2;
+            }
         }
 
         if (! Eloquent::isConnected()) {
@@ -53,16 +59,40 @@ class SetConfigCommand extends LnmsCommand
         }
 
         if (! $force && ! $value) {
-            if ($this->confirm(trans('commands.config:set.confirm', ['setting' => $setting]))) {
-                Config::erase($setting);
+            $message = $parent
+                ? trans('commands.config:set.forget_from', ['path' => $this->getChildPath($setting, $parent), 'parent' => $parent])
+                : trans('commands.config:set.confirm', ['setting' => $setting]);
 
-                return 0;
+            if ($this->confirm($message)) {
+                return $this->erase($setting, $parent) ? 0 : 1;
             }
 
             return 3;
         }
 
         $value = $this->juggleType($value);
+
+        // handle appending to arrays
+        if (Str::endsWith($setting, '.+')) {
+            $setting = substr($setting, 0, -2);
+            $sub_data = Config::get($setting, []);
+            if (! is_array($sub_data)) {
+                $this->error(trans('commands.config:set.errors.append'));
+                return 2;
+            }
+
+            array_push($sub_data, $value);
+            $value = $sub_data;
+        }
+
+        // handle setting value inside multi-dimensional array
+        if ($parent) {
+            $parent_data = Config::get($parent);
+            Arr::set($parent_data, $this->getChildPath($setting, $parent), $value);
+            $value = $parent_data;
+            $setting = $parent;
+        }
+
         $configItem = $definition->get($setting);
         if (! $force && ! $configItem->checkValue($value)) {
             $message = ($configItem->type || $configItem->validate)
@@ -71,6 +101,10 @@ class SetConfigCommand extends LnmsCommand
             $this->error($message);
 
             return 2;
+        }
+
+        if ($parent) {
+            dd($value);
         }
 
         if (Config::persist($setting, $value)) {
@@ -92,5 +126,66 @@ class SetConfigCommand extends LnmsCommand
         $json = json_decode($value, true);
 
         return json_last_error() ? $value : $json;
+    }
+
+    private function findParentSetting(DynamicConfig $definition, $setting): ?string
+    {
+        $parts = explode('.', $setting);
+        array_pop($parts); // looking for parent, not this setting
+
+        while (! empty($parts)) {
+            $name = implode('.', $parts);
+            if ($definition->isValidSetting($name)) {
+                return $name;
+            }
+            array_pop($parts);
+        }
+
+        return null;
+    }
+
+    private function erase($setting, $parent = null)
+    {
+        if ($parent) {
+            $data = Config::get($parent);
+
+            if (preg_match("/^$parent\.?(?<sub>.+)\\.(?<index>\\d+)\$/", $setting, $matches)) {
+                // nested inside the parent setting, update just the required part
+                $sub_data = Arr::get($data, $matches['sub']);
+                $this->forgetWithIndex($sub_data, $matches['index']);
+                Arr::set($data, $matches['sub'], $sub_data);
+            } else {
+                // not nested, just forget the setting
+                $this->forgetWithIndex($data, $this->getChildPath($setting, $parent));
+            }
+
+            return Config::persist($parent, $data);
+        }
+
+        return Config::erase($setting);
+    }
+
+    private function getChildPath($setting, $parent = null): string
+    {
+        return ltrim(Str::after($setting, $parent), '.');
+    }
+
+    private function hasSequentialIndex($array): bool
+    {
+        if (! is_array($array) || $array === []) {
+            return false;
+        }
+
+        return array_keys($array) === range(0, count($array) - 1);
+    }
+
+    private function forgetWithIndex(&$data, $matches)
+    {
+        // detect sequentially numeric indexed array so we can re-index the array
+        if ($this->hasSequentialIndex($data)) {
+            array_splice($data, (int) $matches, 1);
+        } else {
+            Arr::forget($data, $matches);
+        }
     }
 }

--- a/resources/lang/en/commands.php
+++ b/resources/lang/en/commands.php
@@ -13,14 +13,16 @@ return [
     'config:set' => [
         'description' => 'Set configuration value (or unset)',
         'arguments' => [
-            'setting' => 'setting to set in dot notation (example: snmp.community.0)',
+            'setting' => 'setting to set in dot notation (example: snmp.community.0) To append to an array suffix with .+',
             'value' => 'value to set, unset setting if this is omitted',
         ],
         'options' => [
             'ignore-checks' => 'Ignore all safety checks',
         ],
         'confirm' => 'Reset :setting to the default?',
+        'forget_from' => 'Forget :path from :parent?',
         'errors' => [
+            'append' => 'Cannot append to non-array setting',
             'failed' => 'Failed to set :setting',
             'invalid' => 'This is not a valid setting. Please check your spelling',
             'nodb' => 'Database is not connected',


### PR DESCRIPTION
Re-index arrays when forgetting a value from a sequential numerically indexed array
Allow array appending with a +

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
