### PR TITLE
OSPF issue when devices don't support OSPF-MIB::ospfIfTable

### DIFF
--- a/LibreNMS/Data/Source/SnmpResponse.php
+++ b/LibreNMS/Data/Source/SnmpResponse.php
@@ -112,7 +112,7 @@ class SnmpResponse
         $values = [];
         $line = strtok($this->raw, PHP_EOL);
         while ($line !== false) {
-            if (Str::contains($line, ['at this OID', 'this MIB View'])) {
+            if (Str::contains($line, ['at this OID', 'this MIB View', 'End of MIB'])) {
                 // these occur when we seek past the end of data, usually the end of the response, but grab the next line and continue
                 $line = strtok(PHP_EOL);
                 continue;
@@ -171,11 +171,15 @@ class SnmpResponse
     }
 
     /**
-     * Map an snmp table with callback.
+     * Map an snmp table with callback. If invalid data is encountered, an empty collection is returned.
      * Variables passed to the callback will be an array of row values followed by each individual index.
      */
     public function mapTable(callable $callback): Collection
     {
+        if (! $this->isValid()) {
+            return new Collection;
+        }
+
         return collect($this->values())
             ->map(function ($value, $oid) {
                 $parts = explode('[', rtrim($oid, ']'), 2);

--- a/LibreNMS/Modules/Ospf.php
+++ b/LibreNMS/Modules/Ospf.php
@@ -112,7 +112,7 @@ class Ospf implements Module
             $ospf_ports = SnmpQuery::context($context_name)
                 ->hideMib()->enumStrings()
                 ->walk('OSPF-MIB::ospfIfTable')
-                ->mapTable(function ($ospf_port, $ip, $ifIndex = null) use ($context_name, $os) {
+                ->mapTable(function ($ospf_port, $ip, $ifIndex) use ($context_name, $os) {
                     // find port_id
                     $ospf_port['port_id'] = (int) $os->getDevice()->ports()->where('ifIndex', $ifIndex)->value('port_id');
                     if ($ospf_port['port_id'] == 0) {

--- a/LibreNMS/Modules/Ospf.php
+++ b/LibreNMS/Modules/Ospf.php
@@ -112,7 +112,7 @@ class Ospf implements Module
             $ospf_ports = SnmpQuery::context($context_name)
                 ->hideMib()->enumStrings()
                 ->walk('OSPF-MIB::ospfIfTable')
-                ->mapTable(function ($ospf_port, $ip, $ifIndex) use ($context_name, $os) {
+                ->mapTable(function ($ospf_port, $ip, $ifIndex = null) use ($context_name, $os) {
                     // find port_id
                     $ospf_port['port_id'] = (int) $os->getDevice()->ports()->where('ifIndex', $ifIndex)->value('port_id');
                     if ($ospf_port['port_id'] == 0) {


### PR DESCRIPTION
Found out snmp is just returning `End of MIB`. Add that to the snmp query checks.

fixes #13532 

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
