### PR TITLE
Fix graphs showing bps instead of pps

### DIFF
--- a/includes/html/graphs/generic_multi_seperated.inc.php
+++ b/includes/html/graphs/generic_multi_seperated.inc.php
@@ -37,7 +37,11 @@ if ($format == 'octets' || $format == 'bytes') {
     $units = 'Bps';
     $format = 'bits';
 } else {
-    $units = 'bps';
+    if (isset($total_units) && $total_units == 'pps') {
+        $units = 'pps';
+    } else {
+        $units = 'bps';
+    }
     $format = 'bits';
 }
 

--- a/includes/html/graphs/port/nupkts.inc.php
+++ b/includes/html/graphs/port/nupkts.inc.php
@@ -19,7 +19,7 @@ $rrd_list[4]['colour_area_in'] = 'FACF5A';
 $rrd_list[4]['colour_area_out'] = 'FF5959';
 
 $units = '';
-$units_descr = 'Packets';
+$units_descr = 'Packets/sec';
 $total_units = 'pps';
 $colours_in = 'purples';
 $multiplier = '1';


### PR DESCRIPTION
* try to detect if total_units exists (variable comes from errors.inc.php and nupkts.inc.php ) as 'pps' and define graph units as such.
* standardize units_descr for both ucastpackets and errors 

Tested on my dev-server and works well, 'pps' is applied to all metrics.
![image](https://user-images.githubusercontent.com/12242582/134463794-ebf04410-967a-4a44-98cd-09554e8ad320.png)

fixes #13119

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
