### PR TITLE
Change fping6 to fping -6

### DIFF
--- a/LibreNMS/Config.php
+++ b/LibreNMS/Config.php
@@ -461,7 +461,7 @@ class Config
 
         $persist = Eloquent::isConnected();
         // make sure we have full path to binaries in case PATH isn't set
-        foreach (['fping', 'fping6', 'snmpgetnext', 'rrdtool', 'traceroute', 'traceroute6'] as $bin) {
+        foreach (['fping', 'snmpgetnext', 'rrdtool', 'traceroute'] as $bin) {
             if (! is_executable(self::get($bin))) {
                 if ($persist) {
                     self::persist($bin, self::locateBinary($bin));

--- a/LibreNMS/Data/Source/Fping.php
+++ b/LibreNMS/Data/Source/Fping.php
@@ -49,8 +49,7 @@ class Fping
         $fping_tos = Config::get('fping_options.tos', 0);
         $cmd = [$fping];
         if ($address_family == 'ipv6') {
-            $fping6 = Config::get('fping6');
-            $cmd = is_executable($fping6) ? [$fping6] : [$fping, '-6'];
+            $cmd[] = ['-6'];
         }
 
         // build the command

--- a/app/Console/Commands/SmokepingGenerateCommand.php
+++ b/app/Console/Commands/SmokepingGenerateCommand.php
@@ -160,7 +160,7 @@ class SmokepingGenerateCommand extends LnmsCommand
 
         return array_merge(
             $this->buildProbes('FPing', self::DEFAULTIP4PROBE, self::IP4PROBE, Config::get('fping'), $probeCount),
-            $this->buildProbes('FPing6', self::DEFAULTIP6PROBE, self::IP6PROBE, Config::get('fping6'), $probeCount)
+            $this->buildProbes('FPing6', self::DEFAULTIP6PROBE, self::IP6PROBE, Config::locateBinary('fping6'), $probeCount)
         );
     }
 

--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -1649,13 +1649,6 @@
             "order": 0,
             "type": "executable"
         },
-        "fping6": {
-            "default": "fping6",
-            "group": "external",
-            "section": "binaries",
-            "order": 1,
-            "type": "executable"
-        },
         "fping_options.count": {
             "default": 3,
             "group": "poller",
@@ -5352,13 +5345,6 @@
             "group": "external",
             "section": "binaries",
             "order": 13,
-            "type": "executable"
-        },
-        "traceroute6": {
-            "default": "traceroute6",
-            "group": "external",
-            "section": "binaries",
-            "order": 14,
             "type": "executable"
         },
         "transit_descr": {

--- a/resources/lang/de/settings.php
+++ b/resources/lang/de/settings.php
@@ -403,9 +403,6 @@ return [
         'fping' => [
             'description' => 'Pfad zu fping',
         ],
-        'fping6' => [
-            'description' => 'Pfad zu fping6',
-        ],
         'fping_options' => [
             'count' => [
                 'description' => 'fping Anzahl',
@@ -709,9 +706,6 @@ return [
         ],
         'traceroute' => [
             'description' => 'Pfad zu  traceroute',
-        ],
-        'traceroute6' => [
-            'description' => 'Pfad zu traceroute6',
         ],
         'unix-agent' => [
             'connection-timeout' => [

--- a/resources/lang/en/settings.php
+++ b/resources/lang/en/settings.php
@@ -675,9 +675,6 @@ return [
         'fping' => [
             'description' => 'Path to fping',
         ],
-        'fping6' => [
-            'description' => 'Path to fping6',
-        ],
         'fping_options' => [
             'count' => [
                 'description' => 'fping count',
@@ -1458,9 +1455,6 @@ return [
         ],
         'traceroute' => [
             'description' => 'Path to traceroute',
-        ],
-        'traceroute6' => [
-            'description' => 'Path to traceroute6',
         ],
         'twofactor' => [
             'description' => 'Two-Factor',

--- a/resources/lang/fr/settings.php
+++ b/resources/lang/fr/settings.php
@@ -575,9 +575,6 @@ return [
         'fping' => [
             'description' => 'Chemin vers `fping`',
         ],
-        'fping6' => [
-            'description' => 'Chemin vers `fping6`',
-        ],
         'fping_options' => [
             'count' => [
                 'description' => 'Nombre de paquets fping',
@@ -907,9 +904,6 @@ return [
         ],
         'traceroute' => [
             'description' => 'Chemin vers `traceroute`',
-        ],
-        'traceroute6' => [
-            'description' => 'Chemin vers `traceroute6`',
         ],
         'unix-agent' => [
             'connection-timeout' => [

--- a/resources/lang/it/settings.php
+++ b/resources/lang/it/settings.php
@@ -675,9 +675,6 @@ return [
         'fping' => [
             'description' => 'Path to fping',
         ],
-        'fping6' => [
-            'description' => 'Path to fping6',
-        ],
         'fping_options' => [
             'count' => [
                 'description' => 'fping count',
@@ -1458,9 +1455,6 @@ return [
         ],
         'traceroute' => [
             'description' => 'Path to traceroute',
-        ],
-        'traceroute6' => [
-            'description' => 'Path to traceroute6',
         ],
         'twofactor' => [
             'description' => 'Two-Factor',

--- a/resources/lang/zh-CN/settings.php
+++ b/resources/lang/zh-CN/settings.php
@@ -404,9 +404,6 @@ return [
         'fping' => [
             'description' => 'fping 路径',
         ],
-        'fping6' => [
-            'description' => 'fping6 路径',
-        ],
         'fping_options' => [
             'count' => [
                 'description' => 'fping 次数',
@@ -724,9 +721,6 @@ return [
         ],
         'traceroute' => [
             'description' => 'traceroute 路径',
-        ],
-        'traceroute6' => [
-            'description' => 'traceroute6 路径',
         ],
         'unix-agent' => [
             'connection-timeout' => [

--- a/resources/lang/zh-TW/settings.php
+++ b/resources/lang/zh-TW/settings.php
@@ -458,9 +458,6 @@ return [
         'fping' => [
             'description' => 'fping 路徑',
         ],
-        'fping6' => [
-            'description' => 'fping6 路徑',
-        ],
         'fping_options' => [
             'count' => [
                 'description' => 'fping 次數',
@@ -889,9 +886,6 @@ return [
         ],
         'traceroute' => [
             'description' => 'traceroute 路徑',
-        ],
-        'traceroute6' => [
-            'description' => 'traceroute6 路徑',
         ],
         'twofactor' => [
             'description' => '雙因素驗證',


### PR DESCRIPTION
This should not mean any practical change, but users with fping that doesn't support -6 may break
remove traceroute6, it is unused

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
