### PR TITLE
Modified SQL delete statement for vrf is null

### DIFF
--- a/includes/polling/bgp-peers.inc.php
+++ b/includes/polling/bgp-peers.inc.php
@@ -464,11 +464,17 @@ if (\LibreNMS\Config::get('enable_bgp')) {
             $peer['update'] = array_diff_assoc($peer_data, $peer);
             unset($peer_data);
 
+
             if ($peer['update']) {
                 if ($vrfId) {
                     dbUpdate($peer['update'], 'bgpPeers', '`device_id` = ? AND `bgpPeerIdentifier` = ? AND `vrf_id` = ?', [$device['device_id'], $peer['bgpPeerIdentifier'], $vrfId]);
                 } else {
-                    dbUpdate($peer['update'], 'bgpPeers', '`device_id` = ? AND `bgpPeerIdentifier` = ?', [$device['device_id'], $peer['bgpPeerIdentifier']]);
+                    if ($device['os'] == 'timos') {
+                          d_echo("*****ERROR***** Nokia BGP Peers must have a vrfId to be valid");
+		              }
+		              else {
+                          dbUpdate($peer['update'], 'bgpPeers', '`device_id` = ? AND `bgpPeerIdentifier` = ?', [$device['device_id'], $peer['bgpPeerIdentifier']]);
+                      }
                 }
             }
 


### PR DESCRIPTION
I modified the SQL insert and delete statements in both discovery and polling for bgp peers module.  We were running into an issue where peers were being inserted with vrf ID of null which isn't possible on a Nokia device.  The delete statement in the discovery code to clean up peers needed to be is NULL instead of '= null'.  I also checked during polling if the os=nokia and vrf=null, don't add.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
