### PR TITLE
Fix Cisco WLC AP cleanup

### DIFF
--- a/LibreNMS/OS/Ciscowlc.php
+++ b/LibreNMS/OS/Ciscowlc.php
@@ -71,7 +71,7 @@ class Ciscowlc extends Cisco implements
         $valid_ap_ids = [];
 
         foreach ($radios as $mac => $radio) {
-            foreach($radio as $slot => $value) {
+            foreach ($radio as $slot => $value) {
                 $channel = str_replace('ch', '', $value['AIRESPACE-WIRELESS-MIB::bsnAPIfPhyChannelNumber'] ?? '');
 
                 $ap = new AccessPoint([

--- a/LibreNMS/OS/Ciscowlc.php
+++ b/LibreNMS/OS/Ciscowlc.php
@@ -26,7 +26,6 @@
 namespace LibreNMS\OS;
 
 use App\Models\AccessPoint;
-use Illuminate\Support\Arr;
 use LibreNMS\Device\WirelessSensor;
 use LibreNMS\Interfaces\Discovery\Sensors\WirelessApCountDiscovery;
 use LibreNMS\Interfaces\Discovery\Sensors\WirelessClientsDiscovery;
@@ -42,17 +41,18 @@ class Ciscowlc extends Cisco implements
     public function pollOS(): void
     {
         $device = $this->getDeviceArray();
-        $stats = snmpwalk_cache_oid($device, 'bsnAPEntry', [], 'AIRESPACE-WIRELESS-MIB', null, '-OQUsb');
-        $radios = snmpwalk_cache_oid($device, 'bsnAPIfEntry', [], 'AIRESPACE-WIRELESS-MIB', null, '-OQUsb');
-        $APstats = snmpwalk_cache_oid($device, 'bsnApIfNoOfUsers', [], 'AIRESPACE-WIRELESS-MIB', null, '-OQUsxb');
-        $loadParams = snmpwalk_cache_oid($device, 'bsnAPIfLoadChannelUtilization', [], 'AIRESPACE-WIRELESS-MIB', null, '-OQUsb');
-        $interferences = snmpwalk_cache_oid($device, 'bsnAPIfInterferencePower', [], 'AIRESPACE-WIRELESS-MIB', null, '-OQUsb');
+        $apNames = \SnmpQuery::enumStrings()->walk('AIRESPACE-WIRELESS-MIB::bsnAPName')->table(1);
+        $radios = \SnmpQuery::enumStrings()->walk('AIRESPACE-WIRELESS-MIB::bsnAPIfTable')->table(2);
+        \SnmpQuery::walk('AIRESPACE-WIRELESS-MIB::bsnAPIfLoadChannelUtilization')->table(2, $radios);
+        $interferences = \SnmpQuery::walk('AIRESPACE-WIRELESS-MIB::bsnAPIfInterferencePower')->table(3);
 
-        $numAccessPoints = is_countable($stats) ? count($stats) : 0;
+        $numAccessPoints = count($apNames);
         $numClients = 0;
 
-        foreach (Arr::wrap($APstats) as $value) {
-            $numClients += $value['bsnApIfNoOfUsers'];
+        foreach ($radios as $radio) {
+            foreach ($radio as $slot) {
+                $numClients += $slot['AIRESPACE-WIRELESS-MIB::bsnApIfNoOfUsers'];
+            }
         }
 
         $rrd_def = RrdDefinition::make()
@@ -68,67 +68,70 @@ class Ciscowlc extends Cisco implements
         data_update($device, 'ciscowlc', $tags, $fields);
 
         $db_aps = $this->getDevice()->accessPoints->keyBy->getCompositeKey();
+        $valid_ap_ids = [];
 
-        foreach ($radios as $key => $value) {
-            $indexName = substr($key, 0, -2);
-            $channel = str_replace('ch', '', $value['bsnAPIfPhyChannelNumber'] ?? '');
+        foreach ($radios as $mac => $radio) {
+            foreach($radio as $slot => $value) {
+                $channel = str_replace('ch', '', $value['AIRESPACE-WIRELESS-MIB::bsnAPIfPhyChannelNumber'] ?? '');
 
-            $ap = new AccessPoint([
-                'device_id' => $device['device_id'],
-                'name' => $stats[$indexName]['bsnAPName'] ?? '',
-                'radio_number' => Arr::first(explode('.', $key)),
-                'type' => $value['bsnAPIfType'] ?? '',
-                'mac_addr' => str_replace(' ', ':', $stats[$indexName]['bsnAPDot3MacAddress'] ?? ''),
-                'channel' => $channel,
-                'txpow' => $value['bsnAPIfPhyTxPowerLevel'] ?? 0,
-                'radioutil' => $loadParams[$key]['bsnAPIfLoadChannelUtilization'] ?? 0,
-                'numasoclients' => $value['bsnApIfNoOfUsers'] ?? 0,
-                'nummonclients' => 0,
-                'nummonbssid' => 0,
-                'interference' => 128 + ($interferences[$key . '.' . $channel]['bsnAPIfInterferencePower'] ?? -128),
-            ]);
+                $ap = new AccessPoint([
+                    'device_id' => $this->getDeviceId(),
+                    'name' => $apNames[$mac]['AIRESPACE-WIRELESS-MIB::bsnAPName'] ?? '',
+                    'radio_number' => $slot,
+                    'type' => $value['AIRESPACE-WIRELESS-MIB::bsnAPIfType'] ?? '',
+                    'mac_addr' => $mac,
+                    'channel' => $channel,
+                    'txpow' => $value['AIRESPACE-WIRELESS-MIB::bsnAPIfPhyTxPowerLevel'] ?? 0,
+                    'radioutil' => $value['AIRESPACE-WIRELESS-MIB::bsnAPIfLoadChannelUtilization'] ?? 0,
+                    'numasoclients' => $value['AIRESPACE-WIRELESS-MIB::bsnApIfNoOfUsers'] ?? 0,
+                    'nummonclients' => 0,
+                    'nummonbssid' => 0,
+                    'interference' => 128 + ($interferences[$mac][$slot][$channel]['AIRESPACE-WIRELESS-MIB::bsnAPIfInterferencePower'] ?? -128), // why are we adding 128?
+                ]);
 
-            d_echo($ap->toArray());
+                d_echo($ap->toArray());
 
-            // if there is a numeric channel, assume the rest of the data is valid, I guess
-            if (! is_numeric($ap->channel)) {
-                continue;
+                // if there is a numeric channel, assume the rest of the data is valid, I guess
+                if (! is_numeric($ap->channel)) {
+                    continue;
+                }
+
+                $rrd_def = RrdDefinition::make()
+                    ->addDataset('channel', 'GAUGE', 0, 200)
+                    ->addDataset('txpow', 'GAUGE', 0, 200)
+                    ->addDataset('radioutil', 'GAUGE', 0, 100)
+                    ->addDataset('nummonclients', 'GAUGE', 0, 500)
+                    ->addDataset('nummonbssid', 'GAUGE', 0, 200)
+                    ->addDataset('numasoclients', 'GAUGE', 0, 500)
+                    ->addDataset('interference', 'GAUGE', 0, 2000);
+
+                data_update($device, 'arubaap', [
+                    'name' => $ap->name,
+                    'radionum' => $ap->radio_number,
+                    'rrd_name' => ['arubaap', $ap->name . $ap->radio_number],
+                    'rrd_dev' => $rrd_def,
+                ], $ap->only([
+                    'channel',
+                    'txpow',
+                    'radioutil',
+                    'nummonclients',
+                    'nummonbssid',
+                    'numasoclients',
+                    'interference',
+                ]));
+
+                /** @var AccessPoint $db_ap */
+                if ($db_ap = $db_aps->get($ap->getCompositeKey())) {
+                    $ap = $db_ap->fill($ap->getAttributes());
+                }
+
+                $ap->save(); // persist ap
+                $valid_ap_ids[] = $ap->accesspoint_id;
             }
-
-            $rrd_def = RrdDefinition::make()
-                ->addDataset('channel', 'GAUGE', 0, 200)
-                ->addDataset('txpow', 'GAUGE', 0, 200)
-                ->addDataset('radioutil', 'GAUGE', 0, 100)
-                ->addDataset('nummonclients', 'GAUGE', 0, 500)
-                ->addDataset('nummonbssid', 'GAUGE', 0, 200)
-                ->addDataset('numasoclients', 'GAUGE', 0, 500)
-                ->addDataset('interference', 'GAUGE', 0, 2000);
-
-            data_update($device, 'arubaap', [
-                'name' => $ap->name,
-                'radionum' => $ap->radio_number,
-                'rrd_name' => ['arubaap', $ap->name . $ap->radio_number],
-                'rrd_dev' => $rrd_def,
-            ], $ap->only([
-                'channel',
-                'txpow',
-                'radioutil',
-                'nummonclients',
-                'nummonbssid',
-                'numasoclients',
-                'interference',
-            ]));
-
-            /** @var AccessPoint $db_ap */
-            if ($db_ap = $db_aps->get($ap->getCompositeKey())) {
-                $db_aps->forget($ap->getCompositeKey());
-                $ap = $db_ap->fill($ap->getAttributes());
-            }
-
-            $ap->save(); // persist ap
         }
 
-        $db_aps->each->delete(); // delete those not removed
+        // delete invalid aps
+        $this->getDevice()->accessPoints->whereNotIn('accesspoint_id', $valid_ap_ids)->each->delete();
     }
 
     /**

--- a/mibs/cisco/AIRESPACE-REF-MIB
+++ b/mibs/cisco/AIRESPACE-REF-MIB
@@ -1,9 +1,32 @@
+--  **********************************************************
+-- Airespace Reference MIB
+-- Copyright 2005 Cisco Systems, Inc.  All rights reserved.
+
+-- This SNMP Management Information Specification
+-- embodies Cisco's confidential and proprietary
+-- intellectual property.  Cisco retains all title
+-- and ownership in the Specification including any revisions.
+
+-- This Specification is supplied "AS IS", Cisco
+-- makes no warranty, either expressed or implied,
+-- as to the use, operation, condition, or performance of the
+-- Specification.
+
+
+-- Status: Release
+-- Version: 4.0
+-- Internal Source Code Version:1.268
+-- Date: 01 Jan 2006
+--  **********************************************************
+
+
 AIRESPACE-REF-MIB DEFINITIONS ::= BEGIN
 
 IMPORTS
      MODULE-IDENTITY,
      enterprises                 
          FROM SNMPv2-SMI;
+
 
 airespace MODULE-IDENTITY
         LAST-UPDATED "200512190000Z"  -- December 19, 2005
@@ -23,6 +46,7 @@ airespace MODULE-IDENTITY
         REVISION    "200512190000Z"  -- December 19, 2005
         DESCRIPTION
                    "Initial version of this MIB module."
-        ::= { enterprises 14179 }  -- assigned by IANA
 
+        ::= { enterprises 14179 }  -- assigned by IANA
+    
 END

--- a/mibs/cisco/AIRESPACE-SWITCHING-MIB
+++ b/mibs/cisco/AIRESPACE-SWITCHING-MIB
@@ -1,3 +1,25 @@
+-- *******************************************************************
+-- Airespace Switching MIB
+-- Copyright 2001 Airespace, Inc.  All rights reserved.
+
+-- This SNMP Management Information Specification
+-- embodies Airespace's confidential and proprietary
+-- intellectual property.  LVL7 Systems retains all title
+-- and ownership in the Specification including any revisions.
+
+-- This Specification is supplied "AS IS", Airespace
+-- makes no warranty, either expressed or implied,
+-- as to the use, operation, condition, or performance of the
+-- Specification.
+
+
+-- Status: Release
+-- Version: 3.2
+-- Internal Source Code Version:1.75
+-- Date: 19 Dec 2005
+-- *******************************************************************
+
+
 AIRESPACE-SWITCHING-MIB DEFINITIONS ::= BEGIN
 
 IMPORTS
@@ -40,7 +62,7 @@ IMPORTS
                 information such as Inventory, Trap logs, memory and 
                 CPU. This MIB also provides configuration of CLI, 
                 SNMP, LAG, DHCP, Spanning Tree, etc. 
-
+                
                 The relationship between controller and the LWAPP APs
                 can be depicted as follows:
 
@@ -71,6 +93,7 @@ IMPORTS
       +      + +      +     +      +      +      +          +      +
       +......+ +......+     +......+      +......+          +......+
 
+
                 The LWAPP tunnel exists between the controller and
                 the APs.  The MNs communicate with the APs through
                 the protocol defined by the 802.11 standard.
@@ -81,9 +104,9 @@ IMPORTS
                 The APs then encapsulate all the 802.11 frames from
                 wireless clients inside LWAPP frames and forward
                 the LWAPP frames to the controller.
-
+               
                                    GLOSSARY
-
+ 
                 Access Point ( AP )
 
                 An entity that contains an 802.11 medium access
@@ -129,17 +152,20 @@ IMPORTS
                 802.11 protocol operations by the AP to work
                 cooperatively with the other APs and 802.11
                 devices in the network.
+ 
                 REFERENCE
-
+ 
                 [1] Part 11 Wireless LAN Medium Access Control ( MAC )
                 and Physical Layer ( PHY ) Specifications.
-
+  
                 [2] Draft-obara-capwap-lwapp-00.txt, IETF Light 
                 Weight Access Point Protocol. "
 
         REVISION    "200604100000Z"
+
         DESCRIPTION
                    "Updated MIB with description and format"
+
       ::= { airespace 1 }
 
 --********************************************************************
@@ -154,11 +180,14 @@ IMPORTS
     bsnSwitchingGroups       OBJECT IDENTIFIER ::= { bsnSwitching 51 }
     bsnSwitchingCompliances  OBJECT IDENTIFIER ::= { bsnSwitching 52 }
 
+
 --********************************************************************
 -- agentInventoryGroup
 --********************************************************************
 
+
     agentInventoryGroup     OBJECT IDENTIFIER ::= { agentInfoGroup 1 }
+
 
     agentInventorySysDescription OBJECT-TYPE
          SYNTAX      DisplayString
@@ -192,6 +221,7 @@ IMPORTS
                      "Serial number of the switch."
          ::= { agentInventoryGroup 4 }
 
+
     agentInventoryMaintenanceLevel OBJECT-TYPE
          SYNTAX      DisplayString
          MAX-ACCESS  read-only
@@ -200,12 +230,14 @@ IMPORTS
                      "The switch's Inventory Maintenance Level"
          ::= { agentInventoryGroup 6 }
 
+
     agentInventoryBurnedInMacAddress OBJECT-TYPE
          SYNTAX      PhysAddress
          MAX-ACCESS  read-only
          STATUS      current
          DESCRIPTION
                      "Burned-In MAC Address"
+
          ::= { agentInventoryGroup 9 }
 
     agentInventoryOperatingSystem OBJECT-TYPE
@@ -267,6 +299,7 @@ IMPORTS
                      Access Points."
          ::= { agentInventoryGroup 17 }
 
+
     agentInventoryMaxNumberOfAPsSupported OBJECT-TYPE
          SYNTAX      Integer32
          MAX-ACCESS  read-only
@@ -274,6 +307,7 @@ IMPORTS
          DESCRIPTION
                      "Maximum number of APs supported with this
                       Controller."
+
          ::= { agentInventoryGroup 18 }
 
      agentInventoryIsCryptoCard2Present OBJECT-TYPE
@@ -297,6 +331,7 @@ IMPORTS
                      console."
          DEFVAL {false}
          ::= { agentInventoryGroup 20 }
+
 
 --********************************************************************
 -- agentTrapLogGroup
@@ -357,6 +392,7 @@ IMPORTS
                       traps sent since last reset."
          ::= { agentTrapLogGroup 8 }
 
+
     agentApInterferenceProfileFailTrapCount OBJECT-TYPE
          SYNTAX      Integer32
          MAX-ACCESS  read-only
@@ -374,6 +410,7 @@ IMPORTS
                      "The total number of AP Coverge Profile Failure
                       traps sent since last reset."
          ::= { agentTrapLogGroup 10 }
+
 
 --********************************************************************
 -- agentTrapLogTable
@@ -428,11 +465,13 @@ IMPORTS
                      "Description of the trap sent."
          ::= { agentTrapLogEntry 22 }
 
+
 --********************************************************************
 -- agentSwitchInfoGroup
 --********************************************************************
 
     agentSwitchInfoGroup    OBJECT IDENTIFIER ::= { agentInfoGroup 3 }
+
 
     agentSwitchInfoLwappTransportMode OBJECT-TYPE
          SYNTAX      INTEGER {
@@ -504,6 +543,7 @@ IMPORTS
                       earlier device versions."
          ::= { agentSwitchInfoGroup 5 }
 
+
 --********************************************************************
 -- agentResourceInfoGroup
 --********************************************************************
@@ -537,6 +577,7 @@ IMPORTS
 --********************************************************************
 -- agentWcpInfoGroup
 --********************************************************************
+
 
     agentWcpInfoGroup    OBJECT IDENTIFIER ::= { agentInfoGroup 6 }
 
@@ -649,6 +690,7 @@ IMPORTS
          DESCRIPTION
                      "The management IP Address of a controller."
          ::= { agentWcpControllerInfoEntry 10 }
+
 
 --********************************************************************
 -- agentProductGroup
@@ -781,6 +823,7 @@ IMPORTS
                      destroy(6) - Set to this value to disconnect
                                   this user."
          ::= { agentLoginSessionEntry 26 }
+
 
 --********************************************************************
 -- agentTelnetConfigGroup
@@ -981,6 +1024,7 @@ IMPORTS
                      "Agent Lag If Index"
          ::= { agentLagSummaryConfigEntry 2 }
 
+
     agentLagSummaryFlushTimer OBJECT-TYPE
          SYNTAX      Integer32
          MAX-ACCESS  read-create
@@ -1062,6 +1106,7 @@ IMPORTS
                       Lag."
          ::= { agentLagSummaryConfigEntry 30 }
 
+
 --*******************************************************************
 -- agentLagDetailedConfigTable
 --*******************************************************************
@@ -1116,6 +1161,7 @@ IMPORTS
                       description and list of valid values."
          ::= { agentLagDetailedConfigEntry 22 }
 
+
     agentLagConfigMode OBJECT-TYPE
          SYNTAX      INTEGER {
                       off(1),
@@ -1128,6 +1174,7 @@ IMPORTS
                       it is on, all the gigabit ports are bound to one
                       aggregated link."
          ::= { agentLagConfigGroup 4 }
+
 
 --********************************************************************
 -- agentNetworkConfigGroup
@@ -1233,6 +1280,7 @@ IMPORTS
          DESCRIPTION
                      "Sets the idle user timeout."
           ::= { agentNetworkConfigGroup 12 }
+
 
     agentNetworkArpTimeout OBJECT-TYPE
          SYNTAX      Unsigned32(10..2147483647)
@@ -1358,6 +1406,7 @@ IMPORTS
                      "Multicast group address for access points."
          ::= { agentNetworkConfigGroup 25 }
 
+
 --********************************************************************
 -- agentNeworkRouteTable
 --********************************************************************
@@ -1417,6 +1466,8 @@ IMPORTS
          DESCRIPTION
                      "Network Route Row Status."
          ::= { agentNetworkRouteConfigEntry 23 }
+
+
 
 --********************************************************************
 -- agentInterfaceConfigTable
@@ -1667,6 +1718,7 @@ agentInterfaceVlanQuarantine OBJECT-TYPE
                      "The interface entry Row status."
          ::= { agentInterfaceConfigEntry 31 }
 
+
 --********************************************************************
 -- agentNtpConfigGroup - Configuration of Switch Network Time Protocol
 --********************************************************************
@@ -1717,6 +1769,7 @@ agentInterfaceVlanQuarantine OBJECT-TYPE
                      "NTP Server priority index."
          ::= { agentNtpServerEntry 1 }
 
+
     agentNtpServerAddress OBJECT-TYPE
          SYNTAX      IpAddress
          MAX-ACCESS  read-create
@@ -1732,6 +1785,7 @@ agentInterfaceVlanQuarantine OBJECT-TYPE
          DESCRIPTION
                      "NTP server entry row status."
          ::= { agentNtpServerEntry 20 }
+
 
 --********************************************************************
 -- agentDhcpConfigGroup - Configuration of Switch DHCP Server and
@@ -1943,6 +1997,7 @@ agentInterfaceVlanQuarantine OBJECT-TYPE
                      "Dhcp Scope entry row status."
          ::= { agentDhcpScopeEntry 30 }
 
+
 --********************************************************************
 -- agentServicePortConfigGroup
 -- (Interface of type service-port in agentInterfaceConfigTable
@@ -2013,11 +2068,13 @@ agentInterfaceVlanQuarantine OBJECT-TYPE
                        of this group)"
           ::= { agentServicePortConfigGroup 5 }
 
+
 --********************************************************************
 -- agentSnmpConfigGroup
 --********************************************************************
 
     agentSnmpConfigGroup  OBJECT IDENTIFIER  ::=  {agentConfigGroup 5}
+
 
     agentSnmpTrapPortNumber OBJECT-TYPE
          SYNTAX  Unsigned32(1..65534)
@@ -2042,6 +2099,7 @@ agentInterfaceVlanQuarantine OBJECT-TYPE
          DESCRIPTION
         "Snmp Version 2c Status"
          ::= { agentSnmpConfigGroup 3 }
+
 
 --********************************************************************
 -- agentSnmpCommunityConfigTable
@@ -2189,6 +2247,7 @@ agentInterfaceVlanQuarantine OBJECT-TYPE
                      the
                                         community from the agent."
          ::= { agentSnmpCommunityConfigEntry 25 }
+
 
 --********************************************************************
 -- agentSnmpTrapReceiverConfigTable
@@ -2357,6 +2416,7 @@ agentInterfaceVlanQuarantine OBJECT-TYPE
 
  agentSnmpV3ConfigGroup   OBJECT IDENTIFIER  ::=  {agentConfigGroup 6}
 
+
     agentSnmpVersion3Status OBJECT-TYPE
          SYNTAX  INTEGER{disable(0),enable(1)}
          MAX-ACCESS  read-write
@@ -2417,6 +2477,7 @@ agentInterfaceVlanQuarantine OBJECT-TYPE
                      "Agent User Access Mode"
          ::= { agentSnmpV3UserConfigEntry 2 }
 
+
     agentSnmpV3UserAuthenticationType OBJECT-TYPE
          SYNTAX      INTEGER {
                      none(1),
@@ -2475,11 +2536,13 @@ agentInterfaceVlanQuarantine OBJECT-TYPE
                      user account."
          ::= { agentSnmpV3UserConfigEntry 26 }
 
+
 --********************************************************************
 -- agentSpanningTreePortTable
 --********************************************************************
     agentSpanningTreeConfigGroup  OBJECT IDENTIFIER ::=
                                        { agentConfigGroup 7 }
+
 
     agentSpanningTreeMode OBJECT-TYPE
          SYNTAX      INTEGER {
@@ -2491,6 +2554,7 @@ agentInterfaceVlanQuarantine OBJECT-TYPE
          DESCRIPTION
                      "The switch's Spanning Tree Switch Status"
          ::= { agentSpanningTreeConfigGroup 1 }
+
 
 --********************************************************************
 -- agentSwitchConfigGroup
@@ -2581,12 +2645,14 @@ agentInterfaceVlanQuarantine OBJECT-TYPE
                       change to take effect."
          ::= { agentSwitchConfigGroup 5 }
 
+
 --********************************************************************
 -- agentTransferConfigGroup
 --********************************************************************
 
     agentTransferConfigGroup    OBJECT IDENTIFIER ::=
                                        { agentConfigGroup 9 }
+
 
 --*******************************************************************
 -- agentTransferUploadGroup
@@ -2680,6 +2746,7 @@ agentInterfaceVlanQuarantine OBJECT-TYPE
                      "
          ::= { agentTransferUploadGroup 5 }
 
+
     agentTransferUploadStart OBJECT-TYPE
          SYNTAX      INTEGER {
                      enable(1),
@@ -2742,6 +2809,8 @@ agentInterfaceVlanQuarantine OBJECT-TYPE
                       or while decrypting the file after download to
                       the switch."
          ::= { agentTransferConfigGroup 4 }
+
+
 
 --********************************************************************
 -- agentTransferDownloadGroup
@@ -2807,6 +2876,7 @@ agentInterfaceVlanQuarantine OBJECT-TYPE
                       and File Name set to e1r1v1.opr. Note: File
                       Name, File Path, and TFTP Server IP Address are
                       applicable only if the Transfer Mode is TFTP."
+
          ::= { agentTransferDownloadGroup 4 }
 
     agentTransferDownloadDataType OBJECT-TYPE
@@ -2831,6 +2901,7 @@ agentInterfaceVlanQuarantine OBJECT-TYPE
                         -   Signatures
                         -   customWebauth- custom webauth tar ball"
          ::= { agentTransferDownloadGroup 5 }
+
 
     agentTransferDownloadStart OBJECT-TYPE
          SYNTAX      INTEGER {
@@ -2939,6 +3010,7 @@ agentInterfaceVlanQuarantine OBJECT-TYPE
          DESCRIPTION
                      "Enable/disable 802.3ad LACP on this port"
          ::= { agentDot3adAggPortEntry 21 }
+
 
 --********************************************************************
     -- agentPortConfigTable
@@ -3147,6 +3219,7 @@ agentInterfaceVlanQuarantine OBJECT-TYPE
                        dot3MauType100BaseTXFD
                        dot3MauType100BaseFXFD
                        dot3MauType1000BaseSXFD"
+
          REFERENCE "RFC 2668"
          ::= { agentPortConfigEntry 11 }
 
@@ -3184,6 +3257,7 @@ agentInterfaceVlanQuarantine OBJECT-TYPE
                        dot3MauType100BaseTXFD
                        dot3MauType100BaseFXFD
                        dot3MauType1000BaseSXFD"
+
          REFERENCE "RFC 2668"
          ::= { agentPortConfigEntry 12 }
 
@@ -3198,6 +3272,7 @@ agentInterfaceVlanQuarantine OBJECT-TYPE
                  "This object identifies the administration status of
                   auto negotiation for this port."
          ::= { agentPortConfigEntry 13 }
+
 
     agentPortDot3FlowControlMode OBJECT-TYPE
          SYNTAX      INTEGER {
@@ -3315,6 +3390,7 @@ agentInterfaceVlanQuarantine OBJECT-TYPE
                "The current operational state of the port."
        ::= { agentPortConfigEntry 40 }
 
+
 --********************************************************************
 --    agentSystemGroup
 --********************************************************************
@@ -3396,6 +3472,7 @@ agentInterfaceVlanQuarantine OBJECT-TYPE
                      "clear trap log"
          ::= { agentSystemGroup 8 }
 
+
      agentResetSystem OBJECT-TYPE
          SYNTAX      INTEGER {
                      enable(1),
@@ -3406,6 +3483,7 @@ agentInterfaceVlanQuarantine OBJECT-TYPE
          DESCRIPTION
                      "reset the switch"
          ::= { agentSystemGroup 10 }
+
 
 --********************************************************************
  -- portStatsTable
@@ -3548,6 +3626,7 @@ PortStatsEntry ::= SEQUENCE {
          (excluding framing bits but including FCS octets)."
      ::= { portStatsEntry 9 }
 
+
  portStatsPktsTxOversizeOctets      OBJECT-TYPE
      SYNTAX     Counter32
      UNITS      "Packets"
@@ -3559,6 +3638,7 @@ PortStatsEntry ::= SEQUENCE {
          1530 octets in length.
          (excluding framing bits but including FCS octets)."
      ::= { portStatsEntry 30 }
+
 
 --********************************************************************
 --   switchingTraps
@@ -3654,6 +3734,7 @@ PortStatsEntry ::= SEQUENCE {
              "Power Supply Status Change Trap"
          ::= { switchingTraps 12 }
 
+
 --********************************************************************
 --*    Compliance statements
 --********************************************************************
@@ -3724,6 +3805,7 @@ bsnSwitchingAgentInfoGroup OBJECT-GROUP
     DESCRIPTION
         "This collection of objects provide switching information."
     ::= { bsnSwitchingGroups 1}
+
 
 bsnSwitchingAgentConfigGroup OBJECT-GROUP
     OBJECTS {
@@ -3900,6 +3982,7 @@ bsnSwitchingAgentSystemGroup OBJECT-GROUP
          information and config."
     ::= { bsnSwitchingGroups 3 }
 
+
 bsnSwitchingAgentStatsGroup OBJECT-GROUP
     OBJECTS {
         portStatsIndex,
@@ -3980,4 +4063,6 @@ bsnSwitchingTrap NOTIFICATION-GROUP
 --*   End of units of conformance
 --********************************************************************
 
+
 END
+

--- a/mibs/cisco/AIRESPACE-WIRELESS-MIB
+++ b/mibs/cisco/AIRESPACE-WIRELESS-MIB
@@ -1,3 +1,42 @@
+-- **********************************************************
+-- Airespace Wireless MIB
+-- Copyright 2005, 2010-2011, 2014 Cisco Systems Inc. All rights reserved.
+--   
+-- This SNMP Management Information Specification
+-- embodies Cisco's confidential and proprietary
+-- intellectual property.  Cisco retains all title
+-- and ownership in the Specification including any revisions.
+--   
+-- This Specification is supplied "AS IS", Cisco
+-- makes no warranty, either expressed or implied,
+-- as to the use, operation, condition, or performance of the
+-- Specification.
+--   
+
+-- Status: Release
+-- Version: 4.0
+-- Internal Source Code Version:1.268
+-- Date: 01 Jan 2006
+-- **********************************************************
+--   
+-- %DNP%  FYI:  Lines containing a comment starting with the "Do Not
+-- %DNP%  Publish" prefix "%DNP%" (such as these) are automagicially
+-- %DNP%  stripped from MIBS prior to publishing on ftp and cio, and
+-- %DNP%  should be used for comments intended for cisco engineering
+-- %DNP%  eyes only, or for new product identifiers that are not yet
+-- %DNP%  announced.
+--   
+-- %DNP%   ****************************************************
+-- %DNP%   ** As approver for the 3.x review of this this MIB
+-- %DNP%   ** it is essential that I indicate that many of the
+-- %DNP%   ** changes are illegal(see RFC 2578).  In fact,
+-- %DNP%   ** these modifications will break existing applications
+-- %DNP%   ** and force those applications to become aware of
+-- %DNP%   ** which image level supports a particiular version
+-- %DNP%   ** of this MIB.  For example,the order and number of
+-- %DNP%   ** object in many of the notifications were changed.
+-- %DNP%   ****************************************************
+
 AIRESPACE-WIRELESS-MIB DEFINITIONS ::= BEGIN
 
 IMPORTS
@@ -26,12 +65,13 @@ IMPORTS
     airespace
         FROM AIRESPACE-REF-MIB;
 
+
 -- ********************************************************************
 -- *  MODULE IDENTITY
 -- ********************************************************************
 
 bsnWireless MODULE-IDENTITY
-    LAST-UPDATED    "201002090000Z"
+    LAST-UPDATED    "201406260000Z"
     ORGANIZATION    "Airespace, Inc."
     CONTACT-INFO
             "Cisco Systems,
@@ -82,6 +122,7 @@ bsnWireless MODULE-IDENTITY
         +  MN  + +  MN  +     +  MN  +      +  MN  +          +  MN  +
         +      + +      +     +      +      +      +          +      +
         +......+ +......+     +......+      +......+          +......+
+
 
         The LWAPP tunnel exists between the controller and
         the APs.  The MNs communicate with the APs through
@@ -141,6 +182,7 @@ bsnWireless MODULE-IDENTITY
         802.11 protocol operations by the AP to work
         cooperatively with the other APs and 802.11
         devices in the network.
+
         REFERENCE
 
         [1] Part 11 Wireless LAN Medium Access Control ( MAC )
@@ -148,6 +190,53 @@ bsnWireless MODULE-IDENTITY
 
         [2] Draft-obara-capwap-lwapp-00.txt, IETF Light 
         Weight Access Point Protocol."
+    REVISION        "201406260000Z"
+    DESCRIPTION
+        "Added enumerated value 9 - 10 to bsnMobileStationProtocol.
+        Added enumerated value 29 - 50 to bsnAPType. 
+        Updated description for bsnDot11EssStaticWEPKeyIndex, 
+        bsnRrmDot11aThroughputThreshold and bsnRrmDot11bThroughputThreshold."
+    REVISION        "201109270000Z"
+    DESCRIPTION
+        "Modified the following variables with
+        additional enumeration values:
+
+        bsnMobileStationReasonCode,
+        bsnMobileStationProtocol,
+        bsnMobileStationCcxVersion,
+        bsnAPType.
+
+        Modified the following notification variable:
+
+        bsnStationReasonCode
+
+        Deprecated the following variables:
+
+        bsnAPIfDot11CurrentCCAMode,
+        bsnDot11EssIPv6Bridging,
+        bsnAPPortNumber,
+        bsnAPAdminStatus,
+        bsnAPIfAdminStatus,
+        bsnRrmDot11aGlobalAutomaticGrouping,
+        bsnRrmDot11aGroupLeaderMacAddr,
+        bsnRrmIsDot11aGroupLeader,
+        bsnRrmDot11aGroupLastUpdateTime,
+        bsnRrmDot11aGlobalGroupInterval,
+        bsnRrmDot11bGlobalAutomaticGrouping,
+        bsnRrmDot11bGroupLeaderMacAddr,
+        bsnRrmIsDot11bGroupLeader,
+        bsnRrmDot11bGroupLastUpdateTime,
+        bsnRrmDot11bGlobalGroupInterval.
+
+        Deprecated following tables:
+
+        bsnWrasDot11aGroupTable,
+        bsnWrasDot11bGroupTable.
+
+        Deprecated following notifications:
+
+        bsnAPIfUp,
+        bsnAPIfDown."
     REVISION        "201002090000Z"
     DESCRIPTION
         "Updated:-
@@ -243,6 +332,7 @@ bsnWireless MODULE-IDENTITY
         bsnAPDown,
         bsnWrasObsTrap,
         bsnWrasTrap,        
+
         Deprecated:-
         bsnGlobalDot11CountryIndex,
         bsnGlobalDot11LoadBalancing,
@@ -271,6 +361,7 @@ bsnWireless MODULE-IDENTITY
     DESCRIPTION
         "Airespace MIB"
     ::= { airespace 2 }
+
 
 -- *******************************************************************
 -- *  Major sections
@@ -349,6 +440,7 @@ bsnWrasGroups  OBJECT IDENTIFIER
 
 bsnWrasCompliances  OBJECT IDENTIFIER
     ::= { bsnWireless 51 }
+
 
 WEPKeytype ::= TEXTUAL-CONVENTION
     STATUS          current
@@ -651,7 +743,9 @@ bsnDot11EssStaticWEPKeyIndex OBJECT-TYPE
     DESCRIPTION
         "According to 802.11 standard 4 keys are supported.
         So 802.11 Mobile Stations(Client) can have upto 4 
-        keys.  This index is for informing Mobile Station 
+        keys from 1 to 4. The read-only value zero indicates
+        that there is no WEP Authentication key information 
+        available.This index is for informing Mobile Station 
         which key it should use for Static WEP Authentication" 
     ::= { bsnDot11EssEntry 11 }
 
@@ -1263,7 +1357,7 @@ bsnDot11EssIPv6Bridging OBJECT-TYPE
                         enable(1)
                     }
     MAX-ACCESS      read-create
-    STATUS          current
+    STATUS          deprecated
     DESCRIPTION
         "When enabled, IPv6 bridging is applied on the packets."
     DEFVAL          { disable } 
@@ -1389,6 +1483,7 @@ bsnDot11EssRadiusAcctTertiaryServer OBJECT-TYPE
     DESCRIPTION
         "Tertiary Radius Accounting Server for this wlan." 
     ::= { bsnDot11EssEntry 100 }
+ 
 
 -- ***************************************************************
 -- * QOS Profile Table
@@ -1535,6 +1630,7 @@ bsnDot11ResetProfileToDefault OBJECT-TYPE
         "Set this attribute to reset to restore the factory default
         value for the profile." 
     ::= { bsnDot11QosProfileEntry 40 }
+ 
 
 -- ***************************************************************
 -- * Mobile Station Index Table
@@ -1702,7 +1798,12 @@ bsnMobileStationReasonCode OBJECT-TYPE
                         unsupportedRsnVersion(44),
                         invalidRsnIeCapabilities(45),
                         cipherSuiteRejected(46),
-                        missingReasonCode(99)
+                        missingReasonCode(99),
+                        maxAssociatedClientsReached(101),
+                        unSpecifieQosFailure(200),
+                        qosPolicyMismatch(201),
+                        inSufficientBandwidth(202),
+                        inValidQosParams(203)
                     }
     MAX-ACCESS      read-only
     STATUS          current
@@ -1887,7 +1988,10 @@ bsnMobileStationProtocol OBJECT-TYPE
                         unknown(4),
                         mobile(5),
                         dot11n24(6),
-                        dot11n5(7)
+                        dot11n5(7),
+                        ethernet(8),
+                        dot3(9),
+                        dot11ac(10)
                     }
     MAX-ACCESS      read-only
     STATUS          current
@@ -1996,7 +2100,8 @@ bsnMobileStationCcxVersion OBJECT-TYPE
                         ccxv2(2),
                         ccxv3(3),
                         ccxv4(4),
-                        ccxv5(5)
+                        ccxv5(5),
+                        ccxv6(6)
                     }
     MAX-ACCESS      read-only
     STATUS          current
@@ -2028,6 +2133,7 @@ bsnMobileStationStatusCode OBJECT-TYPE
     DESCRIPTION
         "Status Code of the Mobile Station" 
     ::= { bsnMobileStationEntry 42 }
+ 
 
 -- ***************************************************************
 -- * Mobile Station Table Indexed by Mobile Station IpAddress
@@ -2074,6 +2180,7 @@ bsnMobileStationByIpMacAddress OBJECT-TYPE
     DESCRIPTION
         "802.11 Mac Address of the Mobile Station." 
     ::= { bsnMobileStationByIpEntry 2 }
+ 
 
 -- ***************************************************************
 -- * Mobile Station Table Indexed by Mobile Station Username and MAC
@@ -2124,6 +2231,7 @@ bsnMobileStationByUserMacAddress OBJECT-TYPE
     DESCRIPTION
         "802.11 Mac Address of the Mobile Station." 
     ::= { bsnMobileStationByUsernameEntry 2 }
+ 
 
 -- *****************************************************************
 -- *  Airespace Mobile Station Per Radio Per Vap Table
@@ -2180,6 +2288,7 @@ bsnMobileStationMacAddr OBJECT-TYPE
     DESCRIPTION
         "The MAC Address of Mobile Station." 
     ::= { bsnMobileStationPerRadioPerVapEntry 20 }
+ 
 
 -- *******************************************************************
 -- * Begin of bsnMobileStationStatsTable
@@ -2269,6 +2378,7 @@ bsnMobileStationSnr OBJECT-TYPE
     DESCRIPTION
         "Signal to noise Ratio of the Mobile Station." 
     ::= { bsnMobileStationStatsEntry 26 }
+ 
 
 -- *******************************************************************
 -- * Begin of bsnMobileStationExtStatsTable
@@ -2334,6 +2444,7 @@ bsnMobileStationTxFiltered OBJECT-TYPE
     DESCRIPTION
         "Tx packets dropped by the built-in Tx filter" 
     ::= { bsnMobileStationExtStatsEntry 20 }
+ 
 
 -- ***************************************************************
 -- * Mobile Station RSSI data Table
@@ -2440,6 +2551,7 @@ bsnMobileStationRssiDataLastHeard OBJECT-TYPE
     DESCRIPTION
         "No of seconds ago when this RSSI data was recorded." 
     ::= { bsnMobileStationRssiDataEntry 25 }
+ 
 
 -- ***************************************************************
 -- * RF ID Tag Table
@@ -2517,6 +2629,7 @@ bsnTagLastReported OBJECT-TYPE
     DESCRIPTION
         "No of seconds ago when this tag was heard by any AP." 
     ::= { bsnTagEntry 23 }
+ 
 
 -- *******************************************************************
 -- * Begin of bsnTagStatsTable
@@ -2559,6 +2672,7 @@ bsnTagPacketsReceived OBJECT-TYPE
     DESCRIPTION
         "Packets received from an RF ID Tag" 
     ::= { bsnTagStatsEntry 20 }
+ 
 
 -- ***************************************************************
 -- * RF ID Tag Detecting AP Table
@@ -2658,6 +2772,7 @@ bsnTagRssiDataSnr OBJECT-TYPE
         "SNR of the RF ID tag as seen by the radio on this
         detecting AP." 
     ::= { bsnTagRssiDataEntry 26 }
+ 
 
 -- ********************************************************************
 -- * Begin of bsnWatchListClientTable
@@ -2722,6 +2837,7 @@ bsnWatchListClientRowStatus OBJECT-TYPE
     DESCRIPTION
         "A row status type for the bsnWatchListClientEntry" 
     ::= { bsnWatchListClientEntry 20 }
+ 
 
 -- ********************************************************************
 -- * Begin of bsnRougueAPTable
@@ -2977,6 +3093,7 @@ bsnRogueAPDetectingAPName OBJECT-TYPE
     DESCRIPTION
         "AP name of the detecting AP which received max RSSI" 
     ::= { bsnRogueAPEntry 27 }
+ 
 
 -- ********************************************************************
 -- * Begin of bsnRougueAPAirespaceAPTable
@@ -3186,6 +3303,7 @@ bsnRogueAPChannelWidth OBJECT-TYPE
     DESCRIPTION
         "This object represents the channel width of the rogue." 
     ::= { bsnRogueAPAirespaceAPEntry 28 }
+ 
 
 -- *****************************************************************
 -- *  bsnRogueClientPerRogueAPTable
@@ -3232,6 +3350,7 @@ bsnRogueClientDot11MacAddr OBJECT-TYPE
     DESCRIPTION
         "MAC Address of the Rogue Client." 
     ::= { bsnRogueClientPerRogueAPEntry 20 }
+ 
 
 -- ********************************************************************
 -- * Begin of bsnRougueClientTable
@@ -3358,6 +3477,7 @@ bsnRogueClientState OBJECT-TYPE
         Contained means containement is initiated and 
         ongoing" 
     ::= { bsnRogueClientEntry 24 }
+ 
 
 -- ********************************************************************
 -- * Begin of bsnRougueAPTable
@@ -3469,6 +3589,7 @@ bsnRogueClientAirespaceAPSNR OBJECT-TYPE
     DESCRIPTION
         "SNR seen by Airespace AP Interface from Rogue" 
     ::= { bsnRogueClientAirespaceAPEntry 27 }
+ 
 
 -- ********************************************************************
 -- * End of bsnRougueStationTable
@@ -3573,6 +3694,7 @@ bsnThirdPartyAPRowStatus OBJECT-TYPE
     DESCRIPTION
         "Row Status in the ThirdPartyAPEntry." 
     ::= { bsnThirdPartyAPEntry 24 }
+ 
 
 -- ********************************************************************
 -- *  Airespace AP Table.
@@ -3762,7 +3884,7 @@ bsnAPStatsTimer OBJECT-TYPE
 bsnAPPortNumber OBJECT-TYPE
     SYNTAX          INTEGER (0..65535)
     MAX-ACCESS      read-only
-    STATUS          current
+    STATUS          deprecated
     DESCRIPTION
         "Port on the Switch on which this APs traffic is coming
         through." 
@@ -3854,7 +3976,41 @@ bsnAPType OBJECT-TYPE
                         ap800agn(17),
                         ap3500i(18),
                         ap3500e(19),
-                        ap1260(20)
+                        ap1260(20),
+                        ap1040(21),
+                        ap1550(22),
+                        ap602i(23),
+                        ap3500p(24),
+                        ap802gn(25),
+                        ap802agn(26),
+                        ap3600i(27),
+                        ap3600e(28),
+                        ap2600i(29),
+                        ap2600e(30),
+                        ap802hagn(31),
+                        ap1600i(32),
+                        ap1600e(33),
+                        ap702e(34),
+                        ap702i(35),
+                        ap3600p(36),
+                        ap1530i(37),
+                        ap1530e(38),
+                        ap3700e(39),
+                        ap3700i(40),
+                        ap3700p(41),
+                        ap2700e(42),
+                        ap2700i(43),
+                        ap702w(44),
+                        wap2600i(45),
+                        wap2600e(46),
+                        wap1600i(47),
+                        wap1600e(48),
+                        wap702i(49),
+                        wap702e(50),
+                        ap1700i(51),
+                        ap1700e(52),
+                        ap1570e(53),
+                        ap1570i(54)
                     }
     MAX-ACCESS      read-only
     STATUS          current
@@ -3985,10 +4141,11 @@ bsnAPAdminStatus OBJECT-TYPE
                         disable(2)
                     }
     MAX-ACCESS      read-write
-    STATUS          current
+    STATUS          deprecated
     DESCRIPTION
         "Admin State of the AP" 
     ::= { bsnAPEntry 37 }
+ 
 
 -- ********************************************************************
 -- *  BSN Airespace AP Interface Table
@@ -4419,10 +4576,11 @@ bsnAPIfAdminStatus OBJECT-TYPE
                         enable(1)
                     }
     MAX-ACCESS      read-write
-    STATUS          current
+    STATUS          deprecated
     DESCRIPTION
         "Admin status of the interface." 
     ::= { bsnAPIfEntry 34 }
+ 
 
 -- *******************************************************************
 -- * End of bsnAPIfTable
@@ -4490,6 +4648,7 @@ bsnAPIfWlanOverrideRowStatus OBJECT-TYPE
     DESCRIPTION
         "A row status type for the bsnAPIfWlanOverrideEntry" 
     ::= { bsnAPIfWlanOverrideEntry 15 }
+ 
 
 -- *******************************************************************
 -- *  BSN Airespace AP Smt Param Table
@@ -4654,6 +4813,7 @@ bsnAPIfDot11CountryString OBJECT-TYPE
         1. an ASCII space character, if the regulations under
         which the AP Interface is operating encompass all
         environments in the country,
+
         2. an ASCII 'O' character, if the regulations under
         which the AP Interface is operating are for an Outdoor
         environment only, or
@@ -4683,6 +4843,7 @@ bsnAPIfDot11BSSID OBJECT-TYPE
     DESCRIPTION
         "BSSID of this AP config which would be the MAC Address of AP" 
     ::= { bsnAPIfSmtParamEntry 30 }
+ 
 
 -- ********************************************************************
 -- *  bsnAPIfMultiDomainCapabilityTable
@@ -4748,6 +4909,7 @@ bsnAPIfDot11NumberofChannels OBJECT-TYPE
         associated domain country string. The default value 
         of this attribute shall be zero." 
     ::= { bsnAPIfMultiDomainCapabilityEntry 20 }
+ 
 
 -- ********************************************************************
 -- *    bsnDot11MacOperationTable
@@ -4854,6 +5016,7 @@ bsnAPIfDot11MacMaxReceiveLifetime OBJECT-TYPE
         "If bsnAPIfMacParamsAutomaticOn is true then this is
         read only parameter updated by RRM dynamic algorithm" 
     ::= { bsnAPIfMacOperationParamEntry 25 }
+ 
 
 -- *******************************************************************
 -- * Begin of bsnAPIfDot11CountersTable
@@ -5036,6 +5199,7 @@ bsnAPIfDot11FailedCount OBJECT-TYPE
         successfully due to the number of transmit attempts exceeding
         either the  bsnAPIfDot11ShortRetryLimit or dot11LongRetryLimit." 
     ::= { bsnAPIfDot11CountersEntry 33 }
+ 
 
 -- *******************************************************************
 -- * End of bsnAPIfCountersTable
@@ -5165,6 +5329,7 @@ bsnAPIfDot11TxPowerLevel8 OBJECT-TYPE
         "The transmit output power for LEVEL8 in mW. It is 1/128th
         of the Maximum power level available on an AP interface." 
     ::= { bsnAPIfDot11PhyTxPowerEntry 28 }
+ 
 
 -- ********************************************************************
 -- *    End of bsnAPIfDot11PhyTxPowerTable
@@ -5214,7 +5379,7 @@ bsnAPIfDot11CurrentCCAMode OBJECT-TYPE
                         hrcsanded(16)
                     }
     MAX-ACCESS      read-only
-    STATUS          current
+    STATUS          deprecated
     DESCRIPTION
         "The current CCA method in operation.Valid values are:
         energy detect only (edonly) = 01,
@@ -5243,6 +5408,7 @@ bsnAPIfDot11TIThreshold OBJECT-TYPE
         CCA shall report a busy medium upon detecting the RSSI above 
         this threshold." 
     ::= { bsnAPIfDot11PhyChannelEntry 23 }
+ 
 
 -- ********************************************************************
 -- *    End of bsnAPIfDot11PhyDSSSTable
@@ -5368,6 +5534,7 @@ bsnAPIfCoverageExceptionLevel OBJECT-TYPE
     DESCRIPTION
         "Airespace AP coverage exception level between 0 and 100 percent." 
     ::= { bsnAPIfProfileThresholdConfigEntry 28 }
+ 
 
 -- ********************************************************************
 -- * End of bsnAPIfProfileThresholdConfigTable
@@ -5455,6 +5622,7 @@ bsnAPIfPoorSNRClients OBJECT-TYPE
         this Airespace AP at the last measurement interval 
         ( This comes from APF )." 
     ::= { bsnAPIfLoadParametersEntry 24 }
+ 
 
 -- ********************************************************************
 -- * End of bsnAPIfLoadParametersTable
@@ -5519,6 +5687,7 @@ bsnAPIfInterferenceUtilization OBJECT-TYPE
         "Interference from other 802.11 networks on this
         channel" 
     ::= { bsnAPIfChannelInterferenceInfoEntry 22 }
+ 
 
 -- ********************************************************************
 -- * Begin of bsnAPIfRadarChannelStatisticsTable
@@ -5573,6 +5742,7 @@ bsnAPIfRadarSignalLastHeard OBJECT-TYPE
         "This tells how many seconds ago radar signal was heard
         on the channel." 
     ::= { bsnAPIfRadarChannelStatisticsEntry 2 }
+ 
 
 -- ********************************************************************
 -- * End of bsnAPIfRadarChannelInterferenceInfoTable
@@ -5628,6 +5798,7 @@ bsnAPIfDBNoisePower OBJECT-TYPE
         "This is the average noise power in dBm on
         each channel that is available to Airespace AP" 
     ::= { bsnAPIfChannelNoiseInfoEntry 21 }
+ 
 
 -- ********************************************************************
 -- * Begin of bsnAPIfProfileStateTable
@@ -5717,6 +5888,7 @@ bsnAPIfCoverageProfileState OBJECT-TYPE
         AP is not performing adequately against the coverage 
         profile." 
     ::= { bsnAPIfProfileStateEntry 24 }
+ 
 
 -- ********************************************************************
 -- * Begin of bsnAPIfRxNeighborsTable
@@ -5810,6 +5982,7 @@ bsnAPIfRxNeighborChannelWidth OBJECT-TYPE
         "This object represents Channel bandwidth information
         which neighboring Access point is using." 
     ::= { bsnAPIfRxNeighborsEntry 27 }
+ 
 
 -- *****************************************************************
 --   
@@ -6067,6 +6240,7 @@ bsnMeshNodeHops OBJECT-TYPE
     DESCRIPTION
         "number of hops to rap" 
     ::= { bsnMeshNodeEntry 30 }
+ 
 
 -- ********************************************************************
 -- * Begin of bsnMeshNeighsTable
@@ -6240,6 +6414,7 @@ bsnMeshNeighParentChange OBJECT-TYPE
     DESCRIPTION
         "when this node last became parent" 
     ::= { bsnMeshNeighsEntry 20 }
+ 
 
 -- ********************************************************************
 -- * Begin of bsnAPIfStationRSSICoverageInfoTable
@@ -6298,6 +6473,7 @@ bsnAPIfStationCountOnRSSI OBJECT-TYPE
     DESCRIPTION
         "Number of stations on this RSSI Level" 
     ::= { bsnAPIfStationRSSICoverageInfoEntry 23 }
+ 
 
 -- ********************************************************************
 -- * Begin of bsnAPIfStationSNRCoverageInfoTable
@@ -6356,6 +6532,7 @@ bsnAPIfStationCountOnSNR OBJECT-TYPE
     DESCRIPTION
         "Number of stations on this SNR Level" 
     ::= { bsnAPIfStationSNRCoverageInfoEntry 23 }
+ 
 
 -- ********************************************************************
 -- * Begin of bsnAPIfRecommendedRFParametersTable
@@ -6424,6 +6601,7 @@ bsnAPIfRecommendedFragmentationThreshold OBJECT-TYPE
         "Recommended Fragmentation Threshold by RRM for this
         APIf" 
     ::= { bsnAPIfRecommendedRFParametersEntry 24 }
+ 
 
 -- *******************************************************************
 -- * Global Dot11 Parameters
@@ -6433,6 +6611,7 @@ bsnAPIfRecommendedFragmentationThreshold OBJECT-TYPE
 
 bsnGlobalDot11Config  OBJECT IDENTIFIER
     ::= { bsnGlobalDot11 1 }
+
 
 -- ********************************************************************
 -- *  BSN Dot11 Global Universal Parameters that apply to both a and b
@@ -6912,6 +7091,7 @@ bsnAppleTalkEnabled OBJECT-TYPE
 bsnTrustedApPolicyConfig  OBJECT IDENTIFIER
     ::= { bsnGlobalDot11Config 40 }
 
+
 bsnPolicyForMisconfiguredAps OBJECT-TYPE
     SYNTAX          INTEGER  {
                         alarmOnly(0),
@@ -7028,6 +7208,7 @@ bsnTrustedApEntryExpirationTimeout OBJECT-TYPE
 bsnClientExclusionPolicyConfig  OBJECT IDENTIFIER
     ::= { bsnGlobalDot11Config 41 }
 
+
 bsnExcessive80211AssocFailures OBJECT-TYPE
     SYNTAX          INTEGER  {
                         disable(0),
@@ -7113,6 +7294,7 @@ bsnIPTheftORReuse OBJECT-TYPE
 
 bsnSignatureConfig  OBJECT IDENTIFIER
     ::= { bsnGlobalDot11Config 42 }
+
 
 bsnStandardSignatureTable OBJECT-TYPE
     SYNTAX          SEQUENCE OF BsnStandardSignatureEntry 
@@ -7328,6 +7510,7 @@ bsnStandardSignatureInterval OBJECT-TYPE
         "Interval of the signature. This specifies the interval
         when the signature is applied to a packet." 
     ::= { bsnStandardSignatureEntry 21 }
+ 
 
 -- *******************************************************************
 -- *  Packet Matching Patterns of a Standard Signature
@@ -7421,6 +7604,7 @@ bsnStandardSignaturePatternRowStatus OBJECT-TYPE
         "Row Status for creation/deletion. Signature Pattern will allowed
         to be created, deleted and edited in later releases." 
     ::= { bsnStandardSignaturePatternEntry 15 }
+ 
 
 -- ********************************************************************
 -- *  Custom Signature List.
@@ -7640,6 +7824,7 @@ bsnCustomSignatureInterval OBJECT-TYPE
         "Interval of the signature. This specifies the interval
         when the signature is applied to a packet." 
     ::= { bsnCustomSignatureEntry 21 }
+ 
 
 -- *******************************************************************
 -- *  Packet Matching Patterns of a Custom Signature
@@ -7733,6 +7918,8 @@ bsnCustomSignaturePatternRowStatus OBJECT-TYPE
         "Row Status for creation/deletion. Signature Pattern will
         allowed to be created, deleted and edited in later releases." 
     ::= { bsnCustomSignaturePatternEntry 15 }
+ 
+
 
 -- ********************************************************************
 -- *  Global parameter for Signature Check enable/disable
@@ -7757,6 +7944,7 @@ bsnSignatureCheckState OBJECT-TYPE
 
 bsnRfIdTagConfig  OBJECT IDENTIFIER
     ::= { bsnGlobalDot11Config 43 }
+
 
 bsnRfIdTagStatus OBJECT-TYPE
     SYNTAX          INTEGER  {
@@ -7797,6 +7985,7 @@ bsnRfIdTagAutoTimeoutStatus OBJECT-TYPE
 
 bsnAPNeighborAuthConfig  OBJECT IDENTIFIER
     ::= { bsnGlobalDot11Config 44 }
+
 
 bsnAPNeighborAuthStatus OBJECT-TYPE
     SYNTAX          INTEGER  {
@@ -7850,6 +8039,7 @@ bsnFastSSIDChangeFeature OBJECT-TYPE
 bsnBridgingPolicyConfig  OBJECT IDENTIFIER
     ::= { bsnGlobalDot11Config 47 }
 
+
 bsnBridgingZeroTouchConfig OBJECT-TYPE
     SYNTAX          INTEGER  {
                         disable(0),
@@ -7890,6 +8080,7 @@ bsnGlobalDot11h  OBJECT IDENTIFIER
 
 bsnGlobalDot11bConfig  OBJECT IDENTIFIER
     ::= { bsnGlobalDot11b 1 }
+
 
 bsnGlobalDot11bNetworkStatus OBJECT-TYPE
     SYNTAX          INTEGER  {
@@ -8346,6 +8537,7 @@ bsnGlobalDot11bDTPCSupport OBJECT-TYPE
 bsnGlobalDot11bPhy  OBJECT IDENTIFIER
     ::= { bsnGlobalDot11b 2 }
 
+
 bsnGlobalDot11bMediumOccupancyLimit OBJECT-TYPE
     SYNTAX          INTEGER (0..1000)
     MAX-ACCESS      read-only
@@ -8590,6 +8782,7 @@ bsnGlobalDot11bShortPreambleOptionImplemented OBJECT-TYPE
 
 bsnGlobalDot11aConfig  OBJECT IDENTIFIER
     ::= { bsnGlobalDot11a 1 }
+
 
 bsnGlobalDot11aNetworkStatus OBJECT-TYPE
     SYNTAX          INTEGER  {
@@ -8997,6 +9190,7 @@ bsnGlobalDot11aDTPCSupport OBJECT-TYPE
 bsnGlobalDot11aPhy  OBJECT IDENTIFIER
     ::= { bsnGlobalDot11a 2 }
 
+
 bsnGlobalDot11aMediumOccupancyLimit OBJECT-TYPE
     SYNTAX          INTEGER (0..1000)
     MAX-ACCESS      read-only
@@ -9215,6 +9409,7 @@ bsnGlobalDot11aChannelAgilityEnabled OBJECT-TYPE
 bsnGlobalDot11hConfig  OBJECT IDENTIFIER
     ::= { bsnGlobalDot11h 1 }
 
+
 -- *******************************************************************
 -- These global attributes are to Enable/Disable Power Control and
 -- Channel Switch for 802.11h
@@ -9282,13 +9477,14 @@ bsnRrmDot11b  OBJECT IDENTIFIER
 bsnRrmDot11aGroup  OBJECT IDENTIFIER
     ::= { bsnRrmDot11a 1 }
 
+
 bsnRrmDot11aGlobalAutomaticGrouping OBJECT-TYPE
     SYNTAX          INTEGER  {
                         automatic(1),
                         off(2)
                     }
     MAX-ACCESS      read-write
-    STATUS          current
+    STATUS          deprecated
     DESCRIPTION
         "Dynamic grouping has two modes: on and off. When the grouping
         is off, no dynamic grouping occurs. Each Airespace Switch 
@@ -9302,7 +9498,7 @@ bsnRrmDot11aGlobalAutomaticGrouping OBJECT-TYPE
 bsnRrmDot11aGroupLeaderMacAddr OBJECT-TYPE
     SYNTAX          MacAddress
     MAX-ACCESS      read-only
-    STATUS          current
+    STATUS          deprecated
     DESCRIPTION
         "This is the MAC address of the group leader for the dot11a
         group containing this Airespace Switch." 
@@ -9314,7 +9510,7 @@ bsnRrmIsDot11aGroupLeader OBJECT-TYPE
                         yes(1)
                     }
     MAX-ACCESS      read-only
-    STATUS          current
+    STATUS          deprecated
     DESCRIPTION
         "If this Airespace Switch is a Dot11a Group Leader then this
         attribute will be true else it will be false." 
@@ -9323,7 +9519,7 @@ bsnRrmIsDot11aGroupLeader OBJECT-TYPE
 bsnRrmDot11aGroupLastUpdateTime OBJECT-TYPE
     SYNTAX          Unsigned32
     MAX-ACCESS      read-only
-    STATUS          current
+    STATUS          deprecated
     DESCRIPTION
         "Last time the dot11a grouping was updated on this Airespace
         Switch. This is valid only if the Airespace Switch is a 
@@ -9333,7 +9529,7 @@ bsnRrmDot11aGroupLastUpdateTime OBJECT-TYPE
 bsnRrmDot11aGlobalGroupInterval OBJECT-TYPE
     SYNTAX          Unsigned32
     MAX-ACCESS      read-only
-    STATUS          current
+    STATUS          deprecated
     DESCRIPTION
         "When grouping is on, this interval(in secs) represents the
         period with which the grouping algorithm is run. Grouping 
@@ -9350,17 +9546,18 @@ bsnRrmDot11aGlobalGroupInterval OBJECT-TYPE
 bsnWrasDot11aGroupTable OBJECT-TYPE
     SYNTAX          SEQUENCE OF BsnWrasDot11aGroupEntry 
     MAX-ACCESS      not-accessible
-    STATUS          current
+    STATUS          deprecated
     DESCRIPTION
         "This is a table of Airespace Switch addresses that identifies
         the members of the Dot11a RF group containing this Airespace 
-        Switch. Max size is 20 entries."
+        Switch. Max size is 20 entries. This has been deprecated for 
+        clrRrmDot11BandGrpMemberTable."
     ::= { bsnRrmDot11aGroup 9 }
 
 bsnWrasDot11aGroupEntry OBJECT-TYPE
     SYNTAX          BsnWrasDot11aGroupEntry
     MAX-ACCESS      not-accessible
-    STATUS          current
+    STATUS          deprecated
     DESCRIPTION
         "..."
     INDEX           { bsnWrasDot11aPeerMacAddress } 
@@ -9374,7 +9571,7 @@ BsnWrasDot11aGroupEntry ::= SEQUENCE {
 bsnWrasDot11aPeerMacAddress OBJECT-TYPE
     SYNTAX          MacAddress
     MAX-ACCESS      read-only
-    STATUS          current
+    STATUS          deprecated
     DESCRIPTION
         "The MAC address of the member Switch." 
     ::= { bsnWrasDot11aGroupEntry 1 }
@@ -9382,10 +9579,11 @@ bsnWrasDot11aPeerMacAddress OBJECT-TYPE
 bsnWrasDot11aPeerIpAddress OBJECT-TYPE
     SYNTAX          IpAddress
     MAX-ACCESS      read-only
-    STATUS          current
+    STATUS          deprecated
     DESCRIPTION
         "The IP address of the Airespace Switch." 
     ::= { bsnWrasDot11aGroupEntry 21 }
+ 
 
 -- ********************************************************************
 -- * Begin bsnRrmDot11aAPDefault
@@ -9393,6 +9591,7 @@ bsnWrasDot11aPeerIpAddress OBJECT-TYPE
 
 bsnRrmDot11aAPDefault  OBJECT IDENTIFIER
     ::= { bsnRrmDot11a 6 }
+
 
 -- ********************************************************************
 -- * Begin bsnRrmDot11aAPProfile
@@ -9427,7 +9626,7 @@ bsnRrmDot11aThroughputThreshold OBJECT-TYPE
     MAX-ACCESS      read-write
     STATUS          current
     DESCRIPTION
-        "802.11A throughput threshold between 1000 and 100000" 
+        "802.11A throughput threshold between 1000 and 1000000" 
     ::= { bsnRrmDot11aAPDefault 4 }
 
 bsnRrmDot11aMobilesThreshold OBJECT-TYPE
@@ -9543,30 +9742,33 @@ bsnRrmDot11aSetFactoryDefault OBJECT-TYPE
 bsnRrmDot11bGroup  OBJECT IDENTIFIER
     ::= { bsnRrmDot11b 1 }
 
+
 bsnRrmDot11bGlobalAutomaticGrouping OBJECT-TYPE
     SYNTAX          INTEGER  {
                         automatic(1),
                         off(2)
                     }
     MAX-ACCESS      read-write
-    STATUS          current
+    STATUS          deprecated
     DESCRIPTION
         "Dynamic grouping has two modes: on and off. When the grouping
         is off, no dynamic grouping occurs. Each Airespace Switch 
         optimizes only its own Airespace APs' parameters. When 
         grouping is on, the Airespace Switchs form groups and
         elect leaders to perform better dynamic parameter 
-        optimization."
+        optimization. This has been deprecated for 
+        clrRrmDot11BandGrpTable."
     DEFVAL          { automatic } 
     ::= { bsnRrmDot11bGroup 1 }
 
 bsnRrmDot11bGroupLeaderMacAddr OBJECT-TYPE
     SYNTAX          MacAddress
     MAX-ACCESS      read-only
-    STATUS          current
+    STATUS          deprecated
     DESCRIPTION
         "This is the MAC address of the group leader for the dot11b
-        group containing this Airespace Switch." 
+        group containing this Airespace Switch. This has been 
+         deprecated for clrRrmDot11BandGrpTable." 
     ::= { bsnRrmDot11bGroup 2 }
 
 bsnRrmIsDot11bGroupLeader OBJECT-TYPE
@@ -9575,33 +9777,35 @@ bsnRrmIsDot11bGroupLeader OBJECT-TYPE
                         yes(1)
                     }
     MAX-ACCESS      read-only
-    STATUS          current
+    STATUS          deprecated
     DESCRIPTION
         "If this Airespace Switch is a Dot11b Group Leader then this
-        attribute will be true else it will be false." 
+        attribute will be true else it will be false. This has been 
+         deprecated for clrRrmDot11BandGrpTable." 
     ::= { bsnRrmDot11bGroup 3 }
 
 bsnRrmDot11bGroupLastUpdateTime OBJECT-TYPE
     SYNTAX          Unsigned32
     MAX-ACCESS      read-only
-    STATUS          current
+    STATUS          deprecated
     DESCRIPTION
         "Last time the dot11b grouping was updated on this Airespace
         Switch. This is valid only if the Airespace Switch is a group
-        leader." 
+        leader. This has been deprecated for clrRrmDot11BandGrpTable." 
     ::= { bsnRrmDot11bGroup 4 }
 
 bsnRrmDot11bGlobalGroupInterval OBJECT-TYPE
     SYNTAX          Unsigned32
     MAX-ACCESS      read-only
-    STATUS          current
+    STATUS          deprecated
     DESCRIPTION
         "When grouping is on, this interval(in secs) represents the
         period with which the grouping algorithm is run. Grouping 
         algorithm will also run when the group contents changes and 
         the automatic grouping is enabled. A dynamic grouping can be 
         started upon request from the system administrator. Default 
-        value is 3600 secs."
+        value is 3600 secs. This has been 
+        deprecated for clrRrmDot11BandGrpTable."
     DEFVAL          { 3600 } 
     ::= { bsnRrmDot11bGroup 5 }
 -- ************************************************************
@@ -9611,17 +9815,18 @@ bsnRrmDot11bGlobalGroupInterval OBJECT-TYPE
 bsnWrasDot11bGroupTable OBJECT-TYPE
     SYNTAX          SEQUENCE OF BsnWrasDot11bGroupEntry 
     MAX-ACCESS      not-accessible
-    STATUS          current
+    STATUS          deprecated
     DESCRIPTION
         "This is a table of Airespace Switch addresses that identifies
         the members of the Dot11b RF group containing this Airespace 
-        Switch. Max size is 20 entries."
+        Switch. Max size is 20 entries. This has been deprecated for 
+        clrRrmDot11BandGrpMemberTable."
     ::= { bsnRrmDot11bGroup 9 }
 
 bsnWrasDot11bGroupEntry OBJECT-TYPE
     SYNTAX          BsnWrasDot11bGroupEntry
     MAX-ACCESS      not-accessible
-    STATUS          current
+    STATUS          deprecated
     DESCRIPTION
         "..."
     INDEX           { bsnWrasDot11bPeerMacAddress } 
@@ -9635,7 +9840,7 @@ BsnWrasDot11bGroupEntry ::= SEQUENCE {
 bsnWrasDot11bPeerMacAddress OBJECT-TYPE
     SYNTAX          MacAddress
     MAX-ACCESS      read-only
-    STATUS          current
+    STATUS          deprecated
     DESCRIPTION
         "The MAC address of the GIGE interface." 
     ::= { bsnWrasDot11bGroupEntry 1 }
@@ -9643,10 +9848,11 @@ bsnWrasDot11bPeerMacAddress OBJECT-TYPE
 bsnWrasDot11bPeerIpAddress OBJECT-TYPE
     SYNTAX          IpAddress
     MAX-ACCESS      read-only
-    STATUS          current
+    STATUS          deprecated
     DESCRIPTION
         "The IP address of the Airespace Switch." 
     ::= { bsnWrasDot11bGroupEntry 21 }
+ 
 
 -- ************************************************************
 -- * End of bsnWrasDot11bGroup Table
@@ -9659,6 +9865,7 @@ bsnWrasDot11bPeerIpAddress OBJECT-TYPE
 
 bsnRrmDot11bAPDefault  OBJECT IDENTIFIER
     ::= { bsnRrmDot11b 6 }
+
 
 bsnRrmDot11bForeignInterferenceThreshold OBJECT-TYPE
     SYNTAX          INTEGER (0..100)
@@ -9690,7 +9897,8 @@ bsnRrmDot11bThroughputThreshold OBJECT-TYPE
     MAX-ACCESS      read-write
     STATUS          current
     DESCRIPTION
-        "802.11A Airespace AP data-rate threshold between 1000 and 100000" 
+        "802.11A Airespace AP data-rate threshold between 1000 and
+        1000000" 
     ::= { bsnRrmDot11bAPDefault 4 }
 
 bsnRrmDot11bMobilesThreshold OBJECT-TYPE
@@ -10100,6 +10308,7 @@ bsnRadiusAuthServerRowStatus OBJECT-TYPE
     DESCRIPTION
         "Row Status for creation/deletion" 
     ::= { bsnRadiusAuthServerEntry 26 }
+ 
 
 -- *******************************************************************
 -- * Begin of bsnRadiusAccServerTable
@@ -10319,6 +10528,7 @@ bsnRadiusAccServerRowStatus OBJECT-TYPE
     DESCRIPTION
         "Row Status for creation/deletion" 
     ::= { bsnRadiusAccServerEntry 26 }
+ 
 
 -- *******************************************************************
 -- * Begin of bsnRadiusAuthServerStatsTable
@@ -10497,6 +10707,7 @@ bsnRadiusAuthClientPacketsDropped OBJECT-TYPE
         received from this server on the authentication port
         and dropped for some other reason." 
     ::= { bsnRadiusAuthServerStatsEntry 36 }
+ 
 
 -- *******************************************************************
 -- * Begin of bsnRadiusAccServerStatsTable
@@ -10650,6 +10861,7 @@ bsnRadiusAccClientPacketsDropped OBJECT-TYPE
         this server on the accounting port and dropped for some
         other reason." 
     ::= { bsnRadiusAccServerStatsEntry 34 }
+ 
 
 -- *******************************************************************
 -- bsnUsersTable
@@ -10745,6 +10957,7 @@ bsnUserRowStatus OBJECT-TYPE
     DESCRIPTION
         "Row Status" 
     ::= { bsnUsersEntry 26 }
+ 
 
 -- *******************************************************************
 -- bsnMacFilterTable
@@ -10815,6 +11028,7 @@ bsnMacFilterRowStatus OBJECT-TYPE
     DESCRIPTION
         "Row Status" 
     ::= { bsnMacFilterEntry 24 }
+ 
 
 -- *******************************************************************
 -- bsnLocalNetUserTable
@@ -10926,6 +11140,7 @@ bsnLocalNetUserRowStatus OBJECT-TYPE
     DESCRIPTION
         "Row Status" 
     ::= { bsnLocalNetUserEntry 24 }
+ 
 
 -- *******************************************************************
 -- bsnLocalManagementUserTable
@@ -10989,6 +11204,7 @@ bsnLocalManagementUserRowStatus OBJECT-TYPE
     DESCRIPTION
         "Row Status" 
     ::= { bsnLocalManagementUserEntry 23 }
+ 
 
 -- *******************************************************************
 -- bsnAclTable
@@ -11045,6 +11261,7 @@ bsnAclRowStatus OBJECT-TYPE
     DESCRIPTION
         "Row Status of the ACL." 
     ::= { bsnAclEntry 20 }
+ 
 
 -- *******************************************************************
 -- bsnAclRuleTable
@@ -11263,6 +11480,8 @@ bsnAclRuleRowStatus OBJECT-TYPE
     DESCRIPTION
         "Row Status of the ACL Rule." 
     ::= { bsnAclRuleEntry 40 }
+ 
+
 
 -- *******************************************************************
 -- bsnAAA common attributes
@@ -11426,6 +11645,7 @@ bsnBlackListClientRowStatus OBJECT-TYPE
     DESCRIPTION
         "Row Status" 
     ::= { bsnBlackListClientEntry 22 }
+ 
 
 -- *******************************************************************
 -- * Begin of bsnExternalPolicyServerTable
@@ -11528,6 +11748,8 @@ bsnExternalPolicyServerRowStatus OBJECT-TYPE
     DESCRIPTION
         "Row Status for creation/deletion" 
     ::= { bsnExternalPolicyServerEntry 26 }
+ 
+
 
 bsnExternalPolicyServerAclName OBJECT-TYPE
     SYNTAX          DisplayString (SIZE  (0..32))
@@ -11630,6 +11852,8 @@ bsnAPAuthRowStatus OBJECT-TYPE
     DESCRIPTION
         "Row Status" 
     ::= { bsnAPAuthorizationEntry 20 }
+ 
+
 
 -- ********************************************************************
 -- * Begin of bsnWrasIKECertTable
@@ -11721,6 +11945,7 @@ bsnWrasIpsecCertStatus OBJECT-TYPE
     DESCRIPTION
         "A row status type for the IKE Cert Entry." 
     ::= { bsnWrasIpsecCertEntry 24 }
+ 
 
 -- *************************************************************
 -- bsnTrap Object Group
@@ -11744,6 +11969,7 @@ bsnTrapVariable  OBJECT IDENTIFIER
 
 bsnTraps  OBJECT IDENTIFIER
     ::= { bsnTrap 3 }
+
 
 -- *************************************************************
 -- Mobile Station related traps and trapControl
@@ -11959,7 +12185,7 @@ bsnAPIfUp NOTIFICATION-TYPE
                         bsnAPIfUpDownCause,
                         bsnAPName
                     }
-    STATUS          current
+    STATUS          deprecated
     DESCRIPTION
         "When Airespace AP's interface's operation status goes up this
         trap will be sent"
@@ -11974,7 +12200,7 @@ bsnAPIfDown NOTIFICATION-TYPE
                         bsnAPIfUpDownCause,
                         bsnAPName
                     }
-    STATUS          current
+    STATUS          deprecated
     DESCRIPTION
         "When Airespace AP's interface's operation status goes down
         this trap will be sent."
@@ -13087,12 +13313,49 @@ bsnStationReasonCode OBJECT-TYPE
                         unsupportedRsnVersion(44),
                         invalidRsnIeCapabilities(45),
                         cipherSuiteRejected(46),
-                        missingReasonCode(99)
+                        missingReasonCode(99),
+                        maxAssociatedClientsReached(101),
+                        unSpecifiedQosFailure(200),
+                        qosPolicyMismatch(201),
+                        inSufficientBandwidth(202),
+                        inValidQosParams(203)
                     }
     MAX-ACCESS      accessible-for-notify
     STATUS          current
     DESCRIPTION
-        "" 
+        "unspecified - Unspecified.
+        previousAuthNotValid - Previous Authentication 
+                                         was not valid.
+        deauthenticationLeaving       - Leaving due to 
+                                      deauthentication.     
+        disassociationDueToInactivity - Disassociation 
+                                     due to Inactivity.
+        disassociationAPBusy - Disassociation since AP 
+                                              was busy.
+        class2FrameFromNonAuthStation -  Class 2 frame 
+                        from non authenticated station.
+        class2FrameFromNonAssStation - Class 2 frame 
+                           from non associated station.
+        disassociationStaHasLeft - Station has left due 
+                                     to disassociation.
+        staReqAssociationWithoutAuth    - Station send 
+            association request without authentication.
+        invalidInformationElement - Invalid information 
+                                               element.
+        groupCipherInvalid      - Invalid group Cipher.
+        unicastCipherInvalid  - Invalid unicast cipher.
+        akmpInvalid                     - Invalid AKMP.
+        unsupportedRsnVersion - Unsupported RSN version.
+        invalidRsnIeCapabilities       - Invalid RSN IE 
+                                           capabilities.
+        cipherSuiteRejected     - Cipher suite rejected.
+        missingReasonCode      - Reason code is missing.
+        maxAssociatedClientsReached - Maximum allowed 
+                   associated client number has reached.
+        unSpecifiedQosFailure - Unsupported QOS failure.
+        qosPolicyMismatch      - Mismatch on QOS policy.
+        inSufficientBandwidth  - Insufficient bandwidth.
+        inValidQosParams       - Invalid QOS parameters." 
     ::= { bsnTrapVariable 37 }
 
 bsnStationBlacklistingReasonCode OBJECT-TYPE
@@ -13639,6 +13902,7 @@ bsnImpersonatingSourceMacAddr OBJECT-TYPE
 bsnSyslog  OBJECT IDENTIFIER
     ::= { bsnUtility 1 }
 
+
 bsnSyslogEnable OBJECT-TYPE
     SYNTAX          INTEGER  {
                         no(0),
@@ -13663,6 +13927,7 @@ bsnSyslogRemoteAddress OBJECT-TYPE
 
 bsnPing  OBJECT IDENTIFIER
     ::= { bsnUtility 2 }
+
 
 bsnPingTestTable OBJECT-TYPE
     SYNTAX          SEQUENCE OF BsnPingTestEntry 
@@ -13771,6 +14036,7 @@ bsnPingTestRowStatus OBJECT-TYPE
     DESCRIPTION
         "Row Status" 
     ::= { bsnPingTestEntry 25 }
+ 
 
 -- ********************************************************************
 -- bsn Link
@@ -13778,6 +14044,7 @@ bsnPingTestRowStatus OBJECT-TYPE
 
 bsnLinkTest  OBJECT IDENTIFIER
     ::= { bsnUtility 3 }
+
 
 bsnLinkTestTable OBJECT-TYPE
     SYNTAX          SEQUENCE OF BsnLinkTestEntry 
@@ -13894,6 +14161,7 @@ bsnLinkTestRowStatus OBJECT-TYPE
     DESCRIPTION
         "Row Status" 
     ::= { bsnLinkTestEntry 30 }
+ 
 
 -- ********************************************************************
 -- * Begin of bsnMobility
@@ -13904,6 +14172,7 @@ bsnMobilityConfig  OBJECT IDENTIFIER
 
 bsnMobilityStats  OBJECT IDENTIFIER
     ::= { bsnMobility 2 }
+
 
 bsnMobilityProtocolPortNum OBJECT-TYPE
     SYNTAX          Integer32
@@ -14003,6 +14272,7 @@ bsnMobilityGroupMemberRowStatus OBJECT-TYPE
     DESCRIPTION
         "Row Status" 
     ::= { bsnMobilityGroupMembersEntry 22 }
+ 
 
 -- ********************************************************************
 -- *    bsnMobilityAnchorsTable
@@ -14058,6 +14328,8 @@ bsnMobilityAnchorRowStatus OBJECT-TYPE
     DESCRIPTION
         "Row Status" 
     ::= { bsnMobilityAnchorsEntry 20 }
+ 
+
 
 -- ********************************************************************
 -- * Begin of bsnMobilityStats
@@ -14463,9 +14735,11 @@ bsnMemberTotalCommunicationErrors OBJECT-TYPE
     DESCRIPTION
         "Total Communication errors" 
     ::= { bsnMobilityGroupDirectoryEntry 30 }
+ 
 
 bsnAPGroupsVlanConfig  OBJECT IDENTIFIER
     ::= { bsnWireless 10 }
+
 
 -- ********************************************************************
 -- Airespace Site Specific WLAN Configuration Paramaters
@@ -14534,6 +14808,7 @@ bsnAPGroupsVlanRowStatus OBJECT-TYPE
         "Row Status for creation/deletion of entries in
         bsnAPGroupsVlanTable" 
     ::= { bsnAPGroupsVlanEntry 20 }
+ 
 
 -- ********************************************************************
 -- * Begin of bsnAPGroupsVlanMappingTable
@@ -14598,6 +14873,8 @@ bsnAPGroupsVlanMappingRowStatus OBJECT-TYPE
         "Row Status for creation/deletion of WLAN-interface-mappings
         asscoiated with sites." 
     ::= { bsnAPGroupsVlanMappingEntry 20 }
+ 
+
 
 bsnAPIPAddressFallback NOTIFICATION-TYPE
     OBJECTS         {
@@ -14958,7 +15235,6 @@ bsnEssGroup OBJECT-GROUP
                         bsnDot11EssL2tpSecurity,
                         bsnDot11EssBroadcastSsid,
                         bsnDot11EssExternalPolicyValidation,
-                        bsnDot11EssIPv6Bridging,
                         bsnDot11EssRowStatus,
                         bsnDot11EssWmePolicySetting,
                         bsnDot11Ess80211ePolicySetting,
@@ -15495,12 +15771,6 @@ bsnGlobalDot11Group OBJECT-GROUP
 
 bsnRrmGroup OBJECT-GROUP
     OBJECTS         {
-                        bsnRrmDot11aGroupLeaderMacAddr,
-                        bsnRrmIsDot11aGroupLeader,
-                        bsnRrmDot11aGroupLastUpdateTime,
-                        bsnRrmDot11aGlobalGroupInterval,
-                        bsnWrasDot11aPeerMacAddress,
-                        bsnWrasDot11aPeerIpAddress,
                         bsnRrmDot11aForeignInterferenceThreshold,
                         bsnRrmDot11aForeignNoiseThreshold,
                         bsnRrmDot11aRFUtilizationThreshold,
@@ -15515,13 +15785,6 @@ bsnRrmGroup OBJECT-GROUP
                         bsnRrmDot11aCoverageMeasurementInterval,
                         bsnRrmDot11aChannelMonitorList,
                         bsnRrmDot11aSetFactoryDefault,
-                        bsnRrmDot11bGlobalAutomaticGrouping,
-                        bsnRrmDot11bGroupLeaderMacAddr,
-                        bsnRrmIsDot11bGroupLeader,
-                        bsnRrmDot11bGroupLastUpdateTime,
-                        bsnRrmDot11bGlobalGroupInterval,
-                        bsnWrasDot11bPeerMacAddress,
-                        bsnWrasDot11bPeerIpAddress,
                         bsnRrmDot11bForeignInterferenceThreshold,
                         bsnRrmDot11bForeignNoiseThreshold,
                         bsnRrmDot11bRFUtilizationThreshold,
@@ -15661,7 +15924,8 @@ bsnAAAGroup OBJECT-GROUP
         "This collection of objects provide the information
         about Airespace Authentication, Authorization, and 
         Accounting Attributes. These objects are defined under
-        bsnAAA object."
+        bsnAAA object.
+        bsnAAAGroup object is superseded by banAAGroupRev1."
     ::= { bsnWrasGroups 5 }
 
 bsnTrapsGroup OBJECT-GROUP
@@ -15946,7 +16210,7 @@ bsnWrasTrap NOTIFICATION-GROUP
                         bsnDot11StationBlacklisted,
                         bsnDot11StationAssociate,
                         bsnAPUp,
-        			    bsnAPDown,
+                        bsnAPDown,
                         bsnAPAssociated,
                         bsnAPDisassociated,
                         bsnAPIfUp,
@@ -16074,7 +16338,6 @@ bsnEssGroupRev1 OBJECT-GROUP
                         bsnDot11EssL2tpSecurity,
                         bsnDot11EssBroadcastSsid,
                         bsnDot11EssExternalPolicyValidation,
-                        bsnDot11EssIPv6Bridging,
                         bsnDot11EssRowStatus,
                         bsnDot11EssWmePolicySetting,
                         bsnDot11Ess80211ePolicySetting,
@@ -16417,8 +16680,7 @@ bsnGlobalDot11GroupRev1 OBJECT-GROUP
                         bsnGlobalDot11aChannelAgilityEnabled,
                         bsnGlobalDot11hPowerConstraint,
                         bsnGlobalDot11hChannelSwitchEnable,
-                        bsnGlobalDot11hChannelSwitchMode,
-                        bsnRrmDot11aGlobalAutomaticGrouping
+                        bsnGlobalDot11hChannelSwitchMode
                     }
     STATUS          current
     DESCRIPTION
@@ -16759,7 +17021,6 @@ bsnApGroupRev1 OBJECT-GROUP
                         bsnAPPrimaryMwarName,
                         bsnAPReset,
                         bsnAPStatsTimer,
-                        bsnAPPortNumber,
                         bsnAPModel,
                         bsnAPSerialNumber,
                         bsnAPClearConfig,
@@ -16778,7 +17039,6 @@ bsnApGroupRev1 OBJECT-GROUP
                         bsnAPIOSVersion,
                         bsnAPCertificateType,
                         bsnAPEthernetMacAddress,
-                        bsnAPAdminStatus,
                         bsnAPIfSlotId,
                         bsnAPIfType,
                         bsnAPIfPhyChannelAssignment,
@@ -16802,7 +17062,6 @@ bsnApGroupRev1 OBJECT-GROUP
                         bsnAPIfChannelList,
                         bsnAPIfAbsolutePowerList,
                         bsnAPIfRegulatoryDomainSupport,
-                        bsnAPIfAdminStatus,
                         bsnAPIfDot11BeaconPeriod,
                         bsnAPIfDot11MediumOccupancyLimit,
                         bsnAPIfDot11CFPPeriod,
@@ -16950,7 +17209,7 @@ bsnUtilityGroupRev1 OBJECT-GROUP
         "This collection of objects provide the information
         about Airespace General Utilities such as ping, syslog.
         These objects are defined under bsnUtility."
-    ::= { bsnWrasGroups 19 }   
+    ::= { bsnWrasGroups 19 }
 
 bsnWrasObsGroupRev1 OBJECT-GROUP
     OBJECTS         {
@@ -16964,7 +17223,7 @@ bsnWrasObsGroupRev1 OBJECT-GROUP
     DESCRIPTION
         "This collection of objects are  obsoleted in bsnWireless
         module."
-    ::= { bsnWrasGroups 20 }     
+    ::= { bsnWrasGroups 20 }
 
 bsnWrasObsTrap NOTIFICATION-GROUP
    NOTIFICATIONS    {
@@ -16975,6 +17234,8 @@ bsnWrasObsTrap NOTIFICATION-GROUP
     DESCRIPTION
         "This  collection of objects provides all notification
         that Switch need to generate to the Management System."
-    ::= { bsnWrasGroups 21 }    
+    ::= { bsnWrasGroups 21 }
 
 END
+
+


### PR DESCRIPTION
Cisco WLC AP polling is blowing up installs by constantly adding more APs to the DB.


#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
