### PR TITLE
Poll SPU memory from Juniper SRX devices

### DIFF
--- a/includes/definitions/discovery/junos.yaml
+++ b/includes/definitions/discovery/junos.yaml
@@ -17,6 +17,12 @@ modules:
                         oid: JUNIPER-MIB::jnxOperatingDescr
                         op: 'regex'
                         value: '/(fan|sensor)/i'
+            -
+                oid: JUNIPER-SRX5000-SPU-MONITORING-MIB::jnxJsSPUMonitoringObjectsEntry
+                percent_used: JUNIPER-SRX5000-SPU-MONITORING-MIB::jnxJsSPUMonitoringMemoryUsage
+                num_oid: '.1.3.6.1.4.1.2636.3.39.1.12.1.1.1.5.{{ $index }}'
+                descr: '{{ $JUNIPER-SRX5000-SPU-MONITORING-MIB::jnxJsSPUMonitoringNodeDescr }} SPU {{ $JUNIPER-SRX5000-SPU-MONITORING-MIB::jnxJsSPUMonitoringFPCIndex }}/{{ $JUNIPER-SRX5000-SPU-MONITORING-MIB::jnxJsSPUMonitoringSPUIndex }}'
+
     processors:
         data:
             -
@@ -37,7 +43,7 @@ modules:
                 oid: jnxJsSPUMonitoringObjectsEntry
                 value: jnxJsSPUMonitoringCPUUsage
                 num_oid: '.1.3.6.1.4.1.2636.3.39.1.12.1.1.1.4.{{ $index }}'
-                descr: '{{ $jnxJsSPUMonitoringNodeDescr }}'
+                descr: '{{ $jnxJsSPUMonitoringNodeDescr }} SPU {{ $jnxJsSPUMonitoringFPCIndex }}/{{ $jnxJsSPUMonitoringSPUIndex }}'
     sensors:
         pre-cache:
             data:


### PR DESCRIPTION
Poll SPU memory statistics from Juniper SRX devices.

This is mostly useful on High-End SRX which have separate cards dedicated for session processing.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
