### PR TITLE
WIP: Centralize in DeviceObserver log messages on device add/del

### DIFF
--- a/LibreNMS/Util/Url.php
+++ b/LibreNMS/Util/Url.php
@@ -139,7 +139,7 @@ class Url
             $text = $label;
         }
 
-        $content = '<div class=list-large>' . addslashes(htmlentities($port->device->displayName() . ' - ' . $label)) . '</div>';
+        $content = '<div class=list-large>' . addslashes(htmlentities((isset($port->device) ? $port->device->displayName() : '') . ' - ' . $label)) . '</div>';
         if ($description = $port->getDescription()) {
             $content .= addslashes(htmlentities($description)) . '<br />';
         }

--- a/app/Models/Device.php
+++ b/app/Models/Device.php
@@ -35,7 +35,7 @@ class Device extends BaseModel
 
     public $timestamps = false;
     protected $primaryKey = 'device_id';
-    protected $fillable = ['hostname', 'ip', 'status', 'status_reason', 'sysName', 'sysDescr', 'sysObjectID', 'hardware', 'version', 'features', 'serial', 'icon', 'overwrite_ip', 'os', 'community', 'port', 'transport', 'snmpver', 'poller_group', 'port_association_mode', 'snmp_disable', 'authPriv'];
+    protected $fillable = ['hostname', 'ip', 'status', 'status_reason', 'sysName', 'sysDescr', 'sysObjectID', 'hardware', 'version', 'features', 'serial', 'icon', 'overwrite_ip', 'os', 'community', 'port', 'transport', 'snmpver', 'poller_group', 'port_association_mode', 'snmp_disable'];
     protected $casts = [
         'last_polled' => 'datetime',
         'status' => 'boolean',

--- a/app/Models/Device.php
+++ b/app/Models/Device.php
@@ -35,7 +35,7 @@ class Device extends BaseModel
 
     public $timestamps = false;
     protected $primaryKey = 'device_id';
-    protected $fillable = ['hostname', 'ip', 'status', 'status_reason', 'sysName', 'sysDescr', 'sysObjectID', 'hardware', 'version', 'features', 'serial', 'icon', 'overwrite_ip', 'os', 'community', 'port', 'transport', 'snmpver', 'poller_group', 'port_association_mode', 'snmp_disable'];
+    protected $fillable = ['hostname', 'ip', 'status', 'status_reason', 'sysName', 'sysDescr', 'sysObjectID', 'hardware', 'version', 'features', 'serial', 'icon', 'overwrite_ip', 'os', 'community', 'port', 'transport', 'snmpver', 'poller_group', 'port_association_mode', 'snmp_disable', 'authPriv'];
     protected $casts = [
         'last_polled' => 'datetime',
         'status' => 'boolean',

--- a/app/Models/Device.php
+++ b/app/Models/Device.php
@@ -35,7 +35,37 @@ class Device extends BaseModel
 
     public $timestamps = false;
     protected $primaryKey = 'device_id';
-    protected $fillable = ['hostname', 'ip', 'status', 'status_reason', 'sysName', 'sysDescr', 'sysObjectID', 'hardware', 'version', 'features', 'serial', 'icon', 'overwrite_ip', 'os', 'community', 'port', 'transport', 'snmpver', 'poller_group', 'port_association_mode', 'snmp_disable'];
+    protected $fillable = [
+        'hostname',
+        'ip',
+        'status',
+        'status_reason',
+        'sysName',
+        'sysDescr',
+        'sysObjectID',
+        'hardware',
+        'version',
+        'features',
+        'serial',
+        'icon',
+        'overwrite_ip',
+        'os',
+        'community',
+        'port',
+        'transport',
+        'snmpver',
+        'poller_group',
+        'port_association_mode',
+        'snmp_disable',
+        // ---- snmpV3 fields ----
+        'authlevel',
+        'authname',
+        'authpass',
+        'authalgo',
+        'cryptopass',
+        'cryptoalgo',
+    ];
+
     protected $casts = [
         'last_polled' => 'datetime',
         'status' => 'boolean',

--- a/app/Models/Device.php
+++ b/app/Models/Device.php
@@ -35,7 +35,7 @@ class Device extends BaseModel
 
     public $timestamps = false;
     protected $primaryKey = 'device_id';
-    protected $fillable = ['hostname', 'ip', 'status', 'status_reason', 'sysName', 'sysDescr', 'sysObjectID', 'hardware', 'version', 'features', 'serial', 'icon'];
+    protected $fillable = ['hostname', 'ip', 'status', 'status_reason', 'sysName', 'sysDescr', 'sysObjectID', 'hardware', 'version', 'features', 'serial', 'icon', 'overwrite_ip', 'os', 'community', 'port', 'transport', 'snmpver', 'poller_group', 'port_association_mode', 'snmp_disable'];
     protected $casts = [
         'last_polled' => 'datetime',
         'status' => 'boolean',

--- a/app/Models/Port.php
+++ b/app/Models/Port.php
@@ -61,30 +61,34 @@ class Port extends DeviceRelatedModel
      */
     public function getLabel()
     {
-        $os = $this->device->os;
+        $label = '';
 
-        if (\LibreNMS\Config::getOsSetting($os, 'ifname')) {
-            $label = $this->ifName;
-        } elseif (\LibreNMS\Config::getOsSetting($os, 'ifalias')) {
-            $label = $this->ifAlias;
-        }
+        if (isset($this->device) && is_object($this->device)) {
+            $os = $this->device->os;
 
-        if (empty($label)) {
-            $label = $this->ifDescr;
-
-            if (\LibreNMS\Config::getOsSetting($os, 'ifindex')) {
-                $label .= " $this->ifIndex";
+            if (\LibreNMS\Config::getOsSetting($os, 'ifname')) {
+                $label = $this->ifName;
+            } elseif (\LibreNMS\Config::getOsSetting($os, 'ifalias')) {
+                $label = $this->ifAlias;
             }
-        }
 
-        foreach ((array) \LibreNMS\Config::get('rewrite_if', []) as $src => $val) {
-            if (Str::contains(strtolower($label), strtolower($src))) {
-                $label = $val;
+            if (empty($label)) {
+                $label = $this->ifDescr;
+
+                if (\LibreNMS\Config::getOsSetting($os, 'ifindex')) {
+                    $label .= " $this->ifIndex";
+                }
             }
-        }
 
-        foreach ((array) \LibreNMS\Config::get('rewrite_if_regexp', []) as $reg => $val) {
-            $label = preg_replace($reg . 'i', $val, $label);
+            foreach ((array) \LibreNMS\Config::get('rewrite_if', []) as $src => $val) {
+                if (Str::contains(strtolower($label), strtolower($src))) {
+                    $label = $val;
+                }
+            }
+
+            foreach ((array) \LibreNMS\Config::get('rewrite_if_regexp', []) as $reg => $val) {
+                $label = preg_replace($reg . 'i', $val, $label);
+            }
         }
 
         return $label;

--- a/app/Observers/DeviceObserver.php
+++ b/app/Observers/DeviceObserver.php
@@ -3,6 +3,7 @@
 namespace App\Observers;
 
 use App\Models\Device;
+use Log;
 
 class DeviceObserver
 {
@@ -14,7 +15,7 @@ class DeviceObserver
      */
     public function created(Device $device)
     {
-        \Log::event("Device $device->hostname has been created", $device, 'system', 3);
+        Log::event("Device $device->hostname has been created", $device, 'system', 3);
     }
 
     /**
@@ -25,7 +26,7 @@ class DeviceObserver
      */
     public function deleted(Device $device)
     {
-        \Log::event("Device $device->hostname has been deleted", $device, 'system', 3);
+        Log::event("Device $device->hostname has been deleted", $device, 'system', 3);
     }
 
     /**
@@ -44,11 +45,11 @@ class DeviceObserver
         // key attribute changes
         foreach (['os', 'sysName', 'version', 'hardware', 'features', 'serial', 'icon', 'type'] as $attribute) {
             if ($device->isDirty($attribute)) {
-                \Log::event(self::attributeChangedMessage($attribute, $device->$attribute, $device->getOriginal($attribute)), $device, 'system', 3);
+                Log::event(self::attributeChangedMessage($attribute, $device->$attribute, $device->getOriginal($attribute)), $device, 'system', 3);
             }
         }
         if ($device->isDirty('location_id')) {
-            \Log::event(self::attributeChangedMessage('location', (string) $device->location, null), $device, 'system', 3);
+            Log::event(self::attributeChangedMessage('location', (string) $device->location, null), $device, 'system', 3);
         }
     }
 
@@ -61,7 +62,7 @@ class DeviceObserver
     public function deleting(Device $device)
     {
         // delete with NULL Device, so it doesn't get's deleted by daily cleanup scripts
-        \Log::event("Device $device->hostname has been removed", null, 'system', 3);
+        Log::event("Device $device->hostname has been removed", null, 'system', 3);
 
         // delete related data
         $device->ports()->delete();

--- a/app/Observers/DeviceObserver.php
+++ b/app/Observers/DeviceObserver.php
@@ -62,6 +62,9 @@ class DeviceObserver
      */
     public function deleting(Device $device)
     {
+        $device->disabled = 1;
+        $device->save();
+        
         // delete related data
         $device->ports()->delete();
         $device->syslogs()->delete();

--- a/app/Observers/DeviceObserver.php
+++ b/app/Observers/DeviceObserver.php
@@ -60,7 +60,8 @@ class DeviceObserver
      */
     public function deleting(Device $device)
     {
-        \Log::event("Device $device->hostname has been removed", $device, 'system', 3);
+        // delete with NULL Device, so it doesn't get's deleted by daily cleanup scripts
+        \Log::event("Device $device->hostname has been removed", null, 'system', 3);
 
         // delete related data
         $device->ports()->delete();

--- a/app/Observers/DeviceObserver.php
+++ b/app/Observers/DeviceObserver.php
@@ -26,7 +26,8 @@ class DeviceObserver
      */
     public function deleted(Device $device)
     {
-        Log::event("Device $device->hostname has been deleted", $device, 'system', 3);
+        // delete with NULL Device, so it doesn't get's deleted by daily cleanup scripts
+        Log::event("Device $device->hostname has been removed", null, 'system', 3);
     }
 
     /**
@@ -61,9 +62,6 @@ class DeviceObserver
      */
     public function deleting(Device $device)
     {
-        // delete with NULL Device, so it doesn't get's deleted by daily cleanup scripts
-        Log::event("Device $device->hostname has been removed", null, 'system', 3);
-
         // delete related data
         $device->ports()->delete();
         $device->syslogs()->delete();

--- a/app/Observers/DeviceObserver.php
+++ b/app/Observers/DeviceObserver.php
@@ -7,6 +7,28 @@ use App\Models\Device;
 class DeviceObserver
 {
     /**
+     * Handle the device "created" event.
+     *
+     * @param  \App\Models\Device  $device
+     * @return void
+     */
+    public function created(Device $device)
+    {
+        \Log::event("Device $device->hostname has been created", $device, 'system', 3);
+    }
+
+    /**
+     * Handle the device "deleted" event.
+     *
+     * @param  \App\Models\Device  $device
+     * @return void
+     */
+    public function deleted(Device $device)
+    {
+        \Log::event("Device $device->hostname has been deleted", $device, 'system', 3);
+    }
+
+    /**
      * Handle the device "updated" event.
      *
      * @param  \App\Models\Device  $device
@@ -38,6 +60,8 @@ class DeviceObserver
      */
     public function deleting(Device $device)
     {
+        \Log::event("Device $device->hostname has been removed", $device, 'system', 3);
+
         // delete related data
         $device->ports()->delete();
         $device->syslogs()->delete();

--- a/app/Observers/DeviceObserver.php
+++ b/app/Observers/DeviceObserver.php
@@ -64,7 +64,7 @@ class DeviceObserver
     {
         $device->disabled = 1;
         $device->save();
-        
+
         // delete related data
         $device->ports()->delete();
         $device->syslogs()->delete();


### PR DESCRIPTION
Centralize in DeviceObserver log messages when device is added or deleted:

Notes:
 * switched from db* functions to eloquent.
 * added  public functions:  
         * created
         * deleted
* added log::event in deleting also.

I don't know why, but the log::event inside the "deleting" doesn't work sometimes, that's why I added the "deleted" function, and then It worked.

Messages format:
created:
``` "Device $device->hostname has been created"  ```
deleted:
``` "Device $device->hostname has been deleted"  ```
deleting:
``` "Device $device->hostname has been removed"  ```

This way, if the community reports any problem, we know which message came through and from what function.
We just don't want to loose the message on eventlog, just because the device doesn't exists inside the db...
As this Observer is used in other parts of LibreNMS, I wanted to be sure we allways got eventlog with the information that "some librenms user deleted a certain device", this is important to track changes, this is not a full Audit, but a basic nice to have feature for the community...

Thank you @murrant and @Jellyfrog for all the help, and teamwork!
Any needfull, just let me know...
cheers!

Here are the usual tests/checks:
```
~$ ./lnms dev:check
Running PHP lint check...
PHP 7.4.23 | 10 parallel jobs
..                                                           2/2 (100 %)


Checked 2 files in 0.1 seconds
No syntax error found
success (0.13s)
Running style check...
PHP CS Fixer 2.19.0 Testament by Fabien Potencier and Dariusz Ruminski
Runtime: PHP 7.4.23
Loaded config default from ".php-cs-fixer.php".
Using cache file ".php_cs.cache".
Paths from configuration file have been overridden by paths provided as command arguments.
FS
Legend: ?-unknown, I-invalid file syntax (file ignored), S-skipped (cached or empty file), .-no changes, F-fixed, E-error
   1) app/Observers/DeviceObserver.php (no_whitespace_in_blank_line)

Fixed all files in 0.141 seconds, 18.000 MB memory used
success (0.63s)
Running unit check...
PHPUnit 9.5.6 by Sebastian Bergmann and contributors.

SSSSSSSSSSSS....SSSSSSSSSSSS........S.........S......SSSSSSSS   61 / 2479 (  2%)
.SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS  122 / 2479 (  4%)
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS  183 / 2479 (  7%)
SSSSSSSSSSSSSSSSSSSS.........................................  244 / 2479 (  9%)
.............................................................  305 / 2479 ( 12%)
.............................................................  366 / 2479 ( 14%)
.............................................................  427 / 2479 ( 17%)
.............................................................  488 / 2479 ( 19%)
.............................................................  549 / 2479 ( 22%)
.............................................................  610 / 2479 ( 24%)
.............................................................  671 / 2479 ( 27%)
.............................................................  732 / 2479 ( 29%)
.............................................................  793 / 2479 ( 31%)
.......................................................SS....  854 / 2479 ( 34%)
....................................SSSSSSS..........SSSSSSSS  915 / 2479 ( 36%)
SS.............SSSSSSSS......................................  976 / 2479 ( 39%)
.........

Time: 04:44.163, Memory: 446.50 MB

OK, but incomplete, skipped, or risky tests!
Tests: 2479, Assertions: 4602, Skipped: 202.
success (289.38s)
```

As we saw, me and @Jellyfrog , there are some occurrences of lost eventlogs that might occur in this situations:

 * polling has started for the device.  and at the same time "Device delete! " is requested, polling will add eventlogs of
what interfaces and updates he might encounter, this might occur after device was deleted (where eventlog was cleared).

For this we should add, to the daily cleanup scripts, a sanitization SQL:
```delete from eventlog where device_id not in (select device_id from devices);```

This delete, will not delete log::event generated inside function "DeviceObserver.deleting", because here we forced device=null .


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
