### PR TITLE
feature: Added support for Nexus PVLAN MAC in FDB

### DIFF
--- a/includes/discovery/fdb-table.inc.php
+++ b/includes/discovery/fdb-table.inc.php
@@ -19,9 +19,12 @@ foreach ($sql_result as $entry) {
 $insert = []; // populate $insert with database entries
 if (file_exists(Config::get('install_dir') . "/includes/discovery/fdb-table/{$device['os']}.inc.php")) {
     require Config::get('install_dir') . "/includes/discovery/fdb-table/{$device['os']}.inc.php";
-} elseif ($device['os'] == 'ios' || $device['os'] == 'iosxe' || $device['os'] == 'nxos') {
-    //ios,iosxe,nxos are all Cisco
+} elseif ($device['os'] == 'ios' || $device['os'] == 'iosxe') {
+    //ios,iosxe are all Cisco
     include Config::get('install_dir') . '/includes/discovery/fdb-table/ios.inc.php';
+} elseif ($device['os'] == 'nxos') {
+    //nxos check
+    include Config::get('install_dir') . '/includes/discovery/fdb-table/nxos.inc.php';
 }
 
 if (empty($insert)) {

--- a/includes/discovery/fdb-table/nxos.inc.php
+++ b/includes/discovery/fdb-table/nxos.inc.php
@@ -1,0 +1,67 @@
+<?php
+
+$vtpdomains = snmpwalk_group($device, 'managementDomainName', 'CISCO-VTP-MIB');
+$vlans = snmpwalk_group($device, 'vtpVlanEntry', 'CISCO-VTP-MIB', 2);
+
+$device_hw = dbFetchRow('SELECT * FROM `devices` WHERE `device_id` = ?', [$device['device_id']]);
+
+foreach ($vtpdomains as $vtpdomain_id => $vtpdomain) {
+    echo "VTP Domain $vtpdomain_id {$vtpdomain['managementDomainName']}> ";
+    foreach ($vlans[$vtpdomain_id] as $vlan_raw => $vlan) {
+        echo "$vlan_raw ";
+        if (! array_key_exists($vlan_raw, $vlans_dict)) {
+            $newvlan_id = dbInsert([
+                'device_id' => $device['device_id'],
+                'vlan_domain' => $vtpdomain_id,
+                'vlan_vlan' => $vlan_raw,
+                'vlan_name' => $vlan['vtpVlanName'],
+                'vlan_type' => $vlan['vtpVlanType'],
+            ], 'vlans');
+            $vlans_dict[$vlan_raw] = $newvlan_id;
+        }
+
+        if (($vlan['vtpVlanState'] === '1') && ($vlan_raw < 1002 || $vlan_raw > 1005)) {
+            $device_vlan = array_merge($device, ['community' => $device['community'] . '@' . $vlan_raw, 'context_name' => "vlan-$vlan_raw"]);
+
+            $fdbPort_table = snmpwalk_group($device_vlan, 'dot1dTpFdbPort', 'BRIDGE-MIB', 0);
+
+            $portid_dict = [];
+            $dot1dBasePortIfIndex = snmpwalk_group($device_vlan, 'dot1dBasePortIfIndex', 'BRIDGE-MIB');
+            foreach ($dot1dBasePortIfIndex as $portLocal => $data) {
+                $port = get_port_by_index_cache($device['device_id'], $data['dot1dBasePortIfIndex']);
+                $portid_dict[$portLocal] = $port['port_id'];
+            }
+
+            foreach ((array) $fdbPort_table['dot1dTpFdbPort'] as $mac => $dot1dBasePort) {
+                $mac_address = implode(array_map('zeropad', explode(':', $mac)));
+                if (strlen($mac_address) != 12) {
+                    d_echo("MAC address padding failed for $mac\n");
+                    continue;
+                }
+                $port_id = $portid_dict[$dot1dBasePort];
+
+                //If true, the Port is a PVLAN port and the port_id wasn't returned in the right format.
+                //Also check if we're dealing with a N3K-C30xxxx, others could be fine
+                if ($dot1dBasePort < 55 && ! $port_id && str_contains($device_hw['hardware'], 'N3K-C30')) {
+                    d_echo("Found BasePort without portID, Port: $dot1dBasePort");
+                    //Interfaces on Nexus use the same format: "Ethernetx/y", build interface string
+                    $interface_string = "Ethernet1/$dot1dBasePort";
+                    d_echo("Interface-Name: $interface_string, trying to find a match in ports Table");
+                    $dev_int = dbFetchCell('SELECT * FROM `ports` WHERE `device_id` = ? AND `ifName` = ?', [$device['device_id'], $interface_string]);
+                    if (! $dev_int) {
+                        d_echo("Interface lookup failed for BasePort: $dot1dBasePort");
+                    } else {
+                        $port_id = $dev_int;
+                    }
+                }
+
+                $vlan_id = isset($vlans_dict[$vlan_raw]) ? $vlans_dict[$vlan_raw] : 0;
+                $insert[$vlan_id][$mac_address]['port_id'] = $port_id;
+                d_echo("vlan $vlan_id mac $mac_address port ($dot1dBasePort) $port_id\n");
+            }
+
+            unset($device_vlan);
+        } //end if operational
+    } // end for each vlan
+    echo PHP_EOL;
+} // end for each vlan domain


### PR DESCRIPTION
Hello,
We’ve had a problem where Cisco Nexus Devices doesn’t show the port on which a MAC Address is connected inside the FDB Table.
 It’s not populated if the MAC is learned from a port which is configured with private VLANs.


Normally the Switch returns the dot1dTpFdbPort which can be mapped to a physical port, for example:
```
dot1dTpFdbPort[34:e3:80:f1:7e:e0] = 4105
vlan 1988 mac 34e380f17ee0 port (4105) 11217
```


If pvlan is active, the returned port cannot be mapped to a port_id. 
The switch returns the number of the physical port, not the dot1dBasePort number which is needed for the mapping.
Example:
`dot1dTpFdbPort[34:e3:80:a7:37:10] = 44`

To get the portId the “ports”-table is queried, and the returned value is added to the portId.
For example, a port which is configured with pvlan:
```
dot1dTpFdbPort[34:e3:80:a7:37:10] = 44
Found BasePort without portID, Port: 44
Interface-Name: Ethernet1/44, trying to find a match in ports Table
SQL[SELECT * FROM `ports` WHERE `device_id` = ? AND `ifName` = ? [1816,"Ethernet1\/44"] 0.74ms]
vlan 1988 mac 34e380a73710 port (44) 11261
```

To be completely safe, this is only done if the returned $dot1dBasePort is < 55 and the device is a N3K-C30, because this is the only switch group I can test. If somebody could test this against N5k or N7k and the problem is present there, this could be extended.
The “nxos.inc.php” is a copy from “ios.inc.php” so these tests doesn’t need to be checked against non nxos devices.

How are your opinions? 
If something needs to be changed, I’ll try, PHP isn’t really my world :D

Thanks!


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
