### PR TITLE
detect truenas scale

### DIFF
--- a/includes/definitions/truenas.yaml
+++ b/includes/definitions/truenas.yaml
@@ -23,6 +23,6 @@ discovery:
         sysObjectID:
             - .1.3.6.1.4.1.8072.3.2.8
             - .1.3.6.1.4.1.50536.3
-        sysDescr:
-            - FreeNAS
-            - TrueNAS
+        sysDescr_regex:
+            - '/freenas/i'
+            - '/truenas/i'


### PR DESCRIPTION
truenas scale doesnt include `TrueNAS` in the sysDescr, so use case-insensitive to detect it instead

`22.02.0. Hardware: x86_64 Intel(R) Celeron(R) CPU G1610T @ 2.30GHz. Software: Linux 5.10.93+truenas (revision #1 SMP Fri Feb 18 14:37:37 UTC 2022)`

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
