### PR TITLE
WIP - Sensors - Adding count_rate sensortype (with RRD COUNTER instead of GAUGE)

### DIFF
--- a/app/Models/Sensor.php
+++ b/app/Models/Sensor.php
@@ -19,6 +19,7 @@ class Sensor extends DeviceRelatedModel
         'chromatic_dispersion' => 'indent',
         'cooling'              => 'thermometer-full',
         'count'                => 'hashtag',
+        'count_rate'           => 'hashtag',
         'current'              => 'bolt fa-flip-horizontal',
         'dbm'                  => 'sun-o',
         'delay'                => 'clock-o',

--- a/doc/Developing/os/Health-Information.md
+++ b/doc/Developing/os/Health-Information.md
@@ -6,38 +6,39 @@ information for your new device.
 Currently we have support for the following health metrics along with
 the values we expect to see the data in:
 
-| Class                           | Measurement                 |
-| ------------------------------- | --------------------------- |
-| airflow                         | cfm                         |
-| ber                             | ratio                       |
-| charge                          | %                           |
-| chromatic_dispersion            | ps/nm                       |
-| cooling                         | W                           |
-| count                           | #                           |
-| current                         | A                           |
-| dbm                             | dBm                         |
-| delay                           | s                           |
-| eer                             | eer                         |
-| fanspeed                        | rpm                         |
-| frequency                       | Hz                          |
-| humidity                        | %                           |
-| load                            | %                           |
-| loss                            | %                           |
-| power                           | W                           |
-| power_consumed                  | kWh                         |
-| power_factor                    | ratio                       |
-| pressure                        | kPa                         |
-| quality_factor                  | dB                          |
-| runtime                         | Min                         |
-| signal                          | dBm                         |
-| snr                             | SNR                         |
-| state                           | #                           |
-| temperature                     | C                           |
-| tv_signal                       | dBmV                        |
-| bitrate                         | bps                         |
-| voltage                         | V                           |
-| waterflow                       | l/m                         |
-| percent                         | %                           |
+| Class                       | Measurement     | Comment |
+| --------------------------- | --------------- | ------- |
+| airflow                     | cfm             | |
+| ber                         | ratio           | |
+| charge                      | %               | |
+| chromatic_dispersion        | ps/nm           | |
+| cooling                     | W               | |
+| count                       | #               | |
+| count_rate                  | #/s             | Computes variation in RRD (using type COUNTER instead of GAUGE) |
+| current                     | A               | | 
+| dbm                         | dBm             | |
+| delay                       | s               | |
+| eer                         | eer             | |
+| fanspeed                    | rpm             | |
+| frequency                   | Hz              | |
+| humidity                    | %               | |
+| load                        | %               | |
+| loss                        | %               | |
+| power                       | W               | |
+| power_consumed              | kWh             | |
+| power_factor                | ratio           | |
+| pressure                    | kPa             | |
+| quality_factor              | dB              | |
+| runtime                     | Min             | |
+| signal                      | dBm             | |
+| snr                         | SNR             | |
+| state                       | #               | |
+| temperature                 | C               | |
+| tv_signal                   | dBmV            | |
+| bitrate                     | bps             | |
+| voltage                     | V               | |
+| waterflow                   | l/m             | |
+| percent                     | %               | |
 
 #### Simple health discovery
 

--- a/doc/Developing/os/Health-Information.md
+++ b/doc/Developing/os/Health-Information.md
@@ -15,7 +15,7 @@ the values we expect to see the data in:
 | cooling                     | W               | |
 | count                       | #               | |
 | count_rate                  | #/s             | Computes variation in RRD (using type COUNTER instead of GAUGE) |
-| current                     | A               | | 
+| current                     | A               | |
 | dbm                         | dBm             | |
 | delay                       | s               | |
 | eer                         | eer             | |

--- a/includes/definitions/discovery/mcafeewebgateway.yaml
+++ b/includes/definitions/discovery/mcafeewebgateway.yaml
@@ -8,6 +8,30 @@ modules:
                 -
                     oid:
                         - stCategoryName
+        count_rate:
+            data:
+                -
+                    oid: stHttpRequests
+                    num_oid: '.1.3.6.1.4.1.1230.2.7.2.2.1.{{ $index }}'
+                    index: 'stHttpRequests.{{ $index }}'
+                    descr: 'Rate of HTTP requests'
+                -
+                    oid: stConnectionsLegitimate
+                    num_oid: '.1.3.6.1.4.1.1230.2.7.2.1.3.{{ $index }}'
+                    descr: 'Rate of legitimate connections'
+                    index: 'stConnectionsLegitimate.{{ $index }}'
+                -
+                    oid: stCategoryCount
+                    num_oid: '.1.3.6.1.4.1.1230.2.7.2.1.10.1.2.{{ $index }}'
+                    index: 'stCategoryCount.{{ $index }}'
+                    descr: 'Rate of {{ $stCategoryName }} Blocked'
+                    group: Categories
+                -
+                    oid: stHttpsRequests
+                    num_oid: '.1.3.6.1.4.1.1230.2.7.2.3.1.{{ $index }}'
+                    index: 'stHttpsRequests.{{ $index }}'
+                    descr: 'Rate of HTTPS requests'
+
         count:
             data:
                 -

