### PR TITLE
Fix allow_unauth_graphs

### DIFF
--- a/html/graph.php
+++ b/html/graph.php
@@ -10,6 +10,7 @@
 use LibreNMS\Data\Store\Datastore;
 use LibreNMS\Util\Debug;
 
+$auth = false;
 $start = microtime(true);
 
 $init_modules = ['web', 'graphs', 'auth'];

--- a/includes/html/graphs/graph.inc.php
+++ b/includes/html/graphs/graph.inc.php
@@ -31,7 +31,6 @@ $prev_from = ($from - $period);
 
 $graph_image_type = $vars['graph_type'] ?? Config::get('webui.graph_type');
 $rrd_options = '';
-$auth = false;
 
 require Config::get('install_dir') . "/includes/html/graphs/$type/auth.inc.php";
 


### PR DESCRIPTION
This patch fixes the functionality of the setting "allow_unauth_graphs" which does not work anymore since the "Rrd graph optimizations" patch. The variable $auth is already set in html/graph.php when the setting "allow_unauth_graphs" is set. But this variable gets overwritten in includes/html/graphs/graph.inc.php. With this patch the variable $auth is initialized in html/graph.php before checking if the user is allowed to view the graph.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
