### PR TITLE
Workaround don't poll WLC on IOSXE

### DIFF
--- a/LibreNMS/OS/Iosxe.php
+++ b/LibreNMS/OS/Iosxe.php
@@ -31,9 +31,11 @@ use LibreNMS\Interfaces\Discovery\Sensors\WirelessRsrpDiscovery;
 use LibreNMS\Interfaces\Discovery\Sensors\WirelessRsrqDiscovery;
 use LibreNMS\Interfaces\Discovery\Sensors\WirelessRssiDiscovery;
 use LibreNMS\Interfaces\Discovery\Sensors\WirelessSnrDiscovery;
+use LibreNMS\Interfaces\Polling\OSPolling;
 use LibreNMS\OS\Traits\CiscoCellular;
 
 class Iosxe extends Ciscowlc implements
+    OSPolling,
     WirelessCellDiscovery,
     WirelessChannelDiscovery,
     WirelessRssiDiscovery,
@@ -42,4 +44,9 @@ class Iosxe extends Ciscowlc implements
     WirelessSnrDiscovery
 {
     use CiscoCellular;
+
+    public function pollOS(): void
+    {
+        // Don't poll Ciscowlc FIXME remove when wireless-controller module exists
+    }
 }


### PR DESCRIPTION
Wierd interactions caused an unrelated change to cause all IOS-XE devices to start polling wireless controller oids, which always times out increasing polling time a decent amount.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
