### PR TITLE
Detect sending non-html emails as html

### DIFF
--- a/LibreNMS/Alert/Transport/Mail.php
+++ b/LibreNMS/Alert/Transport/Mail.php
@@ -46,7 +46,6 @@ class Mail extends Transport
         }
 
         return send_mail($email, $obj['title'], $msg, $html);
-
     }
 
     public static function configTemplate()


### PR DESCRIPTION
and use `<br />` for line returns instead of \r\n

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
