### PR TITLE
Dark mode improvements

### DIFF
--- a/html/css/dark.css
+++ b/html/css/dark.css
@@ -7232,3 +7232,7 @@
   #overDiv{
     background: #353a41;
   }
+  .bootgrid-table td.loading, .bootgrid-table td.no-results {
+    background: #3e444c;
+    text-align: center;
+  }

--- a/html/css/dark.css
+++ b/html/css/dark.css
@@ -7210,6 +7210,15 @@
     color: black;
   }
 
-.expandable:hover span {
-    background-color: #2e3338;
-}
+  .expandable:hover span {
+      background-color: #2e3338;
+  }
+  table.table tr:not(:first-child){
+    background: #3e444c!important;
+  }
+  table.table tr:not(:first-child):hover{
+    background: #4f565f!important;
+  }
+  div[role=listbox]{
+    background: rgb(70, 76, 83);
+  }

--- a/html/css/dark.css
+++ b/html/css/dark.css
@@ -7222,3 +7222,13 @@
   div[role=listbox]{
     background: rgb(70, 76, 83);
   }
+  .overlib, .overlib-contents{
+    background: #353a41;
+    color: #bebfbf;
+  }
+  .overlib-text, .overlib-contents list-large{
+    color: #bebfbf;
+  }
+  #overDiv{
+    background: #353a41;
+  }

--- a/html/css/dark.css
+++ b/html/css/dark.css
@@ -7213,10 +7213,10 @@
   .expandable:hover span {
       background-color: #2e3338;
   }
-  table.table tr:not(:first-child){
+  table tr:not(:first-child){
     background: #3e444c!important;
   }
-  table.table tr:not(:first-child):hover{
+  table tr:not(:first-child):hover{
     background: #4f565f!important;
   }
   div[role=listbox]{

--- a/includes/html/pages/apps/overview.inc.php
+++ b/includes/html/pages/apps/overview.inc.php
@@ -43,7 +43,7 @@ foreach (Application::query()->hasAccess(Auth::user())->with('device')->get()->s
         $overlib_content = generate_overlib_content($graph_array, optional($app->device)->displayName() . ' - ' . $app->displayName() . $content_add);
 
         echo "<div style='display: block; padding: 1px; padding-top: 3px; margin: 2px; min-width: " . $width_div . 'px; max-width:' . $width_div . "px; min-height:165px; max-height:165px;
-                      text-align: center; float: left; background-color: #f5f5f5;'>";
+                      text-align: center; float: left;'>";
         echo \LibreNMS\Util\Url::overlibLink($overlib_url, $overlib_link, $overlib_content);
         echo '</div>';
     }//end foreach

--- a/includes/html/print-interface.inc.php
+++ b/includes/html/print-interface.inc.php
@@ -82,11 +82,11 @@ echo "</td><td width=100 onclick=\"location.href='" . generate_port_url($port) .
 
 if ($port_details) {
     $port['graph_type'] = 'port_bits';
-    echo generate_port_link($port, "<img src='graph.php?type=port_bits&amp;id=" . $port['port_id'] . '&amp;from=' . Config::get('time.day') . '&amp;to=' . Config::get('time.now') . '&amp;width=100&amp;height=20&amp;legend=no&amp;bg=' . str_replace('#', '', $row_colour) . "'>");
+    echo generate_port_link($port, "<img src='graph.php?type=port_bits&amp;id=" . $port['port_id'] . '&amp;from=' . Config::get('time.day') . '&amp;to=' . Config::get('time.now') . '&amp;width=100&amp;height=20&amp;legend=no&amp;bg=' . str_replace('#', '', $row_colour) . "00'>");
     $port['graph_type'] = 'port_upkts';
-    echo generate_port_link($port, "<img src='graph.php?type=port_upkts&amp;id=" . $port['port_id'] . '&amp;from=' . Config::get('time.day') . '&amp;to=' . Config::get('time.now') . '&amp;width=100&amp;height=20&amp;legend=no&amp;bg=' . str_replace('#', '', $row_colour) . "'>");
+    echo generate_port_link($port, "<img src='graph.php?type=port_upkts&amp;id=" . $port['port_id'] . '&amp;from=' . Config::get('time.day') . '&amp;to=' . Config::get('time.now') . '&amp;width=100&amp;height=20&amp;legend=no&amp;bg=' . str_replace('#', '', $row_colour) . "00'>");
     $port['graph_type'] = 'port_errors';
-    echo generate_port_link($port, "<img src='graph.php?type=port_errors&amp;id=" . $port['port_id'] . '&amp;from=' . Config::get('time.day') . '&amp;to=' . Config::get('time.now') . '&amp;width=100&amp;height=20&amp;legend=no&amp;bg=' . str_replace('#', '', $row_colour) . "'>");
+    echo generate_port_link($port, "<img src='graph.php?type=port_errors&amp;id=" . $port['port_id'] . '&amp;from=' . Config::get('time.day') . '&amp;to=' . Config::get('time.now') . '&amp;width=100&amp;height=20&amp;legend=no&amp;bg=' . str_replace('#', '', $row_colour) . "00'>");
 }
 
 echo "</td><td width=120 onclick=\"location.href='" . generate_port_url($port) . "'\" >";


### PR DESCRIPTION
Please give a short description what your pull request is for
- Minor change to internal css to modify all tables without 'table' class applied
![image](https://user-images.githubusercontent.com/7550822/129486024-524d7612-f137-4c0b-a426-e924ce5a691c.png)
- Transparency on mini graphs on ports/details
- Dark background on most popups
![image](https://user-images.githubusercontent.com/7550822/129486153-02388238-9479-4118-a056-929856358ecb.png)
![image](https://user-images.githubusercontent.com/7550822/129486195-dc46dc77-859b-41d8-9f4d-98fc4ca3916e.png)
- Alert table without any alerts now has dark background
![image](https://user-images.githubusercontent.com/7550822/129563250-e047c5ef-f505-4112-be49-d1cb352061a4.png)


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
