### PR TITLE
fix db delete on cisco-vrf-lite discovery

### DIFF
--- a/includes/discovery/cisco-vrf-lite.inc.php
+++ b/includes/discovery/cisco-vrf-lite.inc.php
@@ -99,13 +99,10 @@ if (Config::get('enable_vrf_lite_cisco')) {
     $tmpVrfC = dbFetchRows('SELECT * FROM vrf_lite_cisco WHERE device_id = ? ', [
         $device['device_id'], ]);
 
-    //Delete all vrf that chaged
+    //Delete all vrf that changed
     foreach ($tmpVrfC as $vrfC) {
-        unset($ids[$vrfC['vrf_lite_cisco_id']]);
-    }
-    if (! empty($ids)) {
-        foreach ($ids as $id) {
-            dbDelete('vrf_lite_cisco', 'vrf_lite_cisco_id = ? ', [$id]);
+        if (! in_array($vrfC['vrf_lite_cisco_id'], $ids)) {
+            dbDelete('vrf_lite_cisco', 'vrf_lite_cisco_id = ? ', [$vrfC['vrf_lite_cisco_id']]);
         }
     }
     unset($ids);


### PR DESCRIPTION
Vrf are not correctly delete from the database correctly  when you removed an vrf from cisco snmp-server context.
This causing very high discovery polling time as he still trying to poll old vrf context et get some timeout.

tested on cisco nxos and snmpv3 configuration.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
