### PR TITLE
SNMP Trap handler: UpsTrapOnBattery

### DIFF
--- a/LibreNMS/Snmptrap/Handlers/UpsTrapOnBattery.php
+++ b/LibreNMS/Snmptrap/Handlers/UpsTrapOnBattery.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * UpsTrapOnBattery.php
+ *
+ * -Description-
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * @link       https://www.librenms.org
+ *
+ * @author     TheGreatDoc
+ */
+
+namespace LibreNMS\Snmptrap\Handlers;
+
+use App\Models\Device;
+use Illuminate\Support\Str;
+use LibreNMS\Interfaces\SnmptrapHandler;
+use LibreNMS\Snmptrap\Trap;
+use Log;
+
+class UpsTrapOnBattery implements SnmptrapHandler
+{
+    /**
+     * Handle snmptrap.
+     * Data is pre-parsed and delivered as a Trap.
+     *
+     * @param  Device  $device
+     * @param  Trap  $trap
+     * @return void
+     */
+    public function handle(Device $device, Trap $trap)
+    {
+        $min_remaining = Str::before($trap->getOidData($trap->findOid('UPS-MIB::upsEstimatedMinutesRemaining')), ' ');
+        $sec_time = Str::before($trap->getOidData($trap->findOid('UPS-MIB::upsSecondsOnBattery')), ' ');
+        Log::event("UPS running on battery for $sec_time seconds. Estimated $min_remaining minutes remaining", $device->device_id, 'trap', 5);
+        $sensor_remaining = $device->sensors()->where('sensor_index', '200')->where('sensor_type', 'rfc1628')->first();
+        if (! $sensor_remaining) {
+            Log::warning("Snmptrap upsTrapOnBattery: Could not find matching sensor \'Estimated battery time remaining\' for device: " . $device->hostname);
+
+            return;
+        }
+        $sensor_remaining->sensor_current = $min_remaining / $sensor_remaining->sensor_divisor;
+        $sensor_remaining->save();
+
+        $sensor_time = $device->sensors()->where('sensor_index', '100')->where('sensor_type', 'rfc1628')->first();
+        if (! $sensor_time) {
+            Log::warning("Snmptrap upsTrapOnBattery: Could not find matching sensor \'Time on battery\' for device: " . $device->hostname);
+
+            return;
+        }
+        $sensor_time->sensor_current = $sec_time / $sensor_time->sensor_divisor;
+        $sensor_time->save();
+
+        $sensor_output = $device->sensors()->where('sensor_type', 'upsOutputSourceState')->first();
+        if (! $sensor_output) {
+            Log::warning("Snmptrap upsTrapOnBattery: Could not find matching sensor \'upsOutputSourceState\' for device: " . $device->hostname);
+
+            return;
+        }
+        $sensor_output->sensor_current = 5;
+        $sensor_output->save();
+    }
+}

--- a/config/snmptraps.php
+++ b/config/snmptraps.php
@@ -106,6 +106,6 @@ return [
         'VEEAM-MIB::onBackupJobCompleted' => \LibreNMS\Snmptrap\Handlers\VeeamBackupJobCompleted::class,
         'VEEAM-MIB::onVmBackupJobCompleted' => \LibreNMS\Snmptrap\Handlers\VeeamVmBackupJobCompleted::class,
         'HP-ICF-FAULT-FINDER-MIB::hpicfFaultFinderTrap' => \LibreNMS\Snmptrap\Handlers\HpFault::class,
-        'UPS-MIB::upsTrapOnBattery' => \LibreNMS\Snmptrap\Handlers\upsTrapOnBattery::class,
+        'UPS-MIB::upsTrapOnBattery' => \LibreNMS\Snmptrap\Handlers\UpsTrapOnBattery::class,
     ],
 ];

--- a/config/snmptraps.php
+++ b/config/snmptraps.php
@@ -106,5 +106,6 @@ return [
         'VEEAM-MIB::onBackupJobCompleted' => \LibreNMS\Snmptrap\Handlers\VeeamBackupJobCompleted::class,
         'VEEAM-MIB::onVmBackupJobCompleted' => \LibreNMS\Snmptrap\Handlers\VeeamVmBackupJobCompleted::class,
         'HP-ICF-FAULT-FINDER-MIB::hpicfFaultFinderTrap' => \LibreNMS\Snmptrap\Handlers\HpFault::class,
+        'UPS-MIB::upsTrapOnBattery' => \LibreNMS\Snmptrap\Handlers\upsTrapOnBattery::class,
     ],
 ];

