### PR TITLE
Newer versions of Jira use HTTP code 201 fore created issues

### DIFF
--- a/LibreNMS/Alert/Transport/Jira.php
+++ b/LibreNMS/Alert/Transport/Jira.php
@@ -78,7 +78,7 @@ class Jira extends Transport
 
         $ret = curl_exec($curl);
         $code = curl_getinfo($curl, CURLINFO_HTTP_CODE);
-        if ($code == 200) {
+        if ($code == 200 || $code == 201) {
             $jiraout = json_decode($ret, true);
             d_echo('Created jira issue ' . $jiraout['key'] . ' for ' . $obj['hostname']);
 


### PR DESCRIPTION
Looks like newer versions of Jira use the HTTP code 201 to return that a ticket is created correctly. Updated the Transport to allow HTTP return code 201, too.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
