### PR TITLE
Fix Ciscowlc AP-polling

### DIFF
--- a/LibreNMS/OS/Ciscowlc.php
+++ b/LibreNMS/OS/Ciscowlc.php
@@ -74,6 +74,7 @@ class Ciscowlc extends Cisco implements
             $channel = str_replace('ch', '', $value['bsnAPIfPhyChannelNumber'] ?? '');
 
             $ap = new AccessPoint([
+                'device_id' => $device['device_id'],
                 'name' => $stats[$indexName]['bsnAPName'] ?? '',
                 'radio_number' => Arr::first(explode('.', $key)),
                 'type' => $value['bsnAPIfType'] ?? '',


### PR DESCRIPTION
After the PR #13460 it seems that the CiscoWLC-module broke in a way that all polled access points are having a device_id of 0. This is a fix to insert the device_id back.

After applying this fix, old records should probably be removed somehow. 
SQL: delete access_points from access_points where device_id = 0;

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
