### PR TITLE
Fix NULL device alert caused by services

### DIFF
--- a/includes/services.inc.php
+++ b/includes/services.inc.php
@@ -200,7 +200,7 @@ function poll_service($service)
 
         // Run alert rules due to status changed
         $rules = new AlertRules;
-        $rules->runRules($service->device_id);
+        $rules->runRules($service['device_id']);
     }
 
     if ($service['service_message'] != $msg) {


### PR DESCRIPTION
Fixing the NULL device alert problem mentioned in #13424

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
