### PR TITLE
Remove old composer preinstall script

### DIFF
--- a/LibreNMS/ComposerHelper.php
+++ b/LibreNMS/ComposerHelper.php
@@ -61,17 +61,6 @@ class ComposerHelper
 
     public static function preInstall(Event $event)
     {
-        $vendor_dir = $event->getComposer()->getConfig()->get('vendor-dir');
-
-        if (! is_file("$vendor_dir/autoload.php")) {
-            // checkout vendor from 1.36
-            $cmds = [
-                "git checkout 609676a9f8d72da081c61f82967e1d16defc0c4e -- $vendor_dir",
-                "git reset HEAD $vendor_dir",  // don't add vendor directory to the index
-            ];
-
-            self::exec($cmds);
-        }
     }
 
     /**


### PR DESCRIPTION
This hook has always been confusing to me and seems to be able to cause more harm than good 

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
