### PR TITLE
[bug] Fix & extend MAC OUI table updates

### DIFF
--- a/LibreNMS/Util/Rewrite.php
+++ b/LibreNMS/Util/Rewrite.php
@@ -156,10 +156,11 @@ class Rewrite
     public static function readableOUI($mac)
     {
         $cached = Cache::get('OUIDB-' . (substr($mac, 0, 6)), '');
-        if ($cached == "IEEE Registration Authority") {
+        if ($cached == 'IEEE Registration Authority') {
             // Then we may have a shorter prefix, so let's try them one ater the other, ordered by probability
             return Cache::get('OUIDB-' . (substr($mac, 0, 7)), Cache::get('OUIDB-' . (substr($mac, 0, 9))));
         }
+
         return $cached;
     }
 

--- a/LibreNMS/Util/Rewrite.php
+++ b/LibreNMS/Util/Rewrite.php
@@ -155,9 +155,12 @@ class Rewrite
      */
     public static function readableOUI($mac)
     {
-        $key = 'OUIDB-' . (substr($mac, 0, 6));
-
-        return Cache::get($key, '');
+        $cached = Cache::get('OUIDB-' . (substr($mac, 0, 6)), '');
+        if ($cached == "IEEE Registration Authority") {
+            // Then we may have a shorter prefix, so let's try them one ater the other, ordered by probability
+            return Cache::get('OUIDB-' . (substr($mac, 0, 7)), Cache::get('OUIDB-' . (substr($mac, 0, 9))));
+        }
+        return $cached;
     }
 
     /**

--- a/LibreNMS/Util/Rewrite.php
+++ b/LibreNMS/Util/Rewrite.php
@@ -158,7 +158,7 @@ class Rewrite
         $cached = Cache::get('OUIDB-' . (substr($mac, 0, 6)), '');
         if ($cached == 'IEEE Registration Authority') {
             // Then we may have a shorter prefix, so let's try them one ater the other, ordered by probability
-            return Cache::get('OUIDB-' . (substr($mac, 0, 9)), Cache::get('OUIDB-' . (substr($mac, 0, 7))));
+            return Cache::get('OUIDB-' . substr($mac, 0, 9)) ?: Cache::get('OUIDB-' . substr($mac, 0, 7));
         }
 
         return $cached;

--- a/LibreNMS/Util/Rewrite.php
+++ b/LibreNMS/Util/Rewrite.php
@@ -158,7 +158,7 @@ class Rewrite
         $cached = Cache::get('OUIDB-' . (substr($mac, 0, 6)), '');
         if ($cached == 'IEEE Registration Authority') {
             // Then we may have a shorter prefix, so let's try them one ater the other, ordered by probability
-            return Cache::get('OUIDB-' . (substr($mac, 0, 7)), Cache::get('OUIDB-' . (substr($mac, 0, 9))));
+            return Cache::get('OUIDB-' . (substr($mac, 0, 9)), Cache::get('OUIDB-' . (substr($mac, 0, 7))));
         }
 
         return $cached;

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1432,7 +1432,8 @@ function cache_mac_oui()
     if ($lock->get()) {
         echo 'Caching Mac OUI' . PHP_EOL;
         try {
-            $mac_oui_url = 'https://raw.githubusercontent.com/wireshark/wireshark/master/manuf';
+            $mac_oui_url = 'https://gitlab.com/wireshark/wireshark/-/raw/master/manuf';
+            //$mac_oui_url_mirror = 'https://raw.githubusercontent.com/wireshark/wireshark/master/manuf';
             echo '  -> Downloading ...' . PHP_EOL;
             $get = Requests::get($mac_oui_url, [], ['proxy' => get_proxy()]);
             echo '  -> Processing CSV ...' . PHP_EOL;

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1440,18 +1440,22 @@ function cache_mac_oui()
             foreach (explode("\n", $csv_data) as $csv_line) {
                 unset($oui);
                 $entry = str_getcsv($csv_line, "\t");
-                if (is_array($entry) && count($entry) >= 3 && strlen($entry[0]) == 8) {
+
+                $length = strlen($entry[0]);
+                $prefix = strtolower(str_replace(':', '', $entry[0]));
+
+                if (is_array($entry) && count($entry) >= 3 && $length == 8) {
                     // We have a standard OUI xx:xx:xx
-                    $oui = strtolower(str_replace(':', '', $entry[0]));
-                } elseif (is_array($entry) && count($entry) >= 3 && strlen($entry[0]) == 20) {
+                    $oui = $prefix;
+                } elseif (is_array($entry) && count($entry) >= 3 && $length == 20) {
                     // We have a smaller range (xx:xx:xx:X or xx:xx:xx:xx:X)
-                    if (substr($entry[0], -2) == '28') {
-                        $oui = strtolower(str_replace(':', '', substr($entry[0], 0, 10)));
-                    } elseif (substr($entry[0], -2) == '36') {
-                        $oui = strtolower(str_replace(':', '', substr($entry[0], 0, 13)));
+                    if (substr($prefix, -2) == '28') {
+                        $oui = substr($prefix, 0, 7);
+                    } elseif (substr($prefix, -2) == '36') {
+                        $oui = substr($prefix, 0, 9);
                     }
                 }
-                if ($oui) {
+                if (isset($oui)) {
                     echo "Adding $oui, $entry[2]\n";
                     $key = 'OUIDB-' . $oui;
                     Cache::put($key, $entry[2], $mac_oui_cache_time);

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1434,6 +1434,7 @@ function cache_mac_oui()
         try {
             $mac_oui_url = 'https://gitlab.com/wireshark/wireshark/-/raw/master/manuf';
             //$mac_oui_url_mirror = 'https://raw.githubusercontent.com/wireshark/wireshark/master/manuf';
+
             echo '  -> Downloading ...' . PHP_EOL;
             $get = Requests::get($mac_oui_url, [], ['proxy' => get_proxy()]);
             echo '  -> Processing CSV ...' . PHP_EOL;
@@ -1457,7 +1458,7 @@ function cache_mac_oui()
                     }
                 }
                 if (isset($oui)) {
-                    echo "Adding $oui, $entry[2]\n";
+                    echo "Adding $oui, $entry[2]" . PHP_EOL;
                     $key = 'OUIDB-' . $oui;
                     Cache::put($key, $entry[2], $mac_oui_cache_time);
                 }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1445,9 +1445,9 @@ function cache_mac_oui()
                     $oui = strtolower(str_replace(':', '', $entry[0]));
                 } elseif (is_array($entry) && count($entry) >= 3 && strlen($entry[0]) == 20) {
                     // We have a smaller range (xx:xx:xx:X or xx:xx:xx:xx:X)
-                    if (substr($entry[0], -2) == "28") {
+                    if (substr($entry[0], -2) == '28') {
                         $oui = strtolower(str_replace(':', '', substr($entry[0], 0, 10)));
-                    } elseif (substr($entry[0], -2) == "36") {
+                    } elseif (substr($entry[0], -2) == '36') {
                         $oui = strtolower(str_replace(':', '', substr($entry[0], 0, 13)));
                     }
                 }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1432,17 +1432,29 @@ function cache_mac_oui()
     if ($lock->get()) {
         echo 'Caching Mac OUI' . PHP_EOL;
         try {
-            $mac_oui_url = 'https://macaddress.io/database/macaddress.io-db.json';
+            $mac_oui_url = 'https://raw.githubusercontent.com/wireshark/wireshark/master/manuf';
             echo '  -> Downloading ...' . PHP_EOL;
             $get = Requests::get($mac_oui_url, [], ['proxy' => get_proxy()]);
-            echo '  -> Processing ...' . PHP_EOL;
-            $json_data = $get->body;
-            foreach (explode("\n", $json_data) as $json_line) {
-                $entry = json_decode($json_line);
-                if ($entry && $entry->{'assignmentBlockSize'} == 'MA-L') {
-                    $oui = strtolower(str_replace(':', '', $entry->{'oui'}));
+            echo '  -> Processing CSV ...' . PHP_EOL;
+            $csv_data = $get->body;
+            foreach (explode("\n", $csv_data) as $csv_line) {
+                unset($oui);
+                $entry = str_getcsv($csv_line, "\t");
+                if (is_array($entry) && count($entry) >= 3 && strlen($entry[0]) == 8) {
+                    // We have a standard OUI xx:xx:xx
+                    $oui = strtolower(str_replace(':', '', $entry[0]));
+                } elseif (is_array($entry) && count($entry) >= 3 && strlen($entry[0]) == 20) {
+                    // We have a smaller range (xx:xx:xx:X or xx:xx:xx:xx:X)
+                    if (substr($entry[0], -2) == "28") {
+                        $oui = strtolower(str_replace(':', '', substr($entry[0], 0, 10)));
+                    } elseif (substr($entry[0], -2) == "36") {
+                        $oui = strtolower(str_replace(':', '', substr($entry[0], 0, 13)));
+                    }
+                }
+                if ($oui) {
+                    echo "Adding $oui, $entry[2]\n";
                     $key = 'OUIDB-' . $oui;
-                    Cache::put($key, $entry->{'companyName'}, $mac_oui_cache_time);
+                    Cache::put($key, $entry[2], $mac_oui_cache_time);
                 }
             }
         } catch (Exception $e) {


### PR DESCRIPTION
The source (macaddress.io) is now hiding the vendor names in free version. So we'll directly fetch the source in wireshark git readonly repository. 

We'll also now parse all prefixes, not only the /24 prefixes like before, but also the /28 and /36. 

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
