### PR TITLE
[WebUI] Removing colon symbol from multiple dialogs

### DIFF
--- a/includes/html/modal/alert_schedule.inc.php
+++ b/includes/html/modal/alert_schedule.inc.php
@@ -39,32 +39,32 @@ if (\Auth::user()->hasGlobalAdmin()) {
                         </div>
                     </div>
                     <div class="form-group">
-                        <label for="title" class="col-sm-4 control-label">Title <exp>*</exp>: </label>
+                        <label for="title" class="col-sm-4 control-label">Title <exp>*</exp> </label>
                         <div class="col-sm-8">
                             <input type="text" class="form-control" id="title" name="title" placeholder="Maintenance title">
                         </div>
                     </div>
                     <div class="form-group">
-                        <label for="notes" class="col-sm-4 control-label">Notes: </label>
+                        <label for="notes" class="col-sm-4 control-label">Notes </label>
                         <div class="col-sm-8">
                             <textarea class="form-control" id="notes" name="notes" placeholder="Maintenance notes"></textarea>
                         </div>
                     </div>
                     <div class="form-group">
-                        <label for="recurring" class="col-sm-4 control-label">Recurring <strong class="text-danger">*</strong>: </label>
+                        <label for="recurring" class="col-sm-4 control-label">Recurring <strong class="text-danger">*</strong> </label>
                         <div class="col-sm-8">
                             <input type="checkbox" id="recurring" name="recurring" data-size="small" data-on-text="Yes" data-off-text="No" onChange="recurring_switch();" value=0 />
                         </div>
                     </div>
                     <div id="norecurringgroup">
                         <div class="form-group">
-                            <label for="start" class="col-sm-4 control-label">Start <exp>*</exp>: </label>
+                            <label for="start" class="col-sm-4 control-label">Start <exp>*</exp> </label>
                             <div class="col-sm-8">
                                 <input type="text" class="form-control date" id="start" name="start" value="" data-date-format="YYYY-MM-DD HH:mm">
                             </div>
                         </div>
                         <div class="form-group">
-                            <label for="end" class="col-sm-4 control-label">End <exp>*</exp>: </label>
+                            <label for="end" class="col-sm-4 control-label">End <exp>*</exp> </label>
                             <div class="col-sm-8">
                                 <input type="text" class="form-control date" id="end" name="end" value="" data-date-format="YYYY-MM-DD HH:mm">
                             </div>
@@ -72,31 +72,31 @@ if (\Auth::user()->hasGlobalAdmin()) {
                     </div>
                     <div id="recurringgroup" style="display:none;">
                         <div class="form-group">
-                            <label for="start_recurring_dt" class="col-sm-4 control-label">Start date <exp>*</exp>: </label>
+                            <label for="start_recurring_dt" class="col-sm-4 control-label">Start date <exp>*</exp> </label>
                             <div class="col-sm-8">
                                 <input type="text" class="form-control date" id="start_recurring_dt" name="start_recurring_dt" value="" data-date-format="YYYY-MM-DD">
                             </div>
                         </div>
                         <div class="form-group">
-                            <label for="end_recurring_dt" class="col-sm-4 control-label">End date: </label>
+                            <label for="end_recurring_dt" class="col-sm-4 control-label">End date </label>
                             <div class="col-sm-8">
                                 <input type="text" class="form-control date" id="end_recurring_dt" name="end_recurring_dt" value="" data-date-format="YYYY-MM-DD">
                             </div>
                         </div>
                         <div class="form-group">
-                            <label for="start_recurring_hr" class="col-sm-4 control-label">Start hour <exp>*</exp>: </label>
+                            <label for="start_recurring_hr" class="col-sm-4 control-label">Start hour <exp>*</exp> </label>
                             <div class="col-sm-8">
                                 <input type="text" class="form-control date" id="start_recurring_hr" name="start_recurring_hr" value="" data-date-format="HH:mm">
                             </div>
                         </div>
                         <div class="form-group">
-                            <label for="end_recurring_hr" class="col-sm-4 control-label">End hour <exp>*</exp>: </label>
+                            <label for="end_recurring_hr" class="col-sm-4 control-label">End hour <exp>*</exp> </label>
                             <div class="col-sm-8">
                                 <input type="text" class="form-control date" id="end_recurring_hr" name="end_recurring_hr" value="" data-date-format="HH:mm">
                             </div>
                         </div>
                         <div class="form-group">
-                            <label for="recurring_day" class="col-sm-4 control-label">Only on weekday: </label>
+                            <label for="recurring_day" class="col-sm-4 control-label">Only on weekday </label>
                             <div class="col-sm-8">
                                 <div style="float: left;"><label><input type="checkbox" style="width: 20px;" class="form-control" name="recurring_day[]" value="1" />Mo</label></div>
                                 <div style="float: left;padding-left: 20px;"><label><input type="checkbox" style="width: 20px;" class="form-control" name="recurring_day[]" value="2" />Tu</label></div>
@@ -109,7 +109,7 @@ if (\Auth::user()->hasGlobalAdmin()) {
                         </div>
                     </div>
                     <div class="form-group">
-                         <label for='maps' class='col-sm-4 control-label'>Map To <exp>*</exp>: </label>
+                         <label for='maps' class='col-sm-4 control-label'>Map To <exp>*</exp> </label>
                         <div class="col-sm-8">
                             <select id="maps" name="maps[]" class="form-control" multiple="multiple"></select>
                         </div>

--- a/includes/html/modal/alert_template.inc.php
+++ b/includes/html/modal/alert_template.inc.php
@@ -28,23 +28,23 @@ if (! Auth::user()->hasGlobalAdmin()) {
                 <div class="row">
                     <div class="col-md-12">
                         <div class="form-group">
-                            <label for="name">Template name: </label>
+                            <label for="name">Template name </label>
                             <input type="text" class="form-control input-sm" id="name" name="name">
                         </div>
                         <div class="form-group">
-                            <label for="template">Template: </label>
+                            <label for="template">Template </label>
                             <textarea class="form-control" id="template" name="template" style="font-family: Menlo, Monaco, Consolas, 'Courier New', monospace;" rows="15"></textarea>
                         </div>
                         <div class="form-group">
-                            <label for="rules_list">Attach template to rules: </label>
+                            <label for="rules_list">Attach template to rules </label>
                             <select id="rules_list" name="rules_list[]" class="form-control" multiple="multiple"></select>
                         </div>
                         <div class="form-group">
-                            <label for="title">Alert title: </label>
+                            <label for="title">Alert title </label>
                             <input type="text" class="form-control input-sm" id="title" name="title" placeholder="Alert Title">
                         </div>
                         <div class="form-group">
-                            <label for="title_rec">Recovery title: </label>
+                            <label for="title_rec">Recovery title </label>
                             <input type="text" class="form-control input-sm" id="title_rec" name="title_rec" placeholder="Recovery Title">
                         </div>
                         <button type="button" class="btn btn-primary btn-sm" name="create-template" id="create-template">Create template</button>

--- a/includes/html/modal/new_alert_rule.inc.php
+++ b/includes/html/modal/new_alert_rule.inc.php
@@ -52,7 +52,7 @@ if (Auth::user()->hasGlobalAdmin()) {
                         <div class="tab-content">
                             <div role="tabpanel" class="tab-pane active" id="main">
                                 <div class='form-group' title="The description of this alert rule.">
-                                    <label for='rule_name' class='col-sm-3 col-md-2 control-label'>Rule name: </label>
+                                    <label for='rule_name' class='col-sm-3 col-md-2 control-label'>Rule name </label>
                                     <div class='col-sm-9 col-md-10'>
                                         <input type='text' id='rule_name' name='name' class='form-control validation' maxlength='200' required>
                                     </div>
@@ -79,7 +79,7 @@ if (Auth::user()->hasGlobalAdmin()) {
                                     </div>
                                 </div>
                                 <div class="form-group" title="How to display the alert.  OK: green, Warning: yellow, Critical: red">
-                                    <label for='severity' class='col-sm-3 col-md-2 control-label'>Severity: </label>
+                                    <label for='severity' class='col-sm-3 col-md-2 control-label'>Severity </label>
                                     <div class="col-sm-2">
                                         <select name='severity' id='severity' class='form-control'>
                                             <option value='ok'>OK</option>
@@ -89,53 +89,53 @@ if (Auth::user()->hasGlobalAdmin()) {
                                     </div>
                                 </div>
                                 <div class="form-group form-inline">
-                                    <label for='count' class='col-sm-3 col-md-2 control-label' title="How many notifications to issue while active before stopping. -1 means no limit. If interval is 0, this has no effect.">Max alerts: </label>
+                                    <label for='count' class='col-sm-3 col-md-2 control-label' title="How many notifications to issue while active before stopping. -1 means no limit. If interval is 0, this has no effect.">Max alerts </label>
                                     <div class="col-sm-2" title="How many notifications to issue while active before stopping. -1 means no limit. If interval is 0, this has no effect.">
                                         <input type='text' id='count' name='count' class='form-control' size="4" value="123">
                                     </div>
                                     <div class="col-sm-3" title="How long to wait before issuing a notification. If the alert clears before the delay, no notification will be issued. (s,m,h,d)">
-                                        <label for='delay' class='control-label' style="vertical-align: top;">Delay: </label>
+                                        <label for='delay' class='control-label' style="vertical-align: top;">Delay </label>
                                         <input type='text' id='delay' name='delay' class='form-control' size="4">
                                     </div>
                                     <div class="col-sm-4 col-md-3" title="How often to re-issue notifications while this alert is active. 0 means notify once. This is affected by the poller interval. (s,m,h,d)">
-                                        <label for='interval' class='control-label' style="vertical-align: top;">Interval: </label>
+                                        <label for='interval' class='control-label' style="vertical-align: top;">Interval </label>
                                         <input type='text' id='interval' name='interval' class='form-control' size="4">
                                     </div>
                                 </div>
                                 <div class='form-group form-inline'>
-                                    <label for='mute' class='col-sm-3 col-md-2 control-label' title="Show alert status in the webui, but do not issue notifications.">Mute alerts: </label>
+                                    <label for='mute' class='col-sm-3 col-md-2 control-label' title="Show alert status in the webui, but do not issue notifications.">Mute alerts </label>
                                     <div class='col-sm-2' title="Show alert status in the webui, but do not issue notifications.">
                                         <input type="checkbox" name="mute" id="mute">
                                     </div>
-                                    <label for='invert' class='col-sm-3 col-md-3 control-label' title="Alert when this rule doesn't match." style="vertical-align: top;">Invert rule match: </label>
+                                    <label for='invert' class='col-sm-3 col-md-3 control-label' title="Alert when this rule doesn't match." style="vertical-align: top;">Invert rule match </label>
                                     <div class='col-sm-2' title="Alert when this rule doesn't match.">
                                         <input type='checkbox' name='invert' id='invert'>
                                     </div>
                                 </div>
                                 <div class="form-group" title="Issue recovery notifications.">
-                                    <label for='recovery' class='col-sm-3 col-md-2 control-label'>Recovery alerts: </label>
+                                    <label for='recovery' class='col-sm-3 col-md-2 control-label'>Recovery alerts </label>
                                     <div class='col-sm-2'>
                                         <input type='checkbox' name='recovery' id='recovery'>
                                     </div>
                                 </div>
                                 <div class="form-group form-inline">
-                                    <label for='maps' class='col-sm-3 col-md-2 control-label' title="Restricts this alert rule to the selected devices, groups and locations.">Match devices, groups and locations list: </label>
+                                    <label for='maps' class='col-sm-3 col-md-2 control-label' title="Restricts this alert rule to the selected devices, groups and locations.">Match devices, groups and locations list </label>
                                     <div class="col-sm-7" style="width: 56%;">
                                         <select id="maps" name="maps[]" class="form-control" multiple="multiple"></select>
                                     </div>
                                     <div>
-                                        <label for='invert_map' class='col-md-1' style="width: 14.1333%;" text-align="left" title="If ON, alert rule check will run on all devices except the selected devices and groups.">All devices except in list: </label>
+                                        <label for='invert_map' class='col-md-1' style="width: 14.1333%;" text-align="left" title="If ON, alert rule check will run on all devices except the selected devices and groups.">All devices except in list </label>
                                         <input type='checkbox' name='invert_map' id='invert_map'>
                                     </div>
                                 </div>
                                 <div class="form-group" title="Restricts this alert rule to specified transports.">
-                                    <label for="transports" class="col-sm-3 col-md-2 control-label">Transports: </label>
+                                    <label for="transports" class="col-sm-3 col-md-2 control-label">Transports </label>
                                     <div class="col-sm-9 col-md-10">
                                         <select id="transports" name="transports[]" class="form-control" multiple="multiple"></select>
                                     </div>
                                 </div>
                                 <div class='form-group' title="A link to some documentation on how to handle this alert. This will be included in notifications.">
-                                    <label for='proc' class='col-sm-3 col-md-2 control-label'>Procedure URL: </label>
+                                    <label for='proc' class='col-sm-3 col-md-2 control-label'>Procedure URL </label>
                                     <div class='col-sm-9 col-md-10'>
                                         <input type='text' id='proc' name='proc' class='form-control validation' pattern='(http|https)://.*' maxlength='80'>
                                     </div>

--- a/includes/html/modal/new_customoid.inc.php
+++ b/includes/html/modal/new_customoid.inc.php
@@ -21,19 +21,19 @@ if (! (Auth::user()->hasGlobalAdmin())) {
                     <input type="hidden" name="type" id="type" value="customoid">
                     <input type="hidden" name="action" id="action" value="">
                     <div class='form-group' title="A description of the OID">
-                        <label for='name' class='col-sm-4 col-md-3 control-label'>Name: </label>
+                        <label for='name' class='col-sm-4 col-md-3 control-label'>Name </label>
                         <div class='col-sm-8 col-md-9'>
                             <input type='text' id='name' name='name' class='form-control validation' maxlength='200' required>
                         </div>
                     </div>
                     <div class="form-group" title="SNMP OID">
-                        <label for='oid' class='col-sm-4 col-md-3 control-label'>OID: </label>
+                        <label for='oid' class='col-sm-4 col-md-3 control-label'>OID </label>
                         <div class='col-sm-8 col-md-9'>
                             <input type='text' id='oid' name='oid' class='form-control validation' maxlength='255' required>
                         </div>
                     </div>
                     <div class="form-group" title="SNMP data type">
-                        <label for='datatype' class='col-sm-4 col-md-3 control-label'>Data Type: </label>
+                        <label for='datatype' class='col-sm-4 col-md-3 control-label'>Data Type </label>
                         <div class='col-sm-8 col-md-9'>
                             <select class="form-control" id="datatype" name="datatype">
                                 <option value="COUNTER">COUNTER</option>
@@ -42,26 +42,26 @@ if (! (Auth::user()->hasGlobalAdmin())) {
                         </div>
                     </div>
                     <div class="form-group" title="Unit of value being polled">
-                        <label for='unit' class='col-sm-4 col-md-3 control-label'>Unit: </label>
+                        <label for='unit' class='col-sm-4 col-md-3 control-label'>Unit </label>
                         <div class='col-sm-8 col-md-9'>
                             <input type='text' id='unit' name='unit' class='form-control validation' maxlength='10'>
                         </div>
                     </div>
                     <div class='form-group form-inline'>
-                        <label class='col-sm-4 col-md-3 control-label'>Calculations: </label>
+                        <label class='col-sm-4 col-md-3 control-label'>Calculations </label>
                         <div class="col-sm-8">
-                            <label for='divisor' class='col-sm-4 col-md-3 control-label' title="Divide raw SNMP value by">Divisor: </label>
+                            <label for='divisor' class='col-sm-4 col-md-3 control-label' title="Divide raw SNMP value by">Divisor </label>
                             <div class="col-sm-4 col-md-3" title="Divide raw SNMP value by">
                                 <input type='text' id='divisor' name='divisor' class='form-control' size="4">
                             </div>
-                            <label for='multiplier' class='col-sm-4 col-md-3 control-label' title="Multiply raw SNMP value by">Multiplier: </label>
+                            <label for='multiplier' class='col-sm-4 col-md-3 control-label' title="Multiply raw SNMP value by">Multiplier </label>
                             <div class="col-sm-4 col-md-3" title="Multiply raw SNMP value by">
                                 <input type='text' id='multiplier' name='multiplier' class='form-control' size="4">
                             </div>
                         </div>
                     </div>
                     <div class="form-group" title="User function to apply to value">
-                        <label for='user_func' class='col-sm-4 col-md-3 control-label'>User Function: </label>
+                        <label for='user_func' class='col-sm-4 col-md-3 control-label'>User Function </label>
                         <div class='col-sm-8 col-md-9'>
                             <select class="form-control" id="user_func" name="user_func">
                                 <option value=""></option>
@@ -72,37 +72,37 @@ if (! (Auth::user()->hasGlobalAdmin())) {
                         </div>
                     </div>
                     <div class='form-group form-inline'>
-                        <label class='col-sm-4 col-md-3 control-label'>Alert Thresholds: </label>
+                        <label class='col-sm-4 col-md-3 control-label'>Alert Thresholds </label>
                         <div class="col-sm-8">
-                            <label for='limit' class='col-sm-4 col-md-3 control-label' title="Level to alert above">High: </label>
+                            <label for='limit' class='col-sm-4 col-md-3 control-label' title="Level to alert above">High </label>
                             <div class="col-sm-4 col-md-3" title="Level to alert above">
                                 <input type='text' id='limit' name='limit' class='form-control' size="4">
                             </div>
-                            <label for='limit_low' class='col-sm-4 col-md-3 control-label' title="Level to alert below">Low: </label>
+                            <label for='limit_low' class='col-sm-4 col-md-3 control-label' title="Level to alert below">Low </label>
                             <div class="col-sm-4 col-md-3" title="Level to alert below">
                                 <input type='text' id='limit_low' name='limit_low' class='form-control' size="4">
                             </div>
                         </div>
                     </div>
                     <div class='form-group form-inline'>
-                        <label class='col-sm-4 col-md-3 control-label'>Warning Thresholds: </label>
+                        <label class='col-sm-4 col-md-3 control-label'>Warning Thresholds </label>
                         <div class="col-sm-8">
-                            <label for='limit_warn' class='col-sm-4 col-md-3 control-label' title="Level to warn above">High: </label>
+                            <label for='limit_warn' class='col-sm-4 col-md-3 control-label' title="Level to warn above">High </label>
                             <div class="col-sm-4 col-md-3" title="Level to warn above">
                                 <input type='text' id='limit_warn' name='limit_warn' class='form-control' size="4">
                             </div>
-                            <label for='limit_low_warn' class='col-sm-4 col-md-3 control-label' title="Level to warn below">Low: </label>
+                            <label for='limit_low_warn' class='col-sm-4 col-md-3 control-label' title="Level to warn below">Low </label>
                             <div class="col-sm-4 col-md-3" title="Level to warn below">
                                <input type='text' id='limit_low_warn' name='limit_low_warn' class='form-control' size="4">
                             </div>
                         </div>
                     </div>
                     <div class="form-group" title="Alerts for this OID enabled">
-                        <label for='alerts' class='col-sm-4 col-md-3 control-label'>Alerts Enabled: </label>
+                        <label for='alerts' class='col-sm-4 col-md-3 control-label'>Alerts Enabled </label>
                         <div class='col-sm-4 col-md-3'>
                             <input type='checkbox' name='alerts' id='alerts'>
                         </div>
-                        <label for='passed' class='col-sm-4 col-md-3 control-label'>Passed Check: </label>
+                        <label for='passed' class='col-sm-4 col-md-3 control-label'>Passed Check </label>
                         <div class='col-sm-4 col-md-3'>
                             <input type='checkbox' name='cpassed' id='cpassed' disabled>
                             <input type='hidden' name='passed' id='passed' value="">


### PR DESCRIPTION
Please give a short description what your pull request is for

In order to make multiple dialogs more visually consistent with other pages in the system, removed the colon simbol ":" to the very right of each control description, where present.

Updated:
Custom OID (includes/html/modal/new_customoid.inc.php)
New Alert Rule (includes/html/modal/new_alert_rule.inc.php)
New Scheduled Maintenance (includes/html/modal/alert_schedule.inc.php)
New Alert Template (includes/html/modal/alert_template.inc.php)

Not Updated:
New Alert Transport (includes/html/modal/edit_alert_transport.inc.php)
Because it proves to be more difficult to update, I will create a separate Pull Request if possible.

Regards
GG


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