--- a/includes/definitions/discovery/mcafeewebgateway.yaml
+++ b/includes/definitions/discovery/mcafeewebgateway.yaml
@@ -8,30 +8,6 @@ modules:
                 -
                     oid:
                         - stCategoryName
-        count_rate:
-            data:
-                -
-                    oid: stHttpRequests
-                    num_oid: '.1.3.6.1.4.1.1230.2.7.2.2.1.{{ $index }}'
-                    index: 'stHttpRequests.{{ $index }}'
-                    descr: 'Rate of HTTP requests'
-                -
-                    oid: stConnectionsLegitimate
-                    num_oid: '.1.3.6.1.4.1.1230.2.7.2.1.3.{{ $index }}'
-                    descr: 'Rate of legitimate connections'
-                    index: 'stConnectionsLegitimate.{{ $index }}'
-                -
-                    oid: stCategoryCount
-                    num_oid: '.1.3.6.1.4.1.1230.2.7.2.1.10.1.2.{{ $index }}'
-                    index: 'stCategoryCount.{{ $index }}'
-                    descr: 'Rate of {{ $stCategoryName }} Blocked'
-                    group: Categories
-                -
-                    oid: stHttpsRequests
-                    num_oid: '.1.3.6.1.4.1.1230.2.7.2.3.1.{{ $index }}'
-                    index: 'stHttpsRequests.{{ $index }}'
-                    descr: 'Rate of HTTPS requests'
-
         count:
             data:
                 -

