### PR TITLE
Cleanup Port hover minigraph description when using "Interface Description Parsing"

### DIFF
--- a/LibreNMS/Util/Url.php
+++ b/LibreNMS/Util/Url.php
@@ -135,7 +135,9 @@ class Url
         }
 
         $content = '<div class=list-large>' . addslashes(htmlentities($port->device->displayName() . ' - ' . $label)) . '</div>';
-        if ($port->ifAlias) {
+        if ($port['port_descr_descr']) {
+            $content .= addslashes(\LibreNMS\Util\Clean::html($port['port_descr_descr'], [])) . '<br />';
+        } elseif ($port['ifAlias']) {
             $content .= addslashes(htmlentities($port->ifAlias)) . '<br />';
         }
 

--- a/includes/html/functions.inc.php
+++ b/includes/html/functions.inc.php
@@ -347,7 +347,9 @@ function generate_port_link($port, $text = null, $type = null, $overlib = 1, $si
     }
 
     $content = '<div class=list-large>' . $port['hostname'] . ' - ' . Rewrite::normalizeIfName(addslashes(\LibreNMS\Util\Clean::html($port['label'], []))) . '</div>';
-    if ($port['ifAlias']) {
+    if ($port['port_descr_descr']) {
+        $content .= addslashes(\LibreNMS\Util\Clean::html($port['port_descr_descr'], [])) . '<br />';
+    } elseif ($port['ifAlias']) {
         $content .= addslashes(\LibreNMS\Util\Clean::html($port['ifAlias'], [])) . '<br />';
     }
 

--- a/includes/html/pages/device/ports.inc.php
+++ b/includes/html/pages/device/ports.inc.php
@@ -103,7 +103,7 @@ if ($vars['view'] == 'minigraphs') {
 
     foreach (dbFetchRows('select * from ports WHERE device_id = ? AND `disabled` = 0 ORDER BY ifIndex', [$device['device_id']]) as $port) {
         $port = cleanPort($port, $device);
-        echo "<div class='minigraph-div'><div style='font-weight: bold;'>" . generate_port_link($port) . "</div>";
+        echo "<div class='minigraph-div'><div style='font-weight: bold;'>" . generate_port_link($port) . '</div>';
     }
 
     echo '</div>';

--- a/includes/html/pages/device/ports.inc.php
+++ b/includes/html/pages/device/ports.inc.php
@@ -101,19 +101,9 @@ if ($vars['view'] == 'minigraphs') {
     echo "<div style='display: block; clear: both; margin: auto; min-height: 500px;'>";
     unset($seperator);
 
-    // FIXME - FIX THIS. UGLY.
     foreach (dbFetchRows('select * from ports WHERE device_id = ? AND `disabled` = 0 ORDER BY ifIndex', [$device['device_id']]) as $port) {
         $port = cleanPort($port, $device);
-        echo "<div class='minigraph-div'><div style='font-weight: bold;'>" . makeshortif($port['ifDescr']) . '</div>
-            <a href="' . generate_port_url($port) . "\" onmouseover=\"return overlib('<div class=\'overlib-content\'>\
-      	    <div class=\'overlib-text\'>" . $device['hostname'] . ' - ' . $port['ifDescr'] . "</div>\
-            <span class=\'overlib-title\'>" . $port['ifAlias'] . "</span>\
-            <img src=\'graph.php?type=" . $graph_type . '&amp;id=' . $port['port_id'] . '&amp;from=' . $from . '&amp;to=' . \LibreNMS\Config::get('time.now') . "&amp;width=450&amp;height=150\'>\
-            </div>\
-            ', CENTER, LEFT, FGCOLOR, '#e5e5e5', BGCOLOR, '#e5e5e5', WIDTH, 400, HEIGHT, 150);\" onmouseout=\"return nd();\"  >" . "<img src='graph.php?type=" . $graph_type . '&amp;id=' . $port['port_id'] . '&amp;from=' . $from . '&amp;to=' . \LibreNMS\Config::get('time.now') . "&amp;width=180&amp;height=45&amp;legend=no'>
-            </a>
-            <div style='font-size: 9px;'>" . substr(short_port_descr($port['ifAlias']), 0, 32) . '</div>
-            </div>';
+        echo "<div class='minigraph-div'><div style='font-weight: bold;'>" . generate_port_link($port) . "</div>";
     }
 
     echo '</div>';

--- a/includes/html/pages/iftype.inc.php
+++ b/includes/html/pages/iftype.inc.php
@@ -52,9 +52,8 @@ if ($if_list) {
         }
 
         echo "<tr class='iftype'>
-            <td><span class=list-large>" . generate_port_link($port, $port['port_descr_descr']) . "</span><br />
-            <span class=interface-desc style='float: left;'>" . generate_device_link($port) . ' ' . generate_port_link($port) . ' </span></td>
-            <td>' . generate_port_link($port, makeshortif($port['ifDescr'])) . '</td>
+            <td><span class=list-large>" . generate_port_link($port) . "</span><br />
+            <span class=interface-desc style='float: left;'>" . generate_device_link($port) . ' - ' . generate_port_link($port) . ' </span></td>
             <td>' . $port['port_descr_speed'] . '</td>
             <td>' . $port['port_descr_circuit'] . '</td>
             <td>' . $port['port_descr_notes'] . "</td>


### PR DESCRIPTION
Use port_descr_descr if exists (it should if using Interface Description Parsing), if no default to std ifDescr.

Port description: Cust: Example Customer [10Mbit] (T1 Telco Y CCID129031) {EXAMP0001}
Current result: Cust: Example Customer [10Mbit] (T1 Telco Y CCID129031) {EXAMP0001}
NEW description: Example Customer

Port description: Core: core.router01 FastEthernet0/0 (Telco X CCID023141)
Current result in device-Ports (/device/X/ports): Core: core.router01 FastEthernet0/0 (Telco X CCID023141)
Current result in ports-Core (/iftype/type=core  : Corecore.router01 FastEthernet0/0 (Telco X CCID023141)
NEW description: core.router01 FastEthernet0/0

Use the same generate_port_link() in:
- Devices - Ports
- Ports - All/Errored/Ignored
- Ports - "Types"
- Ports - Customer

I could attach some screenshot, but I think my description is pretty clear.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
