### PR TITLE
Use commit date to compare pull requestes

### DIFF
--- a/LibreNMS/Util/GitHub.php
+++ b/LibreNMS/Util/GitHub.php
@@ -391,14 +391,14 @@ GRAPHQL;
             $this->getPullRequest();
         }
 
-        if (! isset($previous_release['published_at'])) {
+        if (! isset($previous_release['created_at'])) {
             throw new Exception(
                 $previous_release['message'] ??
                 "Could not find previous release tag. ($this->from)"
             );
         }
 
-        $this->getPullRequests($previous_release['published_at']);
+        $this->getPullRequests($previous_release['created_at']);
         $this->buildChangeLog();
         $this->formatChangeLog();
 


### PR DESCRIPTION
"The created_at attribute is the date of the commit used for the release, and not the date when the release was drafted or published."

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
