### PR TITLE
Use local timezone for outages pages

### DIFF
--- a/app/Http/Controllers/Table/OutagesController.php
+++ b/app/Http/Controllers/Table/OutagesController.php
@@ -113,7 +113,7 @@ class OutagesController extends TableController
         }
 
         $output = "<span style='display:inline;'>";
-        $output .= (new Carbon($timestamp))->format(Config::get('dateformat.compact'));
+        $output .= (Carbon::createFromTimestamp($timestamp))->format(Config::get('dateformat.compact')); // Convert epoch to local time
         $output .= '</span>';
 
         return $output;


### PR DESCRIPTION
When viewing outages from Web UI, all the rows are converted to human readable timestrings using Carbon. However, the timezone is still UTC and not the correct local timezone of the PHP. Outages table uses Unix epoch timestamps in the database and not MySQL / MariaDB timestamps.

Tested the fix with Europe/Helsinki timezone and it seems to output correct values.

Fixes issue #13253 

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
