### PR TITLE
Bump version to 21.5.1

### DIFF
--- a/LibreNMS/Util/Version.php
+++ b/LibreNMS/Util/Version.php
@@ -30,7 +30,7 @@ use Symfony\Component\Process\Process;
 class Version
 {
     // Update this on release
-    const VERSION = '21.5.0';
+    const VERSION = '21.5.1';
 
     protected $is_git_install = false;
 


### PR DESCRIPTION
I just changed the version constant in LibreNMS/Util/Version.php from 21.5.0 to 21.5.1. 

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
