### PR TITLE
Help users that did not upgrade MySQL try two

### DIFF
--- a/database/migrations/2020_12_14_091314_create_port_groups_table.php
+++ b/database/migrations/2020_12_14_091314_create_port_groups_table.php
@@ -12,16 +12,24 @@ class CreatePortGroupsTable extends Migration
      */
     public function up()
     {
-        // drop table if exists, migration can fail when creating index.
+        // migration can fail when creating index if the user's SQL server isn't new enough.
         if (Schema::hasTable('port_groups')) {
-            Schema::drop('port_groups');
-        }
+            $table = Schema::getConnection()->getDoctrineSchemaManager()
+                ->listTableDetails('port_groups');
 
-        Schema::create('port_groups', function (Blueprint $table) {
-            $table->increments('id');
-            $table->string('name')->unique();
-            $table->string('desc')->nullable();
-        });
+            // if the table exists and the index doesn't, add the index.
+            if (! $table->hasIndex('port_groups_name_unique')) {
+                Schema::table('port_groups', function (Blueprint $table) {
+                    $table->unique('name');
+                });
+            }
+        } else {
+            Schema::create('port_groups', function (Blueprint $table) {
+                $table->increments('id');
+                $table->string('name')->unique();
+                $table->string('desc')->nullable();
+            });
+        }
     }
 
     /**


### PR DESCRIPTION
Instead of dropping the table and re-creating.  Just try adding the index.  This way it won't fail if they somehow did the port_group_port migration first.  And still should fail if the index cannot be created.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
