### PR TITLE
[WebUI] Removing the colon symbol to the right of a control label

### DIFF
--- a/includes/html/pages/device/edit/device.inc.php
+++ b/includes/html/pages/device/edit/device.inc.php
@@ -124,7 +124,7 @@ $disable_notify = get_dev_attrib($device, 'disable_notify');
 <?php echo csrf_field() ?>
 <input type=hidden name="editing" value="yes">
     <div class="form-group" data-toggle="tooltip" data-container="body" data-placement="bottom" title="Change the hostname used for name resolution" >
-        <label for="edit-hostname-input" class="col-sm-2 control-label" >Hostname / IP:</label>
+        <label for="edit-hostname-input" class="col-sm-2 control-label" >Hostname / IP</label>
         <div class="col-sm-6">
             <input type="text" id="edit-hostname-input" name="hostname" class="form-control" disabled value="<?php echo htmlentities($device['hostname']); ?>" />
         </div>
@@ -133,25 +133,25 @@ $disable_notify = get_dev_attrib($device, 'disable_notify');
         </div>
     </div>
     <div class="form-group" data-toggle="tooltip" data-container="body" data-placement="bottom" title="Display Name for this device.  Keep short. Available placeholders: hostname, sysName, sysName_fallback, ip" >
-        <label for="edit-display-input" class="col-sm-2 control-label" >Display Name:</label>
+        <label for="edit-display-input" class="col-sm-2 control-label" >Display Name</label>
         <div class="col-sm-6">
             <input type="text" id="edit-display-input" name="display" class="form-control" placeholder="System Default" value="<?php echo htmlentities($device_model->display); ?>">
         </div>
     </div>
     <div class="form-group" data-toggle="tooltip" data-container="body" data-placement="bottom" title="Use this IP instead of resolved one for polling" >
-        <label for="edit-overwrite_ip-input" class="col-sm-2 control-label text-danger" >Overwrite IP (do not use):</label>
+        <label for="edit-overwrite_ip-input" class="col-sm-2 control-label text-danger" >Overwrite IP (do not use)</label>
         <div class="col-sm-6">
             <input type="text" id="edit-overwrite_ip-input" name="overwrite_ip" class="form-control" value="<?php echo htmlentities($device_model->overwrite_ip); ?>">
         </div>
     </div>
      <div class="form-group">
-        <label for="descr" class="col-sm-2 control-label">Description:</label>
+        <label for="descr" class="col-sm-2 control-label">Description</label>
         <div class="col-sm-6">
             <textarea id="descr" name="descr" class="form-control"><?php echo \LibreNMS\Util\Clean::html($device_model->purpose, []); ?></textarea>
         </div>
     </div>
     <div class="form-group">
-        <label for="type" class="col-sm-2 control-label">Type:</label>
+        <label for="type" class="col-sm-2 control-label">Type</label>
         <div class="col-sm-6">
             <select id="type" name="type" class="form-control">
                 <?php
@@ -178,7 +178,7 @@ $disable_notify = get_dev_attrib($device, 'disable_notify');
        </div>
     </div>
     <div class="form-group">
-        <label for="sysLocation" class="col-sm-2 control-label">Override sysLocation:</label>
+        <label for="sysLocation" class="col-sm-2 control-label">Override sysLocation</label>
         <div class="col-sm-6">
           <input onChange="edit.sysLocation.disabled=!edit.override_sysLocation.checked; edit.sysLocation.select()" type="checkbox" name="override_sysLocation" data-size="small"
                 <?php
@@ -225,7 +225,7 @@ $disable_notify = get_dev_attrib($device, 'disable_notify');
       </div>
     </div>
     <div class="form-group">
-        <label for="parent_id" class="col-sm-2 control-label">This device depends on:</label>
+        <label for="parent_id" class="col-sm-2 control-label">This device depends on</label>
         <div class="col-sm-6">
             <select multiple name="parent_id[]" id="parent_id" class="form-control" style="width: 100%">
                 <?php
@@ -273,7 +273,7 @@ if (\LibreNMS\Config::get('distributed_poller') === true) {
                 }//endif
 ?>
     <div class="form-group">
-        <label for="disabled" class="col-sm-2 control-label">Disable polling and alerting:</label>
+        <label for="disabled" class="col-sm-2 control-label">Disable polling and alerting</label>
         <div class="col-sm-6">
           <input name="disabled" type="checkbox" id="disabled" value="1" data-size="small"
                 <?php
@@ -291,7 +291,7 @@ if (\LibreNMS\Config::get('distributed_poller') === true) {
     </div>
 
     <div class="form-group">
-      <label for="disable_notify" class="col-sm-2 control-label">Disable alerting:</label>
+      <label for="disable_notify" class="col-sm-2 control-label">Disable alerting</label>
       <div class="col-sm-6">
         <input id="disable_notify" type="checkbox" name="disable_notify" data-size="small"
                 <?php
@@ -304,7 +304,7 @@ if (\LibreNMS\Config::get('distributed_poller') === true) {
     <div class="form-group">
         <label for="ignore" class="col-sm-2 control-label" title="Tag device to ignore alerts. Alert checks will still run.
 However, ignore tag can be read in alert rules.
-If `devices.ignore = 0` or `macros.device = 1` condition is is set and ignore alert tag is on, the alert rule won't match.">Ignore alert tag:</label>
+If `devices.ignore = 0` or `macros.device = 1` condition is is set and ignore alert tag is on, the alert rule won't match.">Ignore alert tag</label>
         <div class="col-sm-6">
            <input name="ignore" type="checkbox" id="ignore" value="1" data-size="small"
                 <?php


### PR DESCRIPTION
In order to make the "Device setting" tab while Editing a device more consistent with other pages in the system, removed the colon simbol ":" to the very right of each control description, where present.
This because in no other HTML pages we find that the label with the control description is followed by a colon symbol.

Regards
GG

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
