### PR TITLE
Add LDAP bind and userlist filter support to ldap-authorization

### DIFF
--- a/LibreNMS/Authentication/LdapAuthorizationAuthorizer.php
+++ b/LibreNMS/Authentication/LdapAuthorizationAuthorizer.php
@@ -167,7 +167,9 @@ class LdapAuthorizationAuthorizer extends AuthorizerBase
         $userlist = [];
 
         $filter = '(' . Config::get('auth_ldap_prefix') . '*)';
-
+        if (Config::get('auth_ldap_userlist_filter') != null) {
+            $filter = '(' . Config::get('auth_ldap_userlist_filter') . ')';
+        }
         $search = ldap_search($this->ldap_connection, trim(Config::get('auth_ldap_suffix'), ','), $filter);
         $entries = ldap_get_entries($this->ldap_connection, $search);
 

--- a/LibreNMS/Authentication/LdapAuthorizationAuthorizer.php
+++ b/LibreNMS/Authentication/LdapAuthorizationAuthorizer.php
@@ -233,7 +233,7 @@ class LdapAuthorizationAuthorizer extends AuthorizerBase
      *
      * @return string
      */
-    protected function getFullDn($username)
+    protected function getFullDn(string $username)
     {
         return Config::get('auth_ldap_prefix', '') . $username . Config::get('auth_ldap_suffix', '');
     }

--- a/LibreNMS/Authentication/LdapAuthorizationAuthorizer.php
+++ b/LibreNMS/Authentication/LdapAuthorizationAuthorizer.php
@@ -59,6 +59,17 @@ class LdapAuthorizationAuthorizer extends AuthorizerBase
                 throw new AuthenticationException('Fatal error: LDAP TLS required but not successfully negotiated:' . ldap_error($this->ldap_connection));
             }
         }
+        if ((Config::has('auth_ldap_binduser') || Config::has('auth_ldap_binddn')) && Config::has('auth_ldap_bindpassword')) {
+            if (Config::get('auth_ldap_binddn') == null) {
+                Config::set('auth_ldap_binddn', $this->getFullDn(Config::get('auth_ldap_binduser')));
+            }
+            $username = Config::get('auth_ldap_binddn');
+            $password = Config::get('auth_ldap_bindpassword');
+            $bind_result = ldap_bind($this->ldap_connection, $username, $password);
+            if (! $bind_result) {
+                throw new AuthenticationException('Fatal error: LDAP bind configured but not successfully authenticated:' . ldap_error($this->ldap_connection));
+            }
+        }
     }
 
     public function authenticate($credentials)
@@ -213,6 +224,18 @@ class LdapAuthorizationAuthorizer extends AuthorizerBase
         }
 
         return false;
+    }
+
+    /**
+     * Get the full dn with auth_ldap_prefix and auth_ldap_suffix
+     *
+     * @internal
+     *
+     * @return string
+     */
+    protected function getFullDn($username)
+    {
+        return Config::get('auth_ldap_prefix', '') . $username . Config::get('auth_ldap_suffix', '');
     }
 
     protected function getMembername($username)

--- a/doc/Extensions/Authentication.md
+++ b/doc/Extensions/Authentication.md
@@ -339,13 +339,49 @@ will use LDAP to determine and assign the userlevel of a user. The
 userlevel will be calculated by using LDAP group membership
 information as the ___ldap___ module does.
 
-The configuration is the same as for the ___ldap___ module with one extra option: auth_ldap_cache_ttl.
+The configuration is similar to the ___ldap___ module with one extra option: auth_ldap_cache_ttl.
 This option allows to control how long user information (user_exists, userid, userlevel) are cached within the PHP Session.
 The default value is 300 seconds.
 To disabled this caching (highly discourage) set this option to 0.
 
