### PR TITLE
Update to fix table row color and hover color for dark.css

### DIFF
--- a/html/css/dark.css
+++ b/html/css/dark.css
@@ -7213,11 +7213,11 @@
   .expandable:hover span {
       background-color: #2e3338;
   }
-  table tr:not(:first-child){
-    background: #3e444c!important;
+  table tr:nth-child(odd){
+    background: #2a2e33!important;
   }
-  table tr:not(:first-child):hover{
-    background: #4f565f!important;
+  table tr:hover{
+    background: #2d3237!important;
   }
   div[role=listbox]{
     background: rgb(70, 76, 83);


### PR DESCRIPTION
The last update changed row color for all rows except the first instead of changing color for every 2nd row.

Table coloring after
![grafik](https://user-images.githubusercontent.com/10722552/133451248-e9d7ff02-efca-4a7a-835b-a18cd63c9041.png)

Table coloring before
![grafik](https://user-images.githubusercontent.com/10722552/133451030-8ae5bd38-f7e7-4338-8e6c-b884258bd2cc.png)

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
