### PR TITLE
Add security context service

### DIFF
--- a/doc/Installation/Install-LibreNMS.md
+++ b/doc/Installation/Install-LibreNMS.md
@@ -423,6 +423,7 @@ Feel free to tune the performance settings in librenms.conf to meet your needs.
     ```
     semanage fcontext -a -t httpd_sys_content_t '/opt/librenms/html(/.*)?'
     semanage fcontext -a -t httpd_sys_rw_content_t '/opt/librenms/(logs|rrd|storage)(/.*)?'
+    semanage fcontext -a -t bin_t '/opt/librenms/librenms-service.py'
     restorecon -RFvv /opt/librenms
     setsebool -P httpd_can_sendmail=1
     setsebool -P httpd_execmem 1


### PR DESCRIPTION
Using Almalinux 8.4 with LibreNMS 21+ and SELinux, I ran into a problem where the service would quit with `status=203/EXEC` because of the following SELinux enforcement:

```
type=AVC msg=audit(1631272189.992:1032): avc:  denied  { execute } for  pid=2873 comm="(rvice.py)" name="librenms-service.py" dev="sda3" ino=714393 scontext=system_u:system_r:init_t:s0 tcontext=system_u:object_r:httpd_sys_content_t:s0 tclass=file permissive=0
```

This patchs sets a binary context to allow execution with SELinux.


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
