### PR TITLE
Improve alert template saving

### DIFF
--- a/includes/html/forms/alert-templates.inc.php
+++ b/includes/html/forms/alert-templates.inc.php
@@ -28,63 +28,67 @@ if (! Auth::user()->hasGlobalAdmin()) {
     exit(json_encode($response));
 }
 
-$template_id = 0;
-$template_newid = 0;
-$create = true;
+try {
+    Blade::render($vars['template']);
+    Blade::render($vars['title']);
+    Blade::render($vars['title_rec']);
 
-$name = strip_tags($vars['name']);
-if ((isset($vars['template']) && empty(Blade::render($vars['template']))) ||
-    (! empty($vars['title']) && empty(Blade::render($vars['title']))) ||
-    (! empty($vars['title_rec']) && empty(Blade::render($vars['title_rec'])))
-    ) {
-    $message = 'Template failed to be parsed, please check the syntax';
-} elseif (! empty($name)) {
-    if ($vars['template'] && is_numeric($vars['template_id'])) {
-        // Update template
-        $create = false;
-        $template_id = $vars['template_id'];
-        if (! dbUpdate(['template' => $vars['template'], 'name' => $name, 'title' => $vars['title'], 'title_rec' => $vars['title_rec']], 'alert_templates', 'id = ?', [$template_id]) >= 0) {
-            $status = 'ok';
-        } else {
-            $message = 'Failed to update the template';
-        }
-    } elseif ($vars['template']) {
-        // Create template
-        if ($name != 'Default Alert Template') {
-            $template_newid = dbInsert(['template' => $vars['template'], 'name' => $name, 'title' => $vars['title'], 'title_rec' => $vars['title_rec']], 'alert_templates');
-            if ($template_newid != false) {
-                $template_id = $template_newid;
+    $template_id = 0;
+    $template_newid = 0;
+    $create = true;
+
+    $name = strip_tags($vars['name']);
+    if (! empty($name)) {
+        if ($vars['template'] && is_numeric($vars['template_id'])) {
+            // Update template
+            $create = false;
+            $template_id = $vars['template_id'];
+            if (! dbUpdate(['template' => $vars['template'], 'name' => $name, 'title' => $vars['title'], 'title_rec' => $vars['title_rec']], 'alert_templates', 'id = ?', [$template_id]) >= 0) {
                 $status = 'ok';
             } else {
-                $message = 'Could not create alert template';
+                $message = 'Failed to update the template';
+            }
+        } elseif ($vars['template']) {
+            // Create template
+            if ($name != 'Default Alert Template') {
+                $template_newid = dbInsert(['template' => $vars['template'], 'name' => $name, 'title' => $vars['title'], 'title_rec' => $vars['title_rec']], 'alert_templates');
+                if ($template_newid != false) {
+                    $template_id = $template_newid;
+                    $status = 'ok';
+                } else {
+                    $message = 'Could not create alert template';
+                }
+            } else {
+                $message = 'This template name is reserved!';
             }
         } else {
-            $message = 'This template name is reserved!';
+            $message = 'We could not work out what you wanted to do!';
         }
-    } else {
-        $message = 'We could not work out what you wanted to do!';
-    }
-    if ($status == 'ok') {
-        $alertRulesOk = true;
-        dbDelete('alert_template_map', 'alert_templates_id = ?', [$template_id]);
-        $rules = explode(',', $vars['rules']);
-        if ($rules !== false) {
-            foreach ($rules as $rule_id) {
-                if (! dbInsert(['alert_rule_id' => $rule_id, 'alert_templates_id' => $template_id], 'alert_template_map')) {
-                    $alertRulesOk = false;
+        if ($status == 'ok') {
+            $alertRulesOk = true;
+            dbDelete('alert_template_map', 'alert_templates_id = ?', [$template_id]);
+            $rules = explode(',', $vars['rules']);
+            if ($rules !== false) {
+                foreach ($rules as $rule_id) {
+                    if (! dbInsert(['alert_rule_id' => $rule_id, 'alert_templates_id' => $template_id], 'alert_template_map')) {
+                        $alertRulesOk = false;
+                    }
                 }
             }
+            if ($alertRulesOk) {
+                $status = 'ok';
+                $message = 'Alert template has been ' . ($create ? 'created' : 'updated') . ' and attached rules have been updated.';
+            } else {
+                $status = 'warning';
+                $message = 'Alert template has been ' . ($create ? 'created' : 'updated') . ' but some attached rules have not been updated.';
+            }
         }
-        if ($alertRulesOk) {
-            $status = 'ok';
-            $message = 'Alert template has been ' . ($create ? 'created' : 'updated') . ' and attached rules have been updated.';
-        } else {
-            $status = 'warning';
-            $message = 'Alert template has been ' . ($create ? 'created' : 'updated') . ' but some attached rules have not been updated.';
-        }
+    } else {
+        $message = "You haven't given name to your template";
     }
-} else {
-    $message = "You haven't given name to your template";
+} catch (Exception $e) {
+    $message = 'Template failed to be parsed, please check the syntax. ';
+    $message .= $e->getMessage();
 }
 
 $response = ['status' => $status, 'message' => $message, 'newid' => $template_newid];


### PR DESCRIPTION
Instead of checking if the result is empty to see if the template parses, just catch exceptions.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
