### PR TITLE
no longer turn \n into n when fetching stuff via json_app_get

### DIFF
--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -634,7 +634,10 @@ function json_app_get($device, $extend, $min_version = 1)
     }
 
     //  turn the JSON into a array
-    $parsed_json = json_decode(stripslashes($output), true);
+    $output=str_replace( '\n', "%%%NEWLINENELINENEWLINE%%%", $output);
+    $output=stripslashes($output);
+    $output=str_replace( "%%%NEWLINENELINENEWLINE%%%", '\n', $output);
+    $parsed_json = json_decode($output, true);
 
     // improper JSON or something else was returned. Populate the variable with an error.
     if (json_last_error() !== JSON_ERROR_NONE) {

--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -634,10 +634,10 @@ function json_app_get($device, $extend, $min_version = 1)
     }
 
     //  turn the JSON into a array
-    $rand_data = '|||%%%@@@' . rand() . 'NEWLINENELINENEWLINE@@@%%%|||';
-    $output = str_replace('\n', $rand_data, $output);
+    $replacement_key = chr(0) . chr(0) . chr(0) . rand() . chr(0) . chr(0) . chr(0);
+    $output = str_replace('\n', $replacement_key, $output);
     $output = stripslashes($output);
-    $output = str_replace($rand_data, '\n', $output);
+    $output = str_replace($replacement_key, '\n', $output);
     $parsed_json = json_decode($output, true);
 
     // improper JSON or something else was returned. Populate the variable with an error.

--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -634,7 +634,7 @@ function json_app_get($device, $extend, $min_version = 1)
     }
 
     //  turn the JSON into a array
-    $output = preg_replace('/\\\([^n])/', '$1', $output);
+    $output = preg_replace('/\\\([^n\\\])/', '$1', $output);
     $parsed_json = json_decode($output, true);
 
     // improper JSON or something else was returned. Populate the variable with an error.

--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -634,7 +634,7 @@ function json_app_get($device, $extend, $min_version = 1)
     }
 
     //  turn the JSON into a array
-    $output = preg_replace('/\\\([^nbfrt"\\\\])/', '$1', $output);
+    $output = preg_replace('/\\\([^nbfrt"])/', '$1', $output);
     $parsed_json = json_decode($output, true);
 
     // improper JSON or something else was returned. Populate the variable with an error.

--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -634,6 +634,10 @@ function json_app_get($device, $extend, $min_version = 1)
     }
 
     //  turn the JSON into a array
+    $rand_data=rand();
+    $output = str_replace('\n', '|||%%%@@@' . $rand_data  . 'NEWLINENELINENEWLINE@@@%%%|||', $output);
+    $output = stripslashes($output);
+    $output = str_replace('|||%%%@@@' . $rand_data . 'NEWLINENELINENEWLINE@@@%%%|||', '\n', $output);
     $parsed_json = json_decode($output, true);
 
     // improper JSON or something else was returned. Populate the variable with an error.

--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -634,9 +634,9 @@ function json_app_get($device, $extend, $min_version = 1)
     }
 
     //  turn the JSON into a array
-    $output=str_replace( '\n', "%%%NEWLINENELINENEWLINE%%%", $output);
+    $output=str_replace( '\n', '|||%%%@@@NEWLINENELINENEWLINE@@@%%%|||', $output);
     $output=stripslashes($output);
-    $output=str_replace( "%%%NEWLINENELINENEWLINE%%%", '\n', $output);
+    $output=str_replace( '|||%%%@@@NEWLINENELINENEWLINE@@@%%%|||', '\n', $output);
     $parsed_json = json_decode($output, true);
 
     // improper JSON or something else was returned. Populate the variable with an error.

--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -634,7 +634,7 @@ function json_app_get($device, $extend, $min_version = 1)
     }
 
     //  turn the JSON into a array
