### PR TITLE
API add_device: respond with more device information

### DIFF
--- a/doc/API/Devices.md
+++ b/doc/API/Devices.md
@@ -1151,7 +1151,15 @@ Output:
 ```json
 {
     "status": "ok",
-    "message": "Device localhost.localdomain (57) has been added successfully"
+    "message": "Device localhost.localdomain (57) has been added successfully",
+    "devices": [
+        {
+            "device_id": "57",
+            "hostname": "localhost",
+            ...
+            "serial": null,
+            "icon": null
+        }
 }
 ```
 

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -420,6 +420,7 @@ function add_device(Illuminate\Http\Request $request)
     }
 
     $device = device_by_id_cache($device_id);
+
     return api_success([$device], 'devices', $response);
 }
 

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -419,7 +419,8 @@ function add_device(Illuminate\Http\Request $request)
         return api_error(500, $e->getMessage());
     }
 
-    return api_success_noresult(201, "Device $hostname ($device_id) has been added successfully");
+    $device = device_by_id_cache($device_id);
+    return api_success([$device], 'devices', $response);
 }
 
 function del_device(Illuminate\Http\Request $request)


### PR DESCRIPTION
further Information in Response Message on API add_device

before:
```
{
    "status": "ok",
    "message": "Device localhost.localdomain (57) has been added successfully"
}

```

after:
```
{
    "status": "ok",
    "message": "Device localhost.localdomain (57) has been added successfully",
    "devices": [
        {
            "device_id": "57",
            "hostname": "localhost",
            ...
            "serial": null,
            "icon": null
        }
}
```
> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
