### PR TITLE
Adding API route to set bgpPeerDescr field

### DIFF
--- a/doc/API/Routing.md
+++ b/doc/API/Routing.md
@@ -103,6 +103,33 @@ Output:
 }
 ```
 
+### `edit_bgp_descr`
+
+This is a POST type request
+Set the BGP session description by ID
+
+Route: `/api/v0/bgp/:id`
+
+Input:
+
+- id = The id of the BGP Peer Session.
+- bgp_descr = The description for the bgpPeerDescr field on the BGP Session.
+
+Example:
+
+```curl
+curl -v -H 'X-Auth-Token: YOURAPITOKENHERE' --data '{"bgp_descr": "Your description here"}' https://librenms.org/api/v0/bgp/4
+```
+
+Output:
+
+```json
+{
+    "status": "ok",
+    "message": "BGP description for peer X.X.X.X on device 1 updated to Your description here"
+}
+```
+
 ### `list_cbgp`
 
 List the current BGP sessions counters.

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -604,8 +604,8 @@ function get_bgp(Illuminate\Http\Request $request)
 
 function edit_bgp_descr(Illuminate\Http\Request $request)
 {
-    $data = json_decode($request->getContent(), true);
-    if (! $data) {
+    $bgp_descr = $request->json('bgp_descr');
+    if (! $bgp_descr) {
         return api_error(500, 'Invalid JSON data');
     }
 
@@ -616,9 +616,6 @@ function edit_bgp_descr(Illuminate\Http\Request $request)
     }
 
     $peer = \App\Models\BgpPeer::firstWhere('bgpPeer_id', $bgpPeerId);
-
-    // get description
-    $bgp_descr = $data['bgp_descr'];
 
     // update existing bgp
     if ($peer === null) {

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -619,9 +619,8 @@ function edit_bgp_descr(Illuminate\Http\Request $request)
 
     // update existing bgp
     if (count($bgps) == 0) {
-        return api_error(404, "BGP peer " . $bgpPeerId . " does not exist");
-    }
-    else if (is_array($bgps) && count($bgps) == 1) {
+        return api_error(404, 'BGP peer ' . $bgpPeerId . ' does not exist');
+    } elseif (is_array($bgps) && count($bgps) == 1) {
         $bgp = $bgps[0];
 
         $update_data = [
@@ -632,7 +631,7 @@ function edit_bgp_descr(Illuminate\Http\Request $request)
             return api_error(500, 'Failed to update existing bgp');
         }
     }
-    return api_success_noresult(200, "BGP description for peer " . $bgp['bgpPeerIdentifier'] . " on device " . $bgp['device_id'] . " updated to " . $bgp_descr . ".");
+    return api_success_noresult(200, 'BGP description for peer ' . $bgp['bgpPeerIdentifier'] . ' on device ' . $bgp['device_id'] . ' updated to ' . $bgp_descr . '.');
 }
 
 function list_cbgp(Illuminate\Http\Request $request)

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -616,7 +616,7 @@ function edit_bgp_descr(Illuminate\Http\Request $request)
         return api_error(400, 'Invalid id has been provided');
     }
 
-    $bgps = dbFetchRows("SELECT * FROM `bgpPeers` WHERE `bgpPeer_id` = ?", [$bgpPeerId]);
+    $bgps = dbFetchRows('SELECT * FROM `bgpPeers` WHERE `bgpPeer_id` = ?', [$bgpPeerId]);
 
     // get description
     $bgp_descr = $data['bgp_descr'];

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -612,7 +612,11 @@ function edit_bgp_descr(Illuminate\Http\Request $request)
     $bgp = [];
     //find existing bgp for update
     $bgpPeerId = $request->route('id');
-    $bgps = dbFetchRows("SELECT * FROM `bgpPeers` WHERE `bgpPeer_id` = $bgpPeerId LIMIT 1");
+    if (! is_numeric($bgpPeerId)) {
+        return api_error(400, 'Invalid id has been provided');
+    }
+
+    $bgps = dbFetchRows("SELECT * FROM `bgpPeers` WHERE `bgpPeer_id` = ?", [$bgpPeerId]);
 
     // get description
     $bgp_descr = $data['bgp_descr'];

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -631,6 +631,7 @@ function edit_bgp_descr(Illuminate\Http\Request $request)
             return api_error(500, 'Failed to update existing bgp');
         }
     }
+
     return api_success_noresult(200, 'BGP description for peer ' . $bgp['bgpPeerIdentifier'] . ' on device ' . $bgp['device_id'] . ' updated to ' . $bgp_descr . '.');
 }
 

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -602,6 +602,39 @@ function get_bgp(Illuminate\Http\Request $request)
     return api_success($bgp_session, 'bgp_session');
 }
 
+function edit_bgp_descr(Illuminate\Http\Request $request)
+{
+    $data = json_decode($request->getContent(), true);
+    if (! $data) {
+        return api_error(500, 'Invalid JSON data');
+    }
+
+    $bgp = [];
+    //find existing bgp for update
+    $bgpPeerId = $request->route('id');
+    $bgps = dbFetchRows("SELECT * FROM `bgpPeers` WHERE `bgpPeer_id` = $bgpPeerId LIMIT 1");
+
+    // get description
+    $bgp_descr = $data['bgp_descr'];
+
+    // update existing bgp
+    if (count($bgps) == 0) {
+        return api_error(404, "BGP peer " . $bgpPeerId . " does not exist");
+    }
+    else if (is_array($bgps) && count($bgps) == 1) {
+        $bgp = $bgps[0];
+
+        $update_data = [
+            'bgpPeerDescr' => $bgp_descr,
+        ];
+        $update = dbUpdate($update_data, 'bgpPeers', 'bgpPeer_id=?', [$bgpPeerId]);
+        if ($update === false || $update < 0) {
+            return api_error(500, 'Failed to update existing bgp');
+        }
+    }
+    return api_success_noresult(200, "BGP description for peer " . $bgp['bgpPeerIdentifier'] . " on device " . $bgp['device_id'] . " updated to " . $bgp_descr . ".");
+}
+
 function list_cbgp(Illuminate\Http\Request $request)
 {
     $sql = '';

--- a/routes/api.php
+++ b/routes/api.php
@@ -84,6 +84,7 @@ Route::group(['prefix' => 'v0', 'namespace' => '\App\Api\Controllers'], function
         Route::delete('locations/{location}', 'LegacyApiController@del_location')->name('del_location');
         Route::delete('services/{id}', 'LegacyApiController@del_service_from_host')->name('del_service_from_host');
         Route::patch('services/{id}', 'LegacyApiController@edit_service_for_host')->name('edit_service_for_host');
+        Route::post('bgp/{id}', 'LegacyApiController@edit_bgp_descr')->name('edit_bgp_descr');
     });
 
     // restricted by access


### PR DESCRIPTION
DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.

Hello,

To add information about the BGP session in our alerts, we need to use the bgpPeerDescr field.
To ease the configuration of this field I created a new route in the API that update this value in database.

Maybe this feature will be usefull for others so I submitted it here.
Please just tell me if it needs some improvements or if you don't want this feature in the project.

Do not forget to clear the routes cached with "php artisan route:clear".

Bye
