### PR TITLE
[bug] Limit VLAN context STP discovery to Cisco until better fix

### DIFF
--- a/LibreNMS/OS/Traits/BridgeMib.php
+++ b/LibreNMS/OS/Traits/BridgeMib.php
@@ -44,7 +44,7 @@ trait BridgeMib
 
         $timeFactor = $this->stpTimeFactor ?? 0.01;
 
-        $vlans = ($protocol == 1 && $this->getName() == 'Cisco') ? $this->getDevice()->vlans : new Collection;
+        $vlans = ($protocol == 1 && preg_match('/^ios.*/', $this->getName())) ? $this->getDevice()->vlans : new Collection;
         $instances = new Collection;
 
         foreach ($vlans->isEmpty() ? [null] : $vlans as $vlan) {

--- a/LibreNMS/OS/Traits/BridgeMib.php
+++ b/LibreNMS/OS/Traits/BridgeMib.php
@@ -44,7 +44,7 @@ trait BridgeMib
 
         $timeFactor = $this->stpTimeFactor ?? 0.01;
 
-        $vlans = $protocol == 1 ? $this->getDevice()->vlans : new Collection;
+        $vlans = ($protocol == 1 && $this->getName() == "Cisco"  ) ? $this->getDevice()->vlans : new Collection;
         $instances = new Collection;
 
         foreach ($vlans->isEmpty() ? [null] : $vlans as $vlan) {

--- a/LibreNMS/OS/Traits/BridgeMib.php
+++ b/LibreNMS/OS/Traits/BridgeMib.php
@@ -44,7 +44,7 @@ trait BridgeMib
 
         $timeFactor = $this->stpTimeFactor ?? 0.01;
 
-        $vlans = ($protocol == 1 && $this->getName() == "Cisco"  ) ? $this->getDevice()->vlans : new Collection;
+        $vlans = ($protocol == 1 && $this->getName() == 'Cisco') ? $this->getDevice()->vlans : new Collection;
         $instances = new Collection;
 
         foreach ($vlans->isEmpty() ? [null] : $vlans as $vlan) {


### PR DESCRIPTION
Huawei switches (At least) are blacklisting any SNMP client polling wrong communities. And they also do not support context indexed_by_vlan BRIDGE MIB, so any attempt to discover ended up in blacklisting of LNMS by the device.

Until better fix, the indexed_by_vlan part is only enabled with Cisco switches.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
