### PR TITLE
Poll current connections for F5 ltm

### DIFF
--- a/includes/html/graphs/device/bigip_ltm_allpm_currconns.inc.php
+++ b/includes/html/graphs/device/bigip_ltm_allpm_currconns.inc.php
@@ -2,7 +2,7 @@
 /*
  * LibreNMS module to display F5 LTM Virtual Server Details
  *
- * Copyright (c) 2016 Aaron Daniels <aaron@daniels.id.au>
+ * Copyright (c) 2021 Martin Bergström <martin@bergstr0m.se>
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the

--- a/includes/html/graphs/device/bigip_ltm_allpm_currconns.inc.php
+++ b/includes/html/graphs/device/bigip_ltm_allpm_currconns.inc.php
@@ -1,0 +1,74 @@
+<?php
+/*
+ * LibreNMS module to display F5 LTM Virtual Server Details
+ *
+ * Copyright (c) 2016 Aaron Daniels <aaron@daniels.id.au>
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.  Please see LICENSE.txt at the top level of
+ * the source code distribution for details.
+ */
+
+$component = new LibreNMS\Component();
+$components = $component->getComponents($device['device_id']);
+
+// We only care about our device id.
+$components = $components[$device['device_id']];
+
+// We extracted all the components for this device, now lets only get the LTM ones.
+$keep = [];
+$types = ['f5-ltm-pool', 'f5-ltm-poolmember'];
+foreach ($components as $k => $v) {
+    foreach ($types as $type) {
+        if ($v['type'] == $type) {
+            $keep[$k] = $v;
+        }
+    }
+}
+$components = $keep;
+
+include 'includes/html/graphs/common.inc.php';
+$rrd_options .= ' -l 0 -E ';
+$rrd_options .= " COMMENT:'LTM Pool Members                               Now      Avg      Max\\n'";
+$colours = array_merge(\LibreNMS\Config::get('graph_colours.mixed'), \LibreNMS\Config::get('graph_colours.manycolours'), \LibreNMS\Config::get('graph_colours.manycolours'));
+$count = 0;
+d_echo('<pre>');
+
+// Is the ID we are looking for a valid LTM VS Pool
+if ($components[$vars['id']]['type'] == 'f5-ltm-pool') {
+    $parent = $components[$vars['id']]['UID'];
+
+    // Find all pool members
+    foreach ($components as $compid => $comp) {
+        if ($comp['type'] != 'f5-ltm-poolmember') {
+            continue;
+        }
+        if (! strstr($comp['UID'], $parent)) {
+            continue;
+        }
+
+        $label = $comp['label'];
+        $hash = $comp['hash'];
+        $rrd_filename = Rrd::name($device['hostname'], [$comp['type'], $label, $hash]);
+        if (Rrd::checkRrdExists($rrd_filename)) {
+            d_echo("\n  Adding PM: " . $label . "\t+ added to the graph");
+
+            // Grab a colour from the array.
+            if (isset($colours[$count])) {
+                $colour = $colours[$count];
+            } else {
+                d_echo("\nError: Out of colours. Have: " . (count($colours) - 1) . ', Requesting:' . $count);
+            }
+
+            $rrd_options .= ' DEF:DS' . $count . '=' . $rrd_filename . ':currconns:AVERAGE ';
+            $rrd_options .= ' LINE1.25:DS' . $count . '#' . $colour . ":'" . str_pad(substr($label, 0, 40), 40) . "'";
+            $rrd_options .= ' GPRINT:DS' . $count . ':LAST:%6.2lf%s ';
+            $rrd_options .= ' GPRINT:DS' . $count . ':AVERAGE:%6.2lf%s ';
+            $rrd_options .= ' GPRINT:DS' . $count . ":MAX:%6.2lf%s\l ";
+            $count++;
+        }
+    } // End Foreach
+}
+d_echo('</pre>');

