### PR TITLE
Improve cleanup scripts

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2049,6 +2049,7 @@ function get_device_oid_limit($device)
  */
 function lock_and_purge($table, $sql)
 {
+    // TODO: add block delete statements
     $purge_name = $table . '_purge';
     $lock = Cache::lock($purge_name, 86000);
     if ($lock->get()) {

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2062,7 +2062,7 @@ function lock_and_purge($table, $sql, int $count = 1000)
             }
             while (true) {
                 // Deletes are done in blocks to avoid a single very large operation.
-                if ( ! dbDelete($table, $sql, [$purge_days]) > 0 ) {
+                if (! dbDelete($table, $sql, [$purge_days]) > 0) {
                     break;
                 }
             }
@@ -2088,7 +2088,7 @@ function lock_and_purge_query($table, $sql, $msg)
 {
     $purge_name = $table . '_purge';
 
-    $purge_duration = Config::get($purge_name); 
+    $purge_duration = Config::get($purge_name);
     if (! (is_numeric($purge_duration) && $purge_duration > 0)) {
         return -2;
     }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2057,9 +2057,7 @@ function lock_and_purge($table, $sql, int $count = 1000)
 
         $name = str_replace('_', ' ', ucfirst($table));
         if (is_numeric($purge_days)) {
-            if (is_numeric($count)) {
-                $sql = $sql . " LIMIT $count";
-            }
+            $sql = $sql . " LIMIT $count";
             while (true) {
                 // Deletes are done in blocks to avoid a single very large operation.
                 if (! dbDelete($table, $sql, [$purge_days]) > 0) {


### PR DESCRIPTION
update `lock_and_purge` shared function to do dbDelete in blocks of 1000 rows, similar to how the cleanup for `syslog` currently happens

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
