### PR TITLE
Ensure 'add_device' API returns indexed-array (as per doco)

### DIFF
--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -417,7 +417,7 @@ function add_device(Illuminate\Http\Request $request)
 
     $message = "Device $device->hostname ($device->device_id) has been added successfully";
 
-    return api_success($device->attributesToArray(), 'devices', $message);
+    return api_success([$device->attributesToArray()], 'devices', $message);
 }
 
 function del_device(Illuminate\Http\Request $request)


### PR DESCRIPTION
A prior commit removed the indexed-array around the returned value.  This commit restores to prior behaviour so that existing integrations using the API do not have to change,


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
