### PR TITLE
Add good regex matching to ignoring interfaces

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -880,7 +880,7 @@ function include_dir($dir, $regex = '')
 
 /**
  * Check if port is valid to poll.
- * Settings: empty_ifdescr, good_if, bad_if, bad_if_regexp, bad_ifname_regexp, bad_ifalias_regexp, bad_iftype, bad_ifoperstatus
+ * Settings: empty_ifdescr, good_if, good_if_regexp, bad_if, bad_if_regexp, bad_ifname_regexp, bad_ifalias_regexp, bad_iftype, bad_ifoperstatus
  *
  * @param array $port
  * @param array $device
@@ -913,6 +913,14 @@ function is_port_valid($port, $device)
 
     if (str_i_contains($ifDescr, Config::getOsSetting($device['os'], 'good_if', Config::get('good_if')))) {
         return true;
+    }
+
+    foreach (Config::getCombined($device['os'], 'good_if_regexp') as $bir) {
+        if (preg_match($bir ."i", $ifDescr)) {
+            d_echo("ignored by ifDescr: $ifDescr (matched: $bir)\n");
+
+            return true;
+        }
     }
 
     foreach (Config::getCombined($device['os'], 'bad_if') as $bi) {


### PR DESCRIPTION
Adding a good_if_regexp to make efficient filtering using regex. 
See this useful when there is a need to skip all the virtual interfaces and only monitor Physical interfaces. 

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
