### PR TITLE
Fix empty label in generate_port_link

### DIFF
--- a/includes/html/functions.inc.php
+++ b/includes/html/functions.inc.php
@@ -329,7 +329,7 @@ function generate_port_link($port, $text = null, $type = null, $overlib = 1, $si
     $graph_array = [];
 
     if (! $text) {
-        $text = Rewrite::normalizeIfName($port['label']);
+        $text = Rewrite::normalizeIfName($port['label'] ?? $port['ifName']);
     }
 
     if ($type) {


### PR DESCRIPTION
When label is not set (like before #12871 is applied), generate_port_link create a link without any text (invisible). Now it uses ifName as a fallback value to avoid this situation.

Before fix: 
![Capture d’écran 2021-05-13 à 16 25 24](https://user-images.githubusercontent.com/38363551/118139671-e124fb00-b407-11eb-95c6-e862bc3bd633.png)

After fix: 
![Capture d’écran 2021-05-13 à 16 23 29](https://user-images.githubusercontent.com/38363551/118139542-c05ca580-b407-11eb-93f8-d370c70798d9.png)

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
