### PR TITLE
APC Load, wrong low precision oid

### DIFF
--- a/includes/discovery/sensors/load/apc.inc.php
+++ b/includes/discovery/sensors/load/apc.inc.php
@@ -33,7 +33,7 @@ if ($phasecount > 1) {
         $oids = snmp_get($device, $item['HighPrecOid'] . '.' . $item['index'], '-OsqnU', $item['mib']);
         if (empty($oids)) {
             $oids = snmp_get($device, $item['AdvOid'] . '.' . $item['index'], '-OsqnU', $item['mib']);
-            $current_oid = '.1.3.6.1.4.1.318.1.1.1.4.3.3';
+            $current_oid = '.1.3.6.1.4.1.318.1.1.1.4.2.3';
             $current = $oids;
             $item['divisor'] = 1;
         } else {


### PR DESCRIPTION
Fixed the OID for the non HighPrec Load, which should be 4.2.3.


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
