### PR TITLE
Fix links to connected devices in old style maps

### DIFF
--- a/html/network-map.php
+++ b/html/network-map.php
@@ -68,7 +68,7 @@ if (isset($_GET['format']) && preg_match('/^[a-z]*$/', $_GET['format'])) {
                     }
                     $loc_id = $locations[$device['location']];
 
-                    $map .= '"' . $device['hostname'] . '" [fontsize=20, fillcolor="lightblue", group=' . $loc_id . ' URL="' . Config::get('base_url') . '/device/device=' . $device['device_id'] . "/tab=neighbours/selection=map/\" shape=box3d]\n";
+                    $map .= '"' . $device['hostname'] . '" [fontsize=20, fillcolor="lightblue", group=' . $loc_id . ' URL="' . Config::get('base_url') . 'device/device=' . $device['device_id'] . "/tab=neighbours/selection=map/\" shape=box3d]\n";
                 }
 
                 foreach ($links as $link) {
@@ -129,24 +129,24 @@ if (isset($_GET['format']) && preg_match('/^[a-z]*$/', $_GET['format'])) {
                             }
                             $ifdone[$src][$sif['port_id']] = 1;
                         } else {
-                            $map .= '"' . $sif['port_id'] . '" [label="' . $sif['label'] . '", fontsize=12, fillcolor=lightblue, URL="' . Config::get('base_url') . '/device/device=' . $device['device_id'] . "/tab=port/port=$local_port_id/\"]\n";
+                            $map .= '"' . $sif['port_id'] . '" [label="' . $sif['label'] . '", fontsize=12, fillcolor=lightblue, URL="' . Config::get('base_url') . 'device/device=' . $device['device_id'] . "/tab=port/port=$local_port_id/\"]\n";
                             if (! $ifdone[$src][$sif['port_id']]) {
                                 $map .= "\"$src\" -> \"" . $sif['port_id'] . "\" [weight=500000, arrowsize=0, len=0];\n";
                                 $ifdone[$src][$sif['port_id']] = 1;
                             }
 
                             if ($dst_host) {
-                                $map .= "\"$dst\" [URL=\"" . Config::get('base_url') . "/device/device=$dst_host/tab=neighbours/selection=map/\", fontsize=20, shape=box3d]\n";
+                                $map .= "\"$dst\" [URL=\"" . Config::get('base_url') . "device/device=$dst_host/tab=neighbours/selection=map/\", fontsize=20, shape=box3d]\n";
                             } else {
                                 $map .= "\"$dst\" [ fontsize=20 shape=box3d]\n";
                             }
 
                             if ($dst_host == $device['device_id'] || $where == '') {
-                                $map .= '"' . $dif['port_id'] . '" [label="' . $dif['label'] . '", fontsize=12, fillcolor=lightblue, URL="' . Config::get('base_url') . "/device/device=$dst_host/tab=port/port=$remote_port_id/\"]\n";
+                                $map .= '"' . $dif['port_id'] . '" [label="' . $dif['label'] . '", fontsize=12, fillcolor=lightblue, URL="' . Config::get('base_url') . "device/device=$dst_host/tab=port/port=$remote_port_id/\"]\n";
                             } else {
                                 $map .= '"' . $dif['port_id'] . '" [label="' . $dif['label'] . ' ", fontsize=12, fillcolor=lightgray';
                                 if ($dst_host) {
-                                    $map .= ', URL="' . Config::get('base_url') . "/device/device=$dst_host/tab=port/port=$remote_port_id/\"";
+                                    $map .= ', URL="' . Config::get('base_url') . "device/device=$dst_host/tab=port/port=$remote_port_id/\"";
                                 }
                                 $map .= "]\n";
                             }
@@ -223,7 +223,7 @@ if (isset($_GET['format']) && preg_match('/^[a-z]*$/', $_GET['format'])) {
     if (Auth::check()) {
         // FIXME level 10 only?
         echo '<center>
-                  <object width=1200 height=1000 data="' . Config::get('base_url') . '/network-map.php?format=svg" type="image/svg+xml"></object>
+                  <object width=1200 height=1000 data="' . Config::get('base_url') . 'network-map.php?format=svg" type="image/svg+xml"></object>
               </center>
         ';
     }


### PR DESCRIPTION
When using the old style maps when you click on one of the connected
devices (bubbles on the right side) the link points to
$HOSTNAME//device... looking at other examples base_url seems to
include the trailing slash. Removing the additional slash fixes the
links for me.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
