### PR TITLE
Added --ping-only to snmp-scan.py

### DIFF
--- a/doc/Extensions/Auto-Discovery.md
+++ b/doc/Extensions/Auto-Discovery.md
@@ -161,24 +161,26 @@ within your LibreNMS installation directory.
 Here the script's help-page for reference:
 
 ```text
-usage: snmp-scan.py [-h] [-r NETWORK] [-t THREADS] [-l] [-v]
+usage: snmp-scan.py [-h] [-t THREADS] [-g GROUP] [-l] [-v] [--ping-fallback] [--ping-only] [-P] [network ...]
 
 Scan network for snmp hosts and add them to LibreNMS.
 
-optional arguments:
-  -h, --help     show this help message and exit
-  -r NETWORK     CIDR noted IP-Range to scan. Can be specified multiple times
-                 This argument is only required if $config['nets'] is not set
-                 Example: 192.168.0.0/24 Example: 192.168.0.0/31 will be
-                 treated as an RFC3021 p-t-p network with two addresses,
-                 192.168.0.0 and 192.168.0.1 Example: 192.168.0.1/32 will be
-                 treated as a single host address
-  -t THREADS     How many IPs to scan at a time. More will increase the scan
-                 speed, but could overload your system. Default: 32
-  -l, --legend   Print the legend.
-  -v, --verbose  Show debug output. Specifying multiple times increases the
-                 verbosity.
+positional arguments:
+  network          CIDR noted IP-Range to scan. Can be specified multiple times
+                   This argument is only required if 'nets' config is not set
+                   Example: 192.168.0.0/24
+                   Example: 192.168.0.0/31 will be treated as an RFC3021 p-t-p network with two addresses, 192.168.0.0 and 192.168.0.1
+                   Example: 192.168.0.1/32 will be treated as a single host address
 
+optional arguments:
+  -h, --help       show this help message and exit
+  -t THREADS       How many IPs to scan at a time.  More will increase the scan speed, but could overload your system. Default: 32
+  -g GROUP         The poller group all scanned devices will be added to. Default: The first group listed in 'distributed_poller_group', or 0 if not specificed
+  -l, --legend     Print the legend.
+  -v, --verbose    Show debug output. Specifying multiple times increases the verbosity.
+  --ping-fallback  Add the device as an ICMP only device if it replies to ping but not SNMP.
+  --ping-only      Always add the device as an ICMP only device.
+  -P, --ping       Deprecated. Use --ping-fallback instead.
 ```
 
 ### Discovered devices

--- a/snmp-scan.py
+++ b/snmp-scan.py
@@ -173,17 +173,6 @@ Example: 192.168.0.0/31 will be treated as an RFC3021 p-t-p network with two add
 Example: 192.168.0.1/32 will be treated as a single host address""",
     )
     parser.add_argument(
-        "-P",
-        "--ping",
-        action="store_const",
-        const="-b",
-        default="",
-        help="""Add the device as an ICMP only device if it replies to ping but not SNMP.
-Example: """
-        + __file__
-        + """ -P 192.168.0.0/24""",
-    )
-    parser.add_argument(
         "-t",
         dest="threads",
         type=int,
@@ -206,6 +195,24 @@ Example: """
         action="count",
         help="Show debug output. Specifying multiple times increases the verbosity.",
     )
+    
+    pinggrp = parser.add_mutually_exclusive_group()
+    pinggrp.add_argument(
+        "--ping-fallback",
+        action="store_const",
+        dest="ping",
+        const="-b",
+        default="",
+        help="Add the device as an ICMP only device if it replies to ping but not SNMP.",
+    )
+    pinggrp.add_argument(
+        "--ping-only",
+        action="store_const",
+        dest="ping",
+        const="-P",
+        default="",
+        help="Always add the device as an ICMP only device.",
+    )
 
     # compatibility arguments
     parser.add_argument("-r", dest="network", action="append", help=argparse.SUPPRESS)
@@ -214,6 +221,16 @@ Example: """
     )
     parser.add_argument("-n", action="store_true", help=argparse.SUPPRESS)
     parser.add_argument("-b", action="store_true", help=argparse.SUPPRESS)
+    pinggrp.add_argument(
+        "-P",
+        "--ping",
+        action="store_const",
+        dest="ping",
+        const="-b",
+        default="",
+        help="Deprecated; Use --ping-fallback instead.",
+        #help.argparse.SUPPRESS, #uncomment after grace period
+    )
 
     args = parser.parse_args()
 

--- a/snmp-scan.py
+++ b/snmp-scan.py
@@ -195,7 +195,7 @@ Example: 192.168.0.1/32 will be treated as a single host address""",
         action="count",
         help="Show debug output. Specifying multiple times increases the verbosity.",
     )
-    
+
     pinggrp = parser.add_mutually_exclusive_group()
     pinggrp.add_argument(
         "--ping-fallback",
@@ -229,7 +229,7 @@ Example: 192.168.0.1/32 will be treated as a single host address""",
         const="-b",
         default="",
         help="Deprecated; Use --ping-fallback instead.",
-        #help.argparse.SUPPRESS, #uncomment after grace period
+        # help=argparse.SUPPRESS, #uncomment after grace period
     )
 
     args = parser.parse_args()

--- a/snmp-scan.py
+++ b/snmp-scan.py
@@ -278,7 +278,7 @@ Example: 192.168.0.1/32 will be treated as a single host address""",
     networks = []
     for net in netargs if netargs else CONFIG.get("nets", []):
         try:
-            networks.append(ip_network(u"%s" % net, True))
+            networks.append(ip_network("%s" % net, True))
             debug("Network parsed: {}".format(net), 2)
         except ValueError as e:
             parser.error("Invalid network format {}".format(e))


### PR DESCRIPTION
Added possibility to add found devices as ping-only devices with `snmp-scan.py`. Up to now it was not possible if the device reponds to SNMP. Also changed the arguments for `snmp-scan.py` to be consistent. It now has `--ping-only` and `--ping-fallback` the later does the same as `-P` and `--ping` before. Marked these two as "deprecated" as it they are not explicit anymore but kept them working for compatibility reasons.

I did not update the test data as it was not fully clear if it is needed and how to do it. If so, please leave a comment what needs to be done - I'll update this PR accordingly.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [X] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
