### PR TITLE
Poller optimisations

### DIFF
--- a/LibreNMS/wrapper.py
+++ b/LibreNMS/wrapper.py
@@ -310,9 +310,8 @@ def poll_worker(
                                 command,
                                 shell=True,
                                 stdin=subprocess.PIPE,
-                                stdout=subprocess.PIPE
+                                stdout=subprocess.PIPE,
                             )
-
 
                     # This is the string that will signify the end of the poller process
                     endofinput = "### Poll of " + str(device_id) + " complete ###"
@@ -497,8 +496,9 @@ def wrapper(
     target_polltime = STEPPING * 0.95
     if _lockfile != None:
         import fcntl
+
         try:
-            lockfd = open(_lockfile, mode='w')
+            lockfd = open(_lockfile, mode="w")
             fcntl.lockf(lockfd, fcntl.LOCK_EX)
 
             # Do not proceed if it took too long to acquire the lock
@@ -506,13 +506,19 @@ def wrapper(
             if (c_time - s_time) > (STEPPING * _lockwait / 100):
                 fcntl.lockf(lockfd, fcntl.LOCK_UN)
                 lockfd.close()
-                logger.critical("It took too long ({}) to acquire the file lock - exiting.".format(c_time - s_time))
+                logger.critical(
+                    "It took too long ({}) to acquire the file lock - exiting.".format(
+                        c_time - s_time
+                    )
+                )
                 sys.exit(2)
 
             # Re-calculate the target poll time by subtracting the lock time from the stepping
             target_polltime = (s_time - c_time + STEPPING) * 0.95
         except Exception:
-            logger.critical("Could not open lock file {} for writing.".format(_lockfile))
+            logger.critical(
+                "Could not open lock file {} for writing.".format(_lockfile)
+            )
             raise
             sys.exit(2)
 
@@ -702,6 +708,7 @@ def wrapper(
     # Unlock and close the lockfile if needed
     if _lockfile != None:
         import fcntl
+
         fcntl.lockf(lockfd, fcntl.LOCK_UN)
         lockfd.close()
 

--- a/LibreNMS/wrapper.py
+++ b/LibreNMS/wrapper.py
@@ -364,7 +364,6 @@ def poll_worker(
                         with open(device_log, "w", encoding="utf-8") as dev_log_file:
                             dev_log_file.write(output)
 
-
                 elapsed_time = int(time.time() - start_time)
                 print_queue.put(
                     [
@@ -388,7 +387,6 @@ def poll_worker(
         poller.stdout.close()
         while poller.returncode is None:
             poller.wait()
-
 
 class DBConfig:
     """

--- a/LibreNMS/wrapper.py
+++ b/LibreNMS/wrapper.py
@@ -311,7 +311,7 @@ def poll_worker(
                             command,
                             shell=True,
                             stdin=subprocess.PIPE,
-                            stdout=subprocess.PIPE
+                            stdout=subprocess.PIPE,
                         )
 
                 # This is the string that will signify the end of the poller process

--- a/LibreNMS/wrapper.py
+++ b/LibreNMS/wrapper.py
@@ -387,6 +387,7 @@ def poll_worker(
         while poller.returncode is None:
             poller.wait()
 
+
 class DBConfig:
     """
     Bare minimal config class for LibreNMS.service.DB class usage

--- a/LibreNMS/wrapper.py
+++ b/LibreNMS/wrapper.py
@@ -618,8 +618,13 @@ def wrapper(
         else:
             amount_of_workers = est_workers
 
+    if all_poll_time > 0:
+        fast_pct = fast_poll_time / all_poll_time
+    else:
+        fast_pct = 0.5
+
     # Work out how many fast workers are needed as a percent of the total time
-    amount_of_fast_workers = int(amount_of_workers * fast_poll_time / all_poll_time) + 1
+    amount_of_fast_workers = int(amount_of_workers * fast_pct) + 1
     if amount_of_fast_workers == 0:
         amount_of_fast_workers = 1
     if amount_of_fast_workers > amount_of_workers:

--- a/LibreNMS/wrapper.py
+++ b/LibreNMS/wrapper.py
@@ -238,7 +238,7 @@ def poll_worker(
 
     global ERRORS
 
-    if persistent and not DISTRIBUTED_POLLING:
+    if persistent:
         executable = os.path.join(
             os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
             wrappers[wrapper_type]["executable"],
@@ -381,7 +381,7 @@ def poll_worker(
         poll_queue.task_done()
 
     # Close and clean up the poller process
-    if persistent and not DISTRIBUTED_POLLING:
+    if persistent:
         poller.stdin.close()
         poller.stdout.close()
         while poller.returncode is None:

--- a/poller-wrapper.py
+++ b/poller-wrapper.py
@@ -92,17 +92,13 @@ try:
 except (IndexError, ValueError):
     lockwait = DEFAULT_LOCKWAIT
     logger.warning(
-        "Bogus lock wait time given. Using default {}% of step time.".format(
-            lockwait
-        )
+        "Bogus lock wait time given. Using default {}% of step time.".format(lockwait)
     )
 
 if lockwait < 0 or lockwait >= 100:
     lockwait = DEFAULT_LOCKWAIT
     logger.warning(
-        "Bogus lock wait time given. Using default {}% of step time.".format(
-            lockwait
-        )
+        "Bogus lock wait time given. Using default {}% of step time.".format(lockwait)
     )
 
 wrapper.wrapper(


### PR DESCRIPTION
Update the poller and wrapper to improve the efficiency of the poller process. On our system the average CPU usage reduced from 70% to 60% as a result of these changes, and also resulted in the same number of threads being able to poll the devices in less time.

The efficiency is gained by:

Running a persistent copy of the poller for each worker during each polling run. This removes the overhead of compiling PHP for each device polled (even with opcache enabled)
Splitting the workload into 2 queues, and processing the devices that poll fastest from fastest to slowest, while still polling the devices that poll slowest in from slowest to fastest.
Splitting the worker threads so there are more threads assigned to the "slow" devices.
Calculating the number of threads required to completed the poll in less than the $STEP time, and using the command-line value as the maximum
The net result of 2 and 3 above is that the instant CPU load from the "fast" devices is reduced because there are less threads processing these devices. As the time taken to poll each "slow" devices speeds up, the time taken to poll each "fast" device slows down. This results in a more even flow of poll results into the database and time series database.

The net result of 4 above is that the polling load is spread evenly, and we don't try and run at 100% for a short time, then sit idle for the remainder of the polling time.

To answer the questions from PR13398:
 - There is no problem if the poller is being re-worked.  I think that if these changes can be merged immediately, we can see immediate improvements.  I would hope that any future improvements to the poller would try to achieve the same results (spread the CPU load over the whole polling interval, and reduce the number of times the poller process is forked).  
 - The code still polls the slowest devices first, so it still makes sure the slowest device gets polled in time.  It just adds another set of workers to poll the fastest devices in parallel to make better use of the CPU, and avoid a big spike in CPU use at the end of the polling run when all workers are polling "fast" devices.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
