### PR TITLE
fix availability widget service backend error

### DIFF
--- a/app/Http/Controllers/Widgets/AvailabilityMapController.php
+++ b/app/Http/Controllers/Widgets/AvailabilityMapController.php
@@ -183,6 +183,6 @@ class AvailabilityMapController extends WidgetController
             $data[] = $row;
         }
 
-        return [$services, $totals];
+        return [$data, $totals];
     }
 }


### PR DESCRIPTION
PHPStan fixes in #13038 seem to have broken backend for availability map services type.    Fixed another devices one in #13043 which may conflict on same file - not sure of correct process in that case :)

Before:
![image](https://user-images.githubusercontent.com/78184917/125792697-124dd69b-8c96-4464-8d55-46eae4c9eece.png)

After:
![image](https://user-images.githubusercontent.com/78184917/125792757-aeb2e81b-6910-4f01-b406-c900ae05746b.png)

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
