### PR TITLE
change the variable to detect version for mikrotik ups runtime device divisor

### DIFF
--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -795,7 +795,7 @@ function get_device_divisor($device, $os_version, $sensor_type, $oid)
         }
 
         if (Str::startsWith($oid, '.1.3.6.1.2.1.33.1.2.3.')) {
-            if ($device['os'] == 'routeros' && version_compare($os_version, '6.47', '<')) {
+            if ($device['os'] == 'routeros' && version_compare($device['version'], '6.47', '<')) {
                 return 60;
             }
 


### PR DESCRIPTION
Please give a short description what your pull request is for

replace the variable $os_version with $device_version as mentioned in issue #13441 

As it currently is the $os_version variable always has an empty string causing the if statement to always match. which the $device['version'] variable contains the mikrotik version number as would be expected.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
