### PR TITLE
Update for Ubuntu 20 RRDCached Permission Errors

### DIFF
--- a/doc/Extensions/RRDCached.md
+++ b/doc/Extensions/RRDCached.md
@@ -41,6 +41,7 @@ so you can view the disk I/O usage delta.
 ## Installation Manual for
 
 1. [RRDCached installation Ubuntu 16](#rrdcached-installation-ubuntu-16)
+1. [RRDCached installation Ubuntu 20.04](#rrdcached-installation-ubuntu-20)
 1. [RRDCached installation Debian Buster](#rrdcached-installation-debian-buster)
 1. [RRDCached installation Debian Stretch](#rrdcached-installation-debian-stretch)
 1. [RRDCached installation CentOS 7 or 8](#rrdcached-installation-centos-7-or-8)
@@ -89,6 +90,50 @@ systemctl restart rrdcached.service
 
 ```php
 $config['rrdcached'] = "unix:/run/rrdcached.sock";
+```
+
+### RRDCached installation Ubuntu 20
+(rrdcached 1.7.2)
+
+1: Install rrdcached
+
+```bash
+sudo apt-get install rrdcached
+```
+
+2: Edit `/etc/default/rrdcached` to include:
+
+```
+DAEMON=/usr/bin/rrdcached
+DAEMON_USER=librenms
+DAEMON_GROUP=librenms
+WRITE_THREADS=4
+WRITE_TIMEOUT=1800
+WRITE_JITTER=1800
+BASE_PATH=/opt/librenms/rrd/
+JOURNAL_PATH=/var/lib/rrdcached/journal/
+PIDFILE=/run/rrdcached.pid
+SOCKFILE=/run/rrdcached.sock
+SOCKGROUP=librenms
+BASE_OPTIONS="-B -F -R"
+```
+
+2: Fix permissions
+
+```bash
+chown librenms:librenms /var/lib/rrdcached/journal/
+```
+
+3: Restart the rrdcached service
+
+```bash
+systemctl restart rrdcached.service
+```
+
+5: Edit `/opt/librenms/config.php` to include:
+
+```php
+$config['rrdcached'] = "unix://run/rrdcached.sock";
 ```
 
 ### RRDCached installation Debian Buster
@@ -148,6 +193,7 @@ $config['rrdcached'] = "IPADDRESS:42217";
 ```
 
 NOTE: change IPADDRESS to the ip the rrdcached server is listening on.
+
 
 ### RRDCached installation Debian Stretch
 (rrdcached 1.6.0)


### PR DESCRIPTION
Please give a short description what your pull request is for

While following the available documentation and attempting to install on Ubuntu 20.04 with RRDCached 1.7.2 the instructions as written for Ubuntu 16 did not work for me - I would get RRDCached permissions errors. Never had this happen on older Ubuntu/RRDCached versions. The fix was to change

$config['rrdcached'] = "unix:/run/rrdcached.sock";
to
$config['rrdcached'] = "unix://run/rrdcached.sock";

with everything else being exactly the same. So I'm sharing it.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
