### PR TITLE
Change default graph view to zoom in on traffic.

### DIFF
--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -3318,7 +3318,7 @@
             "type": "array"
         },
         "graphs.port_speed_zoom": {
-            "default": true,
+            "default": false,
             "type": "boolean",
             "group": "webui",
             "section": "graph",


### PR DESCRIPTION
People like to see their tiny utilization up close.

`lnms config:set graphs.port_speed_zoom true` to set zoom to port speed to accurately show utilization at a glance.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
