### PR TITLE
snmp.unescape setting

### DIFF
--- a/LibreNMS/Config.php
+++ b/LibreNMS/Config.php
@@ -33,6 +33,7 @@ use Illuminate\Support\Str;
 use LibreNMS\Data\Store\Rrd;
 use LibreNMS\DB\Eloquent;
 use LibreNMS\Util\Debug;
+use LibreNMS\Util\Version;
 use Log;
 
 class Config
@@ -472,6 +473,9 @@ class Config
 
         if (! self::has('rrdtool_version')) {
             self::persist('rrdtool_version', Rrd::version());
+        }
+        if (! self::has('snmp.unescape')) {
+            self::persist('snmp.unescape', version_compare(Version::get()->netSnmp(), '5.8.0', '<'));
         }
 
         self::populateTime();

--- a/LibreNMS/Data/Source/SnmpResponse.php
+++ b/LibreNMS/Data/Source/SnmpResponse.php
@@ -28,6 +28,7 @@ namespace LibreNMS\Data\Source;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
+use LibreNMS\Config;
 use Log;
 
 class SnmpResponse
@@ -128,6 +129,11 @@ class SnmpResponse
             while ($line !== false && ! Str::contains($line, self::DELIMITER)) {
                 $value .= PHP_EOL . $line;
                 $line = strtok(PHP_EOL);
+            }
+
+            // remove extra escapes
+            if (Config::get('snmp.unescape')) {
+                $value = stripslashes($value);
             }
 
             if (Str::startsWith($value, '"') && Str::endsWith($value, '"')) {

--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -5130,6 +5130,9 @@
                 "public"
             ]
         },
+        "snmp.unescape": {
+            "type": "boolean"
+        },
         "snmp.exec_timeout": {
             "default": 1200,
             "type": "integer",

--- a/tests/data/arista-mos_metamux48.json
+++ b/tests/data/arista-mos_metamux48.json
@@ -5,7 +5,7 @@
                 {
                     "sysName": "<private>",
                     "sysObjectID": ".1.3.6.1.4.1.43191.1.6.7",
-                    "sysDescr": "Metamako MOS release 0.32.0 \\\\\\\\(build mos-0.32+22\\\\\\\\) running on a MetaMux 48 with L-Series",
+                    "sysDescr": "Metamako MOS release 0.32.0 \\\\(build mos-0.32+22\\\\) running on a MetaMux 48 with L-Series",
                     "sysContact": "<private>",
                     "version": "0.32.0",
                     "hardware": null,


### PR DESCRIPTION
Works around issue with (I think net-snmp < 5.8.0) where it adds backslashes.

Only for SnmpQuery for now, I guess could be added to legacy functions.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
