### PR TITLE
More sensor data on inventory page

### DIFF
--- a/includes/html/pages/device/entphysical.inc.php
+++ b/includes/html/pages/device/entphysical.inc.php
@@ -7,6 +7,12 @@ function printEntPhysical($device, $ent, $level, $class)
     $ents = dbFetchRows('SELECT * FROM `entPhysical` WHERE device_id = ? AND entPhysicalContainedIn = ? ORDER BY entPhysicalContainedIn,entPhysicalIndex', [$device['device_id'], $ent]);
 
     foreach ($ents as $ent) {
+        //Let's find if we have any sensors attached to the current entity;
+        //We hit this code for every type of entity because not all vendors have 1 'sensor' entity per sensor
+        $sensors = DeviceCache::getPrimary()->sensors()->where(function (Builder $query) use ($ent) {
+            return $query->where('entPhysicalIndex', $ent['entPhysicalIndex'])
+                ->orWhere('sensor_index', $ent['entPhysicalIndex']);
+        })->get();
         echo "
  <li class='$class'>";
 
@@ -20,13 +26,6 @@ function printEntPhysical($device, $ent, $level, $class)
             echo '<i class="fa fa-square fa-lg icon-theme" aria-hidden="true"></i> ';
         } elseif ($ent['entPhysicalClass'] == 'sensor') {
             echo '<i class="fa fa-heartbeat fa-lg icon-theme" aria-hidden="true"></i> ';
-            $sensor = DeviceCache::getPrimary()->sensors()->where(function (Builder $query) use ($ent) {
-                return $query->where('entPhysicalIndex', $ent['entPhysicalIndex'])
-                    ->orWhere('sensor_index', $ent['entPhysicalIndex']);
-            })->first();
-            if ($sensor) {
-                $link = "<a href='graphs/id=" . $sensor->sensor_id . '/type=sensor_' . $sensor->sensor_class . "/' onmouseover=\"return overlib('<img src=\'graph.php?id=" . $sensor->sensor_id . '&amp;type=sensor_' . $sensor->sensor_class . '&amp;from=-2d&amp;to=now&amp;width=400&amp;height=150&amp;a=' . $ent['entPhysical_id'] . "\'><img src=\'graph.php?id=" . $sensor->sensor_id . '&amp;type=sensor_' . $sensor->sensor_class . '&amp;from=-2w&amp;to=now&amp;width=400&amp;height=150&amp;a=' . $ent['entPhysical_id'] . "\'>', LEFT,FGCOLOR,'#e5e5e5', BGCOLOR, '#c0c0c0', BORDER, 5, CELLPAD, 4, CAPCOLOR, '#050505');\" onmouseout=\"return nd();\">";
-            }
         } elseif ($ent['entPhysicalClass'] == 'backplane') {
             echo '<i class="fa fa-bars fa-lg icon-theme" aria-hidden="true"></i> ';
         } elseif ($ent['entPhysicalClass'] == 'stack') {
@@ -39,36 +38,35 @@ function printEntPhysical($device, $ent, $level, $class)
             echo '<strong>' . $ent['entPhysicalParentRelPos'] . '.</strong> ';
         }
 
-        if (isset($link)) {
-            echo $link;
-        }
 
+        $display_entPhysicalName = $ent['entPhysicalName'];
         if ($ent['ifIndex']) {
             $interface = get_port_by_ifIndex($device['device_id'], $ent['ifIndex']);
             $interface = cleanPort($interface);
-            $ent['entPhysicalName'] = generate_port_link($interface);
+            $display_entPhysicalName = generate_port_link($interface);
         }
 
