### PR TITLE
Wrong statement used for Oxidized ignore_groups

### DIFF
--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -1408,7 +1408,7 @@ function list_oxidized(Illuminate\Http\Request $request)
         }
         //Exclude groups from being sent to Oxidized
         if (in_array($output['group'], Config::get('oxidized.ignore_groups'))) {
-            break;
+            continue;
         }
 
         $return[] = $output;


### PR DESCRIPTION
Used wrong statement to filter groups so all entries were ignored when a match was found. 
Now works as expected

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
