### PR TITLE
Fix class error name

### DIFF
--- a/includes/html/graphs/device/ber.inc.php
+++ b/includes/html/graphs/device/ber.inc.php
@@ -1,6 +1,6 @@
 <?php
 
-$class = 'er';
+$class = 'ber';
 $unit = '';
 $unit_long = '';
 


### PR DESCRIPTION
Mistake on $class variable, value was 'er' instead of 'ber'.
This error prevented the ber graph located at Devices->Health->Overview
to correctly appear.

Before :
![Screenshot from 2022-03-08 14-44-42](https://user-images.githubusercontent.com/97433029/157250127-9b1c4522-334f-4438-a091-84aaeb39bb65.png)

After:
![Screenshot from 2022-03-08 14-42-52](https://user-images.githubusercontent.com/97433029/157250179-a62164da-9be2-4def-9046-546127e5c519.png)



DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
