### PR TITLE
LLDP - Extend discovery lldp code to support different subtypes

### DIFF
--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -300,7 +300,7 @@ if (($device['os'] == 'routeros')) {
                     $remote_device_id,
                     $remote_port_mac
                 );
-                if ($remote_port_id == 0 ) { //We did not find it
+                if ($remote_port_id == 0) { //We did not find it
                     $remote_port_name = $remote_port_name . ' (' . $remote_port_mac . ')';
                 }
                 if (empty($lldp['lldpRemSysName'])) {

--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -242,8 +242,15 @@ if (($device['os'] == 'routeros')) {
             foreach ($lldp_instance as $entry_instance => $lldp) {
                 // normalize MAC address if present
                 $remote_port_mac = '';
+                $remote_port_name = $lldp['lldpRemPortId'];
+                if ($lldp['lldpRemChassisIdSubtype'] == 4) { // 4 = macaddress
+                    $remote_port_mac = str_replace([' ', ':', '-'], '', strtolower($lldp['lldpRemChassisId']));
+                }
                 if ($lldp['lldpRemPortIdSubtype'] == 3) { // 3 = macaddress
                     $remote_port_mac = str_replace([' ', ':', '-'], '', strtolower($lldp['lldpRemPortId']));
+                }
+                if ($lldp['lldpRemChassisIdSubtype'] == 6 || $lldp['lldpRemChassisIdSubtype'] == 2) { // 6=ifName 2=ifAlias
+                    $remote_port_name = $lldp['lldpRemChassisId'];
                 }
 
                 $remote_device_id = find_device_id($lldp['lldpRemSysName'], $lldp['lldpRemManAddr'], $remote_port_mac);
@@ -272,11 +279,11 @@ if (($device['os'] == 'routeros')) {
 
                 $remote_device = device_by_id_cache($remote_device_id);
                 if ($remote_device['os'] == 'calix') {
-                    $lldp['lldpRemPortId'] = 'EthPort ' . $lldp['lldpRemPortId'];
+                    $remote_port_name = 'EthPort ' . $lldp['lldpRemPortId'];
                 }
 
                 if ($remote_device['os'] == 'xos') {
-                    $slot_port = explode(':', $lldp['lldpRemPortId']);
+                    $slot_port = explode(':', $remote_port_name);
                     if (sizeof($slot_port) == 2) {
                         $n_slot = (int) $slot_port[0];
                         $n_port = (int) $slot_port[1];
@@ -284,27 +291,31 @@ if (($device['os'] == 'routeros')) {
                         $n_slot = 1;
                         $n_port = (int) $slot_port[0];
                     }
-                    $lldp['lldpRemPortId'] = (string) ($n_slot * 1000 + $n_port);
+                    $remote_port_name = (string) ($n_slot * 1000 + $n_port);
                 }
 
                 $remote_port_id = find_port_id(
                     $lldp['lldpRemPortDesc'],
-                    $lldp['lldpRemPortId'],
+                    $remote_port_name,
                     $remote_device_id,
                     $remote_port_mac
                 );
-
+                if ($remote_port_id == 0 ) { //We did not find it
+                    $remote_port_name = $remote_port_name . ' (' . $remote_port_mac . ')';
+                }
                 if (empty($lldp['lldpRemSysName'])) {
                     $lldp['lldpRemSysName'] = $remote_device['sysName'] ?: $remote_device['hostname'];
                 }
-
-                if ($interface['port_id'] && $lldp['lldpRemSysName'] && $lldp['lldpRemPortId']) {
+                if (empty($lldp['lldpRemSysName'])) {
+                    $lldp['lldpRemSysName'] = $lldp['lldpRemSysDesc'];
+                }
+                if ($interface['port_id'] && $lldp['lldpRemSysName'] && $remote_port_name) {
                     discover_link(
                         $interface['port_id'],
                         'lldp',
                         $remote_port_id,
                         $lldp['lldpRemSysName'],
-                        $lldp['lldpRemPortId'],
+                        $remote_port_name,
                         null,
                         $lldp['lldpRemSysDesc'],
                         $device['device_id'],


### PR DESCRIPTION
LLDP MIB allows different type of data inside 2 of the fields : **lldpRemChassisId** and **lldpRemPortId**. 
The type of data is provided via 2 other fields : 
**lldpRemChassisIdSubtype**: chassisComponent(1), interfaceAlias(2), portComponent(3), macAddress(4), networkAddress(5), interfaceName(6), local(7)
**lldpRemPortIdSubtype**: interfaceAlias(1), portComponent(2), macAddress(3), networkAddress(4), interfaceName(5), agentCircuitId(6), local(7)

This PR uses a little bit more of those subtypes indications to workaround missing or currently-not-useful LLDP entries. 
Like if PortID is not provided but ChassisID is the ifName, then use that as portID, etc etc...

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
