### PR TITLE
PHP8 compatibility for ntp-server polling app

### DIFF
--- a/includes/polling/applications/ntp-server.inc.php
+++ b/includes/polling/applications/ntp-server.inc.php
@@ -16,7 +16,7 @@ try {
     $legacy = $e->getOutput();
 
     $ntp = [
-        data => [],
+        'data' => [],
     ];
 
     [$ntp['data']['stratum'], $ntp['data']['offset'], $ntp['data']['frequency'], $ntp['data']['jitter'],


### PR DESCRIPTION
It appears that the ntp-server application script uses an undefined constant when initializing its data array. The use of undefined constants previously generated a warning, and since PHP 8.0 generates an error instead.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
