### PR TITLE
fix a few issues with variable names

### DIFF
--- a/includes/html/graphs/application/suricata_alert.inc.php
+++ b/includes/html/graphs/application/suricata_alert.inc.php
@@ -9,8 +9,8 @@ $printtotal = 0;
 $addarea = 0;
 $transparency = 15;
 
-if (isset($vars['instance'])) {
-    $rrd_filename = Rrd::name($device['hostname'], ['app', $name, $app['app_id'], $vars['instance']]);
+if (isset($vars['pool'])) {
+    $rrd_filename = Rrd::name($device['hostname'], ['app', $name, $app['app_id'], $vars['pool']]);
 } else {
     $rrd_filename = Rrd::name($device['hostname'], ['app', $name, $app['app_id']]);
 }

--- a/includes/html/graphs/application/suricata_app_flows.inc.php
+++ b/includes/html/graphs/application/suricata_app_flows.inc.php
@@ -9,8 +9,8 @@ $printtotal = 0;
 $addarea = 0;
 $transparency = 15;
 
-if (isset($vars['instance'])) {
-    $rrd_filename = Rrd::name($device['hostname'], ['app', $name, $app['app_id'], $vars['instance']]);
+if (isset($vars['pool'])) {
+    $rrd_filename = Rrd::name($device['hostname'], ['app', $name, $app['app_id'], $vars['pool']]);
 } else {
     $rrd_filename = Rrd::name($device['hostname'], ['app', $name, $app['app_id']]);
 }

--- a/includes/html/graphs/application/suricata_app_tx.inc.php
+++ b/includes/html/graphs/application/suricata_app_tx.inc.php
@@ -9,8 +9,8 @@ $printtotal = 0;
 $addarea = 0;
 $transparency = 15;
 
-if (isset($vars['instance'])) {
-    $rrd_filename = Rrd::name($device['hostname'], ['app', $name, $app['app_id'], $vars['instance']]);
+if (isset($vars['pool'])) {
+    $rrd_filename = Rrd::name($device['hostname'], ['app', $name, $app['app_id'], $vars['pool']]);
 } else {
     $rrd_filename = Rrd::name($device['hostname'], ['app', $name, $app['app_id']]);
 }

--- a/includes/html/graphs/application/suricata_bytes.inc.php
+++ b/includes/html/graphs/application/suricata_bytes.inc.php
@@ -9,8 +9,8 @@ $printtotal = 0;
 $addarea = 0;
 $transparency = 15;
 
-if (isset($vars['instance'])) {
-    $rrd_filename = Rrd::name($device['hostname'], ['app', $name, $app['app_id'], $vars['instance']]);
+if (isset($vars['pool'])) {
+    $rrd_filename = Rrd::name($device['hostname'], ['app', $name, $app['app_id'], $vars['pool']]);
 } else {
     $rrd_filename = Rrd::name($device['hostname'], ['app', $name, $app['app_id']]);
 }

--- a/includes/html/graphs/application/suricata_dec_proto.inc.php
+++ b/includes/html/graphs/application/suricata_dec_proto.inc.php
@@ -9,8 +9,8 @@ $printtotal = 0;
 $addarea = 0;
 $transparency = 15;
 
-if (isset($vars['instance'])) {
-    $rrd_filename = Rrd::name($device['hostname'], ['app', $name, $app['app_id'], $vars['instance']]);
+if (isset($vars['pool'])) {
+    $rrd_filename = Rrd::name($device['hostname'], ['app', $name, $app['app_id'], $vars['pool']]);
 } else {
     $rrd_filename = Rrd::name($device['hostname'], ['app', $name, $app['app_id']]);
 }

--- a/includes/html/graphs/application/suricata_flow_proto.inc.php
+++ b/includes/html/graphs/application/suricata_flow_proto.inc.php
@@ -9,8 +9,8 @@ $printtotal = 0;
 $addarea = 0;
 $transparency = 15;
 
-if (isset($vars['instance'])) {
-    $rrd_filename = Rrd::name($device['hostname'], ['app', $name, $app['app_id'], $vars['instance']]);
+if (isset($vars['pool'])) {
+    $rrd_filename = Rrd::name($device['hostname'], ['app', $name, $app['app_id'], $vars['pool']]);
 } else {
     $rrd_filename = Rrd::name($device['hostname'], ['app', $name, $app['app_id']]);
 }

--- a/includes/html/graphs/application/suricata_mem_use.inc.php
+++ b/includes/html/graphs/application/suricata_mem_use.inc.php
@@ -9,8 +9,8 @@ $printtotal = 0;
 $addarea = 0;
 $transparency = 15;
 
-if (isset($vars['instance'])) {
-    $rrd_filename = Rrd::name($device['hostname'], ['app', $name, $app['app_id'], $vars['instance']]);
+if (isset($vars['pool'])) {
+    $rrd_filename = Rrd::name($device['hostname'], ['app', $name, $app['app_id'], $vars['pool']]);
 } else {
     $rrd_filename = Rrd::name($device['hostname'], ['app', $name, $app['app_id']]);
 }

--- a/includes/html/graphs/application/suricata_nasty_delta.inc.php
+++ b/includes/html/graphs/application/suricata_nasty_delta.inc.php
@@ -9,8 +9,8 @@ $printtotal = 0;
 $addarea = 0;
 $transparency = 15;
 
-if (isset($vars['instance'])) {
-    $rrd_filename = Rrd::name($device['hostname'], ['app', $name, $app['app_id'], $vars['instance']]);
+if (isset($vars['pool'])) {
+    $rrd_filename = Rrd::name($device['hostname'], ['app', $name, $app['app_id'], $vars['pool']]);
 } else {
     $rrd_filename = Rrd::name($device['hostname'], ['app', $name, $app['app_id']]);
 }
@@ -24,7 +24,7 @@ if (Rrd::checkRrdExists($rrd_filename)) {
     ];
     $rrd_list[] = [
         'filename' => $rrd_filename,
-        'descr'    => 'IfDropped',
+        'descr'    => 'If Dropped',
         'ds'       => 'ifdropped',
     ];
     $rrd_list[] = [
@@ -34,12 +34,12 @@ if (Rrd::checkRrdExists($rrd_filename)) {
     ];
     $rrd_list[] = [
         'filename' => $rrd_filename,
-        'descr'    => 'Dec_Invalid',
+        'descr'    => 'Dec Inv.',
         'ds'       => 'dec_invalid',
     ];
     $rrd_list[] = [
         'filename' => $rrd_filename,
-        'descr'    => 'Too_Many_Layers',
+        'descr'    => 'Too Many Layers',
         'ds'       => 'dec_too_many_layer',
     ];
 } else {

--- a/includes/html/graphs/application/suricata_nasty_percent.inc.php
+++ b/includes/html/graphs/application/suricata_nasty_percent.inc.php
@@ -2,15 +2,15 @@
 
 $name = 'suricata';
 $app_id = $app['app_id'];
-$unit_text = 'Percent_Of_Packets';
+$unit_text = '% Of Packets';
 $colours = 'psychedelic';
 $dostack = 0;
 $printtotal = 0;
 $addarea = 0;
 $transparency = 15;
 
-if (isset($vars['instance'])) {
-    $rrd_filename = Rrd::name($device['hostname'], ['app', $name, $app['app_id'], $vars['instance']]);
+if (isset($vars['pool'])) {
+    $rrd_filename = Rrd::name($device['hostname'], ['app', $name, $app['app_id'], $vars['pool']]);
 } else {
     $rrd_filename = Rrd::name($device['hostname'], ['app', $name, $app['app_id']]);
 }
@@ -24,7 +24,7 @@ if (Rrd::checkRrdExists($rrd_filename)) {
     ];
     $rrd_list[] = [
         'filename' => $rrd_filename,
-        'descr'    => 'If_Dropped',
+        'descr'    => 'If Dropped',
         'ds'       => 'ifdrop_percent',
     ];
     $rrd_list[] = [

--- a/includes/html/graphs/application/suricata_packets.inc.php
+++ b/includes/html/graphs/application/suricata_packets.inc.php
@@ -9,8 +9,8 @@ $printtotal = 1;
 $addarea = 0;
 $transparency = 15;
 
-if (isset($vars['instance'])) {
-    $rrd_filename = Rrd::name($device['hostname'], ['app', $name, $app['app_id'], $vars['instance']]);
+if (isset($vars['pool'])) {
+    $rrd_filename = Rrd::name($device['hostname'], ['app', $name, $app['app_id'], $vars['pool']]);
 } else {
     $rrd_filename = Rrd::name($device['hostname'], ['app', $name, $app['app_id']]);
 }

--- a/includes/html/graphs/application/suricata_uptime.inc.php
+++ b/includes/html/graphs/application/suricata_uptime.inc.php
@@ -9,8 +9,8 @@ $printtotal = 0;
 $addarea = 0;
 $transparency = 15;
 
-if (isset($vars['instance'])) {
-    $rrd_filename = Rrd::name($device['hostname'], ['app', $name, $app['app_id'], $vars['instance']]);
+if (isset($vars['pool'])) {
+    $rrd_filename = Rrd::name($device['hostname'], ['app', $name, $app['app_id'], $vars['pool']]);
 } else {
     $rrd_filename = Rrd::name($device['hostname'], ['app', $name, $app['app_id']]);
 }

--- a/includes/html/pages/device/apps/suricata.inc.php
+++ b/includes/html/pages/device/apps/suricata.inc.php
@@ -25,11 +25,11 @@ while (isset($suricata_instances[$int_int])) {
     $int_int++;
 
     $append = '';
-    if (isset($pools[$int_int])) {
+    if (isset($suricata_instances[$int_int])) {
         $append = ', ';
     }
 
-    echo generate_link($label, $link_array, ['pool'=>$pool]) . $append;
+    echo generate_link($label, $link_array, ['pool'=>$instance]) . $append;
 }
 
 print_optionbar_end();
@@ -56,8 +56,8 @@ foreach ($graphs as $key => $text) {
     $graph_array['id'] = $app['app_id'];
     $graph_array['type'] = 'application_' . $key;
 
-    if (isset($vars['instance'])) {
-        $graph_array['instance'] = $vars['instance'];
+    if (isset($vars['pool'])) {
+        $graph_array['pool'] = $vars['pool'];
     }
 
     echo '<div class="panel panel-default">


### PR DESCRIPTION
Found I was using the wrong variable name in one part, meaning it would never change instances when viewing graphs.

After fixing it, I found that apparently instance appearing in the URL as a variable name causes issues. After fixing that, I found that apparently the variable name instance causes it to complain about permissions. So I went through and changed the variable name for displaying the graphs for specific instances from instance to pool.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
