### PR TITLE
WebUI - Search results for ports

### DIFF
--- a/app/Models/Port.php
+++ b/app/Models/Port.php
@@ -101,15 +101,11 @@ class Port extends DeviceRelatedModel
     }
 
     /**
-     * Get the description of this port either the parsed description or ifAlias
+     * Get the description of this port
      */
-    public function getDescription(bool $short = false): string
+    public function getDescription(): string
     {
-        if ($short) {
-            return (string) ($this->port_descr_descr ?: $this->ifAlias);
-        } else {
-            return (string) ($this->ifAlias);
-        }
+        return (string) ($this->ifAlias);
     }
 
     /**

--- a/app/Models/Port.php
+++ b/app/Models/Port.php
@@ -103,9 +103,13 @@ class Port extends DeviceRelatedModel
     /**
      * Get the description of this port either the parsed description or ifAlias
      */
-    public function getDescription(): string
+    public function getDescription(bool $short = false): string
     {
-        return (string) ($this->port_descr_descr ?: $this->ifAlias);
+        if ($short) {
+            return (string) ($this->port_descr_descr ?: $this->ifAlias);
+        } else {
+            return (string) ($this->ifAlias);
+        }
     }
 
     /**

--- a/includes/html/functions.inc.php
+++ b/includes/html/functions.inc.php
@@ -350,11 +350,7 @@ function generate_port_link($port, $text = null, $type = null, $overlib = 1, $si
     }
 
     $content = '<div class=list-large>' . $port['hostname'] . ' - ' . Rewrite::normalizeIfName(addslashes(\LibreNMS\Util\Clean::html($port['label'], []))) . '</div>';
-    if ($port['port_descr_descr']) {
-        $content .= addslashes(\LibreNMS\Util\Clean::html($port['port_descr_descr'], [])) . '<br />';
-    } elseif ($port['ifAlias']) {
-        $content .= addslashes(\LibreNMS\Util\Clean::html($port['ifAlias'], [])) . '<br />';
-    }
+    $content .= addslashes(\LibreNMS\Util\Clean::html($port['ifAlias'], [])) . '<br />';
 
     $content .= "<div style=\'width: 850px\'>";
     $graph_array['type'] = $port['graph_type'];

--- a/includes/html/pages/iftype.inc.php
+++ b/includes/html/pages/iftype.inc.php
@@ -7,7 +7,7 @@ if ($bg == '#ffffff') {
     $bg = '#ffffff';
 }
 
-$types_array = explode(',', $vars['type']);
+$types_array = explode(',', strip_tags($vars['type']));
 $ports = get_ports_from_type($types_array);
 
 foreach ($ports as $port) {
@@ -42,7 +42,7 @@ if ($if_list) {
         $port = cleanPort($port);
         $done = 'yes';
         unset($class);
-        $port['ifAlias'] = str_ireplace($type . ': ', '', $port['ifAlias']);
+        $port['ifAlias'] = str_ireplace($port['type'] . ': ', '', $port['ifAlias']);
         $port['ifAlias'] = str_ireplace('[PNI]', 'Private', $port['ifAlias']);
         $ifclass = ifclass($port['ifOperStatus'], $port['ifAdminStatus']);
         if ($bg == '#ffffff') {


### PR DESCRIPTION
My NOC is complaining that searchs in LibreNMS gives less details on the port descriptions. Which is true for ports with parsed descriptions, following #13143

This PR restores the behaviour for Parsed Descriptions in Search results as well as PortURL, both using $port->getDescription();
It also removes the code in function.php for `generate_port_link()`, thx @murrant .

And a setting could be added to enable shorter display in case necessary (@fbourqui )

Before
![Capture d’écran 2022-02-14 à 17 16 42](https://user-images.githubusercontent.com/38363551/153903173-ad8d6ee8-528a-4f5d-8838-0ba2a606e975.png)

After
![Capture d’écran 2022-02-14 à 17 16 12](https://user-images.githubusercontent.com/38363551/153903153-26e27e46-7187-4fbd-b473-77b5b50c9a82.png)


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
