### PR TITLE
scripts/json-app-tool.php JSON generation fix and add -S for SNMP extend name

### DIFF
--- a/scripts/json-app-tool.php
+++ b/scripts/json-app-tool.php
@@ -34,7 +34,7 @@ function string_to_oid($string)
 }//end string_to_oid()
 
 // Options!
-$short_opts = 'sktmlhj:a:';
+$short_opts = 'sktmlhj:a:S';
 $options = getopt($short_opts);
 
 // print the help
@@ -47,6 +47,7 @@ if (isset($options['h'])) {
   -m      Extract and print metric variables from the JSON file.
   -k      If m is specified, just print the keys in tested order.
   -a      The application name for use with -s and -t.
+  -S      SNMP extend name. Defaults to the same as -a.
   -h      Show this help text.
 
 -j must always be specified.
@@ -138,9 +139,14 @@ if (! isset($options['a'])) {
     exit(1);
 }
 
+// -S defaults to -a if not set
+if (! isset($options['S'])) {
+    $options['S'] = $options['a'];
+}
+
 // Output snmprec data for snmpsim for use with testing.
 if (isset($options['s'])) {
-    $oid = string_to_oid($options['a']);
+    $oid = string_to_oid($options['S']);
     echo "1.3.6.1.2.1.1.1.0|4|Linux server 3.10.0-693.5.2.el7.x86_64 #1 SMP Fri Oct 20 20:32:50 UTC 2017 x86_64\n" .
         "1.3.6.1.2.1.1.2.0|6|1.3.6.1.4.1.8072.3.2.10\n" .
         "1.3.6.1.2.1.1.3.0|67|77550514\n" .
@@ -159,25 +165,24 @@ if (isset($options['t'])) {
     $test_data = [
         'applications' => [
             'discovery' => [
-                'applications' => [
+                'applications' => [ [
                     'app_type' => $options['a'],
                     'app_state' => 'UNKNOWN',
                     'discovered' => '1',
                     'app_state_prev' => null,
                     'app_status' => '',
                     'app_instance' => '',
-                ],
-                'application_metrics' => [],
+                ], ],
             ],
             'poller' => [
-                'applications' => [
+                'applications' => [ [
                     'app_type' => $options['a'],
                     'app_state' => 'OK',
                     'discovered' => '1',
                     'app_state_prev' => 'UNKNOWN',
                     'app_status' => '',
                     'app_instance' => '',
-                ],
+                ], ],
                 'application_metrics' => [],
             ],
         ],

--- a/scripts/json-app-tool.php
+++ b/scripts/json-app-tool.php
@@ -165,24 +165,24 @@ if (isset($options['t'])) {
     $test_data = [
         'applications' => [
             'discovery' => [
-                'applications' => [ [
+                'applications' => [[
                     'app_type' => $options['a'],
                     'app_state' => 'UNKNOWN',
                     'discovered' => '1',
                     'app_state_prev' => null,
                     'app_status' => '',
                     'app_instance' => '',
-                ], ],
+                ]],
             ],
             'poller' => [
-                'applications' => [ [
+                'applications' => [[
                     'app_type' => $options['a'],
                     'app_state' => 'OK',
                     'discovered' => '1',
                     'app_state_prev' => 'UNKNOWN',
                     'app_status' => '',
                     'app_instance' => '',
-                ], ],
+                ]],
                 'application_metrics' => [],
             ],
         ],


### PR DESCRIPTION
Now properly makes sure it is a hash in a array for discovery and polling instead of just a hash.

Also add -S for when the SNMP extend name and app name don't match.

Wish I would of remembered this and fixed it prior doing the suricata stuff. Would of made it so much simpler, but that was great for reminding me how that all worked.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [X] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
