### PR TITLE
Fix IPV6 test

### DIFF
--- a/tests/IpTest.php
+++ b/tests/IpTest.php
@@ -46,13 +46,22 @@ class IpTest extends TestCase
         $this->assertTrue(IP::isValid('8.8.8.8', true));
         $this->assertTrue(IPv4::isValid('192.168.0.1', true));
         $this->assertTrue(IPv6::isValid('FF81::', true));
-        $this->assertTrue(IPv6::isValid('2001:db8:85a3::8a2e:370:7334', true));
         $this->assertFalse(IPv4::isValid('127.0.0.1', true));
         $this->assertFalse(IPv6::isValid('::1', true));
         $this->assertFalse(IP::isValid('169.254.1.1', true));
         $this->assertFalse(IP::isValid('fe80::1', true));
         $this->assertFalse(IPv4::isValid('fe80::1', true));
         $this->assertFalse(IP::isValid('Falafel', true));
+    }
+
+    /**
+     * See https://github.com/librenms/librenms/pull/13468 for more info
+     *
+     * @requires PHP >= 7.4
+     */
+    public function testIsValidIPv6ExcludeReserved(): void
+    {
+        $this->assertFalse(IPv6::isValid('2001:db8:85a3::8a2e:370:7334', true));
     }
 
     public function testIpParse()


### PR DESCRIPTION
The test checks if 2001:db8... is a valid ipv6 *not* in reserved ranges.
A bug in PHP (https://bugs.php.net/bug.php?id=61700) made it wrongly pass.
Now said bug has been resolved, so lets update the tests.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
