### PR TITLE
Support for fortiswitch in gen_rancid

### DIFF
--- a/scripts/gen_rancid.php
+++ b/scripts/gen_rancid.php
@@ -32,6 +32,7 @@ $rancid_map['edgeos'] = 'edgerouter';
 $rancid_map['edgeswitch'] = 'edgemax';
 $rancid_map['f5'] = 'f5';
 $rancid_map['fortigate'] = 'fortigate';
+$rancid_map['fortiswitch'] = 'fortigate';
 $rancid_map['ftos'] = 'force10';
 $rancid_map['ios'] = 'cisco';
 $rancid_map['iosxe'] = 'cisco';


### PR DESCRIPTION
This patch will support fortiswitches in gen_rancid. The backend on the rancid side is the same for fortigate and fortiswitch.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
