### PR TITLE
Allow non-snmp modules to run when snmp disabled

### DIFF
--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -292,11 +292,9 @@ function poll_device($device, $force_module = false)
     $response = device_is_up($device, true);
 
     if ($response['status'] == '1') {
-        if ($device['snmp_disable']) {
-            Config::set('poller_modules', ['availability' => true]);
-        } else {
+        if (! $device['snmp_disable']) {
             // we always want the core module to be included, prepend it
-            Config::set('poller_modules', ['core' => true, 'availability' => true] + Config::get('poller_modules'));
+            Config::set('poller_modules', ['core' => true] + Config::get('poller_modules'));
         }
 
         printChangedStats(true); // don't count previous stats

--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -294,7 +294,14 @@ function poll_device($device, $force_module = false)
     $helper->saveMetrics();
 
     if ($helper->isUp()) {
-        if (! $device['snmp_disable']) {
+        if ($device['snmp_disable']) {
+            // only non-snmp modules
+            Config::set('poller_modules', array_intersect_key(Config::get('poller_modules'), [
+                'availability' => true,
+                'ipmi' => true,
+                'unix-agent' => true,
+            ]));
+        } else {
             // we always want the core module to be included, prepend it
             Config::set('poller_modules', ['core' => true] + Config::get('poller_modules'));
         }

--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -4360,6 +4360,13 @@
             "default": true,
             "type": "boolean"
         },
+        "poller_modules.availability": {
+            "order": 25,
+            "group": "poller",
+            "section": "poller_modules",
+            "default": true,
+            "type": "boolean"
+        },
         "poller_modules.ipmi": {
             "order": 210,
             "group": "poller",


### PR DESCRIPTION
availability, ipmi, unix-agent

This also allows them to be disabled. (notably the availability module was not able to be disabled)


#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
