### PR TITLE
Leave it to generate_device_link for sysName/hostName/IP

### DIFF
--- a/includes/html/pages/routing/bgp.inc.php
+++ b/includes/html/pages/routing/bgp.inc.php
@@ -312,7 +312,7 @@ if (! Auth::user()->hasGlobalRead()) {
         unset($sep);
 
         echo '  <td></td>
-            <td width=150>' . $localaddresslink . '<br />' . generate_device_link($peer, shorthost($peer['hostname']), ['tab' => 'routing', 'proto' => 'bgp']) . '</td>
+            <td width=150>' . $localaddresslink . '<br />' . generate_device_link($peer, null, ['tab' => 'routing', 'proto' => 'bgp']) . '</td>
             <td width=30><b>&#187;</b></td>
             <td width=150>' . $peeraddresslink . "</td>
             <td width=50><b>$peer_type</b></td>

--- a/includes/html/print-interface.inc.php
+++ b/includes/html/print-interface.inc.php
@@ -293,7 +293,7 @@ if ($port_details && Config::get('enable_port_relationship') === true && port_pe
         $pw_peer_int = dbFetchRow('SELECT * FROM `ports` AS I, pseudowires AS P WHERE I.device_id = ? AND P.cpwVcID = ? AND P.port_id = I.port_id', [$pseudowire['peer_device_id'], $pseudowire['cpwVcID']]);
 
         $pw_peer_int = cleanPort($pw_peer_int);
-        echo "$br<i class='fa fa-cube fa-lg' style='color:green' aria-hidden='true'></i><b> " . generate_port_link($pw_peer_int, makeshortif($pw_peer_int['label'])) . ' on ' . generate_device_link($pw_peer_dev, shorthost($pw_peer_dev['hostname'])) . '</b>';
+        echo "$br<i class='fa fa-cube fa-lg' style='color:green' aria-hidden='true'></i><b> " . generate_port_link($pw_peer_int, makeshortif($pw_peer_int['label'])) . ' on ' . generate_device_link($pw_peer_dev) . '</b>';
         $br = '<br />';
     }
 

--- a/includes/html/print-interface.inc.php
+++ b/includes/html/print-interface.inc.php
@@ -269,7 +269,7 @@ if (strpos($port['label'], 'oopback') === false && ! $graph_type) {
                 echo "<i class='fa fa-arrow-right fa-lg' style='color:green' aria-hidden='true'></i> ";
             }
 
-            echo '<b>' . generate_port_link($link_if, makeshortif($link_if['label'])) . ' on ' . generate_device_link($link_if, shorthost($link_if['hostname']));
+            echo '<b>' . generate_port_link($link_if, makeshortif($link_if['label'])) . ' on ' . generate_device_link($link_if);
 
             if ($int_links_v6[$int_link]) {
                 echo " <b style='color: #a10000;'>v6</b>";

--- a/includes/html/table/alertlog-stats.inc.php
+++ b/includes/html/table/alertlog-stats.inc.php
@@ -72,7 +72,7 @@ foreach (dbFetchRows($sql, $param) as $alertlog) {
     $response[] = [
         'id' => $rulei++,
         'count' => $alertlog['COUNT(*)'],
-        'hostname' => '<div class="incident">' . generate_device_link($dev, shorthost($dev['hostname'])),
+        'hostname' => '<div class="incident">' . generate_device_link($dev),
         'alert_rule' => $alertlog['name'],
     ];
 }//end foreach

--- a/includes/html/table/alertlog.inc.php
+++ b/includes/html/table/alertlog.inc.php
@@ -108,7 +108,7 @@ foreach (dbFetchRows($sql, $param) as $alertlog) {
         'time_logged' => $alertlog['humandate'],
         'details' => '<a class="fa fa-plus incident-toggle" style="display:none" data-toggle="collapse" data-target="#incident' . ($rulei) . '" data-parent="#alerts"></a>',
         'verbose_details' => "<button type='button' class='btn btn-alert-details fa fa-info command-alert-details' style='display:none' aria-label='Details' id='alert-details' data-alert_log_id='{$alert_log_id}'></button>",
-        'hostname' => '<div class="incident">' . generate_device_link($dev, shorthost($dev['hostname'])) . '<div id="incident' . ($rulei) . '" class="collapse">' . $fault_detail . '</div></div>',
+        'hostname' => '<div class="incident">' . generate_device_link($dev) . '<div id="incident' . ($rulei) . '" class="collapse">' . $fault_detail . '</div></div>',
         'alert' => htmlspecialchars($alertlog['alert']),
         'status' => "<i class='alert-status " . $status . "' title='" . ($alert_state ? 'active' : 'recovered') . "'></i>",
         'severity' => $alertlog['severity'],

--- a/includes/html/table/poll-log.inc.php
+++ b/includes/html/table/poll-log.inc.php
@@ -62,7 +62,7 @@ foreach (dbFetchRows($sql, $param) as $device) {
         $device['group_name'] = 'General';
     }
     $response[] = [
-        'hostname'              => generate_device_link($device, format_hostname($device), ['tab' => 'graphs', 'group' => 'poller']),
+        'hostname'              => generate_device_link($device, null, ['tab' => 'graphs', 'group' => 'poller']),
         'last_polled'           => $device['last_polled'],
         'poller_group'          => $device['group_name'],
         'location'              => $device['location'],

--- a/includes/html/table/stp-ports.inc.php
+++ b/includes/html/table/stp-ports.inc.php
@@ -40,9 +40,9 @@ foreach (dbFetchRows($sql, [$device_id]) as $stp_ports_db) {
         'state'              => $stp_ports_db['state'],
         'enable'             => $stp_ports_db['enable'],
         'pathCost'           => $stp_ports_db['pathCost'],
-        'designatedRoot'     => ($root_device ? generate_device_link($root_device, $root_device['hostname']) : \LibreNMS\Util\Rewrite::readableOUI($stp_ports_db['designatedRoot'])) . '<br>' . \LibreNMS\Util\Rewrite::readableMac($stp_ports_db['designatedRoot']),
+        'designatedRoot'     => ($root_device ? generate_device_link($root_device) : \LibreNMS\Util\Rewrite::readableOUI($stp_ports_db['designatedRoot'])) . '<br>' . \LibreNMS\Util\Rewrite::readableMac($stp_ports_db['designatedRoot']),
         'designatedCost'     => $stp_ports_db['designatedCost'],
-        'designatedBridge'   => ($bridge_device ? generate_device_link($bridge_device, $bridge_device['hostname']) : \LibreNMS\Util\Rewrite::readableOUI($stp_ports_db['designatedBridge'])) . '<br>' . \LibreNMS\Util\Rewrite::readableMac($stp_ports_db['designatedBridge']),
+        'designatedBridge'   => ($bridge_device ? generate_device_link($bridge_device) : \LibreNMS\Util\Rewrite::readableOUI($stp_ports_db['designatedBridge'])) . '<br>' . \LibreNMS\Util\Rewrite::readableMac($stp_ports_db['designatedBridge']),
         'designatedPort'     => $stp_ports_db['designatedPort'],
         'forwardTransitions' => $stp_ports_db['forwardTransitions'],
     ];


### PR DESCRIPTION
Instead of forcing the "hostname", we leave it to `generate_device_link` which will use whatever config (sysname, hostname, ip etc) to generate the displayed name of the device

Before: 
![Capture d’écran 2021-07-04 à 17 16 28](https://user-images.githubusercontent.com/38363551/124390937-38e83000-dcee-11eb-8414-c31c32231035.png)

After: The snmp sysname is displayed exactly as in other screens of LibreNMS 
![Capture d’écran 2021-07-04 à 19 18 10](https://user-images.githubusercontent.com/38363551/124393849-cdf22580-dcfc-11eb-827a-88a9ab2bfb09.png)

On STP page : 
Before:
![Capture d’écran 2021-07-04 à 19 16 01](https://user-images.githubusercontent.com/38363551/124393784-6dfb7f00-dcfc-11eb-9ec8-d6fb3c4d4d95.png)

After:
![Capture d’écran 2021-07-04 à 19 16 28](https://user-images.githubusercontent.com/38363551/124393787-718f0600-dcfc-11eb-90c6-19ac8a2c48c4.png)

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
