### PR TITLE
device:poll log poll complete

### DIFF
--- a/LibreNMS/Poller.php
+++ b/LibreNMS/Poller.php
@@ -138,6 +138,10 @@ class Poller
                 $this->device->displayName(),
                 $this->device->device_id,
                 $measurement->getDuration()));
+            \Log::channel('single')->alert(sprintf("INFO: device:poll %s (%s) polled in %0.3fs",
+                $this->device->hostname,
+                $this->device->device_id,
+                $measurement->getDuration()));
 
             // check if the poll took too long and log an event
             if ($measurement->getDuration() > Config::get('rrd.step')) {

--- a/LibreNMS/Poller.php
+++ b/LibreNMS/Poller.php
@@ -138,7 +138,7 @@ class Poller
                 $this->device->displayName(),
                 $this->device->device_id,
                 $measurement->getDuration()));
-            \Log::channel('single')->alert(sprintf("INFO: device:poll %s (%s) polled in %0.3fs",
+            \Log::channel('single')->alert(sprintf('INFO: device:poll %s (%s) polled in %0.3fs',
                 $this->device->hostname,
                 $this->device->device_id,
                 $measurement->getDuration()));


### PR DESCRIPTION
A bit awkward because it is info, but the default file log level is error, so log at alert level, but put "INFO" in the message to not alarm users.
The watchguard depends on this log message.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
