### PR TITLE
Added OS Security updates (for YUM only so far)

### DIFF
--- a/doc/Extensions/Applications.md
+++ b/doc/Extensions/Applications.md
@@ -1351,6 +1351,7 @@ The application should be auto-discovered as described at the top of
 the page. If it is not, please follow the steps set out under `SNMP
 Extend` heading top of page.
 
+
 ## PHP-FPM
 
 ### SNMP Extend

--- a/includes/html/graphs/application/os-updates_packages.inc.php
+++ b/includes/html/graphs/application/os-updates_packages.inc.php
@@ -18,6 +18,7 @@ $rrd_filename = Rrd::name($device['hostname'], ['app', $name, $app_id]);
 
 $array = [
     'packages' => ['descr' => 'packages', 'colour' => '2B9220'],
+    'security_updates' => ['descr' => 'security updates', 'colour' => 'D46A6A'],
 ];
 
 $i = 0;

--- a/includes/html/pages/apps.inc.php
+++ b/includes/html/pages/apps.inc.php
@@ -125,6 +125,7 @@ $graphs['nfs-server'] = [
 ];
 $graphs['os-updates'] = [
     'packages',
+    'security_updates'
 ];
 $graphs['dhcp-stats'] = [
     'stats',

--- a/includes/polling/applications/os-updates.inc.php
+++ b/includes/polling/applications/os-updates.inc.php
@@ -9,12 +9,18 @@ $mib = 'NET-SNMP-EXTEND-MIB';
 $oid = '.1.3.6.1.4.1.8072.1.3.2.4.1.2.8.111.115.117.112.100.97.116.101.1';
 
 $rrd_name = ['app', $name, $app_id];
-$rrd_def = RrdDefinition::make()->addDataset('packages', 'GAUGE', 0);
+$rrd_def = RrdDefinition::make()
+    ->addDataset('packages', 'GAUGE', 0)
+    ->addDataset('security_updates', 'GAUGE', 0);
 
 $osupdates = snmp_get($device, $oid, $options, $mib);
+$lines = explode(',', $osupdates);
 
-$fields = ['packages' => $osupdates];
+$fields = [
+    'packages' => is_numeric($lines[0]) ? $lines[0] : null,
+    'security_updates' => is_numeric($lines[1]) ? $lines[1] : null
+];
 
 $tags = ['name' => $name, 'app_id' => $app_id, 'rrd_def' => $rrd_def, 'rrd_name' => $rrd_name];
 data_update($device, 'app', $tags, $fields);
-update_application($app, $osupdates, $fields, $osupdates);
+update_application($app, $osupdates, $fields);

--- a/misc/alert_rules.json
+++ b/misc/alert_rules.json
@@ -250,6 +250,10 @@
     "name": "Applications OS-Updates, New Updates Available"
   },
   {
+    "rule": "applications.app_type = \"ossec-updates\" && applications.app_status >= \"1\"",
+    "name": "Applications OS-Security-Updates, New Updates Available"
+  },
+  {
     "rule": "devices.os = \"hpblmos\" && sensors.sensor_type = \"hpblmos_psustate\" && sensors.sensor_current = \"[3-4]\"",
     "name": "HPE BladeSystem has a bad power supply"
   },


### PR DESCRIPTION
Adds OS Security updates, useful when managing tons of servers to avoid notification fatigue caused by non-stop updates of packages.
This way, security updates can be placed in a rule separately from standard os updates.

Will submit the required change for librenms-agent in a PR in that repo in a minute.


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
