### PR TITLE
hrSystem Columns have to be optional

### DIFF
--- a/database/migrations/2021_10_03_164200_update_hrsystem_table.php
+++ b/database/migrations/2021_10_03_164200_update_hrsystem_table.php
@@ -14,9 +14,9 @@ class UpdateHrSystemTable extends Migration
     public function up()
     {
         Schema::table('hrSystem', function (Blueprint $table) {
-            $table->integer('hrSystemNumUsers')->default(0)->nullable()->change();
-            $table->integer('hrSystemProcesses')->default(0)->nullable()->change();
-            $table->integer('hrSystemMaxProcesses')->default(0)->nullable()->change();
+            $table->integer('hrSystemNumUsers')->default(null)->->change();
+            $table->integer('hrSystemProcesses')->default(null)->->change();
+            $table->integer('hrSystemMaxProcesses')->default(null)->change();
         });
     }
 
@@ -28,9 +28,9 @@ class UpdateHrSystemTable extends Migration
     public function down()
     {
         Schema::table('hrSystem', function (Blueprint $table) {
-            $table->integer('hrSystemNumUsers')->default(0)->nullable(false)->change();
-            $table->integer('hrSystemProcesses')->default(0)->nullable(false)->change();
-            $table->integer('hrSystemMaxProcesses')->default(0)->nullable(false)->change();
+            $table->integer('hrSystemNumUsers')->default(0)->change();
+            $table->integer('hrSystemProcesses')->default(0)->change();
+            $table->integer('hrSystemMaxProcesses')->default(0)->change();
         });
     }
 }

--- a/database/migrations/2021_10_03_164200_update_hrsystem_table.php
+++ b/database/migrations/2021_10_03_164200_update_hrsystem_table.php
@@ -14,9 +14,9 @@ class UpdateHrSystemTable extends Migration
     public function up()
     {
         Schema::table('hrSystem', function (Blueprint $table) {
-            $table->integer('hrSystemNumUsers')->default(null)->change();
-            $table->integer('hrSystemProcesses')->default(null)->change();
-            $table->integer('hrSystemMaxProcesses')->default(null)->change();
+            $table->integer('hrSystemNumUsers')->default(null)->nullable()->change();
+            $table->integer('hrSystemProcesses')->default(null)->nullable()->change();
+            $table->integer('hrSystemMaxProcesses')->default(null)->nullable()->change();
         });
     }
 

--- a/database/migrations/2021_10_03_164200_update_hrsystem_table.php
+++ b/database/migrations/2021_10_03_164200_update_hrsystem_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateHrSystemTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('hrSystem', function (Blueprint $table) {
+            $table->integer('hrSystemNumUsers')->default(0)->nullable()->change();
+            $table->integer('hrSystemProcesses')->default(0)->nullable()->change();
+            $table->integer('hrSystemMaxProcesses')->default(0)->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('hrSystem', function (Blueprint $table) {
+            $table->integer('hrSystemNumUsers')->default(0)->change();
+            $table->integer('hrSystemProcesses')->default(0)->change();
+            $table->integer('hrSystemMaxProcesses')->default(0)->change();
+        });
+    }
+}

--- a/database/migrations/2021_10_03_164200_update_hrsystem_table.php
+++ b/database/migrations/2021_10_03_164200_update_hrsystem_table.php
@@ -14,9 +14,9 @@ class UpdateHrSystemTable extends Migration
     public function up()
     {
         Schema::table('hrSystem', function (Blueprint $table) {
-            $table->integer('hrSystemNumUsers')->default(null)->nullable()->change();
-            $table->integer('hrSystemProcesses')->default(null)->nullable()->change();
-            $table->integer('hrSystemMaxProcesses')->default(null)->nullable()->change();
+            $table->integer('hrSystemNumUsers')->nullable()->change();
+            $table->integer('hrSystemProcesses')->nullable()->change();
+            $table->integer('hrSystemMaxProcesses')->nullable()->change();
         });
     }
 

--- a/database/migrations/2021_10_03_164200_update_hrsystem_table.php
+++ b/database/migrations/2021_10_03_164200_update_hrsystem_table.php
@@ -14,9 +14,9 @@ class UpdateHrSystemTable extends Migration
     public function up()
     {
         Schema::table('hrSystem', function (Blueprint $table) {
-            $table->integer('hrSystemNumUsers')->nullable()->change();
-            $table->integer('hrSystemProcesses')->nullable()->change();
-            $table->integer('hrSystemMaxProcesses')->nullable()->change();
+            $table->integer('hrSystemNumUsers')->nullable()->default(null)->change();
+            $table->integer('hrSystemProcesses')->nullable()->default(null)->change();
+            $table->integer('hrSystemMaxProcesses')->nullable()->default(null)->change();
         });
     }
 

