### PR TITLE
PHP 8 Unit Conversion Fix

### DIFF
--- a/LibreNMS/Util/Number.php
+++ b/LibreNMS/Util/Number.php
@@ -36,7 +36,7 @@ class Number
 
     public static function formatSi($value, $round = 2, $sf = 3, $suffix = 'B')
     {
-	$value = (int) $value;
+        $value = (float) $value;
         $neg = $value < 0;
         if ($neg) {
             $value = $value * -1;
@@ -67,7 +67,7 @@ class Number
 
     public static function formatBi($value, $round = 2, $sf = 3, $suffix = 'B')
     {
-	$value = (int) $value;
+        $value = (float) $value;
         $neg = $value < 0;
         if ($neg) {
             $value = $value * -1;

--- a/LibreNMS/Util/Number.php
+++ b/LibreNMS/Util/Number.php
@@ -36,6 +36,7 @@ class Number
 
     public static function formatSi($value, $round = 2, $sf = 3, $suffix = 'B')
     {
+	$value = (int) $value;
         $neg = $value < 0;
         if ($neg) {
             $value = $value * -1;
@@ -66,6 +67,7 @@ class Number
 
     public static function formatBi($value, $round = 2, $sf = 3, $suffix = 'B')
     {
+	$value = (int) $value;
         $neg = $value < 0;
         if ($neg) {
             $value = $value * -1;


### PR DESCRIPTION
Fix production.ERROR: Unsupported operand types: string / int with older devices and unit conversions.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
