### PR TITLE
Allow device renaming even when the RRD files are on a remote rrdcached

### DIFF
--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -1939,8 +1939,13 @@ function rename_device(Illuminate\Http\Request $request)
     } elseif ($new_device) {
         return api_error(500, 'Device failed to rename, new hostname already exists');
     } else {
-        if (renamehost($device_id, $new_hostname, 'api') == '') {
-            return api_success_noresult(200, 'Device has been renamed');
+        $result = renamehost($device_id, $new_hostname, 'api');
+        if ($result['message'] == '') {
+            if ($result['manual_rrd_rename']) {
+                return api_success_noresult(200, 'Device has been renamed but the RRD folder will have to be renamed manually, are you running a remote rrdcached?');
+            } else {
+                return api_success_noresult(200, 'Device has been renamed');
+            }
         } else {
             return api_error(500, 'Device failed to be renamed');
         }

--- a/includes/html/pages/device/edit/device.inc.php
+++ b/includes/html/pages/device/edit/device.inc.php
@@ -56,8 +56,12 @@ if ($_POST['editing']) {
         if (isset($_POST['hostname']) && $_POST['hostname'] !== '' && $_POST['hostname'] !== $device['hostname']) {
             if (Auth::user()->hasGlobalAdmin()) {
                 $result = renamehost($device['device_id'], trim($_POST['hostname']), 'webui');
-                if ($result == '') {
-                    flash()->addSuccess("Hostname updated from {$device['hostname']} to {$_POST['hostname']}");
+                if ($result['message'] == '') {
+                    if ($result['manual_rrd_rename']) {
+                        flash()->addSuccess("Hostname updated from {$device['hostname']} to {$_POST['hostname']} but the RRD folder will have to be renamed manually, are you running a remote rrdcached?");
+                    } else {
+                        flash()->addSuccess("Hostname updated from {$device['hostname']} to {$_POST['hostname']}");
+                    }
                     $reload = true;
                 } else {
                     flash()->addError($result . '.  Does your web server have permission to modify the rrd files?');

--- a/renamehost.php
+++ b/renamehost.php
@@ -26,11 +26,15 @@ if ($argv[1] && $argv[2]) {
             exit(1);
         } else {
             $result = renamehost($id, $tohost, 'console');
-            if ($result == '') {
-                echo "Renamed $host\n";
+            if ($result['message'] == '') {
+                if ($result['manual_rrd_rename']) {
+                    echo "Renamed $host but the RRD folder will have to be renamed manually, are you running a remote rrdcached?\n";
+                } else {
+                    echo "Renamed $host\n";
+                }
                 exit(0);
             } else {
-                echo "NOT renamed: $result";
+                echo "NOT renamed: {$result['message']}";
                 exit(1);
             }
         }


### PR DESCRIPTION
Trying to rename a device on LibreNMS while using rrdcached on another host / distinct filesystem fails because LibreNMS cannot find the RRD folder to rename (`Rrd::dirFromHost` returns a file path that doesn't exist locally, which makes the call to `rename` fail).

As there is no way for LibreNMS to move a folder on a remote host, we can at least allow the device to be renamed in the database and warn the user that they should move the RRD folder themselves.

We detect that we're using a remote rrdcached by checking that the folder **does not exist** by path but exists by calling `Rrd::checkRrdExists`.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
