### PR TITLE
Validate schema in utc

### DIFF
--- a/LibreNMS/DB/Schema.php
+++ b/LibreNMS/DB/Schema.php
@@ -346,6 +346,8 @@ class Schema
         $output = [];
         $db_name = DB::connection($connection)->getDatabaseName();
 
+        DB::statement("SET TIME_ZONE='+00:00'"); // set timezone to UTC to avoid timezone issues
+
         foreach (DB::connection($connection)->select(DB::raw("SELECT TABLE_NAME FROM information_schema.TABLES WHERE TABLE_SCHEMA = '$db_name' ORDER BY TABLE_NAME;")) as $table) {
             $table = $table->TABLE_NAME;
             foreach (DB::connection($connection)->select(DB::raw("SELECT COLUMN_NAME, COLUMN_TYPE, IS_NULLABLE, COLUMN_DEFAULT, EXTRA FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = '$db_name' AND TABLE_NAME='$table' ORDER BY ORDINAL_POSITION")) as $data) {

--- a/LibreNMS/Validations/Database.php
+++ b/LibreNMS/Validations/Database.php
@@ -319,6 +319,11 @@ class Database extends BaseValidation
             $schema_update[] = $this->dropTableSql($table);
         }
 
+        // set utc timezone if timestamp issues
+        if (preg_grep('/\d{4}-\d\d-\d\d \d\d:\d\d:\d\d/', $schema_update)) {
+            array_unshift($schema_update, "SET TIME_ZONE='+00:00';");
+        }
+
         if (empty($schema_update)) {
             $validator->ok('Database schema correct');
         } else {


### PR DESCRIPTION
if timestamp is off, prepend sql query to set UTC for session
This will prevent new installs from showing that some timestamps are off, even when they are correct.

Will probably annoy people that bothered to "correct" the bad validation to the incorrect timestamps in the first place. (as it was actually wrong)

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
