### PR TITLE
Better handling of some alerting errors

### DIFF
--- a/LibreNMS/Alert/AlertUtil.php
+++ b/LibreNMS/Alert/AlertUtil.php
@@ -93,19 +93,19 @@ class AlertUtil
         $uids = [];
         foreach ($results as $result) {
             $tmp = null;
-            if (is_numeric($result['bill_id'])) {
+            if (isset($result['bill_id']) && is_numeric($result['bill_id'])) {
                 $tmpa = dbFetchRows('SELECT user_id FROM bill_perms WHERE bill_id = ?', [$result['bill_id']]);
                 foreach ($tmpa as $tmp) {
                     $uids[$tmp['user_id']] = $tmp['user_id'];
                 }
             }
-            if (is_numeric($result['port_id'])) {
+            if (isset($result['port_id']) && is_numeric($result['port_id'])) {
                 $tmpa = dbFetchRows('SELECT user_id FROM ports_perms WHERE port_id = ?', [$result['port_id']]);
                 foreach ($tmpa as $tmp) {
                     $uids[$tmp['user_id']] = $tmp['user_id'];
                 }
             }
-            if (is_numeric($result['device_id'])) {
+            if (isset($result['device_id']) && is_numeric($result['device_id'])) {
                 if (Config::get('alert.syscontact') == true) {
                     if (dbFetchCell("SELECT attrib_value FROM devices_attribs WHERE attrib_type = 'override_sysContact_bool' AND device_id = ?", [$result['device_id']])) {
                         $tmpa = dbFetchCell("SELECT attrib_value FROM devices_attribs WHERE attrib_type = 'override_sysContact_string' AND device_id = ?", [$result['device_id']]);

--- a/LibreNMS/Alert/Transport.php
+++ b/LibreNMS/Alert/Transport.php
@@ -65,12 +65,12 @@ abstract class Transport implements TransportInterface
      * @param  string  $input
      * @return array
      */
-    protected function parseUserOptions($input)
+    protected function parseUserOptions(string $input): array
     {
         $options = [];
-        foreach (explode(PHP_EOL, $input) as $option) {
+        foreach (preg_split('/\\r\\n|\\r|\\n/', $input, -1, PREG_SPLIT_NO_EMPTY) as $option) {
             if (Str::contains($option, '=')) {
-                [$k,$v] = explode('=', $option, 2);
+                [$k, $v] = explode('=', $option, 2);
                 $options[$k] = trim($v);
             }
         }

--- a/LibreNMS/Alert/Transport/Api.php
+++ b/LibreNMS/Alert/Transport/Api.php
@@ -24,6 +24,7 @@
 
 namespace LibreNMS\Alert\Transport;
 
+use App\View\SimpleTemplate;
 use LibreNMS\Alert\Transport;
 use LibreNMS\Util\Proxy;
 
@@ -46,31 +47,14 @@ class Api extends Transport
     private function contactAPI($obj, $api, $options, $method, $auth, $headers, $body)
     {
         $request_opts = [];
-        $request_heads = [];
-        $query = [];
 
         $method = strtolower($method);
         $host = explode('?', $api, 2)[0]; //we don't use the parameter part, cause we build it out of options.
 
         //get each line of key-values and process the variables for Headers;
-        foreach (preg_split('/\\r\\n|\\r|\\n/', $headers, -1, PREG_SPLIT_NO_EMPTY) as $current_line) {
-            [$u_key, $u_val] = explode('=', $current_line, 2);
-            foreach ($obj as $p_key => $p_val) {
-                $u_val = str_replace('{{ $' . $p_key . ' }}', $p_val, $u_val);
-            }
-            //store the parameter in the array for HTTP headers
-            $request_heads[$u_key] = $u_val;
-        }
+        $request_heads = $this->parseUserOptions(SimpleTemplate::parse($headers, $obj));
         //get each line of key-values and process the variables for Options;
-        foreach (preg_split('/\\r\\n|\\r|\\n/', $options, -1, PREG_SPLIT_NO_EMPTY) as $current_line) {
-            [$u_key, $u_val] = explode('=', $current_line, 2);
-            // Replace the values
-            foreach ($obj as $p_key => $p_val) {
-                $u_val = str_replace('{{ $' . $p_key . ' }}', $p_val, $u_val);
-            }
-            //store the parameter in the array for HTTP query
-            $query[$u_key] = $u_val;
-        }
+        $query = $this->parseUserOptions(SimpleTemplate::parse($options, $obj));
 
         $client = new \GuzzleHttp\Client();
         $request_opts['proxy'] = Proxy::forGuzzle();
@@ -89,10 +73,7 @@ class Api extends Transport
             $res = $client->request('PUT', $host, $request_opts);
         } else { //Method POST
             $request_opts['query'] = $query;
-            foreach ($obj as $metric => $value) {
-                $body = str_replace('{{ $' . $metric . ' }}', $value, $body);
-            }
-            $request_opts['body'] = $body;
+            $request_opts['body'] = SimpleTemplate::parse($body, $obj);
             $res = $client->request('POST', $host, $request_opts);
         }
 

--- a/LibreNMS/Alert/Transport/Matrix.php
+++ b/LibreNMS/Alert/Transport/Matrix.php
@@ -23,6 +23,7 @@
 
 namespace LibreNMS\Alert\Transport;
 
+use App\View\SimpleTemplate;
 use LibreNMS\Alert\Transport;
 use LibreNMS\Util\Proxy;
 
@@ -51,9 +52,7 @@ class Matrix extends Transport
         $request_heads['Content-Type'] = 'application/json';
         $request_heads['Accept'] = 'application/json';
 
-        foreach ($obj as $p_key => $p_val) {
-            $message = str_replace('{{ $' . $p_key . ' }}', $p_val, $message);
-        }
+        $message = SimpleTemplate::parse($message, $obj);
 
         $body = ['body'=>$message, 'msgtype'=>'m.text'];
 

--- a/LibreNMS/Alert/Transport/Rocket.php
+++ b/LibreNMS/Alert/Transport/Rocket.php
@@ -28,6 +28,8 @@ use LibreNMS\Util\Proxy;
 
 class Rocket extends Transport
 {
+    protected $name = 'Rocket Chat';
+
     public function deliverAlert($obj, $opts)
     {
         $rocket_opts = $this->parseUserOptions($this->config['rocket-options']);
@@ -51,10 +53,10 @@ class Rocket extends Transport
                     'text' => $rocket_msg,
                 ],
             ],
-            'channel' => $api['channel'],
-            'username' => $api['username'],
-            'icon_url' => $api['icon_url'],
-            'icon_emoji' => $api['icon_emoji'],
+            'channel' => $api['channel'] ?? null,
+            'username' => $api['username'] ?? null,
+            'icon_url' => $api['icon_url'] ?? null,
+            'icon_emoji' => $api['icon_emoji'] ?? null,
         ];
         $alert_message = json_encode($data);
         curl_setopt($curl, CURLOPT_HTTPHEADER, ['Content-Type: application/json']);

--- a/LibreNMS/Device/YamlDiscovery.php
+++ b/LibreNMS/Device/YamlDiscovery.php
@@ -175,7 +175,7 @@ class YamlDiscovery
             foreach (explode('.', $index) as $pos => $subindex) {
                 $variables['subindex' . $pos] = $subindex;
             }
-            $value = SimpleTemplate::parse($value, $variables);
+            $value = SimpleTemplate::parse($def[$name] ?? '', $variables);
 
             // search discovery data for values
             $template = new SimpleTemplate($value);

--- a/LibreNMS/Device/YamlDiscovery.php
+++ b/LibreNMS/Device/YamlDiscovery.php
@@ -175,7 +175,7 @@ class YamlDiscovery
             foreach (explode('.', $index) as $pos => $subindex) {
                 $variables['subindex' . $pos] = $subindex;
             }
-            $value = SimpleTemplate::parse($def[$name] ?? '', $variables);
+            $value = (string) (new SimpleTemplate($def[$name] ?? '', $variables))->keepEmptyTemplates();
 
             // search discovery data for values
             $template = new SimpleTemplate($value);

--- a/LibreNMS/OS/Traits/YamlOSDiscovery.php
+++ b/LibreNMS/OS/Traits/YamlOSDiscovery.php
@@ -27,6 +27,7 @@ namespace LibreNMS\OS\Traits;
 
 use App\Models\Device;
 use App\Models\Location;
+use App\View\SimpleTemplate;
 use Illuminate\Support\Arr;
 use LibreNMS\Util\StringHelpers;
 use Log;
@@ -75,7 +76,7 @@ trait YamlOSDiscovery
                 }
 
                 $device->$field = isset($os_yaml["{$field}_template"])
-                    ? $this->parseTemplate($os_yaml["{$field}_template"], $data)
+                    ? SimpleTemplate::parse($os_yaml["{$field}_template"], $data)
                     : $value;
             }
         }
@@ -129,13 +130,6 @@ trait YamlOSDiscovery
                 }
             }
         }
-    }
-
-    private function parseTemplate($template, $data)
-    {
-        return trim(preg_replace_callback('/{{ ([^ ]+) }}/', function ($matches) use ($data) {
-            return $data[$matches[1]] ?? '';
-        }, $template));
     }
 
     private function translateSysObjectID($mib, $regex)

--- a/LibreNMS/OS/Traits/YamlOSDiscovery.php
+++ b/LibreNMS/OS/Traits/YamlOSDiscovery.php
@@ -76,7 +76,7 @@ trait YamlOSDiscovery
                 }
 
                 $device->$field = isset($os_yaml["{$field}_template"])
