### PR TITLE
Fix nototal graph option

### DIFF
--- a/includes/html/graphs/generic_multi_data_separated.inc.php
+++ b/includes/html/graphs/generic_multi_data_separated.inc.php
@@ -65,7 +65,7 @@ foreach ($rrd_list as $rrd) {
     $rrd_options .= ' CDEF:outB' . $i . '_neg=outB' . $i . ',' . $stacked['stacked'] . ',*';
     $rrd_options .= ' CDEF:octets' . $i . '=inB' . $i . ',outB' . $i . ',+';
 
-    if (! $args['nototal']) {
+    if (! $nototal) {
         $in_thing .= $seperator . $in . $i . ',UN,0,' . $in . $i . ',IF';
         $out_thing .= $seperator . $out . $i . ',UN,0,' . $out . $i . ',IF';
         $pluses .= $plus;

--- a/includes/html/graphs/generic_multi_seperated.inc.php
+++ b/includes/html/graphs/generic_multi_seperated.inc.php
@@ -52,7 +52,7 @@ if ($width > '500') {
     $rrd_options .= sprintf(" COMMENT:'%12s'", 'Current');
     $rrd_options .= sprintf(" COMMENT:'%10s'", 'Average');
     $rrd_options .= sprintf(" COMMENT:'%10s'", 'Maximum');
-    if (! $$args['nototal']) {
+    if (! $nototal) {
         $rrd_options .= sprintf(" COMMENT:'%8s'", 'Total');
     }
 } else {
@@ -67,7 +67,7 @@ if ($_GET['previous']) {
     $rrd_options .= sprintf(" COMMENT:'\t'", '');
     $rrd_options .= sprintf(" COMMENT:'%10s'", 'P Avg');
     $rrd_options .= sprintf(" COMMENT:'%10s'", 'P Max');
-    if (! $args['nototal']) {
+    if (! $nototal) {
         $rrd_options .= sprintf(" COMMENT:'%8s'", 'P Total');
     }
 }
@@ -110,7 +110,7 @@ foreach ($rrd_list as $rrd) {
         $rrd_options .= ' SHIFT:outB' . $i . "X:$period";
     }
 
-    if (! $args['nototal']) {
+    if (! $nototal) {
         $in_thing .= $seperator . 'inB' . $i . ',UN,0,' . 'inB' . $i . ',IF';
         $out_thing .= $seperator . 'outB' . $i . ',UN,0,' . 'outB' . $i . ',IF';
         $pluses .= $plus;
@@ -146,7 +146,7 @@ foreach ($rrd_list as $rrd) {
     $rrd_options .= ' GPRINT:inbits' . $i . ':AVERAGE:%6.' . $float_precision . "lf%s$units";
     $rrd_options .= ' GPRINT:inbits' . $i . ':MAX:%6.' . $float_precision . "lf%s$units";
 
-    if (! $args['nototal']) {
+    if (! $nototal) {
         $rrd_options .= ' GPRINT:totinB' . $i . ':%6.' . $float_precision . "lf%s$total_units";
     }
 
@@ -154,7 +154,7 @@ foreach ($rrd_list as $rrd) {
         $rrd_options .= " COMMENT:' \t'";
         $rrd_options .= ' GPRINT:inbits' . $i . 'X:AVERAGE:%6.' . $float_precision . "lf%s$units";
         $rrd_options .= ' GPRINT:inbits' . $i . 'X:MAX:%6.' . $float_precision . "lf%s$units";
-        if (! $args['nototal']) {
+        if (! $nototal) {
             $rrd_options .= ' GPRINT:totinB' . $i . 'X' . ':%6.' . $float_precision . "lf%s$total_units";
         }
     }
@@ -166,7 +166,7 @@ foreach ($rrd_list as $rrd) {
     $rrd_options .= ' GPRINT:outbits' . $i . ':AVERAGE:%6.' . $float_precision . "lf%s$units";
     $rrd_options .= ' GPRINT:outbits' . $i . ':MAX:%6.' . $float_precision . "lf%s$units";
 
-    if (! $args['nototal']) {
+    if (! $nototal) {
         $rrd_options .= ' GPRINT:totoutB' . $i . ':%6.' . $float_precision . "lf%s$total_units";
     }
 
@@ -174,7 +174,7 @@ foreach ($rrd_list as $rrd) {
         $rrd_options .= " COMMENT:' \t'";
         $rrd_options .= ' GPRINT:outbits' . $i . 'X:AVERAGE:%6.' . $float_precision . "lf%s$units";
         $rrd_options .= ' GPRINT:outbits' . $i . 'X:MAX:%6.' . $float_precision . "lf%s$units";
-        if (! $args['nototal']) {
+        if (! $nototal) {
             $rrd_options .= ' GPRINT:totoutB' . $i . 'X' . ':%6.' . $float_precision . "lf%s$total_units";
         }
     }
@@ -213,7 +213,7 @@ if ($_GET['previous'] == 'yes') {
     $rrd_optionsb .= ' LINE1.25:dout' . $format . 'X#666666:';
 }
 
-if (! $args['nototal']) {
+if (! $nototal) {
     $rrd_options .= ' CDEF:inB=' . $in_thing . $pluses;
     $rrd_options .= ' CDEF:outB=' . $out_thing . $pluses;
     $rrd_options .= ' CDEF:octets=inB,outB,+';

--- a/includes/html/graphs/qfp/packets.inc.php
+++ b/includes/html/graphs/qfp/packets.inc.php
@@ -42,6 +42,6 @@ $colours_in = 'purples';
 $multiplier = '1';
 $colours_out = 'oranges';
 
-$args['nototal'] = 1;
+$nototal = 1;
 
 include 'includes/html/graphs/generic_multi_seperated.inc.php';

--- a/includes/html/graphs/qfp/throughput.inc.php
+++ b/includes/html/graphs/qfp/throughput.inc.php
@@ -42,6 +42,6 @@ $colours_in = 'purples';
 $multiplier = '1';
 $colours_out = 'oranges';
 
-$args['nototal'] = 1;
+$nototal = 1;
 
 include 'includes/html/graphs/generic_multi_seperated.inc.php';


### PR DESCRIPTION
This patch fixes the graph option nototal which did not work for the port graphs "interface non unicast" and "interface errors".

![Screenshot 2021-11-30 195244](https://user-images.githubusercontent.com/25873532/144109704-571d2e74-e683-4289-bd20-66b07757d560.png)

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
