### PR TITLE
Eaton Network MS xups sensors

### DIFF
--- a/includes/definitions/discovery/eaton-mgeups.yaml
+++ b/includes/definitions/discovery/eaton-mgeups.yaml
@@ -189,27 +189,7 @@ modules:
                     states:
                         - { descr: 'No Alarm', graph: 0, value: 0, generic: 0 }
                         - { descr: 'Alarm raised', graph: 0, value: 1, generic: 2 }
-                -
-                    oid: xupsAlarmID
-                    value: xupsAlarmID
-                    num_oid: '.1.3.6.1.4.1.534.1.7.2.1.1.{{ $index }}'
-                    descr: 'XUPS Alarm Description'
-                    index: 'xupsAlarmID.{{ $index }}'
-                    state_name: xupsAlarmID
-                    states:
-                        - { descr: 'On Battery', graph: 0, value: 3, generic: 2 }
-                        - { descr: 'Low Battery', graph: 0, value: 4, generic: 2 }
-                        - { descr: 'Utility Power Restored', graph: 0, value: 5, generic: 2 }
-                        - { descr: 'Return From Low Battery', graph: 0, value: 6, generic: 2 }
-                        - { descr: 'Output Overload', graph: 0, value: 7 , generic: 2 }
-                        - { descr: 'Internal Failure', graph: 0, value: 8, generic: 2 }
-                        - { descr: 'Battery Discharged', graph: 0, value: 9, generic: 2 }
-                        - { descr: 'Inverter Failure', graph: 0, value: 10, generic: 2 }
-                        - { descr: 'On Bypass', graph: 0, value: 11, generic: 2 }
-                        - { descr: 'Bypass Not Available', graph: 0, value: 12, generic: 2 }
-                        - { descr: 'Output Off', graph: 0, value: 13, generic: 2 }
-                        - { descr: 'Input Failure', graph: 0, value: 14, generic: 2 }
-                        - { descr: 'Building Alarm', graph: 0, value: 15, generic: 2 }
-                        - { descr: 'Shutdown Imminent', graph: 0, value: 16, generic: 2 }
-                        - { descr: 'On Inverter', graph: 0, value: 17, generic: 2 }
+                        - { descr: 'Alarms raised', graph: 0, value: 2, generic: 2 }
+                        - { descr: 'Alarms raised', graph: 0, value: 3, generic: 2 }
+                        - { descr: 'Alarms raised', graph: 0, value: 4, generic: 2 }
 

--- a/includes/definitions/discovery/eaton-mgeups.yaml
+++ b/includes/definitions/discovery/eaton-mgeups.yaml
@@ -28,7 +28,7 @@ modules:
                     value: xupsEnvAmbientTemp
                     num_oid: '.1.3.6.1.4.1.534.1.6.1.{{ $index }}'
                     descr: 'Ambient'
-                    index: 'xupsEnvTemp.{{ $index }}'
+                    index: 'xupsEnvAmbientTemp.{{ $index }}'
         humidity:
             data:
                 -

--- a/includes/definitions/discovery/eaton-mgeups.yaml
+++ b/includes/definitions/discovery/eaton-mgeups.yaml
@@ -1,4 +1,4 @@
-mib: MG-SNMP-UPS-MIB:EATON-OIDS:EATON-EMP-MIB
+mib: MG-SNMP-UPS-MIB:EATON-OIDS:EATON-EMP-MIB:XUPS-MIB
 modules:
     os:
         hardware:
@@ -21,8 +21,14 @@ modules:
                     oid: xupsEnvironment
                     value: xupsEnvRemoteTemp
                     num_oid: '.1.3.6.1.4.1.534.1.6.5.{{ $index }}'
-                    descr: 'Environment'
+                    descr: 'Remote'
                     index: 'xupsEnvRemoteTemp.{{ $index }}'
+                -
+                    oid: xupsEnvironment
+                    value: xupsEnvAmbientTemp
+                    num_oid: '.1.3.6.1.4.1.534.1.6.1.{{ $index }}'
+                    descr: 'Ambient'
+                    index: 'xupsEnvTemp.{{ $index }}'
         humidity:
             data:
                 -
@@ -173,4 +179,37 @@ modules:
                         - { descr: 'Tolerance Volt. Out', graph: 0, value: 2, generic: 2 }
                         - { descr: 'Tolerance Freq. Out', graph: 0, value: 3, generic: 2 }
                         - { descr: 'No Voltage', graph: 0, value: 4, generic: 2 }
+                -
+                    oid: xupsAlarms
+                    value: xupsAlarms
+                    num_oid: '.1.3.6.1.4.1.534.1.7.1.{{ $index }}'
+                    descr: 'XUPS Alarm'
+                    index: 'xupsAlarms.{{ $index }}'
+                    state_name: xupsAlarms
+                    states:
+                        - { descr: 'No Alarm', graph: 0, value: 0, generic: 0 }
+                        - { descr: 'Alarm raised', graph: 0, value: 1, generic: 2 }
+                -
+                    oid: xupsAlarmID
+                    value: xupsAlarmID
+                    num_oid: '.1.3.6.1.4.1.534.1.7.2.1.1.{{ $index }}'
+                    descr: 'XUPS Alarm Description'
+                    index: 'xupsAlarmID.{{ $index }}'
+                    state_name: xupsAlarmID
+                    states:
+                        - { descr: 'On Battery', graph: 0, value: 3, generic: 2 }
+                        - { descr: 'Low Battery', graph: 0, value: 4, generic: 2 }
+                        - { descr: 'Utility Power Restored', graph: 0, value: 5, generic: 2 }
+                        - { descr: 'Return From Low Battery', graph: 0, value: 6, generic: 2 }
+                        - { descr: 'Output Overload', graph: 0, value: 7 , generic: 2 }
+                        - { descr: 'Internal Failure', graph: 0, value: 8, generic: 2 }
+                        - { descr: 'Battery Discharged', graph: 0, value: 9, generic: 2 }
+                        - { descr: 'Inverter Failure', graph: 0, value: 10, generic: 2 }
+                        - { descr: 'On Bypass', graph: 0, value: 11, generic: 2 }
+                        - { descr: 'Bypass Not Available', graph: 0, value: 12, generic: 2 }
+                        - { descr: 'Output Off', graph: 0, value: 13, generic: 2 }
+                        - { descr: 'Input Failure', graph: 0, value: 14, generic: 2 }
+                        - { descr: 'Building Alarm', graph: 0, value: 15, generic: 2 }
+                        - { descr: 'Shutdown Imminent', graph: 0, value: 16, generic: 2 }
+                        - { descr: 'On Inverter', graph: 0, value: 17, generic: 2 }
 


### PR DESCRIPTION
This patch does two things:
(0. Add the XUPS mib to discovery definitions)
1. Add the ambient temperature sensor exposed in the the xups mib, rename the current xups temp sensor
2. Flag alerts raised in the xups mib. I choose to put this with the other (mgups) alerts under 'State Sensors'.

The reason for (2) is that I have devices where an alert *is* raised with the xups mib, but not in the mgups mib. 

The reasons for not exposing more details about the xups alerts in LibreNMS is that the onboard web UI for these devices can be kinda vague about what the alert is about ("contact Eaton for a battery check"), and I am not certain I fully understand the xups mib.

Hence I just flag an alert and the user will have to check the actual device and/or support provider.


#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
