### PR TITLE
bug - Fix missing uptime in fillable (Device Model)

### DIFF
--- a/app/Models/Device.php
+++ b/app/Models/Device.php
@@ -67,6 +67,7 @@ class Device extends BaseModel
         'timeout',
         'transport',
         'version',
+        'uptime',
     ];
 
     protected $casts = [


### PR DESCRIPTION
fixes #13386 

Seems that uptime is not fillable, but it used in the new rewrite of Core Module. This fixes it. A few devices in my master instance failed with uptime

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
