### PR TITLE
fix windows fanspeed

### DIFF
--- a/includes/discovery/sensors/fanspeed/windows.inc.php
+++ b/includes/discovery/sensors/fanspeed/windows.inc.php
@@ -2,4 +2,4 @@
 
 use LibreNMS\Config;
 
-include_once Config::get('install_dir') . '/includes/discovery/sensors/fanspeeds/supermicro.inc.php';
+include_once Config::get('install_dir') . '/includes/discovery/sensors/fanspeed/supermicro.inc.php';


### PR DESCRIPTION
this fixes the wrong folder its looking for the windows supermicro php file
```
Fanspeed: 
Warning: include_once(/opt/librenms/includes/discovery/sensors/fanspeeds/supermicro.inc.php): failed to open stream: No such file or directory in /opt/librenms/includes/discovery/sensors/fanspeed/windows.inc.php on line 5

Warning: include_once(): Failed opening '/opt/librenms/includes/discovery/sensors/fanspeeds/supermicro.inc.php' for inclusion (include_path='.:/usr/share/php') in /opt/librenms/includes/discovery/sensors/fanspeed/windows.inc.php on line 5
array (
)  
SQL[SELECT * FROM sensors AS S, devices AS D WHERE S.sensor_class=? AND S.device_id = D.device_id AND D.device_id = ? AND S.poller_type = ? ["fanspeed",19,"snmp"] 0.53ms] 
  
```

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
