### PR TITLE
Remove non-working Dell specific alert rules from the collection

### DIFF
--- a/misc/alert_rules.json
+++ b/misc/alert_rules.json
@@ -85,7 +85,7 @@
     "severity": "critical"
   },
   {
- "rule": "macros.state_sensor_critical && sensors.sensor_alert = 1"
+    "rule": "macros.state_sensor_critical && sensors.sensor_alert = 1",
     "name": "State Sensor Critical",
     "default": true
   },

--- a/misc/alert_rules.json
+++ b/misc/alert_rules.json
@@ -85,12 +85,12 @@
     "severity": "critical"
   },
   {
-    "rule": "macros.state_sensor_critical && sensors.sensor_alert = 1",
+    "rule": "macros.state_sensor_critical",
     "name": "State Sensor Critical",
     "default": true
   },
   {
-    "rule": "macros.state_sensor_warning && sensors.sensor_alert = 1",
+    "rule": "macros.state_sensor_warning",
     "name": "State Sensor Warning"
   },
   {
@@ -314,30 +314,6 @@
     "name": "Palo Alto Networks passive firewall changed to active"
   },
   {
-    "rule": "sensors.sensor_current ~ \"[2|6]\" && sensors.sensor_oid = \".1.3.6.1.4.1.674.10893.1.20.130.15.1.4.1\"",
-    "name": "Dell Server Raid Battery Failed/Degraded"
-  },
-  {
-    "rule": "sensors.sensor_current = \"2\" && sensors.sensor_oid = \".1.3.6.1.4.1.674.10892.1.1100.32.1.5\"",
-    "name": "Dell Server CPU Status Critical"
-  },
-  {
-    "rule": "sensors.sensor_current ~ \"[2|6]\" && sensors.sensor_oid = \".1.3.6.1.4.1.674.10893.1.20.130.1.1.5\"",
-    "name": "Dell Server Disk Controller State Failed/Degraded"
-  },
-  {
-    "rule": "sensors.sensor_current ~ \"[2|5]\" && sensors.sensor_oid = \".1.3.6.1.4.1.674.10893.1.20.130.4.1.4\"",
-    "name": "Dell Server Disk Array State Failed/Degraded"
-  },
-  {
-    "rule": "sensors.sensor_current ~ \"[5|6]\" && sensors.sensor_oid = \".1.3.6.1.4.1.674.10892.1.600.12.1.5\"",
-    "name": "Dell Server PSU State Critical/NonRecvoverable"
-  },
-  {
-    "rule": "sensors.sensor_current ~ \"[2|6]\" && sensors.sensor_oid = \".1.3.6.1.4.1.674.10893.1.20.140.1.1.4\"",
-    "name": "Dell Server Virtual Disk Failed/Degraded"
-  },
-  {
     "rule": "sensors.sensor_current = \"2\" && sensors.sensor_oid = \".1.3.6.1.4.1.25506.8.35.9.1.1.1.2\"",
     "name": "Comware Fan Status failed"
   },
@@ -356,38 +332,6 @@
   {
     "rule": "sensors.sensor_current = \"3\" && sensors.sensor_oid = \".1.3.6.1.4.1.4413.1.1.43.1.15.1.2.1\"",
     "name": "UBNT EdgeSwitch Chassis state failed"
-  },
-  {
-    "rule": "sensors.sensor_current ~ \"[5|6|7|8|9|10]\" && sensors.sensor_oid = \".1.3.6.1.4.1.674.10892.5.5.1.20.130.4.1.4\"",
-    "name": "Dell iDRAC Physical Disk Failed/Degraded"
-  },
-  {
-    "rule": "sensors.sensor_current ~ \"[3|4]\" && sensors.sensor_oid = \".1.3.6.1.4.1.674.10892.5.5.1.20.140.1.1.4\"",
-    "name": "Dell iDRAC Virtual Disk Failed/Degraded"
-  },
-  {
-    "rule": "sensors.sensor_current ~ \"5\" && sensors.sensor_oid = \".1.3.6.1.4.1.674.10892.5.4.1100.30.1.5\"",
-    "name": "Dell iDRAC Processor Status Critical"
-  },
-  {
-    "rule": "sensors.sensor_current ~ \"5\" && sensors.sensor_oid = \".1.3.6.1.4.1.674.10892.5.4.1100.50.1.5\"",
-    "name": "Dell iDRAC Memory Status Critical"
-  },
-  {
-    "rule": "sensors.sensor_current ~ \"10\" && sensors.sensor_oid = \".1.3.6.1.4.1.674.10892.5.4.600.20.1.5\"",
-    "name": "Dell iDRAC Voltage Probe Status Failed"
-  },
-  {
-    "rule": "sensors.sensor_current ~ \"10\" && sensors.sensor_oid = \".1.3.6.1.4.1.674.10892.5.4.600.30.1.5\"",
-    "name": "Dell iDRAC Amperage Probe Status Failed"
-  },
-  {
-    "rule": "sensors.sensor_current ~ \"10\" && sensors.sensor_oid = \".1.3.6.1.4.1.674.10892.5.4.600.50.1.5\"",
-    "name": "Dell iDRAC Battery Status Failed"
-  },
-  {
-    "rule": "sensors.sensor_current ~ \"[5|6]\" && sensors.sensor_oid = \".1.3.6.1.4.1.674.10892.2.2.1\"",
-    "name": "Dell iDRAC Global System Status Critical/NonRecoverable"
   },
   {
     "rule": "devices.os = \"Netscaler\" && sensors.sensor_type = \"sysHighAvailabilityMode\" && sensors.sensor_current != `sensors.sensor_prev` && sensors.lastupdate < \"DATE_SUB(NOW(),INTERVAL 5 MINUTE)\" && macros.device_up = \"1\"",

--- a/misc/alert_rules.json
+++ b/misc/alert_rules.json
@@ -85,12 +85,12 @@
     "severity": "critical"
   },
   {
-    "rule": "macros.state_sensor_critical",
+ "rule": "macros.state_sensor_critical && sensors.sensor_alert = 1"
     "name": "State Sensor Critical",
     "default": true
   },
   {
-    "rule": "macros.state_sensor_warning",
+    "rule": "macros.state_sensor_warning && sensors.sensor_alert = 1",
     "name": "State Sensor Warning"
   },
   {


### PR DESCRIPTION
Removed non-working Dell alert rules and removed constraints fo state_sensor_warning in order to make this rule working

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [no changes] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [no changes here] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
