### PR TITLE
Fix the displayed unit for frequency and distance in the wireless section

### DIFF
--- a/includes/html/functions.inc.php
+++ b/includes/html/functions.inc.php
@@ -1319,11 +1319,11 @@ function get_sensor_label_color($sensor, $type = 'sensors')
         return "<span class='label $label_style'>" . trim($sensor['sensor_current']) . ' ' . $unit . '</span>';
     }
 
-    if ($type == 'wireless' && $sensor['sensor_class'] == "frequency") {
+    if ($type == 'wireless' && $sensor['sensor_class'] == 'frequency') {
         return "<span class='label $label_style'>" . trim(Number::formatSi($sensor['sensor_current'] * 1000000, 2, 3, 'Hz')) . '</span>';
     }
 
-    if ($type == 'wireless' && $sensor['sensor_class'] == "distance") {
+    if ($type == 'wireless' && $sensor['sensor_class'] == 'distance') {
         return "<span class='label $label_style'>" . trim(Number::formatSi($sensor['sensor_current'] * 1000, 2, 3, 'm')) . '</span>';
     }
 

--- a/includes/html/functions.inc.php
+++ b/includes/html/functions.inc.php
@@ -1319,6 +1319,14 @@ function get_sensor_label_color($sensor, $type = 'sensors')
         return "<span class='label $label_style'>" . trim($sensor['sensor_current']) . ' ' . $unit . '</span>';
     }
 
+    if ($type == 'wireless' && $sensor['sensor_class'] == "frequency") {
+        return "<span class='label $label_style'>" . trim(Number::formatSi($sensor['sensor_current'] * 1000000, 2, 3, 'Hz')) . '</span>';
+    }
+
+    if ($type == 'wireless' && $sensor['sensor_class'] == "distance") {
+        return "<span class='label $label_style'>" . trim(Number::formatSi($sensor['sensor_current'] * 1000, 2, 3, 'm')) . '</span>';
+    }
+
     return "<span class='label $label_style'>" . trim(Number::formatSi($sensor['sensor_current'], 2, 3, $unit)) . '</span>';
 }
 


### PR DESCRIPTION
This fixes the wrongly displayed unit under Wireless -> Frequency and Wireless -> Distance.

![Screenshot 2021-12-13 020722](https://user-images.githubusercontent.com/25873532/145737610-a6a40ad4-be14-4bc4-81e3-a65c8266205e.png)
![Screenshot 2021-12-13 020737](https://user-images.githubusercontent.com/25873532/145737612-75188c69-219e-4e5f-b8db-2c94292fff50.png)

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
