### PR TITLE
[no_bulk] DDM* MIBs for Jetstream OS

### DIFF
--- a/includes/definitions/discovery/jetstream.yaml
+++ b/includes/definitions/discovery/jetstream.yaml
@@ -1,5 +1,4 @@
----
-mib: TPLINK-SYSINFO-MIB:TPLINK-SYSMONITOR-MIB:TPLINK-DDMSTATUS-MIB:TPLINK-DDMBIASCURTHRESHOLD-MIB:TPLINK-DDMRXPOWTHRESHOLD-MIB:TPLINK-DDMTXPOWTHRESHOLD-MIB:TPLINK-DDMTEMPTHRESHOLD-MIB:TPLINK-DDMVOLTHRESHOLD-MIB:TPLINK-POWER-OVER-ETHERNET-MIB
+mib: TPLINK-SYSINFO-MIB:TPLINK-SYSMONITOR-MIB:TPLINK-DDMSTATUS-MIB:TPLINK-DDMBIASCURTHRESHOLD-MIB:TPLINK-DDMTEMPTHRESHOLD-MIB:TPLINK-DDMVOLTHRESHOLD-MIB:TPLINK-DDMRXPOWTHRESHOLD-MIB:TPLINK-DDMTXPOWTHRESHOLD-MIB:TPLINK-POWER-OVER-ETHERNET-MIB
 modules:
     os:
         hardware: TPLINK-SYSINFO-MIB::tpSysInfoHwVersion.0
@@ -22,72 +21,73 @@ modules:
             data:
                 -
                     oid:
-                        - ddmBiasCurThresholdLowAlarm
-                        - ddmBiasCurThresholdLowWarn
-                        - ddmBiasCurThresholdHighAlarm
-                        - ddmBiasCurThresholdHighWarn
-                        - ddmTempThresholdLowAlarm
-                        - ddmTempThresholdLowWarn
-                        - ddmTempThresholdHighAlarm
-                        - ddmTempThresholdHighWarn
-                        - ddmVolThresholdLowAlarm
-                        - ddmVolThresholdLowWarn
-                        - ddmVolThresholdHighAlarm
-                        - ddmVolThresholdHighWarn
-                        - ddmRxPowThresholdLowAlarm
-                        - ddmRxPowThresholdLowWarn
-                        - ddmRxPowThresholdHighAlarm
-                        - ddmRxPowThresholdHighWarn
-                        - ddmTxPowThresholdLowAlarm
-                        - ddmTxPowThresholdLowWarn
-                        - ddmTxPowThresholdHighAlarm
-                        - ddmTxPowThresholdHighWarn
+                        - TPLINK-DDMSTATUS-MIB::ddmStatusTable
+                        - TPLINK-DDMBIASCURTHRESHOLD-MIB::ddmBiasCurThresholdLowAlarm
+                        - TPLINK-DDMBIASCURTHRESHOLD-MIB::ddmBiasCurThresholdLowWarn
+                        - TPLINK-DDMBIASCURTHRESHOLD-MIB::ddmBiasCurThresholdHighAlarm
+                        - TPLINK-DDMBIASCURTHRESHOLD-MIB::ddmBiasCurThresholdHighWarn
+                        - TPLINK-DDMTEMPTHRESHOLD-MIB::ddmTempThresholdLowAlarm
+                        - TPLINK-DDMTEMPTHRESHOLD-MIB::ddmTempThresholdLowWarn
+                        - TPLINK-DDMTEMPTHRESHOLD-MIB::ddmTempThresholdHighAlarm
+                        - TPLINK-DDMTEMPTHRESHOLD-MIB::ddmTempThresholdHighWarn
+                        - TPLINK-DDMVOLTHRESHOLD-MIB::ddmVolThresholdLowAlarm
+                        - TPLINK-DDMVOLTHRESHOLD-MIB::ddmVolThresholdLowWarn
+                        - TPLINK-DDMVOLTHRESHOLD-MIB::ddmVolThresholdHighAlarm
+                        - TPLINK-DDMVOLTHRESHOLD-MIB::ddmVolThresholdHighWarn
+                        - TPLINK-DDMRXPOWTHRESHOLD-MIB::ddmRxPowThresholdLowAlarm
+                        - TPLINK-DDMRXPOWTHRESHOLD-MIB::ddmRxPowThresholdLowWarn
+                        - TPLINK-DDMRXPOWTHRESHOLD-MIB::ddmRxPowThresholdHighAlarm
+                        - TPLINK-DDMRXPOWTHRESHOLD-MIB::ddmRxPowThresholdHighWarn
+                        - TPLINK-DDMTXPOWTHRESHOLD-MIB::ddmTxPowThresholdLowAlarm
+                        - TPLINK-DDMTXPOWTHRESHOLD-MIB::ddmTxPowThresholdLowWarn
+                        - TPLINK-DDMTXPOWTHRESHOLD-MIB::ddmTxPowThresholdHighAlarm
+                        - TPLINK-DDMTXPOWTHRESHOLD-MIB::ddmTxPowThresholdHighWarn
         current:
             data:
                 -
