### PR TITLE
enclose IPv6 literal in [brackets] for snmpget and unix-agent

### DIFF
--- a/LibreNMS/Util/Rewrite.php
+++ b/LibreNMS/Util/Rewrite.php
@@ -447,4 +447,14 @@ class Rewrite
     {
         return str_pad($num, $length, '0', STR_PAD_LEFT);
     }
+
+    /**
+     * If given input is an IPv6 address, wrap it in [] for use in applications that require it
+     * @param string $ip
+     * @return string
+     */
+    public static function addIpv6Brackets($ip): string
+    {
+        return IPv6::isValid($ip) ? "[$ip]" : $ip;
+    }
 }

--- a/includes/polling/unix-agent.inc.php
+++ b/includes/polling/unix-agent.inc.php
@@ -12,7 +12,7 @@ if ($device['os_group'] == 'unix' || $device['os'] == 'windows') {
     }
 
     $agent_start = microtime(true);
-    $poller_target = Device::pollerTarget($device['hostname']);
+    $poller_target = \LibreNMS\Util\Rewrite::addIpv6Brackets(Device::pollerTarget($device['hostname']));
     $agent = fsockopen($poller_target, $agent_port, $errno, $errstr, \LibreNMS\Config::get('unix-agent.connection-timeout'));
 
     if (! $agent) {

--- a/includes/snmp.inc.php
+++ b/includes/snmp.inc.php
@@ -176,7 +176,7 @@ function gen_snmp_cmd($cmd, $device, $oids, $options = null, $mib = null, $mibdi
         array_push($cmd, '-r', $retries);
     }
 
-    $pollertarget = Device::pollerTarget($device);
+    $pollertarget = \LibreNMS\Util\Rewrite::addIpv6Brackets(Device::pollerTarget($device));
     $cmd[] = $device['transport'] . ':' . $pollertarget . ':' . $device['port'];
     $cmd = array_merge($cmd, (array) $oids);
 


### PR DESCRIPTION
This fixes SNMP polling when a target is specified as an IPv6 literal.  Before this change, IPv6 SNMP polling was only possible by specifying a DNS name that resolves to an IPv6 address.

See e.g. https://community.librenms.org/t/unable-to-add-ipv6-devices-using-snmp-udp6-but-can-snmpwalk-telnet-to-them-from-librenms/16374

Previously, for IP `2001:db8::1234` this code would generate an `snmpget` command line that looked like:
```
snmpget [...flags...] udp6:2001:db8::1234:161 [...oids...]
```
which is wrong.  Now, it generates:
```
snmpget [...flags...] udp6:[2001:db8::1234]:161 [...oids...]
```
which is correct.

---

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
