### PR TITLE
Escape net-snmp unformatted strings, try 2

### DIFF
--- a/LibreNMS/Data/Source/SnmpResponse.php
+++ b/LibreNMS/Data/Source/SnmpResponse.php
@@ -132,7 +132,7 @@ class SnmpResponse
 
             if (Str::startsWith($value, '"') && Str::endsWith($value, '"')) {
                 // unformatted string from net-snmp, remove extra escapes
-                $values[$oid] = stripslashes(trim($value, "\\\" \n\r"));
+                $values[$oid] = trim(stripslashes($value), "\" \n\r");
             } else {
                 $values[$oid] = trim($value);
             }

--- a/app/Console/Commands/SnmpFetch.php
+++ b/app/Console/Commands/SnmpFetch.php
@@ -46,7 +46,7 @@ class SnmpFetch extends LnmsCommand
         $spec = $this->argument('device spec');
         $device_ids = Device::query()->when($spec !== 'all', function (Builder $query) use ($spec) {
             return $query->where('device_id', $spec)
-                ->orWhere('hostname', 'regexp', $spec);
+                ->orWhere('hostname', 'regexp', "^$spec$");
         })->pluck('device_id');
 
         if ($device_ids->isEmpty()) {

--- a/tests/Unit/SnmpResponseTest.php
+++ b/tests/Unit/SnmpResponseTest.php
@@ -47,6 +47,13 @@ class SnmpResponseTest extends TestCase
         $this->assertEquals(['' => 'IF-MIB::ifDescr'], $response->values());
         $this->assertEquals('IF-MIB::ifDescr', $response->value());
         $this->assertEquals(['IF-MIB::ifDescr'], $response->table());
+
+        // unescaped strings
+        $response = new SnmpResponse("Q-BRIDGE-MIB::dot1qVlanStaticName[1] = \"default\"\nQ-BRIDGE-MIB::dot1qVlanStaticName[9] = \"\\\\Surrounded\\\\\"");
+        $this->assertTrue($response->isValid());
+        $this->assertEquals('default', $response->value());
+        $this->assertEquals(['Q-BRIDGE-MIB::dot1qVlanStaticName[1]' => 'default', 'Q-BRIDGE-MIB::dot1qVlanStaticName[9]' => '\\Surrounded\\'], $response->values());
+        $this->assertEquals(['Q-BRIDGE-MIB::dot1qVlanStaticName' => [1 => 'default', 9 => '\\Surrounded\\']], $response->table());
     }
 
     public function testMultiLine(): void


### PR DESCRIPTION
To reproduce unescaped strings, set `mibs :` in snmp.conf

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
