### PR TITLE
API Call for instant Device discovery

### DIFF
--- a/doc/API/Devices.md
+++ b/doc/API/Devices.md
@@ -103,6 +103,37 @@ Output:
 }
 ```
 
+### `discover_device_now`
+
+Trigger an instant  discovery of given device.
+
+Route: `/api/v0/devices/:hostname/discover/now`
+
+- hostname can be either the device hostname or id
+
+Input:
+
+  -
+
+Example:
+
+```curl
+curl -H 'X-Auth-Token: YOURAPITOKENHERE' https://librenms.org/api/v0/devices/localhost/discover/now
+```
+
+Output:
+
+```json
+{
+    "status": "ok",
+    "result": {
+        "status": 0,
+        "message": "Device will be rediscovered"
+    },
+    "count": 2
+}
+```
+
 ### `availability`
 
 Get calculated availabilities of given device.

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -819,7 +819,7 @@ function get_graphs(Illuminate\Http\Request $request)
     });
 }
 
-function trigger_device_discovery(Illuminate\Http\Request $request, $internal=false)
+function trigger_device_discovery(Illuminate\Http\Request $request, $internal = false)
 {
     // return details of a single device
     $hostname = $request->route('hostname');

--- a/routes/api.php
+++ b/routes/api.php
@@ -91,6 +91,7 @@ Route::group(['prefix' => 'v0', 'namespace' => '\App\Api\Controllers'], function
     Route::group(['prefix' => 'devices'], function () {
         Route::get('{hostname}', 'LegacyApiController@get_device')->name('get_device');
         Route::get('{hostname}/discover', 'LegacyApiController@trigger_device_discovery')->name('trigger_device_discovery');
+        Route::get('{hostname}/discover/now', 'LegacyApiController@trigger_device_discovery_now')->name('trigger_device_discovery_now');
         Route::get('{hostname}/availability', 'LegacyApiController@device_availability')->name('device_availability');
         Route::get('{hostname}/outages', 'LegacyApiController@device_outages')->name('device_outages');
         Route::get('{hostname}/graphs/health/{type}/{sensor_id?}', 'LegacyApiController@get_graph_generic_by_hostname')->name('get_health_graph');


### PR DESCRIPTION
Enforce instant device discovery via API Call

Usecase:
Device has been added via API, some further adjustments have to be done.
But before a discovery is needed.

with this PR this is possible:
1. Add Device via API
2. enforce Discovery via API
3. adjust Device specific settings via API

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
