### PR TITLE
Feature config seeder

### DIFF
--- a/database/seeders/ConfigSeeder.php
+++ b/database/seeders/ConfigSeeder.php
@@ -33,11 +33,15 @@ use Symfony\Component\Yaml\Yaml;
 
 class ConfigSeeder extends Seeder
 {
-    private $directory;
+    private $directories;
 
     public function __construct()
     {
-        $this->directory = dirname(__FILE__) . '/config';
+        $this->directories = [dirname(__FILE__) . '/config'];
+
+        if (is_dir('/data/config')) {
+            $this->directories[] = '/data/config';
+        }
     }
 
     public function run()
@@ -45,18 +49,20 @@ class ConfigSeeder extends Seeder
         if (\App\Models\Config::exists()) {
             echo "Skipped config seeding, existing config\n";
 
-            return;  // don't over-write existing settings.
+            return;  // don't overwrite existing settings.
         }
 
-        foreach (glob($this->directory . '/*.y*ml') as $file) { // both .yml and .yaml extensions
-            $settings = Yaml::parse(file_get_contents($file));
-            foreach (Arr::wrap($settings) as $key => $value) {
-                if (! is_string($key)) {
-                    echo 'Skipped non-string config key: ' . json_encode($key) . PHP_EOL;
-                    continue;
-                }
+        foreach ($this->directories as $directory) {
+            foreach (glob("$directory/*.y*ml") as $file) { // both .yml and .yaml extensions
+                $settings = Yaml::parse(file_get_contents($file));
+                foreach (Arr::wrap($settings) as $key => $value) {
+                    if (! is_string($key)) {
+                        echo 'Skipped non-string config key: ' . json_encode($key) . PHP_EOL;
+                        continue;
+                    }
 
-                Config::persist($key, $value);
+                    Config::persist($key, $value);
+                }
             }
         }
     }

--- a/database/seeders/ConfigSeeder.php
+++ b/database/seeders/ConfigSeeder.php
@@ -44,6 +44,7 @@ class ConfigSeeder extends Seeder
     {
         if (\App\Models\Config::exists()) {
             echo "Skipped config seeding, existing config\n";
+
             return;  // don't over-write existing settings.
         }
 
@@ -51,7 +52,7 @@ class ConfigSeeder extends Seeder
             $settings = Yaml::parse(file_get_contents($file));
             foreach (Arr::wrap($settings) as $key => $value) {
                 if (! is_string($key)) {
-                    echo "Skipped non-string config key: " . json_encode($key) . PHP_EOL;
+                    echo 'Skipped non-string config key: ' . json_encode($key) . PHP_EOL;
                     continue;
                 }
 

--- a/database/seeders/ConfigSeeder.php
+++ b/database/seeders/ConfigSeeder.php
@@ -46,8 +46,8 @@ class ConfigSeeder extends Seeder
 
     public function run()
     {
-        if (\App\Models\Config::exists()) {
-            echo "Skipped config seeding, existing config\n";
+        if (\App\Models\Config::exists() && ! $this->command->option('force')) {
+            echo "Skipped config seeding, existing config.  Use --force to override.\n";
 
             return;  // don't overwrite existing settings.
         }

--- a/database/seeders/ConfigSeeder.php
+++ b/database/seeders/ConfigSeeder.php
@@ -55,7 +55,7 @@ class ConfigSeeder extends Seeder
         }
 
         if (\App\Models\Config::exists()) {
-            if (! $this->command->confirm(trans('commands.db:seed.existing_config'), true)) {
+            if (! $this->command->confirm(trans('commands.db:seed.existing_config'), false)) {
                 return; // don't overwrite existing settings.
             }
         }

--- a/database/seeders/ConfigSeeder.php
+++ b/database/seeders/ConfigSeeder.php
@@ -1,0 +1,62 @@
+<?php
+/*
+ * ConfigSeeder.php
+ *
+ * Imports yaml config settings from the database/seeders/config directory and imports them into the database
+ * This way we can have a nice initial config set.  Primarily for docker and other automations.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @package    LibreNMS
+ * @link       http://librenms.org
+ * @copyright  2021 Tony Murray
+ * @author     Tony Murray <murraytony@gmail.com>
+ */
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Arr;
+use LibreNMS\Config;
+use Symfony\Component\Yaml\Yaml;
+
+class ConfigSeeder extends Seeder
+{
+    private $directory;
+
+    public function __construct()
+    {
+        $this->directory = dirname(__FILE__) . '/config';
+    }
+
+    public function run()
+    {
+        if (\App\Models\Config::exists()) {
+            echo "Skipped config seeding, existing config\n";
+            return;  // don't over-write existing settings.
+        }
+
+        foreach (glob($this->directory . '/*.y*ml') as $file) { // both .yml and .yaml extensions
+            $settings = Yaml::parse(file_get_contents($file));
+            foreach (Arr::wrap($settings) as $key => $value) {
+                if (! is_string($key)) {
+                    echo "Skipped non-string config key: " . json_encode($key) . PHP_EOL;
+                    continue;
+                }
+
+                Config::persist($key, $value);
+            }
+        }
+    }
+}

--- a/database/seeders/ConfigSeeder.php
+++ b/database/seeders/ConfigSeeder.php
@@ -33,6 +33,9 @@ use Symfony\Component\Yaml\Yaml;
 
 class ConfigSeeder extends Seeder
 {
+    /**
+     * @var string[]
+     */
     private $directories;
 
     public function __construct()
@@ -44,7 +47,7 @@ class ConfigSeeder extends Seeder
         }
     }
 
-    public function run()
+    public function run(): void
     {
         $files = array_merge(...array_map(function ($dir) {
             return glob("$dir/*.y*ml");  // both .yml and .yaml extensions

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -16,5 +16,6 @@ class DatabaseSeeder extends Seeder
         $this->call(DefaultAlertTemplateSeeder::class);
         $this->call(DefaultWidgetSeeder::class);
         $this->call(DefaultLegacySchemaSeeder::class);
+        $this->call(ConfigSeeder::class);
     }
 }

--- a/database/seeders/config/.gitignore
+++ b/database/seeders/config/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/resources/lang/en/commands.php
+++ b/resources/lang/en/commands.php
@@ -30,6 +30,9 @@ return [
             'no-validation' => 'Cannot set :setting, it is missing validation definition.',
         ],
     ],
+    'db:seed' => [
+        'existing_config' => 'Database contains existing settings. Continue?',
+    ],
     'dev:check' => [
         'description' => 'LibreNMS code checks. Running with no options runs all checks',
         'arguments' => [


### PR DESCRIPTION
Place yaml key value files in database/seeders/config to pre-populate the config database
This feature is primarily for docker images and other automation
There is no validation

example snmp.yaml
```yaml
snmp.community:
    - public
    - private
snmp.max_repeaters: 30
```

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
