### PR TITLE
Patch 2

### DIFF
--- a/LibreNMS/Util/Clean.php
+++ b/LibreNMS/Util/Clean.php
@@ -42,6 +42,24 @@ class Clean
     {
         return preg_replace('/[^a-zA-Z0-9\-._]/', '', $file);
     }
+    
+    /**
+     * Sanitize host name by removing all invalid characters.
+     * Behaves the same as Clean::fileName() except that it also allows valid IP addresses.
+     *
+     * @param  string  $file
+     * @return string|string[]|null
+     */
+    public static function hostName($string)
+    {
+        // If the string parses as a valid IP address it's ok
+        if (inet_pton($string) !== false) {
+            return $string;
+        }
+        
+        // Otherwise delegate to fileName
+        return self::fileName($string);
+    }
 
     /**
      * Sanitize string to only contain alpha, numeric, dashes, and underscores

--- a/LibreNMS/Util/Clean.php
+++ b/LibreNMS/Util/Clean.php
@@ -53,8 +53,10 @@ class Clean
     public static function hostName($string)
     {
         // If the string parses as a valid IP address it's ok
-        if (inet_pton($string) !== false) {
-            return $string;
+        $address = inet_pton($string);
+        if ($address !== false) {
+            // Return address in clean RFC 5952 notation
+            return inet_ntop($address);
         }
         
         // Otherwise delegate to fileName

--- a/includes/services.inc.php
+++ b/includes/services.inc.php
@@ -123,7 +123,7 @@ function poll_service($service)
     $old_status = $service['service_status'];
     $service['service_type'] = Clean::fileName($service['service_type']);
     $service['service_ip'] = Clean::fileName($service['service_ip']);
-    $service['hostname'] = Clean::fileName($service['hostname']);
+    $service['hostname'] = Clean::hostName($service['hostname']);
     $service['overwrite_ip'] = Clean::fileName($service['overwrite_ip']);
     $check_cmd = '';
 


### PR DESCRIPTION
This is a proposed fix for #13938. Since LibreNMS 22.4.0 the services commands are cleaned by passing the parameters through `Clean::fileName()`. This causes problems for commands where the hostname is an IPv6 address, as that removes all colons from the address.

My proposed solution is to add `Clean::hostName()` that first tries to parse the provided parameter as an IPv4 or IPv6 address. If it parses as an address then it is converted back to a canonically formatted IP address and returned. Otherwise the parameter is passed to `Clean::fileName()` so that every input that is not an IP address is handled the same as before.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [X] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