-                    oid: ddmStatusEntry
+                    oid: TPLINK-DDMSTATUS-MIB::ddmStatusTable
                     num_oid: '.1.3.6.1.4.1.11863.6.96.1.7.1.1.4.{{ $index }}'
-                    value: ddmStatusBiasCurrent
-                    descr: 'DDM Bias Current {{ $ddmStatusPort }}'
+                    value: TPLINK-DDMSTATUS-MIB::ddmStatusBiasCurrent
+                    descr: 'DDM Bias Current {{ $TPLINK-DDMSTATUS-MIB::ddmStatusPort }}'
                     divisor: 1000
                     entPhysicalIndex: '{{ $index }}'
                     entPhysicalIndex_measured: ports
                     group: SFPs
                     index: 'ddmStatusBiasCurrent.{{ $index }}'
-                    low_limit: ddmBiasCurThresholdLowAlarm
-                    low_warn_limit: ddmBiasCurThresholdLowWarn
-                    high_limit: ddmBiasCurThresholdHighAlarm
-                    warn_limit: ddmBiasCurThresholdHighWarn
+                    low_limit: TPLINK-DDMBIASCURTHRESHOLD-MIB::ddmBiasCurThresholdLowAlarm
+                    low_warn_limit: TPLINK-DDMBIASCURTHRESHOLD-MIB::ddmBiasCurThresholdLowWarn
+                    high_limit: TPLINK-DDMBIASCURTHRESHOLD-MIB::ddmBiasCurThresholdHighAlarm
+                    warn_limit: TPLINK-DDMBIASCURTHRESHOLD-MIB::ddmBiasCurThresholdHighWarn
         dbm:
             data:
                 -
-                    oid: ddmStatusEntry
+                    oid: TPLINK-DDMSTATUS-MIB::ddmStatusTable
                     num_oid: '.1.3.6.1.4.1.11863.6.96.1.7.1.1.5.{{ $index }}'
-                    value: ddmStatusTxPow
-                    descr: 'DDM TX Power {{ $ddmStatusPort }}'
+                    value: TPLINK-DDMSTATUS-MIB::ddmStatusTxPow
+                    descr: 'DDM TX Power {{ $TPLINK-DDMSTATUS-MIB::ddmStatusPort }}'
                     entPhysicalIndex: '{{ $index }}'
                     entPhysicalIndex_measured: ports
                     group: SFPs
                     index: 'ddmStatusTxPow.{{ $index }}'
                     user_func: mw_to_dbm
-                    low_limit: ddmTxPowThresholdLowAlarm
-                    low_warn_limit: ddmTxPowThresholdLowWarn
-                    high_limit: ddmTxPowThresholdHighAlarm
-                    warn_limit: ddmTxPowThresholdHighWarn
+                    low_limit: TPLINK-DDMTXPOWTHRESHOLD-MIB::ddmTxPowThresholdLowAlarm
+                    low_warn_limit: TPLINK-DDMTXPOWTHRESHOLD-MIB::ddmTxPowThresholdLowWarn
+                    high_limit: TPLINK-DDMTXPOWTHRESHOLD-MIB::ddmTxPowThresholdHighAlarm
+                    warn_limit: TPLINK-DDMTXPOWTHRESHOLD-MIB::ddmTxPowThresholdHighWarn
                 -
-                    oid: ddmStatusEntry
+                    oid: TPLINK-DDMSTATUS-MIB::ddmStatusTable
                     num_oid: '.1.3.6.1.4.1.11863.6.96.1.7.1.1.6.{{ $index }}'
-                    value: ddmStatusRxPow
-                    descr: 'DDM RX Power {{ $ddmStatusPort }}'
+                    value: TPLINK-DDMSTATUS-MIB::ddmStatusRxPow
+                    descr: 'DDM RX Power {{ $TPLINK-DDMSTATUS-MIB::ddmStatusPort }}'
                     entPhysicalIndex: '{{ $index }}'
                     entPhysicalIndex_measured: ports
                     group: SFPs
                     index: 'ddmStatusRxPow.{{ $index }}'
                     user_func: mw_to_dbm
