### PR TITLE
For Nokia (timos): Add discovery for lane monitoring of power and bia…

### DIFF
--- a/includes/discovery/sensors/current/timos.inc.php
+++ b/includes/discovery/sensors/current/timos.inc.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * timos.inc.php
+ *
+ * LibreNMS current discovery module for Nokia SROS (formerly TimOS)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * @link       https://www.librenms.org
+ * @copyright  2021 Nick Peelman
+ * @author     Nick Peelman <nick@peelman.us>
+ */
+
+$multiplier = 1;
+$divisor = 50000;
+foreach ($pre_cache['timos_oids'] as $index => $entry) {
+    if (is_numeric($entry['tmnxDDMTxBiasCurrent']) && $entry['tmnxDDMTxBiasCurrent'] != 0 && $entry['tmnxDDMTxBiasCurrentLowAlarm'] != 0) {
+        $oid = '.1.3.6.1.4.1.6527.3.1.2.2.4.31.1.11.' . $index;
+        $value = $entry['tmnxDDMTxBiasCurrent'] / $divisor;
+        $entPhysicalIndex = $index;
+        $entPhysicalIndex_measured = 'ports';
+
+        $limit_low = $entry['tmnxDDMTxBiasCurrentLowAlarm'] / $divisor;
+        $warn_limit_low = $entry['tmnxDDMTxBiasCurrentLowWarning'] / $divisor;
+        $limit = $entry['tmnxDDMTxBiasCurrentHiAlarm'] / $divisor;
+        $warn_limit = $entry['tmnxDDMTxBiasCurrentHiWarning'] / $divisor;
+
+        $port_descr = get_port_by_index_cache($device['device_id'], str_replace('1.', '', $index));
+        $descr = $port_descr['ifName'] . ' Tx Current';
+
+        discover_sensor($valid['sensor'], 'dbm', $device, $oid, 'tx-' . $index, 'timos', $descr, $divisor, $multiplier, $limit_low, $warn_limit_low, $warn_limit, $limit, $value, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured, $user_func);
+    }
+}
+
+foreach ($pre_cache['timos_lanes_oids'] as $index => $entry) {
+    if (is_numeric($entry['tmnxDDMLaneTxBiasCurrent']) && $entry['tmnxDDMLaneTxBiasCurrent'] != 0 && $entry['tmnxDDMLaneTxBiasCurrentLowAlarm'] != 0) {
+        $oid = '.1.3.6.1.4.1.6527.3.1.2.2.4.66.1.7.' . $index;
+        $value = $entry['tmnxDDMLaneTxBiasCurrent'] / $divisor;
+
+        $entPhysicalIndex = $index;
+        $entPhysicalIndex_measured = 'ports';
+
+        $limit_low = $entry['tmnxDDMLaneTxBiasCurrentLowAlarm'] / $divisor;
+        $warn_limit_low = $entry['tmnxDDMLaneTxBiasCurrentLowWarn'] / $divisor;
+        $limit = $entry['tmnxDDMLaneTxBiasCurrentHiAlarm'] / $divisor;
+        $warn_limit = $entry['tmnxDDMLaneTxBiasCurrentHiWarn'] / $divisor;
+
+        $port_descr = get_port_by_index_cache($device['device_id'], str_replace(['1.','.1','.2','.3','.4'], '', $index));
+        $descr = $port_descr['ifName'] . '/' . end(explode('.', $index)) . ' Tx Current';
+
+        discover_sensor($valid['sensor'], 'current', $device, $oid, 'biascurrent-' . $index, 'junos', $descr, $divisor, $multiplier, $limit_low, $warn_limit_low, $warn_limit, $limit, $value, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured);
+    }
+}

--- a/includes/discovery/sensors/current/timos.inc.php
+++ b/includes/discovery/sensors/current/timos.inc.php
@@ -21,7 +21,6 @@
  * @copyright  2021 Nick Peelman
  * @author     Nick Peelman <nick@peelman.us>
  */
