### PR TITLE
Fix for PFSense state table removals field

### DIFF
--- a/LibreNMS/OS/Pfsense.php
+++ b/LibreNMS/OS/Pfsense.php
@@ -85,11 +85,11 @@ class Pfsense extends Unix implements OSPolling
             $this->enableGraph('pf_inserts');
         }
 
-        if (is_numeric($oids[0]['pfStateTableCount'] ?? null)) {
+        if (is_numeric($oids[0]['pfStateTableRemovals'] ?? null)) {
             $rrd_def = RrdDefinition::make()->addDataset('removals', 'COUNTER', 0);
 
             $fields = [
-                'removals' => $oids[0]['pfStateTableCount'],
+                'removals' => $oids[0]['pfStateTableRemovals'],
             ];
 
             $tags = compact('rrd_def');


### PR DESCRIPTION
Please give a short description what your pull request is for

The state table removals field was incorrect and the resulting graph/s were showing incorrect values.
This pull request just changes the incorrect field name to the correct one. 

This incorrect field name was pfStateTableCount and this pull request changes it to pfStateTableRemovals

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
