### PR TITLE
Fix Dispatcher service not discovering poller groups

### DIFF
--- a/LibreNMS/queuemanager.py
+++ b/LibreNMS/queuemanager.py
@@ -527,7 +527,7 @@ class DiscoveryQueueManager(TimedQueueManager):
         :param lock_manager: the single instance of lock manager
         """
         TimedQueueManager.__init__(
-            self, config, lock_manager, "discovery", False, config.discovery.enabled
+            self, config, lock_manager, "discovery", True, config.discovery.enabled
         )
         self._db = LibreNMS.DB(self.config)
 


### PR DESCRIPTION
The discovery workers were not monitoring non-default poller group queues

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
