### PR TITLE
Cache astext in tests to avoid DNS lookup

### DIFF
--- a/tests/Feature/SnmpTraps/BgpTrapTest.php
+++ b/tests/Feature/SnmpTraps/BgpTrapTest.php
@@ -26,6 +26,7 @@ namespace LibreNMS\Tests\Feature\SnmpTraps;
 
 use App\Models\BgpPeer;
 use App\Models\Device;
+use LibreNMS\Config;
 use LibreNMS\Snmptrap\Dispatcher;
 use LibreNMS\Snmptrap\Trap;
 
@@ -33,8 +34,10 @@ class BgpTrapTest extends SnmpTrapTestCase
 {
     public function testBgpUp()
     {
+        // Cache it to avoid DNS Lookup
+        Config::set('astext.1', 'PHPUnit ASTEXT');
         $device = Device::factory()->create();
-        $bgppeer = BgpPeer::factory()->make(['bgpPeerState' => 'idle']);
+        $bgppeer = BgpPeer::factory()->make(['bgpPeerState' => 'idle', 'bgpPeerRemoteAs' => 1]);
         $device->bgppeers()->save($bgppeer);
 
         $trapText = "$device->hostname
@@ -56,8 +59,10 @@ BGP4-MIB::bgpPeerState.$bgppeer->bgpPeerIdentifier established\n";
 
     public function testBgpDown()
     {
+        // Cache it to avoid DNS Lookup
+        Config::set('astext.1', 'PHPUnit ASTEXT');
         $device = Device::factory()->create();
-        $bgppeer = BgpPeer::factory()->make(['bgpPeerState' => 'established']);
+        $bgppeer = BgpPeer::factory()->make(['bgpPeerState' => 'established', 'bgpPeerRemoteAs' => 1]);
         $device->bgppeers()->save($bgppeer);
 
         $trapText = "$device->hostname


### PR DESCRIPTION
Occasionally also breaks the tests with network hiccup or so

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
