### PR TITLE
Fix Oxidized Config tab showing when Device OS or Device Type is disabled

### DIFF
--- a/app/Http/Controllers/Device/Tabs/ShowConfigController.php
+++ b/app/Http/Controllers/Device/Tabs/ShowConfigController.php
@@ -78,7 +78,7 @@ class ShowConfigController extends Controller implements DeviceTab
 
         if (Config::has('oxidized.ignore_types.0')) {
             foreach (Config::get('oxidized.ignore_types') as $ignoreType) {
-                if($ignoreType == $device->type){
+                if ($ignoreType == $device->type) {
                     $enabled = false;
                 }
             }
@@ -86,7 +86,7 @@ class ShowConfigController extends Controller implements DeviceTab
 
         if (Config::has('oxidized.ignore_os.0')) {
             foreach (Config::get('oxidized.ignore_os') as $ignoreOS) {
-                if($ignoreOS == $device->os){
+                if ($ignoreOS == $device->os) {
                     $enabled = false;
                 }
             }

--- a/app/Http/Controllers/Device/Tabs/ShowConfigController.php
+++ b/app/Http/Controllers/Device/Tabs/ShowConfigController.php
@@ -70,9 +70,29 @@ class ShowConfigController extends Controller implements DeviceTab
 
     private function oxidizedEnabled(Device $device)
     {
-        return Config::get('oxidized.enabled') === true
-            && Config::has('oxidized.url')
-            && $device->getAttrib('override_Oxidized_disable') !== 'true';
+        $enabled = false;
+
+        $enabled = Config::get('oxidized.enabled') === true
+                && Config::has('oxidized.url')
+                && $device->getAttrib('override_Oxidized_disable') !== 'true';
+
+        if (Config::has('oxidized.ignore_types.0')) {
+            foreach (Config::get('oxidized.ignore_types') as $ignoreType) {
+                if($ignoreType == $device->type){
+                    $enabled = false;
+                }
+            }
+        }
+
+        if (Config::has('oxidized.ignore_os.0')) {
+            foreach (Config::get('oxidized.ignore_os') as $ignoreOS) {
+                if($ignoreOS == $device->os){
+                    $enabled = false;
+                }
+            }
+        }
+
+        return $enabled;
     }
 
     private function getRancidPath()

--- a/app/Http/Controllers/Device/Tabs/ShowConfigController.php
+++ b/app/Http/Controllers/Device/Tabs/ShowConfigController.php
@@ -70,29 +70,11 @@ class ShowConfigController extends Controller implements DeviceTab
 
     private function oxidizedEnabled(Device $device)
     {
-        $enabled = false;
-
-        $enabled = Config::get('oxidized.enabled') === true
+        return Config::get('oxidized.enabled') === true
                 && Config::has('oxidized.url')
-                && $device->getAttrib('override_Oxidized_disable') !== 'true';
-
-        if (Config::has('oxidized.ignore_types.0')) {
-            foreach (Config::get('oxidized.ignore_types') as $ignoreType) {
-                if ($ignoreType == $device->type) {
-                    $enabled = false;
-                }
-            }
-        }
-
-        if (Config::has('oxidized.ignore_os.0')) {
-            foreach (Config::get('oxidized.ignore_os') as $ignoreOS) {
-                if ($ignoreOS == $device->os) {
-                    $enabled = false;
-                }
-            }
-        }
-
-        return $enabled;
+                && $device->getAttrib('override_Oxidized_disable') !== 'true'
+                && ! in_array($device->type, Config::get('oxidized.ignore_types', []))
+                && ! in_array($device->os, Config::get('oxidized.ignore_os', []));
     }
 
     private function getRancidPath()


### PR DESCRIPTION
Fix Oxidized Config tab showing when Device OS or Device Type is disabled

Fixes https://github.com/librenms/librenms/issues/13808


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
