### PR TITLE
filter out NULL lat/lng values from Geographical Map display queries

### DIFF
--- a/includes/html/common/worldmap.inc.php
+++ b/includes/html/common/worldmap.inc.php
@@ -83,7 +83,7 @@ var greenMarker = L.AwesomeMarkers.icon({
         // Admin or global read-only - show all devices
         $sql = "SELECT DISTINCT(`device_id`),`location`,`sysName`,`hostname`,`os`,`status`,`lat`,`lng` FROM `devices`
                 LEFT JOIN `locations` ON `devices`.`location_id`=`locations`.`id`
-                WHERE `disabled`=0 AND `ignore`=0 AND ((`lat` != '' AND `lng` != '') OR (`location` REGEXP '\[[0-9\.\, ]+\]')) 
+                WHERE `disabled`=0 AND `ignore`=0 AND ((`lat` != '' AND `lng` != '') OR (`location` REGEXP '\[[0-9\.\, ]+\]'))
                 AND (`lat` IS NOT NULL AND `lng` IS NOT NULL)
                 AND `status` IN " . dbGenPlaceholders(count($show_status)) .
                 ' ORDER BY `status` ASC, `hostname`';

--- a/includes/html/common/worldmap.inc.php
+++ b/includes/html/common/worldmap.inc.php
@@ -95,7 +95,7 @@ var greenMarker = L.AwesomeMarkers.icon({
         $sql = "SELECT DISTINCT(`devices`.`device_id`) as `device_id`,`location`,`sysName`,`hostname`,`os`,`status`,`lat`,`lng`
                 FROM `devices`
                 LEFT JOIN `locations` ON `devices`.location_id=`locations`.`id`
-                WHERE `disabled`=0 AND `ignore`=0 AND ((`lat` != '' AND `lng` != '') OR (`location` REGEXP '\[[0-9\.\, ]+\]')) 
+                WHERE `disabled`=0 AND `ignore`=0 AND ((`lat` != '' AND `lng` != '') OR (`location` REGEXP '\[[0-9\.\, ]+\]'))
                 AND (`lat` IS NOT NULL AND `lng` IS NOT NULL)
                 AND `devices`.`device_id` IN " . dbGenPlaceholders(count($device_ids)) .
                 ' AND `status` IN ' . dbGenPlaceholders(count($show_status)) .

--- a/includes/html/common/worldmap.inc.php
+++ b/includes/html/common/worldmap.inc.php
@@ -83,7 +83,8 @@ var greenMarker = L.AwesomeMarkers.icon({
         // Admin or global read-only - show all devices
         $sql = "SELECT DISTINCT(`device_id`),`location`,`sysName`,`hostname`,`os`,`status`,`lat`,`lng` FROM `devices`
                 LEFT JOIN `locations` ON `devices`.`location_id`=`locations`.`id`
-                WHERE `disabled`=0 AND `ignore`=0 AND ((`lat` != '' AND `lng` != '') OR (`location` REGEXP '\[[0-9\.\, ]+\]'))
+                WHERE `disabled`=0 AND `ignore`=0 AND ((`lat` != '' AND `lng` != '') OR (`location` REGEXP '\[[0-9\.\, ]+\]')) 
+                AND (`lat` IS NOT NULL AND `lng` IS NOT NULL)
                 AND `status` IN " . dbGenPlaceholders(count($show_status)) .
                 ' ORDER BY `status` ASC, `hostname`';
         $param = $show_status;
@@ -94,7 +95,8 @@ var greenMarker = L.AwesomeMarkers.icon({
         $sql = "SELECT DISTINCT(`devices`.`device_id`) as `device_id`,`location`,`sysName`,`hostname`,`os`,`status`,`lat`,`lng`
                 FROM `devices`
                 LEFT JOIN `locations` ON `devices`.location_id=`locations`.`id`
-                WHERE `disabled`=0 AND `ignore`=0 AND ((`lat` != '' AND `lng` != '') OR (`location` REGEXP '\[[0-9\.\, ]+\]'))
+                WHERE `disabled`=0 AND `ignore`=0 AND ((`lat` != '' AND `lng` != '') OR (`location` REGEXP '\[[0-9\.\, ]+\]')) 
+                AND (`lat` IS NOT NULL AND `lng` IS NOT NULL)
                 AND `devices`.`device_id` IN " . dbGenPlaceholders(count($device_ids)) .
                 ' AND `status` IN ' . dbGenPlaceholders(count($show_status)) .
                 ' ORDER BY `status` ASC, `hostname`';


### PR DESCRIPTION
This change makes the fullscreen Geographical Map respond the same as dashboard widget maps by ignoring invalid location data - preventing invalid data from breaking map display. 
fixes #12984

It simply filters out NULL values from the DB queries so the map will always display.

![image](https://user-images.githubusercontent.com/78184917/123201597-90fc8680-d4e5-11eb-8887-dfa97265cc05.png)


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
