### PR TITLE
Added TOS support for fping

### DIFF
--- a/LibreNMS/Data/Source/Fping.php
+++ b/LibreNMS/Data/Source/Fping.php
@@ -46,6 +46,7 @@ class Fping
         $interval = max($interval, 20);
 
         $fping = Config::get('fping');
+        $fping_tos = Config::get('fping_options.tos', 0);
         $cmd = [$fping];
         if ($address_family == 'ipv6') {
             $fping6 = Config::get('fping6');
@@ -62,6 +63,8 @@ class Fping
             $interval,
             '-t',
             max($timeout, $interval),
+            '-O',
+            $fping_tos,
             $host,
         ]);
 

--- a/app/Jobs/PingCheck.php
+++ b/app/Jobs/PingCheck.php
@@ -82,8 +82,9 @@ class PingCheck implements ShouldQueue
         // set up fping process
         $timeout = Config::get('fping_options.timeout', 500); // must be smaller than period
         $retries = Config::get('fping_options.retries', 2);  // how many retries on failure
+        $tos = Config::get('fping_options.tos', 0);  // TOS marking
 
-        $this->command = ['fping', '-f', '-', '-e', '-t', $timeout, '-r', $retries];
+        $this->command = ['fping', '-f', '-', '-e', '-t', $timeout, '-r', $retries, '-O', $tos];
         $this->wait = Config::get('rrd.step', 300) * 2;
     }
 

--- a/doc/Support/Configuration.md
+++ b/doc/Support/Configuration.md
@@ -167,6 +167,7 @@ lnms config:set fping6 fping6
 lnms config:set fping_options.timeout 500
 lnms config:set fping_options.count 3
 lnms config:set fping_options.interval 500
+lnms config:set fping_options.tos 184
 ```
 
 `fping` configuration options:
@@ -178,6 +179,7 @@ lnms config:set fping_options.interval 500
   to each target.
 * `interval` (`fping` parameter `-p`): Time in milliseconds that fping
   waits between successive packets to an individual target.
+* `tos` (`fping`parameter `-O`): TOS marking in decimal or hex to be used
 
 > NOTE: Setting a higher timeout value than the interval value can
 > lead to slowing down poller. Example:

--- a/doc/Support/Configuration.md
+++ b/doc/Support/Configuration.md
@@ -179,7 +179,7 @@ lnms config:set fping_options.tos 184
   to each target.
 * `interval` (`fping` parameter `-p`): Time in milliseconds that fping
   waits between successive packets to an individual target.
-* `tos` (`fping`parameter `-O`): TOS marking in decimal or hex to be used
+* `tos` (`fping`parameter `-O`): Set the type of service flag (TOS). Value can be either decimal or hexadecimal (0xh) format. Can be used to ensure that ping packets are queued in following QOS mecanisms in the network. Table is accessible in the [TOS Wikipedia page](https://en.wikipedia.org/wiki/Type_of_service).
 
 > NOTE: Setting a higher timeout value than the interval value can
 > lead to slowing down poller. Example:


### PR DESCRIPTION
This PR adds support for fping option `-O` that sets the TOS field.

Usecase : a remote device on a slowish xdsl link that has QOS enabled (for voice). With this new fping option, TOS field is set to 184, ping goes thru happily and at least we know the device is up and running. 


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
