### PR TITLE
Show Detail by default Option on Alert Widget

### DIFF
--- a/app/Http/Controllers/Widgets/AlertsController.php
+++ b/app/Http/Controllers/Widgets/AlertsController.php
@@ -42,7 +42,7 @@ class AlertsController extends WidgetController
         'location' => 1,
         'sort' => 1,
         'hidenavigation' => 0,
-        'details' => 0,
+        'uncollapse_key_count' => 1,
     ];
 
     public function getView(Request $request)

--- a/app/Http/Controllers/Widgets/AlertsController.php
+++ b/app/Http/Controllers/Widgets/AlertsController.php
@@ -42,6 +42,7 @@ class AlertsController extends WidgetController
         'location' => 1,
         'sort' => 1,
         'hidenavigation' => 0,
+        'details' => 0,
     ];
 
     public function getView(Request $request)

--- a/includes/html/functions.inc.php
+++ b/includes/html/functions.inc.php
@@ -869,7 +869,7 @@ function alert_details($details)
         $all_fault_detail .= $fault_detail;
     }//end foreach
 
-    return array($all_fault_detail, $max_row_length);
+    return [$all_fault_detail, $max_row_length];
 }//end alert_details()
 
 function dynamic_override_config($type, $name, $device)

--- a/includes/html/functions.inc.php
+++ b/includes/html/functions.inc.php
@@ -753,8 +753,10 @@ function alert_details($details)
         $details = json_decode(gzuncompress($details), true);
     }
 
-    $fault_detail = '';
+    $max_row_length = 0;
+    $all_fault_detail = '';
     foreach ($details['rule'] as $o => $tmp_alerts) {
+        $fault_detail = '';
         $fallback = true;
         $fault_detail .= '#' . ($o + 1) . ':&nbsp;';
         if ($tmp_alerts['bill_id']) {
@@ -861,9 +863,13 @@ function alert_details($details)
         }
 
         $fault_detail .= '<br>';
+
+        $max_row_length = strlen(strip_tags($fault_detail)) > $max_row_length ? strlen(strip_tags($fault_detail)) : $max_row_length;
+
+        $all_fault_detail .= $fault_detail;
     }//end foreach
 
-    return $fault_detail;
+    return array($all_fault_detail, $max_row_length);
 }//end alert_details()
 
 function dynamic_override_config($type, $name, $device)

