### PR TITLE
Add configuration support for IPMIv2 Kg key

### DIFF
--- a/includes/common.php
+++ b/includes/common.php
@@ -47,6 +47,7 @@ function external_exec($command)
             '/-X\' \'[\S]+\'/',
             '/-P\' \'[\S]+\'/',
             '/-H\' \'[\S]+\'/',
+            '/-y\' \'[\S]+\'/',
             '/(udp|udp6|tcp|tcp6):([^:]+):([\d]+)/',
         ];
         $replacements = [
@@ -57,6 +58,7 @@ function external_exec($command)
             '-X\' \'PASSWORD\'',
             '-P\' \'PASSWORD\'',
             '-H\' \'HOSTNAME\'',
+            '-y\' \'KG_KEY\'',
             '\1:HOSTNAME:\3',
         ];
 

--- a/includes/discovery/sensors/ipmi.inc.php
+++ b/includes/discovery/sensors/ipmi.inc.php
@@ -9,10 +9,15 @@ if ($ipmi['host'] = get_dev_attrib($device, 'ipmi_hostname')) {
 
     $ipmi['user'] = get_dev_attrib($device, 'ipmi_username');
     $ipmi['password'] = get_dev_attrib($device, 'ipmi_password');
+    $ipmi['kg_key'] = get_dev_attrib($device, 'ipmi_kg_key');
 
     $cmd = [Config::get('ipmitool', 'ipmitool')];
     if (Config::get('own_hostname') != $device['hostname'] || $ipmi['host'] != 'localhost') {
-        array_push($cmd, '-H', $ipmi['host'], '-U', $ipmi['user'], '-P', $ipmi['password'], '-L', 'USER');
+        if (empty($ipmi['kg_key']) || is_null($ipmi['kg_key'])) {
+            array_push($cmd, '-H', $ipmi['host'], '-U', $ipmi['user'], '-P', $ipmi['password'], '-L', 'USER');
+        } else {
+            array_push($cmd, '-H', $ipmi['host'], '-U', $ipmi['user'], '-P', $ipmi['password'], '-y', $ipmi['kg_key'], '-L', 'USER');
+        }
     }
 
     foreach (Config::get('ipmi.type', []) as $ipmi_type) {

--- a/includes/html/pages/device/edit/ipmi.inc.php
+++ b/includes/html/pages/device/edit/ipmi.inc.php
@@ -6,6 +6,7 @@ if ($_POST['editing']) {
         $ipmi_port = (int) $_POST['ipmi_port'];
         $ipmi_username = $_POST['ipmi_username'];
         $ipmi_password = $_POST['ipmi_password'];
+        $ipmi_kg_key = $_POST['ipmi_kg_key'];
 
         if ($ipmi_hostname != '') {
             set_dev_attrib($device, 'ipmi_hostname', $ipmi_hostname);
@@ -29,6 +30,12 @@ if ($_POST['editing']) {
             set_dev_attrib($device, 'ipmi_password', $ipmi_password);
         } else {
             del_dev_attrib($device, 'ipmi_password');
+        }
+        
+        if ($ipmi_kg_key != '') {
+            set_dev_attrib($device, 'ipmi_kg_key', $ipmi_kg_key);
+        } else {
+            del_dev_attrib($device, 'ipmi_kg_key');
         }
 
         $update_message = 'Device IPMI data updated.';
@@ -71,6 +78,12 @@ if ($updated && $update_message) {
     <label for="impi_password" class="col-sm-2 control-label">IPMI/BMC Password</label>
     <div class="col-sm-6">
       <input id="ipmi_password" name="ipmi_password" type="password" class="form-control" value="<?php echo get_dev_attrib($device, 'ipmi_password'); ?>" />
+    </div>
+  </div>
+  <div class="form-group">
+    <label for="ipmi_kg_key" class="col-sm-2 control-label">IPMIv2 Kg key</label>
+    <div class="col-sm-6">
+      <input id="ipmi_kg_key" name="ipmi_kg_key" type="password" class="form-control" value="<?php echo get_dev_attrib($device, 'ipmi_kg_key'); ?>" placeholder="A0FE1A760B304... (Leave blank if none)" />
     </div>
   </div>
   <div class="row">

--- a/includes/html/pages/device/edit/ipmi.inc.php
+++ b/includes/html/pages/device/edit/ipmi.inc.php
@@ -31,7 +31,7 @@ if ($_POST['editing']) {
         } else {
             del_dev_attrib($device, 'ipmi_password');
         }
-        
+
         if ($ipmi_kg_key != '') {
             set_dev_attrib($device, 'ipmi_kg_key', $ipmi_kg_key);
         } else {

--- a/includes/polling/ipmi.inc.php
+++ b/includes/polling/ipmi.inc.php
@@ -13,13 +13,18 @@ if (is_array($ipmi_rows)) {
         $ipmi['port'] = filter_var($device['attribs']['ipmi_port'], FILTER_VALIDATE_INT) ? $device['attribs']['ipmi_port'] : '623';
         $ipmi['user'] = $device['attribs']['ipmi_username'];
         $ipmi['password'] = $device['attribs']['ipmi_password'];
+        $ipmi['kg_key'] = $device['attribs']['ipmi_kg_key'];
         $ipmi['type'] = $device['attribs']['ipmi_type'];
 
         echo 'Fetching IPMI sensor data...';
 
         $cmd = [Config::get('ipmitool', 'ipmitool')];
         if (Config::get('own_hostname') != $device['hostname'] || $ipmi['host'] != 'localhost') {
-            array_push($cmd, '-H', $ipmi['host'], '-U', $ipmi['user'], '-P', $ipmi['password'], '-L', 'USER', '-p', $ipmi['port']);
+            if (empty($ipmi['kg_key']) || is_null($ipmi['kg_key'])) {
+                array_push($cmd, '-H', $ipmi['host'], '-U', $ipmi['user'], '-P', $ipmi['password'], '-L', 'USER', '-p', $ipmi['port']);
+            } else {
+                array_push($cmd, '-H', $ipmi['host'], '-U', $ipmi['user'], '-P', $ipmi['password'], '-L', 'USER', '-p', $ipmi['port'], '-y', $ipmi['kg_key']);
+            }
         }
 
         // Check to see if we know which IPMI interface to use


### PR DESCRIPTION
Some IPMI devices require the Kg key to be specified in addition to the standard username and password. In my case, a server of mine (Cisco C220 M3) requires it. If it's missing, `ipmitool` shows `Error: Unable to establish IPMI v2 / RMCP+ session`. Verbose output shows the connection stops at the error `> RAKP 4 message has invalid integrity check value`.

Functionality has been tested on my end. Missing stats, such as fan tachometers, have been added in successfully. 

I edited these on GitHub's web editor, hopefully the 4 commits that it took doesn't bother anyone 🙏

### Changelog
* Added configuration support for IPMIv2 Kg encryption key

### Screenshot
![image](https://user-images.githubusercontent.com/4461705/158007802-3478e53c-0965-4b00-8d93-8ae91e875ac2.png)


#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] (No changes) If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
