### PR TITLE
add urlencode for location link in device view

### DIFF
--- a/resources/views/device/header.blade.php
+++ b/resources/views/device/header.blade.php
@@ -8,7 +8,7 @@
             <span title="@lang('Scheduled Maintenance')" class="fa fa-wrench fa-fw fa-lg"></span>
         @endif
         <span style="font-size: 20px;">@deviceLink($device)</span><br/>
-        <a href="{{ url('/devices/location=' . $device->location) }}">{{ $device->location }}</a>
+        <a href="{{ url('/devices/location=' . urlencode($device->location)) }}">{{ $device->location }}</a>
     </div>
     <div class="pull-right">
         @foreach($overview_graphs as $graph)


### PR DESCRIPTION
some of my devices have / in syslocation, which leads to wrong grouping in /devices/location=

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
