### PR TITLE
Smokeping sub site requires fcgiwrap

### DIFF
--- a/doc/Extensions/Smokeping.md
+++ b/doc/Extensions/Smokeping.md
@@ -186,6 +186,17 @@ You should be able to load the Smokeping web interface at `http://yourhost/cgi-b
 This section assumes you have configured LibreNMS with Nginx as
 specified in [Configure Nginx](../Installation/Installation-Ubuntu-1804-Nginx.md).
 
+Note, you need to install fcgiwrap for CGI wrapper interact with Nginx
+
+```
+apt install fcgiwrap
+```
+Then configure Nginx with the default configuration
+
+```
+cp /usr/share/doc/fcgiwrap/examples/nginx.conf /etc/nginx/fcgiwrap.conf
+```
+
 Add the following configuration to your `/etc/nginx/conf.d/librenms` config file.
 
 The following will configure Nginx to respond to `http://yourlibrenms/smokeping`:


### PR DESCRIPTION
It team! is necessary to install fcgiwrap, for CGI wrapper interact with Nginx, if you dont have installed the page doesn't work.

Thanks,
Regards

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
