### PR TITLE
Adding html_entity_decode function to fix HTML encoded characters in …

### DIFF
--- a/LibreNMS/Alert/Transport/Slack.php
+++ b/LibreNMS/Alert/Transport/Slack.php
@@ -38,7 +38,7 @@ class Slack extends Transport
     {
         $host = $api['url'];
         $curl = curl_init();
-        $slack_msg = strip_tags($obj['msg']);
+        $slack_msg = html_entity_decode(strip_tags($obj['msg']), ENT_QUOTES);
         $color = self::getColorForState($obj['state']);
         $data = [
             'attachments' => [


### PR DESCRIPTION
DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.


Hello,

After adding some custom  Slack alerts to notify commits on Juniper equipments, I saw some strange HTML encoded characters like \&#039; in those alerts.
This problem was not present with Telegram so I suggest it appears in the Slack transport code.

Exemple of a message in Slack : 
Alert for device xxxx - Syslog - Commit on Device
Timestamp: 2021-08-09 12:54:43
 Syslog Message : UI_CMDLINE_READ_LINE: User \&#039;geg347\&#039;, command \&#039;commit comment \&quot;Testing\&#039;\&#039;3\&quot; \&#039;

So I just added the function html_entity_decode to the text field in Transport's script of Slack. I tested it in a Test environment and it worked for me.

Same message with the fix : 
Syslog Message : UI_CMDLINE_READ_LINE: User 'geg347', command 'commit comment "Testing''4" '

It shouldn't break anything but if you need some more checks just tell me.

Bye

