### PR TITLE
Fixed displaying hostname in create bill when port is passed

### DIFF
--- a/includes/html/modal/new_bill.inc.php
+++ b/includes/html/modal/new_bill.inc.php
@@ -23,6 +23,7 @@ if (Auth::user()->hasGlobalAdmin()) {
         $bill_data['bill_ref'] = $port['port_descr_circuit'];
         $bill_data['bill_notes'] = $port['port_descr_speed'];
         $port_device_id = $port['device_id'];
+        $device['hostname'] = $port['hostname'];
     } ?>
 
  <div class="modal fade bs-example-modal-sm" id="create-bill" tabindex="-1" role="dialog" aria-labelledby="Create" aria-hidden="true">


### PR DESCRIPTION
Fixes: https://community.librenms.org/t/cant-create-bill-from-newly-added-device-ports/18286

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
