### PR TITLE
Docs: Plugins should be called statically

### DIFF
--- a/doc/Extensions/Plugin-System.md
+++ b/doc/Extensions/Plugin-System.md
@@ -75,7 +75,7 @@ following system hooks are currently available:
   work here and display your results in a frame.
 
 ```
-    public function device_overview_container($device) {
+    public static function device_overview_container($device) {
         echo('<div class="container-fluid"><div class="row"> <div class="col-md-12"> <div class="panel panel-default panel-condensed"> <div class="panel-heading"><strong>'.get_class().' Plugin </strong> </div>');
         echo('  Example plugin in "Device - Overview" tab <br>');
         echo('</div></div></div></div>');
@@ -88,7 +88,7 @@ following system hooks are currently available:
   results in a frame.
 
 ```
-    public function port_container($device, $port) {
+    public static function port_container($device, $port) {
         echo('<div class="container-fluid"><div class="row"> <div class="col-md-12"> <div class="panel panel-default panel-condensed"> <div class="panel-heading"><strong>'.get_class().' plugin in "Port" tab</strong> </div>');
         echo ('Example display in Port tab</br>');
         echo('</div></div></div></div>');


### PR DESCRIPTION
Have to be a static function. Throws execption since update to PHP8

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
