### PR TITLE
Fixed missing quotes on edit device

### DIFF
--- a/includes/html/pages/device/edit/device.inc.php
+++ b/includes/html/pages/device/edit/device.inc.php
@@ -121,7 +121,7 @@ $disable_notify = get_dev_attrib($device, 'disable_notify');
     <div class="form-group" data-toggle="tooltip" data-container="body" data-placement="bottom" title="Change the hostname used for name resolution" >
         <label for="edit-hostname-input" class="col-sm-2 control-label" >Hostname:</label>
         <div class="col-sm-6">
-            <input type="text" id="edit-hostname-input" name="hostname" class="form-control" disabled value=<?php echo \LibreNMS\Util\Clean::html($device['hostname'], []); ?> />
+            <input type="text" id="edit-hostname-input" name="hostname" class="form-control" disabled value="<?php echo \LibreNMS\Util\Clean::html($device['hostname'], []); ?>" />
         </div>
         <div class="col-sm-2">
             <button name="hostname-edit-button" id="hostname-edit-button" class="btn btn-danger"> <i class="fa fa-pencil"></i> </button>


### PR DESCRIPTION
**Problem:**
Form field on edit device is not wrapped in quotes. 

**Description:**
We are using a combination of spaces in the Hostname and Overwrite IP in order to have friendlier looking device names in our lists, as recommended by PipoCanaja on the forums.

We noticed that while the form accepts and stores device names with spaces, when you return to edit them, only the information before the first space is visible.

**Resolution:**
After applying this change, we are able to edit device names that have spaces in them.

![libre_fixquotes](https://user-images.githubusercontent.com/20563869/124797571-6ae0d880-df20-11eb-8dc7-41c82b8be58d.png)

**Reference:**
https://community.librenms.org/t/device-feature-override-sysname/7757/5

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
