### PR TITLE
Rename config var auth_redirect_handler -> auth_logout_handler

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -59,6 +59,6 @@ class LoginController extends Controller
 
     protected function loggedOut(Request $request)
     {
-        return redirect(Config::get('auth_redirect_handler', $this->redirectTo));
+        return redirect(Config::get('auth_logout_handler', $this->redirectTo));
     }
 }


### PR DESCRIPTION
This change addresses a typo introduced in the refactor of
https://github.com/librenms/librenms/pull/13311/commits/d4325a2e9ef9c324af84d4b5840e2d1047bc1ad9
which makes the variable name inconsistent with the documentation (https://docs.librenms.org/Extensions/Authentication/#logout-behaviour).

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
