### PR TITLE
Correct prefix for "kilo" should be small k, not capital K

### DIFF
--- a/LibreNMS/Util/Number.php
+++ b/LibreNMS/Util/Number.php
@@ -43,7 +43,7 @@ class Number
         }
 
         if ($value >= '0.1') {
-            $sizes = ['', 'K', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y'];
+            $sizes = ['', 'k', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y'];
             $ext = $sizes[0];
             for ($i = 1; (($i < count($sizes)) && ($value >= 1000)); $i++) {
                 $value = $value / 1000;


### PR DESCRIPTION
Ref: https://en.wikipedia.org/wiki/Kilo-

For example in the Fanspeed values 4500 RPM (Rounds Per Minute) should be written as 4.5 kRPM, not 4.5 KRPM.

Regards
GG

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