-    $output = str_replace(["\\", "\\\"", "\'", '\{'], ["\\", "\"", "'", '{'], $output);
+    $output = str_replace(['\\', '\\"', "\'", '\{'], ['\\', '"', "'", '{'], $output);
     $parsed_json = json_decode($output, true);
 
     // improper JSON or something else was returned. Populate the variable with an error.

--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -634,10 +634,10 @@ function json_app_get($device, $extend, $min_version = 1)
     }
 
     //  turn the JSON into a array
-    $rand_data=rand();
-    $output = str_replace('\n', '|||%%%@@@' . $rand_data  . 'NEWLINENELINENEWLINE@@@%%%|||', $output);
+    $rand_data = '|||%%%@@@' . rand() . 'NEWLINENELINENEWLINE@@@%%%|||';
+    $output = str_replace('\n', $rand_data, $output);
     $output = stripslashes($output);
-    $output = str_replace('|||%%%@@@' . $rand_data . 'NEWLINENELINENEWLINE@@@%%%|||', '\n', $output);
+    $output = str_replace($rand_data, '\n', $output);
     $parsed_json = json_decode($output, true);
 
     // improper JSON or something else was returned. Populate the variable with an error.

--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -634,7 +634,7 @@ function json_app_get($device, $extend, $min_version = 1)
     }
 
     //  turn the JSON into a array
-    $output = preg_replace('/\\\([^nb"\\\\])/', '$1', $output);
+    $output = preg_replace('/\\\([^nb"])/', '$1', $output);
     $parsed_json = json_decode($output, true);
 
     // improper JSON or something else was returned. Populate the variable with an error.

--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -634,11 +634,7 @@ function json_app_get($device, $extend, $min_version = 1)
     }
 
     //  turn the JSON into a array
-
-    $replacement_key = chr(0) . chr(0) . chr(0) . rand() . chr(0) . chr(0) . chr(0);
-    $output = str_replace('\n', $replacement_key, $output);
-    $output = stripslashes($output);
-    $output = str_replace($replacement_key, '\n', $output);
+    $output = preg_replace('/\\\([^n])/', '$1', $output);
     $parsed_json = json_decode($output, true);
 
     // improper JSON or something else was returned. Populate the variable with an error.

--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -634,7 +634,7 @@ function json_app_get($device, $extend, $min_version = 1)
     }
 
     //  turn the JSON into a array
-    $output = preg_replace('/\\\([^nb"])/', '$1', $output);
+    $output = preg_replace('/\\\([^nbfrt\\\\])/', '$1', $output);
     $parsed_json = json_decode($output, true);
 
     // improper JSON or something else was returned. Populate the variable with an error.

--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -634,10 +634,7 @@ function json_app_get($device, $extend, $min_version = 1)
     }
 
     //  turn the JSON into a array
-    $replacement_key = chr(0) . chr(0) . chr(0) . rand() . chr(0) . chr(0) . chr(0);
-    $output = str_replace('\n', $replacement_key, $output);
-    $output = stripslashes($output);
-    $output = str_replace($replacement_key, '\n', $output);
+    $output = preg_replace('/\\\[^n]/', '', $output);
     $parsed_json = json_decode($output, true);
 
     // improper JSON or something else was returned. Populate the variable with an error.

--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -634,9 +634,9 @@ function json_app_get($device, $extend, $min_version = 1)
     }
 
     //  turn the JSON into a array
-    $output = str_replace( '\n', '|||%%%@@@NEWLINENELINENEWLINE@@@%%%|||', $output);
+    $output = str_replace('\n', '|||%%%@@@NEWLINENELINENEWLINE@@@%%%|||', $output);
     $output = stripslashes($output);
-    $output = str_replace( '|||%%%@@@NEWLINENELINENEWLINE@@@%%%|||', '\n', $output);
+    $output = str_replace('|||%%%@@@NEWLINENELINENEWLINE@@@%%%|||', '\n', $output);
     $parsed_json = json_decode($output, true);
 
     // improper JSON or something else was returned. Populate the variable with an error.

