### PR TITLE
Show OS definition in  lnms config:get

### DIFF
--- a/app/Console/Commands/GetConfigCommand.php
+++ b/app/Console/Commands/GetConfigCommand.php
@@ -5,6 +5,7 @@ namespace App\Console\Commands;
 use App\Console\Commands\Traits\CompletesConfigArgument;
 use App\Console\LnmsCommand;
 use LibreNMS\Config;
+use LibreNMS\Util\OS;
 use Symfony\Component\Console\Input\InputArgument;
 
 class GetConfigCommand extends LnmsCommand
@@ -34,6 +35,12 @@ class GetConfigCommand extends LnmsCommand
     public function handle()
     {
         $setting = $this->argument('setting');
+
+        // load os definition if requested
+        if (preg_match('/^os\.(?<os>[^.]+)/', $setting, $matches)) {
+            OS::loadDefinition($matches['os']);
+        }
+
         if ($this->option('json')) {
             $this->line($setting ? json_encode(Config::get($setting)) : Config::toJson());
 

--- a/app/Console/Commands/GetConfigCommand.php
+++ b/app/Console/Commands/GetConfigCommand.php
@@ -36,9 +36,10 @@ class GetConfigCommand extends LnmsCommand
     {
         $setting = $this->argument('setting');
 
-        // load os definition if requested
+        // load os definition if requested, and remove special definition_loaded key
         if (preg_match('/^os\.(?<os>[^.]+)/', $setting, $matches)) {
             OS::loadDefinition($matches['os']);
+            Config::forget("os.{$matches['os']}.definition_loaded");
         }
 
         if ($this->option('json')) {


### PR DESCRIPTION
Makes it easier to see what configs can be overridden with lnms config:set.

lnms config:get os.linux

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
