### PR TITLE
implement support for usernames comming from reverse proxies

### DIFF
--- a/LibreNMS/Authentication/HttpAuthAuthorizer.php
+++ b/LibreNMS/Authentication/HttpAuthAuthorizer.php
@@ -63,4 +63,13 @@ class HttpAuthAuthorizer extends MysqlAuthorizer
 
         return -1;
     }
+
+    public function getExternalUsername()
+    {
+        if (isset($_SERVER['HTTP_X_REMOTE_USER'])) {
+            return $_SERVER['HTTP_X_REMOTE_USER'];
+        }
+
+        return parent::getExternalUsername();
+    }
 }


### PR DESCRIPTION
I use the http-auth authentication method, because my authentication is done front apache using openidc. For that reason I want to provide the username of my already authenticated user. For that reason I added support for a specific custom header which is used to extract this username from there.

The custom header "HTTP_X_REMOTE_USER" is only valid for that authentication method. If we want an additional layer of security, we could also add a config switch to control this behavior.

My setup looks now like

$config['auth_mechanism'] = "http-auth";

and the username is used from this customheader. The header itself is set by ma front apache which handles this authentication.