### PR TITLE
Fix scripts to allow pathname with space

### DIFF
--- a/LibreNMS/Exceptions/FilePermissionsException.php
+++ b/LibreNMS/Exceptions/FilePermissionsException.php
@@ -113,7 +113,7 @@ class FilePermissionsException extends \Exception implements UpgradeableExceptio
         }
 
         // always print chwon/setfacl/chmod commands
-        $commands[] = "sudo chown -R $user:$group $install_dir";
+        $commands[] = "sudo chown -R $user:$group '$install_dir'";
         $commands[] = 'sudo setfacl -d -m g::rwx ' . implode(' ', $dirs);
         $commands[] = 'sudo chmod -R ug=rwX ' . implode(' ', $dirs);
 

--- a/LibreNMS/Validations/Dependencies.php
+++ b/LibreNMS/Validations/Dependencies.php
@@ -52,7 +52,7 @@ class Dependencies extends BaseValidation
             return;
         }
 
-        $composer_output = trim(shell_exec($validator->getBaseDir() . '/scripts/composer_wrapper.php --version'));
+        $composer_output = trim(shell_exec("'" . $validator->getBaseDir() . "/scripts/composer_wrapper.php' --version"));
         $found = preg_match(
             '/Composer.*(\d+\.\d+\.\d+(-RC\d*|-beta\d?|-alpha\d+)?)/',
             $composer_output,
@@ -67,7 +67,7 @@ class Dependencies extends BaseValidation
             $validator->ok('Composer Version: ' . $matches[1]);
         }
 
-        $dep_check = shell_exec($validator->getBaseDir() . '/scripts/composer_wrapper.php install --no-dev --dry-run');
+        $dep_check = shell_exec("'" . $validator->getBaseDir() . "/scripts/composer_wrapper.php' install --no-dev --dry-run");
         preg_match_all('/Installing ([^ ]+\/[^ ]+) \(/', $dep_check, $dep_missing);
         if (! empty($dep_missing[0])) {
             $result = ValidationResult::fail('Missing dependencies!', $validator->getBaseDir() . '/scripts/composer_wrapper.php install --no-dev');

--- a/daily.sh
+++ b/daily.sh
@@ -278,7 +278,7 @@ main () {
     if [[ -z "$arg" ]]; then
         up=$(php daily.php -f update >&2; echo $?)
         if [[ "$up" == "0" ]]; then
-            ${DAILY_SCRIPT} no-code-update
+            "${DAILY_SCRIPT}" no-code-update
             set_notifiable_result update 1  # make sure there are no update notifications if update is disabled
             exit
         fi
@@ -333,14 +333,14 @@ main () {
         fi
 
         # Call ourself again in case above pull changed or added something to daily.sh
-        ${DAILY_SCRIPT} post-pull "${old_ver}" "${new_ver}"
+        "${DAILY_SCRIPT}" post-pull "${old_ver}" "${new_ver}"
     else
         case $arg in
             no-code-update)
                 # Updates of the code are disabled, just check for schema updates
                 # and clean up the db.
                 status_run 'Updating SQL-Schema' 'php includes/sql-schema/update.php'
-                status_run 'Cleaning up DB' "$DAILY_SCRIPT cleanup"
+                status_run 'Cleaning up DB' "'$DAILY_SCRIPT' cleanup"
             ;;
             post-pull)
                 # re-check dependencies after pull with the new code

--- a/scripts/composer_wrapper.php
+++ b/scripts/composer_wrapper.php
@@ -53,7 +53,7 @@ if (php_sapi_name() == 'cli' && isset($_SERVER['TERM'])) {
 }
 
 if (is_file($install_dir . '/composer.phar')) {
-    $exec = PHP_BINDIR . '/php ' . $install_dir . '/composer.phar';
+    $exec = PHP_BINDIR . "/php '" . $install_dir . "/composer.phar'";
 
     // If older than 1 week, try update
     if (time() - filemtime($install_dir . '/composer.phar') > 60 * 60 * 24 * 7) {
@@ -80,7 +80,7 @@ if (is_file($install_dir . '/composer.phar')) {
         } elseif (@hash_file('SHA384', $dest) === $good_sha) {
             // Installer verified
             shell_exec(PHP_BINDIR . "/php $dest");
-            $exec = PHP_BINDIR . "/php $install_dir/composer.phar";
+            $exec = PHP_BINDIR . "/php '$install_dir/composer.phar'";
         } else {
             echo "Error: Corrupted download, signature doesn't match for $installer_url\n";
         }


### PR DESCRIPTION
Although it's recommended to set `install_dir` to `/opt/librenms`, it could better handle different pathnames.

Tested by run `validate.php` and `daily.sh` in the pathname `/opt/foo $(echo bar)/librenms`.

Not fully tested. It will still cause errors by pathname including `'` (and maybe `"`).

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
