### PR TITLE
Documentation cleanup of General, Install, Getting Started sections

### DIFF
--- a/doc/Extensions/Device-Groups.md
+++ b/doc/Extensions/Device-Groups.md
@@ -1,13 +1,15 @@
 source: Extensions/Device-Groups.md
 path: blob/master/doc/
 
+# Grouping Devices
+
 LibreNMS supports grouping your devices together in much the same way
 as you can configure alerts. This document will hopefully help you get
 started.
 
-# Dynamic Groups
+## Dynamic Groups
 
-## Rule Editor
+### Rule Editor
 
 The rule is based on the MySQL structure your data is in. Such as __tablename.columnname__.
 If you already know the entity you want, you can browse around inside
@@ -25,7 +27,7 @@ If you want to group them by DC, you could use the rule
 `devices.hostname` regex `dc1\..*\.example\.com` (Don't forget to
 escape periods in the regex)
 
-# Static Groups
+## Static Groups
 
 You can create static groups (and convert dynamic groups to static) to
 put specific devices in a group. Just select static as the type and

--- a/doc/General/Acknowledgement.md
+++ b/doc/General/Acknowledgement.md
@@ -2,10 +2,12 @@ source: General/Acknowledgement.md
 path: blob/master/doc/
 path: blob/master/doc/
 
+# Acknowledgements
+
 LibreNMS wouldn't be what it is today without the use of some other amazing projects.
 We list below what we make use of including the license compliance.
 
