### PR TITLE
Use the same error message for different kind of authentiction errors

### DIFF
--- a/LibreNMS/Authentication/MysqlAuthorizer.php
+++ b/LibreNMS/Authentication/MysqlAuthorizer.php
@@ -23,7 +23,7 @@ class MysqlAuthorizer extends AuthorizerBase
         $enabled = $user_data->enabled;
 
         if (! $enabled) {
-            throw new AuthenticationException($message = 'login denied');
+            throw new AuthenticationException();
         }
 
         if (Hash::check($password, $hash)) {

--- a/app/Providers/LegacyUserProvider.php
+++ b/app/Providers/LegacyUserProvider.php
@@ -128,7 +128,7 @@ class LegacyUserProvider implements UserProvider
             }
 
             if (empty($credentials['username']) || ! $authorizer->authenticate($credentials)) {
-                throw new AuthenticationException('Invalid Credentials');
+                throw new AuthenticationException();
             }
 
             return true;


### PR DESCRIPTION
This prevents usernames to be guessed as the application confirms or denies their existence.

Thanks @Thelinos on Discord for reporting this

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
