### PR TITLE
Add APC SmartAvrReducing trap handlers

### DIFF
--- a/LibreNMS/Snmptrap/Handlers/ApcSmartAvrReducing.php
+++ b/LibreNMS/Snmptrap/Handlers/ApcSmartAvrReducing.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * ApcSmartAvrReducing.php
+ *
+ * APC UPS Compensating for a high input voltage.
+ *
+ * -Description-
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * @link       https://www.librenms.org
+ *
+ * @author     Andy Norwood(bonzo81)
+ */
+
+namespace LibreNMS\Snmptrap\Handlers;
+
+use App\Models\Device;
+use LibreNMS\Interfaces\SnmptrapHandler;
+use LibreNMS\Snmptrap\Trap;
+use Log;
+
+class ApcSmartAvrReducing implements SnmptrapHandler
+{
+    /**
+     * Handle snmptrap.
+     * Data is pre-parsed and delivered as a Trap.
+     *
+     * @param  Device  $device
+     * @param  Trap  $trap
+     * @return void
+     */
+    public function handle(Device $device, Trap $trap)
+    {
+        $message = $trap->getOidData($trap->findOid('PowerNet-MIB::mtrapargsString'));
+        Log::event($message, $device->device_id, 'trap', 3);
+    }
+}

--- a/LibreNMS/Snmptrap/Handlers/ApcSmartAvrReducingOff.php
+++ b/LibreNMS/Snmptrap/Handlers/ApcSmartAvrReducingOff.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * ApcSmartAvrReducingOff.php
+ *
+ * APC UPS No longer compensating for a high input voltage.
+ *
+ * -Description-
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * @link       https://www.librenms.org
+ *
+ * @author     Andy Norwood(bonzo81)
+ */
+
+namespace LibreNMS\Snmptrap\Handlers;
+
+use App\Models\Device;
+use LibreNMS\Interfaces\SnmptrapHandler;
+use LibreNMS\Snmptrap\Trap;
+use Log;
+
+class ApcSmartAvrReducingOff implements SnmptrapHandler
+{
+    /**
+     * Handle snmptrap.
+     * Data is pre-parsed and delivered as a Trap.
+     *
+     * @param  Device  $device
+     * @param  Trap  $trap
+     * @return void
+     */
+    public function handle(Device $device, Trap $trap)
+    {
+        $message = $trap->getOidData($trap->findOid('PowerNet-MIB::mtrapargsString'));
+        Log::event($message, $device->device_id, 'trap', 1);
+    }
+}

--- a/config/snmptraps.php
+++ b/config/snmptraps.php
@@ -100,6 +100,8 @@ return [
         'PowerNet-MIB::rPDUNearOverloadCleared' => \LibreNMS\Snmptrap\Handlers\ApcPduNearOverloadCleared::class,
         'PowerNet-MIB::rPDUOverload' => \LibreNMS\Snmptrap\Handlers\ApcPduOverload::class,
         'PowerNet-MIB::rPDUOverloadCleared' => \LibreNMS\Snmptrap\Handlers\ApcPduOverloadCleared::class,
+        'PowerNet-MIB::smartAvrReducing' => \LibreNMS\Snmptrap\Handlers\ApcSmartAvrReducing::class,
+        'PowerNet-MIB::smartAvrReducingOff' => \LibreNMS\Snmptrap\Handlers\ApcSmartAvrReducingOff::class,
         'RUCKUS-EVENT-MIB::ruckusEventAssocTrap' => \LibreNMS\Snmptrap\Handlers\RuckusAssocTrap::class,
         'RUCKUS-EVENT-MIB::ruckusEventDiassocTrap' => \LibreNMS\Snmptrap\Handlers\RuckusDiassocTrap::class,
         'RUCKUS-EVENT-MIB::ruckusEventSetErrorTrap' => \LibreNMS\Snmptrap\Handlers\RuckusSetError::class,

--- a/tests/Feature/SnmpTraps/ApcSmartAvrReducingOffTest.php
+++ b/tests/Feature/SnmpTraps/ApcSmartAvrReducingOffTest.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * ApcSmartAvrReducingOffTest.php
+ *
+ * -Description-
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * @link       https://www.librenms.org
+ *
+ * @author     Andy Norwood(bonzo81)
+ */
+
+namespace LibreNMS\Tests\Feature\SnmpTraps;
+
+use App\Models\Device;
+use LibreNMS\Snmptrap\Dispatcher;
+use LibreNMS\Snmptrap\Trap;
+
+class ApcSmartAvrReducingOffTest extends SnmpTrapTestCase
+{
+    /**
+     * Test ApcSmartAvrReducingOff handle
+     *
+     * @return void
+     */
+    public function testApcSmartAvrReducingOff()
+    {
+        $device = Device::factory()->create(); /** @var Device $device */
+        $trapText = "$device->hostname
+UDP: [$device->ip]:57602->[10.0.0.1]:162
+SNMPv2-MIB::sysUpTime.0 459:20:47:26.90
+SNMPv2-MIB::snmpTrapOID.0 PowerNet-MIB::smartAvrReducingOff
+PowerNet-MIB::mtrapargsString \"UPS: No longer compensating for a high input voltage.\"
+SNMPv2-MIB::snmpTrapEnterprise.0 PowerNet-MIB::apc";
+
+        $trap = new Trap($trapText);
+        $message = 'UPS: No longer compensating for a high input voltage.';
+        \Log::shouldReceive('event')->once()->with($message, $device->device_id, 'trap', 1);
+        $this->assertTrue(Dispatcher::handle($trap), 'Could not handle testApcSmartAvrReducingOff trap');
+    }
+}

--- a/tests/Feature/SnmpTraps/ApcSmartAvrReducingTest.php
+++ b/tests/Feature/SnmpTraps/ApcSmartAvrReducingTest.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * ApcSmartAvrReducingTest.php
+ *
+ * -Description-
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * @link       https://www.librenms.org
+ *
+ * @author     Andy Norwood(bonzo81)
+ */
+
+namespace LibreNMS\Tests\Feature\SnmpTraps;
+
+use App\Models\Device;
+use LibreNMS\Snmptrap\Dispatcher;
+use LibreNMS\Snmptrap\Trap;
+
+class ApcSmartAvrReducingTest extends SnmpTrapTestCase
+{
+    /**
+     * Test ApcSmartAvrReducing handle
+     *
+     * @return void
+     */
+    public function testApcSmartAvrReducing()
+    {
+        $device = Device::factory()->create(); /** @var Device $device */
+        $trapText = "$device->hostname
+UDP: [$device->ip]:57602->[10.0.0.1]:162
+SNMPv2-MIB::sysUpTime.0 459:20:47:26.90
+SNMPv2-MIB::snmpTrapOID.0 PowerNet-MIB::smartAvrReducing
+PowerNet-MIB::mtrapargsString \"UPS: Compensating for a high input voltage.\"
+SNMPv2-MIB::snmpTrapEnterprise.0 PowerNet-MIB::apc";
+
+        $trap = new Trap($trapText);
+        $message = 'UPS: Compensating for a high input voltage.';
+        \Log::shouldReceive('event')->once()->with($message, $device->device_id, 'trap', 3);
+        $this->assertTrue(Dispatcher::handle($trap), 'Could not handle testApcSmartAvrReducing trap');
+    }
+}


### PR DESCRIPTION
Please give a short description what your pull request is for

Additional APC trap handlers for PowerNet-MIB::smartAvrReducing and PowerNet-MIB::smartAvrReducingOff. Both handlers simply display the message received from the trap.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
