### PR TITLE
Add ISIS-details to alert details

### DIFF
--- a/includes/html/functions.inc.php
+++ b/includes/html/functions.inc.php
@@ -766,8 +766,15 @@ function alert_details($details)
         }
 
         if ($tmp_alerts['port_id']) {
-            $tmp_alerts = cleanPort($tmp_alerts);
-            $fault_detail .= generate_port_link($tmp_alerts) . ';&nbsp;';
+            if ($tmp_alerts['isisISAdjState']) {
+                $fault_detail .= 'Adjacent ' . $tmp_alerts['isisISAdjIPAddrAddress'];
+                $port = \App\Models\Port::find($tmp_alerts['port_id']);
+                $fault_detail .= ', Interface ' . \LibreNMS\Util\Url::portLink($port);
+            }
+            else {
+                $tmp_alerts = cleanPort($tmp_alerts);
+                $fault_detail .= generate_port_link($tmp_alerts) . ';&nbsp;';
+            }
             $fallback = false;
         }
 


### PR DESCRIPTION
Adds neighbor address and local interface to alert details for ISIS-alerts. For the details to work correctly, the poller needs to be able to poll the same interface index that is associated to the adjacency.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

![isis-details](https://user-images.githubusercontent.com/7031571/163291448-e9f1af27-7a72-42a4-9113-7a37aa13098c.PNG)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
