### PR TITLE
Add skip_values to Liebert capacity sensor definitions

### DIFF
--- a/includes/definitions/discovery/liebert.yaml
+++ b/includes/definitions/discovery/liebert.yaml
@@ -242,30 +242,35 @@ modules:
                     num_oid: '.1.3.6.1.4.1.476.1.42.3.4.3.9.{{ $index }}'
                     descr: 'Cooling Capacity Usage'
                     index: 'lgpEnvStateCoolingCapacity.{{ $index }}'
+                    skip_values: 4294967295
                 -
                     oid: lgpEnvStateFanCapacity
                     value: lgpEnvStateFanCapacity
                     num_oid: '.1.3.6.1.4.1.476.1.42.3.4.3.16.{{ $index }}'
                     descr: 'Fan Capacity Usage'
                     index: 'lgpEnvStateFanCapacity.{{ $index }}'
+                    skip_values: 4294967295
                 -
                     oid: lgpEnvStateFreeCoolingCapacity
                     value: lgpEnvStateFreeCoolingCapacity
                     num_oid: '.1.3.6.1.4.1.476.1.42.3.4.3.17.{{ $index }}'
                     descr: 'Free Cooling Capacity Usage'
                     index: 'lgpEnvStateFreeCoolingCapacity.{{ $index }}'
+                    skip_values: 4294967295
                 -
                     oid: lgpEnvStateDehumidifyingCapacity
                     value: lgpEnvStateDehumidifyingCapacity
                     num_oid: '.1.3.6.1.4.1.476.1.42.3.4.3.18.{{ $index }}'
                     descr: 'Dehumidifying Capacity Usage'
                     index: 'lgpEnvStateDehumidifyingCapacity.{{ $index }}'
+                    skip_values: 4294967295
                 -
                     oid: lgpEnvStateHumidifyingCapacity
                     value: lgpEnvStateHumidifyingCapacity
                     num_oid: '.1.3.6.1.4.1.476.1.42.3.4.3.19.{{ $index }}'
                     descr: 'Humidifying Capacity Usage'
                     index: 'lgpEnvStateHumidifyingCapacity.{{ $index }}'
+                    skip_values: 4294967295
         power_factor:
             data:
                 -


### PR DESCRIPTION
Capacity sensors can read as MAX_INT% for functions that are not used.  Filter them out at discovery time rather than collect and graph them.

Before:

![liebert_maxint_before](https://user-images.githubusercontent.com/184975/132420669-d3229685-e56b-464a-8e39-a08cb8b7837c.png)

After:

![liebert_maxint_after](https://user-images.githubusercontent.com/184975/132420696-9699bf9a-aef0-4537-b891-14a5ebba838c.png)


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
