### PR TITLE
Fix horizontal scrollbar in device list always visible

### DIFF
--- a/resources/views/device/actions.blade.php
+++ b/resources/views/device/actions.blade.php
@@ -1,6 +1,6 @@
 <div class="container-fluid" style="padding-left: 0; padding-right: 0;">
     @foreach($actions as $row)
-        <div class="row" style="padding-bottom: 5px">
+        <div>
             @foreach($row as $action)
                 @include('device.action-icon', $action)
             @endforeach


### PR DESCRIPTION
#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] ~If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).~

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.

#### Description

Using the class `row` for each icon line [introduced](https://github.com/librenms/librenms/commit/94ee737f3d158a57efec280139852817eb929244) an overflow coming from the "margins" which always shows the scroll bar:
![image](https://user-images.githubusercontent.com/10722552/148244122-506d5f45-dc94-4ab2-86d6-3415d84e5ca7.png)

I propose to remove the class `row` completely to:
* fix the horizontal scroll bar
* compact the rows which allows for more devices to be listed in the same space
(the icons themself will get even closer, but are too small anyway to be suited for good handling without a mouse pointer)

![image](https://user-images.githubusercontent.com/10722552/148244469-f89c5cff-c467-4a51-9b55-0488fdc9a61c.png)

