### PR TITLE
Update cleanup config document

### DIFF
--- a/doc/Support/Cleanup-options.md
+++ b/doc/Support/Cleanup-options.md
@@ -11,15 +11,20 @@ entries. With Cleanup Options, you can stay in control.
 
 These options rely on ```daily.sh``` running from cron as per the installation instructions.
 
-Cleanup Options are set in ```config.php```
+You can adjust the config in Global Setting -> System -> Cleanup.
+
+Cleanup Options can also be set in ```config.php```
 
 ```php
-$config['syslog_purge']                              = 30;
 $config['eventlog_purge']                            = 30;
+$config['syslog_purge']                              = 30;
+$config['route_purge']                               = 10;
+$config['alert_log_purge']                           = 365;
 $config['authlog_purge']                             = 30;
+$config['ports_fdb_purge']                           = 10;
 $config['device_perf_purge']                         = 7;
-$config['rrd_purge']                                 = 90;// Not set by default
-$config['ports_purge']                               = true;// Set to false by default
+$config['rrd_purge']                                 = 0;
+$config['ports_purge']                               = 10;
 ```
 
 These options will ensure data within LibreNMS over X days old is

--- a/doc/Support/Configuration.md
+++ b/doc/Support/Configuration.md
@@ -882,25 +882,7 @@ Please refer to [Authentication](../Extensions/Authentication.md)
 
 ## Cleanup options
 
-These options rely on daily.sh running from cron as per the installation instructions.
-
-```php
-$config['syslog_purge']                                   = 30;
-$config['eventlog_purge']                                 = 30;
-$config['authlog_purge']                                  = 30;
-$config['device_perf_purge']                              = 7;
-$config['alert_log_purge']                                = 365;
-$config['port_fdb_purge']                                 = 10;
-$config['rrd_purge']                                      = 90;// Not set by default
-```
-
-These options will ensure data within LibreNMS over X days old is
-automatically purged. You can alter these individually. values are in days.
-
-> NOTE: Please be aware that `$config['rrd_purge']` is _NOT_ set by
-> default. This option will remove any old data within  the rrd
-> directory automatically - only enable this if you are comfortable
-> with that happening.
+Please refer to [Cleanup Options](../Support/Cleanup-options.md)
 
 ## Syslog options
 

