### PR TITLE
WIP: FabOS remove disabled dbm sensors

### DIFF
--- a/includes/discovery/sensors/dbm/fabos.inc.php
+++ b/includes/discovery/sensors/dbm/fabos.inc.php
@@ -10,27 +10,30 @@ foreach ($fabosSfpRxPower as $oid => $entry) {
     foreach ($entry as $index => $current) {
         if (is_numeric($current)) {
             $ifIndex = $index + 1073741823;
-            discover_sensor(
-                $valid['sensor'],
-                'dbm',
-                $device,
-                ".$oid.$index",
-                'swSfpRxPower.' . $index,
-                'brocade',
-                makeshortif($ifDescr[$ifIndex]) . ' RX',
-                1,
-                1,
-                -35,
-                -30,
-                -3,
-                0,
-                $current,
-                'snmp',
-                $ifIndex,
-                'ports',
-                null,
-                'Receive Power'
-            );
+            $ifAdminStatus = dbFetchCell("SELECT `ifAdminStatus` FROM `ports` WHERE `ifIndex`= ? AND `device_id` = ? AND `ifAdminStatus` = 'up'", [$ifIndex, $device['device_id']]);
+            if ($ifAdminStatus == 'up') {
+                discover_sensor(
+                    $valid['sensor'],
+                    'dbm',
+                    $device,
+                    ".$oid.$index",
+                    'swSfpRxPower.' . $index,
+                    'brocade',
+                    makeshortif($ifDescr[$ifIndex]) . ' RX',
+                    1,
+                    1,
+                    -5,
+                    null,
+                    null,
+                    0,
+                    $current,
+                    'snmp',
+                    $ifIndex,
+                    'ports',
+                    null,
+                    'Receive Power'
+                );
+            }
         }
     }
 }
@@ -39,26 +42,30 @@ foreach ($fabosSfpTxPower as $oid => $entry) {
     foreach ($entry as $index => $current) {
         if (is_numeric($current)) {
             $ifIndex = $index + 1073741823;
-            discover_sensor(
-                $valid['sensor'],
-                'dbm',
-                $device,
-                ".$oid.$index",
-                'swSfpTxPower.' . $index,
-                'brocade',
-                makeshortif($ifDescr[$ifIndex]) . ' TX',
-                1,
-                1,
-                -5,
-                null,
-                null,
-                0,
-                $current,
-                'snmp',
-                $ifIndex,
-                'ports',
-                null,
-                'Transmit Power');
+            $ifAdminStatus = dbFetchCell("SELECT `ifAdminStatus` FROM `ports` WHERE `ifIndex`= ? AND `device_id` = ? AND `ifAdminStatus` = 'up'", [$ifIndex, $device['device_id']]);
+            if ($ifAdminStatus == 'up') {
+                discover_sensor(
+                    $valid['sensor'],
+                    'dbm',
+                    $device,
+                    ".$oid.$index",
+                    'swSfpTxPower.' . $index,
+                    'brocade',
+                    makeshortif($ifDescr[$ifIndex]) . ' TX',
+                    1,
+                    1,
+                    -5,
+                    null,
+                    null,
+                    0,
+                    $current,
+                    'snmp',
+                    $ifIndex,
+                    'ports',
+                    null,
+                    'Transmit Power'
+                );
+            }
         }
     }
 }


### PR DESCRIPTION
In #12777 the dbm sensors are added for fabos switches (brocade). Also admin disabled ports are added resulting in sensor below limit alerts.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
