### PR TITLE
don't hardcode index for Mikrotik LTE wireless statistics

### DIFF
--- a/LibreNMS/OS/Routeros.php
+++ b/LibreNMS/OS/Routeros.php
@@ -221,8 +221,9 @@ class Routeros extends OS implements
         if (is_null($this->data)) {
             $wl60 = snmpwalk_cache_oid($this->getDeviceArray(), 'mtxrWl60GTable', [], 'MIKROTIK-MIB');
             $wlap = snmpwalk_cache_oid($this->getDeviceArray(), 'mtxrWlApTable', [], 'MIKROTIK-MIB');
+            $wllte = snmpwalk_cache_oid($this->getDeviceArray(), 'mtxrLTEModemTable', [], 'MIKROTIK-MIB');
             $wl60sta = snmpwalk_cache_oid($this->getDeviceArray(), 'mtxrWl60GStaTable', [], 'MIKROTIK-MIB');
-            $this->data = $wl60 + $wlap;
+            $this->data = $wl60 + $wlap + $wllte;
             $this->data = $this->data + $wl60sta;
         }
 
@@ -265,6 +266,18 @@ class Routeros extends OS implements
                     'SSID: ' . $entry['mtxrWlApSsid'],
                     $entry[$oid]
                 );
+            } elseif (($entry['mtxrLTEModemInterfaceIndex'] !== null)) {
+                $intname = snmp_get($this->getDeviceArray(),
+                    'mtxrInterfaceStatsName.' . $index, '-OQv', 'MIKROTIK-MIB');
+                $sensors[] = new WirelessSensor(
+                    $type,
+                    $this->getDeviceId(),
+                    $num_oid_base . $index,
+                    'mikrotik',
+                    $index,
+                    $intname,
+                    $entry[$oid]
+                );
             } else {
                 $sensors[] = new WirelessSensor(
                     $type,
@@ -281,55 +294,82 @@ class Routeros extends OS implements
         return $sensors;
     }
 
+    /**
+     * Discover LTE RSRQ.  This is in Dbm. Type is Dbm.
+     * Returns an array of LibreNMS\Device\Sensor objects that have been discovered
+     *
+     * @return array Sensors
+     */
     public function discoverWirelessRsrq()
     {
-        $sinr = '.1.3.6.1.4.1.14988.1.1.16.1.1.3.1'; //MIKROTIK-MIB::mtxrLTEModemSignalRSRQ
-
-        return [
-            new WirelessSensor(
+        $data = $this->fetchData();
+        $sensors = [];
+        foreach ($data as $index => $entry) {
+            $intname = snmp_get($this->getDeviceArray(),
+                'mtxrInterfaceStatsName.' . $index, '-OQv', 'MIKROTIK-MIB');
+            $sensors[] = new WirelessSensor(
                 'rsrq',
                 $this->getDeviceId(),
-                $sinr,
+                '.1.3.6.1.4.1.14988.1.1.16.1.1.3.' . $index,
                 'routeros',
-                0,
-                'Signal RSRQ',
+                $index,
+                $intname . ': Signal RSRQ',
                 null
-            ),
-        ];
+            ); // mtxrLTEModemSignalRSRQ
+        }
+        return $sensors;
     }
 
+    /**
+     * Discover LTE RSRP.  This is in Dbm. Type is Dbm.
+     * Returns an array of LibreNMS\Device\Sensor objects that have been discovered
+     *
+     * @return array Sensors
+     */
     public function discoverWirelessRsrp()
     {
-        $sinr = '.1.3.6.1.4.1.14988.1.1.16.1.1.4.1'; //MIKROTIK-MIB::mtxrLTEModemSignalRSRP
-
-        return [
-            new WirelessSensor(
+        $data = $this->fetchData();
+        $sensors = [];
+        foreach ($data as $index => $entry) {
+            $intname = snmp_get($this->getDeviceArray(),
+                'mtxrInterfaceStatsName.' . $index, '-OQv', 'MIKROTIK-MIB');
+            $sensors[] = new WirelessSensor(
                 'rsrp',
                 $this->getDeviceId(),
-                $sinr,
+                '.1.3.6.1.4.1.14988.1.1.16.1.1.4.' . $index,
                 'routeros',
-                0,
-                'Signal RSRP',
+                $index,
+                $intname . ': Signal RSRP',
                 null
-            ),
-        ];
+            ); // mtxrLTEModemSignalRSRP
+        }
+        return $sensors;
     }
 
+    /**
+     * Discover LTE SINR.  This is in Dbm. Type is Dbm.
+     * Returns an array of LibreNMS\Device\Sensor objects that have been discovered
+     *
+     * @return array Sensors
+     */
     public function discoverWirelessSinr()
     {
-        $sinr = '.1.3.6.1.4.1.14988.1.1.16.1.1.7.1'; //MIKROTIK-MIB::mtxrLTEModemSignalSINR
-
-        return [
-            new WirelessSensor(
+        $data = $this->fetchData();
+        $sensors = [];
+        foreach ($data as $index => $entry) {
+            $intname = snmp_get($this->getDeviceArray(),
+                'mtxrInterfaceStatsName.' . $index, '-OQv', 'MIKROTIK-MIB');
+            $sensors[] = new WirelessSensor(
                 'sinr',
                 $this->getDeviceId(),
-                $sinr,
+                '.1.3.6.1.4.1.14988.1.1.16.1.1.7.' . $index,
                 'routeros',
-                0,
-                'Signal SINR',
+                $index,
+                $intname . ': Signal SINR',
                 null
-            ),
-        ];
+            ); // mtxrLTEModemSignalSINR
+        }
+        return $sensors;
     }
 
     public function pollOS()


### PR DESCRIPTION
c69efb34443 added support for signal quality statistics for LTE modems on Mikrotik devices, but hardcoded the index to 1 so did not work in some cases, e.g. on ltap mini I have this (some fields masked) from a walk of MIKROTIK-MIB::mtxrLTEModemTable;

```
MIKROTIK-MIB::mtxrLTEModemSignalRSSI.3 = INTEGER: 0
MIKROTIK-MIB::mtxrLTEModemSignalRSRQ.3 = INTEGER: -10
MIKROTIK-MIB::mtxrLTEModemSignalRSRP.3 = INTEGER: -104
MIKROTIK-MIB::mtxrLTEModemCellId.3 = INTEGER: 21XXXX
MIKROTIK-MIB::mtxrLTEModemAccessTechnology.3 = INTEGER: eutran(7)
MIKROTIK-MIB::mtxrLTEModemSignalSINR.3 = INTEGER: 14
MIKROTIK-MIB::mtxrLTEModemEnbId.3 = INTEGER: 84XX
MIKROTIK-MIB::mtxrLTEModemSectorId.3 = INTEGER: 0
MIKROTIK-MIB::mtxrLTEModemLac.3 = INTEGER: 24XX
MIKROTIK-MIB::mtxrLTEModemIMEI.3 = STRING: 355654XXXXXXXXX
MIKROTIK-MIB::mtxrLTEModemIMSI.3 = STRING: 234200XXXXXXXXX
MIKROTIK-MIB::mtxrLTEModemUICC.3 = STRING: 89442001XXXXXXXXXXXX
MIKROTIK-MIB::mtxrLTEModemRAT.3 = STRING: Evolved 3G (LTE)
```

I'm not brilliant at php and don't know the codebase all that well so the diff is hacked together based on other parts in the file, and isn't perfect - in particular there's no good identifier to use as an interface name in the table so I pull it from mtxrInterfaceStatsName.$index; not sure how/where I can cache it so there's room for improvement there. It functions ok for me and I think is an improvement over what's there now.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
