### PR TITLE
Added Basic authentication capability to Alertmanager Transport

### DIFF
--- a/LibreNMS/Alert/Transport/Alertmanager.php
+++ b/LibreNMS/Alert/Transport/Alertmanager.php
@@ -93,7 +93,7 @@ class Alertmanager extends Transport
         curl_setopt($curl, CURLOPT_CONNECTTIMEOUT_MS, 5000);
         curl_setopt($curl, CURLOPT_POST, true);
 
-        if ($username != "" && $password != "") {
+        if ($username != '' && $password != '') {
             curl_setopt($curl, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
             curl_setopt($curl, CURLOPT_USERNAME, $username);
             curl_setopt($curl, CURLOPT_PASSWORD, $password);

--- a/LibreNMS/Alert/Transport/Alertmanager.php
+++ b/LibreNMS/Alert/Transport/Alertmanager.php
@@ -36,7 +36,6 @@ class Alertmanager extends Transport
         $alertmanager_opts = $this->parseUserOptions($this->config['alertmanager-options']);
         $alertmanager_opts['url'] = $this->config['alertmanager-url'];
 
-
         $alertmanager_username = $this->config['alertmanager-username'];
         $alertmanager_password = $this->config['alertmanager-password'];
 

--- a/LibreNMS/Alert/Transport/Alertmanager.php
+++ b/LibreNMS/Alert/Transport/Alertmanager.php
@@ -43,7 +43,7 @@ class Alertmanager extends Transport
         return $this->contactAlertmanager($obj, $alertmanager_opts, $alertmanager_username, $alertmanager_password);
     }
 
-    public function contactAlertmanager($obj, $api, $username, $password)
+    public function contactAlertmanager($obj, $api, string $username, string $password)
     {
         if ($obj['state'] == AlertState::RECOVERED) {
             $alertmanager_status = 'endsAt';
@@ -81,7 +81,7 @@ class Alertmanager extends Transport
         return $this->postAlerts($url, $data, $username, $password);
     }
 
-    public static function postAlerts($url, $data, $username, $password)
+    public static function postAlerts($url, $data, string $username, string $password)
     {
         $curl = curl_init();
         Proxy::applyToCurl($curl);

--- a/doc/Alerting/Transports.md
+++ b/doc/Alerting/Transports.md
@@ -75,6 +75,9 @@ label's value will be the string you provided just as it was a fixed string.
 Multiple Alertmanager URLs (comma separated) are supported. Each
 URL will be tried and the search will stop at the first success.
 
+Basic HTTP authentication with a username and a password is supported.
+If you let those value blank, no authentication will be used.
+
 [Alertmanager Docs](https://prometheus.io/docs/alerting/alertmanager/)
 
 **Example:**
@@ -82,6 +85,8 @@ URL will be tried and the search will stop at the first success.
 | Config | Example |
 | ------ | ------- |
 | Alertmanager URL(s)   | http://alertmanager1.example.com,http://alertmanager2.example.com |
+| Alertmanager Username | myUsername |
+| Alertmanager Password | myPassword |
 | Alertmanager Options: | source=librenms <br/> customlabel=value <br/> extra_dynamic_value=variable_name |
 
 ## API


### PR DESCRIPTION
Hello dear LibreNMS Community,

Here I added the ability to connect to an Alertmanager instance with HTTP Basic Authentication.
(But in the Prometheus Documentation, it is said that this feature is still experimental).

I also added the Username and Password fields in the WebUI when creating a Alertmanager's Transport.
If you let those fields empty no authentication will be used.
Please find bellow a screenshot of this new window for Alertmanager's Transport.

I quickly completed the documentation.

Tell me if further changes are needed (like securing the text variable) or if you don't want this feature.

Have a nice evening!

geg347

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.

![alertmanager-basic-auth](https://user-images.githubusercontent.com/37312097/159543092-25cfbfeb-3e4d-4800-9d0a-1854e46c3d95.png)

