### PR TITLE
airos: fix latitude having an extra - in the middle after the decimal point

### DIFF
--- a/LibreNMS/OS/Airos.php
+++ b/LibreNMS/OS/Airos.php
@@ -77,6 +77,7 @@ class Airos extends OS implements
         $regex = '/(-?\d+)\.-?(\d+)/';
         $location->lng = (float) preg_replace($regex, '$1.$2', $location->getAttributes()['lng']);
         $location->lat = (float) preg_replace($regex, '$1.$2', $location->getAttributes()['lat']);
+
         return $location;
     }
 

--- a/LibreNMS/OS/Airos.php
+++ b/LibreNMS/OS/Airos.php
@@ -73,10 +73,10 @@ class Airos extends OS implements
     {
         $location = parent::fetchLocation();
 
-        // fix longitude having an extra - in the middle after the decimal point
-        $location->lng = (float) preg_replace('/(-?\d+)\.-?(\d+)/', '$1.$2', $location->getAttributes()['lng']);
-        // fix latitude having an extra - in the middle after the decimal point
-        $location->lat = (float) preg_replace('/(-?\d+)\.-?(\d+)/', '$1.$2', $location->getAttributes()['lat']);
+        // fix having an extra - in the middle after the decimal point
+        $regex = '/(-?\d+)\.-?(\d+)/';
+        $location->lng = (float) preg_replace($regex, '$1.$2', $location->getAttributes()['lng']);
+        $location->lat = (float) preg_replace($regex, '$1.$2', $location->getAttributes()['lat']);
         return $location;
     }
 

--- a/LibreNMS/OS/Airos.php
+++ b/LibreNMS/OS/Airos.php
@@ -75,7 +75,8 @@ class Airos extends OS implements
 
         // fix longitude having an extra - in the middle after the decimal point
         $location->lng = (float) preg_replace('/(-?\d+)\.-?(\d+)/', '$1.$2', $location->getAttributes()['lng']);
-
+        // fix latitude having an extra - in the middle after the decimal point
+        $location->lat = (float) preg_replace('/(-?\d+)\.-?(\d+)/', '$1.$2', $location->getAttributes()['lat']);
         return $location;
     }
 


### PR DESCRIPTION
fix latitude having an extra - in the middle after the decimal point

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
