### PR TITLE
[WebUI] Custom OID - Removing the colon symbol

### DIFF
--- a/includes/html/modal/new_customoid.inc.php
+++ b/includes/html/modal/new_customoid.inc.php
@@ -21,19 +21,19 @@ if (! (Auth::user()->hasGlobalAdmin())) {
                     <input type="hidden" name="type" id="type" value="customoid">
                     <input type="hidden" name="action" id="action" value="">
                     <div class='form-group' title="A description of the OID">
-                        <label for='name' class='col-sm-4 col-md-3 control-label'>Name: </label>
+                        <label for='name' class='col-sm-4 col-md-3 control-label'>Name </label>
                         <div class='col-sm-8 col-md-9'>
                             <input type='text' id='name' name='name' class='form-control validation' maxlength='200' required>
                         </div>
                     </div>
                     <div class="form-group" title="SNMP OID">
-                        <label for='oid' class='col-sm-4 col-md-3 control-label'>OID: </label>
+                        <label for='oid' class='col-sm-4 col-md-3 control-label'>OID </label>
                         <div class='col-sm-8 col-md-9'>
                             <input type='text' id='oid' name='oid' class='form-control validation' maxlength='255' required>
                         </div>
                     </div>
                     <div class="form-group" title="SNMP data type">
-                        <label for='datatype' class='col-sm-4 col-md-3 control-label'>Data Type: </label>
+                        <label for='datatype' class='col-sm-4 col-md-3 control-label'>Data Type </label>
                         <div class='col-sm-8 col-md-9'>
                             <select class="form-control" id="datatype" name="datatype">
                                 <option value="COUNTER">COUNTER</option>
@@ -42,26 +42,26 @@ if (! (Auth::user()->hasGlobalAdmin())) {
                         </div>
                     </div>
                     <div class="form-group" title="Unit of value being polled">
-                        <label for='unit' class='col-sm-4 col-md-3 control-label'>Unit: </label>
+                        <label for='unit' class='col-sm-4 col-md-3 control-label'>Unit </label>
                         <div class='col-sm-8 col-md-9'>
                             <input type='text' id='unit' name='unit' class='form-control validation' maxlength='10'>
                         </div>
                     </div>
                     <div class='form-group form-inline'>
-                        <label class='col-sm-4 col-md-3 control-label'>Calculations: </label>
+                        <label class='col-sm-4 col-md-3 control-label'>Calculations </label>
                         <div class="col-sm-8">
-                            <label for='divisor' class='col-sm-4 col-md-3 control-label' title="Divide raw SNMP value by">Divisor: </label>
+                            <label for='divisor' class='col-sm-4 col-md-3 control-label' title="Divide raw SNMP value by">Divisor </label>
                             <div class="col-sm-4 col-md-3" title="Divide raw SNMP value by">
                                 <input type='text' id='divisor' name='divisor' class='form-control' size="4">
                             </div>
-                            <label for='multiplier' class='col-sm-4 col-md-3 control-label' title="Multiply raw SNMP value by">Multiplier: </label>
+                            <label for='multiplier' class='col-sm-4 col-md-3 control-label' title="Multiply raw SNMP value by">Multiplier </label>
                             <div class="col-sm-4 col-md-3" title="Multiply raw SNMP value by">
                                 <input type='text' id='multiplier' name='multiplier' class='form-control' size="4">
                             </div>
                         </div>
                     </div>
                     <div class="form-group" title="User function to apply to value">
-                        <label for='user_func' class='col-sm-4 col-md-3 control-label'>User Function: </label>
+                        <label for='user_func' class='col-sm-4 col-md-3 control-label'>User Function </label>
                         <div class='col-sm-8 col-md-9'>
                             <select class="form-control" id="user_func" name="user_func">
                                 <option value=""></option>
@@ -72,37 +72,37 @@ if (! (Auth::user()->hasGlobalAdmin())) {
                         </div>
                     </div>
                     <div class='form-group form-inline'>
-                        <label class='col-sm-4 col-md-3 control-label'>Alert Thresholds: </label>
+                        <label class='col-sm-4 col-md-3 control-label'>Alert Thresholds </label>
                         <div class="col-sm-8">
-                            <label for='limit' class='col-sm-4 col-md-3 control-label' title="Level to alert above">High: </label>
+                            <label for='limit' class='col-sm-4 col-md-3 control-label' title="Level to alert above">High </label>
                             <div class="col-sm-4 col-md-3" title="Level to alert above">
                                 <input type='text' id='limit' name='limit' class='form-control' size="4">
                             </div>
-                            <label for='limit_low' class='col-sm-4 col-md-3 control-label' title="Level to alert below">Low: </label>
+                            <label for='limit_low' class='col-sm-4 col-md-3 control-label' title="Level to alert below">Low </label>
                             <div class="col-sm-4 col-md-3" title="Level to alert below">
                                 <input type='text' id='limit_low' name='limit_low' class='form-control' size="4">
                             </div>
                         </div>
                     </div>
                     <div class='form-group form-inline'>
-                        <label class='col-sm-4 col-md-3 control-label'>Warning Thresholds: </label>
+                        <label class='col-sm-4 col-md-3 control-label'>Warning Thresholds </label>
                         <div class="col-sm-8">
-                            <label for='limit_warn' class='col-sm-4 col-md-3 control-label' title="Level to warn above">High: </label>
+                            <label for='limit_warn' class='col-sm-4 col-md-3 control-label' title="Level to warn above">High </label>
                             <div class="col-sm-4 col-md-3" title="Level to warn above">
                                 <input type='text' id='limit_warn' name='limit_warn' class='form-control' size="4">
                             </div>
-                            <label for='limit_low_warn' class='col-sm-4 col-md-3 control-label' title="Level to warn below">Low: </label>
+                            <label for='limit_low_warn' class='col-sm-4 col-md-3 control-label' title="Level to warn below">Low </label>
                             <div class="col-sm-4 col-md-3" title="Level to warn below">
                                <input type='text' id='limit_low_warn' name='limit_low_warn' class='form-control' size="4">
                             </div>
                         </div>
                     </div>
                     <div class="form-group" title="Alerts for this OID enabled">
-                        <label for='alerts' class='col-sm-4 col-md-3 control-label'>Alerts Enabled: </label>
+                        <label for='alerts' class='col-sm-4 col-md-3 control-label'>Alerts Enabled </label>
                         <div class='col-sm-4 col-md-3'>
                             <input type='checkbox' name='alerts' id='alerts'>
                         </div>
-                        <label for='passed' class='col-sm-4 col-md-3 control-label'>Passed Check: </label>
+                        <label for='passed' class='col-sm-4 col-md-3 control-label'>Passed Check </label>
                         <div class='col-sm-4 col-md-3'>
                             <input type='checkbox' name='cpassed' id='cpassed' disabled>
                             <input type='hidden' name='passed' id='passed' value="">


### PR DESCRIPTION
In order to make the "Custom OID" >> "Add New OID" modal page more visually consistent with other pages in the system, removed the colon simbol ":" to the very right of each control description, where present.

Regards
GG

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
