### PR TITLE
Fix APC high precision divisor

### DIFF
--- a/includes/discovery/sensors/temperature/apc.inc.php
+++ b/includes/discovery/sensors/temperature/apc.inc.php
@@ -9,7 +9,7 @@ if (! $oids) {
     // upsAdvBatteryTemperature, used in case high precision is not available
     $oids = snmp_get($device, '.1.3.6.1.4.1.318.1.1.1.2.2.2.0', '-OsqnU', '');
     d_echo($oids . "\n");
-    $divisor = 1;
+    $precision = 1;
 }
 
 if ($oids) {


### PR DESCRIPTION
Fixes the wrong temperature multiplier in APC devices . In case high precision is not available and using older APC firmware

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
