### PR TITLE
Added the option to show or hide unreachable devices in the alert widget

### DIFF
--- a/app/Http/Controllers/Widgets/AlertsController.php
+++ b/app/Http/Controllers/Widgets/AlertsController.php
@@ -43,6 +43,7 @@ class AlertsController extends WidgetController
         'sort' => 1,
         'hidenavigation' => 0,
         'uncollapse_key_count' => 1,
+        'unreachable' => null,
     ];
 
     public function getView(Request $request)

--- a/includes/html/table/alerts.inc.php
+++ b/includes/html/table/alerts.inc.php
@@ -45,7 +45,7 @@ if (is_numeric($vars['fired'])) {
 }
 
 if (is_numeric($vars['unreachable'])) {
-    # Sub-select to flag if at least one parent is set, and all parents are offline
+    // Sub-select to flag if at least one parent is set, and all parents are offline
     $where .= ' AND (SELECT IF(COUNT(`dr`.`parent_device_id`) > 0 AND COUNT(`dr`.`parent_device_id`)=count(`d`.`device_id`),1,0) FROM `device_relationships` `dr` LEFT JOIN `devices` `d` ON `dr`.`parent_device_id`=`d`.`device_id` AND `d`.`status`=0 WHERE `dr`.`child_device_id`=`devices`.`device_id`)=' . $vars['unreachable'];
 }
 

--- a/includes/html/table/alerts.inc.php
+++ b/includes/html/table/alerts.inc.php
@@ -44,6 +44,11 @@ if (is_numeric($vars['fired'])) {
     $where .= ' AND `alerts`.`alerted`=' . $alert_states['alerted'];
 }
 
+if (is_numeric($vars['unreachable'])) {
+    # Sub-select to flag if at least one parent is set, and all parents are offline
+    $where .= ' AND (SELECT IF(COUNT(`dr`.`parent_device_id`) > 0 AND COUNT(`dr`.`parent_device_id`)=count(`d`.`device_id`),1,0) FROM `device_relationships` `dr` LEFT JOIN `devices` `d` ON `dr`.`parent_device_id`=`d`.`device_id` AND `d`.`status`=0 WHERE `dr`.`child_device_id`=`devices`.`device_id`)=' . $vars['unreachable'];
+}
+
 if (is_numeric($vars['state'])) {
     $where .= ' AND `alerts`.`state`=' . $vars['state'];
     if ($vars['state'] == $alert_states['recovered']) {

--- a/resources/views/widgets/alerts.blade.php
+++ b/resources/views/widgets/alerts.blade.php
@@ -22,6 +22,7 @@
             ...request,
             id: "alerts",
             acknowledged: '{{ $acknowledged }}',
+            unreachable: '{{ $unreachable }}',
             fired: '{{ $fired }}',
             min_severity: '{{ $min_severity }}',
             group: '{{ $device_group }}',

--- a/resources/views/widgets/settings/alerts.blade.php
+++ b/resources/views/widgets/settings/alerts.blade.php
@@ -17,8 +17,8 @@
         <label for="unreachable-{{ $id }}" class="control-label">{{ __('Show unreachable') }}:</label>
         <select class="form-control" name="unreachable" id="unreachable-{{ $id }}">
             <option value="">{{ __('not filtered') }}</option>
-            <option value="1" @if($unreachable === '1') selected @endif>{{ __('show only unreachable') }}</option>
-            <option value="0" @if($unreachable === '0') selected @endif>{{ __('hide unreachable') }}</option>
+            <option value="1" @if($unreachable === '1') selected @endif>{{ __('show only alerts where all parent devices are down') }}</option>
+            <option value="0" @if($unreachable === '0') selected @endif>{{ __('hide alerts where all parent devices are down') }}</option>
         </select>
     </div>
     <div class="form-group">

--- a/resources/views/widgets/settings/alerts.blade.php
+++ b/resources/views/widgets/settings/alerts.blade.php
@@ -14,6 +14,14 @@
         </select>
     </div>
     <div class="form-group">
+        <label for="unreachable-{{ $id }}" class="control-label">{{ __('Show unreachable') }}:</label>
+        <select class="form-control" name="unreachable" id="unreachable-{{ $id }}">
+            <option value="">{{ __('not filtered') }}</option>
+            <option value="1" @if($unreachable === '1') selected @endif>{{ __('show only unreachable') }}</option>
+            <option value="0" @if($unreachable === '0') selected @endif>{{ __('hide unreachable') }}</option>
+        </select>
+    </div>
+    <div class="form-group">
         <label for="fired-{{ $id }}" class="control-label">{{ __('Show only fired') }}:</label>
         <select class="form-control" name="fired" id="fired-{{ $id }}">
             <option value="">{{ __('not filtered') }}</option>


### PR DESCRIPTION
I have added an option on the alerts widget for unreachable hosts (hosts with parent(s) set where all parents have a device status of "0".  It can be used to stop the alert widget from having too much noise from a single site with multiple devices being offline.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
