### PR TITLE
Increase RestartSec time to a reasonable value

### DIFF
--- a/misc/librenms.service
+++ b/misc/librenms.service
@@ -8,7 +8,7 @@ ExecReload=/bin/kill -HUP $MAINPID
 WorkingDirectory=/opt/librenms
 User=librenms
 Group=librenms
-RestartSec=2
+RestartSec=10
 Restart=always
 
 [Install]

--- a/misc/librenms.service.scl
+++ b/misc/librenms.service.scl
@@ -8,7 +8,7 @@ ExecReload=/bin/kill -HUP $MAINPID
 WorkingDirectory=/opt/librenms
 User=librenms
 Group=librenms
-RestartSec=2
+RestartSec=10
 Restart=always
 
 [Install]


### PR DESCRIPTION
Using systemd with `RestartSec=2` can trigger the default service restart rate limiting (5 times in 10 seconds) set by `StartLimitIntervalSec` and `StartLimitBurst`.
Raising to a reasonable value (which is already in use in librenms-watchdog service) so we don't get stuck with systemd rate limiting.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
