### PR TITLE
Alert rule delay/interval empty = 0

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -21,7 +21,6 @@ use LibreNMS\Fping;
 use LibreNMS\Modules\Core;
 use LibreNMS\Util\IPv4;
 use LibreNMS\Util\IPv6;
-use LibreNMS\Util\Time;
 use PHPMailer\PHPMailer\PHPMailer;
 use Symfony\Component\Process\Process;
 
@@ -1098,20 +1097,19 @@ function validate_device_id($id)
 
 function convert_delay($delay)
 {
-    $delay = preg_replace('/\s/', '', $delay);
-    if (strstr($delay, 'm', true)) {
-        $delay_sec = $delay * 60;
-    } elseif (strstr($delay, 'h', true)) {
-        $delay_sec = $delay * 3600;
-    } elseif (strstr($delay, 'd', true)) {
-        $delay_sec = $delay * 86400;
-    } elseif (is_numeric($delay)) {
-        $delay_sec = $delay;
-    } else {
-        $delay_sec = 300;
+    if (preg_match('/(\d+)([mhd]?)/', $delay, $matches)) {
+        $multipliers = [
+            'm' => 60,
+            'h' => 3600,
+            'd' => 86400,
+        ];
+
+        $multiplier = $multipliers[$matches[2]] ?? 1;
+
+        return $matches[1] * $multiplier;
     }
 
-    return $delay_sec;
+    return $delay === '' ? 0 : 300;
 }
 
 function normalize_snmp_ip_address($data)


### PR DESCRIPTION
The alert rule delay was falling back to the default delay of 300s if the input box was empty.   Most people would assume empty = 0, so make it match user's expectations.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
