### PR TITLE
Added support for Voltage and service states for GEMDS OS ( WIP)

### DIFF
--- a/includes/definitions/discovery/gemds.yaml
+++ b/includes/definitions/discovery/gemds.yaml
@@ -9,7 +9,6 @@ modules:
         state:
             data:
                 - oid: mServStatusTable
-                  num_oid: ".1.3.6.1.4.1.4130.10.3.1.1.2.1.{{ $index }}"
                   value: mServServiceStatus
                   state_name: "mServServiceName.{{ $index }}"
                   descr: "mServServiceName"
@@ -25,11 +24,18 @@ modules:
                   num_oid: ".1.3.6.1.4.1.4130.10.1.1.1.2.6.{{ $index }}"
                   index: "mSysTemperature.{{ $index }}"
                   descr: "System Temperature"
-                  divisor: 1
+                  low_warn_limit: -35
+                  low_limit: -40
+                  warn_limit: 65
+                  high_limit: 70
+                  
         voltage:
             data:
                 - oid: mSysPowerSupplyVoltage
                   num_oid: ".1.3.6.1.4.1.4130.10.1.1.1.2.9.{{ $index }}"
                   index: "mSysPowerSupplyVoltage.{{ $index }}"
                   descr: "Input Voltage"
-                  divisor: 1
+                  low_warn_limit: 12
+                  low_limit: 10
+                  warn_limit: 58
+                  high_limit: 61

--- a/includes/definitions/discovery/gemds.yaml
+++ b/includes/definitions/discovery/gemds.yaml
@@ -1,14 +1,35 @@
-mib: MDS-SYSTEM-MIB
-modules: 
-  os: 
-    hardware: "MDS-SYSTEM-MIB::mSysProductConfiguration.0"
-    serial: "MDS-SYSTEM-MIB::mSysSerialNumberPlatform.0"
-    version: "MDS-SYSTEM-MIB::mSysVersion.2"
-  sensors: 
-    temperature: 
-      data: 
-        - 
-          descr: "System Temperature"
-          index: "mSysTemperature.{{ $index }}"
-          num_oid: ".1.3.6.1.4.1.4130.10.1.1.1.2.6.{{ $index }}"
-          oid: mSysTemperature
+mib: MDS-SYSTEM-MIB:MDS-SERVICES-MIB:MDS-SERVICE-GPS-MIB:MDS-SERIAL-MIB:MDS-IF-CELL-MIB:MDS-EVENT-MIB:MDS-REG-MIB:MDS-ORBIT-SMI-MIB:MDS-IF-NX-MIB:MDS-IF-LW-MIB:MDS-IF-LN-MIB:MDS-IF-IEEE80211-MIB
+modules:
+    os:
+        hardware: "MDS-SYSTEM-MIB::mSysProductConfiguration.0"
+        serial: "MDS-SYSTEM-MIB::mSysSerialNumberPlatform.0"
+        version: "MDS-SYSTEM-MIB::mSysVersion.2"
+
+    sensors:
+        state:
+            data:
+                - oid: mServStatusTable
+                  num_oid: ".1.3.6.1.4.1.4130.10.3.1.1.2.1.{{ $index }}"
+                  value: mServServiceStatus
+                  state_name: "mServServiceName.{{ $index }}"
+                  descr: "mServServiceName"
+                  index: "mServStatusTable.{{ $index }}"
+                  states:
+                      - { descr: running, graph: 0, value: 0, generic: 0 }
+                      - { descr: disabled, graph: 0, value: 1, generic: 3 }
+                      - { descr: error, graph: 0, value: 2, generic: 2 }
+                      - { descr: not running, graph: 0, value: 3, generic: 3 }
+        temperature:
+            data:
+                - oid: mSysTemperature
+                  num_oid: ".1.3.6.1.4.1.4130.10.1.1.1.2.6.{{ $index }}"
+                  index: "mSysTemperature.{{ $index }}"
+                  descr: "System Temperature"
+                  divisor: 1
+        voltage:
+            data:
+                - oid: mSysPowerSupplyVoltage
+                  num_oid: ".1.3.6.1.4.1.4130.10.1.1.1.2.9.{{ $index }}"
+                  index: "mSysPowerSupplyVoltage.{{ $index }}"
+                  descr: "Input Voltage"
+                  divisor: 1


### PR DESCRIPTION
Added support for reading the devices input voltage and an overview of the service states. 
I need some help to figure out why the service states works fine the first time they get pulled but the second time Librenms is pulling the device all the services changes to running. 

Screen shoots of issue: https://imgur.com/a/2FpB1UL

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
