### PR TITLE
Add better default sensor alert template

### DIFF
--- a/database/seeders/DefaultAlertTemplateSeeder.php
+++ b/database/seeders/DefaultAlertTemplateSeeder.php
@@ -28,8 +28,37 @@ class DefaultAlertTemplateSeeder extends Seeder
                 'title_rec' => '',
             ],
             [
-                'name' => 'Temperature',
-                'template' => '{{ $alert->title }}' . PHP_EOL . 'Severity: {{ $alert->severity }}' . PHP_EOL . '@if ($alert->state == 0) Time elapsed: {{ $alert->elapsed }} @endif' . PHP_EOL . 'Timestamp: {{ $alert->timestamp }}' . PHP_EOL . 'Unique-ID: {{ $alert->uid }}' . PHP_EOL . 'Rule: @if ($alert->name) {{ $alert->name }} @else {{ $alert->rule }} @endif' . PHP_EOL . '@if ($alert->faults) Faults:' . PHP_EOL . '@foreach ($alert->faults as $key => $value)' . PHP_EOL . '  #{{ $key }}: {{ $value[\'string\'] }}' . PHP_EOL . '  Temperature: {{ $value[\'sensor_current\'] }}' . PHP_EOL . '  Previous Measurement: {{ $value[\'sensor_prev\'] }}' . PHP_EOL . '@endforeach' . PHP_EOL . '@endif',
+                'name' => 'Sensors',
+                'template' => <<<'EOD'
+                    {{ $alert->title }}
+
+                    Device Name: {{ $alert->hostname }}
+                    Severity: {{ $alert->severity }}
+                    Timestamp: {{ $alert->timestamp }}
+                    Uptime: {{ $alert->uptime_short }}
+                    @if ($alert->state == 0)
+                    Time elapsed: {{ $alert->elapsed }}
+                    @endif
+                    Location: {{ $alert->location }}
+                    Description: {{ $alert->description }}
+                    Features: {{ $alert->features }}
+                    Notes: {{ $alert->notes }}
+
+                    Rule: {{ $alert->name ?? $alert->rule }}
+                    @if ($alert->faults)
+                    Faults:
+                    @foreach ($alert->faults as $key => $value)
+                    @php($unit = __("sensors.${value["sensor_class"]}.unit"))
+                    #{{ $key }}: {{ $value['sensor_descr'] ?? 'Sensor' }}
+
+                    Current: {{ $value['sensor_current'].$unit }}
+                    Previous: {{ $value['sensor_prev'].$unit }}
+                    Limit: {{ $value['sensor_limit'].$unit }}
+                    Over Limit: {{ round($value['sensor_current']-$value['sensor_limit'], 2).$unit }}
+
+                    @endforeach
+                    @endif
+                    EOD,
                 'title' => '',
                 'title_rec' => '',
             ],

--- a/doc/Alerting/Templates.md
+++ b/doc/Alerting/Templates.md
@@ -195,7 +195,6 @@ Timestamp: {{ $alert->timestamp }}
 Location: {{ $alert->location }}
 Description: {{ $alert->description }}
 Features: {{ $alert->features }}
-Purpose: {{ $alert->purpose }}
 Notes: {{ $alert->notes }}
 
 Server: {{ $alert->sysName }}
@@ -205,7 +204,7 @@ Percent Utilized: {{ $value['storage_perc'] }}
 @endforeach
 ```
 
-#### Temperature Sensors
+#### Value Sensors (Temperature, Humidity, Fanspeed, ...)
 
 ```text
 {{ $alert->title }}
@@ -214,47 +213,26 @@ Device Name: {{ $alert->hostname }}
 Severity: {{ $alert->severity }}
 Timestamp: {{ $alert->timestamp }}
 Uptime: {{ $alert->uptime_short }}
-@if ($alert->state == 0) Time elapsed: {{ $alert->elapsed }} @endif
-Location: {{ $alert->location }}
-Description: {{ $alert->description }}
-Features: {{ $alert->features }}
-Purpose: {{ $alert->purpose }}
-Notes: {{ $alert->notes }}
-
-Rule: @if ($alert->name) {{ $alert->name }} @else {{ $alert->rule }} @endif
-@if ($alert->faults) Faults:
-@foreach ($faults as $key => $value)
-#{{ $key }}: Temperature: {{ $value['sensor_current'] }} °C
-** @php echo ($value['sensor_current']-$value['sensor_limit']); @endphp°C over limit
-Previous Measurement: {{ $value['sensor_prev'] }} °C
-High Temperature Limit: {{ $value['sensor_limit'] }} °C
-@endforeach
+@if ($alert->state == 0)
+Time elapsed: {{ $alert->elapsed }}
 @endif
-```
-
-#### Value Sensors
-
-```text
-{{ $alert->title }}
-
-Device Name: {{ $alert->hostname }}
-Severity: {{ $alert->severity }}
-Timestamp: {{ $alert->timestamp }}
-Uptime: {{ $alert->uptime_short }}
-@if ($alert->state == 0) Time elapsed: {{ $alert->elapsed }} @endif
 Location: {{ $alert->location }}
 Description: {{ $alert->description }}
 Features: {{ $alert->features }}
-Purpose: {{ $alert->purpose }}
 Notes: {{ $alert->notes }}
 
-Rule: @if ($alert->name) {{ $alert->name }} @else {{ $alert->rule }} @endif
-@if ($alert->faults) Faults:
+Rule: {{ $alert->name ?? $alert->rule }}
+@if ($alert->faults)
+Faults:
 @foreach ($alert->faults as $key => $value)
-#{{ $key }}: Sensor {{ $value['sensor_current'] }}
-** @php echo ($value['sensor_current']-$value['sensor_limit']); @endphp over limit
-Previous Measurement: {{ $value['sensor_prev'] }}
-Limit: {{ $value['sensor_limit'] }}
+@php($unit = __("sensors.${value["sensor_class"]}.unit"))
+#{{ $key }}: {{ $value['sensor_descr'] ?? 'Sensor' }}
+
+Current: {{ $value['sensor_current'].$unit }}
+Previous: {{ $value['sensor_prev'].$unit }}
+Limit: {{ $value['sensor_limit'].$unit }}
+Over Limit: {{ round($value['sensor_current']-$value['sensor_limit'], 2).$unit }}
+
 @endforeach
 @endif
 ```


### PR DESCRIPTION
This combines the temperature and "value" sensor, and as a bonus inserts the unit (%) for the sensor class

Generates:
```
Alert for device 127.1.6.1 - Sensor over limit - Check Device Health Settings

Device Name: 127.1.6.1
Severity: critical
Timestamp: 2022-01-23 18:00:01
Uptime:  207d 18h 43m 33s
Location: private
Description:
Features:
Notes:

Rule: Sensor over limit - Check Device Health Settings
Faults:
#1: Environment Sensor Humidity

Current: 56%
Previous: %
Limit: 50%
Over Limit: 6%

```

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
