### PR TITLE
Sort dashboard entries alphabetically

### DIFF
--- a/app/Http/Controllers/OverviewController.php
+++ b/app/Http/Controllers/OverviewController.php
@@ -39,7 +39,7 @@ class OverviewController extends Controller
     public function default(Request $request)
     {
         $user = Auth::user();
-        $dashboards = Dashboard::allAvailable($user)->with('user:user_id,username')->get()->keyBy('dashboard_id');
+        $dashboards = Dashboard::allAvailable($user)->with('user:user_id,username')->orderBy('dashboard_name')->get()->keyBy('dashboard_id');
 
         // Split dashboards into user owned or shared
         [$user_dashboards, $shared_dashboards] = $dashboards->partition(function ($dashboard) use ($user) {


### PR DESCRIPTION
Sort dashboard entries alphabetically by their name as device groups already do in their menu. Gives the benefit of making similarly named dashboards which are then sorted in the correct order.

Current approach (sort by id):
![sort-old](https://user-images.githubusercontent.com/7031571/133162546-e66fca25-db93-443e-9a13-f3b505a1a31f.PNG)

New approach (sort by name):
![sort-new](https://user-images.githubusercontent.com/7031571/133162571-c96535c7-0291-41ec-aca4-fbffccc79655.PNG)


#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