--- a/includes/html/graphs/device/bigip_ltm_allpm_currconns.inc.php
+++ b/includes/html/graphs/device/bigip_ltm_allpm_currconns.inc.php
@@ -51,7 +51,7 @@ if ($components[$vars['id']]['type'] == 'f5-ltm-pool') {
 
         $label = $comp['label'];
         $hash = $comp['hash'];
-        $rrd_filename = Rrd::name($device['hostname'], [$comp['type'], $label, $hash]);
+        $rrd_filename = Rrd::name($device['hostname'], [$comp['type'], $label, $hash, 'currconns']);
         if (Rrd::checkRrdExists($rrd_filename)) {
             d_echo("\n  Adding PM: " . $label . "\t+ added to the graph");
 

--- a/includes/html/graphs/device/bigip_ltm_allvs_currconns.inc.php
+++ b/includes/html/graphs/device/bigip_ltm_allvs_currconns.inc.php
@@ -2,7 +2,7 @@
 /*
  * LibreNMS module to display F5 LTM Virtual Server Details
  *
- * Copyright (c) 2016 Aaron Daniels <aaron@daniels.id.au>
+ * Copyright (c) 2021 Martin Bergström <martin@bergstr0m.se>
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the

--- a/includes/html/graphs/device/bigip_ltm_allvs_currconns.inc.php
+++ b/includes/html/graphs/device/bigip_ltm_allvs_currconns.inc.php
@@ -1,0 +1,51 @@
+<?php
+/*
+ * LibreNMS module to display F5 LTM Virtual Server Details
+ *
+ * Copyright (c) 2016 Aaron Daniels <aaron@daniels.id.au>
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.  Please see LICENSE.txt at the top level of
+ * the source code distribution for details.
+ */
+
+$component = new LibreNMS\Component();
+$options = [];
+$options['filter']['type'] = ['=', 'f5-ltm-vs'];
+$components = $component->getComponents($device['device_id'], $options);
+
+// We only care about our device id.
+$components = $components[$device['device_id']];
+
+include 'includes/html/graphs/common.inc.php';
+$rrd_options .= ' -l 0 -E ';
+$rrd_options .= " COMMENT:'VS Current Connections       Now      Avg      Max\\n'";
+$colours = array_merge(\LibreNMS\Config::get('graph_colours.mixed'), \LibreNMS\Config::get('graph_colours.manycolours'));
+$colcount = 0;
+$count = 0;
+
+// add all LTM VS on this device.
+foreach ($components as $compid => $comp) {
+    $label = $comp['label'];
+    $hash = $comp['hash'];
+    $rrd_filename = Rrd::name($device['hostname'], [$comp['type'], $label, $hash]);
+    if (Rrd::checkRrdExists($rrd_filename)) {
+        // Grab a colour from the array.
+        if (isset($colours[$colcount])) {
+            $colour = $colours[$colcount];
+        } else {
+            $colcount = 0;
+            $colour = $colours[$colcount];
+        }
+
+        $rrd_options .= ' DEF:DS' . $count . '=' . $rrd_filename . ':currconns:AVERAGE ';
+        $rrd_options .= ' LINE1.25:DS' . $count . '#' . $colour . ":'" . str_pad(substr($label, 0, 60), 60) . "'";
+        $rrd_options .= ' GPRINT:DS' . $count . ':LAST:%6.2lf%s ';
+        $rrd_options .= ' GPRINT:DS' . $count . ':AVERAGE:%6.2lf%s ';
+        $rrd_options .= ' GPRINT:DS' . $count . ":MAX:%6.2lf%s\l ";
+        $count++;
+        $colcount++;
+    }
+}

--- a/includes/html/graphs/device/bigip_ltm_allvs_currconns.inc.php
+++ b/includes/html/graphs/device/bigip_ltm_allvs_currconns.inc.php
@@ -30,7 +30,7 @@ $count = 0;
 foreach ($components as $compid => $comp) {
     $label = $comp['label'];
     $hash = $comp['hash'];
-    $rrd_filename = Rrd::name($device['hostname'], [$comp['type'], $label, $hash]);
+    $rrd_filename = Rrd::name($device['hostname'], [$comp['type'], $label, $hash, 'currconns']);
     if (Rrd::checkRrdExists($rrd_filename)) {
         // Grab a colour from the array.
         if (isset($colours[$colcount])) {

--- a/includes/html/graphs/device/bigip_ltm_vs_currconns.inc.php
+++ b/includes/html/graphs/device/bigip_ltm_vs_currconns.inc.php
@@ -2,7 +2,7 @@
 /*
  * LibreNMS module to display F5 LTM Virtual Server Details
  *
- * Copyright (c) 2016 Aaron Daniels <aaron@daniels.id.au>
+ * Copyright (c) 2021 Martin Bergström <martin@bergstr0m.se>
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the

--- a/includes/html/graphs/device/bigip_ltm_vs_currconns.inc.php
+++ b/includes/html/graphs/device/bigip_ltm_vs_currconns.inc.php
@@ -1,0 +1,44 @@
+<?php
+/*
+ * LibreNMS module to display F5 LTM Virtual Server Details
+ *
+ * Copyright (c) 2016 Aaron Daniels <aaron@daniels.id.au>
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.  Please see LICENSE.txt at the top level of
+ * the source code distribution for details.
+ */
+
+$component = new LibreNMS\Component();
+$options = [];
+$options['filter']['type'] = ['=', 'f5-ltm-vs'];
+$components = $component->getComponents($device['device_id'], $options);
+
+// We only care about our device id.
+$components = $components[$device['device_id']];
+
+// Is the ID we are looking for a valid LTM VS
+if (isset($components[$vars['id']])) {
+    $label = $components[$vars['id']]['label'];
+    $hash = $components[$vars['id']]['hash'];
+
+    $rrd_filename = Rrd::name($device['hostname'], ['f5-ltm-vs', $label, $hash]);
+    if (Rrd::checkRrdExists($rrd_filename)) {
+        require 'includes/html/graphs/common.inc.php';
+        $ds = 'currconns';
+
+        $colour_area = '9999cc';
+        $colour_line = '0000cc';
+
+        $colour_area_max = '9999cc';
+
+        $graph_max = 1;
+        $graph_min = 0;
+
+        $unit_text = 'Current Connections';
+        $line_text = 'Current Connections';
+        require 'includes/html/graphs/generic_simplex.inc.php';
+    }
+}

--- a/includes/html/graphs/device/bigip_ltm_vs_currconns.inc.php
+++ b/includes/html/graphs/device/bigip_ltm_vs_currconns.inc.php
@@ -24,7 +24,7 @@ if (isset($components[$vars['id']])) {
     $label = $components[$vars['id']]['label'];
     $hash = $components[$vars['id']]['hash'];
 
-    $rrd_filename = Rrd::name($device['hostname'], ['f5-ltm-vs', $label, $hash]);
+    $rrd_filename = Rrd::name($device['hostname'], ['f5-ltm-vs', $label, $hash, 'currconns']);
     if (Rrd::checkRrdExists($rrd_filename)) {
         require 'includes/html/graphs/common.inc.php';
         $ds = 'currconns';

--- a/includes/html/pages/device/loadbalancer/ltm_pool_details.inc.php
+++ b/includes/html/pages/device/loadbalancer/ltm_pool_details.inc.php
@@ -112,6 +112,23 @@ if ($components[$vars['poolid']]['type'] == 'f5-ltm-pool') {
         <div class="col-md-12">
             <div class="container-fluid">
                 <div class='row'>
+                    <div class="panel panel-default" id="currconnections">
+                        <div class="panel-heading">
+                            <h3 class="panel-title">Current Connections</h3>
+                        </div>
+                        <div class="panel-body">
+                            <?php
+                            $graph_array = [];
+    $graph_array['device'] = $device['device_id'];
+    $graph_array['height'] = '100';
+    $graph_array['width'] = '215';
+    $graph_array['legend'] = 'no';
+    $graph_array['to'] = \LibreNMS\Config::get('time.now');
+    $graph_array['type'] = 'device_bigip_ltm_allpm_currconns';
+    $graph_array['id'] = $vars['poolid'];
+    require 'includes/html/print-graphrow.inc.php'; ?>
+                        </div>
+                    </div>
                     <div class="panel panel-default" id="connections">
                         <div class="panel-heading">
                             <h3 class="panel-title">Connections</h3>

--- a/includes/html/pages/device/loadbalancer/ltm_vs_all.inc.php
+++ b/includes/html/pages/device/loadbalancer/ltm_vs_all.inc.php
@@ -64,6 +64,23 @@
     </tbody>
 </table>
 
+<div class="panel panel-default" id="currconnections">
+    <div class="panel-heading">
+        <h3 class="panel-title">Current Connections</h3>
+    </div>
+    <div class="panel-body">
+        <?php
+        $graph_array = [];
+        $graph_array['device'] = $device['device_id'];
+        $graph_array['height'] = '100';
+        $graph_array['width'] = '215';
+        $graph_array['legend'] = 'no';
+        $graph_array['to'] = \LibreNMS\Config::get('time.now');
+        $graph_array['type'] = 'device_bigip_ltm_allvs_currconns';
+        require 'includes/html/print-graphrow.inc.php';
+        ?>
+    </div>
+</div>
 <div class="panel panel-default" id="connections">
     <div class="panel-heading">
         <h3 class="panel-title">Connections</h3>

--- a/includes/html/pages/device/loadbalancer/ltm_vs_det.inc.php
+++ b/includes/html/pages/device/loadbalancer/ltm_vs_det.inc.php
@@ -19,6 +19,24 @@ if ($components[$vars['vsid']]['type'] == 'f5-ltm-vs') {
         <div class="col-md-12">
             <div class="container-fluid">
                 <div class='row'>
+                    <div class="panel panel-default" id="currconnections">
+                        <div class="panel-heading">
+                            <h3 class="panel-title">Current Connections</h3>
+                        </div>
+                        <div class="panel-body">
+                            <?php
+                            $graph_array = [];
+    $graph_array['device'] = $device['device_id'];
+    $graph_array['height'] = '100';
+    $graph_array['width'] = '215';
+    $graph_array['legend'] = 'no';
+    $graph_array['to'] = \LibreNMS\Config::get('time.now');
+    $graph_array['type'] = 'device_bigip_ltm_vs_currconns';
+    $graph_array['id'] = $vars['vsid'];
+    require 'includes/html/print-graphrow.inc.php'; ?>
+                        </div>
+                    </div>
+
                     <div class="panel panel-default" id="connections">
                         <div class="panel-heading">
                             <h3 class="panel-title">Connections</h3>

--- a/includes/html/pages/device/loadbalancer/ltm_vs_pool.inc.php
+++ b/includes/html/pages/device/loadbalancer/ltm_vs_pool.inc.php
@@ -104,6 +104,24 @@ if ($components[$vars['poolid']]['type'] == 'f5-ltm-pool') {
         <div class="col-md-12">
             <div class="container-fluid">
                 <div class='row'>
+                    <div class="panel panel-default" id="currconnections">
+                        <div class="panel-heading">
+                            <h3 class="panel-title">Current Connections</h3>
+                        </div>
+                        <div class="panel-body">
+                            <?php
+                            $graph_array = [];
+    $graph_array['device'] = $device['device_id'];
+    $graph_array['height'] = '100';
+    $graph_array['width'] = '215';
+    $graph_array['legend'] = 'no';
+    $graph_array['to'] = \LibreNMS\Config::get('time.now');
+    $graph_array['type'] = 'device_bigip_ltm_allpm_currconns';
+    $graph_array['id'] = $vars['poolid'];
+    require 'includes/html/print-graphrow.inc.php'; ?>
+                        </div>
+		    </div>
+
                     <div class="panel panel-default" id="connections">
                         <div class="panel-heading">
                             <h3 class="panel-title">Connections</h3>

--- a/includes/polling/loadbalancers.inc.php
+++ b/includes/polling/loadbalancers.inc.php
@@ -12,4 +12,5 @@
 if ($device['os'] == 'f5') {
     include 'includes/polling/loadbalancers/f5-ltm.inc.php';
     include 'includes/polling/loadbalancers/f5-gtm.inc.php';
+    include 'includes/polling/loadbalancers/f5-ltm-currconns.inc.php';
 }

--- a/includes/polling/loadbalancers/f5-ltm-currconns.inc.php
+++ b/includes/polling/loadbalancers/f5-ltm-currconns.inc.php
@@ -2,7 +2,7 @@
 /*
  * LibreNMS module to display F5 LTM Details
  *
- * Copyright (c) 2016 Aaron Daniels <aaron@daniels.id.au>
+ * Copyright (c) 2021 Martin Bergström <martin@bergstr0m.se>
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the

--- a/includes/polling/loadbalancers/f5-ltm-currconns.inc.php
+++ b/includes/polling/loadbalancers/f5-ltm-currconns.inc.php
@@ -1,0 +1,164 @@
+<?php
+/*
+ * LibreNMS module to display F5 LTM Details
+ *
+ * Copyright (c) 2016 Aaron Daniels <aaron@daniels.id.au>
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.  Please see LICENSE.txt at the top level of
+ * the source code distribution for details.
+ */
+
+use LibreNMS\RRD\RrdDefinition;
+
+// Define some error messages
+$error_poolaction = [];
+$error_poolaction[0] = 'Unused';
+$error_poolaction[1] = 'Reboot';
+$error_poolaction[2] = 'Restart';
+$error_poolaction[3] = 'Failover';
+$error_poolaction[4] = 'Failover and Restart';
+$error_poolaction[5] = 'Go Active';
+$error_poolaction[6] = 'None';
+
+$component = new LibreNMS\Component();
+$options['filter']['disabled'] = ['=', 0];
+$options['filter']['ignore'] = ['=', 0];
+$components = $component->getComponents($device['device_id'], $options);
+
+// We only care about our device id.
+$components = $components[$device['device_id']];
+
+// We extracted all the components for this device, now lets only get the LTM ones.
+$keep = [];
+$types = ['f5-ltm-vs', 'f5-ltm-bwc', 'f5-ltm-pool', 'f5-ltm-poolmember'];
+foreach ($components as $k => $v) {
+    foreach ($types as $type) {
+        if ($v['type'] == $type) {
+            $keep[$k] = $v;
+        }
+    }
+}
+$components = $keep;
+
+// Only collect SNMP data if we have enabled components
+if (! empty($components)) {
+    // Let's gather the stats..
+    $f5_stats['ltmVirtualServStatEntryPktsin'] = snmpwalk_array_num($device, '.1.3.6.1.4.1.3375.2.2.10.2.3.1.6', 0);
+    $f5_stats['ltmVirtualServStatEntryPktsout'] = snmpwalk_array_num($device, '.1.3.6.1.4.1.3375.2.2.10.2.3.1.8', 0);
+    $f5_stats['ltmVirtualServStatEntryBytesin'] = snmpwalk_array_num($device, '.1.3.6.1.4.1.3375.2.2.10.2.3.1.7', 0);
+    $f5_stats['ltmVirtualServStatEntryBytesout'] = snmpwalk_array_num($device, '.1.3.6.1.4.1.3375.2.2.10.2.3.1.9', 0);
+    $f5_stats['ltmVirtualServStatEntryTotconns'] = snmpwalk_array_num($device, '.1.3.6.1.4.1.3375.2.2.10.2.3.1.11', 0);
+    $f5_stats['ltmVirtualServStatEntryCurrconns'] = snmpwalk_array_num($device, '.1.3.6.1.4.1.3375.2.2.10.2.3.1.12', 0);
+
+    $f5_stats['ltmBwcEntryPktsin'] = snmpwalk_array_num($device, '.1.3.6.1.4.1.3375.2.2.13.1.3.1.7', 0);
+    $f5_stats['ltmBwcEntryBytesin'] = snmpwalk_array_num($device, '.1.3.6.1.4.1.3375.2.2.13.1.3.1.4', 0);
+    $f5_stats['ltmBwcEntryBytesDropped'] = snmpwalk_array_num($device, '.1.3.6.1.4.1.3375.2.2.13.1.3.1.6', 0);
+    $f5_stats['ltmBwcEntryBytesPassed'] = snmpwalk_array_num($device, '.1.3.6.1.4.1.3375.2.2.13.1.3.1.5', 0);
+
+    $f5_stats['ltmPoolMemberStatEntryPktsin'] = snmpwalk_array_num($device, '.1.3.6.1.4.1.3375.2.2.5.4.3.1.5', 0);
+    $f5_stats['ltmPoolMemberStatEntryPktsout'] = snmpwalk_array_num($device, '.1.3.6.1.4.1.3375.2.2.5.4.3.1.7', 0);
+    $f5_stats['ltmPoolMemberStatEntryBytesin'] = snmpwalk_array_num($device, '.1.3.6.1.4.1.3375.2.2.5.4.3.1.6', 0);
+    $f5_stats['ltmPoolMemberStatEntryBytesout'] = snmpwalk_array_num($device, '.1.3.6.1.4.1.3375.2.2.5.4.3.1.8', 0);
+    $f5_stats['ltmPoolMemberStatEntryTotconns'] = snmpwalk_array_num($device, '.1.3.6.1.4.1.3375.2.2.5.4.3.1.10', 0);
+    $f5_stats['ltmPoolMemberStatEntryCurrconns'] = snmpwalk_array_num($device, '.1.3.6.1.4.1.3375.2.2.5.4.3.1.11', 0);
+
+    // and check the status
+    $f5_stats['ltmVsStatusEntryState'] = snmpwalk_array_num($device, '1.3.6.1.4.1.3375.2.2.10.13.2.1.2', 0);
+    $f5_stats['ltmVsStatusEntryMsg'] = snmpwalk_array_num($device, '1.3.6.1.4.1.3375.2.2.10.13.2.1.5', 0);
+
+    $f5_stats['ltmPoolMbrStatusEntryState'] = snmpwalk_array_num($device, '1.3.6.1.4.1.3375.2.2.5.6.2.1.5', 0);
+    $f5_stats['ltmPoolMbrStatusEntryAvail'] = snmpwalk_array_num($device, '1.3.6.1.4.1.3375.2.2.5.6.2.1.6', 0);
+    $f5_stats['ltmPoolMbrStatusEntryMsg'] = snmpwalk_array_num($device, '1.3.6.1.4.1.3375.2.2.5.6.2.1.8', 0);
+
+    $f5_stats['ltmPoolEntryMinup'] = snmpwalk_array_num($device, '1.3.6.1.4.1.3375.2.2.5.1.2.1.4', 0);
+    $f5_stats['ltmPoolEntryMinupstatus'] = snmpwalk_array_num($device, '1.3.6.1.4.1.3375.2.2.5.1.2.1.5', 0);
+    $f5_stats['ltmPoolEntryMinupaction'] = snmpwalk_array_num($device, '1.3.6.1.4.1.3375.2.2.5.1.2.1.6', 0);
+    $f5_stats['ltmPoolEntryCurrentup'] = snmpwalk_array_num($device, '1.3.6.1.4.1.3375.2.2.5.1.2.1.8', 0);
+
+    // Loop through the components and extract the data.
+    foreach ($components as $key => &$array) {
+        $type = $array['type'];
+        $UID = $array['UID'];
+        $label = $array['label'];
+        $hash = $array['hash'];
+        $rrd_name = [$type, $label, $hash, 'currconns'];
+
+        if ($type == 'f5-ltm-vs') {
+            $rrd_def = RrdDefinition::make()
+                ->addDataset('currconns', 'GAUGE', 0);
+
+            $fields = [
+                'currconns' => $f5_stats['ltmVirtualServStatEntryCurrconns']['1.3.6.1.4.1.3375.2.2.10.2.3.1.12.' . $UID],
+            ];
+
+            // Let's print some debugging info.
+            d_echo("\n\nComponent: " . $key . "\n");
+            d_echo('    Type: ' . $type . "\n");
+            d_echo('    Label: ' . $label . "\n");
+
+            // Let's check the status.
+            $array['state'] = $f5_stats['ltmVsStatusEntryState']['1.3.6.1.4.1.3375.2.2.10.13.2.1.2.' . $UID];
+            if (($array['state'] == 2) || ($array['state'] == 3)) {
+                // The Virtual Server is unavailable.
+                $array['status'] = 2;
+                $array['error'] = $f5_stats['ltmVsStatusEntryMsg']['1.3.6.1.4.1.3375.2.2.10.13.2.1.5.' . $UID];
+            } else {
+                // All is good.
+                $array['status'] = 0;
+                $array['error'] = '';
+            }
+        } 
+        elseif ($type == 'f5-ltm-poolmember') {
+            $rrd_def = RrdDefinition::make()
+                ->addDataset('currconns', 'GAUGE', 0);
+
+            $array['state'] = $f5_stats['ltmPoolMbrStatusEntryState']['1.3.6.1.4.1.3375.2.2.5.6.2.1.5.' . $UID];
+            $array['available'] = $f5_stats['ltmPoolMbrStatusEntryAvail']['1.3.6.1.4.1.3375.2.2.5.6.2.1.6.' . $UID];
+
+            $fields = [
+                'currconns' => $f5_stats['ltmPoolMemberStatEntryCurrconns']['1.3.6.1.4.1.3375.2.2.5.4.3.1.11.' . $UID],
+            ];
+
+            // Let's print some debugging info.
+            d_echo("\n\nComponent: " . $key . "\n");
+            d_echo('    Type: ' . $type . "\n");
+            d_echo('    Label: ' . $label . "\n");
+
+            // If available and bad state
+            // 0 = None, 1 = Green, 2 = Yellow, 3 = Red, 4 = Blue
+            if (($array['available'] == 1) && ($array['state'] == 3)) {
+                // Warning Alarm, the pool member is down.
+                $array['status'] = 1;
+                $array['error'] = 'Pool Member is Down: ' . $f5_stats['ltmPoolMbrStatusEntryMsg']['1.3.6.1.4.1.3375.2.2.5.6.2.1.8.' . $UID];
+            } else {
+                // All is good.
+                $array['status'] = 0;
+                $array['error'] = '';
+            }
+        } else {
+            d_echo('Type is unknown: ' . $type . "\n");
+            continue;
+        }
+
+        $tags = compact('rrd_name', 'rrd_def', 'type', 'hash', 'label');
+        data_update($device, $type, $tags, $fields);
+    } // End foreach components
+
+    unset($f5_stats);
+
+    // Write the Components back to the DB.
+    $component->setComponentPrefs($device['device_id'], $components);
+} // end if count components
+
+// Clean-up after yourself!
+unset(
+    $type,
+    $components,
+    $component,
+    $options,
+    $error_poolaction,
+    $keep
+);

--- a/includes/polling/loadbalancers/f5-ltm-currconns.inc.php
+++ b/includes/polling/loadbalancers/f5-ltm-currconns.inc.php
@@ -46,24 +46,8 @@ $components = $keep;
 // Only collect SNMP data if we have enabled components
 if (! empty($components)) {
     // Let's gather the stats..
-    $f5_stats['ltmVirtualServStatEntryPktsin'] = snmpwalk_array_num($device, '.1.3.6.1.4.1.3375.2.2.10.2.3.1.6', 0);
-    $f5_stats['ltmVirtualServStatEntryPktsout'] = snmpwalk_array_num($device, '.1.3.6.1.4.1.3375.2.2.10.2.3.1.8', 0);
-    $f5_stats['ltmVirtualServStatEntryBytesin'] = snmpwalk_array_num($device, '.1.3.6.1.4.1.3375.2.2.10.2.3.1.7', 0);
-    $f5_stats['ltmVirtualServStatEntryBytesout'] = snmpwalk_array_num($device, '.1.3.6.1.4.1.3375.2.2.10.2.3.1.9', 0);
-    $f5_stats['ltmVirtualServStatEntryTotconns'] = snmpwalk_array_num($device, '.1.3.6.1.4.1.3375.2.2.10.2.3.1.11', 0);
-    $f5_stats['ltmVirtualServStatEntryCurrconns'] = snmpwalk_array_num($device, '.1.3.6.1.4.1.3375.2.2.10.2.3.1.12', 0);
-
-    $f5_stats['ltmBwcEntryPktsin'] = snmpwalk_array_num($device, '.1.3.6.1.4.1.3375.2.2.13.1.3.1.7', 0);
-    $f5_stats['ltmBwcEntryBytesin'] = snmpwalk_array_num($device, '.1.3.6.1.4.1.3375.2.2.13.1.3.1.4', 0);
-    $f5_stats['ltmBwcEntryBytesDropped'] = snmpwalk_array_num($device, '.1.3.6.1.4.1.3375.2.2.13.1.3.1.6', 0);
-    $f5_stats['ltmBwcEntryBytesPassed'] = snmpwalk_array_num($device, '.1.3.6.1.4.1.3375.2.2.13.1.3.1.5', 0);
-
-    $f5_stats['ltmPoolMemberStatEntryPktsin'] = snmpwalk_array_num($device, '.1.3.6.1.4.1.3375.2.2.5.4.3.1.5', 0);
-    $f5_stats['ltmPoolMemberStatEntryPktsout'] = snmpwalk_array_num($device, '.1.3.6.1.4.1.3375.2.2.5.4.3.1.7', 0);
-    $f5_stats['ltmPoolMemberStatEntryBytesin'] = snmpwalk_array_num($device, '.1.3.6.1.4.1.3375.2.2.5.4.3.1.6', 0);
-    $f5_stats['ltmPoolMemberStatEntryBytesout'] = snmpwalk_array_num($device, '.1.3.6.1.4.1.3375.2.2.5.4.3.1.8', 0);
-    $f5_stats['ltmPoolMemberStatEntryTotconns'] = snmpwalk_array_num($device, '.1.3.6.1.4.1.3375.2.2.5.4.3.1.10', 0);
-    $f5_stats['ltmPoolMemberStatEntryCurrconns'] = snmpwalk_array_num($device, '.1.3.6.1.4.1.3375.2.2.5.4.3.1.11', 0);
+    f5_stats['ltmVirtualServStatEntryCurrconns'] = snmpwalk_array_num($device, '.1.3.6.1.4.1.3375.2.2.10.2.3.1.12', 0);
+    f5_stats['ltmPoolMemberStatEntryCurrconns'] = snmpwalk_array_num($device, '.1.3.6.1.4.1.3375.2.2.5.4.3.1.11', 0);
 
     // and check the status
     $f5_stats['ltmVsStatusEntryState'] = snmpwalk_array_num($device, '1.3.6.1.4.1.3375.2.2.10.13.2.1.2', 0);
@@ -72,11 +56,6 @@ if (! empty($components)) {
     $f5_stats['ltmPoolMbrStatusEntryState'] = snmpwalk_array_num($device, '1.3.6.1.4.1.3375.2.2.5.6.2.1.5', 0);
     $f5_stats['ltmPoolMbrStatusEntryAvail'] = snmpwalk_array_num($device, '1.3.6.1.4.1.3375.2.2.5.6.2.1.6', 0);
     $f5_stats['ltmPoolMbrStatusEntryMsg'] = snmpwalk_array_num($device, '1.3.6.1.4.1.3375.2.2.5.6.2.1.8', 0);
-
-    $f5_stats['ltmPoolEntryMinup'] = snmpwalk_array_num($device, '1.3.6.1.4.1.3375.2.2.5.1.2.1.4', 0);
-    $f5_stats['ltmPoolEntryMinupstatus'] = snmpwalk_array_num($device, '1.3.6.1.4.1.3375.2.2.5.1.2.1.5', 0);
-    $f5_stats['ltmPoolEntryMinupaction'] = snmpwalk_array_num($device, '1.3.6.1.4.1.3375.2.2.5.1.2.1.6', 0);
-    $f5_stats['ltmPoolEntryCurrentup'] = snmpwalk_array_num($device, '1.3.6.1.4.1.3375.2.2.5.1.2.1.8', 0);
 
     // Loop through the components and extract the data.
     foreach ($components as $key => &$array) {

--- a/includes/polling/loadbalancers/f5-ltm-currconns.inc.php
+++ b/includes/polling/loadbalancers/f5-ltm-currconns.inc.php
@@ -33,7 +33,7 @@ $components = $components[$device['device_id']];
 
 // We extracted all the components for this device, now lets only get the LTM ones.
 $keep = [];
-$types = ['f5-ltm-vs', 'f5-ltm-bwc', 'f5-ltm-pool', 'f5-ltm-poolmember'];
+$types = ['f5-ltm-vs', 'f5-ltm-poolmember'];
 foreach ($components as $k => $v) {
     foreach ($types as $type) {
         if ($v['type'] == $type) {
@@ -46,8 +46,8 @@ $components = $keep;
 // Only collect SNMP data if we have enabled components
 if (! empty($components)) {
     // Let's gather the stats..
-    f5_stats['ltmVirtualServStatEntryCurrconns'] = snmpwalk_array_num($device, '.1.3.6.1.4.1.3375.2.2.10.2.3.1.12', 0);
-    f5_stats['ltmPoolMemberStatEntryCurrconns'] = snmpwalk_array_num($device, '.1.3.6.1.4.1.3375.2.2.5.4.3.1.11', 0);
+    $f5_stats['ltmVirtualServStatEntryCurrconns'] = snmpwalk_array_num($device, '.1.3.6.1.4.1.3375.2.2.10.2.3.1.12', 0);
+    $f5_stats['ltmPoolMemberStatEntryCurrconns'] = snmpwalk_array_num($device, '.1.3.6.1.4.1.3375.2.2.5.4.3.1.11', 0);
 
     // and check the status
     $f5_stats['ltmVsStatusEntryState'] = snmpwalk_array_num($device, '1.3.6.1.4.1.3375.2.2.10.13.2.1.2', 0);
@@ -89,8 +89,7 @@ if (! empty($components)) {
                 $array['status'] = 0;
                 $array['error'] = '';
             }
-        } 
-        elseif ($type == 'f5-ltm-poolmember') {
+        } elseif ($type == 'f5-ltm-poolmember') {
             $rrd_def = RrdDefinition::make()
                 ->addDataset('currconns', 'GAUGE', 0);
 

--- a/includes/polling/loadbalancers/f5-ltm.inc.php
+++ b/includes/polling/loadbalancers/f5-ltm.inc.php
@@ -51,6 +51,7 @@ if (! empty($components)) {
     $f5_stats['ltmVirtualServStatEntryBytesin'] = snmpwalk_array_num($device, '.1.3.6.1.4.1.3375.2.2.10.2.3.1.7', 0);
     $f5_stats['ltmVirtualServStatEntryBytesout'] = snmpwalk_array_num($device, '.1.3.6.1.4.1.3375.2.2.10.2.3.1.9', 0);
     $f5_stats['ltmVirtualServStatEntryTotconns'] = snmpwalk_array_num($device, '.1.3.6.1.4.1.3375.2.2.10.2.3.1.11', 0);
+    $f5_stats['ltmVirtualServStatEntryCurrconns'] = snmpwalk_array_num($device, '.1.3.6.1.4.1.3375.2.2.10.2.3.1.12', 0);
 
     $f5_stats['ltmBwcEntryPktsin'] = snmpwalk_array_num($device, '.1.3.6.1.4.1.3375.2.2.13.1.3.1.7', 0);
     $f5_stats['ltmBwcEntryBytesin'] = snmpwalk_array_num($device, '.1.3.6.1.4.1.3375.2.2.13.1.3.1.4', 0);
@@ -62,6 +63,7 @@ if (! empty($components)) {
     $f5_stats['ltmPoolMemberStatEntryBytesin'] = snmpwalk_array_num($device, '.1.3.6.1.4.1.3375.2.2.5.4.3.1.6', 0);
     $f5_stats['ltmPoolMemberStatEntryBytesout'] = snmpwalk_array_num($device, '.1.3.6.1.4.1.3375.2.2.5.4.3.1.8', 0);
     $f5_stats['ltmPoolMemberStatEntryTotconns'] = snmpwalk_array_num($device, '.1.3.6.1.4.1.3375.2.2.5.4.3.1.10', 0);
+    $f5_stats['ltmPoolMemberStatEntryCurrconns'] = snmpwalk_array_num($device, '.1.3.6.1.4.1.3375.2.2.5.4.3.1.11', 0);
 
     // and check the status
     $f5_stats['ltmVsStatusEntryState'] = snmpwalk_array_num($device, '1.3.6.1.4.1.3375.2.2.10.13.2.1.2', 0);
@@ -108,7 +110,8 @@ if (! empty($components)) {
                 ->addDataset('pktsout', 'COUNTER', 0)
                 ->addDataset('bytesin', 'COUNTER', 0)
                 ->addDataset('bytesout', 'COUNTER', 0)
-                ->addDataset('totconns', 'COUNTER', 0);
+                ->addDataset('totconns', 'COUNTER', 0)
+                ->addDataset('currconns', 'COUNTER', 0);
 
             $fields = [
                 'pktsin' => $f5_stats['ltmVirtualServStatEntryPktsin']['1.3.6.1.4.1.3375.2.2.10.2.3.1.6.' . $UID],
@@ -116,6 +119,7 @@ if (! empty($components)) {
                 'bytesin' => $f5_stats['ltmVirtualServStatEntryBytesin']['1.3.6.1.4.1.3375.2.2.10.2.3.1.7.' . $UID],
                 'bytesout' => $f5_stats['ltmVirtualServStatEntryBytesout']['1.3.6.1.4.1.3375.2.2.10.2.3.1.9.' . $UID],
                 'totconns' => $f5_stats['ltmVirtualServStatEntryTotconns']['1.3.6.1.4.1.3375.2.2.10.2.3.1.11.' . $UID],
+                'currconns' => $f5_stats['ltmVirtualServStatEntryCurrconns']['1.3.6.1.4.1.3375.2.2.10.2.3.1.12.' . $UID],
             ];
 
             // Let's print some debugging info.
@@ -170,7 +174,8 @@ if (! empty($components)) {
                 ->addDataset('pktsout', 'COUNTER', 0)
                 ->addDataset('bytesin', 'COUNTER', 0)
                 ->addDataset('bytesout', 'COUNTER', 0)
-                ->addDataset('totconns', 'COUNTER', 0);
+                ->addDataset('totconns', 'COUNTER', 0)
+                ->addDataset('currconns', 'COUNTER', 0);
 
             $array['state'] = $f5_stats['ltmPoolMbrStatusEntryState']['1.3.6.1.4.1.3375.2.2.5.6.2.1.5.' . $UID];
             $array['available'] = $f5_stats['ltmPoolMbrStatusEntryAvail']['1.3.6.1.4.1.3375.2.2.5.6.2.1.6.' . $UID];
@@ -181,6 +186,7 @@ if (! empty($components)) {
                 'bytesin' => $f5_stats['ltmPoolMemberStatEntryBytesin']['1.3.6.1.4.1.3375.2.2.5.4.3.1.6.' . $UID],
                 'bytesout' => $f5_stats['ltmPoolMemberStatEntryBytesout']['1.3.6.1.4.1.3375.2.2.5.4.3.1.8.' . $UID],
                 'totconns' => $f5_stats['ltmPoolMemberStatEntryTotconns']['1.3.6.1.4.1.3375.2.2.5.4.3.1.10.' . $UID],
+                'currconns' => $f5_stats['ltmPoolMemberStatEntryCurrconns']['1.3.6.1.4.1.3375.2.2.5.4.3.1.11.' . $UID],
             ];
 
             // Let's print some debugging info.

--- a/includes/polling/loadbalancers/f5-ltm.inc.php
+++ b/includes/polling/loadbalancers/f5-ltm.inc.php
@@ -51,7 +51,6 @@ if (! empty($components)) {
     $f5_stats['ltmVirtualServStatEntryBytesin'] = snmpwalk_array_num($device, '.1.3.6.1.4.1.3375.2.2.10.2.3.1.7', 0);
     $f5_stats['ltmVirtualServStatEntryBytesout'] = snmpwalk_array_num($device, '.1.3.6.1.4.1.3375.2.2.10.2.3.1.9', 0);
     $f5_stats['ltmVirtualServStatEntryTotconns'] = snmpwalk_array_num($device, '.1.3.6.1.4.1.3375.2.2.10.2.3.1.11', 0);
-    $f5_stats['ltmVirtualServStatEntryCurrconns'] = snmpwalk_array_num($device, '.1.3.6.1.4.1.3375.2.2.10.2.3.1.12', 0);
 
     $f5_stats['ltmBwcEntryPktsin'] = snmpwalk_array_num($device, '.1.3.6.1.4.1.3375.2.2.13.1.3.1.7', 0);
     $f5_stats['ltmBwcEntryBytesin'] = snmpwalk_array_num($device, '.1.3.6.1.4.1.3375.2.2.13.1.3.1.4', 0);
@@ -63,7 +62,6 @@ if (! empty($components)) {
     $f5_stats['ltmPoolMemberStatEntryBytesin'] = snmpwalk_array_num($device, '.1.3.6.1.4.1.3375.2.2.5.4.3.1.6', 0);
     $f5_stats['ltmPoolMemberStatEntryBytesout'] = snmpwalk_array_num($device, '.1.3.6.1.4.1.3375.2.2.5.4.3.1.8', 0);
     $f5_stats['ltmPoolMemberStatEntryTotconns'] = snmpwalk_array_num($device, '.1.3.6.1.4.1.3375.2.2.5.4.3.1.10', 0);
-    $f5_stats['ltmPoolMemberStatEntryCurrconns'] = snmpwalk_array_num($device, '.1.3.6.1.4.1.3375.2.2.5.4.3.1.11', 0);
 
     // and check the status
     $f5_stats['ltmVsStatusEntryState'] = snmpwalk_array_num($device, '1.3.6.1.4.1.3375.2.2.10.13.2.1.2', 0);
@@ -110,8 +108,7 @@ if (! empty($components)) {
                 ->addDataset('pktsout', 'COUNTER', 0)
                 ->addDataset('bytesin', 'COUNTER', 0)
                 ->addDataset('bytesout', 'COUNTER', 0)
-                ->addDataset('totconns', 'COUNTER', 0)
-                ->addDataset('currconns', 'COUNTER', 0);
+                ->addDataset('totconns', 'COUNTER', 0);
 
             $fields = [
                 'pktsin' => $f5_stats['ltmVirtualServStatEntryPktsin']['1.3.6.1.4.1.3375.2.2.10.2.3.1.6.' . $UID],
@@ -119,7 +116,6 @@ if (! empty($components)) {
                 'bytesin' => $f5_stats['ltmVirtualServStatEntryBytesin']['1.3.6.1.4.1.3375.2.2.10.2.3.1.7.' . $UID],
                 'bytesout' => $f5_stats['ltmVirtualServStatEntryBytesout']['1.3.6.1.4.1.3375.2.2.10.2.3.1.9.' . $UID],
                 'totconns' => $f5_stats['ltmVirtualServStatEntryTotconns']['1.3.6.1.4.1.3375.2.2.10.2.3.1.11.' . $UID],
-                'currconns' => $f5_stats['ltmVirtualServStatEntryCurrconns']['1.3.6.1.4.1.3375.2.2.10.2.3.1.12.' . $UID],
             ];
 
             // Let's print some debugging info.
@@ -174,8 +170,7 @@ if (! empty($components)) {
                 ->addDataset('pktsout', 'COUNTER', 0)
                 ->addDataset('bytesin', 'COUNTER', 0)
                 ->addDataset('bytesout', 'COUNTER', 0)
-                ->addDataset('totconns', 'COUNTER', 0)
-                ->addDataset('currconns', 'COUNTER', 0);
+                ->addDataset('totconns', 'COUNTER', 0);
 
             $array['state'] = $f5_stats['ltmPoolMbrStatusEntryState']['1.3.6.1.4.1.3375.2.2.5.6.2.1.5.' . $UID];
             $array['available'] = $f5_stats['ltmPoolMbrStatusEntryAvail']['1.3.6.1.4.1.3375.2.2.5.6.2.1.6.' . $UID];
@@ -186,7 +181,6 @@ if (! empty($components)) {
                 'bytesin' => $f5_stats['ltmPoolMemberStatEntryBytesin']['1.3.6.1.4.1.3375.2.2.5.4.3.1.6.' . $UID],
                 'bytesout' => $f5_stats['ltmPoolMemberStatEntryBytesout']['1.3.6.1.4.1.3375.2.2.5.4.3.1.8.' . $UID],
                 'totconns' => $f5_stats['ltmPoolMemberStatEntryTotconns']['1.3.6.1.4.1.3375.2.2.5.4.3.1.10.' . $UID],
-                'currconns' => $f5_stats['ltmPoolMemberStatEntryCurrconns']['1.3.6.1.4.1.3375.2.2.5.4.3.1.11.' . $UID],
             ];
 
             // Let's print some debugging info.


### PR DESCRIPTION
Adds polling for "current connections" for LTM VS:es and LTM Pools.
Unfortunately this adds a new DS to a already existing RRD-file and therefore the RRD-file needs to be recreated.

![bild](https://user-images.githubusercontent.com/9891659/122686593-25c76180-d212-11eb-9004-63e630f4edc6.png)

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
