### PR TITLE
vrp - Collect sticky mac addresses in fdb-table

### DIFF
--- a/includes/discovery/fdb-table/vrp.inc.php
+++ b/includes/discovery/fdb-table/vrp.inc.php
@@ -15,6 +15,7 @@
  */
 
 $fdbPort_table = snmpwalk_group($device, 'hwDynFdbPort', 'HUAWEI-L2MAM-MIB');
+$hwCfgMacAddrQueryIfIndex = snmpwalk_group($device, 'hwCfgMacAddrQueryIfIndex', 'HUAWEI-L2MAM-MIB', 10);
 
 if (! empty($fdbPort_table)) {
     echo 'HUAWEI-L2MAM-MIB:' . PHP_EOL;
@@ -39,3 +40,34 @@ if (! empty($fdbPort_table)) {
         }
     }
 }
+
+// Static (sticky) mac addresses are not stored in the same table.
+if (! empty($hwCfgMacAddrQueryIfIndex)) {
+    echo 'HUAWEI-L2MAM-MIB (static):' . PHP_EOL;
+    foreach ($hwCfgMacAddrQueryIfIndex as $vlan => $data) {
+        if (! empty($data[0][0][0])) {
+            foreach ($data[0][0][0] as $mac => $data_next) {
+                if (! empty($data_next['showall'][0][0][0][0]['hwCfgMacAddrQueryIfIndex'])) {
+                    $basePort = $data_next['showall'][0][0][0][0]['hwCfgMacAddrQueryIfIndex'];
+                    $ifIndex = reset($basePort);
+                    if (! $ifIndex) {
+                        continue;
+                    }
+                    $port = get_port_by_index_cache($device['device_id'], $ifIndex);
+                    $port_id = $port['port_id'];
+                    $mac_address = implode(array_map('zeropad', explode(':', $mac)));
+                    if (strlen($mac_address) != 12) {
+                        d_echo("MAC address padding failed for $mac\n");
+                        continue;
+                    }
+                    $vlan_id = isset($vlans_dict[$vlan]) ? $vlans_dict[$vlan] : 0;
+                    $insert[$vlan_id][$mac_address]['port_id'] = $port_id;
+                    d_echo("vlan $vlan mac $mac_address port ($ifIndex) $port_id\n");
+                }
+            }
+        }
+    }
+}
+
+unset ($fdbPort_table);
+unset ($hwCfgMacAddrQueryIfIndex);

--- a/includes/discovery/fdb-table/vrp.inc.php
+++ b/includes/discovery/fdb-table/vrp.inc.php
@@ -69,5 +69,5 @@ if (! empty($hwCfgMacAddrQueryIfIndex)) {
     }
 }
 
-unset ($fdbPort_table);
-unset ($hwCfgMacAddrQueryIfIndex);
+unset($fdbPort_table);
+unset($hwCfgMacAddrQueryIfIndex);


### PR DESCRIPTION
Huawei switches have 2 different ways to provide mac addresses in SNMP. Standard (dynamic) is already supported. But ports with sticky (port-security) mac addresses are listed in another table. This PR adds support for it. 

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
