### PR TITLE
Skip invalid OSPF data

### DIFF
--- a/LibreNMS/Modules/Ospf.php
+++ b/LibreNMS/Modules/Ospf.php
@@ -62,6 +62,10 @@ class Ospf implements Module
 
             $ospf_instances = collect();
             foreach ($ospf_instances_poll as $ospf_instance_id => $ospf_entry) {
+                if (empty($ospf_entry['ospfRouterId'])) {
+                    continue; // skip invalid data
+                }
+
                 $instance = OspfInstance::updateOrCreate([
                     'device_id' => $os->getDeviceId(),
                     'ospf_instance_id' => $ospf_instance_id,


### PR DESCRIPTION
Check if ospfRouterId exists, if not, then the data is bad

Should fix #13537 

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
