### PR TITLE
Adjust low and high default temperature guesses 

### DIFF
--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -359,7 +359,7 @@ function sensor_low_limit($class, $current)
     // matching an empty case executes code until a break is reached
     switch ($class) {
         case 'temperature':
-            $limit = $current - 10;
+            $limit = Config::get('sensors.temperature_low_guess', 18);
             break;
         case 'voltage':
             $limit = $current * 0.85;
@@ -397,7 +397,7 @@ function sensor_limit($class, $current)
     // matching an empty case executes code until a break is reached
     switch ($class) {
         case 'temperature':
-            $limit = $current + 20;
+            $limit = Config::get('sensors.temperature_high_guess', 70);
             break;
         case 'voltage':
             $limit = $current * 1.15;

--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -4903,7 +4903,24 @@
         },
         "sensors.guess_limits": {
             "default": true,
+            "group": "discovery",
+            "section": "sensors"
+            "order": 1,
             "type": "boolean"
+        },
+        "sensors.temperature_low_guess": {
+            "default": 18,
+            "group": "discovery",
+            "section": "sensors"
+            "order": 2,
+            "type": "integer"
+        },
+        "sensors.temperature_low_guess": {
+            "default": 70,
+            "group": "discovery",
+            "section": "sensors"
+            "order": 3,
+            "type": "integer"
         },
         "service_poller_enabled": {
             "default": true,

--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -4915,7 +4915,7 @@
             "order": 2,
             "type": "integer"
         },
-        "sensors.temperature_low_guess": {
+        "sensors.temperature_high_guess": {
             "default": 70,
             "group": "discovery",
             "section": "sensors"

--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -4904,21 +4904,21 @@
         "sensors.guess_limits": {
             "default": true,
             "group": "discovery",
-            "section": "sensors"
+            "section": "sensors",
             "order": 1,
             "type": "boolean"
         },
         "sensors.temperature_low_guess": {
             "default": 18,
             "group": "discovery",
-            "section": "sensors"
+            "section": "sensors",
             "order": 2,
             "type": "integer"
         },
         "sensors.temperature_high_guess": {
             "default": 70,
             "group": "discovery",
-            "section": "sensors"
+            "section": "sensors",
             "order": 3,
             "type": "integer"
         },

--- a/resources/lang/en/settings.php
+++ b/resources/lang/en/settings.php
@@ -38,6 +38,7 @@ return [
             'general' => ['name' => 'General Discovery Settings'],
             'route' => ['name' => 'Routes Discovery Module'],
             'discovery_modules' => ['name' => 'Discovery Modules'],
+            'sensors' => ['sensors' => 'Sensors Module'],
             'storage' => ['name' => 'Storage Module'],
             'networks' => ['name' => 'Networks'],
         ],
@@ -1262,6 +1263,18 @@ return [
                 'mono' => 'Mono',
             ],
         ],
+        'sensors' => [
+            'guess_limits' => [
+                'description' => 'Guess sensor thresholds',
+                'help' => 'Attempt to pick minimum/maximum values for sensors if not provided using various methods.',
+             ],
+            'temperature_low_guess' => [
+                'description' => 'Low temperature threshold',
+                'help' => 'Estimate for low temperature threshold if not specified by device.',
+            'temperature_high_guess' => [
+                'description' => 'Low temperature threshold',
+                'help' => 'Estimate for high temperature threshold if not specified by device.',
+         ],
         'snmp' => [
             'transports' => [
                 'description' => 'Transport (priority)',


### PR DESCRIPTION
TIA-942 states a datacentre should have a minumum temperature of 18 degrees. This works as a good value for both chassis cooling sensors, and for environmental as it's around the point where condensation can start to form in humid environments.

Maximum temperature is a little trickier, as it varies depending on context. For an environmental sensor in a data centre, 27 degrees is the bad number. In a wiring cupboard though, it could be 40 degrees or so.

A quick sample of Intel CPU specifications list the maximum temperature above 70 for core temperature, up to 100. I can't find any hard numbers but it looks like Turbo enabled processors start throttling around 80 degrees. Checking my own instance, around 3% of the temperature sensors are exceed that threshold; all under heavy load.

The real solution is for thresholds to be provided by the vendor, but one of the most common sensor types (lm_sensors) does not do this. My feeling is the current behaviour doesn't really help anyone.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
