### PR TITLE
Discovery: mark snmp disabled devices as skipped

### DIFF
--- a/discovery.php
+++ b/discovery.php
@@ -112,7 +112,7 @@ if (! empty(\LibreNMS\Config::get('distributed_poller_group'))) {
 }
 
 global $device;
-foreach (dbFetch("SELECT * FROM `devices` WHERE disabled = 0 AND snmp_disable = 0 $where ORDER BY device_id DESC", $sqlparams) as $device) {
+foreach (dbFetch("SELECT * FROM `devices` WHERE disabled = 0 $where ORDER BY device_id DESC", $sqlparams) as $device) {
     DeviceCache::setPrimary($device['device_id']);
     $discovered_devices += (int) discover_device($device, $module_override);
 }

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -123,7 +123,7 @@ function load_discovery(&$device)
 function discover_device(&$device, $force_module = false)
 {
     if ($device['snmp_disable'] == '1') {
-        return false;
+        return true;
     }
 
     global $valid;


### PR DESCRIPTION
The reason is to change the return code to a success instead of failure for the dispatcher and other scripts.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
