### PR TITLE
Update device_component_down_junos macro

### DIFF
--- a/misc/macros.json
+++ b/misc/macros.json
@@ -6,7 +6,7 @@
     "component_normal": "(%component.status = 0 && %macros.component)",
     "component_warning": "(%component.status = 1 && %macros.component)",
     "device": "(%devices.disabled = 0 && %devices.ignore = 0)",
-    "device_component_down_junos": "%sensors.sensor_class = \"state\" && %sensors.sensor_current != \"6\" && %sensors.sensor_type = \"jnxFruState\" && %sensors.sensor_current != \"2\" && %sensors.sensor_alert = \"1\"",
+    "device_component_down_junos": "%sensors.sensor_class = \"state\" && %sensors.sensor_current != \"6\" && (%sensors.sensor_type = \"jnxFruState\" || %sensors.sensor_type = \"jnxFruTable\") && %sensors.sensor_current != \"2\" && %sensors.sensor_alert = \"1\"",
     "device_component_down_cisco": "%sensors.sensor_current != \"1\" && %sensors.sensor_current != \"5\" && %sensors.sensor_type REGEXP \"^cisco.*State$\" && %sensors.sensor_alert = \"1\"",
     "device_up": "(%devices.status = 1 && %macros.device)",
     "device_down": "(%devices.status = 0 && %macros.device)",


### PR DESCRIPTION
Detect state changes in sensors in both jnxFruState and jnxFruTable

Our Juniper MX's seem to use the latter.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
