### PR TITLE
UI: Fix second menu bar in Apps screens

### DIFF
--- a/includes/html/pages/apps/default.inc.php
+++ b/includes/html/pages/apps/default.inc.php
@@ -52,5 +52,3 @@ foreach ($apps as $app) {
     echo '</div>';
     echo '</div>';
 }//end foreach
-
-echo '</table>';

--- a/includes/html/pages/device/apps/certificate.inc.php
+++ b/includes/html/pages/device/apps/certificate.inc.php
@@ -17,7 +17,7 @@ foreach ($domain_list as $label) {
     $cert_name = $label;
 
     if ($vars['cert_name'] == $cert_name) {
-        $label = '<span class="pagemenu-selected">' . $label  . '</span>';
+        $label = '<span class="pagemenu-selected">' . $label . '</span>';
     }
 
     array_push($cert_name_list, generate_link($label, $link_array, ['cert_name' => $cert_name]));

--- a/includes/html/pages/device/apps/certificate.inc.php
+++ b/includes/html/pages/device/apps/certificate.inc.php
@@ -17,7 +17,7 @@ foreach ($domain_list as $label) {
     $cert_name = $label;
 
     if ($vars['cert_name'] == $cert_name) {
-        $label = sprintf('⚫ %s', $label);
+        $label = '<span class="pagemenu-selected">' . $label  . '</span>';
     }
 
     array_push($cert_name_list, generate_link($label, $link_array, ['cert_name' => $cert_name]));

--- a/includes/html/pages/device/apps/chronyd.inc.php
+++ b/includes/html/pages/device/apps/chronyd.inc.php
@@ -19,7 +19,7 @@ while (isset($sources[$sources_ctr])) {
     $label = $source;
 
     if ($vars['source'] == $source) {
-        $label = '>>' . $source . '<<';
+        $label = '<span class="pagemenu-selected">' . $source . '</span>';
     }
 
     $sources_ctr++;

--- a/includes/html/pages/device/apps/docker.inc.php
+++ b/includes/html/pages/device/apps/docker.inc.php
@@ -17,7 +17,7 @@ foreach ($domain_list as $label) {
     $container = $label;
 
     if ($vars['container'] == $container) {
-        $label = '<span class="pagemenu-selected">' . $label  . '</span>';
+        $label = '<span class="pagemenu-selected">' . $label . '</span>';
     }
 
     array_push($containers_list, generate_link($label, $link_array, ['container' => $container]));

--- a/includes/html/pages/device/apps/docker.inc.php
+++ b/includes/html/pages/device/apps/docker.inc.php
@@ -17,7 +17,7 @@ foreach ($domain_list as $label) {
     $container = $label;
 
     if ($vars['container'] == $container) {
-        $label = sprintf('⚫ %s', $label);
+        $label = '<span class="pagemenu-selected">' . $label  . '</span>';
     }
 
     array_push($containers_list, generate_link($label, $link_array, ['container' => $container]));

--- a/includes/html/pages/device/apps/mdadm.inc.php
+++ b/includes/html/pages/device/apps/mdadm.inc.php
@@ -17,7 +17,7 @@ foreach ($mdadm_arrays as $label) {
     $array = $label;
 
     if ($vars['array'] == $array) {
-        $label = sprintf('⚫ %s', $label);
+        $label = '<span class="pagemenu-selected">' . $label  . '</span>';
     }
 
     array_push($array_list, generate_link($label, $link_array, ['array' => $array]));

--- a/includes/html/pages/device/apps/mdadm.inc.php
+++ b/includes/html/pages/device/apps/mdadm.inc.php
@@ -17,7 +17,7 @@ foreach ($mdadm_arrays as $label) {
     $array = $label;
 
     if ($vars['array'] == $array) {
-        $label = '<span class="pagemenu-selected">' . $label  . '</span>';
+        $label = '<span class="pagemenu-selected">' . $label . '</span>';
     }
 
     array_push($array_list, generate_link($label, $link_array, ['array' => $array]));

--- a/includes/html/pages/device/apps/portactivity.inc.php
+++ b/includes/html/pages/device/apps/portactivity.inc.php
@@ -20,7 +20,7 @@ while (isset($ports[$ports_int])) {
     $label = $ports[$ports_int];
 
     if ($vars['port'] == $port) {
-        $label = '>>' . $port . '<<';
+        $label = '<span class="pagemenu-selected">' . $port . '</span>';
     }
 
     $ports_int++;

--- a/includes/html/pages/device/apps/postgres.inc.php
+++ b/includes/html/pages/device/apps/postgres.inc.php
@@ -19,7 +19,7 @@ while (isset($databases[$db_int])) {
     $label = $db;
 
     if ($vars['database'] == $db) {
-        $label = '>>' . $db . '<<';
+        $label = '<span class="pagemenu-selected">' . $db . '</span>';
     }
 
     $db_int++;

--- a/includes/html/pages/device/apps/smart.inc.php
+++ b/includes/html/pages/device/apps/smart.inc.php
@@ -17,7 +17,7 @@ foreach ($disks as $label) {
     $disk = $label;
 
     if ($vars['disk'] == $disk) {
-        $label = '<span class="pagemenu-selected">' . $label  . '</span>';
+        $label = '<span class="pagemenu-selected">' . $label . '</span>';
     }
 
     array_push($drives, generate_link($label, $link_array, ['disk'=>$disk]));

--- a/includes/html/pages/device/apps/smart.inc.php
+++ b/includes/html/pages/device/apps/smart.inc.php
@@ -17,7 +17,7 @@ foreach ($disks as $label) {
     $disk = $label;
 
     if ($vars['disk'] == $disk) {
-        $label = sprintf('⚫ %s', $label);
+        $label = '<span class="pagemenu-selected">' . $label  . '</span>';
     }
 
     array_push($drives, generate_link($label, $link_array, ['disk'=>$disk]));

--- a/includes/html/pages/device/apps/zfs.inc.php
+++ b/includes/html/pages/device/apps/zfs.inc.php
@@ -19,7 +19,7 @@ while (isset($pools[$pool_int])) {
     $label = $pool;
 
     if ($vars['pool'] == $pool) {
-        $label = '>>' . $pool . '<<';
+        $label = '<span class="pagemenu-selected">' . $pool . '</span>';
     }
 
     $pool_int++;


### PR DESCRIPTION
Bring the UI of the second menu bar on applications pages more in line with the rest of the LibreNMS UI.

Sometimes a "⚫" was used to indicate the active menu item, some other times arrows were used (Example: ">> _item_ <<")
The solution that is used now is the CSS class ```<span class="pagemenu-selected">``` that is also used in the other menu bars.


### Example 1
![image](https://user-images.githubusercontent.com/1002588/154695988-564e783f-8150-4b15-9a0b-11e93eaec166.png) ![image](https://user-images.githubusercontent.com/1002588/154696426-004eaaac-afc6-4da5-a5af-351a2580cfc4.png)

### Example 2
![image](https://user-images.githubusercontent.com/1002588/154696532-31e81ed9-af93-4b5f-acbb-c00fc67f68d5.png) ![image](https://user-images.githubusercontent.com/1002588/154696570-f88ac425-234b-473c-82b4-2ed2212aa1c2.png)


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