--- a/includes/html/table/alerts.inc.php
+++ b/includes/html/table/alerts.inc.php
@@ -110,7 +110,7 @@ $format = $vars['format'];
 foreach (dbFetchRows($sql, $param) as $alert) {
     $log = dbFetchCell('SELECT details FROM alert_log WHERE rule_id = ? AND device_id = ? ORDER BY id DESC LIMIT 1', [$alert['rule_id'], $alert['device_id']]);
     $alert_log_id = dbFetchCell('SELECT id FROM alert_log WHERE rule_id = ? AND device_id = ? ORDER BY id DESC LIMIT 1', [$alert['rule_id'], $alert['device_id']]);
-    $fault_detail = alert_details($log);
+    list($fault_detail, $max_row_length) = alert_details($log);
     $info = json_decode($alert['info'], true);
 
     $alert_to_ack = '<button type="button" class="btn btn-danger command-ack-alert fa fa-eye" aria-hidden="true" title="Mark as acknowledged" data-target="ack-alert" data-state="' . $alert['state'] . '" data-alert_id="' . $alert['id'] . '" data-alert_state="' . $alert['state'] . '" name="ack-alert"></button>';
@@ -136,8 +136,8 @@ foreach (dbFetchRows($sql, $param) as $alert) {
     }
 
     $hostname = '<div class="incident">' . generate_device_link($alert, format_hostname($alert, shorthost($alert['hostname']))) . '<div id="incident' . ($alert['id']) . '"';
-    if (is_numeric($vars['details'])) {
-        $hostname .= (int) $vars['details'] ? '' : ' class="collapse"';
+    if (is_numeric($vars['uncollapse_key_count'])) {
+        $hostname .= $max_row_length < (int) $vars['uncollapse_key_count'] ? '' : ' class="collapse"';
     } else {
         $hostname .= ' class="collapse"';
     }

--- a/includes/html/table/alerts.inc.php
+++ b/includes/html/table/alerts.inc.php
@@ -135,7 +135,13 @@ foreach (dbFetchRows($sql, $param) as $alert) {
         }
     }
 
-    $hostname = '<div class="incident">' . generate_device_link($alert, format_hostname($alert, shorthost($alert['hostname']))) . '<div id="incident' . ($alert['id']) . '" class="collapse">' . $fault_detail . '</div></div>';
+    $hostname = '<div class="incident">' . generate_device_link($alert, format_hostname($alert, shorthost($alert['hostname']))) . '<div id="incident' . ($alert['id']) . '"';
+    if (is_numeric($vars['details'])) {
+        $hostname .= (int)$vars['details'] ? '' : ' class="collapse"';
+    } else {
+        $hostname .= ' class="collapse"';
+    }
+    $hostname .= '>' . $fault_detail . '</div></div>';
 
     $severity = $alert['severity'];
     $severity_ico = '<span class="alert-status label-' . alert_layout($severity)['background_color'] . '">&nbsp;</span>';

--- a/includes/html/table/alerts.inc.php
+++ b/includes/html/table/alerts.inc.php
@@ -137,7 +137,7 @@ foreach (dbFetchRows($sql, $param) as $alert) {
 
     $hostname = '<div class="incident">' . generate_device_link($alert, format_hostname($alert, shorthost($alert['hostname']))) . '<div id="incident' . ($alert['id']) . '"';
     if (is_numeric($vars['details'])) {
-        $hostname .= (int)$vars['details'] ? '' : ' class="collapse"';
+        $hostname .= (int) $vars['details'] ? '' : ' class="collapse"';
     } else {
         $hostname .= ' class="collapse"';
     }

--- a/includes/html/table/alerts.inc.php
+++ b/includes/html/table/alerts.inc.php
@@ -110,7 +110,7 @@ $format = $vars['format'];
 foreach (dbFetchRows($sql, $param) as $alert) {
     $log = dbFetchCell('SELECT details FROM alert_log WHERE rule_id = ? AND device_id = ? ORDER BY id DESC LIMIT 1', [$alert['rule_id'], $alert['device_id']]);
     $alert_log_id = dbFetchCell('SELECT id FROM alert_log WHERE rule_id = ? AND device_id = ? ORDER BY id DESC LIMIT 1', [$alert['rule_id'], $alert['device_id']]);
-    list($fault_detail, $max_row_length) = alert_details($log);
+    [$fault_detail, $max_row_length] = alert_details($log);
     $info = json_decode($alert['info'], true);
 
     $alert_to_ack = '<button type="button" class="btn btn-danger command-ack-alert fa fa-eye" aria-hidden="true" title="Mark as acknowledged" data-target="ack-alert" data-state="' . $alert['state'] . '" data-alert_id="' . $alert['id'] . '" data-alert_state="' . $alert['state'] . '" name="ack-alert"></button>';

--- a/resources/views/widgets/alerts.blade.php
+++ b/resources/views/widgets/alerts.blade.php
@@ -27,6 +27,7 @@
             group: '{{ $device_group }}',
             proc: '{{ $proc }}',
             sort: '{{ $sort }}',
+            details: '{{ $details }}',
             device_id: '{{ $device }}'
         }),
         responseHandler: response => {

--- a/resources/views/widgets/alerts.blade.php
+++ b/resources/views/widgets/alerts.blade.php
@@ -27,7 +27,7 @@
             group: '{{ $device_group }}',
             proc: '{{ $proc }}',
             sort: '{{ $sort }}',
-            details: '{{ $details }}',
+            uncollapse_key_count: '{{ $uncollapse_key_count }}',
             device_id: '{{ $device }}'
         }),
         responseHandler: response => {

--- a/resources/views/widgets/settings/alerts.blade.php
+++ b/resources/views/widgets/settings/alerts.blade.php
@@ -61,6 +61,13 @@
         </select>
     </div>
     <div class="form-group">
+        <label for="details-{{ $id }}" class="control-label">@lang('Show Alert Details by default'):</label>
+        <select class="form-control" name="details" id="details-{{ $id }}">
+            <option value="1" @if($details == 1) selected @endif>@lang('show')</option>
+            <option value="0" @if($details == 0) selected @endif>@lang('hide')</option>
+        </select>
+    </div>
+    <div class="form-group">
         <label for="sort-{{ $id }}" class="control-label">@lang('Sort alerts by'):</label>
         <select class="form-control" name="sort" id="sort-{{ $id }}">
             <option value="" @if($sort == 1) selected @endif>@lang('timestamp, descending')</option>

--- a/resources/views/widgets/settings/alerts.blade.php
+++ b/resources/views/widgets/settings/alerts.blade.php
@@ -61,12 +61,8 @@
         </select>
     </div>
     <div class="form-group">
-        <label for="details-{{ $id }}" class="control-label">@lang('Show Alert Details by default'):</label>
-        <select class="form-control" name="details" id="details-{{ $id }}">
-            <option value="1" @if($details == 1) selected @endif>@lang('show')</option>
-            <option value="0" @if($details == 0) selected @endif>@lang('hide')</option>
-        </select>
-    </div>
+        <label for="uncollapse_key_count-{{ $id }}" class="control-label">@lang('Automatic uncollapse Alert if length below characters'):</label>
+        <input class="form-control" type="uncollapse_key_count" min="1" step="1" name="uncollapse_key_count" id="uncollapse_key_count-{{ $id }}" value="{{ $uncollapse_key_count }}">
     <div class="form-group">
         <label for="sort-{{ $id }}" class="control-label">@lang('Sort alerts by'):</label>
         <select class="form-control" name="sort" id="sort-{{ $id }}">


### PR DESCRIPTION
Adds an Option to show Details in Alert Widget by Default

![image](https://user-images.githubusercontent.com/7978916/135687760-b58383a3-6eec-46c9-a75a-7fac343d66b3.png)

Widget Settings

![image](https://user-images.githubusercontent.com/7978916/135687887-adc0d6d6-894d-49c8-aaa2-6d9b5f75f5bd.png)




#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
