### PR TITLE
Fix: pseudowire cpwVcID can exceed database max value

### DIFF
--- a/database/migrations/2021_11_12_123037_change_cpwVcID_to_unsignedInteger.php
+++ b/database/migrations/2021_11_12_123037_change_cpwVcID_to_unsignedInteger.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class ChangecpwVcIDtounsignedInteger extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('pseudowires', function (Blueprint $table) {
+            $table->unsignedInteger('cpwVcID')->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('pseudowires', function (Blueprint $table) {
+            $table->integer('cpwVcID')->change();
+        });
+    }
+}

--- a/misc/db_schema.yaml
+++ b/misc/db_schema.yaml
@@ -1732,7 +1732,7 @@ pseudowires:
     - { Field: port_id, Type: 'int unsigned', 'Null': false, Extra: '' }
     - { Field: peer_device_id, Type: 'int unsigned', 'Null': false, Extra: '' }
     - { Field: peer_ldp_id, Type: int, 'Null': false, Extra: '' }
-    - { Field: cpwVcID, Type: int, 'Null': false, Extra: '' }
+    - { Field: cpwVcID, Type: 'int unsigned', 'Null': false, Extra: '' }
     - { Field: cpwOid, Type: int, 'Null': false, Extra: '' }
     - { Field: pw_type, Type: varchar(32), 'Null': false, Extra: '' }
     - { Field: pw_psntype, Type: varchar(32), 'Null': false, Extra: '' }


### PR DESCRIPTION
This pull request is to change the "pseudowires" table "cpwVcID" column type from INT to INT UNSIGNED. See the community post [here](https://community.librenms.org/t/alter-pseudowires-table-to-change-cpwvcid-from-type-int-to-bigint/17369) for further explanation of the need for this PR.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