-                    ? SimpleTemplate::parse($os_yaml["{$field}_template"], $data)
+                    ? trim(SimpleTemplate::parse($os_yaml["{$field}_template"], $data))
                     : $value;
             }
         }

--- a/LibreNMS/Util/StringHelpers.php
+++ b/LibreNMS/Util/StringHelpers.php
@@ -25,8 +25,6 @@
 
 namespace LibreNMS\Util;
 
-use Stringable;
-
 class StringHelpers
 {
     /**
@@ -157,6 +155,6 @@ class StringHelpers
      */
     public static function isStringable($var): bool
     {
-        return $var === null || is_scalar($var) || $var instanceof Stringable;
+        return $var === null || is_scalar($var) || (is_object($var) && method_exists($var, '__toString'));
     }
 }

--- a/LibreNMS/Util/StringHelpers.php
+++ b/LibreNMS/Util/StringHelpers.php
@@ -25,6 +25,8 @@
 
 namespace LibreNMS\Util;
 
+use Stringable;
+
 class StringHelpers
 {
     /**
@@ -145,5 +147,16 @@ class StringHelpers
         }, $class);
 
         return $namespace . $class;
+    }
+
+    /**
+     * Check if variable can be cast to a string
+     *
+     * @param  mixed  $var
+     * @return bool
+     */
+    public static function isStringable($var): bool
+    {
+        return $var === null || is_scalar($var) || $var instanceof Stringable;
     }
 }

