### PR TITLE
collect-snmp-data.php can now capture snmp context test data

### DIFF
--- a/LibreNMS/Util/ModuleTestHelper.php
+++ b/LibreNMS/Util/ModuleTestHelper.php
@@ -144,7 +144,7 @@ class ModuleTestHelper
         $this->json_file = $path;
     }
 
-    public function captureFromDevice($device_id, $prefer_new = false, $full = false): void
+    public function captureFromDevice(int $device_id, bool $prefer_new = false, bool $full = false): void
     {
         if ($full) {
             $snmp_oids[] = [
@@ -456,7 +456,7 @@ class ModuleTestHelper
         return $snmpTypes[$text];
     }
 
-    private function saveSnmprec($data, $context = null, $write = true, $prefer_new = false)
+    private function saveSnmprec(array $data, ?string $context = null, bool $write = true, bool $prefer_new = false): string
     {
         $filename = $this->snmprec_file;
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -5931,31 +5931,6 @@ parameters:
 			path: LibreNMS/Util/Laravel.php
 
 		-
-			message: "#^Method LibreNMS\\\\Util\\\\ModuleTestHelper\\:\\:captureFromDevice\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: LibreNMS/Util/ModuleTestHelper.php
-
-		-
-			message: "#^Method LibreNMS\\\\Util\\\\ModuleTestHelper\\:\\:captureFromDevice\\(\\) has parameter \\$device_id with no type specified\\.$#"
-			count: 1
-			path: LibreNMS/Util/ModuleTestHelper.php
-
-		-
-			message: "#^Method LibreNMS\\\\Util\\\\ModuleTestHelper\\:\\:captureFromDevice\\(\\) has parameter \\$full with no type specified\\.$#"
-			count: 1
-			path: LibreNMS/Util/ModuleTestHelper.php
-
-		-
-			message: "#^Method LibreNMS\\\\Util\\\\ModuleTestHelper\\:\\:captureFromDevice\\(\\) has parameter \\$prefer_new with no type specified\\.$#"
-			count: 1
-			path: LibreNMS/Util/ModuleTestHelper.php
-
-		-
-			message: "#^Method LibreNMS\\\\Util\\\\ModuleTestHelper\\:\\:captureFromDevice\\(\\) has parameter \\$write with no type specified\\.$#"
-			count: 1
-			path: LibreNMS/Util/ModuleTestHelper.php
-
-		-
 			message: "#^Method LibreNMS\\\\Util\\\\ModuleTestHelper\\:\\:cleanSnmprecData\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: LibreNMS/Util/ModuleTestHelper.php
@@ -6057,26 +6032,6 @@ parameters:
 
 		-
 			message: "#^Method LibreNMS\\\\Util\\\\ModuleTestHelper\\:\\:qPrint\\(\\) has parameter \\$var with no type specified\\.$#"
-			count: 1
-			path: LibreNMS/Util/ModuleTestHelper.php
-
-		-
-			message: "#^Method LibreNMS\\\\Util\\\\ModuleTestHelper\\:\\:saveSnmprec\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: LibreNMS/Util/ModuleTestHelper.php
-
-		-
-			message: "#^Method LibreNMS\\\\Util\\\\ModuleTestHelper\\:\\:saveSnmprec\\(\\) has parameter \\$data with no type specified\\.$#"
-			count: 1
-			path: LibreNMS/Util/ModuleTestHelper.php
-
-		-
-			message: "#^Method LibreNMS\\\\Util\\\\ModuleTestHelper\\:\\:saveSnmprec\\(\\) has parameter \\$prefer_new with no type specified\\.$#"
-			count: 1
-			path: LibreNMS/Util/ModuleTestHelper.php
-
-		-
-			message: "#^Method LibreNMS\\\\Util\\\\ModuleTestHelper\\:\\:saveSnmprec\\(\\) has parameter \\$write with no type specified\\.$#"
 			count: 1
 			path: LibreNMS/Util/ModuleTestHelper.php
 

--- a/scripts/collect-snmp-data.php
+++ b/scripts/collect-snmp-data.php
@@ -135,7 +135,8 @@ try {
 
     echo 'Capturing Data: ';
     \LibreNMS\Util\OS::updateCache(true); // Force update of OS Cache
-    $capture->captureFromDevice($device['device_id'], true, $prefer_new_snmprec, $full);
+    $capture->captureFromDevice($device['device_id'], $prefer_new_snmprec, $full);
+    echo "\nVerify these file(s) do not contain any private data before sharing!\n";
 } catch (InvalidModuleException $e) {
     echo $e->getMessage() . PHP_EOL;
 }


### PR DESCRIPTION
This is helpful for devices that use context for multiple data sets such as VLANs and VRFs.

Allows us to test things that use those now, but does make more snmprec files :/

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
