### PR TITLE
Add generic PSU status failed alert rule template

### DIFF
--- a/misc/alert_rules.json
+++ b/misc/alert_rules.json
@@ -354,6 +354,10 @@
     "name": "Cisco PSU status failed"
   },
   {
+    "rule": "sensors.sensor_current = \"8\" && sensors.sensor_oid ~ \".1.3.6.1.4.1.2636.3.1.15.1.8.2.[1-4].[0-2].0\"",
+    "name": "Juniper PSU status failed"
+  },
+  {
     "rule": "sensors.sensor_current = \"3\" && sensors.sensor_oid = \".1.3.6.1.4.1.4413.1.1.43.1.15.1.2.1\"",
     "name": "UBNT EdgeSwitch Chassis state failed"
   },

--- a/misc/alert_rules.json
+++ b/misc/alert_rules.json
@@ -354,8 +354,8 @@
     "name": "Cisco PSU status failed"
   },
   {
-    "rule": "sensors.sensor_current = \"8\" && sensors.sensor_oid ~ \".1.3.6.1.4.1.2636.3.1.15.1.8.2.[1-4].[0-2].0\"",
-    "name": "Juniper PSU status failed"
+    "builder": {"condition":"AND","rules":[{"id":"sensors.sensor_alert","field":"sensors.sensor_alert","type":"string","input":"text","operator":"equal","value":"1"},{"condition":"OR","rules":[{"id":"sensors.sensor_descr","field":"sensors.sensor_descr","type":"string","input":"text","operator":"regex","value":".*Power Supply.*"},{"id":"sensors.sensor_descr","field":"sensors.sensor_descr","type":"string","input":"text","operator":"regex","value":".*PEM.*"},{"id":"sensors.sensor_descr","field":"sensors.sensor_descr","type":"string","input":"text","operator":"regex","value":".*PSU.*"}]},{"condition":"OR","rules":[{"id":"macros.state_sensor_warning","field":"macros.state_sensor_warning","type":"boolean","input":"radio","operator":"equal","value":"1"},{"id":"macros.state_sensor_critical","field":"macros.state_sensor_critical","type":"boolean","input":"radio","operator":"equal","value":"1"}]}],"valid":true},
+    "name": "Generic PSU status failed"
   },
   {
     "rule": "sensors.sensor_current = \"3\" && sensors.sensor_oid = \".1.3.6.1.4.1.4413.1.1.43.1.15.1.2.1\"",


### PR DESCRIPTION
Hello dear LibreNMS Community,

Here you are a simple PR to add alert rule template for Juniper PSU status failed. As Cisco was already available I adapted the OIDs and created this one.

I put a regex because depending on which Juniper device the OID differ. I have successfully tested for QFX(5k and 10k), MX, EX (in dual stack) and SRX (in dual stack). I did not try with stack higher than 2 (it may be needed to adapt regex).

Hoping this could be helpful for others.

Do not hesitate to challenge me if you need changes on this simple PR (like documentation).

Have a nice day!

geg347

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.