-                    low_limit: ddmRxPowThresholdLowAlarm
-                    low_warn_limit: ddmRxPowThresholdLowWarn
-                    high_limit: ddmRxPowThresholdHighAlarm
-                    warn_limit: ddmRxPowThresholdHighWarn
+                    low_limit: TPLINK-DDMRXPOWTHRESHOLD-MIB::ddmRxPowThresholdLowAlarm
+                    low_warn_limit: TPLINK-DDMRXPOWTHRESHOLD-MIB::ddmRxPowThresholdLowWarn
+                    high_limit: TPLINK-DDMRXPOWTHRESHOLD-MIB::ddmRxPowThresholdHighAlarm
+                    warn_limit: TPLINK-DDMRXPOWTHRESHOLD-MIB::ddmRxPowThresholdHighWarn
         power:
             data:
                 -
@@ -117,10 +117,10 @@ modules:
         state:
             data:
                 -
-                    oid: ddmStatusEntry
+                    oid: TPLINK-DDMSTATUS-MIB::ddmStatusTable
                     num_oid: '.1.3.6.1.4.1.11863.6.96.1.7.1.1.7.{{ $index }}'
-                    value: ddmStatusDataReady
-                    descr: 'DDM Data Ready {{ $ddmStatusPort }}'
+                    value: TPLINK-DDMSTATUS-MIB::ddmStatusDataReady
+                    descr: 'DDM Data Ready {{ $TPLINK-DDMSTATUS-MIB::ddmStatusPort }}'
                     entPhysicalIndex: '{{ $index }}'
                     entPhysicalIndex_measured: ports
                     group: SFPs
@@ -132,10 +132,10 @@ modules:
                         - {value: 2, generic: 2, graph: 2, descr: N/A}
                     state_name: ddmStatusDataReady
                 -
-                    oid: ddmStatusEntry
+                    oid: TPLINK-DDMSTATUS-MIB::ddmStatusTable
                     num_oid: '.1.3.6.1.4.1.11863.6.96.1.7.1.1.8.{{ $index }}'
-                    value: ddmStatusLossSignal
-                    descr: 'DDM Loss of Signal {{ $ddmStatusPort }}'
+                    value: TPLINK-DDMSTATUS-MIB::ddmStatusLossSignal
+                    descr: 'DDM Loss of Signal {{ $TPLINK-DDMSTATUS-MIB::ddmStatusPort }}'
                     entPhysicalIndex: '{{ $index }}'
                     entPhysicalIndex_measured: ports
                     group: SFPs
@@ -144,10 +144,10 @@ modules:
                     states: *ddm_states
                     state_name: ddmStatusLossSignal
                 -
-                    oid: ddmStatusEntry
+                    oid: TPLINK-DDMSTATUS-MIB::ddmStatusTable
                     num_oid: '.1.3.6.1.4.1.11863.6.96.1.7.1.1.9.{{ $index }}'
-                    value: ddmStatusTxFault
-                    descr: 'DDM TX Fault {{ $ddmStatusPort }}'
+                    value: TPLINK-DDMSTATUS-MIB::ddmStatusTxFault
+                    descr: 'DDM TX Fault {{ $TPLINK-DDMSTATUS-MIB::ddmStatusPort }}'
                     entPhysicalIndex: '{{ $index }}'
                     entPhysicalIndex_measured: ports
                     group: SFPs
@@ -158,30 +158,30 @@ modules:
         temperature:
             data:
                 -
-                    oid: ddmStatusEntry
+                    oid: TPLINK-DDMSTATUS-MIB::ddmStatusTable
                     num_oid: '.1.3.6.1.4.1.11863.6.96.1.7.1.1.2.{{ $index }}'
-                    value: ddmStatusTemperature
-                    descr: 'DDM Temperature {{ $ddmStatusPort }}'
+                    value: TPLINK-DDMSTATUS-MIB::ddmStatusTemperature
+                    descr: 'DDM Temperature {{ $TPLINK-DDMSTATUS-MIB::ddmStatusPort }}'
                     entPhysicalIndex: '{{ $index }}'
                     entPhysicalIndex_measured: ports
                     group: SFPs
                     index: 'ddmStatusTemperature.{{ $index }}'
-                    low_limit: ddmTempThresholdLowAlarm
-                    low_warn_limit: ddmTempThresholdLowWarn
-                    high_limit: ddmTempThresholdHighAlarm
-                    warn_limit: ddmTempThresholdHighWarn
+                    low_limit: TPLINK-DDMTEMPTHRESHOLD-MIB::ddmTempThresholdLowAlarm
+                    low_warn_limit: TPLINK-DDMTEMPTHRESHOLD-MIB::ddmTempThresholdLowWarn
+                    high_limit: TPLINK-DDMTEMPTHRESHOLD-MIB::ddmTempThresholdHighAlarm
+                    warn_limit: TPLINK-DDMTEMPTHRESHOLD-MIB::ddmTempThresholdHighWarn
         voltage:
             data:
                 -
-                    oid: ddmStatusEntry
+                    oid: TPLINK-DDMSTATUS-MIB::ddmStatusTable
                     num_oid: '.1.3.6.1.4.1.11863.6.96.1.7.1.1.3.{{ $index }}'
