### PR TITLE
Oxidized reload Nodes when add device

### DIFF
--- a/app/Observers/DeviceObserver.php
+++ b/app/Observers/DeviceObserver.php
@@ -16,6 +16,7 @@ class DeviceObserver
     public function created(Device $device)
     {
         Log::event("Device $device->hostname has been created", $device, 'system', 3);
+        // Reload Oxidized if needed
         oxidized_reload_nodes();
     }
 

--- a/app/Observers/DeviceObserver.php
+++ b/app/Observers/DeviceObserver.php
@@ -16,6 +16,7 @@ class DeviceObserver
     public function created(Device $device)
     {
         Log::event("Device $device->hostname has been created", $device, 'system', 3);
+        oxidized_reload_nodes();
     }
 
     /**
@@ -65,6 +66,8 @@ class DeviceObserver
 
         // handle device dependency updates
         $device->children->each->updateMaxDepth($device->device_id);
+        // Reload Oxidized if needed
+        oxidized_reload_nodes();
     }
 
     /**

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -600,6 +600,7 @@ function createHost(
         }
     }
     if ($device->save()) {
+        oxidized_reload_nodes();
         return $device->device_id;
     }
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -601,7 +601,7 @@ function createHost(
     }
     if ($device->save()) {
         oxidized_reload_nodes();
-        
+
         return $device->device_id;
     }
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -601,6 +601,7 @@ function createHost(
     }
     if ($device->save()) {
         oxidized_reload_nodes();
+        
         return $device->device_id;
     }
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -354,8 +354,6 @@ function delete_device($id)
 
     $ret .= "Removed device $host\n";
     log_event("Device $host has been removed", 0, 'system', 3);
-    oxidized_reload_nodes();
-
     return $ret;
 }
 
@@ -600,8 +598,6 @@ function createHost(
         }
     }
     if ($device->save()) {
-        oxidized_reload_nodes();
-
         return $device->device_id;
     }
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -354,7 +354,7 @@ function delete_device($id)
 
     $ret .= "Removed device $host\n";
     log_event("Device $host has been removed", 0, 'system', 3);
-    
+
     return $ret;
 }
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -354,6 +354,7 @@ function delete_device($id)
 
     $ret .= "Removed device $host\n";
     log_event("Device $host has been removed", 0, 'system', 3);
+    
     return $ret;
 }
 


### PR DESCRIPTION
Fix automatic Oxidized reload when adding device. Function got called when deleting device only.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.


