### PR TITLE
Fix net-snmp unformatted strings

### DIFF
--- a/LibreNMS/Data/Source/SnmpResponse.php
+++ b/LibreNMS/Data/Source/SnmpResponse.php
@@ -129,7 +129,12 @@ class SnmpResponse
                 $line = strtok(PHP_EOL);
             }
 
-            $values[$oid] = trim($value, "\\\" \n\r");
+            if (Str::startsWith($value, '"') && Str::endsWith($value, '"')) {
+                // unformatted string from net-snmp, remove extra escapes
+                $values[$oid] = stripslashes(trim($value, "\\\" \n\r"));
+            } else {
+                $values[$oid] = trim($value);
+            }
         }
 
         return $values;

--- a/LibreNMS/Modules/Core.php
+++ b/LibreNMS/Modules/Core.php
@@ -45,8 +45,8 @@ class Core implements Module
         $device = $os->getDevice();
         $device->fill([
             'sysObjectID' => $snmpdata['.1.3.6.1.2.1.1.2.0'] ?? null,
-            'sysName' => strtolower(trim($snmpdata['.1.3.6.1.2.1.1.5.0'] ?? '')),
-            'sysDescr' => isset($snmpdata['.1.3.6.1.2.1.1.1.0']) ? str_replace(chr(218), "\n", $snmpdata['.1.3.6.1.2.1.1.1.0']) : null,
+            'sysName' => $snmpdata['.1.3.6.1.2.1.1.5.0'] ?? null,
+            'sysDescr' => $snmpdata['.1.3.6.1.2.1.1.1.0'] ?? null,
         ]);
 
         foreach ($device->getDirty() as $attribute => $value) {
@@ -84,9 +84,9 @@ class Core implements Module
 
         $device = $os->getDevice();
         $device->fill([
-            'sysName' => str_replace("\n", '', strtolower($snmpdata['.1.3.6.1.2.1.1.5.0'] ?? '')),
+            'sysName' => $snmpdata['.1.3.6.1.2.1.1.5.0'] ?? null,
             'sysObjectID' => $snmpdata['.1.3.6.1.2.1.1.2.0'] ?? null,
-            'sysDescr' => str_replace(chr(218), "\n", $snmpdata['.1.3.6.1.2.1.1.1.0'] ?? ''),
+            'sysDescr' => $snmpdata['.1.3.6.1.2.1.1.1.0'] ?? null,
         ]);
 
         $this->calculateUptime($os, $snmpdata['.1.3.6.1.2.1.1.3.0'] ?? null);

--- a/app/Models/Device.php
+++ b/app/Models/Device.php
@@ -419,12 +419,12 @@ class Device extends BaseModel
 
     // ---- Accessors/Mutators ----
 
-    public function getIconAttribute($icon)
+    public function getIconAttribute($icon): string
     {
         return Str::start(Url::findOsImage($this->os, $this->features, $icon), 'images/os/');
     }
 
-    public function getIpAttribute($ip)
+    public function getIpAttribute($ip): ?string
     {
         if (empty($ip)) {
             return null;
@@ -433,22 +433,22 @@ class Device extends BaseModel
         return @inet_ntop($ip) ?: null;
     }
 
-    public function setIpAttribute($ip)
+    public function setIpAttribute($ip): void
     {
         $this->attributes['ip'] = inet_pton($ip);
     }
 
-    public function setStatusAttribute($status)
+    public function setStatusAttribute($status): void
     {
         $this->attributes['status'] = (int) $status;
     }
 
-    public function setSysDescrAttribute($sysDescr)
+    public function setSysDescrAttribute(?string $sysDescr): void
     {
         $this->attributes['sysDescr'] = $sysDescr === null ? null : trim(str_replace(chr(218), "\n", $sysDescr), "\\\" \r\n\t\0");
     }
 
-    public function setSysNameAttribute($sysName)
+    public function setSysNameAttribute(?string $sysName): void
     {
         $this->attributes['sysName'] = $sysName === null ? null : str_replace("\n", '', strtolower(trim($sysName)));
     }

--- a/app/Models/Device.php
+++ b/app/Models/Device.php
@@ -443,6 +443,16 @@ class Device extends BaseModel
         $this->attributes['status'] = (int) $status;
     }
 
+    public function setSysDescrAttribute($sysDescr)
+    {
+        $this->attributes['sysDescr'] = $sysDescr === null ? null : trim(str_replace(chr(218), "\n", $sysDescr), "\\\" \r\n\t\0");
+    }
+
+    public function setSysNameAttribute($sysName)
+    {
+        $this->attributes['sysName'] = $sysName === null ? null : str_replace("\n", '', strtolower(trim($sysName)));
+    }
+
     // ---- Query scopes ----
 
     public function scopeIsUp($query)

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -9491,17 +9491,7 @@ parameters:
 			path: app/Models/Device.php
 
 		-
-			message: "#^Method App\\\\Models\\\\Device\\:\\:getIconAttribute\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/Models/Device.php
-
-		-
 			message: "#^Method App\\\\Models\\\\Device\\:\\:getIconAttribute\\(\\) has parameter \\$icon with no type specified\\.$#"
-			count: 1
-			path: app/Models/Device.php
-
-		-
-			message: "#^Method App\\\\Models\\\\Device\\:\\:getIpAttribute\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/Models/Device.php
 
@@ -9706,22 +9696,12 @@ parameters:
 			path: app/Models/Device.php
 
 		-
-			message: "#^Method App\\\\Models\\\\Device\\:\\:setIpAttribute\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/Models/Device.php
-
-		-
 			message: "#^Method App\\\\Models\\\\Device\\:\\:setIpAttribute\\(\\) has parameter \\$ip with no type specified\\.$#"
 			count: 1
 			path: app/Models/Device.php
 
 		-
 			message: "#^Method App\\\\Models\\\\Device\\:\\:setLocation\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/Models/Device.php
-
-		-
-			message: "#^Method App\\\\Models\\\\Device\\:\\:setStatusAttribute\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/Models/Device.php
 

--- a/tests/AddHostCliTest.php
+++ b/tests/AddHostCliTest.php
@@ -138,6 +138,6 @@ class AddHostCliTest extends DBTestCase
         $this->assertEquals(1, $device->snmp_disable, 'snmp is not disabled');
         $this->assertEquals('hardware', $device->hardware, 'Wrong hardware name');
         $this->assertEquals('nameOfOS', $device->os, 'Wrong os name');
-        $this->assertEquals('System', $device->sysName, 'Wrong system name');
+        $this->assertEquals('system', $device->sysName, 'Wrong system name');
     }
 }


### PR DESCRIPTION
When net-snmp returns an unformatted string (with quotes around it), it also has backslashes to escape certain characters.  Remove those.

Did not fix this in legacy code, unsure if that is desirable.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
