### PR TITLE
Dispatcher use new poller

### DIFF
--- a/LibreNMS/queuemanager.py
+++ b/LibreNMS/queuemanager.py
@@ -493,7 +493,7 @@ class PollerQueueManager(QueueManager):
         if self.lock(device_id, timeout=self.config.poller.frequency):
             logger.info("Polling device {}".format(device_id))
 
-            exit_code, output = LibreNMS.call_script("poller.php", ("-h", device_id))
+            exit_code, output = LibreNMS.call_script("lnms", ("device:poll", device_id))
             if exit_code == 0:
                 self.unlock(device_id)
             else:


### PR DESCRIPTION
Changes the dispatcher to use the new poller.

DO NOT MERGE yet... this is to make it easy to test.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