--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -625,6 +625,7 @@
         },
         "authlog_purge": {
             "default": 30,
+            "units": "days",
             "group": "system",
             "section": "cleanup",
             "order": 4,
@@ -861,6 +862,7 @@
         },
         "device_perf_purge": {
             "default": 7,
+            "units": "days",
             "group": "system",
             "section": "cleanup",
             "order": 7,
@@ -1551,6 +1553,7 @@
         },
         "eventlog_purge": {
             "default": 30,
+            "units": "days",
             "group": "system",
             "section": "cleanup",
             "order": 0,
@@ -4703,6 +4706,7 @@
         },
         "route_purge": {
             "default": 10,
+            "units": "days",
             "group": "system",
             "section": "cleanup",
             "order": 2,
@@ -4733,6 +4737,7 @@
             "section": "cleanup",
             "order": 8,
             "default": 0,
+            "units": "days",
             "type": "integer"
         },
         "rrd_rra": {
@@ -5159,9 +5164,10 @@
         },
         "syslog_purge": {
             "default": 30,
+            "units": "days",
             "group": "system",
             "section": "cleanup",
-            "order": 2,
+            "order": 1,
             "type": "integer"
         },
         "temp_dir": {

--- a/resources/lang/de/settings.php
+++ b/resources/lang/de/settings.php
@@ -308,7 +308,7 @@ return [
             'help' => 'Anzahl an Tagen welche ein Benutzer eingeloggt bleibt wenn er die Checkbox zum eingeloggt bleiben nutzt',
         ],
         'authlog_purge' => [
-            'description' => 'Entferne Auth log Einträge welche älter sind als (Tage)',
+            'description' => 'Entferne Auth log Einträge welche älter sind als',
             'help' => 'Wird durch daily.sh erledigt',
         ],
         'base_url' => [
@@ -316,7 +316,7 @@ return [
             'help' => 'Sollte nur gesetzt werden wenn man den Zugriff nur über einen bestimmten Hostnamen/Port erlauben möchte',
         ],
         'device_perf_purge' => [
-            'description' => 'Entferne Performanzdaten welche älter sind als (Tage)',
+            'description' => 'Entferne Performanzdaten welche älter sind als',
             'help' => 'Wird durch daily.sh erledigt',
         ],
         'distributed_poller' => [
@@ -393,7 +393,7 @@ return [
             'help' => 'Name benutzt als Teil der "from" E-Mail Adresse',
         ],
         'eventlog_purge' => [
-            'description' => 'Entferne Event Log Daten welche älter sind als (Tage)',
+            'description' => 'Entferne Event Log Daten welche älter sind als',
             'help' => 'Wird durch daily.sh erledigt',
         ],
         'favicon' => [
@@ -586,7 +586,7 @@ return [
             'help' => 'Bereinigung wird erledigt durch daily.sh',
         ],
         'ports_purge' => [
-            'description' => 'Ports älter als (days)',
+            'description' => 'Ports älter als',
             'help' => 'Bereinigung wird erledigt durch daily.sh',
         ],
         'public_status' => [
@@ -606,7 +606,7 @@ return [
             'help' => 'Verzeichnis für RRD Dateien.  Standardmässig ist RRD innerhalb des LibreNMS Verzeichnisses.  Eine Änderung verschiebt nicht die vorhandenen RRD Dateien.',
         ],
         'rrd_purge' => [
-            'description' => 'RRD Dateien älter als (Tage)',
+            'description' => 'RRD Dateien älter als',
             'help' => 'Bereinigung wird erledigt durch daily.sh',
         ],
         'rrd_rra' => [
@@ -700,7 +700,7 @@ return [
             'description' => 'Filtere Syslog Meldungen beinhaltend',
         ],
         'syslog_purge' => [
-            'description' => 'Syslog Einträge älter als (Tage)',
+            'description' => 'Syslog Einträge älter als',
             'help' => 'Bereinigung wird erledigt durch daily.sh',
         ],
         'title_image' => [

--- a/resources/lang/en/settings.php
+++ b/resources/lang/en/settings.php
@@ -414,7 +414,7 @@ return [
             'help' => 'Number of days to keep a user logged in when checking the remember me checkbox at log in.',
         ],
         'authlog_purge' => [
-            'description' => 'Auth log entries older than (days)',
+            'description' => 'Auth log entries older than',
             'help' => 'Cleanup done by daily.sh',
         ],
         'peering_descr' => [
@@ -438,7 +438,7 @@ return [
             'help' => 'This should *only* be set if you want to *force* a particular hostname/port. It will prevent the web interface being usable form any other hostname',
         ],
         'device_perf_purge' => [
-            'description' => 'Device performance entries older than (days)',
+            'description' => 'Device performance entries older than',
             'help' => 'Cleanup done by daily.sh',
         ],
         'discovery_modules' => [
@@ -646,7 +646,7 @@ return [
             'help' => 'Name used as part of the from address',
         ],
         'eventlog_purge' => [
-            'description' => 'Event log entries older than (days)',
+            'description' => 'Event log entries older than',
             'help' => 'Cleanup done by daily.sh',
         ],
         'favicon' => [
@@ -1150,7 +1150,7 @@ return [
             'help' => 'Cleanup done by daily.sh',
         ],
         'ports_purge' => [
-            'description' => 'Ports older than (days)',
+            'description' => 'Ports older than',
             'help' => 'Cleanup done by daily.sh',
         ],
         'prometheus' => [
@@ -1190,7 +1190,7 @@ return [
             ],
         ],
         'route_purge' => [
-            'description' => 'Route entries older than (days)',
+            'description' => 'Route entries older than',
             'help' => 'Cleanup done by daily.sh',
         ],
         'rrd' => [
@@ -1206,7 +1206,7 @@ return [
             'help' => 'Location of rrd files.  Default is rrd inside the LibreNMS directory.  Changing this setting does not move the rrd files.',
         ],
         'rrd_purge' => [
-            'description' => 'RRD Files entries older than (days)',
+            'description' => 'RRD Files entries older than',
             'help' => 'Cleanup done by daily.sh',
         ],
         'rrd_rra' => [
@@ -1318,7 +1318,7 @@ return [
             'description' => 'Filter syslog messages containing',
         ],
         'syslog_purge' => [
-            'description' => 'Syslog entries older than (days)',
+            'description' => 'Syslog entries older than',
             'help' => 'Cleanup done by daily.sh',
         ],
         'title_image' => [

--- a/resources/lang/fr/settings.php
+++ b/resources/lang/fr/settings.php
@@ -355,11 +355,11 @@ return [
             'help' => 'Durée de conservation de l\'utilisateur quand la case "Se souvenir de moi" est cochée',
         ],
         'authlog_purge' => [
-            'description' => 'Journaux de connexions plus anciens que (jours)',
+            'description' => 'Journaux de connexions plus anciens que',
             'help' => 'Nettoyage effectué par daily.sh',
         ],
         'device_perf_purge' => [
-            'description' => 'Stats de performances plus anciennes que (jours)',
+            'description' => 'Stats de performances plus anciennes que',
             'help' => 'Statistiques de performances des équipements. Le nettoyage effectué par daily.sh',
         ],
         'discovery_modules' => [
@@ -565,7 +565,7 @@ return [
             'help' => 'Nom utilisé dans le champ "from" de l\'adresse',
         ],
         'eventlog_purge' => [
-            'description' => 'Journaux d\'évenements plus anciens que (jours)',
+            'description' => 'Journaux d\'évenements plus anciens que',
             'help' => 'Nettoyage effectué par daily.sh',
         ],
         'favicon' => [
@@ -774,7 +774,7 @@ return [
             'help' => 'Nettoyage effectué par daily.sh',
         ],
         'ports_purge' => [
-            'description' => 'Interfaces, entrées plus anciennes que (jours)',
+            'description' => 'Interfaces, entrées plus anciennes que',
             'help' => 'Nettoyage effectué par daily.sh',
         ],
         'public_status' => [
@@ -798,7 +798,7 @@ return [
             'help' => 'Emplacement des fichiers rrd.  Défaut: fichiers rrd dans le répertoire de LibreNMS. La modification de cette valeur ne déplace pas les fichiers RRD.',
         ],
         'rrd_purge' => [
-            'description' => 'RRD, fichiers non modifiés depuis plus de (jours)',
+            'description' => 'RRD, fichiers non modifiés depuis plus de',
             'help' => 'Nettoyage effectué par daily.sh',
         ],
         'rrd_rra' => [
@@ -898,7 +898,7 @@ return [
             'description' => 'Filtrer les messages syslog contenant',
         ],
         'syslog_purge' => [
-            'description' => 'Entrées syslogs plus anciennes que (jours)',
+            'description' => 'Entrées syslogs plus anciennes que',
             'help' => 'Nettoyage effectué par daily.sh',
         ],
         'title_image' => [

--- a/resources/lang/it/settings.php
+++ b/resources/lang/it/settings.php
@@ -361,7 +361,7 @@ return [
             'help' => 'Number of days to keep a user logged in when checking the remember me checkbox at log in.',
         ],
         'authlog_purge' => [
-            'description' => 'Auth log entries older than (days)',
+            'description' => 'Auth log entries older than',
             'help' => 'Cleanup done by daily.sh',
         ],
         'base_url' => [
@@ -369,7 +369,7 @@ return [
             'help' => 'This should *only* be set if you want to *force* a particular hostname/port. It will prevent the web interface being usable form any other hostname',
         ],
         'device_perf_purge' => [
-            'description' => 'Device performance entries older than (days)',
+            'description' => 'Device performance entries older than',
             'help' => 'Cleanup done by daily.sh',
         ],
         'discovery_modules' => [
@@ -574,7 +574,7 @@ return [
             'help' => 'Name used as part of the from address',
         ],
         'eventlog_purge' => [
-            'description' => 'Event log entries older than (days)',
+            'description' => 'Event log entries older than',
             'help' => 'Cleanup done by daily.sh',
         ],
         'favicon' => [
@@ -1020,7 +1020,7 @@ return [
             'help' => 'Cleanup done by daily.sh',
         ],
         'ports_purge' => [
-            'description' => 'Ports older than (days)',
+            'description' => 'Ports older than',
             'help' => 'Cleanup done by daily.sh',
         ],
         'prometheus' => [
@@ -1046,7 +1046,7 @@ return [
             'help' => 'No route will be discovered if the size of the routing table is bigger than this number',
         ],
         'route_purge' => [
-            'description' => 'Route entries older than (days)',
+            'description' => 'Route entries older than',
             'help' => 'Cleanup done by daily.sh',
         ],
         'rrd' => [
@@ -1062,7 +1062,7 @@ return [
             'help' => 'Location of rrd files.  Default is rrd inside the LibreNMS directory.  Changing this setting does not move the rrd files.',
         ],
         'rrd_purge' => [
-            'description' => 'RRD Files entries older than (days)',
+            'description' => 'RRD Files entries older than',
             'help' => 'Cleanup done by daily.sh',
         ],
         'rrd_rra' => [
@@ -1156,7 +1156,7 @@ return [
             'description' => 'Filter syslog messages containing',
         ],
         'syslog_purge' => [
-            'description' => 'Syslog entries older than (days)',
+            'description' => 'Syslog entries older than',
             'help' => 'Cleanup done by daily.sh',
         ],
         'title_image' => [

--- a/resources/lang/zh-CN/settings.php
+++ b/resources/lang/zh-CN/settings.php
@@ -309,7 +309,7 @@ return [
             'help' => 'Number of days to keep a user logged in when checking the remember me checkbox at log in.',
         ],
         'authlog_purge' => [
-            'description' => '验证记录项目大于 (天)',
+            'description' => '验证记录项目大于',
             'help' => 'Cleanup done by daily.sh',
         ],
         'base_url' => [
@@ -317,7 +317,7 @@ return [
             'help' => 'This should *only* be set if you want to *force* a particular hostname/port. It will prevent the web interface being usable form any other hostname',
         ],
         'device_perf_purge' => [
-            'description' => '装置效能项目大于 (天)',
+            'description' => '装置效能项目大于',
             'help' => 'Cleanup done by daily.sh',
         ],
         'distributed_poller' => [
@@ -394,7 +394,7 @@ return [
             'help' => 'Name used as part of the from address',
         ],
         'eventlog_purge' => [
-            'description' => '事件记录大于 (天)',
+            'description' => '事件记录大于',
             'help' => '由 daily.sh 进行清理作业',
         ],
         'favicon' => [
@@ -593,7 +593,7 @@ return [
             'help' => 'Cleanup done by daily.sh',
         ],
         'ports_purge' => [
-            'description' => '连接埠大于 (天)',
+            'description' => '连接埠大于',
             'help' => 'Cleanup done by daily.sh',
         ],
         'public_status' => [
@@ -605,7 +605,7 @@ return [
             'help' => 'No route will be discovered if the size of the routing table is bigger than this number',
         ],
         'route_purge' => [
-            'description' => '路由记录大于 (天)',
+            'description' => '路由记录大于',
             'help' => 'Cleanup done by daily.sh',
         ],
         'rrd' => [
@@ -621,7 +621,7 @@ return [
             'help' => 'Location of rrd files.  Default is rrd inside the LibreNMS directory.  Changing this setting does not move the rrd files.',
         ],
         'rrd_purge' => [
-            'description' => 'RRD 档案项目大于 (天)',
+            'description' => 'RRD 档案项目大于',
             'help' => 'Cleanup done by daily.sh',
         ],
         'rrd_rra' => [
@@ -715,7 +715,7 @@ return [
             'description' => 'Filter syslog messages containing',
         ],
         'syslog_purge' => [
-            'description' => 'Syslog 项目大于 (天)',
+            'description' => 'Syslog 项目大于',
             'help' => 'Cleanup done by daily.sh',
         ],
         'title_image' => [

--- a/resources/lang/zh-TW/settings.php
+++ b/resources/lang/zh-TW/settings.php
@@ -361,7 +361,7 @@ return [
             'help' => 'Number of days to keep a user logged in when checking the remember me checkbox at log in.',
         ],
         'authlog_purge' => [
-            'description' => '驗證記錄項目大於 (天)',
+            'description' => '驗證記錄項目大於',
             'help' => 'Cleanup done by daily.sh',
         ],
         'base_url' => [
@@ -369,7 +369,7 @@ return [
             'help' => 'This should *only* be set if you want to *force* a particular hostname/port. It will prevent the web interface being usable form any other hostname',
         ],
         'device_perf_purge' => [
-            'description' => '裝置效能項目大於 (天)',
+            'description' => '裝置效能項目大於',
             'help' => 'Cleanup done by daily.sh',
         ],
         'distributed_poller' => [
@@ -446,7 +446,7 @@ return [
             'help' => 'Name used as part of the from address',
         ],
         'eventlog_purge' => [
-            'description' => '事件記錄大於 (天)',
+            'description' => '事件記錄大於',
             'help' => '由 daily.sh 進行清理作業',
         ],
         'favicon' => [
@@ -708,7 +708,7 @@ return [
             'help' => 'Cleanup done by daily.sh',
         ],
         'ports_purge' => [
-            'description' => '連接埠大於 (天)',
+            'description' => '連接埠大於',
             'help' => 'Cleanup done by daily.sh',
         ],
         'prometheus' => [
@@ -748,7 +748,7 @@ return [
             ],
         ],
         'route_purge' => [
-            'description' => '路由記錄大於 (天)',
+            'description' => '路由記錄大於',
             'help' => 'Cleanup done by daily.sh',
         ],
         'rrd' => [
@@ -764,7 +764,7 @@ return [
             'help' => 'Location of rrd files.  Default is rrd inside the LibreNMS directory.  Changing this setting does not move the rrd files.',
         ],
         'rrd_purge' => [
-            'description' => 'RRD 檔案項目大於 (天)',
+            'description' => 'RRD 檔案項目大於',
             'help' => 'Cleanup done by daily.sh',
         ],
         'rrd_rra' => [
@@ -868,7 +868,7 @@ return [
             'description' => 'Filter syslog messages containing',
         ],
         'syslog_purge' => [
-            'description' => 'Syslog 項目大於 (天)',
+            'description' => 'Syslog 項目大於',
             'help' => 'Cleanup done by daily.sh',
         ],
         'title_image' => [


### PR DESCRIPTION
- Add missed `units` for config definition
- Change values in two documents to the actual default value
- `syslog_purge` and `route_purge` having `order=2`, change the former to `order=1`
- Sort configs in the two documents by `order`.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
