### PR TITLE
Follow redirects when reloading Oxidized nodes list

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1254,6 +1254,7 @@ function oxidized_reload_nodes()
         curl_setopt($ch, CURLOPT_TIMEOUT_MS, 5000);
         curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 5);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
         curl_setopt($ch, CURLOPT_HEADER, 1);
         curl_exec($ch);
         curl_close($ch);


### PR DESCRIPTION
By default curl doesn't follow redirects and just stops if it encounters one. 
This might be a issue if you put oxidized behind a proxy. 

Link to PHP Curl docs for references
[PHP Curl Docs](https://www.php.net/manual/en/function.curl-setopt.php)

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
