### PR TITLE
change printer-supplies rrd name to include the supply_type

### DIFF
--- a/LibreNMS/Modules/PrinterSupplies.php
+++ b/LibreNMS/Modules/PrinterSupplies.php
@@ -76,7 +76,7 @@ class PrinterSupplies implements Module
 
             $tags = [
                 'rrd_def'     => RrdDefinition::make()->addDataset('toner', 'GAUGE', 0, 20000),
-                'rrd_name'    => ['toner', $toner['supply_index']],
+                'rrd_name'    => ['toner', $toner['supply_type'], $toner['supply_index']],
                 'rrd_oldname' => ['toner', $toner['supply_descr']],
                 'index'       => $toner['supply_index'],
             ];

--- a/includes/html/graphs/device/toner.inc.php
+++ b/includes/html/graphs/device/toner.inc.php
@@ -47,7 +47,7 @@ foreach (dbFetchRows('SELECT * FROM printer_supplies where device_id = ?', [$dev
     $hostname = gethostbyid($toner['device_id']);
 
     $descr = \LibreNMS\Data\Store\Rrd::safeDescr(substr(str_pad($toner['supply_descr'], 16), 0, 16));
-    $rrd_filename = Rrd::name($device['hostname'], ['toner', $toner['supply_index']]);
+    $rrd_filename = Rrd::name($device['hostname'], ['toner', $toner['supply_type'], $toner['supply_index']]);
     $id = $toner['supply_id'];
 
     $rrd_options .= " DEF:toner$id=$rrd_filename:toner:AVERAGE";

--- a/includes/html/graphs/toner/auth.inc.php
+++ b/includes/html/graphs/toner/auth.inc.php
@@ -5,7 +5,7 @@ if (is_numeric($vars['id'])) {
 
     if (is_numeric($toner['device_id']) && ($auth || device_permitted($toner['device_id']))) {
         $device = device_by_id_cache($toner['device_id']);
-        $rrd_filename = Rrd::name($device['hostname'], ['toner', $toner['supply_index']]);
+        $rrd_filename = Rrd::name($device['hostname'], ['toner', $toner['supply_type'], $toner['supply_index']]);
 
         $title = generate_device_link($device);
         $title .= ' :: Toner :: ' . htmlentities($toner['supply_descr']);


### PR DESCRIPTION
this fix changes the printer-supplies rrd name to include the supply_type
so the paper trays dont overlap with the toner graphs
**BEFORE:**
toner 1: toner-1.rrd
toner 2: toner-2.rrd
tray 1: toner-1.rrd
tray 2: toner-2.rrd
**AFTER:**
toner 1: toner-toner-1.rrd
toner 2: toner-toner-2.rrd
tray 1: toner-input-1.rrd
tray 2: toner-input-2.rrd

sadly this doesnt migrate the existing graphs but creates new ones instead

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
