### PR TITLE
Fix api transport mult-line parsing

### DIFF
--- a/LibreNMS/Alert/Transport.php
+++ b/LibreNMS/Alert/Transport.php
@@ -3,6 +3,7 @@
 namespace LibreNMS\Alert;
 
 use App\Models\AlertTransport;
+use App\View\SimpleTemplate;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Str;
 use LibreNMS\Config;
@@ -63,15 +64,16 @@ abstract class Transport implements TransportInterface
      * Helper function to parse free form text box defined in ini style to key value pairs
      *
      * @param  string  $input
+     * @param  array  $replacements for SimpleTemplate if desired
      * @return array
      */
-    protected function parseUserOptions(string $input): array
+    protected function parseUserOptions(string $input, array $replacements = []): array
     {
         $options = [];
         foreach (preg_split('/\\r\\n|\\r|\\n/', $input, -1, PREG_SPLIT_NO_EMPTY) as $option) {
             if (Str::contains($option, '=')) {
                 [$k, $v] = explode('=', $option, 2);
-                $options[$k] = trim($v);
+                $options[$k] = empty($replacements) ? trim($v) : SimpleTemplate::parse(trim($v), $replacements);
             }
         }
 

--- a/LibreNMS/Alert/Transport.php
+++ b/LibreNMS/Alert/Transport.php
@@ -26,6 +26,23 @@ abstract class Transport implements TransportInterface
     }
 
     /**
+     * Returns a list of all available transports
+     * @return array
+     */
+    public static function list(): array
+    {
+        $list = [];
+        foreach (glob(base_path('LibreNMS/Alert/Transport/*.php')) as $file) {
+            $transport = strtolower(basename($file, '.php'));
+            $class = self::getClass($transport);
+            $instance = new $class;
+            $list[$transport] = $instance->name();
+        }
+
+        return $list;
+    }
+
+    /**
      * Transport constructor.
      *
      * @param  null  $transport

--- a/LibreNMS/Alert/Transport.php
+++ b/LibreNMS/Alert/Transport.php
@@ -27,6 +27,7 @@ abstract class Transport implements TransportInterface
 
     /**
      * Returns a list of all available transports
+     *
      * @return array
      */
     public static function list(): array
@@ -81,7 +82,7 @@ abstract class Transport implements TransportInterface
      * Helper function to parse free form text box defined in ini style to key value pairs
      *
      * @param  string  $input
-     * @param  array  $replacements for SimpleTemplate if desired
+     * @param  array  $replacements  for SimpleTemplate if desired
      * @return array
      */
     protected function parseUserOptions(string $input, array $replacements = []): array

--- a/LibreNMS/Alert/Transport/Api.php
+++ b/LibreNMS/Alert/Transport/Api.php
@@ -72,12 +72,8 @@ class Api extends Transport
             $request_opts['body'] = $body;
             $res = $client->request('PUT', $host, $request_opts);
         } else { //Method POST
-//            if ($body) {
-                $request_opts['query'] = $query;
-                $request_opts['body'] = SimpleTemplate::parse($body, $obj);
-//            } else {
-//                $request_opts['form_params'] = $query;
-//            }
+            $request_opts['query'] = $query;
+            $request_opts['body'] = SimpleTemplate::parse($body, $obj);
             $res = $client->request('POST', $host, $request_opts);
         }
 

--- a/LibreNMS/Alert/Transport/Api.php
+++ b/LibreNMS/Alert/Transport/Api.php
@@ -56,7 +56,7 @@ class Api extends Transport
         //get each line of key-values and process the variables for Options;
         $query = $this->parseUserOptions($options, $obj);
 