-
 $multiplier = 1;
 $divisor = 50000;
 foreach ($pre_cache['timos_oids'] as $index => $entry) {
@@ -56,7 +55,7 @@ foreach ($pre_cache['timos_lanes_oids'] as $index => $entry) {
         $limit = $entry['tmnxDDMLaneTxBiasCurrentHiAlarm'] / $divisor;
         $warn_limit = $entry['tmnxDDMLaneTxBiasCurrentHiWarn'] / $divisor;
 
-        $port_descr = get_port_by_index_cache($device['device_id'], str_replace(['1.','.1','.2','.3','.4'], '', $index));
+        $port_descr = get_port_by_index_cache($device['device_id'], str_replace(['1.', '.1', '.2', '.3', '.4'], '', $index));
         $descr = $port_descr['ifName'] . '/' . end(explode('.', $index)) . ' Tx Current';
 
         discover_sensor($valid['sensor'], 'current', $device, $oid, 'biascurrent-' . $index, 'junos', $descr, $divisor, $multiplier, $limit_low, $warn_limit_low, $warn_limit, $limit, $value, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured);

--- a/includes/discovery/sensors/current/timos.inc.php
+++ b/includes/discovery/sensors/current/timos.inc.php
@@ -58,6 +58,6 @@ foreach ($pre_cache['timos_lanes_oids'] as $index => $entry) {
         $port_descr = get_port_by_index_cache($device['device_id'], str_replace(['1.', '.1', '.2', '.3', '.4'], '', $index));
         $descr = $port_descr['ifName'] . '/' . end(explode('.', $index)) . ' Tx Current';
 
-        discover_sensor($valid['sensor'], 'current', $device, $oid, 'biascurrent-' . $index, 'junos', $descr, $divisor, $multiplier, $limit_low, $warn_limit_low, $warn_limit, $limit, $value, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured);
+        discover_sensor($valid['sensor'], 'current', $device, $oid, 'biascurrent-' . $index, 'timos', $descr, $divisor, $multiplier, $limit_low, $warn_limit_low, $warn_limit, $limit, $value, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured);
     }
 }

--- a/includes/discovery/sensors/dbm/timos.inc.php
+++ b/includes/discovery/sensors/dbm/timos.inc.php
@@ -76,7 +76,7 @@ foreach ($pre_cache['timos_lanes_oids'] as $index => $entry) {
         $limit = round(10 * log10($entry['tmnxDDMLaneTxOutputPowerHiAlarm'] / $divisor), 2);
         $warn_limit = round(10 * log10($entry['tmnxDDMLaneTxOutputPowerHiWarn'] / $divisor), 2);
 
-        $port_descr = get_port_by_index_cache($device['device_id'], str_replace(['1.', '.1',' .2', '.3', '.4'], '', $index));
+        $port_descr = get_port_by_index_cache($device['device_id'], str_replace(['1.', '.1', ' .2', '.3', '.4'], '', $index));
         $descr = $port_descr['ifName'] . '/' . end(explode('.', $index)) . ' TX Power';
 
         discover_sensor($valid['sensor'], 'dbm', $device, $oid, 'tx-' . $index, 'timos', $descr, $divisor, $multiplier, $limit_low, $warn_limit_low, $warn_limit, $limit, $value, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured, $user_func);

--- a/includes/discovery/sensors/dbm/timos.inc.php
+++ b/includes/discovery/sensors/dbm/timos.inc.php
@@ -47,3 +47,38 @@ foreach ($pre_cache['timos_oids'] as $index => $entry) {
         discover_sensor($valid['sensor'], 'dbm', $device, $oid, 'tx-' . $index, 'timos', $descr, $divisor, $multiplier, $limit_low, $warn_limit_low, $warn_limit, $limit, $value, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured, $user_func);
     }
 }
+
+foreach ($pre_cache['timos_lanes_oids'] as $index => $entry) {
+    if (is_numeric($entry['tmnxDDMLaneRxOpticalPower']) && $entry['tmnxDDMLaneRxOpticalPower'] != 0 && $entry['tmnxDDMLaneTxOutputPower'] != 0) {
+        $oid = '.1.3.6.1.4.1.6527.3.1.2.2.4.66.1.17.' . $index;
+        $value = round(10 * log10($entry['tmnxDDMLaneRxOpticalPower'] / $divisor), 2);
+
+        $entPhysicalIndex = $index;
+        $entPhysicalIndex_measured = 'ports';
+
+        $limit_low = round(10 * log10($entry['tmnxDDMLaneRxOpticalPwrLowAlarm'] / $divisor), 2);
+        $warn_limit_low = round(10 * log10($entry['tmnxDDMLaneRxOpticalPwrLowWarn'] / $divisor), 2);
+        $limit = round(10 * log10($entry['tmnxDDMLaneRxOpticalPwrHiAlarm'] / $divisor), 2);
+        $warn_limit = round(10 * log10($entry['tmnxDDMLaneRxOpticalPwrHiWarn'] / $divisor), 2);
+
+        $port_descr = get_port_by_index_cache($device['device_id'], str_replace(['1.','.1','.2','.3','.4'], '', $index));
+        $descr = $port_descr['ifName'] . '/' . end(explode('.', $index)) . ' RX Power';
+        discover_sensor($valid['sensor'], 'dbm', $device, $oid, 'rx-' . $index, 'timos', $descr, $divisor, $multiplier, $limit_low, $warn_limit_low, $warn_limit, $limit, $value, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured, $user_func);
+    }
+    if (is_numeric($entry['tmnxDDMLaneTxOutputPower']) && $entry['tmnxDDMLaneTxOutputPower'] != 0 && $entry['tmnxDDMLaneRxOpticalPower'] != 0) {
+        $oid = '.1.3.6.1.4.1.6527.3.1.2.2.4.66.1.12.' . $index;
+        $value = round(10 * log10($entry['tmnxDDMLaneTxOutputPower'] / $divisor), 2);
+        $entPhysicalIndex = $index;
+        $entPhysicalIndex_measured = 'ports';
+
+        $limit_low = round(10 * log10($entry['tmnxDDMLaneTxOutputPowerLowAlarm'] / $divisor), 2);
+        $warn_limit_low = round(10 * log10($entry['tmnxDDMLaneTxOutputPowerLowWarn'] / $divisor), 2);
+        $limit = round(10 * log10($entry['tmnxDDMLaneTxOutputPowerHiAlarm'] / $divisor), 2);
+        $warn_limit = round(10 * log10($entry['tmnxDDMLaneTxOutputPowerHiWarn'] / $divisor), 2);
+
+        $port_descr = get_port_by_index_cache($device['device_id'], str_replace(['1.','.1','.2','.3','.4'], '', $index));
+        $descr = $port_descr['ifName'] . '/' . end(explode('.', $index)) . ' TX Power';
+
+        discover_sensor($valid['sensor'], 'dbm', $device, $oid, 'tx-' . $index, 'timos', $descr, $divisor, $multiplier, $limit_low, $warn_limit_low, $warn_limit, $limit, $value, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured, $user_func);
+    }
+}

--- a/includes/discovery/sensors/dbm/timos.inc.php
+++ b/includes/discovery/sensors/dbm/timos.inc.php
@@ -61,7 +61,7 @@ foreach ($pre_cache['timos_lanes_oids'] as $index => $entry) {
         $limit = round(10 * log10($entry['tmnxDDMLaneRxOpticalPwrHiAlarm'] / $divisor), 2);
         $warn_limit = round(10 * log10($entry['tmnxDDMLaneRxOpticalPwrHiWarn'] / $divisor), 2);
 
-        $port_descr = get_port_by_index_cache($device['device_id'], str_replace(['1.','.1','.2','.3','.4'], '', $index));
+        $port_descr = get_port_by_index_cache($device['device_id'], str_replace(['1.', '.1', '.2', '.3', '.4'], '', $index));
         $descr = $port_descr['ifName'] . '/' . end(explode('.', $index)) . ' RX Power';
         discover_sensor($valid['sensor'], 'dbm', $device, $oid, 'rx-' . $index, 'timos', $descr, $divisor, $multiplier, $limit_low, $warn_limit_low, $warn_limit, $limit, $value, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured, $user_func);
     }
@@ -76,7 +76,7 @@ foreach ($pre_cache['timos_lanes_oids'] as $index => $entry) {
         $limit = round(10 * log10($entry['tmnxDDMLaneTxOutputPowerHiAlarm'] / $divisor), 2);
         $warn_limit = round(10 * log10($entry['tmnxDDMLaneTxOutputPowerHiWarn'] / $divisor), 2);
 
-        $port_descr = get_port_by_index_cache($device['device_id'], str_replace(['1.','.1','.2','.3','.4'], '', $index));
+        $port_descr = get_port_by_index_cache($device['device_id'], str_replace(['1.', '.1',' .2', '.3', '.4'], '', $index));
         $descr = $port_descr['ifName'] . '/' . end(explode('.', $index)) . ' TX Power';
 
         discover_sensor($valid['sensor'], 'dbm', $device, $oid, 'tx-' . $index, 'timos', $descr, $divisor, $multiplier, $limit_low, $warn_limit_low, $warn_limit, $limit, $value, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured, $user_func);

--- a/includes/discovery/sensors/pre-cache/timos.inc.php
+++ b/includes/discovery/sensors/pre-cache/timos.inc.php
@@ -11,3 +11,4 @@
  */
 
 $pre_cache['timos_oids'] = snmpwalk_cache_multi_oid($device, 'tmnxDigitalDiagMonitorEntry', [], 'TIMETRA-PORT-MIB', 'timos');
+$pre_cache['timos_lanes_oids'] = snmpwalk_cache_multi_oid($device, 'tmnxDDMLaneTable', [], 'TIMETRA-PORT-MIB', 'timos');

--- a/includes/discovery/sensors/temperature/timos.inc.php
+++ b/includes/discovery/sensors/temperature/timos.inc.php
@@ -21,7 +21,6 @@
  * @copyright  2021 Nick Peelman
  * @author     Nick Peelman <nick@peelman.us>
  */
-
 $multiplier = 1;
 $divisor = 100;
 foreach ($pre_cache['timos_oids'] as $index => $entry) {

--- a/includes/discovery/sensors/temperature/timos.inc.php
+++ b/includes/discovery/sensors/temperature/timos.inc.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * timos.inc.php
+ *
+ * LibreNMS port temperature discovery module for Nokia SROS (formerly TimOS)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * @link       https://www.librenms.org
+ * @copyright  2021 Nick Peelman
+ * @author     Nick Peelman <nick@peelman.us>
+ */
+
+$multiplier = 1;
+$divisor = 100;
+foreach ($pre_cache['timos_oids'] as $index => $entry) {
+    if (is_numeric($entry['tmnxDDMTemperature']) && $entry['tmnxDDMTemperature'] != 0) {
+        $oid = '.1.3.6.1.4.1.6527.3.1.2.2.4.31.1.1.' . $index;
+        $value = $entry['tmnxDDMTemperature'] / $divisor;
+
+        $entPhysicalIndex = $index;
+        $entPhysicalIndex_measured = 'ports';
+
+        $limit_low = $entry['tmnxDDMTempLowAlarm'] / $divisor;
+        $warn_limit_low = $entry['tmnxDDMTempLowWarning'] / $divisor;
+        $limit = $entry['tmnxDDMTempHiAlarm'] / $divisor;
+        $warn_limit = $entry['tmnxDDMTempHiWarning'] / $divisor;
+        $port_descr = get_port_by_index_cache($device['device_id'], str_replace('1.', '', $index));
+        $descr = $port_descr['ifName'];
+
+        discover_sensor($valid['sensor'], 'temperature', $device, $oid, $index, 'timos', $descr, $divisor, $multiplier, $limit_low, $warn_limit_low, $warn_limit, $limit, $value, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured);
+    }
+}


### PR DESCRIPTION
Add discovery of port temperatures, port bias current, as well as lane power levels and bias current for optics that support multi-lane.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
