### PR TITLE
Alcatel-Lucent aos7 LLDP Neighbors

### DIFF
--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -239,7 +239,6 @@ if (($device['os'] == 'routeros')) {
             } else {
                 $ifIndex = $entry_key;
             }
-	 
             if (($device['os'] == 'aos7')) {
                 $local_port_id = find_port_id($ifName, null, $device['device_id']);
             } else {

--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -221,21 +221,31 @@ if (($device['os'] == 'routeros')) {
                 }
             }
         }
+	if (($device['os'] == 'aos7')) {
+		$lldp_local = snmpwalk_cache_oid($device, 'lldpLocPortEntry', array(), 'LLDP-MIB');
+		$lldp_ports = snmpwalk_group($device, 'lldpLocPortId', 'LLDP-MIB');
+	} else {
 
         $dot1d_array = snmpwalk_group($device, 'dot1dBasePortIfIndex', 'BRIDGE-MIB');
         $lldp_ports = snmpwalk_group($device, 'lldpLocPortId', 'LLDP-MIB');
+	}
     }
 
     foreach ($lldp_array as $key => $lldp_if_array) {
         foreach ($lldp_if_array as $entry_key => $lldp_instance) {
-            if (is_numeric($dot1d_array[$entry_key]['dot1dBasePortIfIndex'])) {
+		if (($device['os'] == 'aos7')) { 
+			$ifName = $lldp_local[$entry_key]['lldpLocPortDesc'];
+		} elseif (is_numeric($dot1d_array[$entry_key]['dot1dBasePortIfIndex'])) {
                 $ifIndex = $dot1d_array[$entry_key]['dot1dBasePortIfIndex'];
             } else {
                 $ifIndex = $entry_key;
             }
 
             $local_port_id = find_port_id($lldp_ports[$entry_key]['lldpLocPortId'], $ifIndex, $device['device_id']);
-            $interface = get_port_by_id($local_port_id);
+            if (($device['os'] == 'aos7')) { 
+	    $interface = dbFetchRow("SELECT * FROM `ports` WHERE `device_id` = ? AND (`ifName`= ? OR `ifDescr` = ?)", array($device['device_id'], $ifName, $ifName));
+	    } else {
+		    $interface = get_port_by_id($local_port_id); }
 
             d_echo($lldp_instance);
 

--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -221,21 +221,20 @@ if (($device['os'] == 'routeros')) {
                 }
             }
         }
-	if (($device['os'] == 'aos7')) {
-		$lldp_local = snmpwalk_cache_oid($device, 'lldpLocPortEntry', array(), 'LLDP-MIB');
-		$lldp_ports = snmpwalk_group($device, 'lldpLocPortId', 'LLDP-MIB');
-	} else {
-
-        $dot1d_array = snmpwalk_group($device, 'dot1dBasePortIfIndex', 'BRIDGE-MIB');
-        $lldp_ports = snmpwalk_group($device, 'lldpLocPortId', 'LLDP-MIB');
-	}
+	      if (($device['os'] == 'aos7')) {
+		  $lldp_local = snmpwalk_cache_oid($device, 'lldpLocPortEntry', array(), 'LLDP-MIB');
+		  $lldp_ports = snmpwalk_group($device, 'lldpLocPortId', 'LLDP-MIB');
+	      } else {
+              $dot1d_array = snmpwalk_group($device, 'dot1dBasePortIfIndex', 'BRIDGE-MIB');
+              $lldp_ports = snmpwalk_group($device, 'lldpLocPortId', 'LLDP-MIB');
+	      }
     }
 
     foreach ($lldp_array as $key => $lldp_if_array) {
         foreach ($lldp_if_array as $entry_key => $lldp_instance) {
-		if (($device['os'] == 'aos7')) { 
-			$ifName = $lldp_local[$entry_key]['lldpLocPortDesc'];
-		} elseif (is_numeric($dot1d_array[$entry_key]['dot1dBasePortIfIndex'])) {
+            if (($device['os'] == 'aos7')) { 
+		$ifName = $lldp_local[$entry_key]['lldpLocPortDesc'];
+	    } elseif (is_numeric($dot1d_array[$entry_key]['dot1dBasePortIfIndex'])) {
                 $ifIndex = $dot1d_array[$entry_key]['dot1dBasePortIfIndex'];
             } else {
                 $ifIndex = $entry_key;
@@ -243,9 +242,10 @@ if (($device['os'] == 'routeros')) {
 
             $local_port_id = find_port_id($lldp_ports[$entry_key]['lldpLocPortId'], $ifIndex, $device['device_id']);
             if (($device['os'] == 'aos7')) { 
-	    $interface = dbFetchRow("SELECT * FROM `ports` WHERE `device_id` = ? AND (`ifName`= ? OR `ifDescr` = ?)", array($device['device_id'], $ifName, $ifName));
+	        $interface = dbFetchRow("SELECT * FROM `ports` WHERE `device_id` = ? AND (`ifName`= ? OR `ifDescr` = ?)", array($device['device_id'], $ifName, $ifName));
 	    } else {
-		    $interface = get_port_by_id($local_port_id); }
+	        $interface = get_port_by_id($local_port_id); 
+	    }
 
             d_echo($lldp_instance);
 

--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -233,19 +233,20 @@ if (($device['os'] == 'routeros')) {
     foreach ($lldp_array as $key => $lldp_if_array) {
         foreach ($lldp_if_array as $entry_key => $lldp_instance) {
             if (($device['os'] == 'aos7')) {
-                $ifName = $lldp_local[$entry_key]['lldpLocPortDesc'];
+		    $ifName = $lldp_local[$entry_key]['lldpLocPortDesc'];
             } elseif (is_numeric($dot1d_array[$entry_key]['dot1dBasePortIfIndex'])) {
                 $ifIndex = $dot1d_array[$entry_key]['dot1dBasePortIfIndex'];
             } else {
                 $ifIndex = $entry_key;
             }
-
-            $local_port_id = find_port_id($lldp_ports[$entry_key]['lldpLocPortId'], $ifIndex, $device['device_id']);
-            if (($device['os'] == 'aos7')) {
-                $interface = dbFetchRow('SELECT * FROM `ports` WHERE `device_id` = ? AND (`ifName`= ? OR `ifDescr` = ?)', [$device['device_id'], $ifName, $ifName]);
-            } else {
+	 
+	    if (($device['os'] == 'aos7')) {
+                  $local_port_id = find_port_id($ifName, null, $device['device_id']);
+	    } else {
+		    $local_port_id = find_port_id($lldp_ports[$entry_key]['lldpLocPortId'], $ifIndex, $device['device_id']);
+	    }
                 $interface = get_port_by_id($local_port_id);
-            }
+            
 
             d_echo($lldp_instance);
 

--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -221,13 +221,13 @@ if (($device['os'] == 'routeros')) {
                 }
             }
         }
-	     if (($device['os'] == 'aos7')) {
+             if (($device['os'] == 'aos7')) {
                  $lldp_local = snmpwalk_cache_oid($device, 'lldpLocPortEntry', [], 'LLDP-MIB');
                  $lldp_ports = snmpwalk_group($device, 'lldpLocPortId', 'LLDP-MIB');
-	     } else {
+             } else {
                  $dot1d_array = snmpwalk_group($device, 'dot1dBasePortIfIndex', 'BRIDGE-MIB');
                  $lldp_ports = snmpwalk_group($device, 'lldpLocPortId', 'LLDP-MIB');
-	     }
+             }
     }
 
     foreach ($lldp_array as $key => $lldp_if_array) {

--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -233,18 +233,18 @@ if (($device['os'] == 'routeros')) {
     foreach ($lldp_array as $key => $lldp_if_array) {
         foreach ($lldp_if_array as $entry_key => $lldp_instance) {
             if (($device['os'] == 'aos7')) {
-		    $ifName = $lldp_local[$entry_key]['lldpLocPortDesc'];
+		$ifName = $lldp_local[$entry_key]['lldpLocPortDesc'];
             } elseif (is_numeric($dot1d_array[$entry_key]['dot1dBasePortIfIndex'])) {
                 $ifIndex = $dot1d_array[$entry_key]['dot1dBasePortIfIndex'];
             } else {
                 $ifIndex = $entry_key;
             }
 	 
-	    if (($device['os'] == 'aos7')) {
-                  $local_port_id = find_port_id($ifName, null, $device['device_id']);
-	    } else {
-		    $local_port_id = find_port_id($lldp_ports[$entry_key]['lldpLocPortId'], $ifIndex, $device['device_id']);
-	    }
+            if (($device['os'] == 'aos7')) {
+                $local_port_id = find_port_id($ifName, null, $device['device_id']);
+            } else {
+                $local_port_id = find_port_id($lldp_ports[$entry_key]['lldpLocPortId'], $ifIndex, $device['device_id']);
+            }
                 $interface = get_port_by_id($local_port_id);
             
 

--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -222,7 +222,7 @@ if (($device['os'] == 'routeros')) {
             }
         }
 	      if (($device['os'] == 'aos7')) {
-		  $lldp_local = snmpwalk_cache_oid($device, 'lldpLocPortEntry', array(), 'LLDP-MIB');
+		  $lldp_local = snmpwalk_cache_oid($device, 'lldpLocPortEntry', [], 'LLDP-MIB');
 		  $lldp_ports = snmpwalk_group($device, 'lldpLocPortId', 'LLDP-MIB');
 	      } else {
               $dot1d_array = snmpwalk_group($device, 'dot1dBasePortIfIndex', 'BRIDGE-MIB');
@@ -233,18 +233,18 @@ if (($device['os'] == 'routeros')) {
     foreach ($lldp_array as $key => $lldp_if_array) {
         foreach ($lldp_if_array as $entry_key => $lldp_instance) {
             if (($device['os'] == 'aos7')) { 
-		$ifName = $lldp_local[$entry_key]['lldpLocPortDesc'];
-	    } elseif (is_numeric($dot1d_array[$entry_key]['dot1dBasePortIfIndex'])) {
+                $ifName = $lldp_local[$entry_key]['lldpLocPortDesc'];
+            } elseif (is_numeric($dot1d_array[$entry_key]['dot1dBasePortIfIndex'])) {
                 $ifIndex = $dot1d_array[$entry_key]['dot1dBasePortIfIndex'];
             } else {
                 $ifIndex = $entry_key;
             }
 
             $local_port_id = find_port_id($lldp_ports[$entry_key]['lldpLocPortId'], $ifIndex, $device['device_id']);
-            if (($device['os'] == 'aos7')) { 
-	        $interface = dbFetchRow("SELECT * FROM `ports` WHERE `device_id` = ? AND (`ifName`= ? OR `ifDescr` = ?)", array($device['device_id'], $ifName, $ifName));
+            if (($device['os'] == 'aos7')) {
+                $interface = dbFetchRow("SELECT * FROM `ports` WHERE `device_id` = ? AND (`ifName`= ? OR `ifDescr` = ?)", array($device['device_id'], $ifName, $ifName));
 	    } else {
-	        $interface = get_port_by_id($local_port_id); 
+                $interface = get_port_by_id($local_port_id); 
 	    }
 
             d_echo($lldp_instance);

--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -242,7 +242,7 @@ if (($device['os'] == 'routeros')) {
 
             $local_port_id = find_port_id($lldp_ports[$entry_key]['lldpLocPortId'], $ifIndex, $device['device_id']);
             if (($device['os'] == 'aos7')) {
-                $interface = dbFetchRow('SELECT * FROM `ports` WHERE `device_id` = ? AND (`ifName`= ? OR `ifDescr` = ?)', [($device['device_id'], $ifName, $ifName)]);
+                $interface = dbFetchRow('SELECT * FROM `ports` WHERE `device_id` = ? AND (`ifName`= ? OR `ifDescr` = ?)', array($device['device_id'], $ifName, $ifName));
             } else {
                 $interface = get_port_by_id($local_port_id); 
             }

--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -221,13 +221,13 @@ if (($device['os'] == 'routeros')) {
                 }
             }
         }
-             if (($device['os'] == 'aos7')) {
-                 $lldp_local = snmpwalk_cache_oid($device, 'lldpLocPortEntry', [], 'LLDP-MIB');
-                 $lldp_ports = snmpwalk_group($device, 'lldpLocPortId', 'LLDP-MIB');
-             } else {
-                 $dot1d_array = snmpwalk_group($device, 'dot1dBasePortIfIndex', 'BRIDGE-MIB');
-                 $lldp_ports = snmpwalk_group($device, 'lldpLocPortId', 'LLDP-MIB');
-             }
+        if (($device['os'] == 'aos7')) {
+            $lldp_local = snmpwalk_cache_oid($device, 'lldpLocPortEntry', [], 'LLDP-MIB');
+            $lldp_ports = snmpwalk_group($device, 'lldpLocPortId', 'LLDP-MIB');
+        } else {
+            $dot1d_array = snmpwalk_group($device, 'dot1dBasePortIfIndex', 'BRIDGE-MIB');
+            $lldp_ports = snmpwalk_group($device, 'lldpLocPortId', 'LLDP-MIB');
+        }
     }
 
     foreach ($lldp_array as $key => $lldp_if_array) {

--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -233,7 +233,7 @@ if (($device['os'] == 'routeros')) {
     foreach ($lldp_array as $key => $lldp_if_array) {
         foreach ($lldp_if_array as $entry_key => $lldp_instance) {
             if (($device['os'] == 'aos7')) {
-		$ifName = $lldp_local[$entry_key]['lldpLocPortDesc'];
+                $ifName = $lldp_local[$entry_key]['lldpLocPortDesc'];
             } elseif (is_numeric($dot1d_array[$entry_key]['dot1dBasePortIfIndex'])) {
                 $ifIndex = $dot1d_array[$entry_key]['dot1dBasePortIfIndex'];
             } else {
@@ -245,8 +245,7 @@ if (($device['os'] == 'routeros')) {
             } else {
                 $local_port_id = find_port_id($lldp_ports[$entry_key]['lldpLocPortId'], $ifIndex, $device['device_id']);
             }
-                $interface = get_port_by_id($local_port_id);
-            
+            $interface = get_port_by_id($local_port_id);
 
             d_echo($lldp_instance);
 

--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -222,17 +222,17 @@ if (($device['os'] == 'routeros')) {
             }
         }
 	      if (($device['os'] == 'aos7')) {
-		  $lldp_local = snmpwalk_cache_oid($device, 'lldpLocPortEntry', [], 'LLDP-MIB');
-		  $lldp_ports = snmpwalk_group($device, 'lldpLocPortId', 'LLDP-MIB');
+                  $lldp_local = snmpwalk_cache_oid($device, 'lldpLocPortEntry', [], 'LLDP-MIB');
+                  $lldp_ports = snmpwalk_group($device, 'lldpLocPortId', 'LLDP-MIB');
 	      } else {
-              $dot1d_array = snmpwalk_group($device, 'dot1dBasePortIfIndex', 'BRIDGE-MIB');
-              $lldp_ports = snmpwalk_group($device, 'lldpLocPortId', 'LLDP-MIB');
+                  $dot1d_array = snmpwalk_group($device, 'dot1dBasePortIfIndex', 'BRIDGE-MIB');
+                  $lldp_ports = snmpwalk_group($device, 'lldpLocPortId', 'LLDP-MIB');
 	      }
     }
 
     foreach ($lldp_array as $key => $lldp_if_array) {
         foreach ($lldp_if_array as $entry_key => $lldp_instance) {
-            if (($device['os'] == 'aos7')) { 
+            if (($device['os'] == 'aos7')) {
                 $ifName = $lldp_local[$entry_key]['lldpLocPortDesc'];
             } elseif (is_numeric($dot1d_array[$entry_key]['dot1dBasePortIfIndex'])) {
                 $ifIndex = $dot1d_array[$entry_key]['dot1dBasePortIfIndex'];
@@ -242,10 +242,10 @@ if (($device['os'] == 'routeros')) {
 
             $local_port_id = find_port_id($lldp_ports[$entry_key]['lldpLocPortId'], $ifIndex, $device['device_id']);
             if (($device['os'] == 'aos7')) {
-                $interface = dbFetchRow("SELECT * FROM `ports` WHERE `device_id` = ? AND (`ifName`= ? OR `ifDescr` = ?)", array($device['device_id'], $ifName, $ifName));
-	    } else {
+                $interface = dbFetchRow('SELECT * FROM `ports` WHERE `device_id` = ? AND (`ifName`= ? OR `ifDescr` = ?)', [($device['device_id'], $ifName, $ifName)]);
+            } else {
                 $interface = get_port_by_id($local_port_id); 
-	    }
+            }
 
             d_echo($lldp_instance);
 

--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -221,13 +221,13 @@ if (($device['os'] == 'routeros')) {
                 }
             }
         }
-	      if (($device['os'] == 'aos7')) {
-                  $lldp_local = snmpwalk_cache_oid($device, 'lldpLocPortEntry', [], 'LLDP-MIB');
-                  $lldp_ports = snmpwalk_group($device, 'lldpLocPortId', 'LLDP-MIB');
-	      } else {
-                  $dot1d_array = snmpwalk_group($device, 'dot1dBasePortIfIndex', 'BRIDGE-MIB');
-                  $lldp_ports = snmpwalk_group($device, 'lldpLocPortId', 'LLDP-MIB');
-	      }
+	     if (($device['os'] == 'aos7')) {
+                 $lldp_local = snmpwalk_cache_oid($device, 'lldpLocPortEntry', [], 'LLDP-MIB');
+                 $lldp_ports = snmpwalk_group($device, 'lldpLocPortId', 'LLDP-MIB');
+	     } else {
+                 $dot1d_array = snmpwalk_group($device, 'dot1dBasePortIfIndex', 'BRIDGE-MIB');
+                 $lldp_ports = snmpwalk_group($device, 'lldpLocPortId', 'LLDP-MIB');
+	     }
     }
 
     foreach ($lldp_array as $key => $lldp_if_array) {
@@ -242,9 +242,9 @@ if (($device['os'] == 'routeros')) {
 
             $local_port_id = find_port_id($lldp_ports[$entry_key]['lldpLocPortId'], $ifIndex, $device['device_id']);
             if (($device['os'] == 'aos7')) {
-                $interface = dbFetchRow('SELECT * FROM `ports` WHERE `device_id` = ? AND (`ifName`= ? OR `ifDescr` = ?)', array($device['device_id'], $ifName, $ifName));
+                $interface = dbFetchRow('SELECT * FROM `ports` WHERE `device_id` = ? AND (`ifName`= ? OR `ifDescr` = ?)', [$device['device_id'], $ifName, $ifName]);
             } else {
-                $interface = get_port_by_id($local_port_id); 
+                $interface = get_port_by_id($local_port_id);
             }
 
             d_echo($lldp_instance);


### PR DESCRIPTION
LLDP Neighbors for Alcatel-Lucent Aos7 is working only for chassis ports.

If the switch has a module installed, LLDP Neighbors  is missing for module ports and doesn't show because data using dot1dBasePortIfIndex from BRIDGE-MIB is not there.

I'm pretty sure is not the greatest way to do this, i looked to some code but at least for AOS7 is working. I'm not sure if I broke something else now. 

I started this in order to get help here.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
