### PR TITLE
Fix top devices widget storage graphs

### DIFF
--- a/app/Http/Controllers/Widgets/TopDevicesController.php
+++ b/app/Http/Controllers/Widgets/TopDevicesController.php
@@ -304,7 +304,7 @@ class TopDevicesController extends WidgetController
                 'to' => Carbon::now()->timestamp,
                 'from' => Carbon::now()->subDay()->timestamp,
                 'id' => $storage->storage_id,
-                'type' => 'device_storage',
+                'type' => 'storage_usage',
                 'legend' => 'no',
             ];
             $overlib_content = Url::overlibContent($graph_array, $device->displayName() . ' - ' . $storage->storage_descr);


### PR DESCRIPTION
referenced the wrong graph, caused it to not work because device was not set.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
