### PR TITLE
Fix poller for Bintec Be.IP Plus

### DIFF
--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -298,7 +298,7 @@ if ($device['os'] === 'f5' && (version_compare($device['version'], '11.2.0', '>=
             ((! isset($hc_test[0]['ifHighSpeed']) && ! is_numeric($hc_test[0]['ifHighSpeed'])))) {
             $ifEntrySnmpFlags = ['-OQUst'];
             if ($device['os'] == 'bintec-beip-plus') {
-                $ifEntrySnmpFlags = ['-OQUs', '-Cc'];
+                $ifEntrySnmpFlags = ['-OQUst', '-Cc'];
             }
             $port_stats = snmpwalk_cache_oid($device, 'ifEntry', $port_stats, 'IF-MIB', null, $ifEntrySnmpFlags);
         } else {

--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -296,7 +296,11 @@ if ($device['os'] === 'f5' && (version_compare($device['version'], '11.2.0', '>=
         // If the device doesn't have ifXentry data, fetch ifEntry instead.
         if ((! isset($hc_test[0]['ifHCInOctets']) && ! is_numeric($hc_test[0]['ifHCInOctets'])) ||
             ((! isset($hc_test[0]['ifHighSpeed']) && ! is_numeric($hc_test[0]['ifHighSpeed'])))) {
-            $port_stats = snmpwalk_cache_oid($device, 'ifEntry', $port_stats, 'IF-MIB', null, '-OQUst');
+            $ifEntrySnmpFlags = ['-OQUst'];
+            if ($device['os'] == 'bintec-beip-plus') {
+                $ifEntrySnmpFlags = ['-OQUs', '-Cc'];
+            }
+            $port_stats = snmpwalk_cache_oid($device, 'ifEntry', $port_stats, 'IF-MIB', null, $ifEntrySnmpFlags);
         } else {
             // For devices with ifXentry data, only specific ifEntry keys are fetched to reduce SNMP load
             foreach ($ifmib_oids as $oid) {
@@ -309,7 +313,11 @@ if ($device['os'] === 'f5' && (version_compare($device['version'], '11.2.0', '>=
             if (Config::get('enable_ports_poe') || Config::get('enable_ports_etherlike')) {
                 $port_stats = snmpwalk_cache_oid($device, 'dot3StatsIndex', $port_stats, 'EtherLike-MIB');
             }
-            $port_stats = snmpwalk_cache_oid($device, 'dot3StatsDuplexStatus', $port_stats, 'EtherLike-MIB');
+            $dot3StatsDuplexStatusSnmpFlags = null;
+            if ($device['os'] == 'bintec-beip-plus') {
+                $dot3StatsDuplexStatusSnmpFlags = '-Cc';
+            }
+            $port_stats = snmpwalk_cache_oid($device, 'dot3StatsDuplexStatus', $port_stats, 'EtherLike-MIB', null, $dot3StatsDuplexStatusSnmpFlags);
             $port_stats = snmpwalk_cache_oid($device, 'dot1qPvid', $port_stats, 'Q-BRIDGE-MIB');
         }
     }

--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -313,7 +313,7 @@ if ($device['os'] === 'f5' && (version_compare($device['version'], '11.2.0', '>=
             if (Config::get('enable_ports_poe') || Config::get('enable_ports_etherlike')) {
                 $port_stats = snmpwalk_cache_oid($device, 'dot3StatsIndex', $port_stats, 'EtherLike-MIB');
             }
-            $dot3StatsDuplexStatusSnmpFlags = null;
+            $dot3StatsDuplexStatusSnmpFlags = '-OQUs';
             if ($device['os'] == 'bintec-beip-plus') {
                 $dot3StatsDuplexStatusSnmpFlags = '-Cc';
             }


### PR DESCRIPTION
This PR is a follow-up to https://github.com/librenms/librenms/pull/12993. After it was integrated, I noticed that the poller did still have problems concerning the "OID not increasing" problem with this router. I'm very sorry that I did not check this issue beforehand.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
