### PR TITLE
ios-fdb-table-fix -- Fixed misnamed dictionary keys for dot1dTpFdbPor…

### DIFF
--- a/includes/discovery/fdb-table/ios.inc.php
+++ b/includes/discovery/fdb-table/ios.inc.php
@@ -24,11 +24,11 @@ foreach ($vtpdomains as $vtpdomain_id => $vtpdomain) {
             $portid_dict = [];
             $dot1dBasePortIfIndex = SnmpQuery::context($vlan_raw, "vlan-$vlan_raw")->walk('BRIDGE-MIB::dot1dBasePortIfIndex')->table(1);
             foreach ($dot1dBasePortIfIndex as $portLocal => $data) {
-                $port = get_port_by_index_cache($device['device_id'], $data['dot1dBasePortIfIndex']);
+                $port = get_port_by_index_cache($device['device_id'], $data['BRIDGE-MIB::dot1dBasePortIfIndex']);
                 $portid_dict[$portLocal] = $port['port_id'];
             }
 
-            foreach ((array) $fdbPort_table['dot1dTpFdbPort'] as $mac => $dot1dBasePort) {
+            foreach ((array) $fdbPort_table['BRIDGE-MIB::dot1dTpFdbPort'] as $mac => $dot1dBasePort) {
                 $mac_address = implode(array_map('zeropad', explode(':', $mac)));
                 if (strlen($mac_address) != 12) {
                     d_echo("MAC address padding failed for $mac\n");


### PR DESCRIPTION
Small fix for dictionary keys in includes/discovery/fdb-table/ios.inc.php

Without this change, running the fdb-table module for a Cisco IOS device in discovery.php was showing null ifIndex values when querying the ports table. Which ultimately meant that records were never inserted into ports_fdb:
```
SNMP['/usr/bin/snmpwalk' '-M' '/opt/librenms/mibs:/opt/librenms/mibs/cisco' '-v3' '-l' 'authPriv' '-n' 'vlan-140' '-x' 'AES' '-X' 'PASSWORD' '-a' 'SHA' '-A' 'PASSWORD' '-u' 'USER' '-OQXUte' 'udp:HOSTNAME:161' 'BRIDGE-MIB::dot1dBasePortIfIndex']  
BRIDGE-MIB::dot1dBasePortIfIndex[40] = 48
BRIDGE-MIB::dot1dBasePortIfIndex[49] = 57
  
  
SQL[SELECT * FROM `ports` WHERE `device_id` = ? AND `ifIndex` = ? [94,null] 1.88ms] 
  
SQL[SELECT * FROM `ports` WHERE `device_id` = ? AND `ifIndex` = ? [94,null] 1.57ms] 
```  
Running a var_dump on the relevant dictionaries (`$dot1dBasePortIfIndex` and `$fdbPort_table`) it appears the crux of the issue is a missing `BRIDGE-MIB::` from the key:
```
SNMP['/usr/bin/snmpwalk' '-M' '/opt/librenms/mibs:/opt/librenms/mibs/cisco' '-v3' '-l' 'authPriv' '-n' 'vlan-140' '-x' 'AES' '-X' 'PASSWORD' '-a' 'SHA' '-A' 'PASSWORD' '-u' 'USER' '-OQXUte' 'udp:HOSTNAME:161' 'BRIDGE-MIB::dot1dBasePortIfIndex']
BRIDGE-MIB::dot1dBasePortIfIndex[40] = 48
BRIDGE-MIB::dot1dBasePortIfIndex[49] = 57


array(1) {
  ["BRIDGE-MIB::dot1dBasePortIfIndex"]=>
  string(2) "48"
}
array(1) {
  ["BRIDGE-MIB::dot1dBasePortIfIndex"]=>
  string(2) "57"
}

array(1) {
  ["BRIDGE-MIB::dot1dTpFdbPort"]=>
  array(1) {
    ["some-mac-address"]=>
    string(2) "49"
  }
}
```
(some-mac-address being a placeholder for the actual mac address in the real output)

See also my help topic on the forums: https://community.librenms.org/t/ports-fdb-entries-not-updating-after-11-13/17513


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
