### PR TITLE
Disable autocomplete for password in login-form

### DIFF
--- a/resources/views/auth/login-form.blade.php
+++ b/resources/views/auth/login-form.blade.php
@@ -24,7 +24,7 @@
             </div>
             <div class="form-group{{ $errors->has('password') ? ' has-error' : '' }}">
                 <div class="col-md-12">
-                    <input type="password" name="password" id="password" class="form-control" placeholder="@lang('Password')" />
+                    <input type="password" name="password" id="password" autocomplete="off" class="form-control" placeholder="@lang('Password')" />
                     @if ($errors->has('password'))
                         <span class="help-block">
                                     <strong>{{ $errors->first('password') }}</strong>


### PR DESCRIPTION
Certain vulnerability scanners (Nexpose in my case) will get this "template" page with curl and see that you can autocomplete the password field. This change should disable it.

I'm not sure how the templating works, but this page outlined in the changed code is not the one I see when I browse to LibreNMS with my browser - I only see it when I `curl -v -k https://<IP>/login`


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