--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -634,7 +634,11 @@ function json_app_get($device, $extend, $min_version = 1)
     }
 
     //  turn the JSON into a array
-    $output = preg_replace('/\\\[^n]/', '', $output);
+
+    $replacement_key = chr(0) . chr(0) . chr(0) . rand() . chr(0) . chr(0) . chr(0);
+    $output = str_replace('\n', $replacement_key, $output);
+    $output = stripslashes($output);
+    $output = str_replace($replacement_key, '\n', $output);
     $parsed_json = json_decode($output, true);
 
     // improper JSON or something else was returned. Populate the variable with an error.

--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -634,9 +634,9 @@ function json_app_get($device, $extend, $min_version = 1)
     }
 
     //  turn the JSON into a array
-    $output=str_replace( '\n', '|||%%%@@@NEWLINENELINENEWLINE@@@%%%|||', $output);
-    $output=stripslashes($output);
-    $output=str_replace( '|||%%%@@@NEWLINENELINENEWLINE@@@%%%|||', '\n', $output);
+    $output = str_replace( '\n', '|||%%%@@@NEWLINENELINENEWLINE@@@%%%|||', $output);
+    $output = stripslashes($output);
+    $output = str_replace( '|||%%%@@@NEWLINENELINENEWLINE@@@%%%|||', '\n', $output);
     $parsed_json = json_decode($output, true);
 
     // improper JSON or something else was returned. Populate the variable with an error.

--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -634,7 +634,7 @@ function json_app_get($device, $extend, $min_version = 1)
     }
 
     //  turn the JSON into a array
-    $output = preg_replace('/\\\([^nbfrt"])/', '$1', $output);
+    $output = preg_replace('/\\\([^nb"\\\\])/', '$1', $output);
     $parsed_json = json_decode($output, true);
 
     // improper JSON or something else was returned. Populate the variable with an error.

--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -634,7 +634,7 @@ function json_app_get($device, $extend, $min_version = 1)
     }
 
     //  turn the JSON into a array
-    $output = preg_replace('/\\\([^nbfrt\\\\])/', '$1', $output);
+    $output = str_replace(["\\", "\\\"", "\'", '\{'], ["\\", "\"", "'", '{'], $output);
     $parsed_json = json_decode($output, true);
 
     // improper JSON or something else was returned. Populate the variable with an error.

--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -634,7 +634,7 @@ function json_app_get($device, $extend, $min_version = 1)
     }
 
     //  turn the JSON into a array
-    $output = preg_replace('/\\\([^n\\\])/', '$1', $output);
+    $output = preg_replace('/\\\([^nbfrt"\\\\])/', '$1', $output);
     $parsed_json = json_decode($output, true);
 
     // improper JSON or something else was returned. Populate the variable with an error.

--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -634,9 +634,6 @@ function json_app_get($device, $extend, $min_version = 1)
     }
 
     //  turn the JSON into a array
-    $output = str_replace('\n', '|||%%%@@@NEWLINENELINENEWLINE@@@%%%|||', $output);
-    $output = stripslashes($output);
-    $output = str_replace('|||%%%@@@NEWLINENELINENEWLINE@@@%%%|||', '\n', $output);
     $parsed_json = json_decode($output, true);
 
     // improper JSON or something else was returned. Populate the variable with an error.

--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -634,7 +634,7 @@ function json_app_get($device, $extend, $min_version = 1)
     }
 
     //  turn the JSON into a array
-    $output = str_replace(['\\', '\\"', "\'", '\{'], ['\\', '"', "'", '{'], $output);
+    $output = str_replace(['\\\\', '\\"', "\'", '\{'], ['\\', '"', "'", '{'], $output);
     $parsed_json = json_decode($output, true);
 
     // improper JSON or something else was returned. Populate the variable with an error.


### PR DESCRIPTION
Came across this while working on Sneck support.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
