### PR TITLE
Fixed the top port errors widget returning bits graphs instead

### DIFF
--- a/resources/views/widgets/top-errors.blade.php
+++ b/resources/views/widgets/top-errors.blade.php
@@ -13,7 +13,7 @@
             <tr>
                 <td class="text-left"><x-device-link :device="$port->device">{{$port->device->shortDisplayName() }}</x-device-link></td>
                 <td class="text-left"><x-port-link :port="$port">{{ $port->getShortLabel() }}</x-port-link></td>
-                <td class="text-left"><x-port-link :port="$port"><x-graph :port="$port" type="port_bits" width="150" height="21"></x-graph></x-port-link></td>
+                <td class="text-left"><x-port-link :port="$port"><x-graph :port="$port" type="port_errors" width="150" height="21"></x-graph></x-port-link></td>
             </tr>
         @endforeach
         </tbody>


### PR DESCRIPTION
Raised via: https://community.librenms.org/t/top-error-dashboard-show-a-line/18362

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
