### PR TITLE
Filter unwanted data in Routes Ajax reply

### DIFF
--- a/app/Http/Controllers/Table/RoutesTablesController.php
+++ b/app/Http/Controllers/Table/RoutesTablesController.php
@@ -221,8 +221,6 @@ class RoutesTablesController extends TableController
         }
         $item['inetCidrRouteMetric1'] = $route_entry->inetCidrRouteMetric1;
         $item['inetCidrRoutePfxLen'] = $route_entry->inetCidrRoutePfxLen;
-        $item['updated_at'] = $route_entry->updated_at;
-        $item['created_at'] = $route_entry->created_at;
 
         return $item;
     }

--- a/app/Http/Controllers/Table/RoutesTablesController.php
+++ b/app/Http/Controllers/Table/RoutesTablesController.php
@@ -169,15 +169,13 @@ class RoutesTablesController extends TableController
      */
     public function formatItem($route_entry)
     {
-        $item = $route_entry->toArray();
-
         if ($route_entry->updated_at) {
             $item['updated_at'] = $route_entry->updated_at->diffForHumans();
         }
         if ($route_entry->created_at) {
             $item['created_at'] = $route_entry->created_at->toDateTimeString();
         }
-        if ($item['inetCidrRouteIfIndex'] == 0) {
+        if ($route_entry->inetCidrRouteIfIndex == 0) {
             $item['inetCidrRouteIfIndex'] = 'Undefined';
         }
         if ($route_entry->inetCidrRouteNextHop) {
@@ -196,21 +194,24 @@ class RoutesTablesController extends TableController
                 $item['inetCidrRouteDest'] = $route_entry->inetCidrRouteDest;
             }
         }
-        $item['inetCidrRouteIfIndex'] = 'ifIndex ' . $item['inetCidrRouteIfIndex'];
+        $item['inetCidrRouteIfIndex'] = 'ifIndex ' . $route_entry->inetCidrRouteIfIndex;
         if ($port = $route_entry->port()->first()) {
             $item['inetCidrRouteIfIndex'] = Url::portLink($port, htmlspecialchars($port->getShortLabel()));
         }
         $device = Device::findByIp($route_entry->inetCidrRouteNextHop);
+        $item['inetCidrRouteNextHop'] = $route_entry->inetCidrRouteNextHop;
         if ($device) {
             if ($device->device_id == $route_entry->device_id || in_array($route_entry->inetCidrRouteNextHop, ['127.0.0.1', '::1'])) {
                 $item['inetCidrRouteNextHop'] = Url::deviceLink($device, 'localhost');
             } else {
-                $item['inetCidrRouteNextHop'] = $item['inetCidrRouteNextHop'] . '<br>(' . Url::deviceLink($device) . ')';
+                $item['inetCidrRouteNextHop'] = $route_entry->inetCidrRouteNextHop . '<br>(' . Url::deviceLink($device) . ')';
             }
         }
+        $item['inetCidrRouteProto'] = $route_entry->inetCidrRouteProto;
         if ($route_entry->inetCidrRouteProto && $route_entry::$translateProto[$route_entry->inetCidrRouteProto]) {
             $item['inetCidrRouteProto'] = $route_entry::$translateProto[$route_entry->inetCidrRouteProto];
         }
+        $item['inetCidrRouteType'] = $route_entry->inetCidrRouteType;
         if ($route_entry->inetCidrRouteType && $route_entry::$translateType[$route_entry->inetCidrRouteType]) {
             $item['inetCidrRouteType'] = $route_entry::$translateType[$route_entry->inetCidrRouteType];
         }
@@ -218,6 +219,10 @@ class RoutesTablesController extends TableController
         if ($route_entry->context_name != '') {
             $item['context_name'] = '<a href="' . Url::generate(['page' => 'routing', 'protocol' => 'vrf', 'vrf' => $route_entry->context_name]) . '">' . htmlspecialchars($route_entry->context_name) . '</a>';
         }
+        $item['inetCidrRouteMetric1'] = $route_entry->inetCidrRouteMetric1;
+        $item['inetCidrRoutePfxLen'] = $route_entry->inetCidrRoutePfxLen;
+        $item['updated_at'] = $route_entry->updated_at;
+        $item['created_at'] = $route_entry->created_at;
 
         return $item;
     }

--- a/includes/html/pages/device/routing/routes.inc.php
+++ b/includes/html/pages/device/routing/routes.inc.php
@@ -6,17 +6,17 @@ $no_refresh = true;
 <table id="routes" class="table table-condensed table-hover table-striped">
     <thead>
         <tr>
-            <th data-column-id="context_name" data-width="125px">VRF</th>
+            <th data-column-id="context_name" data-width="125px" data-formatter="tooltip">VRF</th>
             <th data-column-id="inetCidrRouteDestType" data-width="70px">Proto</th>
-            <th data-column-id="inetCidrRouteDest">Destination</th>
+            <th data-column-id="inetCidrRouteDest" data-formatter="tooltip">Destination</th>
             <th data-column-id="inetCidrRoutePfxLen" data-width="80px">Mask</th>
-            <th data-column-id="inetCidrRouteNextHop">Next hop</th>
-            <th data-column-id="inetCidrRouteIfIndex">Interface</th>
+            <th data-column-id="inetCidrRouteNextHop" data-formatter="tooltip">Next hop</th>
+            <th data-column-id="inetCidrRouteIfIndex" data-formatter="tooltip">Interface</th>
             <th data-column-id="inetCidrRouteMetric1" data-width="85px">Metric</th>
             <th data-column-id="inetCidrRouteType" data-width="85px">Type</th>
             <th data-column-id="inetCidrRouteProto" data-width="85px">Proto</th>
-            <th data-column-id="created_at" data-width="165px">First seen</th>
-            <th data-column-id="updated_at" data-width="165px">Last seen</th>
+            <th data-column-id="created_at" data-width="165px" data-formatter="tooltip">First seen</th>
+            <th data-column-id="updated_at" data-width="165px" data-formatter="tooltip">Last seen</th>
         </tr>
     </thead>
 </table>
@@ -45,6 +45,15 @@ var grid = $("#routes").bootgrid({
             showAllRoutes: showAllRoutes,
             showProtocols: list_showProtocols
         };
+    },
+    formatters: {
+        "tooltip": function (column, row) {
+                var value = row[column.id];
+                if (value.includes('onmouseover=')) {
+                    return value;
+                }
+                return "<span title=\'" + value + "\' data-toggle=\'tooltip\'>" + value + "</span>";
+            },
     },
     url: "ajax/table/routes"
 });


### PR DESCRIPTION
Currently, eloquent DB result is sent as the AJAX reply, effectively sending more column than necessary for the bootgrid table to be filled. 
For my test, 32k for reply instead of 15k after filtering only the expected columns, with this : 
```
        $var_list = ['context_name' => '',
            'inetCidrRouteDestType' => '',
            'inetCidrRouteDest' => '',
            'inetCidrRoutePfxLen' => '',
            'inetCidrRouteNextHop' => '',
            'inetCidrRouteIfIndex' => '',
            'inetCidrRouteMetric1' => '',
            'inetCidrRouteType' => '',
            'inetCidrRouteProto' => '',
            'created_at' => '',
            'updated_at' => '',
        ];
        // Lets filter only the column needed in the AJAX, and not all the DB columns that we selected
        $item = array_intersect_key($item, $var_list);
```

@murrant @Jellyfrog I am pretty sure there is a better way to do this. Let me know. Probably extending the Controller to do this by default would be the best thing to do (all TableControllers would benefit more or less from this kind of optimisation). 

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
