### PR TITLE
Dispatcher: Fix poller groups reverting when setting via the Web UI.

### DIFF
--- a/LibreNMS/service.py
+++ b/LibreNMS/service.py
@@ -794,13 +794,12 @@ class Service:
         try:
             # Report on the poller instance as a whole
             self._db.query(
-                "INSERT INTO poller_cluster(node_id, poller_name, poller_version, poller_groups, last_report, master) "
-                'values("{0}", "{1}", "{2}", "{3}", NOW(), {4}) '
-                'ON DUPLICATE KEY UPDATE poller_version="{2}", last_report=NOW(), master={4}; '.format(
+                "INSERT INTO poller_cluster(node_id, poller_name, poller_version, last_report, master) "
+                'values("{0}", "{1}", "{2}", NOW(), {3}) '
+                'ON DUPLICATE KEY UPDATE poller_version="{2}", last_report=NOW(), master={3}; '.format(
                     self.config.node_id,
                     self.config.name,
                     "librenms-service",
-                    ",".join(str(g) for g in self.config.group),
                     1 if self.is_master else 0,
                 )
             )


### PR DESCRIPTION
Don't update poller groups when updating stats.

Allows updates to the poller groups via the webui, but also means that changes to the local config.php won't be reflected if the groups have been set in the webui.  Also, the webui might show the wrong groups if it is controlled by config.php only.

Chose this way as it is backwards compatible.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
