### PR TITLE
Add "Ping Response" graph to "Ping Only" Device Overview page

### DIFF
--- a/includes/html/pages/device/overview.inc.php
+++ b/includes/html/pages/device/overview.inc.php
@@ -30,6 +30,10 @@ if ($device['os'] == 'cimc') {
     require 'overview/cimc.inc.php';
 }
 
+if ($device['os'] == 'ping') {
+    require 'overview/ping.inc.php';
+}
+
 echo '
     </div>
     <div class="col-md-6">

--- a/includes/html/pages/device/overview/ping.inc.php
+++ b/includes/html/pages/device/overview/ping.inc.php
@@ -1,0 +1,34 @@
+<?php
+
+$perf = \DeviceCache::getPrimary()->perf;
+
+if ($perf->isNotEmpty()) {
+    $perf_url = Url('device') . '/device=' . DeviceCache::getPrimary()->device_id . '/tab=graphs/group=poller/';
+    echo '
+        <div class="row">
+        <div class="col-md-12">
+        <div class="panel panel-default panel-condensed">
+        <div class="panel-heading">
+        <a href="' . Url('device') . '/device=' . DeviceCache::getPrimary()->device_id . '/tab=graphs/group=poller/">
+        <i class="fas fa-area-chart fa-lg icon-theme" aria-hidden="true"></i><strong>Ping Response</strong></a>
+        </div>
+        <table class="table table-hover table-condensed table-striped">
+            <tr>
+            <td colspan="4">';
+
+    $graph = \App\Http\Controllers\Device\Tabs\OverviewController::setGraphWidth([
+        'device' => DeviceCache::getPrimary()->device_id,
+        'type' => 'device_ping_perf',
+        'from' => \LibreNMS\Config::get('time.day'),
+        'legend' => 'yes',
+        'popup_title' => DeviceCache::getPrimary()->hostname . ' - Ping Response',
+    ]);
+
+    echo \LibreNMS\Util\Url::graphPopup($graph, \LibreNMS\Util\Url::lazyGraphTag($graph), $perf_url);
+    echo '  </td>
+            </tr>
+        </table>
+        </div>
+        </div>
+        </div>';
+}//end if

--- a/includes/html/pages/device/overview/ping.inc.php
+++ b/includes/html/pages/device/overview/ping.inc.php
@@ -9,7 +9,7 @@ if ($perf->isNotEmpty()) {
         <div class="col-md-12">
         <div class="panel panel-default panel-condensed">
         <div class="panel-heading">
-        <a href="' . Url('device') . '/device=' . DeviceCache::getPrimary()->device_id . '/tab=graphs/group=poller/">
+        <a href="' . $perf_url . '">
         <i class="fas fa-area-chart fa-lg icon-theme" aria-hidden="true"></i><strong>Ping Response</strong></a>
         </div>
         <table class="table table-hover table-condensed table-striped">


### PR DESCRIPTION
### Add "Ping Response" graph to "Ping Only" Device Overview page

We have some ping-only devices in our network. Opening the Device Overview page for these devices doesn't reveal much useful information.
This PR adds a graph to the "homepage" of the device.

It filters on Device OS type to determine if this graph will be shown, as on "normal" devices, ping really isn't that relevant.
Therefore this PR this doesn't affect the Device pages for other OS types.

Before:
![image](https://user-images.githubusercontent.com/1002588/161306674-fee5c774-5cca-49cb-b7ed-2674ed55ce7c.png)

After:
![image](https://user-images.githubusercontent.com/1002588/161306704-3f369afa-21b3-4900-8ffa-f083b798991a.png)




DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
