### PR TITLE
Gen RANCID host also for FS.com devices

### DIFF
--- a/scripts/gen_rancid.php
+++ b/scripts/gen_rancid.php
@@ -52,6 +52,7 @@ $rancid_map['radlan'] = 'at';
 $rancid_map['ciscowlc'] = 'cisco-wlc8';
 $rancid_map['comware'] = 'h3c';
 $rancid_map['panos'] = 'paloalto';
+$rancid_map['fs-switch'] = 'cisco';
 
 foreach (dbFetchRows("SELECT `hostname`,`os`,`disabled`,`status` FROM `devices` WHERE `ignore` = 0 AND `type` != '' GROUP BY `hostname`") as $devices) {
     if (isset($rancid_map[$devices['os']])) {


### PR DESCRIPTION
On the RANCID perspective, a FS.com switch behaves exactly as a Cisco switch,
and the RANCID modules for Cisco work well.





DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
