### PR TITLE
Catch all module errors

### DIFF
--- a/LibreNMS/Poller.php
+++ b/LibreNMS/Poller.php
@@ -34,6 +34,7 @@ use Carbon\Carbon;
 use DB;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Str;
+use LibreNMS\Enum\Alert;
 use LibreNMS\Exceptions\PollerException;
 use LibreNMS\Modules\LegacyModule;
 use LibreNMS\Polling\ConnectivityHelper;
@@ -175,7 +176,8 @@ class Poller
                     $instance->poll($this->os);
                 } catch (Throwable $e) {
                     // isolate module exceptions so they don't disrupt the polling process
-                    $this->logger->error("%rError in $module module.%n " . $e->getMessage() . PHP_EOL . $e->getTraceAsString(), ['color' => true]);
+                    $this->logger->error("%rError polling $module module for {$this->device->hostname}.%n " . $e->getMessage() . PHP_EOL . $e->getTraceAsString(), ['color' => true]);
+                    $this->logger->event("Error polling $module module. Check log file for more details.", $this->device, 'poller', Alert::ERROR);
                 }
 
                 app(MeasurementManager::class)->printChangedStats();

--- a/LibreNMS/Poller.php
+++ b/LibreNMS/Poller.php
@@ -177,7 +177,7 @@ class Poller
                 } catch (Throwable $e) {
                     // isolate module exceptions so they don't disrupt the polling process
                     $this->logger->error("%rError polling $module module for {$this->device->hostname}.%n " . $e->getMessage() . PHP_EOL . $e->getTraceAsString(), ['color' => true]);
-                    $this->logger->event("Error polling $module module. Check log file for more details.", $this->device, 'poller', Alert::ERROR);
+                    \Log::event("Error polling $module module. Check log file for more details.", $this->device, 'poller', Alert::ERROR);
                 }
 
                 app(MeasurementManager::class)->printChangedStats();

--- a/LibreNMS/Poller.php
+++ b/LibreNMS/Poller.php
@@ -32,7 +32,6 @@ use App\Polling\Measure\Measurement;
 use App\Polling\Measure\MeasurementManager;
 use Carbon\Carbon;
 use DB;
-use Exception;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Str;
 use LibreNMS\Exceptions\PollerException;
@@ -44,6 +43,7 @@ use LibreNMS\Util\Dns;
 use LibreNMS\Util\Git;
 use LibreNMS\Util\StringHelpers;
 use Psr\Log\LoggerInterface;
+use Throwable;
 
 class Poller
 {
@@ -173,9 +173,9 @@ class Poller
                     $module_class = StringHelpers::toClass($module, '\\LibreNMS\\Modules\\');
                     $instance = class_exists($module_class) ? new $module_class : new LegacyModule($module);
                     $instance->poll($this->os);
-                } catch (Exception $e) {
+                } catch (Throwable $e) {
                     // isolate module exceptions so they don't disrupt the polling process
-                    $this->logger->error("Error in $module module. " . $e->getMessage() . PHP_EOL . $e->getTraceAsString() . PHP_EOL);
+                    $this->logger->error("%rError in $module module.%n " . $e->getMessage() . PHP_EOL . $e->getTraceAsString(), ['color' => true]);
                 }
 
                 app(MeasurementManager::class)->printChangedStats();

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -15,6 +15,7 @@
 use Illuminate\Support\Str;
 use LibreNMS\Config;
 use LibreNMS\Device\YamlDiscovery;
+use LibreNMS\Enum\Alert;
 use LibreNMS\Exceptions\HostExistsException;
 use LibreNMS\Exceptions\InvalidIpException;
 use LibreNMS\OS;
@@ -153,7 +154,8 @@ function discover_device(&$device, $force_module = false)
                 include "includes/discovery/$module.inc.php";
             } catch (Throwable $e) {
                 // isolate module exceptions so they don't disrupt the polling process
-                Log::error("%rError in $module module.%n " . $e->getMessage() . PHP_EOL . $e->getTraceAsString(), ['color' => true]);
+                Log::error("%rError discovering $module module for {$device['hostname']}.%n " . $e->getMessage() . PHP_EOL . $e->getTraceAsString(), ['color' => true]);
+                Log::event("Error discovering $module module. Check log file for more details.", $device['device_id'], 'discovery', Alert::ERROR);
             }
 
             $module_time = microtime(true) - $module_start;

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -151,11 +151,9 @@ function discover_device(&$device, $force_module = false)
 
             try {
                 include "includes/discovery/$module.inc.php";
-            } catch (Exception $e) {
+            } catch (Throwable $e) {
                 // isolate module exceptions so they don't disrupt the polling process
-                echo $e->getTraceAsString() . PHP_EOL;
-                c_echo("%rError in $module module.%n " . $e->getMessage() . PHP_EOL);
-                logfile("Error in $module module. " . $e->getMessage() . PHP_EOL . $e->getTraceAsString() . PHP_EOL);
+                Log::error("%rError in $module module.%n " . $e->getMessage() . PHP_EOL . $e->getTraceAsString(), ['color' => true]);
             }
 
             $module_time = microtime(true) - $module_start;

--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -329,7 +329,8 @@ function poll_device($device, $force_module = false)
                     include "includes/polling/$module.inc.php";
                 } catch (Throwable $e) {
                     // isolate module exceptions so they don't disrupt the polling process
-                    Log::error("%rError in $module module.%n " . $e->getMessage() . PHP_EOL . $e->getTraceAsString(), ['color' => true]);
+                    Log::error("%rError polling $module module for {$device['hostname']}.%n " . $e->getMessage() . PHP_EOL . $e->getTraceAsString(), ['color' => true]);
+                    Log::event("Error polling $module module. Check log file for more details.", $device['device_id'], 'poller', Alert::ERROR);
                 }
 
                 $module_time = microtime(true) - $module_start;

--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -327,11 +327,9 @@ function poll_device($device, $force_module = false)
 
                 try {
                     include "includes/polling/$module.inc.php";
-                } catch (Exception $e) {
+                } catch (Throwable $e) {
                     // isolate module exceptions so they don't disrupt the polling process
-                    echo $e->getTraceAsString() . PHP_EOL;
-                    c_echo("%rError in $module module.%n " . $e->getMessage() . PHP_EOL);
-                    logfile("Error in $module module. " . $e->getMessage() . PHP_EOL . $e->getTraceAsString() . PHP_EOL);
+                    Log::error("%rError in $module module.%n " . $e->getMessage() . PHP_EOL . $e->getTraceAsString(), ['color' => true]);
                 }
 
                 $module_time = microtime(true) - $module_start;


### PR DESCRIPTION
As of PHP 7.1, we can now catch errors and exceptions by catching Throwable allowing polling to continue with the next module if one module encounters an error.
Also, log the errors in a consistent way with the entire stack trace and create an event log.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
