### PR TITLE
Add peering details page with look and feel identical to customers page

### DIFF
--- a/app/Http/Controllers/Table/PeeringDetailsController.php
+++ b/app/Http/Controllers/Table/PeeringDetailsController.php
@@ -112,6 +112,10 @@ class PeeringDetailsController extends TableController
         ];
     }
 
+    /**
+     * @param  String $customer
+     * @return array
+     */
     private function getGraphRow($customer)
     {
         $graph_array = [
@@ -133,6 +137,9 @@ class PeeringDetailsController extends TableController
         ];
     }
 
+    /**
+     * @return array
+     */
     private function getTypeStrings()
     {
         return Arr::wrap(Config::get('peering_descr', ['peering']));

--- a/app/Http/Controllers/Table/PeeringDetailsController.php
+++ b/app/Http/Controllers/Table/PeeringDetailsController.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * PeeringDetailsController.php
+ *
+ * -Description-
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * @link       https://www.librenms.org
+ *
+ * @copyright  2018 Tony Murray
+ * @author     Tony Murray <murraytony@gmail.com>
+ */
+
+namespace App\Http\Controllers\Table;
+
+use App\Models\Port;
+use Illuminate\Support\Arr;
+use LibreNMS\Config;
+use LibreNMS\Util\Html;
+use LibreNMS\Util\Url;
+
+class PeeringDetailsController extends TableController
+{
+    public function searchFields($request)
+    {
+        return ['port_descr_descr', 'ifName', 'ifDescr', 'ifAlias', 'hostname', 'sysDescr', 'port_descr_speed', 'port_descr_notes'];
+    }
+
+    public function sortFields($request)
+    {
+        return ['port_descr_descr', 'hostname', 'ifDescr', 'port_descr_speed', 'port_descr_circuit', 'port_descr_notes'];
+    }
+
+    /**
+     * Defines the base query for this resource
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Builder
+     */
+    public function baseQuery($request)
+    {
+        // selecting just the customer name, will fetch port data later
+        return Port::hasAccess($request->user())
+            ->with('device')
+            ->leftJoin('devices', 'ports.device_id', 'devices.device_id')
+            ->select('port_descr_descr')
+            ->whereIn('port_descr_type', $this->getTypeStrings())
+            ->groupBy('port_descr_descr');
+    }
+
+    /**
+     * @param  \Illuminate\Contracts\Pagination\LengthAwarePaginator  $paginator
+     * @return \Illuminate\Http\JsonResponse
+     */
+    protected function formatResponse($paginator)
+    {
+        $customers = collect($paginator->items())->pluck('port_descr_descr');
+        // fetch all ports
+        $ports = Port::whereIn('port_descr_descr', $customers)
+            ->whereIn('port_descr_type', $this->getTypeStrings())
+            ->with('device')
+            ->get()
+            ->groupBy('port_descr_descr');
+
+        $rows = $customers->reduce(function ($rows, $customer) use ($ports) {
+            $graph_row = $this->getGraphRow($customer);
+            foreach ($ports->get($customer) as $port) {
+                $port->port_descr_descr = $customer;
+                $rows->push($this->formatItem($port));
+                $customer = ''; // only display customer in the first row
+            }
+
+            // add graphs row
+            $rows->push($graph_row);
+
+            return $rows;
+        }, collect());
+
+        return response()->json([
+            'current' => $paginator->currentPage(),
+            'rowCount' => $paginator->count(),
+            'rows' => $rows,
+            'total' => $paginator->total(),
+        ]);
+    }
+
+    /**
+     * @param  Port  $port
+     * @return array|\Illuminate\Database\Eloquent\Model|\Illuminate\Support\Collection
+     */
+    public function formatItem($port)
+    {
+        return [
+            'port_descr_descr'   => $port->port_descr_descr,
+            'hostname'          => Url::deviceLink($port->device),
+            'ifDescr'            => Url::portLink($port),
+            'port_descr_speed'   => $port->port_descr_speed,
+            'port_descr_circuit' => $port->port_descr_circuit,
+            'port_descr_notes'   => $port->port_descr_notes,
+        ];
+    }
+
+    private function getGraphRow($customer)
+    {
+        $graph_array = [
+            'type' => 'peering_bits',
+            'height' => 100,
+            'width' => 220,
+            'id' => $customer,
+        ];
+
+        $graph_data = Html::graphRow($graph_array);
+
+        return [
+            'port_descr_descr'   => $graph_data[0],
+            'hostname'          => $graph_data[1],
+            'ifDescr'            => '',
+            'port_descr_speed'   => '',
+            'port_descr_circuit' => $graph_data[2],
+            'port_descr_notes'   => $graph_data[3],
+        ];
+    }
+
+    private function getTypeStrings()
+    {
+        return Arr::wrap(Config::get('peering_descr', ['peering']));
+    }
+}

--- a/app/Http/Controllers/Table/PeeringDetailsController.php
+++ b/app/Http/Controllers/Table/PeeringDetailsController.php
@@ -113,7 +113,7 @@ class PeeringDetailsController extends TableController
     }
 
     /**
-     * @param  String  $customer
+     * @param  string  $customer
      * @return array
      */
     private function getGraphRow($customer)

