### PR TITLE
Add extra dynamic values alerttransport alertmanager

### DIFF
--- a/LibreNMS/Alert/Transport/Alertmanager.php
+++ b/LibreNMS/Alert/Transport/Alertmanager.php
@@ -136,7 +136,7 @@ class Alertmanager extends Transport
                 [
                     'title' => 'Alertmanager Options',
                     'name' => 'alertmanager-options',
-                    'descr' => 'Alertmanager Options',
+                    'descr' => 'Alertmanager Options. You can add any fixed string value or dynamic value from alert details (label name must start with extra_ and value must exists in alert details).',
                     'type' => 'textarea',
                 ],
             ],

--- a/LibreNMS/Alert/Transport/Alertmanager.php
+++ b/LibreNMS/Alert/Transport/Alertmanager.php
@@ -66,7 +66,12 @@ class Alertmanager extends Transport
         $url = $api['url'];
         unset($api['url']);
         foreach ($api as $label => $value) {
-            $data[0]['labels'][$label] = $value;
+            # To allow dynamic values
+            if ((preg_match("/^extra_[A-Za-z0-9]+$/", $label)) && (!empty($obj['faults'][1][$value]))) {
+                $data[0]['labels'][$label] = $obj['faults'][1][$value];
+            } else {
+                $data[0]['labels'][$label] = $value;
+            }
         }
 
         return $this->postAlerts($url, $data);

--- a/LibreNMS/Alert/Transport/Alertmanager.php
+++ b/LibreNMS/Alert/Transport/Alertmanager.php
@@ -66,8 +66,8 @@ class Alertmanager extends Transport
         $url = $api['url'];
         unset($api['url']);
         foreach ($api as $label => $value) {
-            # To allow dynamic values
-            if ((preg_match("/^extra_[A-Za-z0-9]+$/", $label)) && (!empty($obj['faults'][1][$value]))) {
+            // To allow dynamic values
+            if ((preg_match("/^extra_[A-Za-z0-9_]+$/", $label)) && (! empty($obj['faults'][1][$value]))) {
                 $data[0]['labels'][$label] = $obj['faults'][1][$value];
             } else {
                 $data[0]['labels'][$label] = $value;

--- a/LibreNMS/Alert/Transport/Alertmanager.php
+++ b/LibreNMS/Alert/Transport/Alertmanager.php
@@ -67,7 +67,7 @@ class Alertmanager extends Transport
         unset($api['url']);
         foreach ($api as $label => $value) {
             // To allow dynamic values
-            if ((preg_match("/^extra_[A-Za-z0-9_]+$/", $label)) && (! empty($obj['faults'][1][$value]))) {
+            if ((preg_match('/^extra_[A-Za-z0-9_]+$/', $label)) && (! empty($obj['faults'][1][$value]))) {
                 $data[0]['labels'][$label] = $obj['faults'][1][$value];
             } else {
                 $data[0]['labels'][$label] = $value;

--- a/doc/Alerting/Transports.md
+++ b/doc/Alerting/Transports.md
@@ -63,6 +63,15 @@ It is possible to configure as many label values as required in
 Alertmanager Options section. Every label and its value should be
 entered as a new line.
 
+Labels can be a fixed string or a dynamic variable from the alert.
+To set a dynamic variable your label must start with extra_ then
+complete with the name of your label (only characters, figures and
+underscore are allowed here). The value must be the name of
+the variable you want to get (you can see all the variables in 
+Alerts->Notifications by clicking on the Details icon of your alert when it is pending).
+If the variable's name does not match with an existing value the 
+label's value will be the string you provided just as it was a fixed string.
+
 Multiple Alertmanager URLs (comma separated) are supported. Each
 URL will be tried and the search will stop at the first success.
 
@@ -73,7 +82,7 @@ URL will be tried and the search will stop at the first success.
 | Config | Example |
 | ------ | ------- |
 | Alertmanager URL(s)   | http://alertmanager1.example.com,http://alertmanager2.example.com |
-| Alertmanager Options: | source=librenms <br/> customlabel=value |
+| Alertmanager Options: | source=librenms <br/> customlabel=value <br/> extra_dynamic_value=variable_name |
 
 ## API
 


### PR DESCRIPTION
Hello dear LibreNMS Community,

So here you are some changes to be able to add extra dynamic values to the Alert Transport for Alertmanager.
I just added a check in Alertmanager Options that allows to display any variables present in the Alert details (you can view these variables in the WebUI in Alert Notifications and details of a pending alert) if it exists.

You just have to name your Alertmanager Option to start with extra_ and then the name you want it to appears in Alertmanager. The value must be the correct variable name of the variable that you want to get.

For example for a port down you can do : 
extra_int = ifName
in Alertmanager Option field in Alertmanaager Transport creation and in Alertmanager you will have : 
extra_int = et-0/0/0 (or whatever)

Please tell me if there is something else to improve or to document.

Have a nice week-end!
geg347

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
