### PR TITLE
Change how options are handled for SnmpQuery

### DIFF
--- a/LibreNMS/Data/Source/NetSnmpQuery.php
+++ b/LibreNMS/Data/Source/NetSnmpQuery.php
@@ -80,11 +80,7 @@ class NetSnmpQuery implements SnmpQueryInterface
     /**
      * @var array|string
      */
-    private $options = [];
-    /**
-     * @var string[]
-     */
-    private $defaultOptions = ['-OQXUte'];
+    private $options = ['-OQXUte'];
     /**
      * @var \App\Models\Device
      */
@@ -164,17 +160,20 @@ class NetSnmpQuery implements SnmpQueryInterface
     }
 
     /**
-     * Set option(s) for net-snmp command line.
+     * Set option(s) for net-snmp command line. Overrides the default options.
      * Some options may break parsing, but you can manually parse the raw output if needed.
-     * This will override other options set such as setting numeric.  Call with no options to reset to default.
+     * This will override other options set such as setting numeric.
+     * Calling with null will reset to the default options (-OQXUte).
      * Try to avoid setting options this way to keep the API generic.
      *
-     * @param  array|string  $options
+     * @param  array|string|null  $options
      * @return $this
      */
     public function options($options = []): SnmpQueryInterface
     {
-        $this->options = Arr::wrap($options);
+        $this->options = $options !== null
+            ? Arr::wrap($options)
+            : ['-OQXUte'];
 
         return $this;
     }
@@ -241,7 +240,7 @@ class NetSnmpQuery implements SnmpQueryInterface
         // authentication
         $this->buildAuth($cmd);
 
-        $cmd = array_merge($cmd, $this->defaultOptions, $this->options);
+        $cmd = array_merge($cmd, $this->options);
 
         $timeout = $this->device->timeout ?? Config::get('snmp.timeout');
         if ($timeout && $timeout !== 1) {

--- a/LibreNMS/Modules/Core.php
+++ b/LibreNMS/Modules/Core.php
@@ -195,7 +195,7 @@ class Core implements Module
                 }
             } elseif ($key == 'snmpget') {
                 $get_value = SnmpQuery::device($device)
-                    ->options($value['options'] ?? [])
+                    ->options($value['options'] ?? null)
                     ->mibDir($value['mib_dir'] ?? $mibdir)
                     ->get(isset($value['mib']) ? "{$value['mib']}::{$value['oid']}" : $value['oid'])
                     ->value();
@@ -204,7 +204,7 @@ class Core implements Module
                 }
             } elseif ($key == 'snmpwalk') {
                 $walk_value = SnmpQuery::device($device)
-                    ->options($value['options'] ?? [])
+                    ->options($value['options'] ?? null)
                     ->mibDir($value['mib_dir'] ?? $mibdir)
                     ->walk(isset($value['mib']) ? "{$value['mib']}::{$value['oid']}" : $value['oid'])
                     ->raw();

--- a/LibreNMS/Util/ModuleTestHelper.php
+++ b/LibreNMS/Util/ModuleTestHelper.php
@@ -173,7 +173,7 @@ class ModuleTestHelper
                 $data = \SnmpQuery::options($snmp_options)->mibDir($oid_data['mibdir'])->next($oid_data['oid']);
             }
 
-            if ($data->isValid()) {
+            if (isset($data) && $data->isValid()) {
                 $snmprec_data[] = $this->convertSnmpToSnmprec($data);
             }
         }
@@ -368,7 +368,7 @@ class ModuleTestHelper
         }
     }
 
-    private function convertSnmpToSnmprec(SnmpResponse $snmp_data)
+    private function convertSnmpToSnmprec(SnmpResponse $snmp_data): array
     {
         $result = [];
         foreach (explode(PHP_EOL, $snmp_data->raw()) as $line) {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6211,16 +6211,6 @@ parameters:
 			path: LibreNMS/Util/ModuleTestHelper.php
 
 		-
-			message: "#^Method LibreNMS\\\\Util\\\\ModuleTestHelper\\:\\:convertSnmpToSnmprec\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: LibreNMS/Util/ModuleTestHelper.php
-
-		-
-			message: "#^Method LibreNMS\\\\Util\\\\ModuleTestHelper\\:\\:convertSnmpToSnmprec\\(\\) has parameter \\$snmp_data with no type specified\\.$#"
-			count: 1
-			path: LibreNMS/Util/ModuleTestHelper.php
-
-		-
 			message: "#^Method LibreNMS\\\\Util\\\\ModuleTestHelper\\:\\:dataIsEmpty\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: LibreNMS/Util/ModuleTestHelper.php

--- a/tests/Unit/SnmpResponseTest.php
+++ b/tests/Unit/SnmpResponseTest.php
@@ -179,6 +179,10 @@ HOST-RESOURCES-MIB::hrStorageUsed.36 = 127044934
         $this->assertTrue($response->isValid());
         $this->assertEquals('4958', $response->value());
         $this->assertEquals(['.1.3.6.1.2.1.2.2.1.10.1' => '4958', '.1.3.6.1.2.1.2.2.1.10.2' => '349'], $response->values());
+
+        $response = new SnmpResponse(".1.3.6.1.2.1.31.1.1.1.18.1 = \"internal\\\\backslash\"\n");
+        $this->assertTrue($response->isValid());
+        $this->assertEquals('internal\\backslash', $response->value());
     }
 
     public function testErrorHandling(): void


### PR DESCRIPTION
Calling options() now overrides all previous options including the default.
Fix added backslashes when collecting snmp data.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
