### PR TITLE
[WebUI] 1/2 Services - Removing the colon symbol to the right of a co…

### DIFF
--- a/includes/html/print-service-add.inc.php
+++ b/includes/html/print-service-add.inc.php
@@ -7,7 +7,7 @@ echo "
   <div class='alert alert-info'>Service will created for the specified Device.</div>
   <div class='well well-lg'>
     <div class='form-group'>
-      <label for='name' class='col-sm-2 control-label'>Name:</label>
+      <label for='name' class='col-sm-2 control-label'>Name</label>
       <div class='col-sm-5'>
         <input name='name' id='name' class='form-control input-sm'>
       </div>
@@ -16,7 +16,7 @@ echo "
     </div>
     <div class='form-group'>
       <input type='hidden' name='addsrv' value='yes'>
-      <label for='device' class='col-sm-2 control-label'>Device:</label>
+      <label for='device' class='col-sm-2 control-label'>Device</label>
       <div class='col-sm-5'>
         <select name='device' class='form-control input-sm'>
           $devicesform
@@ -26,7 +26,7 @@ echo "
       </div>
     </div>
     <div class='form-group'>
-      <label for='type' class='col-sm-2 control-label'>Check Type:</label>
+      <label for='type' class='col-sm-2 control-label'>Check Type</label>
       <div class='col-sm-5'>
         <select name='type' id='type' class='form-control input-sm'>
           $servicesform
@@ -36,7 +36,7 @@ echo "
       </div>
     </div>
     <div class='form-group'>
-      <label for='descr' class='col-sm-2 control-label'>Description:</label>
+      <label for='descr' class='col-sm-2 control-label'>Description</label>
       <div class='col-sm-5'>
         <textarea name='descr' id='descr' class='form-control input-sm' rows='5'></textarea>
       </div>
@@ -44,7 +44,7 @@ echo "
       </div>
     </div>
     <div class='form-group'>
-      <label for='ip' class='col-sm-2 control-label'>Remote Host:</label>
+      <label for='ip' class='col-sm-2 control-label'>Remote Host</label>
       <div class='col-sm-5'>
         <input name='ip' id='ip' class='form-control input-sm' placeholder='IP Address or Hostname'>
       </div>
@@ -52,7 +52,7 @@ echo "
       </div>
     </div>
     <div class='form-group'>
-      <label for='params' class='col-sm-2 control-label'>Parameters:</label>
+      <label for='params' class='col-sm-2 control-label'>Parameters</label>
       <div class='col-sm-5'>
         <input name='params' id='params' class='form-control input-sm'>
       </div>
@@ -63,13 +63,13 @@ echo "
       </div>
     </div>
     <div class='form-group'>
-      <label for='ignore' class='col-sm-2 control-label'>Ignore Alert Tag:</label>
+      <label for='ignore' class='col-sm-2 control-label'>Ignore Alert Tag</label>
       <div class='col-sm-5'>
         <input name='ignore' id='ignore' type='checkbox'>
       </div>
     </div>
     <div class='form-group'>
-      <label for='disabled' class='col-sm-2 control-label'>Disable Polling and Alerting: </label>
+      <label for='disabled' class='col-sm-2 control-label'>Disable Polling and Alerting </label>
       <div class='col-sm-5'>
         <input name='disabled' id='disabled' type='checkbox'>
       </div>


### PR DESCRIPTION
…ntrol label

In order to make the Services Add or Edit pages while adding a Service more visually consistent with other pages in the system, removed the colon simbol ":" to the very right of each control description, where present.

Regards
GG

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
