### PR TITLE
Fix plugin_active check when plugin is not found

### DIFF
--- a/app/Plugins/PluginManager.php
+++ b/app/Plugins/PluginManager.php
@@ -167,7 +167,7 @@ class PluginManager
      */
     public function pluginEnabled(string $pluginName): bool
     {
-        return $this->getPlugin($pluginName)->plugin_active;
+        return (bool) optional($this->getPlugin($pluginName))->plugin_active;
     }
 
     /**

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -9371,6 +9371,11 @@ parameters:
 			path: app/Models/Device.php
 
 		-
+			message: "#^Method App\\\\Models\\\\Device\\:\\:name\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/Models/Device.php
+
+		-
 			message: "#^Method App\\\\Models\\\\Device\\:\\:scopeHasAccess\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/Models/Device.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -9371,11 +9371,6 @@ parameters:
 			path: app/Models/Device.php
 
 		-
-			message: "#^Method App\\\\Models\\\\Device\\:\\:name\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/Models/Device.php
-
-		-
 			message: "#^Method App\\\\Models\\\\Device\\:\\:scopeHasAccess\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/Models/Device.php


### PR DESCRIPTION
`Error when loading hook App\Plugins\ExamplePlugin\Settings of type App\Plugins\Hooks\SettingsHook for ExamplePlugin: Attempt to read property "plugin_active" on null`

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