-        $client = new \GuzzleHttp\Client();
+        $client = app(\GuzzleHttp\Client::class);
         $request_opts['proxy'] = Proxy::forGuzzle();
         if (isset($auth) && ! empty($auth[0])) {
             $request_opts['auth'] = $auth;

--- a/LibreNMS/Alert/Transport/Api.php
+++ b/LibreNMS/Alert/Transport/Api.php
@@ -52,9 +52,9 @@ class Api extends Transport
         $host = explode('?', $api, 2)[0]; //we don't use the parameter part, cause we build it out of options.
 
         //get each line of key-values and process the variables for Headers;
-        $request_heads = $this->parseUserOptions(SimpleTemplate::parse($headers, $obj));
+        $request_heads = $this->parseUserOptions($headers, $obj);
         //get each line of key-values and process the variables for Options;
-        $query = $this->parseUserOptions(SimpleTemplate::parse($options, $obj));
+        $query = $this->parseUserOptions($options, $obj);
 
         $client = new \GuzzleHttp\Client();
         $request_opts['proxy'] = Proxy::forGuzzle();

--- a/LibreNMS/Alert/Transport/Api.php
+++ b/LibreNMS/Alert/Transport/Api.php
@@ -72,8 +72,12 @@ class Api extends Transport
             $request_opts['body'] = $body;
             $res = $client->request('PUT', $host, $request_opts);
         } else { //Method POST
-            $request_opts['query'] = $query;
-            $request_opts['body'] = SimpleTemplate::parse($body, $obj);
+//            if ($body) {
+                $request_opts['query'] = $query;
+                $request_opts['body'] = SimpleTemplate::parse($body, $obj);
+//            } else {
+//                $request_opts['form_params'] = $query;
+//            }
             $res = $client->request('POST', $host, $request_opts);
         }
 

--- a/database/factories/AlertTransportFactory.php
+++ b/database/factories/AlertTransportFactory.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\AlertTransport;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use LibreNMS\Alert\Transport;
+
+class AlertTransportFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = AlertTransport::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'transport_name' => $this->faker->text(30),
+            'transport_type' => $this->faker->randomElement(Transport::list()),
+            'is_default' => 0,
+            'transport_config' => '',
+        ];
+    }
+
+    public function api(
+        string $options = '',
+        string $method = 'get',
+        string $body = '',
+        string $url = 'https://librenms.org',
+        string $headers = 'test=header',
+        string $username = '',
+        string $password = ''
+    )
+    {
+        $config = [
+            'api-method' => $method,
+            'api-url' => $url,
+            'api-options' => $options,
+            'api-headers' => $headers,
+            'api-body' => $body,
+            'api-auth-username' => $username,
+            'api-auth-password' => $password,
+        ];
+
+        return $this->state(function () use ($config) {
+            return [
+                'transport_type' => 'api',
+                'transport_config' => $config,
+            ];
+        });
+    }
+}