-        if ($ent['entPhysicalModelName'] && $ent['entPhysicalName']) {
-            echo '<strong>' . $ent['entPhysicalModelName'] . '</strong> (' . $ent['entPhysicalName'] . ')';
+        if ($ent['entPhysicalModelName'] && $display_entPhysicalName) {
+            echo '<strong>' . $ent['entPhysicalModelName'] . '</strong> (' . $display_entPhysicalName . ')';
         } elseif ($ent['entPhysicalModelName']) {
             echo '<strong>' . $ent['entPhysicalModelName'] . '</strong>';
         } elseif (is_numeric($ent['entPhysicalName']) && $ent['entPhysicalVendorType']) {
             echo '<strong>' . $ent['entPhysicalName'] . ' ' . $ent['entPhysicalVendorType'] . '</strong>';
-        } elseif ($ent['entPhysicalName']) {
-            echo '<strong>' . $ent['entPhysicalName'] . '</strong>';
+        } elseif ($display_entPhysicalName) {
+            echo '<strong>' . $display_entPhysicalName . '</strong>';
         } elseif ($ent['entPhysicalDescr']) {
             echo '<strong>' . $ent['entPhysicalDescr'] . '</strong>';
         }
 
-        if ($ent['entPhysicalClass'] == 'sensor' && isset($sensor)) {
-            echo ' ';
-            echo $sensor->sensor_class == 'state' ? get_state_label($sensor->toArray()) : get_sensor_label_color($sensor->toArray());
-        }
-
-        if (isset($link)) {
-            echo '</a>';
-            unset($link);
+        // Display matching sensor value (without descr, as we have only one)
+        if ($sensors->count() == 1) {
+            foreach ($sensors as $sensor) {
+                echo "<a href='graphs/id=" . $sensor->sensor_id . '/type=sensor_' . $sensor->sensor_class . "/' onmouseover=\"return overlib('<img src=\'graph.php?id=" . $sensor->sensor_id . '&amp;type=sensor_' . $sensor->sensor_class . '&amp;from=-2d&amp;to=now&amp;width=400&amp;height=150&amp;a=' . $ent['entPhysical_id'] . "\'><img src=\'graph.php?id=" . $sensor->sensor_id . '&amp;type=sensor_' . $sensor->sensor_class . '&amp;from=-2w&amp;to=now&amp;width=400&amp;height=150&amp;a=' . $ent['entPhysical_id'] . "\'>', LEFT,FGCOLOR,'#e5e5e5', BGCOLOR, '#c0c0c0', BORDER, 5, CELLPAD, 4, CAPCOLOR, '#050505');\" onmouseout=\"return nd();\">";
+                //echo "<span style='color: #000099;'>" . $sensor->sensor_class . ': ' . $sensor->sensor_descr . '</span>';
+                echo ' ';
+                echo $sensor->sensor_class == 'state' ? get_state_label($sensor->toArray()) : get_sensor_label_color($sensor->toArray());
+                echo '</a>';
+            }
         }
 
         // display entity state
@@ -118,6 +116,19 @@ function printEntPhysical($device, $ent, $level, $class)
             echo " <br /><span style='color: #000099;'>Serial No. " . $ent['entPhysicalSerialNum'] . '</span> ';
         }
 
+        // Display sensors values with their descr, as we have more than one attached to this entPhysical
+        if ($sensors->count() > 1) {
+            echo "<br>Sensors:<div class='interface-desc' style='margin-left: 20px;'>";
+            foreach ($sensors as $sensor) {
+                $disp_name = str_replace([$ent['entPhysicalDescr'], $ent['entPhysicalName']], ['', ''], $sensor->sensor_descr);
+                echo "<a href='graphs/id=" . $sensor->sensor_id . '/type=sensor_' . $sensor->sensor_class . "/' onmouseover=\"return overlib('<img src=\'graph.php?id=" . $sensor->sensor_id . '&amp;type=sensor_' . $sensor->sensor_class . '&amp;from=-2d&amp;to=now&amp;width=400&amp;height=150&amp;a=' . $ent['entPhysical_id'] . "\'><img src=\'graph.php?id=" . $sensor->sensor_id . '&amp;type=sensor_' . $sensor->sensor_class . '&amp;from=-2w&amp;to=now&amp;width=400&amp;height=150&amp;a=' . $ent['entPhysical_id'] . "\'>', LEFT,FGCOLOR,'#e5e5e5', BGCOLOR, '#c0c0c0', BORDER, 5, CELLPAD, 4, CAPCOLOR, '#050505');\" onmouseout=\"return nd();\">";
+                echo "<span style='color: #000099;'>" . $disp_name . ' ' . $sensor->sensor_class . '</span>';
+                echo ' ';
+                echo $sensor->sensor_class == 'state' ? get_state_label($sensor->toArray()) : get_sensor_label_color($sensor->toArray());
+                echo '</a><br>';
+            }
+            echo '</div>';
+        }
         echo '</div>';
 
         $count = dbFetchCell("SELECT COUNT(*) FROM `entPhysical` WHERE device_id = '" . $device['device_id'] . "' AND entPhysicalContainedIn = '" . $ent['entPhysicalIndex'] . "'");

--- a/includes/html/pages/device/entphysical.inc.php
+++ b/includes/html/pages/device/entphysical.inc.php
@@ -38,7 +38,6 @@ function printEntPhysical($device, $ent, $level, $class)
             echo '<strong>' . $ent['entPhysicalParentRelPos'] . '.</strong> ';
         }
 
-
         $display_entPhysicalName = $ent['entPhysicalName'];
         if ($ent['ifIndex']) {
             $interface = get_port_by_ifIndex($device['device_id'], $ent['ifIndex']);


### PR DESCRIPTION
Not all sensors have an entPhysical entry dedicated. Current code only display those. This patch checks every entPhysical and if they are matched to a sensor, displays it. 

Cisco Before and after:
![Capture d’écran 2021-07-19 à 11 49 33](https://user-images.githubusercontent.com/38363551/126141553-8e5e914e-3be8-4677-b1d5-021f24ac60b3.png)
![Capture d’écran 2021-07-19 à 11 49 17](https://user-images.githubusercontent.com/38363551/126141585-8be0dc82-59d9-43c7-a9d7-82e55588a7c7.png)

Huawei Before and After:
![Capture d’écran 2021-07-19 à 11 47 30](https://user-images.githubusercontent.com/38363551/126141641-c24e645c-5b25-44d6-8404-b3498d9a63be.png)
![Capture d’écran 2021-07-19 à 11 46 42](https://user-images.githubusercontent.com/38363551/126141647-03b12a93-f9df-4e04-9992-884e64702cfc.png)

Adva Before and After:
![Capture d’écran 2021-07-19 à 11 47 57](https://user-images.githubusercontent.com/38363551/126141707-d3cee05a-2a50-41e6-b754-93b8bbd08841.png)
![Capture d’écran 2021-07-19 à 11 48 21](https://user-images.githubusercontent.com/38363551/126141856-36e83115-cb60-4303-97ff-0ffe06e3ec18.png)

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
