### PR TITLE
Do not poll passive ISIS-circuits

### DIFF
--- a/LibreNMS/Modules/Isis.php
+++ b/LibreNMS/Modules/Isis.php
@@ -115,8 +115,8 @@ class Isis implements Module
                     continue;
                 }
 
-                if ($os instanceof Junos && $circuit_id == 16) {
-                    continue; // Do not poll loopback interface
+                if ($circuit_data['isisCircPassiveCircuit']) {
+                    continue; // Do not poll passive interfaces
                 }
 
                 $adjacency_data = Arr::last($adjacencies_data[$circuit_id] ?? [[]]);

--- a/LibreNMS/Modules/Isis.php
+++ b/LibreNMS/Modules/Isis.php
@@ -114,7 +114,7 @@ class Isis implements Module
                     continue;
                 }
 
-                if ($circuit_data['isisCircPassiveCircuit']) {
+                if ($circuit_data['isisCircPassiveCircuit'] == 'true') {
                     continue; // Do not poll passive interfaces
                 }
 


### PR DESCRIPTION
After more testing with the refactored code and new devices, I found an issue where the ISIS-protocol was in passive mode in the device's configuration for some interfaces. These interfaces were still showing adminstate up even though the protocol itself was not activated for those interfaces. In Juniper gear the isisCircPassiveCircuit lists those interfaces. In Juniper gear, the protocol must be enabled within the interface- and protocols-subsection for it to be truly enabled.

WIP note: Testing this with more devices later this week.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
