### PR TITLE
webui - Display metric if available

### DIFF
--- a/includes/html/functions.inc.php
+++ b/includes/html/functions.inc.php
@@ -831,7 +831,12 @@ function alert_details($details)
             $fault_detail .= $tmp_alerts['app_type'];
             $fault_detail .= '</a>';
 
-            $fault_detail .= ' => ' . $tmp_alerts['app_status'];
+            if ($tmp_alerts['app_status']) {
+                $fault_detail .= ' => ' . $tmp_alerts['app_status'];
+            }
+            if ($tmp_alerts['metric']) {
+                $fault_detail .= ' : ' . $tmp_alerts['metric'] . ' => ' . $tmp_alerts['value'];
+            }
             $fallback = false;
         }
 


### PR DESCRIPTION
Continuing #13016

Allow a correct display if application has metrics (like Asterisk does) or if it has not (like OS Update, handled in #13016 )

With a metric and a value: 
![Capture d’écran 2021-07-10 à 01 07 35](https://user-images.githubusercontent.com/38363551/125143687-b27f8400-e11b-11eb-87fa-8df70b56aa81.png)

With only an app_status : 
![Capture d’écran 2021-07-09 à 13 11 44](https://user-images.githubusercontent.com/38363551/125069759-74e90f80-e0b7-11eb-99d8-0c0af5d97ae8.png)

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
