### PR TITLE
fix availability widget device totals

### DIFF
--- a/app/Http/Controllers/Widgets/AvailabilityMapController.php
+++ b/app/Http/Controllers/Widgets/AvailabilityMapController.php
@@ -139,7 +139,7 @@ class AvailabilityMapController extends WidgetController
             $data[] = $row;
         }
 
-        return [$data, ['warn' => 0, 'up' => 0, 'down' => 0, 'maintenance' => 0, 'ignored' => 0, 'disabled' => 0]];
+        return [$data, $totals];
     }
 
     private function getServices($request)


### PR DESCRIPTION
PHPStan fixes in https://github.com/librenms/librenms/pull/13038 seem to have hard-coded availability widget device totals.

Not 100% sure on the intent of the changes and if this is the correct way to fix.

Before:
![image](https://user-images.githubusercontent.com/78184917/125788038-224c8334-d503-469f-a96f-3b29352a7580.png)

After:
![image](https://user-images.githubusercontent.com/78184917/125788073-32b3ebc7-5b4e-43f4-b407-037d4dc544fe.png)


Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