--- a/database/migrations/2021_10_03_164200_update_hrsystem_table.php
+++ b/database/migrations/2021_10_03_164200_update_hrsystem_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateHrSystemTable extends Migration
+class UpdateHrSystemTable extends Migration
 {
     /**
      * Run the migrations.
@@ -28,9 +28,9 @@ class CreateHrSystemTable extends Migration
     public function down()
     {
         Schema::table('hrSystem', function (Blueprint $table) {
-            $table->integer('hrSystemNumUsers')->default(0)->change();
-            $table->integer('hrSystemProcesses')->default(0)->change();
-            $table->integer('hrSystemMaxProcesses')->default(0)->change();
+            $table->integer('hrSystemNumUsers')->default(0)->nullable(false)->change();
+            $table->integer('hrSystemProcesses')->default(0)->nullable(false)->change();
+            $table->integer('hrSystemMaxProcesses')->default(0)->nullable(false)->change();
         });
     }
 }

--- a/database/migrations/2021_10_03_164200_update_hrsystem_table.php
+++ b/database/migrations/2021_10_03_164200_update_hrsystem_table.php
@@ -14,8 +14,8 @@ class UpdateHrSystemTable extends Migration
     public function up()
     {
         Schema::table('hrSystem', function (Blueprint $table) {
-            $table->integer('hrSystemNumUsers')->default(null)->->change();
-            $table->integer('hrSystemProcesses')->default(null)->->change();
+            $table->integer('hrSystemNumUsers')->default(null)->change();
+            $table->integer('hrSystemProcesses')->default(null)->change();
             $table->integer('hrSystemMaxProcesses')->default(null)->change();
         });
     }

--- a/misc/db_schema.yaml
+++ b/misc/db_schema.yaml
@@ -733,9 +733,9 @@ hrSystem:
   Columns:
     - { Field: hrSystem_id, Type: 'int unsigned', 'Null': false, Extra: auto_increment }
     - { Field: device_id, Type: 'int unsigned', 'Null': false, Extra: '' }
-    - { Field: hrSystemNumUsers, Type: int, 'Null': false, Extra: '', Default: '0' }
-    - { Field: hrSystemProcesses, Type: int, 'Null': false, Extra: '', Default: '0' }
-    - { Field: hrSystemMaxProcesses, Type: int, 'Null': false, Extra: '', Default: '0' }
+    - { Field: hrSystemNumUsers, Type: int, 'Null': true, Extra: '', Default: '0' }
+    - { Field: hrSystemProcesses, Type: int, 'Null': true, Extra: '', Default: '0' }
+    - { Field: hrSystemMaxProcesses, Type: int, 'Null': true, Extra: '', Default: '0' }
   Indexes:
     PRIMARY: { Name: PRIMARY, Columns: [hrSystem_id], Unique: true, Type: BTREE }
     hrsystem_device_id_index: { Name: hrsystem_device_id_index, Columns: [device_id], Unique: false, Type: BTREE }

--- a/misc/db_schema.yaml
+++ b/misc/db_schema.yaml
@@ -733,9 +733,9 @@ hrSystem:
   Columns:
     - { Field: hrSystem_id, Type: 'int unsigned', 'Null': false, Extra: auto_increment }
     - { Field: device_id, Type: 'int unsigned', 'Null': false, Extra: '' }
-    - { Field: hrSystemNumUsers, Type: int, 'Null': true, Extra: '', Default: '0' }
-    - { Field: hrSystemProcesses, Type: int, 'Null': true, Extra: '', Default: '0' }
-    - { Field: hrSystemMaxProcesses, Type: int, 'Null': true, Extra: '', Default: '0' }
+    - { Field: hrSystemNumUsers, Type: int, 'Null': true, Extra: '' }
+    - { Field: hrSystemProcesses, Type: int, 'Null': true, Extra: '' }
+    - { Field: hrSystemMaxProcesses, Type: int, 'Null': true, Extra: '' }
   Indexes:
     PRIMARY: { Name: PRIMARY, Columns: [hrSystem_id], Unique: true, Type: BTREE }
     hrsystem_device_id_index: { Name: hrsystem_device_id_index, Columns: [device_id], Unique: false, Type: BTREE }


### PR DESCRIPTION
some Devices do not have all values of hrSystem
e.G. Unify Devices

`Error in hr-mib module. SQLSTATE[23000]: Integrity constraint violation: 1048 Column 'hrSystemProcesses' cannot be null (SQL: insert into `hrSystem` (`device_id`, `hrSystemNumUsers`, `hrSystemProcesses`, `hrSystemMaxProcesses`) values (18, 0, ?, 0))
`

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