--- a/app/Http/Controllers/Table/PeeringDetailsController.php
+++ b/app/Http/Controllers/Table/PeeringDetailsController.php
@@ -19,8 +19,9 @@
  *
  * @link       https://www.librenms.org
  *
- * @copyright  2018 Tony Murray
+ * @copyright  2018 Tony Murray, 2022 Eric Lindsjö
  * @author     Tony Murray <murraytony@gmail.com>
+ * @author     Eric Lindsjö <eric@emj.se>
  */
 
 namespace App\Http\Controllers\Table;

--- a/app/Http/Controllers/Table/PeeringDetailsController.php
+++ b/app/Http/Controllers/Table/PeeringDetailsController.php
@@ -113,7 +113,7 @@ class PeeringDetailsController extends TableController
     }
 
     /**
-     * @param  String $customer
+     * @param  String  $customer
      * @return array
      */
     private function getGraphRow($customer)

--- a/includes/html/graphs/peering/bits.inc.php
+++ b/includes/html/graphs/peering/bits.inc.php
@@ -1,0 +1,37 @@
+<?php
+
+use LibreNMS\Config;
+
+// Generate a list of ports and then call the multi_bits grapher to generate from the list
+
+$cust_descrs = (array) Config::get('peering_descr', ['peering']);
+
+$sql = 'SELECT * FROM `ports` AS I, `devices` AS D WHERE `port_descr_descr` = ? AND D.device_id = I.device_id AND `port_descr_type` IN ' . dbGenPlaceholders(count($cust_descrs));
+$param = $cust_descrs;
+array_unshift($param, $vars['id']);
+
+$rrd_list = [];
+foreach (dbFetchRows($sql, $param) as $port) {
+    $rrd_filename = get_port_rrdfile_path($port['hostname'], $port['port_id']); // FIXME: Unification OK?
+    if (Rrd::checkRrdExists($rrd_filename)) {
+        $rrd_list[] = [
+            'filename'  => $rrd_filename,
+            'descr'     => $port['hostname'] . '-' . $port['ifDescr'],
+            'descr_in'  => shorthost($port['hostname']),
+            'descr_out' => makeshortif($port['ifDescr']),
+        ];
+    }
+}
+
+$units = 'bps';
+$total_units = 'B';
+$colours_in = 'greens';
+$multiplier = '8';
+$colours_out = 'blues';
+
+$nototal = 1;
+
+$ds_in = 'INOCTETS';
+$ds_out = 'OUTOCTETS';
+
+require 'includes/html/graphs/generic_multi_bits_separated.inc.php';

--- a/includes/html/graphs/peering/bits.inc.php
+++ b/includes/html/graphs/peering/bits.inc.php
@@ -1,7 +1,7 @@
 <?php
 
 use LibreNMS\Config;
