### PR TITLE
Allow more compatibility in STP port discovery/polling

### DIFF
--- a/includes/discovery/stp.inc.php
+++ b/includes/discovery/stp.inc.php
@@ -126,12 +126,12 @@ if ($stpprotocol == 'ieee8021d' || $stpprotocol == 'unknown') {
             // set port binding
             $stp_port['port_id'] = dbFetchCell('SELECT port_id FROM `ports` WHERE `device_id` = ? AND `ifIndex` = ?', [$device['device_id'], $stp_raw[$port]['dot1dStpPort']]);
 
-            $dr = str_replace([' ', ':', '-'], '', strtolower($stp_raw[$port]['dot1dStpPortDesignatedRoot']));
-            $dr = substr($dr, -12); //remove first two octets
+            $dr = str_replace(['.', ' ', ':', '-'], '', strtolower($stp_raw[$port]['dot1dStpPortDesignatedRoot']));
+            $dr = substr($dr, -12); //keep the last 12 chars (the mac address)
             $stp_port['designatedRoot'] = $dr;
 
-            $db = str_replace([' ', ':', '-'], '', strtolower($stp_raw[$port]['dot1dStpPortDesignatedBridge']));
-            $db = substr($db, -12); //remove first two octets
+            $db = str_replace(['.', ' ', ':', '-'], '', strtolower($stp_raw[$port]['dot1dStpPortDesignatedBridge']));
+            $db = substr($db, -12); //keep the last 12 chars (the mac address)
             $stp_port['designatedBridge'] = $db;
 
             if ($device['os'] == 'pbn') {
@@ -145,9 +145,15 @@ if ($stpprotocol == 'ieee8021d' || $stpprotocol == 'unknown') {
                     $stp_port['designatedPort'] = $dp;
                 }
             } else {
-                // Port saved in format priority+port (ieee 802.1d-1998: clause 8.5.5.1)
-                $dp = substr($stp_raw[$port]['dot1dStpPortDesignatedPort'], -2); //discard the first octet (priority part)
-                $stp_port['designatedPort'] = hexdec($dp);
+                if (preg_match('/-/', $stp_raw[$port]['dot1dStpPortDesignatedPort'])) {
+                    // Syntax with "priority" dash "portID" like so : 32768-54, both in decimal
+                    $dp = explode('-',$stp_raw[$port]['dot1dStpPortDesignatedPort'])[1];
+                    $stp_port['designatedPort'] = $dp;
+                } else {
+                    // Port saved in format priority+port (ieee 802.1d-1998: clause 8.5.5.1)
+                    $dp = substr($stp_raw[$port]['dot1dStpPortDesignatedPort'], -2); //discard the first octet (priority part)
+                    $stp_port['designatedPort'] = hexdec($dp);
+                }
             }
 
             d_echo($stp_port);

--- a/includes/discovery/stp.inc.php
+++ b/includes/discovery/stp.inc.php
@@ -147,7 +147,7 @@ if ($stpprotocol == 'ieee8021d' || $stpprotocol == 'unknown') {
             } else {
                 if (preg_match('/-/', $stp_raw[$port]['dot1dStpPortDesignatedPort'])) {
                     // Syntax with "priority" dash "portID" like so : 32768-54, both in decimal
-                    $dp = explode('-',$stp_raw[$port]['dot1dStpPortDesignatedPort'])[1];
+                    $dp = explode('-', $stp_raw[$port]['dot1dStpPortDesignatedPort'])[1];
                     $stp_port['designatedPort'] = $dp;
                 } else {
                     // Port saved in format priority+port (ieee 802.1d-1998: clause 8.5.5.1)

--- a/includes/polling/stp.inc.php
+++ b/includes/polling/stp.inc.php
@@ -136,11 +136,11 @@ if ($stpprotocol == 'ieee8021d' || $stpprotocol == 'unknown') {
             // set port binding
             $stp_port['port_id'] = dbFetchCell('SELECT port_id FROM `ports` WHERE `device_id` = ? AND `ifIndex` = ?', [$device['device_id'], $stp_raw[$port]['dot1dStpPort']]);
 
-            $dr = str_replace([' ', ':', '-'], '', strtolower($stp_raw[$port]['dot1dStpPortDesignatedRoot']));
+            $dr = str_replace(['.', ' ', ':', '-'], '', strtolower($stp_raw[$port]['dot1dStpPortDesignatedRoot']));
             $dr = substr($dr, -12); //remove first two octets
             $stp_port['designatedRoot'] = $dr;
 
-            $db = str_replace([' ', ':', '-'], '', strtolower($stp_raw[$port]['dot1dStpPortDesignatedBridge']));
+            $db = str_replace(['.', ' ', ':', '-'], '', strtolower($stp_raw[$port]['dot1dStpPortDesignatedBridge']));
             $db = substr($db, -12); //remove first two octets
             $stp_port['designatedBridge'] = $db;
 
@@ -155,12 +155,16 @@ if ($stpprotocol == 'ieee8021d' || $stpprotocol == 'unknown') {
                     $stp_port['designatedPort'] = $dp;
                 }
             } else {
-                // Port saved in format priority+port (ieee 802.1d-1998: clause 8.5.5.1)
-                $dp = substr($stp_raw[$port]['dot1dStpPortDesignatedPort'], -2); //discard the first octet (priority part)
-                $stp_port['designatedPort'] = hexdec($dp);
+                if (preg_match('/-/', $stp_raw[$port]['dot1dStpPortDesignatedPort'])) {
+                    // Syntax with "priority" dash "portID" like so : 32768-54, both in decimal
+                    $dp = explode('-',$stp_raw[$port]['dot1dStpPortDesignatedPort'])[1];
+                    $stp_port['designatedPort'] = $dp;
+                } else {
+                    // Port saved in format priority+port (ieee 802.1d-1998: clause 8.5.5.1)
+                    $dp = substr($stp_raw[$port]['dot1dStpPortDesignatedPort'], -2); //discard the first octet (priority part)
+                    $stp_port['designatedPort'] = hexdec($dp);
+                }
             }
-
-            //d_echo($stp_port);
 
             // Update db
             dbUpdate($stp_port, 'ports_stp', '`device_id` = ? AND `port_id` = ?', [$device['device_id'], $stp_port['port_id']]);

--- a/includes/polling/stp.inc.php
+++ b/includes/polling/stp.inc.php
@@ -157,7 +157,7 @@ if ($stpprotocol == 'ieee8021d' || $stpprotocol == 'unknown') {
             } else {
                 if (preg_match('/-/', $stp_raw[$port]['dot1dStpPortDesignatedPort'])) {
                     // Syntax with "priority" dash "portID" like so : 32768-54, both in decimal
-                    $dp = explode('-',$stp_raw[$port]['dot1dStpPortDesignatedPort'])[1];
+                    $dp = explode('-', $stp_raw[$port]['dot1dStpPortDesignatedPort'])[1];
                     $stp_port['designatedPort'] = $dp;
                 } else {
                     // Port saved in format priority+port (ieee 802.1d-1998: clause 8.5.5.1)


### PR DESCRIPTION
This fixes Zyxel STP discovery (using "dots" as MAC separator, and using xxx-yy for priority and port)
DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
