### PR TITLE
Add device_group to availability widget hyperlink

### DIFF
--- a/resources/views/widgets/availability-map.blade.php
+++ b/resources/views/widgets/availability-map.blade.php
@@ -5,9 +5,9 @@
         <a href="{{ url('devices/disable_notify=1') }}"><span class="label label-default label-font-border label-border">@lang('alert-disabled'): {{ $device_totals['ignored'] }}</span></a>
         <a href="{{ url('devices/disabled=1') }}"><span class="label blackbg label-font-border label-border">@lang('disabled'): {{ $device_totals['disabled'] }}</span></a>
     @endif
-    <a href="{{ url('devices/state=up') }}"><span class="label label-success label-font-border label-border">@lang('up'): {{ $device_totals['up'] }}</span></a>
+    <a href="{{ url('devices/state=up') }}@if($device_group){{ '/group='.$device_group }}@endif"><span class="label label-success label-font-border label-border">@lang('up'): {{ $device_totals['up'] }}</span></a>
     <span class="label label-warning label-font-border label-border">@lang('warn'): {{ $device_totals['warn'] }}</span>
-    <a href="{{ url('devices/state=down') }}"><span class="label label-danger label-font-border label-border">@lang('down'): {{ $device_totals['down'] }}</span></a>
+    <a href="{{ url('devices/state=down') }}@if($device_group){{ '/group='.$device_group }}@endif"><span class="label label-danger label-font-border label-border">@lang('down'): {{ $device_totals['down'] }}</span></a>
     @if($device_totals['maintenance'])
     <span class="label label-default label-font-border label-border">@lang('maintenance'): {{ $device_totals['maintenance'] }}</span>
     @endif


### PR DESCRIPTION
This PR filters devices by group when clicking the device totals in the availability widget.

**Rationale:** when clicking on the device total shown in a device group filtered availability map, one should expect to see that device group, not _all_ devices.

Before - device group filtering, URL does not filter by group:
![image](https://user-images.githubusercontent.com/78184917/126432497-69206bf4-5644-4a9d-bdcf-4df02ae373a4.png)

After - has relevant group link:
![image](https://user-images.githubusercontent.com/78184917/126432553-46070d5b-d184-43c8-bcb6-7e54f28ad30e.png)
![image](https://user-images.githubusercontent.com/78184917/126432560-85963ffa-cf85-408c-b039-1e917909f5e0.png)

Confirmation it doesn't break unfiltered view:
![image](https://user-images.githubusercontent.com/78184917/126432614-fd84c33b-6193-480f-96bb-18a94be6abdb.png)


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
