### PR TITLE
Aviat WTM reduce snmp load

### DIFF
--- a/includes/definitions/aviat-wtm.yaml
+++ b/includes/definitions/aviat-wtm.yaml
@@ -17,3 +17,25 @@ discovery:
             - .1.3.6.1.4.1.2509.11.1.1.13
             - .1.3.6.1.4.1.2509.11.1.1.14
             - .1.3.6.1.4.1.2509.11.1.1.15
+discovery_modules:
+    ucd-dsktable: false
+    ucd-diskio: false
+    arp-table: false
+    fdb-table: false
+    vlans: false
+    stp: false
+    processors: false
+    mempools: false
+    storage: false
+    ipv4-addresses: false
+    ipv6-addresses: false
+    ports-stack: false
+    hr-device: false
+    bgp-peers: false
+poller_modules:
+    netstats: false
+    route: false
+    hr-mib: false
+    ucd-mib: false
+    ospf: false
+    ipSystemStats: false

--- a/misc/os_schema.json
+++ b/misc/os_schema.json
@@ -147,6 +147,9 @@
                 "services": {
                     "type": "boolean"
                 },
+                "route": {
+                    "type": "boolean"
+                },
                 "stp": {
                     "type": "boolean"
                 },
@@ -274,6 +277,9 @@
                     "type": "boolean"
                 },
                 "ucd-diskio": {
+                    "type": "boolean"
+                },
+                "ucd-dsktable": {
                     "type": "boolean"
                 },
                 "services": {


### PR DESCRIPTION
Starts failing snmp requests after too many consecutive requests...

UPDATE:
It seems they fixed the overload bug (at least some) in 2.11

Reduce default modules on Aviat WTM to reduce overload
SNMP daemon on these devices can fail easily.
Try to reduce snmp load as much as possible even if it is minor.


#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
