### PR TITLE
WIP: Numeric indexes for yaml by default

### DIFF
--- a/LibreNMS/Device/YamlDiscovery.php
+++ b/LibreNMS/Device/YamlDiscovery.php
@@ -294,9 +294,9 @@ class YamlDiscovery
                                 if (isset($data['snmp_flags'])) {
                                     $snmp_flag = Arr::wrap($data['snmp_flags']);
                                 } elseif (Str::contains($oid, '::')) {
-                                    $snmp_flag = ['-OteQUS'];
+                                    $snmp_flag = ['-OtbeQUS'];
                                 } else {
-                                    $snmp_flag = ['-OteQUs'];
+                                    $snmp_flag = ['-OtbeQUs'];
                                 }
                                 $snmp_flag[] = '-Ih';
 


### PR DESCRIPTION
Tables with strings in the index really throw people off.  If we change them to numeric by default it is a little easier for them to figure out.  They can still set it back to string based index if that is what they desire with snmp_flags.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