-# 3rd Party GPLv3 Compliant
+## 3rd Party GPLv3 Compliant
 
 - [Bootstrap](http://getbootstrap.com/): MIT
 - [Font Awesome](http://fontawesome.io/icons/): MIT License

--- a/doc/General/CODE_OF_CONDUCT.md
+++ b/doc/General/CODE_OF_CONDUCT.md
@@ -1,7 +1,9 @@
 source: General/CODE_OF_CONDUCT.md
 path: blob/master/doc/
 
-# Our Pledge
+# Code of Conduct
+
+## Our Pledge
 
 In the interest of fostering an open and welcoming environment, we as
 contributors and maintainers pledge to making participation in our
@@ -10,7 +12,7 @@ regardless of age, body size, disability, ethnicity, gender identity
 and expression, level of experience, nationality, personal appearance,
 race, religion, or sexual identity and orientation.
 
-# Our Standards
+## Our Standards
 
 Examples of behavior that contributes to creating a positive environment include:
 
@@ -30,7 +32,7 @@ Examples of unacceptable behavior by participants include:
 * Other conduct which could reasonably be considered inappropriate in
   a professional setting
 
-# Our Responsibilities
+## Our Responsibilities
 
 Project maintainers are responsible for clarifying the standards of
 acceptable behavior and are expected to take appropriate and fair
@@ -43,7 +45,7 @@ contributions that are not aligned to this Code of Conduct, or to ban
 temporarily or permanently any contributor for other behaviors that
 they deem inappropriate, threatening, offensive, or harmful.
 
-# Scope
+## Scope
 
 This Code of Conduct applies both within project spaces and in public
 spaces when an individual is representing the project or its
@@ -53,7 +55,7 @@ social media account, or acting as an appointed representative at an
 online or offline event. Representation of a project may be further
 defined and clarified by project maintainers.
 
-# Enforcement
+## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior
 may be reported by contacting the project team at
@@ -67,7 +69,7 @@ Project maintainers who do not follow or enforce the Code of Conduct
 in good faith may face temporary or permanent repercussions as
 determined by other members of the project's leadership.
 
-# Attribution
+## Attribution
 
 This Code of Conduct is adapted from the [Contributor
 Covenant][homepage], version 1.4, available at

--- a/doc/General/Callback-Stats-and-Privacy.md
+++ b/doc/General/Callback-Stats-and-Privacy.md
@@ -1,7 +1,9 @@
 source: General/Callback-Stats-and-Privacy.md
 path: blob/master/doc/
 
-# Stats data and your privacy
+# Submitting Stats
+
+## Stats data and your privacy
 
 This document has been put together to explain what LibreNMS does when
 it calls back home to report some anonymous statistics.
@@ -20,7 +22,7 @@ designed like it has.
 Now onto the bit you're interested in, what is submitted and what we
 do with that data.
 
-# What is submitted
+## What is submitted
 
 - All data is anonymous.
 - Generic statistics are taken from the database, these include things
@@ -35,14 +37,14 @@ do with that data.
 - Your IP isn't logged, even via our web service accepting the
   data. We don't need to know who you are so we don't ask.
 
-# What we do with the data
+## What we do with the data
 
 - We store it, not for long - 3 months at the moment although this could change.
 - We use it to generate pretty graphs for people to see.
 - We use it to help prioritise issues and features that need to be worked on.
 - We use sysDescr and sysObjectID to create unit tests and improve OS discovery
 
-# Questions?
+## Questions?
 
 - **Q.** How often is data submitted? **A.** We submit the data once a
   day according to running daily.sh via cron. If you disable this then
@@ -64,7 +66,7 @@ are doing here, if not, please pop into our [discord
 server](https://t.libren.ms/discord) or community forum and ask any
 questions you like.
 
-# How do I enable stats submission?
+## How do I enable stats submission?
 
 If you're happy with all of this - please consider switching the call
 back system on, you can do this within the About LibreNMS page within

--- a/doc/General/Releases.md
+++ b/doc/General/Releases.md
@@ -1,7 +1,7 @@
 source: General/Releases.md
 path: blob/master/doc/
 
-# Introduction
+# Choosing a release
 
 We try to ensure that breaking changes aren't introduced by utilising
 various automated code testing, syntax testing and unit testing along
@@ -10,7 +10,7 @@ well as major refactoring to improve the quality of the code base.
 
 We have two branches available for you to use. The default is the `master` branch.
 
-# Development branch
+## Development branch
 
 Our `master` branch is our dev branch, this is actively commited to
 and it's not uncommon for multiple commits to be merged in daily. As
@@ -27,7 +27,7 @@ branch by setting `$config['update_channel'] = 'master';` in
 
 `cd /opt/librenms && git checkout master`
 
-# Stable branch
+## Stable branch
 
 With this in mind, we provide a monthly stable release which is
 released on or around  the last Sunday of the month. Code pull

--- a/doc/General/Updating.md
+++ b/doc/General/Updating.md
@@ -1,10 +1,12 @@
 source: General/Updating.md
 path: blob/master/doc/
 
+# Updating an Install
+
 By default, LibreNMS is set to automatically update. If you have
 disabled this feature then you can perform a manual update.
 
-# Manual update
+## Manual update
 
 If you would like to perform a manual update then you can do this by
 running the following command as the `librenms` user:
@@ -14,7 +16,7 @@ running the following command as the `librenms` user:
 This will update both the core LibreNMS files but also update the database
 structure if updates are available.
 
-# Advanced users
+## Advanced users
 
 If you absolutely must update manually without using `./daily.sh` then
 you can do so by running the following commands:
@@ -31,8 +33,6 @@ You should continue to run daily.sh.  This does database cleanup and
 other processes in addition to updating. You can disable the daily.sh
 update process as described below.
 
-# Disabling automatic updates
+## Disabling automatic updates
 
-LibreNMS by default performs updates on a daily basis. This can be disabled by setting:
-
-`$config['update'] = 0;`
+LibreNMS by default performs updates on a daily basis. This can be disabled in the WebUI Global Settings under System -> Updates, or using lnms: `./lnms config:set update false`

--- a/doc/Installation/Images.md
+++ b/doc/Installation/Images.md
@@ -1,4 +1,5 @@
-# CentOS
+
+# LibreNMS VMs
 
 > NOTE: We highly advise that you change all passwords on this image
 > when you deploy it!!

--- a/doc/Installation/Install-LibreNMS.md
+++ b/doc/Installation/Install-LibreNMS.md
@@ -1,7 +1,9 @@
 source: Installation/Install-LibreNMS.md
 path: blob/master/doc/
 
-# Prepare Linux Server
+# Install LibreNMS
+
+## Prepare Linux Server
 
 You should have an installed Linux server running one of the supported OS.
 Make sure you select your server's OS in the tabbed options below.

--- a/doc/Installation/index.md
+++ b/doc/Installation/index.md
@@ -28,7 +28,7 @@ We have some pre-built VirtualBox images you can use to get started:
 - [Virtual Machines](Images)
 
 
-### Old Install Docs
+## Old Install Docs
 
 These install docs are no longer updated and may result in an unsuccessful install.
 

--- a/doc/Support/Adding-a-Device.md
+++ b/doc/Support/Adding-a-Device.md
@@ -12,6 +12,14 @@ Using the command line via ssh you can add a new device by changing to
 the directory of your LibreNMS install and typing (be sure to put the
 correct details).
 
+Preferred method:
+```bash
+./lnms device:add [--v1|--v2c] [-c yourSNMPcommunity] yourhostname
+```
+
+You can use `./lnms device:add --help` for a list of available options and defaults.
+
+Alternative:
 ```bash
 ./addhost.php yourhostname [community] [v1|v2c] [port] [udp|udp6|tcp|tcp6]
 ```
@@ -20,6 +28,12 @@ As an example, if your device with the name `mydevice.example.com` is
 configured to use the community `my_company` using snmp `v2c` then you
 would enter:
 
+Preferred method:
+```bash
+./lnms device:add --v2c -c my_company mydevice.example.com
+```
+
+Alternative:
 ```bash
 ./addhost.php mydevice.example.com my_company v2c
 ```
@@ -41,9 +55,9 @@ fill out the optional field `Overwrite IP` with it's IP-Address.
 
 ![Add device](/img/webui_add_device.png)
 
-### Ping Only Device
+## Ping Only Device
 
-You can add ping only devices into LibreNMS through the WebUI. When
+You can add ping only devices into LibreNMS through the WebUI or CLI. When
 adding the device switch the SNMP button to "off". Device will be
 added into LibreNMS as Ping Only Device and will show ICMP Response Graph.
 
@@ -51,9 +65,13 @@ added into LibreNMS as Ping Only Device and will show ICMP Response Graph.
 - Hardware: Optional you can type in whatever you like.
 - OS: Optional this will add the Device's OS Icon.
 
-[How to add ping only devices](https://youtu.be/cjuByubg-uk)
+Via CLI this is done with `./lnms device:add [-P|--ping-only] yourhostname`
 
 ![Ping Only](/img/add-ping-only.png)
+
+A How-to video can be found here: [How to add ping only devices](https://youtu.be/cjuByubg-uk)
+
+## Automatic Discovery and API
 
 If you would like to add devices automatically then you will probably
 want to read the [Auto-discovery

--- a/doc/Support/Features.md
+++ b/doc/Support/Features.md
@@ -3,8 +3,8 @@ path: blob/master/doc/
 
 # Features
 
-Here's a brief list of supported features, some might be missing.
-If you think something is missing, feel free to ask us.
+Here's a brief list of supported features, some might be missing. If
+you think something is missing, feel free to ask us.
 
 * Auto discovery
 * Alerting

--- a/doc/Support/Features.md
+++ b/doc/Support/Features.md
@@ -23,7 +23,7 @@ If you think something is missing, feel free to ask us.
 * API
 * Auto Updating
 
-# Vendors
+## Vendors
 
 Here's a brief list of supported vendors, some might be missing.
 If you are unsure of whether your device is supported or not, feel free to ask us.


### PR DESCRIPTION
This PR corrects TOC presenting and title consistency for documentation sections 1-3: General, Install, Getting Started.

Multiple H1 level headings '#' in mkdoc prevents TOC display.  users directly editing doco files in github preview do not see a TOC display, so have no way to know if it is working or not.

Two additional changes beyond TOC:

1. Preference lnms for device addition
2. .WebUI and lnms reference for daily update disabling.

Before sample:
![image](https://user-images.githubusercontent.com/78184917/124851570-64606880-dfd5-11eb-81c7-9baca1006b38.png)

After sample:
![image](https://user-images.githubusercontent.com/78184917/124851603-70e4c100-dfd5-11eb-98fb-053b16bff2b1.png)

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