-use app\Models\Port
+use App\Models\Port;
 
 // Generate a list of ports and then call the multi_bits grapher to generate from the list
 

--- a/includes/html/graphs/peering/bits.inc.php
+++ b/includes/html/graphs/peering/bits.inc.php
@@ -1,7 +1,7 @@
 <?php
 
-use LibreNMS\Config;
 use App\Models\Port;
+use LibreNMS\Config;
 
 // Generate a list of ports and then call the multi_bits grapher to generate from the list
 

--- a/includes/html/pages/peering-details.inc.php
+++ b/includes/html/pages/peering-details.inc.php
@@ -1,0 +1,35 @@
+<?php
+
+$pagetitle[] = 'Peering Details';
+$no_refresh = true;
+
+?>
+
+<div class="table-responsive">
+    <table id="customers" class="table table-hover table-condensed">
+        <thead>
+            <tr>
+                <th data-column-id="port_descr_descr" data-order="asc" data-formatter="customer">Customer</th>
+                <th data-column-id="hostname">Device</th>
+                <th data-column-id="ifDescr">Interface</th>
+                <th data-column-id="port_descr_speed">Speed</th>
+                <th data-column-id="port_descr_circuit">Circuit</th>
+                <th data-column-id="port_descr_notes">Notes</th>
+            </tr>
+        </thead>
+    </table>
+</div>
+
+<script>
+
+    var grid = $("#customers").bootgrid({
+        ajax: true,
+        rowCount: [50, 100, 250, -1],
+        url: "<?php echo url('/ajax/table/peering_details'); ?>",
+        formatters: {
+            customer: function (column, row) {
+                return '<strong>' + row[column.id] + '</strong>';
+            }
+        }
+    });
+</script>

--- a/resources/views/layouts/menu.blade.php
+++ b/resources/views/layouts/menu.blade.php
@@ -322,6 +322,9 @@
                                 <li><a href="{{ url('iftype/type=peering') }}"><i class="fa fa-handshake-o fa-fw fa-lg"
                                                                                   aria-hidden="true"></i> {{ __('Peering') }}
                                     </a></li>
+                                <li><a href="{{ url('peering-details') }}"><i class="fa fa-handshake-o fa-fw fa-lg"
+                                                                                  aria-hidden="true"></i> Peering Details
+                                    </a></li>
                                 @endconfig
                                 @if(\LibreNMS\Config::get('int_peering') && \LibreNMS\Config::get('int_transit'))
                                     <li><a href="{{ url('iftype/type=peering,transit') }}"><i

--- a/routes/web.php
+++ b/routes/web.php
@@ -154,7 +154,7 @@ Route::group(['middleware' => ['auth'], 'guard' => 'auth'], function () {
         Route::group(['prefix' => 'table', 'namespace' => 'Table'], function () {
             Route::post('alert-schedule', 'AlertScheduleController');
             Route::post('customers', 'CustomersController');
-	    Route::post('peering_details', 'PeeringDetailsController');
+            Route::post('peering_details', 'PeeringDetailsController');
             Route::post('device', 'DeviceController');
             Route::post('edit-ports', 'EditPortsController');
             Route::post('eventlog', 'EventlogController');

--- a/routes/web.php
+++ b/routes/web.php
@@ -154,6 +154,7 @@ Route::group(['middleware' => ['auth'], 'guard' => 'auth'], function () {
         Route::group(['prefix' => 'table', 'namespace' => 'Table'], function () {
             Route::post('alert-schedule', 'AlertScheduleController');
             Route::post('customers', 'CustomersController');
+	    Route::post('peering_details', 'PeeringDetailsController');
             Route::post('device', 'DeviceController');
             Route::post('edit-ports', 'EditPortsController');
             Route::post('eventlog', 'EventlogController');


### PR DESCRIPTION
Add a "peering details" page, showing peering ports with the same look and feel as the customers ports page. This allows for easy browsing of peering ports as well as per-peer aggregated PNI statistics. 

As this page contains proprietary data I'm not able to provide screenshot, but it's identical to the customer page.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