+#### Standard config
+
 ```php
+$config['auth_mechanism'] = 'ldap-authorization';
+$config['auth_ldap_server'] = 'ldap.example.com';               // Set server(s), space separated. Prefix with ldaps:// for ssl
+$config['auth_ldap_suffix'] = ',ou=People,dc=example,dc=com';   // appended to usernames
+$config['auth_ldap_groupbase'] = 'ou=groups,dc=example,dc=com'; // all groups must be inside this
+$config['auth_ldap_groups']['admin']['level'] = 10;             // set admin group to admin level
+$config['auth_ldap_groups']['pfy']['level'] = 5;                // set pfy group to global read only level
+$config['auth_ldap_groups']['support']['level'] = 1;            // set support group as a normal user
+```
+
+#### Additional options (usually not needed)
+
+```php
+$config['auth_ldap_version'] = 3; # v2 or v3
+$config['auth_ldap_port'] = 389;                    // 389 or 636 for ssl
+$config['auth_ldap_starttls'] = True;               // Enable TLS on port 389
+$config['auth_ldap_prefix'] = 'uid=';               // prepended to usernames
+$config['auth_ldap_group']  = 'cn=groupname,ou=groups,dc=example,dc=com'; // generic group with level 0
+$config['auth_ldap_groupmemberattr'] = 'memberUid'; // attribute to use to see if a user is a member of a group
+$config['auth_ldap_groupmembertype'] = 'username';  // username type to find group members by, either username (default), fulldn or puredn
+$config['auth_ldap_emailattr'] = 'mail';            // attribute for email address
+$config['auth_ldap_attr.uid'] = 'uid';              // attribute to check username against
+$config['auth_ldap_userlist_filter'] = 'service=informatique'; // Replace 'service=informatique' by your ldap filter to limit the number of responses if you have an ldap directory with thousand of users
 $config['auth_ldap_cache_ttl'] = 300;
+```
+
+#### LDAP bind user (optional)
+
+If your ldap server does not allow anonymous bind, it is highly
+suggested to create a bind user, otherwise "remember me", alerting
+users, and the API will not work.
+
+```php
+$config['auth_ldap_binduser'] = 'ldapbind'; // will use auth_ldap_prefix and auth_ldap_suffix
+#$config['auth_ldap_binddn'] = 'CN=John.Smith,CN=Users,DC=MyDomain,DC=com'; // overrides binduser
+$config['auth_ldap_bindpassword'] = 'password';
 ```
 
 ## View/embedded graphs without being logged into LibreNMS

--- a/doc/Extensions/Authentication.md
+++ b/doc/Extensions/Authentication.md
@@ -188,7 +188,11 @@ $config['auth_ldap_starttls'] = True;               // Enable TLS on port 389
 $config['auth_ldap_prefix'] = 'uid=';               // prepended to usernames
 $config['auth_ldap_group']  = 'cn=groupname,ou=groups,dc=example,dc=com'; // generic group with level 0
 $config['auth_ldap_groupmemberattr'] = 'memberUid'; // attribute to use to see if a user is a member of a group
+$config['auth_ldap_groupmembertype'] = 'username';  // username type to find group members by, either username (default), fulldn or puredn
 $config['auth_ldap_uid_attribute'] = 'uidnumber';   // attribute for unique id
+$config['auth_ldap_timeout'] = 5;                   // time to wait before giving up (or trying the next server)
+$config['auth_ldap_emailattr'] = 'mail';            // attribute for email address
+$config['auth_ldap_attr.uid'] = 'uid';              // attribute to check username against
 $config['auth_ldap_debug'] = false;                 // enable for verbose debug messages
 $config['auth_ldap_userdn'] = true;                 // Uses a users full DN as the value of the member attribute in a group instead of member: username. (it’s member: uid=username,ou=groups,dc=domain,dc=com)
 $config['auth_ldap_userlist_filter'] = 'service=informatique'; // Replace 'service=informatique' by your ldap filter to limit the number of responses if you have an ldap directory with thousand of users

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1301,11 +1301,6 @@ parameters:
 			path: LibreNMS/Authentication/LdapAuthorizationAuthorizer.php
 
 		-
-			message: "#^Method LibreNMS\\\\Authentication\\\\LdapAuthorizationAuthorizer\\:\\:getFullDn\\(\\) has parameter \\$username with no type specified\\.$#"
-			count: 1
-			path: LibreNMS/Authentication/LdapAuthorizationAuthorizer.php
-
-		-
 			message: "#^Parameter \\#1 \\$link_identifier of function ldap_error expects resource, false given\\.$#"
 			count: 1
 			path: LibreNMS/Authentication/LdapAuthorizationAuthorizer.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1301,6 +1301,11 @@ parameters:
 			path: LibreNMS/Authentication/LdapAuthorizationAuthorizer.php
 
 		-
+			message: "#^Method LibreNMS\\\\Authentication\\\\LdapAuthorizationAuthorizer\\:\\:getFullDn\\(\\) has parameter \\$username with no type specified\\.$#"
+			count: 1
+			path: LibreNMS/Authentication/LdapAuthorizationAuthorizer.php
+
+		-
 			message: "#^Parameter \\#1 \\$link_identifier of function ldap_error expects resource, false given\\.$#"
 			count: 1
 			path: LibreNMS/Authentication/LdapAuthorizationAuthorizer.php


### PR DESCRIPTION
The ldap-authorization module lacks a lot of the options included in the normal ldap auth module, therefore this PR adds the userlist filter and bind user functionality to ldap-authorization.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
