### PR TITLE
Update Liebert.yaml to include GXT5 series  UPS

### DIFF
--- a/includes/definitions/liebert.yaml
+++ b/includes/definitions/liebert.yaml
@@ -9,6 +9,9 @@ discovery:
     -
         sysObjectID:
             - .1.3.6.1.4.1.476.1.42
+    -
+        sysObjectID:
+		        - .1.3.6.1.4.1.8072.3.2.10
 over:
     - { graph: device_power, text: 'Power' }
     - { graph: device_current, text: 'Current' }

--- a/includes/definitions/liebert.yaml
+++ b/includes/definitions/liebert.yaml
@@ -9,8 +9,6 @@ discovery:
     -
         sysObjectID:
             - .1.3.6.1.4.1.476.1.42
-    -
-        sysObjectID:
             - .1.3.6.1.4.1.8072.3.2.10
 over:
     - { graph: device_power, text: 'Power' }

--- a/includes/definitions/liebert.yaml
+++ b/includes/definitions/liebert.yaml
@@ -11,7 +11,7 @@ discovery:
             - .1.3.6.1.4.1.476.1.42
     -
         sysObjectID:
-		        - .1.3.6.1.4.1.8072.3.2.10
+            - .1.3.6.1.4.1.8072.3.2.10
 over:
     - { graph: device_power, text: 'Power' }
     - { graph: device_current, text: 'Current' }


### PR DESCRIPTION
Please give a short description what your pull request is for
- I added an OID to the Liebert.yaml to support GXT5 series that were misidentified as Linux servers.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
<img width="1461" alt="After" src="https://user-images.githubusercontent.com/29550634/164533428-6cb5d5e5-2b79-4239-a0cc-f668313a48f8.png">
<img width="1461" alt="Before" src="https://user-images.githubusercontent.com/29550634/164533437-b65f2224-0dec-43cf-bb5a-0a15481260ac.png">

