### PR TITLE
Priority filtering for syslog widget

### DIFF
--- a/app/Http/Controllers/Select/PriorityController.php
+++ b/app/Http/Controllers/Select/PriorityController.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * PriorityController.php
+ *
+ * -Description-
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * @link       https://www.librenms.org
+ */
+
+namespace App\Http\Controllers\Select;
+
+use App\Models\Syslog;
+
+class PriorityController extends SelectController
+{
+    protected function searchFields($request)
+    {
+        return ['level'];
+    }
+
+    /**
+     * Defines the base query for this resource
+     *
+     * @param \Illuminate\Http\Request $request
+     * @return \Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Builder
+     */
+    protected function baseQuery($request)
+    {
+        return Syslog::query()
+          ->distinct()
+          ->select('level')
+          ->orderBy('level', 'asc');
+    }
+
+    public function formatItem($syslog)
+    {
+        /** @var Syslog $syslog */
+        return [
+            'id' => $syslog->level,
+            'text' => app('translator')->get('syslog.severity.' . $syslog->level),
+        ];
+    }
+}

--- a/app/Http/Controllers/Table/SyslogController.php
+++ b/app/Http/Controllers/Table/SyslogController.php
@@ -37,6 +37,7 @@ class SyslogController extends TableController
             'priority' => 'nullable|string',
             'to' => 'nullable|date',
             'from' => 'nullable|date',
+            'level' => 'nullable|string',
         ];
     }
 
@@ -77,6 +78,9 @@ class SyslogController extends TableController
             })
             ->when($request->to, function ($query) use ($request) {
                 $query->where('timestamp', '<=', $request->to);
+            })
+            ->when($request->level, function ($query) use ($request) {
+                $query->where('level', '<=', $request->level);
             });
     }
 

--- a/app/Http/Controllers/Widgets/SyslogController.php
+++ b/app/Http/Controllers/Widgets/SyslogController.php
@@ -35,6 +35,7 @@ class SyslogController extends WidgetController
         'device' => null,
         'device_group' => null,
         'hidenavigation' => 0,
+        'level' => null,
     ];
 
     public function getSettingsView(Request $request)
@@ -42,6 +43,8 @@ class SyslogController extends WidgetController
         $data = $this->getSettings(true);
 
         $data['device'] = Device::hasAccess($request->user())->find($data['device']);
+
+        $data['priority'] = app('translator')->get('syslog.severity.' . $data['level']);
 
         return view('widgets.settings.syslog', $data);
     }

--- a/resources/views/widgets/settings/syslog.blade.php
+++ b/resources/views/widgets/settings/syslog.blade.php
@@ -25,12 +25,21 @@
         <label for="hidenavigation-{{ $id }}" class="control-label">@lang('Hide Navigation')</label>
         <input type="checkbox" class="form-control" name="hidenavigation" id="hidenavigation-{{ $id }}" value="{{ $hidenavigation }}" data-size="normal" @if($hidenavigation) checked @endif>
     </div>
+    <div class="form-group">
+        <label for="level-{{ $id }}" class="control-label">@lang('Priority')</label>
+        <select class="form-control" name="level" id="level-{{ $id }}" data-placeholder="@lang('All Priorities')">
+            @if($level)
+                <option value="{{ $level }}" selected>{{ $priority }}</option>
+            @endif
+        </select>
+    </div>
 @endsection
 
 @section('javascript')
     <script type="text/javascript">
         init_select2('#device-{{ $id }}', 'device', {}, '{{ $device ? $device->device_id : '' }}');
         init_select2('#device_group-{{ $id }}', 'device-group', {});
+        init_select2('#level-{{ $id }}', 'priority', {});
 
         $('#hidenavigation-{{ $id }}')
             .bootstrapSwitch('offColor','danger')

--- a/resources/views/widgets/syslog.blade.php
+++ b/resources/views/widgets/syslog.blade.php
@@ -22,7 +22,8 @@
         {
             return {
                 device: '{{ $device ?: '' }}',
-                device_group: '{{ $device_group }}'
+                device_group: '{{ $device_group }}',
+                level: '{{ $level }}'
             };
         },
         url: "{{ url('/ajax/table/syslog') }}"

--- a/routes/web.php
+++ b/routes/web.php
@@ -121,6 +121,7 @@ Route::group(['middleware' => ['auth'], 'guard' => 'auth'], function () {
             Route::get('template', 'ServiceTemplateController');
             Route::get('port', 'PortController');
             Route::get('port-field', 'PortFieldController');
+            Route::get('priority', 'PriorityController');
         });
 
         // jquery bootgrid data controllers


### PR DESCRIPTION
HI all,

I am currently in the process of migrating from Observium to LibreNMS. One of the main features I used in Observium was the syslog widget to show only critical logs. I was not able to achieve the same with the current LibreNMS widget so I started to dig a little bit into the implementation and finally found an approach to do exactly what I wanted. With this pull request the syslog widget receives an additional option allowing to define the priority level of log entries to be shown:

![image](https://user-images.githubusercontent.com/10157917/128644408-3f3089e1-8a70-496f-8cc8-02c94e131e2f.png)

As this is my first change on the LibreNMS code I am pretty sure the code is still optimizable. Suggestions are very welcome!

Thanks!

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
