### PR TITLE
Improvements to SSO Authorization and logout handling

### DIFF
--- a/LibreNMS/Authentication/SSOAuthorizer.php
+++ b/LibreNMS/Authentication/SSOAuthorizer.php
@@ -202,11 +202,7 @@ class SSOAuthorizer extends MysqlAuthorizer
             $groups = $valid_groups;
         }
 
-        if (is_numeric(Config::get('sso.static_level'))) {
-            $level = (int) Config::get('sso.static_level');
-        } else {
-            $level = 0;
-        }
+        $level = (int) Config::get('sso.static_level', 0);
 
         $config_map = Config::get('sso.group_level_map');
 

--- a/LibreNMS/Authentication/SSOAuthorizer.php
+++ b/LibreNMS/Authentication/SSOAuthorizer.php
@@ -180,7 +180,7 @@ class SSOAuthorizer extends MysqlAuthorizer
     }
 
     /**
-     * Map a user to a permission level based on a table mapping, 0 if no matching group is found.
+     * Map a user to a permission level based on a table mapping, sso.static_level (default 0) if no matching group is found.
      *
      * @return int
      */
@@ -202,7 +202,11 @@ class SSOAuthorizer extends MysqlAuthorizer
             $groups = $valid_groups;
         }
 
-        $level = 0;
+        if (is_numeric(Config::get('sso.static_level'))) {
+            $level = (int) Config::get('sso.static_level');
+        } else {
+            $level = 0;
+        }
 
         $config_map = Config::get('sso.group_level_map');
 

--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Models\Device;
 use App\Providers\RouteServiceProvider;
 use Illuminate\Foundation\Auth\AuthenticatesUsers;
+use Illuminate\Http\Request;
 use LibreNMS\Config;
 
 class LoginController extends Controller
@@ -54,5 +55,15 @@ class LoginController extends Controller
         }
 
         return view('auth.login');
+    }
+
+    protected function loggedOut(Request $request)
+    {
+        $custom_logout_handler = Config::get('auth_logout_handler');
+        if ($custom_logout_handler) {
+            return redirect($custom_logout_handler);
+        } else {
+            return redirect($this->redirectTo);
+        }
     }
 }

--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -59,11 +59,6 @@ class LoginController extends Controller
 
     protected function loggedOut(Request $request)
     {
-        $custom_logout_handler = Config::get('auth_logout_handler');
-        if ($custom_logout_handler) {
-            return redirect($custom_logout_handler);
-        } else {
-            return redirect($this->redirectTo);
-        }
+        return redirect(Config::get('auth_redirect_handler', $this->redirectTo));
     }
 }

--- a/doc/Extensions/Authentication.md
+++ b/doc/Extensions/Authentication.md
@@ -499,14 +499,20 @@ $config['sso']['group_level_map'] = ['librenms-admins' => 10, 'librenms-readers'
 $config['sso']['group_delimiter'] = ';';
 ```
 
-The mechanism expects to find a delimited list of groups within the
+This mechanism expects to find a delimited list of groups within the
 attribute that ___sso\_group\_attr___ points to. This should be an
-associative array of group name keys, with  privilege levels as
+associative array of group name keys, with privilege levels as
 values. The mechanism will scan the list and find the ___highest___
 privilege level that the user is entitled to, and assign that value to
 the user.
 
-This format may be specific to Shibboleth; other relying party
+If there are no matches between the user's groups and the
+___sso\_group\_level\_map___, the user will be assigned the privilege level
+specified in the ___sso\_static\_level___ variable, with a default of 0 (no access).
+This feature can be used to provide a default access level (such as read-only)
+to all authenticated users.
+
+Additionally, this format may be specific to Shibboleth; other relying party
 software may need changes to the mechanism (e.g. ___mod\_auth\_mellon___
 may create pseudo arrays).
 
@@ -527,7 +533,11 @@ If your Relying Party has a magic URL that needs to be called to end a
 session, you can configure LibreNMS to direct the user to it:
 
 ```php
-$config['post_logout_action'] = '/Shibboleth.sso/Logout';
+# Example for Shibboleth
+$config['auth_logout_handler'] = '/Shibboleth.sso/Logout';
+
+# Example for oauth2-proxy
+$config['auth_logout_handler'] = '/oauth2/sign_out';
 ```
 
 This option functions independently of the Single Sign-on mechanism.

--- a/tests/AuthSSOTest.php
+++ b/tests/AuthSSOTest.php
@@ -397,6 +397,7 @@ class AuthSSOTest extends DBTestCase
 
         $this->basicEnvironmentEnv();
 
+        Config::set('sso.static_level', 0);
         Config::set('sso.group_strategy', 'map');
         Config::set('sso.group_delimiter', ';');
         Config::set('sso.group_attr', 'member');

--- a/tests/AuthSSOTest.php
+++ b/tests/AuthSSOTest.php
@@ -418,6 +418,11 @@ class AuthSSOTest extends DBTestCase
         $_SERVER['member'] = '';
         $this->assertTrue($a->authSSOParseGroups() === 0);
 
+        // Empty with default access level
+        Config::set('sso.static_level', 5);
+        $this->assertTrue($a->authSSOParseGroups() === 5);
+        Config::forget('sso.static_level');
+
         // Null
         $_SERVER['member'] = null;
         $this->assertTrue($a->authSSOParseGroups() === 0);


### PR DESCRIPTION
Changes:
* Adds support for a default access level in the SSO authorization
  plugin when group mapping is enabled.
* Restore functionality of the auth_logout_handler configuration option,
  allowing the user to be redirected to a configured URL to complete
  logout from an external IdP.
* Documentation and test coverage updates


- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [N/A] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
