### PR TITLE
ipv6 discovery switch to new DB syntax

### DIFF
--- a/app/Models/Ipv6Address.php
+++ b/app/Models/Ipv6Address.php
@@ -29,4 +29,13 @@ class Ipv6Address extends PortRelatedModel
 {
     public $timestamps = false;
     protected $primaryKey = 'ipv6_address_id';
+    protected $fillable = [
+        'ipv6_address',
+        'ipv6_compressed',
+        'ipv6_prefixlen',
+        'ipv6_origin',
+        'ipv6_network_id',
+        'port_id',
+        'context_name',
+    ];
 }

--- a/app/Models/Ipv6Address.php
+++ b/app/Models/Ipv6Address.php
@@ -17,10 +17,14 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
+ * Original Code:
  * @link       https://www.librenms.org
  *
  * @copyright  2018 Tony Murray
  * @author     Tony Murray <murraytony@gmail.com>
+ *
+ * Modified by:
+ * @author Peca Nesovanovic <peca.nesovanovic@sattrakt.com>
  */
 
 namespace App\Models;

--- a/app/Models/Ipv6Address.php
+++ b/app/Models/Ipv6Address.php
@@ -17,15 +17,11 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * Original Code:
- *
  * @link       https://www.librenms.org
  *
  * @copyright  2018 Tony Murray
  * @author     Tony Murray <murraytony@gmail.com>
- *
- * Modified by:
- * @author Peca Nesovanovic <peca.nesovanovic@sattrakt.com>
+ * @author     Peca Nesovanovic <peca.nesovanovic@sattrakt.com>
  */
 
 namespace App\Models;

--- a/app/Models/Ipv6Address.php
+++ b/app/Models/Ipv6Address.php
@@ -18,6 +18,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  * Original Code:
+ *
  * @link       https://www.librenms.org
  *
  * @copyright  2018 Tony Murray

