### PR TITLE
VLANs sort in GUI

### DIFF
--- a/app/Http/Controllers/Device/Tabs/VlansController.php
+++ b/app/Http/Controllers/Device/Tabs/VlansController.php
@@ -79,7 +79,7 @@ class VlansController implements DeviceTab
                 ->on('vlans.device_id', 'ports_vlans.device_id');
             })
             ->with(['port.device'])
-            ->select('ports_vlans.*', 'vlans.vlan_name')
+            ->select('ports_vlans.*', 'vlans.vlan_name')->orderBy('vlan_vlan')
             ->get();
 
         $data = $portVlan->groupBy('vlan');


### PR DESCRIPTION
As time pass, VLANs are changing on devices
as VLANs are stored out of order in DB, it is sometimes hard to find VLAN in unsorted GUI

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
(https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
