### PR TITLE
Device tracepath using wrong variables to check for traceroute output

### DIFF
--- a/includes/html/pages/device/overview/tracepath.inc.php
+++ b/includes/html/pages/device/overview/tracepath.inc.php
@@ -26,8 +26,7 @@
 use App\Models\DevicePerf;
 
 $perf_info = DevicePerf::where('device_id', $device['device_id'])->latest('timestamp')->first();
-$perf_debug = json_decode($perf_info['debug'], true);
-if ($perf_debug['traceroute']) {
+if ($perf_info['debug']['traceroute']) {
     echo "
 <div class='row'>
      <div class='col-md-12'>
@@ -36,7 +35,7 @@ if ($perf_debug['traceroute']) {
                  <h3 class='panel-title'>Traceroute ({$perf_info['timestamp']})</h3>
              </div>
              <div class='panel-body'>
-                 <pre>{$perf_debug['traceroute']}</pre>
+                 <pre>{$perf_info['debug']['traceroute']}</pre>
             </div>
          </div>
      </div>


### PR DESCRIPTION
Please give a short description what your pull request is for

<img width="886" alt="image" src="https://user-images.githubusercontent.com/3941142/149219715-b1ea6962-0cf8-4f8a-b26b-2e29941fa76b.png">

Before hand the device overview page would never show a trace route output if it was available.

https://community.librenms.org/t/traceroute-visibility-in-ui/17831

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