--- a/app/Http/Controllers/AlertTransportController.php
+++ b/app/Http/Controllers/AlertTransportController.php
@@ -44,7 +44,8 @@ class AlertTransportController extends Controller
                 return response()->json(['status' => 'ok']);
             }
         } catch (\Exception $e) {
-            $result = $e->getMessage();
+            \Log::error($e);
+            $result = basename($e->getFile(), '.php') . ':' . $e->getLine() . ' ' . $e->getMessage();
         }
 
         return response()->json([

--- a/app/View/SimpleTemplate.php
+++ b/app/View/SimpleTemplate.php
@@ -52,14 +52,25 @@ class SimpleTemplate
         $this->variables = $variables;
     }
 
-    public function setVariable(string $key, string $value): void
+    /**
+     * Add a variable to the set of possible substitutions
+     */
+    public function setVariable(string $key, string $value): SimpleTemplate
     {
         $this->variables[$key] = $value;
+
+        return $this;
     }
 
-    public function replaceWith(callable $callback): void
+    /**
+     * Instead of using the given variables to replace {{ var }}
+     * send the matched variable to this callback, which will return a string to replace it
+     */
+    public function replaceWith(callable $callback): SimpleTemplate
     {
         $this->callback = $callback;
+
+        return $this;
     }
 
     /**
@@ -85,5 +96,4 @@ class SimpleTemplate
             return $replacement;
         }, $this->template);
     }
-
 }

--- a/app/View/SimpleTemplate.php
+++ b/app/View/SimpleTemplate.php
@@ -45,11 +45,25 @@ class SimpleTemplate
      * @var callable
      */
     private $callback;
+    /**
+     * @var bool
+     */
+    private $keepEmpty = false;
 
     public function __construct(string $template, array $variables = [])
     {
         $this->template = $template;
         $this->variables = $variables;
+    }
+
+    /**
+     * By default, unmatched templates will be removed from the output, set this to keep them
+     */
+    public function keepEmptyTemplates(): SimpleTemplate
+    {
+        $this->keepEmpty = true;
+
+        return $this;
     }
 
     /**
@@ -88,7 +102,7 @@ class SimpleTemplate
     public function __toString()
     {
         return preg_replace_callback($this->regex, $this->callback ?? function ($matches) {
-            $replacement = $this->variables[$matches[1]] ?? $matches[0];
+            $replacement = $this->variables[$matches[1]] ?? ($this->keepEmpty ? $matches[0] : '');
             if (! StringHelpers::isStringable($replacement)) {
                 return '';
             }

--- a/app/View/SimpleTemplate.php
+++ b/app/View/SimpleTemplate.php
@@ -1,0 +1,89 @@
+<?php
+/*
+ * SimpleTemplate.php
+ *
+ * Simple variable substitution template
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @package    LibreNMS
+ * @link       http://librenms.org
+ * @copyright  2021 Tony Murray
+ * @author     Tony Murray <murraytony@gmail.com>
+ */
+
+namespace App\View;
+
+use LibreNMS\Util\StringHelpers;
+
+class SimpleTemplate
+{
+    /**
+     * @var string
+     */
+    private $template;
+    /**
+     * @var array
+     */
+    private $variables;
+    /**
+     * @var string
+     */
+    private $regex = '/{{ \$?([a-zA-Z0-9\-_.:]+) }}/';
+    /**
+     * @var callable
+     */
+    private $callback;
+
+    public function __construct(string $template, array $variables = [])
+    {
+        $this->template = $template;
+        $this->variables = $variables;
+    }
+
+    public function setVariable(string $key, string $value): void
+    {
+        $this->variables[$key] = $value;
+    }
+
+    public function replaceWith(callable $callback): void
+    {
+        $this->callback = $callback;
+    }
+
+    /**
+     * Create and parse a simple template
+     *
+     * @param  string  $template
+     * @param  array  $variables
+     * @return string
+     */
+    public static function parse(string $template, array $variables): string
+    {
+        return (string) new static($template, $variables);
+    }
+
+    public function __toString()
+    {
+        return preg_replace_callback($this->regex, $this->callback ?? function ($matches) {
+            $replacement = $this->variables[$matches[1]] ?? '';
+            if (! StringHelpers::isStringable($replacement)) {
+                return '';
+            }
+
+            return $replacement;
+        }, $this->template);
+    }
+
+}

--- a/app/View/SimpleTemplate.php
+++ b/app/View/SimpleTemplate.php
@@ -88,7 +88,7 @@ class SimpleTemplate
     public function __toString()
     {
         return preg_replace_callback($this->regex, $this->callback ?? function ($matches) {
-            $replacement = $this->variables[$matches[1]] ?? '';
+            $replacement = $this->variables[$matches[1]] ?? $matches[0];
             if (! StringHelpers::isStringable($replacement)) {
                 return '';
             }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3821,21 +3821,6 @@ parameters:
 			path: LibreNMS/OS.php
 
 		-
-			message: "#^Method LibreNMS\\\\OS\\:\\:parseTemplate\\(\\) has no return typehint specified\\.$#"
-			count: 1
-			path: LibreNMS/OS.php
-
-		-
-			message: "#^Method LibreNMS\\\\OS\\:\\:parseTemplate\\(\\) has parameter \\$data with no typehint specified\\.$#"
-			count: 1
-			path: LibreNMS/OS.php
-
-		-
-			message: "#^Method LibreNMS\\\\OS\\:\\:parseTemplate\\(\\) has parameter \\$template with no typehint specified\\.$#"
-			count: 1
-			path: LibreNMS/OS.php
-
-		-
 			message: "#^Method LibreNMS\\\\OS\\:\\:persistGraphs\\(\\) has no return typehint specified\\.$#"
 			count: 1
 			path: LibreNMS/OS.php
@@ -4376,21 +4361,6 @@ parameters:
 			path: LibreNMS/OS/Shared/Cisco.php
 
 		-
-			message: "#^Method LibreNMS\\\\OS\\\\Shared\\\\Cisco\\:\\:parseTemplate\\(\\) has no return typehint specified\\.$#"
-			count: 1
-			path: LibreNMS/OS/Shared/Cisco.php
-
-		-
-			message: "#^Method LibreNMS\\\\OS\\\\Shared\\\\Cisco\\:\\:parseTemplate\\(\\) has parameter \\$data with no typehint specified\\.$#"
-			count: 1
-			path: LibreNMS/OS/Shared/Cisco.php
-
-		-
-			message: "#^Method LibreNMS\\\\OS\\\\Shared\\\\Cisco\\:\\:parseTemplate\\(\\) has parameter \\$template with no typehint specified\\.$#"
-			count: 1
-			path: LibreNMS/OS/Shared/Cisco.php
-
-		-
 			message: "#^Method LibreNMS\\\\OS\\\\Shared\\\\Cisco\\:\\:pollSlas\\(\\) has no return typehint specified\\.$#"
 			count: 1
 			path: LibreNMS/OS/Shared/Cisco.php
@@ -4531,21 +4501,6 @@ parameters:
 			path: LibreNMS/OS/Shared/Unix.php
 
 		-
-			message: "#^Method LibreNMS\\\\OS\\\\Shared\\\\Unix\\:\\:parseTemplate\\(\\) has no return typehint specified\\.$#"
-			count: 1
-			path: LibreNMS/OS/Shared/Unix.php
-
-		-
-			message: "#^Method LibreNMS\\\\OS\\\\Shared\\\\Unix\\:\\:parseTemplate\\(\\) has parameter \\$data with no typehint specified\\.$#"
-			count: 1
-			path: LibreNMS/OS/Shared/Unix.php
-
-		-
-			message: "#^Method LibreNMS\\\\OS\\\\Shared\\\\Unix\\:\\:parseTemplate\\(\\) has parameter \\$template with no typehint specified\\.$#"
-			count: 1
-			path: LibreNMS/OS/Shared/Unix.php
-
-		-
 			message: "#^Method LibreNMS\\\\OS\\\\Shared\\\\Unix\\:\\:translateSysObjectID\\(\\) has no return typehint specified\\.$#"
 			count: 1
 			path: LibreNMS/OS/Shared/Unix.php
@@ -4622,21 +4577,6 @@ parameters:
 
 		-
 			message: "#^Method LibreNMS\\\\OS\\\\Shared\\\\Zyxel\\:\\:parseRegex\\(\\) has parameter \\$subject with no typehint specified\\.$#"
-			count: 1
-			path: LibreNMS/OS/Shared/Zyxel.php
-
-		-
-			message: "#^Method LibreNMS\\\\OS\\\\Shared\\\\Zyxel\\:\\:parseTemplate\\(\\) has no return typehint specified\\.$#"
-			count: 1
-			path: LibreNMS/OS/Shared/Zyxel.php
-
-		-
-			message: "#^Method LibreNMS\\\\OS\\\\Shared\\\\Zyxel\\:\\:parseTemplate\\(\\) has parameter \\$data with no typehint specified\\.$#"
-			count: 1
-			path: LibreNMS/OS/Shared/Zyxel.php
-
-		-
-			message: "#^Method LibreNMS\\\\OS\\\\Shared\\\\Zyxel\\:\\:parseTemplate\\(\\) has parameter \\$template with no typehint specified\\.$#"
 			count: 1
 			path: LibreNMS/OS/Shared/Zyxel.php
 

--- a/tests/Unit/Util/StringHelperTest.php
+++ b/tests/Unit/Util/StringHelperTest.php
@@ -61,7 +61,8 @@ class StringHelperTest extends TestCase
         $this->assertFalse(StringHelpers::isStringable([]));
         $this->assertFalse(StringHelpers::isStringable((object) []));
 
-        $stringable = new class {
+        $stringable = new class
+        {
             public function __toString()
             {
                 return '';
@@ -69,7 +70,8 @@ class StringHelperTest extends TestCase
         };
         $this->assertTrue(StringHelpers::isStringable($stringable));
 
-        $nonstringable = new class {
+        $nonstringable = new class
+        {
         };
         $this->assertFalse(StringHelpers::isStringable($nonstringable));
     }

--- a/tests/Unit/Util/StringHelperTest.php
+++ b/tests/Unit/Util/StringHelperTest.php
@@ -36,7 +36,7 @@ class StringHelperTest extends TestCase
      *
      * @return void
      */
-    public function testInferEncoding()
+    public function testInferEncoding(): void
     {
         $this->assertEquals(null, StringHelpers::inferEncoding(null));
         $this->assertEquals('', StringHelpers::inferEncoding(''));
@@ -50,13 +50,14 @@ class StringHelperTest extends TestCase
         $this->assertEquals('コンサート', StringHelpers::inferEncoding(base64_decode('g1KDk4NUgVuDZw==')));
     }
 
-    public function testIsStringable()
+    public function testIsStringable(): void
     {
         $this->assertTrue(StringHelpers::isStringable(null));
         $this->assertTrue(StringHelpers::isStringable(''));
         $this->assertTrue(StringHelpers::isStringable('string'));
         $this->assertTrue(StringHelpers::isStringable(-1));
         $this->assertTrue(StringHelpers::isStringable(1.0));
+        $this->assertTrue(StringHelpers::isStringable(false));
         $this->assertTrue(StringHelpers::isStringable(new SimpleTemplate('')));
 
         $this->assertFalse(StringHelpers::isStringable([]));

--- a/tests/Unit/Util/StringHelperTest.php
+++ b/tests/Unit/Util/StringHelperTest.php
@@ -25,7 +25,6 @@
 
 namespace LibreNMS\Tests\Unit\Util;
 
-use App\View\SimpleTemplate;
 use LibreNMS\Tests\TestCase;
 use LibreNMS\Util\StringHelpers;
 
@@ -58,9 +57,20 @@ class StringHelperTest extends TestCase
         $this->assertTrue(StringHelpers::isStringable(-1));
         $this->assertTrue(StringHelpers::isStringable(1.0));
         $this->assertTrue(StringHelpers::isStringable(false));
-        $this->assertTrue(StringHelpers::isStringable(new SimpleTemplate('')));
 
         $this->assertFalse(StringHelpers::isStringable([]));
         $this->assertFalse(StringHelpers::isStringable((object) []));
+
+        $stringable = new class {
+            public function __toString()
+            {
+                return '';
+            }
+        };
+        $this->assertTrue(StringHelpers::isStringable($stringable));
+
+        $nonstringable = new class {
+        };
+        $this->assertFalse(StringHelpers::isStringable($nonstringable));
     }
 }

--- a/tests/Unit/Util/StringHelperTest.php
+++ b/tests/Unit/Util/StringHelperTest.php
@@ -25,6 +25,7 @@
 
 namespace LibreNMS\Tests\Unit\Util;
 
+use App\View\SimpleTemplate;
 use LibreNMS\Tests\TestCase;
 use LibreNMS\Util\StringHelpers;
 
@@ -47,5 +48,18 @@ class StringHelperTest extends TestCase
 
         config(['app.charset' => 'Shift_JIS']);
         $this->assertEquals('コンサート', StringHelpers::inferEncoding(base64_decode('g1KDk4NUgVuDZw==')));
+    }
+
+    public function testIsStringable()
+    {
+        $this->assertTrue(StringHelpers::isStringable(null));
+        $this->assertTrue(StringHelpers::isStringable(''));
+        $this->assertTrue(StringHelpers::isStringable('string'));
+        $this->assertTrue(StringHelpers::isStringable(-1));
+        $this->assertTrue(StringHelpers::isStringable(1.0));
+        $this->assertTrue(StringHelpers::isStringable(new SimpleTemplate('')));
+
+        $this->assertFalse(StringHelpers::isStringable([]));
+        $this->assertFalse(StringHelpers::isStringable((object) []));
     }
 }


### PR DESCRIPTION
Now that the alert transport test code isn't ignoring errors, the errors have become more visible.
The biggest offender was bad template parsing. So, I consolidated the template parsing into a class called SimpleTemplate.
Fixed a couple of other obvious bugs.
Improved the error output so users can more effectively report issues.

fixes #13437 

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
