### PR TITLE
Hide community and make it XSS safer

### DIFF
--- a/includes/html/pages/addhost.inc.php
+++ b/includes/html/pages/addhost.inc.php
@@ -55,7 +55,7 @@ if (! empty($_POST['hostname'])) {
             }
 
             $snmpver = strip_tags($_POST['snmpver']);
-            print_message("Adding host $hostname communit" . (count(Config::get('snmp.community')) == 1 ? 'y' : 'ies') . ' ' . implode(', ', Config::get('snmp.community')) . " port $port using $transport");
+            print_message("Adding host $hostname communit" . (count(Config::get('snmp.community')) == 1 ? 'y' : 'ies') . ' ' . implode(', ', array_map("\LibreNMS\Util\Clean::html", Config::get('snmp.community'))) . " port $port using $transport");
         } elseif ($_POST['snmpver'] === 'v3') {
             $v3 = [
                 'authlevel'  => strip_tags($_POST['authlevel']),

--- a/includes/html/pages/device/edit/snmp.inc.php
+++ b/includes/html/pages/device/edit/snmp.inc.php
@@ -33,7 +33,7 @@ if ($_POST['editing']) {
                 $update['retries'] = ['NULL'];
             }
 
-            if ($snmpver != 'v3') {
+            if ($snmpver != 'v3' && $_POST['community'] != '********') {
                 $community = $_POST['community'];
                 $update['community'] = $community;
             }
@@ -318,7 +318,7 @@ echo "        </select>
     <div class='form-group'>
     <label for='community' class='col-sm-2 control-label'>SNMP Community</label>
     <div class='col-sm-4'>
-    <input id='community' class='form-control' name='community' value='" . \LibreNMS\Util\Clean::html($device['community']) . "'/>
+    <input id='community' class='form-control' name='community' value='********' onfocus='this.value=(this.value==\"********\" ? decodeURIComponent(\"" . rawurlencode($device['community']) . "\") : this.value);'/>
     </div>
     </div>
     </div>

--- a/includes/html/pages/device/edit/snmp.inc.php
+++ b/includes/html/pages/device/edit/snmp.inc.php
@@ -318,7 +318,7 @@ echo "        </select>
     <div class='form-group'>
     <label for='community' class='col-sm-2 control-label'>SNMP Community</label>
     <div class='col-sm-4'>
-    <input id='community' class='form-control' name='community' value='" . htmlspecialchars($device['community']) . "'/>
+    <input id='community' class='form-control' name='community' value='" . \LibreNMS\Util\Clean::html($device['community']) . "'/>
     </div>
     </div>
     </div>


### PR DESCRIPTION
Community is now hidden by default, until field receives focus. 
And community is unchanged if value is "********" when saved.

And value is now protected to avoid HTML / JS injections.
![Capture d’écran 2022-02-14 à 08 54 55](https://user-images.githubusercontent.com/38363551/153822769-5a3aeae9-2580-4413-a659-1860e1eec0f8.png)

![Capture d’écran 2022-02-14 à 08 55 01](https://user-images.githubusercontent.com/38363551/153822817-78416ac0-5e01-44a2-832d-6c0fec5a4c92.png)


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
