### PR TITLE
Fix uptime polling event

### DIFF
--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -406,7 +406,10 @@ function poll_device($device, $force_module = false)
             echo PHP_EOL;
         }
 
-        $updated = dbUpdate($update_array, 'devices', '`device_id` = ?', [$device['device_id']]);
+        $updated = false;
+        if (! empty($update_array)) {
+            $updated = dbUpdate($update_array, 'devices', '`device_id` = ?', [$device['device_id']]);
+        }
         if ($updated) {
             d_echo('Updating ' . $device['hostname'] . PHP_EOL);
         }


### PR DESCRIPTION
was comparing the wrong values sysUpTime (ms) vs calculated uptime (s)
move uptime code into a method to improve readability
Stored uptime was correct in most cases.
Also fix error with empty update array I encountered while testing.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
