### PR TITLE
Revert to port description on port_link in Ports-Type pages after #13143

### DIFF
--- a/includes/html/pages/iftype.inc.php
+++ b/includes/html/pages/iftype.inc.php
@@ -52,7 +52,7 @@ if ($if_list) {
         }
 
         echo "<tr class='iftype'>
-            <td><span class=list-large>" . $port['port_descr_descr'] . ' ' . generate_port_link($port) . "</span><br />
+            <td><span class=list-large>" . generate_port_link($port, $port['port_descr_descr']) . "</span><br />
             <span class=interface-desc style='float: left;'>" . generate_device_link($port) . ' - ' . generate_port_link($port) . ' </span></td>
             <td>' . $port['port_descr_speed'] . '</td>
             <td>' . $port['port_descr_circuit'] . '</td>

--- a/includes/html/pages/iftype.inc.php
+++ b/includes/html/pages/iftype.inc.php
@@ -52,7 +52,7 @@ if ($if_list) {
         }
 
         echo "<tr class='iftype'>
-            <td><span class=list-large>" . $port['port_descr_descr'] . " " .  generate_port_link($port) . "</span><br />
+            <td><span class=list-large>" . $port['port_descr_descr'] . ' ' . generate_port_link($port) . "</span><br />
             <span class=interface-desc style='float: left;'>" . generate_device_link($port) . ' - ' . generate_port_link($port) . ' </span></td>
             <td>' . $port['port_descr_speed'] . '</td>
             <td>' . $port['port_descr_circuit'] . '</td>

--- a/includes/html/pages/iftype.inc.php
+++ b/includes/html/pages/iftype.inc.php
@@ -52,7 +52,7 @@ if ($if_list) {
         }
 
         echo "<tr class='iftype'>
-            <td><span class=list-large>" . generate_port_link($port) . "</span><br />
+            <td><span class=list-large>" . $port['port_descr_descr'] . " " .  generate_port_link($port) . "</span><br />
             <span class=interface-desc style='float: left;'>" . generate_device_link($port) . ' - ' . generate_port_link($port) . ' </span></td>
             <td>' . $port['port_descr_speed'] . '</td>
             <td>' . $port['port_descr_circuit'] . '</td>


### PR DESCRIPTION
Consistent with Customers pages.
For a port to be in a Ports-Type page, it needs a parsed description PorType : Transit, Peering, Core, Custom, ...

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
