### PR TITLE
Fix widget title injection vulnerability

### DIFF
--- a/app/Http/Controllers/OverviewController.php
+++ b/app/Http/Controllers/OverviewController.php
@@ -104,7 +104,7 @@ class OverviewController extends Controller
         $data = serialize(json_encode($data));
         $dash_config = unserialize($data);
         $hide_dashboard_editor = UserPref::getPref($user, 'hide_dashboard_editor');
-        $widgets = Widget::select('widget_id', 'widget_title')->orderBy('widget_title')->get();
+        $widgets = Widget::select(['widget_id', 'widget_title'])->orderBy('widget_title')->get();
 
         $user_list = [];
         if ($user->can('manage', User::class)) {

--- a/app/Http/Controllers/Widgets/WidgetController.php
+++ b/app/Http/Controllers/Widgets/WidgetController.php
@@ -142,7 +142,7 @@ abstract class WidgetController extends Controller
 
         return response()->json([
             'status' => $status,
-            'title' => __($title),
+            'title' => htmlentities(__($title)),
             'html' => $html,
             'show_settings' => $show_settings,
             'settings' => $settings,


### PR DESCRIPTION
Prevent html/js code from being injected into widget titles.

Reported by nighter on Discord

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
