### PR TITLE
WIP: Add support for multiple Geist watchdog sensors

### DIFF
--- a/includes/discovery/sensors/temperature/geist-watchdog.inc.php
+++ b/includes/discovery/sensors/temperature/geist-watchdog.inc.php
@@ -46,4 +46,23 @@ foreach ($temp_table as $index => $temp_data) {
     }
 }
 
+$sensor_count = 0;
+$temp_table = snmpwalk_cache_oid($device, 'internalTable', [], 'GEIST-V4-MIB');
+foreach ($temp_table as $index => $temp_data) {
+    $current_oid = '.1.3.6.1.4.1.21239.5.1.2.1.5.' . $index;
+    $descr = $temp_data['internalName'];
+    $value = $temp_data['internalTemp'];
+    discover_sensor($valid['sensor'], 'temperature', $device, $current_oid, $sensor_count++, 'geist-watchdog', $descr, 1, 1, null, null, null, null, $value);
+}
+
+$temp_table = snmpwalk_cache_oid($device, 'tempSensorTable', [], 'GEIST-V4-MIB');
+foreach ($temp_table as $index => $temp_data) {
+    if ($temp_data['tempSensorAvail'] == 1) {
+        $current_oid = '.1.3.6.1.4.1.21239.5.1.4.1.5.' . $index;
+        $descr = $temp_data['tempSensorName'];
+        $value = $temp_data['tempSensorTemp'];
+        discover_sensor($valid['sensor'], 'temperature', $device, $current_oid, $sensor_count++, 'geist-watchdog', $descr, 1, 1, null, null, null, null, $value);
+    }
+}
+
 unset($temp_table);

--- a/includes/polling/sensors/temperature/geist-watchdog.inc.php
+++ b/includes/polling/sensors/temperature/geist-watchdog.inc.php
@@ -22,5 +22,7 @@
  * @author     Neil Lathwood <gh+n@laf.io>
  */
 if ($sensor_cache['geist_temp_unit'] === '0') {
-    $sensor_value = fahrenheit_to_celsius($sensor_value / 10) * 10;
+    $sensor_value = fahrenheit_to_celsius($sensor_value / 10);
+} else {
+    $sensor_value = $sensor_value / 10;
 }


### PR DESCRIPTION
Geist Watchdog devices have only been able to inherently support the built-in 'internalTable' for standard temperature monitoring and alerting.  This update adds support for the correct MIB oids to support the discovery and polling of external temperature sensors probes connected to the Watchdog.

* Tested on devices running firmware version 3.4.0

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
