### PR TITLE
Luminato device doesn't support alternative uptimes

### DIFF
--- a/includes/definitions/luminato.yaml
+++ b/includes/definitions/luminato.yaml
@@ -4,6 +4,8 @@ type: network
 icon: teleste
 group: luminato
 mib_dir: teleste
+bad_snmpEngineTime: true
+bad_hrSystemUptime: true
 over:
     - { graph: device_bits, text: 'Device Traffic' }
 discovery:


### PR DESCRIPTION
We have some Luminato devices on our network, and I needed to disable the HR uptime SNMP polling because the devices are not returning valid data.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
