### PR TITLE
Fix deleting a host from the device edit page

### DIFF
--- a/includes/html/pages/device/edit/device.inc.php
+++ b/includes/html/pages/device/edit/device.inc.php
@@ -100,7 +100,7 @@ $disable_notify = get_dev_attrib($device, 'disable_notify');
 <div class="row">
     <!-- Bootstrap 3 doesn't support mediaqueries for text aligns (e.g. text-md-left), which makes these buttons stagger on sm or xs screens -->
     <div class="col-md-2 col-md-offset-2">
-        <form id="delete_host" name="delete_host" method="post" action="delhost/" role="form">
+        <form id="delete_host" name="delete_host" method="post" action="/delhost/" role="form">
             <?php echo csrf_field() ?>
             <input type="hidden" name="id" value="<?php echo $device['device_id']; ?>">
             <button type="submit" class="btn btn-danger" name="Submit"><i class="fa fa-trash"></i> Delete device</button>


### PR DESCRIPTION
When we navigate to the page to edit a device (`/device/11/edit`), and click the `Delete device` button, the form takes us to `/device/11/delhost`. Instead, the form action should be `/delhost` which loads https://github.com/librenms/librenms/blob/master/includes/html/pages/delhost.inc.php.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