--- a/database/factories/AlertTransportFactory.php
+++ b/database/factories/AlertTransportFactory.php
@@ -8,19 +8,9 @@ use LibreNMS\Alert\Transport;
 
 class AlertTransportFactory extends Factory
 {
-    /**
-     * The name of the factory's corresponding model.
-     *
-     * @var string
-     */
     protected $model = AlertTransport::class;
 
-    /**
-     * Define the model's default state.
-     *
-     * @return array
-     */
-    public function definition()
+    public function definition(): array
     {
         return [
             'transport_name' => $this->faker->text(30),
@@ -38,8 +28,7 @@ class AlertTransportFactory extends Factory
         string $headers = 'test=header',
         string $username = '',
         string $password = ''
-    )
-    {
+    ): AlertTransportFactory {
         $config = [
             'api-method' => $method,
             'api-url' => $url,

--- a/includes/html/modal/edit_alert_transport.inc.php
+++ b/includes/html/modal/edit_alert_transport.inc.php
@@ -11,6 +11,7 @@
  * the source code distribution for details.
  */
 
+use LibreNMS\Alert\Transport;
 use LibreNMS\Config;
 
 if (Auth::user()->hasGlobalAdmin()) {
@@ -42,19 +43,9 @@ if (Auth::user()->hasGlobalAdmin()) {
     <?php
 
 // Create list of transport
-    $transport_dir = Config::get('install_dir') . '/LibreNMS/Alert/Transport';
-    $transports_list = [];
-    foreach (scandir($transport_dir) as $transport) {
-        $transport = strstr($transport, '.', true);
-        if (empty($transport)) {
-            continue;
-        }
-        $class = "\LibreNMS\Alert\Transport\\$transport";
-        $instance = new $class;
-        $transports_list[$transport] = $instance->name();
-    }
+    $transports_list = Transport::list();
     foreach ($transports_list as $transport => $name) {
-        echo '<option value="' . strtolower($transport) . '-form">' . $name . '</option>';
+        echo '<option value="' . $transport . '-form">' . $name . '</option>';
     } ?>
                                 </select>
                             </div>
@@ -70,16 +61,16 @@ if (Auth::user()->hasGlobalAdmin()) {
 
     $switches = []; // store names of bootstrap switches
     foreach ($transports_list as $transport => $name) {
-        $class = 'LibreNMS\\Alert\\Transport\\' . $transport;
+        $class = Transport::getClass($transport);
 
         if (! method_exists($class, 'configTemplate')) {
             // Skip since support has not been added
             continue;
         }
 
-        echo '<form method="post" role="form" id="' . strtolower($transport) . '-form" class="form-horizontal transport">';
+        echo '<form method="post" role="form" id="' . $transport . '-form" class="form-horizontal transport">';
         echo csrf_field();
-        echo '<input type="hidden" name="transport-type" value="' . strtolower($transport) . '">';
+        echo '<input type="hidden" name="transport-type" value="' . $transport . '">';
 
         $tmp = call_user_func($class . '::configTemplate');
 

--- a/includes/html/modal/edit_alert_transport.inc.php
+++ b/includes/html/modal/edit_alert_transport.inc.php
@@ -12,7 +12,6 @@
  */
 
 use LibreNMS\Alert\Transport;
-use LibreNMS\Config;
 
 if (Auth::user()->hasGlobalAdmin()) {
     ?>

--- a/includes/html/pages/alert-transports.inc.php
+++ b/includes/html/pages/alert-transports.inc.php
@@ -9,7 +9,7 @@ if ($request->has('oauthtransport')) {
 
     if ($validator->passes()) {
         $transport_name = $request->get('oauthtransport');
-        $class = 'LibreNMS\\Alert\\Transport\\' . $transport_name;
+        $class = \LibreNMS\Alert\Transport::getClass($transport_name);
         if (class_exists($class)) {
             $transport = app($class);
             if ($transport->handleOauth($request)) {

--- a/tests/Traits/MockGuzzleClient.php
+++ b/tests/Traits/MockGuzzleClient.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace LibreNMS\Tests\Traits;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use function array_merge;
+
+/**
+ * @mixin \LibreNMS\Tests\TestCase
+ */
+trait MockGuzzleClient
+{
+    /**
+     * @var MockHandler
+     */
+    private $guzzleMockHandler;
+
+    /**
+     * @var array
+     */
+    private $guzzleConfig;
+
+    /**
+     * @var array
+     */
+    private $guzzleHistory = [];
+
+    /**
+     * @param  array  $queue Sequential Responses to give to the client.
+     * @param  array  $config Guzzle config settings.
+     */
+    public function mockGuzzleClient(array $queue, array $config = []): MockHandler
+    {
+        $this->guzzleConfig = $config;
+        $this->guzzleMockHandler = new MockHandler($queue);
+
+        $this->app->bind(Client::class, function () {
+            $handlerStack = HandlerStack::create($this->guzzleMockHandler);
+            $handlerStack->push(Middleware::history($this->guzzleHistory));
+
+            return new Client(array_merge($this->guzzleConfig, ['handler' => $handlerStack]));
+        });
+
+        return $this->guzzleMockHandler;
+    }
+
+    /**
+     * Get the request and response history to inspect
+     * @return array
+     */
+    public function guzzleHistory(): array
+    {
+        return $this->guzzleHistory;
+    }
+
+    /**
+     * Get the request history to inspect
+     * @return \GuzzleHttp\Psr7\Request[]
+     */
+    public function guzzleRequestHistory(): array
+    {
+        return array_column($this->guzzleHistory, 'request');
+    }
+
+    /**
+     * Get the response history to inspect
+     * @return \GuzzleHttp\Psr7\Response[]
+     */
+    public function guzzleResponseHistory(): array
+    {
+        return array_column($this->guzzleHistory, 'response');
+    }
+}

--- a/tests/Traits/MockGuzzleClient.php
+++ b/tests/Traits/MockGuzzleClient.php
@@ -6,7 +6,6 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
-use function array_merge;
 
 /**
  * @mixin \LibreNMS\Tests\TestCase
@@ -29,8 +28,10 @@ trait MockGuzzleClient
     private $guzzleHistory = [];
 
     /**
-     * @param  array  $queue Sequential Responses to give to the client.
-     * @param  array  $config Guzzle config settings.
+     * Create a Guzzle MockHandler and bind Client with the handler to the Laravel container
+     *
+     * @param  array  $queue  Sequential Responses to give to the client.
+     * @param  array  $config  Guzzle config settings.
      */
     public function mockGuzzleClient(array $queue, array $config = []): MockHandler
     {
@@ -49,6 +50,7 @@ trait MockGuzzleClient
 
     /**
      * Get the request and response history to inspect
+     *
      * @return array
      */
     public function guzzleHistory(): array
@@ -58,6 +60,7 @@ trait MockGuzzleClient
 
     /**
      * Get the request history to inspect
+     *
      * @return \GuzzleHttp\Psr7\Request[]
      */
     public function guzzleRequestHistory(): array
@@ -67,6 +70,7 @@ trait MockGuzzleClient
 
     /**
      * Get the response history to inspect
+     *
      * @return \GuzzleHttp\Psr7\Response[]
      */
     public function guzzleResponseHistory(): array

--- a/tests/Unit/ApiTransportTest.php
+++ b/tests/Unit/ApiTransportTest.php
@@ -13,7 +13,7 @@ class ApiTransportTest extends TestCase
 {
     use MockGuzzleClient;
 
-    public function testGetMultilineVariables()
+    public function testGetMultilineVariables(): void
     {
         $transport = AlertTransport::factory()->api('text={{ $msg }}')->make();
 
@@ -33,7 +33,7 @@ class ApiTransportTest extends TestCase
         $this->assertEquals('text=This%20is%20a%20multi-line%0Aalert.', $history[0]->getUri()->getQuery());
     }
 
-    public function testPostMultilineVariables()
+    public function testPostMultilineVariables(): void
     {
         $transport = AlertTransport::factory()->api(
             'text={{ $msg }}',

--- a/tests/Unit/ApiTransportTest.php
+++ b/tests/Unit/ApiTransportTest.php
@@ -14,6 +14,7 @@ class ApiTransportTest extends TestCase
 
     public function testGetMultilineVariables(): void
     {
+        /** @var AlertTransport $transport */
         $transport = AlertTransport::factory()->api('text={{ $msg }}')->make();
 
         $this->mockGuzzleClient([
@@ -34,6 +35,7 @@ class ApiTransportTest extends TestCase
 
     public function testPostMultilineVariables(): void
     {
+        /** @var AlertTransport $transport */
         $transport = AlertTransport::factory()->api(
             'text={{ $msg }}',
             'post',

--- a/tests/Unit/ApiTransportTest.php
+++ b/tests/Unit/ApiTransportTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace LibreNMS\Tests\Unit;
+
+use App\Models\AlertTransport;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\Psr7\Response;
+use LibreNMS\Config;
+use LibreNMS\Tests\TestCase;
+use LibreNMS\Tests\Traits\MockGuzzleClient;
+
+class ApiTransportTest extends TestCase
+{
+    use MockGuzzleClient;
+
+    public function testGetMultilineVariables()
+    {
+        $transport = AlertTransport::factory()->api('text={{ $msg }}')->make();
+
+        $this->mockGuzzleClient([
+            new Response(200),
+        ]);
+
+        $obj = ['msg' => "This is a multi-line\nalert."];
+        $opts = Config::get('alert.transports.' . $transport->transport_type);
+        $result = $transport->instance()->deliverAlert($obj, $opts);
+
+        $this->assertTrue($result);
+
+        $history = $this->guzzleRequestHistory();
+        $this->assertCount(1, $history);
+        $this->assertEquals('GET', $history[0]->getMethod());
+        $this->assertEquals('text=This%20is%20a%20multi-line%0Aalert.', $history[0]->getUri()->getQuery());
+    }
+
+    public function testPostMultilineVariables()
+    {
+        $transport = AlertTransport::factory()->api(
+            'text={{ $msg }}',
+            'post',
+            'bodytext={{ $msg }}',
+        )->make();
+
+        $this->mockGuzzleClient([
+            new Response(200),
+        ]);
+
+        $obj = ['msg' => "This is a post multi-line\nalert."];
+        $opts = Config::get('alert.transports.' . $transport->transport_type);
+        $result = $transport->instance()->deliverAlert($obj, $opts);
+
+        $this->assertTrue($result);
+
+        $history = $this->guzzleRequestHistory();
+        $this->assertCount(1, $history);
+        $this->assertEquals('POST', $history[0]->getMethod());
+        // FUBAR
+        $this->assertEquals('text=This%20is%20a%20post%20multi-line%0Aalert.', $history[0]->getUri()->getQuery());
+        $this->assertEquals("bodytext=This is a post multi-line\nalert.", (string) $history[0]->getBody());
+    }
+}

--- a/tests/Unit/ApiTransportTest.php
+++ b/tests/Unit/ApiTransportTest.php
@@ -3,7 +3,6 @@
 namespace LibreNMS\Tests\Unit;
 
 use App\Models\AlertTransport;
-use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\Response;
 use LibreNMS\Config;
 use LibreNMS\Tests\TestCase;

--- a/tests/Unit/Data/PrometheusStoreTest.php
+++ b/tests/Unit/Data/PrometheusStoreTest.php
@@ -25,22 +25,21 @@
 
 namespace LibreNMS\Tests\Unit\Data;
 
-use GuzzleHttp\Client;
 use GuzzleHttp\Exception\RequestException;
-use GuzzleHttp\Handler\MockHandler;
-use GuzzleHttp\HandlerStack;
-use GuzzleHttp\Middleware;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use LibreNMS\Config;
 use LibreNMS\Data\Store\Prometheus;
 use LibreNMS\Tests\TestCase;
+use LibreNMS\Tests\Traits\MockGuzzleClient;
 
 /**
  * @group datastores
  */
 class PrometheusStoreTest extends TestCase
 {
+    use MockGuzzleClient;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -51,13 +50,12 @@ class PrometheusStoreTest extends TestCase
 
     public function testFailWrite()
     {
-        $stack = HandlerStack::create(new MockHandler([
+        $this->mockGuzzleClient([
             new Response(422, [], 'Bad response'),
             new RequestException('Exception thrown', new Request('POST', 'test')),
-        ]));
+        ]);
 
-        $client = new Client(['handler' => $stack]);
-        $prometheus = new Prometheus($client);
+        $prometheus = app(Prometheus::class);
 
         \Log::shouldReceive('debug');
         \Log::shouldReceive('error')->once()->with("Prometheus Exception: Client error: `POST http://fake:9999/metrics/job/librenms/instance/test/measurement/none` resulted in a `422 Unprocessable Entity` response:\nBad response\n");
@@ -68,16 +66,11 @@ class PrometheusStoreTest extends TestCase
 
     public function testSimpleWrite()
     {
-        $stack = HandlerStack::create(new MockHandler([
+        $this->mockGuzzleClient([
             new Response(200),
-        ]));
+        ]);
 
-        $container = [];
-        $history = Middleware::history($container);
-
-        $stack->push($history);
-        $client = new Client(['handler' => $stack]);
-        $prometheus = new Prometheus($client);
+        $prometheus = app(Prometheus::class);
 
         $device = ['hostname' => 'testhost'];
         $measurement = 'testmeasure';
@@ -89,15 +82,12 @@ class PrometheusStoreTest extends TestCase
 
         $prometheus->put($device, $measurement, $tags, $fields);
 
-        $this->assertCount(1, $container, 'Did not receive the expected number of requests');
-
-        /** @var Request $request */
-        $request = $container[0]['request'];
-
-        $this->assertEquals('POST', $request->getMethod());
-        $this->assertEquals('/metrics/job/librenms/instance/testhost/measurement/testmeasure/ifName/testifname/type/testtype', $request->getUri()->getPath());
-        $this->assertEquals('fake', $request->getUri()->getHost());
-        $this->assertEquals(9999, $request->getUri()->getPort());
-        $this->assertEquals("ifIn 234234\nifOut 53453\n", (string) $request->getBody());
+        $history = $this->guzzleRequestHistory();
+        $this->assertCount(1, $history, 'Did not receive the expected number of requests');
+        $this->assertEquals('POST', $history[0]->getMethod());
+        $this->assertEquals('/metrics/job/librenms/instance/testhost/measurement/testmeasure/ifName/testifname/type/testtype', $history[0]->getUri()->getPath());
+        $this->assertEquals('fake', $history[0]->getUri()->getHost());
+        $this->assertEquals(9999, $history[0]->getUri()->getPort());
+        $this->assertEquals("ifIn 234234\nifOut 53453\n", (string) $history[0]->getBody());
     }
 }


### PR DESCRIPTION
parse templates after parsing user options, not before

add tests

fixes #13467

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
