### PR TITLE
Show single quotes correcting for device configs

### DIFF
--- a/includes/html/pages/device/showconfig.inc.php
+++ b/includes/html/pages/device/showconfig.inc.php
@@ -301,7 +301,7 @@ if (Auth::user()->hasGlobalAdmin()) {
     }
     if (! empty($text)) {
         $language = isset($previous_config) ? 'diff' : Config::getOsSetting($device['os'], 'config_highlighting', 'ios');
-        $geshi = new GeSHi(htmlspecialchars_decode($text, ENT_QUOTES), $language);
+        $geshi = new GeSHi(htmlspecialchars_decode($text, ENT_QUOTES | ENT_HTML5), $language);
         $geshi->enable_line_numbers(GESHI_FANCY_LINE_NUMBERS);
         $geshi->set_overall_style('color: black;');
         // $geshi->set_line_style('color: #999999');


### PR DESCRIPTION
Previously single quote/apostrophes weren't being decoded correctly from \&apos;, leading to configs being misrepresented in LibreNMS. ENT_HTML5 allows for proper decoding.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
