### PR TITLE
Remove text about report sql issues

### DIFF
--- a/LibreNMS/Validations/Database.php
+++ b/LibreNMS/Validations/Database.php
@@ -328,8 +328,8 @@ class Database extends BaseValidation
         if (empty($schema_update)) {
             $validator->ok('Database schema correct');
         } else {
-            $result = ValidationResult::fail('We have detected that your database schema may be wrong, please report the following to us on Discord (https://t.libren.ms/discord) or the community site (https://t.libren.ms/5gscd):')
-                ->setFix('Run the following SQL statements to fix.')
+            $result = ValidationResult::fail('We have detected that your database schema may be wrong')
+                ->setFix('Run the following SQL statements to fix it')
                 ->setList('SQL Statements', $schema_update);
             $validator->result($result);
         }


### PR DESCRIPTION
This is a bit controversial maybe, but the origin of that text was during the mess of `.sql` migrations.
Many people blindly just post this text on the forum because it's telling them too, and it's not really of any help.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