-                    value: ddmStatusVoltage
-                    descr: 'DDM Voltage {{ $ddmStatusPort }}'
+                    value: TPLINK-DDMSTATUS-MIB::ddmStatusVoltage
+                    descr: 'DDM Voltage {{ $TPLINK-DDMSTATUS-MIB::ddmStatusPort }}'
                     entPhysicalIndex: '{{ $index }}'
                     entPhysicalIndex_measured: ports
                     group: SFPs
                     index: 'ddmStatusVoltage.{{ $index }}'
-                    low_limit: ddmVolThresholdLowAlarm
-                    low_warn_limit: ddmVolThresholdLowWarn
-                    high_limit: ddmVolThresholdHighAlarm
-                    warn_limit: ddmVolThresholdHighWarn
+                    low_limit: TPLINK-DDMVOLTHRESHOLD-MIB::ddmVolThresholdLowAlarm
+                    low_warn_limit: TPLINK-DDMVOLTHRESHOLD-MIB::ddmVolThresholdLowWarn
+                    high_limit: TPLINK-DDMVOLTHRESHOLD-MIB::ddmVolThresholdHighAlarm
+                    warn_limit: TPLINK-DDMVOLTHRESHOLD-MIB::ddmVolThresholdHighWarn

--- a/includes/definitions/jetstream.yaml
+++ b/includes/definitions/jetstream.yaml
@@ -10,3 +10,26 @@ discovery:
     -
         sysDescr:
             - JetStream
+oids:
+    no_bulk:
+        - TPLINK-DDMSTATUS-MIB::ddmStatusTable
+        - TPLINK-DDMBIASCURTHRESHOLD-MIB::ddmBiasCurThresholdLowAlarm
+        - TPLINK-DDMBIASCURTHRESHOLD-MIB::ddmBiasCurThresholdLowWarn
+        - TPLINK-DDMBIASCURTHRESHOLD-MIB::ddmBiasCurThresholdHighAlarm
+        - TPLINK-DDMBIASCURTHRESHOLD-MIB::ddmBiasCurThresholdHighWarn
+        - TPLINK-DDMTEMPTHRESHOLD-MIB::ddmTempThresholdLowAlarm
+        - TPLINK-DDMTEMPTHRESHOLD-MIB::ddmTempThresholdLowWarn
+        - TPLINK-DDMTEMPTHRESHOLD-MIB::ddmTempThresholdHighAlarm
+        - TPLINK-DDMTEMPTHRESHOLD-MIB::ddmTempThresholdHighWarn
+        - TPLINK-DDMVOLTHRESHOLD-MIB::ddmVolThresholdLowAlarm
+        - TPLINK-DDMVOLTHRESHOLD-MIB::ddmVolThresholdLowWarn
+        - TPLINK-DDMVOLTHRESHOLD-MIB::ddmVolThresholdHighAlarm
+        - TPLINK-DDMVOLTHRESHOLD-MIB::ddmVolThresholdHighWarn
+        - TPLINK-DDMRXPOWTHRESHOLD-MIB::ddmRxPowThresholdLowAlarm
+        - TPLINK-DDMRXPOWTHRESHOLD-MIB::ddmRxPowThresholdLowWarn
+        - TPLINK-DDMRXPOWTHRESHOLD-MIB::ddmRxPowThresholdHighAlarm
+        - TPLINK-DDMRXPOWTHRESHOLD-MIB::ddmRxPowThresholdHighWarn
+        - TPLINK-DDMTXPOWTHRESHOLD-MIB::ddmTxPowThresholdLowAlarm
+        - TPLINK-DDMTXPOWTHRESHOLD-MIB::ddmTxPowThresholdLowWarn
+        - TPLINK-DDMTXPOWTHRESHOLD-MIB::ddmTxPowThresholdHighAlarm
+        - TPLINK-DDMTXPOWTHRESHOLD-MIB::ddmTxPowThresholdHighWarn


### PR DESCRIPTION
Older Jetstream devices have problem with DDM MIBs, so they timeout or broke down until reboot if snmpbulkwalk is used for discovery of DDM* MIBs

this PR force problematic MIBs to slow walk 
there is no need for adjusting config.php snmp_bulk = false; for whole jetstream os anymore

added TPLINK-DDMSTATUS-MIB::ddmStatusTable to cache, because this MIB is read multiple time when discovering device

https://github.com/librenms/librenms/issues/13050

tested on:

"hardware"
"T1600G-28TS 2.0"
"TL-SG3428 2.0"
"T2500G-10TS 2.0"
"TL-SG3210 3.0"
"T1600G-28TS 3.0"
"T1600G-18TS 2.0"
"T2600G-18TS 2.0"
"TL-SG2210MP 1.0"

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
