### PR TITLE
Fix PyMySQL upstream dependency bug

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-PyMySQL
+PyMySQL!=1.0.0
 python-dotenv
 redis>=3.0
 setuptools


### PR DESCRIPTION
PyMySQL 1.0.0 requires Python 3.6, but they did not specify that in their setup files.
Block that version so we don't break users on Python 3.5.  (Also, please update your Python)

https://github.com/PyMySQL/PyMySQL/pull/936

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
