### PR TITLE
Fixes broken ifHighSpeed on D-link DES-3028 and introduces 'bad_ifHighSpeed'. For devices that are on the 'bad_ifHighSpeed' list, use ifSpeed (#12957)

### DIFF
--- a/doc/Developing/os/Initial-Detection.md
+++ b/doc/Developing/os/Initial-Detection.md
@@ -67,6 +67,14 @@ that the device doesn't support ifXEntry and to ignore it:
      - cisco2811
 ```
 
+`bad_ifHighSpeed`: This is a list of models for which to tell LibreNMS
+that the device doesn't support ifHighSpeed and to ignore it:
+
+```yaml
+ bad_ifHighSpeed:
+     - DES-3028
+```
+
 `mib_dir`: You can use this to specify an additional directory to
 look in for MIBs. An array is not accepted, only one directory may be specified.
 

--- a/includes/definitions/dlink.yaml
+++ b/includes/definitions/dlink.yaml
@@ -4,6 +4,8 @@ type: network
 icon: dlink
 ifname: true
 empty_ifdescr: true
+bad_ifXEntry:
+    - DES-3028
 discovery:
     -
         sysObjectID_except:

--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -595,6 +595,11 @@ foreach ($ports as $port) {
             }
         }
 
+        // For devices that are on the bad_ifHighSpeed list, use ifSpeed.
+        if (in_array(strtolower($device['hardware']), array_map('strtolower', (array) Config::getOsSetting($device['os'], 'bad_ifHighSpeed', [])))) {
+            $this_port['ifHighSpeed'] = null;
+        }
+
         if (isset($this_port['ifHighSpeed']) && is_numeric($this_port['ifHighSpeed'])) {
             d_echo('ifHighSpeed ');
             $this_port['ifSpeed'] = ($this_port['ifHighSpeed'] * 1000000);

--- a/misc/os_schema.json
+++ b/misc/os_schema.json
@@ -384,6 +384,12 @@
                 "type": "string"
             }
         },
+        "bad_ifHighSpeed": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
         "bad_iftype": {
             "type": "array",
             "items": {


### PR DESCRIPTION
Fixes broken ifHighSpeed on D-link DES-3028 and introduces 'bad_ifHighSpeed'.
For devices that are on the 'bad_ifHighSpeed' list, use ifSpeed (#12957)

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