--- a/app/Models/Ipv6Network.php
+++ b/app/Models/Ipv6Network.php
@@ -32,6 +32,10 @@ class Ipv6Network extends Model
 {
     public $timestamps = false;
     protected $primaryKey = 'ipv6_network_id';
+    protected $fillable = [
+        'ipv6_network',
+        'context_name',
+    ];
 
     // ---- Define Relationships ----
 

--- a/app/Models/Ipv6Network.php
+++ b/app/Models/Ipv6Network.php
@@ -17,10 +17,14 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
+ * Original Code:
  * @link       https://www.librenms.org
  *
  * @copyright  2018 Tony Murray
  * @author     Tony Murray <murraytony@gmail.com>
+ *
+ * Modified by:
+ * @author Peca Nesovanovic <peca.nesovanovic@sattrakt.com>
  */
 
 namespace App\Models;

--- a/app/Models/Ipv6Network.php
+++ b/app/Models/Ipv6Network.php
@@ -17,15 +17,11 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * Original Code:
- *
  * @link       https://www.librenms.org
  *
  * @copyright  2018 Tony Murray
  * @author     Tony Murray <murraytony@gmail.com>
- *
- * Modified by:
- * @author Peca Nesovanovic <peca.nesovanovic@sattrakt.com>
+ * @author     Peca Nesovanovic <peca.nesovanovic@sattrakt.com>
  */
 
 namespace App\Models;

--- a/app/Models/Ipv6Network.php
+++ b/app/Models/Ipv6Network.php
@@ -18,6 +18,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  * Original Code:
+ *
  * @link       https://www.librenms.org
  *
  * @copyright  2018 Tony Murray

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -672,26 +672,22 @@ function discover_process_ipv6(&$valid, $ifIndex, $ipv6_address, $ipv6_prefixlen
     if ($port_id && $ipv6_prefixlen > '0' && $ipv6_prefixlen < '129' && $ipv6_compressed != '::1') {
         d_echo('IPV6: Found port id: ' . $port_id);
 
-        $ipv6netDB = Ipv6Network::firstOrNew([
+        $ipv6netDB = Ipv6Network::updateOrCreate([
             'ipv6_network' => $ipv6_network,
         ], [
             'context_name' => $context_name,
         ]);
 
-        //check if DB data match and check for DB NULL
-        if ($ipv6netDB->context_name != $context_name || $ipv6netDB->context_name == null) {
-            $ipv6netDB->context_name = $context_name;
+        if ($ipv6netDB->wasChanged()) {
             d_echo('IPV6: Update DB ipv6_networks');
         }
-
-        $ipv6netDB->save();
 
         $ipv6_network_id = Ipv6Network::where('ipv6_network', $ipv6_network)->where('context_name', $context_name)->value('ipv6_network_id');
 
         if ($ipv6_network_id) {
             d_echo('IPV6: Found network id: ' . $ipv6_network_id);
 
-            $ipv6adrDB = Ipv6Address::firstOrNew([
+            $ipv6adrDB = Ipv6Address::updateOrCreate([
                 'ipv6_address' => $ipv6_address,
                 'ipv6_prefixlen' => $ipv6_prefixlen,
                 'port_id' => $port_id,
@@ -702,17 +698,9 @@ function discover_process_ipv6(&$valid, $ifIndex, $ipv6_address, $ipv6_prefixlen
                 'context_name' => $context_name,
             ]);
 
-            //check if DB data match and check for DB NULL
-            if ($ipv6adrDB->context_name != $context_name || $ipv6adrDB->context_name == null) {
-                $ipv6adrDB->context_name = $context_name;
+            if ($ipv6adrDB->wasChanged()) {
                 d_echo('IPV6: Update DB ipv6_addresses');
             }
-            if ($ipv6adrDB->ipv6_network_id != $ipv6_network_id) {
-                $ipv6adrDB->ipv6_network_id = $ipv6_network_id;
-                d_echo('IPV6: Update DB ipv6_addresses');
-            }
-
-            $ipv6adrDB->save();
 
             $full_address = "$ipv6_address/$ipv6_prefixlen";
             $valid_address = $full_address . '-' . $port_id;

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -12,6 +12,7 @@
  * See COPYING for more details.
  */
 
+use App\Models\Port;
 use App\Models\Ipv6Address;
 use App\Models\Ipv6Network;
 use Illuminate\Support\Str;
@@ -663,8 +664,12 @@ function discover_process_ipv6(&$valid, $ifIndex, $ipv6_address, $ipv6_prefixlen
     $ipv6_network = $ipv6->getNetwork($ipv6_prefixlen);
     $ipv6_compressed = $ipv6->compressed();
 
-    if (dbFetchCell('SELECT COUNT(*) FROM `ports` WHERE device_id = ? AND `ifIndex` = ?', [$device['device_id'], $ifIndex]) != '0' && $ipv6_prefixlen > '0' && $ipv6_prefixlen < '129' && $ipv6_compressed != '::1') {
-        $port_id = dbFetchCell('SELECT port_id FROM `ports` WHERE device_id = ? AND ifIndex = ?', [$device['device_id'], $ifIndex]);
+    $port_id = Port::where([
+        ['device_id', $device['device_id']],
+        ['ifIndex', $ifIndex],
+        ])->value('port_id');
+
+    if ($port_id && $ipv6_prefixlen > '0' && $ipv6_prefixlen < '129' && $ipv6_compressed != '::1') {
 
         if (is_numeric($port_id)) {
             d_echo('IPV6: Found port id: ' . $port_id);

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -667,56 +667,55 @@ function discover_process_ipv6(&$valid, $ifIndex, $ipv6_address, $ipv6_prefixlen
         $port_id = dbFetchCell('SELECT port_id FROM `ports` WHERE device_id = ? AND ifIndex = ?', [$device['device_id'], $ifIndex]);
 
         if (is_numeric($port_id)) {
+            d_echo('IPV6: Found port id: ' . $port_id);
+
             $ipv6netDB = Ipv6Network::firstOrNew([
                 'ipv6_network' => $ipv6_network,
             ], [
                 'context_name' => $context_name,
             ]);
 
-            if ($context_name == null) {
-                echo "\nDBG:1 cn is null";
-            }
-
-            if ($ipv6netDB->context_name != $context_name) {
+            //check if DB data match and check for DB NULL
+            if ($ipv6netDB->context_name != $context_name || $ipv6netDB->context_name == null) {
                 $ipv6netDB->context_name = $context_name;
-                echo 'n';
-            }
-            if ($context_name == null) {
-                echo "\nDBG:2 cn is null";
+                d_echo('IPV6: Update DB ipv6_networks');
             }
 
             $ipv6netDB->save();
 
             $ipv6_network_id = Ipv6Network::where('ipv6_network', $ipv6_network)->where('context_name', $context_name)->value('ipv6_network_id');
 
-            echo "\nDBG:nid $ipv6_network_id";
+            if ($ipv6_network_id) {
+                d_echo('IPV6: Found network id: ' . $ipv6_network_id);
 
-            $ipv6adrDB = Ipv6Address::firstOrNew([
-                'ipv6_address' => $ipv6_address,
-                'ipv6_prefixlen' => $ipv6_prefixlen,
-                'port_id' => $port_id,
-            ], [
-                'ipv6_compressed' => $ipv6_compressed,
-                'ipv6_origin' => $ipv6_origin,
-                'ipv6_network_id' => $ipv6_network_id,
-                'context_name' => $context_name,
-            ]);
+                $ipv6adrDB = Ipv6Address::firstOrNew([
+                    'ipv6_address' => $ipv6_address,
+                    'ipv6_prefixlen' => $ipv6_prefixlen,
+                    'port_id' => $port_id,
+                ], [
+                    'ipv6_compressed' => $ipv6_compressed,
+                    'ipv6_origin' => $ipv6_origin,
+                    'ipv6_network_id' => $ipv6_network_id,
+                    'context_name' => $context_name,
+                ]);
 
-            if ($ipv6adrDB->context_name != $context_name) {
-                $ipv6adrDB->context_name = $context_name;
-                echo 'n';
-            }
-            if ($ipv6adrDB->ipv6_network_id != $ipv6_network_id) {
-                $ipv6adrDB->ipv6_network_id = $ipv6_network_id;
-                echo 'n';
-            }
+                //check if DB data match and check for DB NULL
+                if ($ipv6adrDB->context_name != $context_name || $ipv6adrDB->context_name == null) {
+                    $ipv6adrDB->context_name = $context_name;
+                    d_echo('IPV6: Update DB ipv6_addresses');
+                }
+                if ($ipv6adrDB->ipv6_network_id != $ipv6_network_id) {
+                    $ipv6adrDB->ipv6_network_id = $ipv6_network_id;
+                    d_echo('IPV6: Update DB ipv6_addresses');
+                }
 
-            $ipv6adrDB->save();
+                $ipv6adrDB->save();
 
-            $full_address = "$ipv6_address/$ipv6_prefixlen";
-            $valid_address = $full_address . '-' . $port_id;
-            $valid['ipv6'][$valid_address] = 1;
-        }
+                $full_address = "$ipv6_address/$ipv6_prefixlen";
+                $valid_address = $full_address . '-' . $port_id;
+                $valid['ipv6'][$valid_address] = 1;
+            }//endif network_id
+        }//endif port_id
     }//end if
 }//end discover_process_ipv6()
 

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -21,6 +21,8 @@ use LibreNMS\Exceptions\InvalidIpException;
 use LibreNMS\OS;
 use LibreNMS\Util\IP;
 use LibreNMS\Util\IPv6;
+use App\Models\Ipv6Address;
+use App\Models\Ipv6Network;
 
 function discover_new_device($hostname, $device = [], $method = '', $interface = '')
 {
@@ -665,45 +667,47 @@ function discover_process_ipv6(&$valid, $ifIndex, $ipv6_address, $ipv6_prefixlen
         $port_id = dbFetchCell('SELECT port_id FROM `ports` WHERE device_id = ? AND ifIndex = ?', [$device['device_id'], $ifIndex]);
 
         if (is_numeric($port_id)) {
-            if (dbFetchCell('SELECT COUNT(*) FROM `ipv6_networks` WHERE `ipv6_network` = ?', [$ipv6_network]) < '1') {
-                dbInsert(['ipv6_network' => $ipv6_network, 'context_name' => $context_name], 'ipv6_networks');
-                echo 'N';
-            } else {
-                //Update Context
-                dbUpdate(['context_name' => $device['context_name']], 'ipv6_networks', '`ipv6_network` = ?', [$ipv6_network]);
+            $ipv6netDB = Ipv6Network::firstOrNew([
+                'ipv6_network' => $ipv6_network
+            ], [
+                'context_name' => $context_name
+            ]);
+
+            if ($context_name == null) { echo "\nDBG:1 cn is null"; }
+
+            if ($ipv6netDB->context_name != $context_name) {
+                $ipv6netDB->context_name = $context_name;
+                echo 'n';
+            }
+            if ($context_name == null) { echo "\nDBG:2 cn is null"; }
+
+            $ipv6netDB->save();
+
+            $ipv6_network_id = Ipv6Network::where('ipv6_network', $ipv6_network)->where('context_name', $context_name)->value('ipv6_network_id');
+
+            echo "\nDBG:nid $ipv6_network_id";
+
+            $ipv6adrDB = Ipv6Address::firstOrNew([
+                'ipv6_address' => $ipv6_address,
+                'ipv6_prefixlen' => $ipv6_prefixlen,
+                'port_id' => $port_id,
+            ], [
+                'ipv6_compressed' => $ipv6_compressed,
+                'ipv6_origin' => $ipv6_origin,
+                'ipv6_network_id' => $ipv6_network_id,
+                'context_name' => $context_name,
+            ]);
+
+            if ($ipv6adrDB->context_name != $context_name) {
+                $ipv6adrDB->context_name = $context_name;
+                echo 'n';
+            }
+            if ($ipv6adrDB->ipv6_network_id != $ipv6_network_id) {
+                $ipv6adrDB->ipv6_network_id = $ipv6_network_id;
                 echo 'n';
             }
 
-            if ($context_name == null) {
-                $ipv6_network_id = dbFetchCell('SELECT `ipv6_network_id` FROM `ipv6_networks` WHERE `ipv6_network` = ? AND `context_name` IS NULL', [$ipv6_network]);
-            } else {
-                $ipv6_network_id = dbFetchCell('SELECT `ipv6_network_id` FROM `ipv6_networks` WHERE `ipv6_network` = ? AND `context_name` = ?', [$ipv6_network, $context_name]);
-            }
-            if (dbFetchCell('SELECT COUNT(*) FROM `ipv6_addresses` WHERE `ipv6_address` = ? AND `ipv6_prefixlen` = ? AND `port_id` = ?', [$ipv6_address, $ipv6_prefixlen, $port_id]) == '0') {
-                dbInsert([
-                    'ipv6_address' => $ipv6_address,
-                    'ipv6_compressed' => $ipv6_compressed,
-                    'ipv6_prefixlen' => $ipv6_prefixlen,
-                    'ipv6_origin' => $ipv6_origin,
-                    'ipv6_network_id' => $ipv6_network_id,
-                    'port_id' => $port_id,
-                    'context_name' => $context_name,
-                ], 'ipv6_addresses');
-                echo '+';
-            } elseif (dbFetchCell('SELECT COUNT(*) FROM `ipv6_addresses` WHERE `ipv6_address` = ? AND `ipv6_prefixlen` = ? AND `port_id` = ? AND `ipv6_network_id` = ""', [$ipv6_address, $ipv6_prefixlen, $port_id]) == '1') {
-                // Update IPv6 network ID if not set
-                if ($context_name == null) {
-                    $ipv6_network_id = dbFetchCell('SELECT `ipv6_network_id` FROM `ipv6_networks` WHERE `ipv6_network` = ? AND `context_name` IS NULL', [$ipv6_network]);
-                } else {
-                    $ipv6_network_id = dbFetchCell('SELECT `ipv6_network_id` FROM `ipv6_networks` WHERE `ipv6_network` = ? AND `context_name` = ?', [$ipv6_network, $context_name]);
-                }
-                dbUpdate(['ipv6_network_id' => $ipv6_network_id], 'ipv6_addresses', '`ipv6_address` = ? AND `ipv6_prefixlen` = ? AND `port_id` = ?', [$ipv6_address, $ipv6_prefixlen, $port_id]);
-                echo 'u';
-            } else {
-                //Update Context
-                dbUpdate(['context_name' => $device['context_name']], 'ipv6_addresses', '`ipv6_address` = ? AND `ipv6_prefixlen` = ? AND `port_id` = ?', [$ipv6_address, $ipv6_prefixlen, $port_id]);
-                echo '.';
-            }
+            $ipv6adrDB->save();
 
             $full_address = "$ipv6_address/$ipv6_prefixlen";
             $valid_address = $full_address . '-' . $port_id;

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -12,6 +12,8 @@
  * See COPYING for more details.
  */
 
+use App\Models\Ipv6Address;
+use App\Models\Ipv6Network;
 use Illuminate\Support\Str;
 use LibreNMS\Config;
 use LibreNMS\Device\YamlDiscovery;
@@ -21,8 +23,6 @@ use LibreNMS\Exceptions\InvalidIpException;
 use LibreNMS\OS;
 use LibreNMS\Util\IP;
 use LibreNMS\Util\IPv6;
-use App\Models\Ipv6Address;
-use App\Models\Ipv6Network;
 
 function discover_new_device($hostname, $device = [], $method = '', $interface = '')
 {
@@ -668,18 +668,22 @@ function discover_process_ipv6(&$valid, $ifIndex, $ipv6_address, $ipv6_prefixlen
 
         if (is_numeric($port_id)) {
             $ipv6netDB = Ipv6Network::firstOrNew([
-                'ipv6_network' => $ipv6_network
+                'ipv6_network' => $ipv6_network,
             ], [
-                'context_name' => $context_name
+                'context_name' => $context_name,
             ]);
 
-            if ($context_name == null) { echo "\nDBG:1 cn is null"; }
+            if ($context_name == null) {
+                echo "\nDBG:1 cn is null";
+            }
 
             if ($ipv6netDB->context_name != $context_name) {
                 $ipv6netDB->context_name = $context_name;
                 echo 'n';
             }
-            if ($context_name == null) { echo "\nDBG:2 cn is null"; }
+            if ($context_name == null) {
+                echo "\nDBG:2 cn is null";
+            }
 
             $ipv6netDB->save();
 


### PR DESCRIPTION

Resolve #13481 

Problem was with DB ipv6_networks and DB ipv6_addresses
both have mismatch with NULL/empty and LNMS put IPv6 addresses without "network_id" in same space

furthermore, addresses without "network_id" does not show in "Overview -> IPv6 Adresses"


#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
