### PR TITLE
[WebUI] Change icon of links pointing to Health from fa-dashboard to …

### DIFF
--- a/app/Http/Controllers/Table/DeviceController.php
+++ b/app/Http/Controllers/Table/DeviceController.php
@@ -244,7 +244,7 @@ class DeviceController extends TableController
         }
 
         if ($sensor_count) {
-            $metrics[] = $this->formatMetric($device, $sensor_count, 'health', 'fa-dashboard');
+            $metrics[] = $this->formatMetric($device, $sensor_count, 'health', 'fa-heartbeat');
         }
 
         if ($wireless_count) {


### PR DESCRIPTION

…fa-hearbeat

Health is always referred to with the fa-heartbeat icon.
Instead, in the device list, the link pointing to device's Health is the fa-dashboard.

![devicelist-before](https://user-images.githubusercontent.com/97920275/151618260-9607fe14-0e5e-4f8d-8901-ceb7a4a845d2.jpg)

In order to make the device-list page more visually consistent, I propose to change the icon from fa-dashboard to fa-heartbeat in the device lists.

![devicelist-after](https://user-images.githubusercontent.com/97920275/151618290-41a4f3c9-de8b-4237-9f8d-dd72b875d3b8.jpg)

Regards
GG

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