--- a/includes/discovery/sensors.inc.php
+++ b/includes/discovery/sensors.inc.php
@@ -62,6 +62,7 @@ $run_sensors = [
     'signal',
     'state',
     'count',
+    'count_rate',
     'temperature',
     'tv_signal',
     'bitrate',

--- a/includes/html/functions.inc.php
+++ b/includes/html/functions.inc.php
@@ -1191,7 +1191,10 @@ function get_sensor_label_color($sensor, $type = 'sensors')
     if ($sensor['sensor_class'] == 'frequency' && $sensor['sensor_type'] == 'openwrt') {
         return "<span class='label $label_style'>" . trim($sensor['sensor_current']) . ' ' . $unit . '</span>';
     }
-
+     if ($sensor['sensor_class'] == 'count_rate') {
+        //compute and display an approx rate for this sensor
+        return "<span class='label $label_style'>" . trim(Number::formatSi(($sensor['sensor_current'] - $sensor['sensor_prev']) / Config::get('rrd.step', 300), 2, 3, $unit)) . '</span>';
+    }
     if ($type == 'wireless' && $sensor['sensor_class'] == 'frequency') {
         return "<span class='label $label_style'>" . trim(Number::formatSi($sensor['sensor_current'] * 1000000, 2, 3, 'Hz')) . '</span>';
     }

--- a/includes/html/functions.inc.php
+++ b/includes/html/functions.inc.php
@@ -1193,7 +1193,7 @@ function get_sensor_label_color($sensor, $type = 'sensors')
     }
     if ($sensor['sensor_class'] == 'count_rate') {
         //compute and display an approx rate for this sensor
-        return "<span class='label $label_style'>" . trim(Number::formatSi(max(0,$sensor['sensor_current'] - $sensor['sensor_prev']) / Config::get('rrd.step', 300), 2, 3, $unit)) . '</span>';
+        return "<span class='label $label_style'>" . trim(Number::formatSi(max(0, $sensor['sensor_current'] - $sensor['sensor_prev']) / Config::get('rrd.step', 300), 2, 3, $unit)) . '</span>';
     }
     if ($type == 'wireless' && $sensor['sensor_class'] == 'frequency') {
         return "<span class='label $label_style'>" . trim(Number::formatSi($sensor['sensor_current'] * 1000000, 2, 3, 'Hz')) . '</span>';

--- a/includes/html/functions.inc.php
+++ b/includes/html/functions.inc.php
@@ -1193,7 +1193,7 @@ function get_sensor_label_color($sensor, $type = 'sensors')
     }
     if ($sensor['sensor_class'] == 'count_rate') {
         //compute and display an approx rate for this sensor
-        return "<span class='label $label_style'>" . trim(Number::formatSi(($sensor['sensor_current'] - $sensor['sensor_prev']) / Config::get('rrd.step', 300), 2, 3, $unit)) . '</span>';
+        return "<span class='label $label_style'>" . trim(Number::formatSi(max(0,$sensor['sensor_current'] - $sensor['sensor_prev']) / Config::get('rrd.step', 300), 2, 3, $unit)) . '</span>';
     }
     if ($type == 'wireless' && $sensor['sensor_class'] == 'frequency') {
         return "<span class='label $label_style'>" . trim(Number::formatSi($sensor['sensor_current'] * 1000000, 2, 3, 'Hz')) . '</span>';

--- a/includes/html/functions.inc.php
+++ b/includes/html/functions.inc.php
@@ -1191,7 +1191,7 @@ function get_sensor_label_color($sensor, $type = 'sensors')
     if ($sensor['sensor_class'] == 'frequency' && $sensor['sensor_type'] == 'openwrt') {
         return "<span class='label $label_style'>" . trim($sensor['sensor_current']) . ' ' . $unit . '</span>';
     }
-     if ($sensor['sensor_class'] == 'count_rate') {
+    if ($sensor['sensor_class'] == 'count_rate') {
         //compute and display an approx rate for this sensor
         return "<span class='label $label_style'>" . trim(Number::formatSi(($sensor['sensor_current'] - $sensor['sensor_prev']) / Config::get('rrd.step', 300), 2, 3, $unit)) . '</span>';
     }

--- a/includes/html/graphs/device/count_rate.inc.php
+++ b/includes/html/graphs/device/count_rate.inc.php
@@ -1,0 +1,8 @@
+<?php
+
+$class = 'count';
+$unit = '#/s';
+$unit_long = '#/s';
+
+$rrd_options .= ' -o';
+require 'includes/html/graphs/device/sensor.inc.php';

--- a/includes/html/graphs/sensor/count_rate.inc.php
+++ b/includes/html/graphs/sensor/count_rate.inc.php
@@ -1,0 +1,18 @@
+<?php
+
+require 'includes/html/graphs/common.inc.php';
+
+$rrd_options .= " COMMENT:'                                        Min        Max      Last\\n'";
+$rrd_options .= " DEF:sensor=$rrd_filename:sensor:AVERAGE";
+$rrd_options .= " LINE1.5:sensor#cc0000:'" . \LibreNMS\Data\Store\Rrd::fixedSafeDescr($sensor['sensor_descr'], 30) . "'";
+$rrd_options .= ' GPRINT:sensor:MIN:%8.0lf';
+$rrd_options .= ' GPRINT:sensor:MAX:%8.0lf';
+$rrd_options .= ' GPRINT:sensor:LAST:%8.0lf\l';
+
+if (is_numeric($sensor['sensor_limit'])) {
+    $rrd_options .= ' HRULE:' . $sensor['sensor_limit'] . '#999999::dashes';
+}
+
+if (is_numeric($sensor['sensor_limit_low'])) {
+    $rrd_options .= ' HRULE:' . $sensor['sensor_limit_low'] . '#999999::dashes';
+}

--- a/includes/html/pages/device/health.inc.php
+++ b/includes/html/pages/device/health.inc.php
@@ -64,7 +64,7 @@ if (DiskIo::where('device_id', $device['device_id'])->count()) {
 }
 
 $sensors = [
-    'airflow', 'ber', 'bitrate', 'charge', 'chromatic_dispersion', 'cooling', 'count', 'current', 'dBm', 'delay', 'eer',
+    'airflow', 'ber', 'bitrate', 'charge', 'chromatic_dispersion', 'cooling', 'count', 'count_rate', 'current', 'dBm', 'delay', 'eer',
     'fanspeed', 'frequency', 'humidity', 'load', 'loss', 'percent', 'power', 'power_consumed', 'power_factor', 'pressure',
     'runtime', 'signal', 'snr', 'state', 'temperature', 'tv_signal', 'voltage', 'waterflow', 'quality_factor',
 ];

--- a/includes/html/pages/device/overview.inc.php
+++ b/includes/html/pages/device/overview.inc.php
@@ -66,6 +66,7 @@ require 'overview/sensors/frequency.inc.php';
 require 'overview/sensors/load.inc.php';
 require 'overview/sensors/state.inc.php';
 require 'overview/sensors/count.inc.php';
+require 'overview/sensors/count_rate.inc.php';
 require 'overview/sensors/percent.inc.php';
 require 'overview/sensors/signal.inc.php';
 require 'overview/sensors/tv_signal.inc.php';

--- a/includes/html/pages/device/overview/sensors/count_rate.inc.php
+++ b/includes/html/pages/device/overview/sensors/count_rate.inc.php
@@ -1,0 +1,8 @@
+<?php
+
+$graph_type = 'sensor_count';
+$sensor_class = 'count_rate';
+$sensor_unit = '#/s';
+$sensor_type = 'count_rate';
+
+require 'includes/html/pages/device/overview/generic/sensor.inc.php';

--- a/includes/html/pages/health.inc.php
+++ b/includes/html/pages/health.inc.php
@@ -48,6 +48,7 @@ $type_text = [
     'loss' => 'Loss',
     'state' => 'State',
     'count' => 'Count',
+    'count_rate' => 'Count rate',
     'signal' => 'Signal',
     'tv_signal' => 'TV signal',
     'bitrate' => 'Bitrate',

--- a/includes/html/pages/health/count_rate.inc.php
+++ b/includes/html/pages/health/count_rate.inc.php
@@ -1,0 +1,7 @@
+<?php
+
+$graph_type = 'sensor_count';
+$class = 'count_rate';
+$unit = '#/s';
+
+require 'includes/html/pages/health/sensors.inc.php';

--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -183,8 +183,12 @@ function record_sensor_data($device, $all_sensors)
 
         $rrd_name = get_sensor_rrd_name($device, $sensor);
 
-        $rrd_def = RrdDefinition::make()->addDataset('sensor', 'GAUGE');
-
+        if ($sensor['sensor_class'] == 'count_rate') {
+            $rrd_def = RrdDefinition::make()->addDataset('sensor', 'COUNTER');
+            //we use the COUNTER rrd to graph the variation instead of the absolute value
+        } else {
+            $rrd_def = RrdDefinition::make()->addDataset('sensor', 'GAUGE');
+        }
         echo "$sensor_value $unit\n";
 
         $fields = [

--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -185,7 +185,7 @@ function record_sensor_data($device, $all_sensors)
 
         if ($sensor['sensor_class'] == 'count_rate') {
             //we use the COUNTER rrd to graph the variation instead of the absolute value
-            $rrd_def = RrdDefinition::make()->addDataset('sensor', 'COUNTER');
+            $rrd_def = RrdDefinition::make()->addDataset('sensor', 'COUNTER', 0);
         } else {
             $rrd_def = RrdDefinition::make()->addDataset('sensor', 'GAUGE');
         }

--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -184,8 +184,8 @@ function record_sensor_data($device, $all_sensors)
         $rrd_name = get_sensor_rrd_name($device, $sensor);
 
         if ($sensor['sensor_class'] == 'count_rate') {
-            $rrd_def = RrdDefinition::make()->addDataset('sensor', 'COUNTER');
             //we use the COUNTER rrd to graph the variation instead of the absolute value
+            $rrd_def = RrdDefinition::make()->addDataset('sensor', 'COUNTER');
         } else {
             $rrd_def = RrdDefinition::make()->addDataset('sensor', 'GAUGE');
         }

--- a/resources/lang/en/sensors.php
+++ b/resources/lang/en/sensors.php
@@ -48,6 +48,12 @@ return [
         'unit' => '',
         'unit_long' => '',
     ],
+    'count_rate' => [
+        'short' => 'Count Rate',
+        'long' => 'Count Rate',
+        'unit' => '#/s',
+        'unit_long' => '#/s',
+    ],
     'current' => [
         'short' => 'Current',
         'long' => 'Current',

--- a/resources/lang/fr/sensors.php
+++ b/resources/lang/fr/sensors.php
@@ -42,10 +42,16 @@ return [
         'unit_long' => 'Watts',
     ],
     'count' => [
-        'short' => 'Count',
-        'long' => 'Count',
+        'short' => 'Compteur',
+        'long' => 'Compteur',
         'unit' => '',
         'unit_long' => '',
+    ],
+    'count_rate' => [
+        'short' => 'Variation',
+        'long' => 'Variation',
+        'unit' => '#/s',
+        'unit_long' => 'Unités par seconde',
     ],
     'current' => [
         'short' => 'Courant',


### PR DESCRIPTION
The goal of this PR is to add a new sensor_class, currently named "Count Rate". Current "Count" type, as all other sensors, is using "GAUGE" RRD type. So a counter that increase is shown exactly the same, increasing. In case you want to see the variation, you are currently left with no option in LibreNMS, except creating a completely new piece of code to do this polling. 

Here, the new sensor_class creates a RRD type COUNTER instead of GAUGE, so the graph variation is computed directly by RRD. 
And a very limited amount of changes is done to display the overview value as (current - prev) / (interval). 

Before: Only an absolute value, no idea of the rate.
![image](https://user-images.githubusercontent.com/38363551/158480365-58cefe23-ea6f-4474-980d-a987e12c86e6.png)

After: You can say the proxy is not very loaded currently. 
![image](https://user-images.githubusercontent.com/38363551/158480388-a10a32cb-0fd2-41b0-9b10-3cfedf6b40d6.png)



DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