--- a/tests/Feature/SnmpTraps/UpsTrapOnBatteryTest.php
+++ b/tests/Feature/SnmpTraps/UpsTrapOnBatteryTest.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * UpsTrapOnBatteryTest.php
+ *
+ * -Description-
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * @link       https://www.librenms.org
+ *
+ * @author     TheGreatDoc
+ */
+
+namespace LibreNMS\Tests\Feature\SnmpTraps;
+
+use App\Models\Device;
+use App\Models\Sensor;
+use LibreNMS\Snmptrap\Dispatcher;
+use LibreNMS\Snmptrap\Trap;
+
+class UpsTrapOnBatteryTest extends SnmpTrapTestCase
+{
+    public function testOnBattery()
+    {
+        $device = Device::factory()->create(); /** @var Device $device */
+        $state = Sensor::factory()->make(['sensor_class' => 'state', 'sensor_type' => 'upsOutputSourceState', 'sensor_current' => '2']); /** @var Sensor $state */
+        $time = Sensor::factory()->make(['sensor_class' => 'runtime', 'sensor_index' => '100', 'sensor_type' => 'rfc1628', 'sensor_current' => '0']); /** @var Sensor $time */
+        $remaining = Sensor::factory()->make(['sensor_class' => 'runtime', 'sensor_index' => '200', 'sensor_type' => 'rfc1628', 'sensor_current' => '371']); /** @var Sensor $remaining */
+        $device->sensors()->save($state);
+        $device->sensors()->save($time);
+        $device->sensors()->save($remaining);
+
+        $trapText = "$device->hostname
+UDP: [$device->ip]:161->[192.168.5.5]:162
+DISMAN-EVENT-MIB::sysUpTimeInstance 9:22:15:00.01
+SNMPv2-MIB::snmpTrapOID.0 UPS-MIB::upsTrapOnBattery
+UPS-MIB::upsEstimatedMinutesRemaining 100 minutes
+UPS-MIB::upsSecondsOnBattery 120 seconds
+UPS-MIB::upsConfigLowBattTime 1 minutes";
+
+        \Log::shouldReceive('warning')->never()->with("Snmptrap upsTrapOnBattery: Could not find matching sensor \'Estimated battery time remaining\' for device: " . $device->hostname);
+        \Log::shouldReceive('warning')->never()->with("Snmptrap upsTrapOnBattery: Could not find matching sensor \'Time on battery\' for device: " . $device->hostname);
+        \Log::shouldReceive('warning')->never()->with("Snmptrap upsTrapOnBattery: Could not find matching sensor \'upsOutputSourceState\' for device: " . $device->hostname);
+
+        $message = 'UPS running on battery for 120 seconds. Estimated 100 minutes remaining';
+        \Log::shouldReceive('event')->once()->with($message, $device->device_id, 'trap', 5);
+
+        $trap = new Trap($trapText);
+        $this->assertTrue(Dispatcher::handle($trap), 'Could not handle UPS-MIB::upsTrapOnBattery trap');
+
+        $state = $state->fresh();
+        $time = $time->fresh();
+        $remaining = $remaining->fresh();
+        $this->assertEquals($state->sensor_current, '5');
+        $this->assertEquals($time->sensor_current, '120');
+        $this->assertEquals($remaining->sensor_current, '100');
+    }
+}

--- a/tests/Feature/SnmpTraps/UpsTrapOnBatteryTest.php
+++ b/tests/Feature/SnmpTraps/UpsTrapOnBatteryTest.php
@@ -31,7 +31,7 @@ use LibreNMS\Snmptrap\Trap;
 
 class UpsTrapOnBatteryTest extends SnmpTrapTestCase
 {
-    public function testOnBattery()
+    public function testOnBattery(): void
     {
         $device = Device::factory()->create(); /** @var Device $device */
         $state = Sensor::factory()->make(['sensor_class' => 'state', 'sensor_type' => 'upsOutputSourceState', 'sensor_current' => '2']); /** @var Sensor $state */


### PR DESCRIPTION
I found that some devices reports this with `UPS-MIB::upsTraps.0.1` and others with `UPS-MIB::upsTrapOnBattery` so this PR adds support for the second.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
