### PR TITLE
Remove extra rows with duplicate keys in SyncsModels trait

### DIFF
--- a/LibreNMS/DB/SyncsModels.php
+++ b/LibreNMS/DB/SyncsModels.php
@@ -41,15 +41,23 @@ trait SyncsModels
     protected function syncModels($device, $relationship, $models): Collection
     {
         $models = $models->keyBy->getCompositeKey();
-        $existing = $device->$relationship->keyBy->getCompositeKey();
+        $existing = $device->$relationship->groupBy->getCompositeKey();
 
-        foreach ($existing as $exist_key => $exist_value) {
+        foreach ($existing as $exist_key => $existing_rows) {
             if ($models->offsetExists($exist_key)) {
                 // update
-                $exist_value->fill($models->get($exist_key)->getAttributes())->save();
+                foreach ($existing_rows as $index => $existing_row) {
+                    if ($index == 0) {
+                        $existing_row->fill($models->get($exist_key)->getAttributes())->save();
+                    } else {
+                        // delete extra rows at this key
+                        $existing_row->delete();
+                        $existing_rows->forget($index);
+                    }
+                }
             } else {
                 // delete
-                $exist_value->delete();
+                $existing_rows->each->delete();
                 $existing->forget($exist_key);
             }
         }
@@ -57,7 +65,7 @@ trait SyncsModels
         $new = $models->diffKeys($existing);
         $device->$relationship()->saveMany($new);
 
-        return $existing->merge($new);
+        return $existing->map->first()->merge($new);
     }
 
     /**


### PR DESCRIPTION
Fixes issues with bad data being left in the DB if it has a duplicate key somehow.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
