### PR TITLE
PHP8 Unit Conversion, Sensor.php

### DIFF
--- a/LibreNMS/Device/Sensor.php
+++ b/LibreNMS/Device/Sensor.php
@@ -412,11 +412,11 @@ class Sensor implements DiscoveryModule, PollerModule
             }
 
             if ($sensor['sensor_divisor'] && $sensor_value !== 0) {
-                $sensor_value = ($sensor_value / $sensor['sensor_divisor']);
+                $sensor_value = (cast_number($sensor_value) / $sensor['sensor_divisor']);
             }
 
             if ($sensor['sensor_multiplier']) {
-                $sensor_value = ($sensor_value * $sensor['sensor_multiplier']);
+                $sensor_value = (cast_number($sensor_value) * $sensor['sensor_multiplier']);
             }
 
             $sensor_data[$sensor['sensor_id']] = $sensor_value;


### PR DESCRIPTION
To address the error seen in librenms.log (and failing poller.php),
```
[2021-10-24 00:00:08] production.ERROR: Unsupported operand types: string / int {"exception":"[object] (TypeError(code: 0): Unsupported operand types: string / int at /opt/librenms/LibreNMS/Device/Sensor.php:415)
```

Fix is to address update to PHP8,

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
