### PR TITLE
Fix python config fetch disrupted by stderr output

### DIFF
--- a/LibreNMS/__init__.py
+++ b/LibreNMS/__init__.py
@@ -13,6 +13,17 @@ from subprocess import check_output
 from time import time
 
 from .command_runner import command_runner
+from .queuemanager import (
+    QueueManager,
+    TimedQueueManager,
+    BillingQueueManager,
+    PingQueueManager,
+    ServicesQueueManager,
+    AlertQueueManager,
+    PollerQueueManager,
+    DiscoveryQueueManager,
+)
+from .service import Service, ServiceConfig
 
 # Hard limit script execution time so we don't get to "hang"
 DEFAULT_SCRIPT_TIMEOUT = 3600

--- a/LibreNMS/__init__.py
+++ b/LibreNMS/__init__.py
@@ -9,20 +9,10 @@ from collections import deque
 from logging.handlers import RotatingFileHandler
 from math import ceil
 from queue import Queue
+from subprocess import check_output
 from time import time
 
 from .command_runner import command_runner
-from .queuemanager import (
-    QueueManager,
-    TimedQueueManager,
-    BillingQueueManager,
-    PingQueueManager,
-    ServicesQueueManager,
-    AlertQueueManager,
-    PollerQueueManager,
-    DiscoveryQueueManager,
-)
-from .service import Service, ServiceConfig
 
 # Hard limit script execution time so we don't get to "hang"
 DEFAULT_SCRIPT_TIMEOUT = 3600
@@ -169,10 +159,7 @@ def get_config_data(base_dir):
 
     config_cmd = ["/usr/bin/env", "php", "%s/config_to_json.php" % base_dir]
     try:
-        exit_code, output = command_runner(config_cmd, timeout=300)
-        if exit_code == 0:
-            return json.loads(output)
-        raise EnvironmentError
+        return json.loads(check_output(config_cmd).decode())
     except Exception as exc:
         logger.critical("ERROR: Could not execute command [%s]: %s" % (config_cmd, exc))
         logger.debug("Traceback:", exc_info=True)


### PR DESCRIPTION
I have no idea how to make command_runner not include debug output, so just use subprocess.check_output

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
