### PR TITLE
Fix typo in filepath for unit-tests to work

### DIFF
--- a/doc/Installation/Installation-Debian-11-Nginx.md
+++ b/doc/Installation/Installation-Debian-11-Nginx.md
@@ -1,4 +1,4 @@
-source: Installation/Installation1Debian-11-Nginx.md
+source: Installation/Installation-Debian-11-Nginx.md
 path: blob/master/doc/
 
 > NOTE: These instructions assume you are the **root** user.  If you


### PR DESCRIPTION
Typo is making unit-tests fail.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
