### PR TITLE
Fix SnmpQuery mibdir from os group

### DIFF
--- a/LibreNMS/Data/Source/NetSnmpQuery.php
+++ b/LibreNMS/Data/Source/NetSnmpQuery.php
@@ -339,7 +339,7 @@ class NetSnmpQuery implements SnmpQueryInterface
         }
 
         // os group
-        if ($os_group = Config::get("os.{$this->device->os}.os_group")) {
+        if ($os_group = Config::get("os.{$this->device->os}.group")) {
             if (file_exists("$base/$os_group")) {
                 $dirs[] = "$base/$os_group";
             }


### PR DESCRIPTION
Wrong key name in the config.  (It is only called os_group in the device array)

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
