### PR TITLE
Add missing python3-pip installation dependency for debian11

### DIFF
--- a/doc/Installation/Installation-Debian-11-Nginx.md
+++ b/doc/Installation/Installation-Debian-11-Nginx.md
@@ -11,7 +11,7 @@ path: blob/master/doc/
 # Install Required Packages
 
 ```bash
-apt install acl curl composer fping git graphviz imagemagick mariadb-client mariadb-server mtr-tiny nginx-full nmap php7.4-cli php7.4-curl php7.4-fpm php7.4-gd php7.4-json php7.4-mbstring php7.4-mysql php7.4-snmp php7.4-xml php7.4-zip python-memcache python-mysqldb rrdtool snmp snmpd whois python3-pymysql python3-dotenv python3-redis python3-setuptools
+apt install acl curl composer fping git graphviz imagemagick mariadb-client mariadb-server mtr-tiny nginx-full nmap php7.4-cli php7.4-curl php7.4-fpm php7.4-gd php7.4-json php7.4-mbstring php7.4-mysql php7.4-snmp php7.4-xml php7.4-zip python-memcache python-mysqldb rrdtool snmp snmpd whois python3-pip python3-pymysql python3-dotenv python3-redis python3-setuptools
 ```
 
 # Add librenms user


### PR DESCRIPTION
Add missing python3-pip dependency for Debian 11 installation.

This was tested on a fresh debian-11.2.0 install (with "SSH server" and "standard system utilities" in the package selection).


Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
