### PR TITLE
return api error when device doesn't exist

### DIFF
--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -266,7 +266,7 @@ function get_device(Illuminate\Http\Request $request)
 
     // find device matching the id
     $device = device_by_id_cache($device_id);
-    if (! $device) {
+    if (! $device || ! $device['type']) {
         return api_error(404, "Device $hostname does not exist");
     }
 

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -266,7 +266,7 @@ function get_device(Illuminate\Http\Request $request)
 
     // find device matching the id
     $device = device_by_id_cache($device_id);
-    if (! $device || ! $device['type']) {
+    if (! $device || ! $device['device_id']) {
         return api_error(404, "Device $hostname does not exist");
     }
 


### PR DESCRIPTION
Function device_by_id_cache returns a hash table, which isn't null despite the device not existing.  This checks to see if the type has been populated to also determine if the device exists. 

Without this, the function always returns a "valid" device, even if one doesn't exist.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
