### PR TITLE
Allow unordered OIDs (global and per-os)

### DIFF
--- a/LibreNMS/Config.php
+++ b/LibreNMS/Config.php
@@ -206,7 +206,7 @@ class Config
      *
      * @param  string|null  $os  The os name
      * @param  string  $key  period separated config variable name
-     * @param  string  $global_prefix prefix for global setting
+     * @param  string  $global_prefix  prefix for global setting
      * @param  array  $default  optional array to return if the setting is not set
      * @return array
      */

--- a/LibreNMS/Config.php
+++ b/LibreNMS/Config.php
@@ -204,29 +204,32 @@ class Config
      * Removes any duplicates.
      * When the arrays have keys, os settings take precedence over global settings
      *
-     * @param  string  $os  The os name
+     * @param  string|null  $os  The os name
      * @param  string  $key  period separated config variable name
+     * @param  string  $global_prefix prefix for global setting
      * @param  array  $default  optional array to return if the setting is not set
      * @return array
      */
-    public static function getCombined($os, $key, $default = [])
+    public static function getCombined(?string $os, string $key, string $global_prefix = '', array $default = []): array
     {
-        if (! self::has($key)) {
-            return self::getOsSetting($os, $key, $default);
-        }
+        $global_key = $global_prefix . $key;
 
         if (! isset(self::$config['os'][$os][$key])) {
-            if (! Str::contains($key, '.')) {
-                return self::get($key, $default);
+            if (! Str::contains($global_key, '.')) {
+                return (array) self::get($global_key, $default);
             }
             if (! self::has("os.$os.$key")) {
-                return self::get($key, $default);
+                return (array) self::get($global_key, $default);
             }
+        }
+
+        if (! self::has("os.$os.$key")) {
+            return (array) self::get($global_key, $default);
         }
 
         return array_unique(array_merge(
-            (array) self::get($key, $default),
-            (array) self::getOsSetting($os, $key, $default)
+            (array) self::get($global_key),
+            (array) self::getOsSetting($os, $key)
         ));
     }
 

--- a/includes/definitions/bintec-beip-plus.yaml
+++ b/includes/definitions/bintec-beip-plus.yaml
@@ -11,3 +11,6 @@ over:
 discovery:
     - sysObjectID:
         - .1.3.6.1.4.1.272.4.201.66.69.50.48
+oids:
+    unordered:
+        - IP-MIB::ipNetToMediaPhysAddress

--- a/includes/discovery/arp-table.inc.php
+++ b/includes/discovery/arp-table.inc.php
@@ -30,12 +30,7 @@ foreach (DeviceCache::getPrimary()->getVrfContexts() as $context_name) {
         include Config::get('install_dir') . "/includes/discovery/arp-table/{$device['os']}.inc.php";
     } else {
         $arp_data = SnmpQuery::context($context_name)->walk('IP-MIB::ipNetToPhysicalPhysAddress')->table(1);
-
-        $mediaQuery = SnmpQuery::context($context_name);
-        if ($device['os'] == 'bintec-beip-plus') {
-            $mediaQuery->allowUnordered();
-        }
-        $arp_data = $mediaQuery->walk('IP-MIB::ipNetToMediaPhysAddress')->table(1, $arp_data);
+        SnmpQuery::context($context_name)->walk('IP-MIB::ipNetToMediaPhysAddress')->table(1, $arp_data);
     }
 
     $sql = 'SELECT * from `ipv4_mac` WHERE `device_id`=? AND `context_name`=?';

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -815,7 +815,7 @@ function get_device_divisor($device, $os_version, $sensor_type, $oid)
  */
 function ignore_storage($os, $descr)
 {
-    foreach (Config::getCombined($os, 'ignore_mount', []) as $im) {
+    foreach (Config::getCombined($os, 'ignore_mount') as $im) {
         if ($im == $descr) {
             d_echo("ignored $descr (matched: $im)\n");
 
@@ -823,7 +823,7 @@ function ignore_storage($os, $descr)
         }
     }
 
-    foreach (Config::getCombined($os, 'ignore_mount_string', []) as $ims) {
+    foreach (Config::getCombined($os, 'ignore_mount_string') as $ims) {
         if (Str::contains($descr, $ims)) {
             d_echo("ignored $descr (matched: $ims)\n");
 
@@ -831,7 +831,7 @@ function ignore_storage($os, $descr)
         }
     }
 
-    foreach (Config::getCombined($os, 'ignore_mount_regexp', []) as $imr) {
+    foreach (Config::getCombined($os, 'ignore_mount_regexp') as $imr) {
         if (preg_match($imr, $descr)) {
             d_echo("ignored $descr (matched: $imr)\n");
 
@@ -1182,15 +1182,15 @@ function add_cbgp_peer($device, $peer, $afi, $safi)
  */
 function can_skip_sensor($device, $sensor_class = '', $sensor_descr = '')
 {
-    if (! empty($sensor_class) && Config::getCombined($device['os'], "disabled_sensors.$sensor_class", false)) {
+    if (! empty($sensor_class) && (Config::getOsSetting($device['os'], "disabled_sensors.$sensor_class") || Config::get("disabled_sensors.$sensor_class"))) {
         return true;
     }
-    foreach (Config::getCombined($device['os'], 'disabled_sensors_regex', []) as $skipRegex) {
+    foreach (Config::getCombined($device['os'], 'disabled_sensors_regex') as $skipRegex) {
         if (! empty($sensor_descr) && preg_match($skipRegex, $sensor_descr)) {
             return true;
         }
     }
-    foreach (Config::getCombined($device['os'], "disabled_sensors_regex.$sensor_class", []) as $skipRegex) {
+    foreach (Config::getCombined($device['os'], "disabled_sensors_regex.$sensor_class") as $skipRegex) {
         if (! empty($sensor_descr) && preg_match($skipRegex, $sensor_descr)) {
             return true;
         }

--- a/includes/snmp.inc.php
+++ b/includes/snmp.inc.php
@@ -130,9 +130,11 @@ function gen_snmpget_cmd($device, $oids, $options = null, $mib = null, $mibdir =
  */
 function gen_snmpwalk_cmd($device, $oids, $options = null, $mib = null, $mibdir = null)
 {
+    $oids = Arr::wrap($oids);
+
     if ($device['snmpver'] == 'v1'
         || (isset($device['os']) && (Config::getOsSetting($device['os'], 'snmp_bulk', true) == false
-                || ! empty(array_intersect(Arr::wrap($oids), Config::getCombined($device['os'], 'oids.no_bulk'))))) // skip for oids that do not work with bulk
+                || ! empty(array_intersect($oids, Config::getCombined($device['os'], 'oids.no_bulk', 'snmp.'))))) // skip for oids that do not work with bulk
     ) {
         $snmpcmd = [Config::get('snmpwalk')];
     } else {
@@ -141,6 +143,11 @@ function gen_snmpwalk_cmd($device, $oids, $options = null, $mib = null, $mibdir 
         if ($max_repeaters > 0) {
             $snmpcmd[] = "-Cr$max_repeaters";
         }
+    }
+
+    // allow unordered responses for specific oids
+    if (! empty(array_intersect($oids, Config::getCombined($device['os'], 'oids.unordered', 'snmp.')))) {
+        $snmpcmd[] = '-Cc';
     }
 
     return gen_snmp_cmd($snmpcmd, $device, $oids, $options, $mib, $mibdir);

--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -5182,7 +5182,14 @@
             "section": "snmp",
             "order": 20,
             "type": "array",
-            "default": null
+            "default": []
+        },
+        "snmp.oids.unordered": {
+            "group": "poller",
+            "section": "snmp",
+            "order": 21,
+            "type": "array",
+            "default": []
         },
         "snmp.timeout": {
             "group": "poller",

--- a/misc/os_schema.json
+++ b/misc/os_schema.json
@@ -368,6 +368,9 @@
             "properties": {
                 "no_bulk": {
                     "type": "array"
+                },
+                "unordered": {
+                    "type": "array"
                 }
             },
             "additionalProperties": false

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -10296,11 +10296,6 @@ parameters:
 			path: tests/ConfigTest.php
 
 		-
-			message: "#^Method LibreNMS\\\\Tests\\\\ConfigTest\\:\\:testGetCombined\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/ConfigTest.php
-
-		-
 			message: "#^Method LibreNMS\\\\Tests\\\\ConfigTest\\:\\:testGetDeviceSetting\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/ConfigTest.php
@@ -10347,16 +10342,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$os of static method LibreNMS\\\\Config\\:\\:getOsSetting\\(\\) expects string, null given\\.$#"
-			count: 1
-			path: tests/ConfigTest.php
-
-		-
-			message: "#^Parameter \\#3 \\$default of static method LibreNMS\\\\Config\\:\\:getCombined\\(\\) expects array, false given\\.$#"
-			count: 2
-			path: tests/ConfigTest.php
-
-		-
-			message: "#^Parameter \\#3 \\$default of static method LibreNMS\\\\Config\\:\\:getCombined\\(\\) expects array, true given\\.$#"
 			count: 1
 			path: tests/ConfigTest.php
 

--- a/resources/lang/en/settings.php
+++ b/resources/lang/en/settings.php
@@ -1387,6 +1387,10 @@ return [
                     'description' => 'Disable snmp bulk for OIDs',
                     'help' => 'Disable snmp bulk operation for certain OIDs. Generally, this should be set on an OS instead. Format should be MIB::OID',
                 ],
+                'unordered' => [
+                    'description' => 'Allow out of order snmp respsonse for OIDs',
+                    'help' => 'Ignore unordered OIDs in snmp responses for certain OIDs. Unordered OIDs could result in an oid loop during an snmpwalk. Generally, this should be set on an OS instead. Format should be MIB::OID',
+                ],
             ],
             'port' => [
                 'description' => 'Port',


### PR DESCRIPTION
This is a risky setting that should only be set when needed to allow buggy devices to return out of order oids.
Allowing out of order oids can result in an oid loop.

Device: oids.unordered
Global: snmp.oids.unordered

Fix global no_bulk setting, was ignored before
(to fix global needed to rework Config::getCombined() a bit to allow a global prefix to be specified)
Removed invalid use of getCombined and updated tests

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
