### PR TITLE
Don't use bulk-walk for PrimeKey Appliances

### DIFF
--- a/includes/definitions/discovery/primekey.yaml
+++ b/includes/definitions/discovery/primekey.yaml
@@ -1,9 +1,5 @@
 mib: PRIMEKEY-APPLIANCE-MIB
 modules:
-    pre-cache:
-        oids:
-            - PRIMEKEY-APPLIANCE-MIB::pkSfp
-            - PRIMEKEY-APPLIANCE-MIB::pkVhsm
     os:
         version: 'PRIMEKEY-APPLIANCE-MIB::pkAVersion'
         serial: 'PRIMEKEY-APPLIANCE-MIB::pkAHsmSerialNumber'
@@ -15,56 +11,56 @@ modules:
                 skip_value_lt: 0
             data:
                 -
-                    oid: PRIMEKEY-APPLIANCE-MIB::pkSfp
+                    oid: PRIMEKEY-APPLIANCE-MIB::pkASfpLoad1m
                     value: PRIMEKEY-APPLIANCE-MIB::pkASfpLoad1m
                     num_oid: '.1.3.6.1.4.1.22408.1.1.2.1.5.108.111.97.100.50.1{{ $index }}'
                     descr: ' 1m CPU load'
                     group: 'CPU'
                     index: pkASfpLoad1m
                 -
-                    oid: PRIMEKEY-APPLIANCE-MIB::pkSfp
+                    oid: PRIMEKEY-APPLIANCE-MIB::pkASfpLoad5m
                     value: PRIMEKEY-APPLIANCE-MIB::pkASfpLoad5m
                     num_oid: '.1.3.6.1.4.1.22408.1.1.2.1.5.108.111.97.100.51.1{{ $index }}'
                     descr: ' 5m CPU load'
                     group: 'CPU'
                     index: pkASfpLoad5m
                 -
-                    oid: PRIMEKEY-APPLIANCE-MIB::pkSfp
+                    oid: PRIMEKEY-APPLIANCE-MIB::pkASfpLoad15m
                     value: PRIMEKEY-APPLIANCE-MIB::pkASfpLoad15m
                     num_oid: '.1.3.6.1.4.1.22408.1.1.2.1.5.108.111.97.100.52.1{{ $index }}'
                     descr: '15m CPU load'
                     group: 'CPU'
                     index: pkASfpLoad15m
                 -
-                    oid: PRIMEKEY-APPLIANCE-MIB::pkSfp
+                    oid: PRIMEKEY-APPLIANCE-MIB::pkAClusterLocalNodeID
                     value: PRIMEKEY-APPLIANCE-MIB::pkAClusterLocalNodeID
                     num_oid: '.1.3.6.1.4.1.22408.1.1.2.1.8.99.108.117.115.116.101.114.49.1{{ $index }}'
                     descr: 'Node ID'
                     group: 'Database'
                     index: pkAClusterLocalNodeID
                 -
-                    oid: PRIMEKEY-APPLIANCE-MIB::pkSfp
+                    oid: PRIMEKEY-APPLIANCE-MIB::pkAClusterSize
                     value: PRIMEKEY-APPLIANCE-MIB::pkAClusterSize
                     num_oid: '.1.3.6.1.4.1.22408.1.1.2.1.8.99.108.117.115.116.101.114.50.1{{ $index }}'
                     descr: 'Node Count'
                     group: 'Database'
                     index: pkAClusterSize
                 -
-                    oid: PRIMEKEY-APPLIANCE-MIB::pkSfp
+                    oid: PRIMEKEY-APPLIANCE-MIB::pkAClusterActiveNodes
                     value: PRIMEKEY-APPLIANCE-MIB::pkAClusterActiveNodes
                     num_oid: '.1.3.6.1.4.1.22408.1.1.2.1.8.99.108.117.115.116.101.114.51.1{{ $index }}'
                     descr: 'Nodes Active'
                     group: 'Database'
                     index: pkAClusterActiveNodes
                 -
-                    oid: PRIMEKEY-APPLIANCE-MIB::pkSfp
+                    oid: PRIMEKEY-APPLIANCE-MIB::pkASfpRaidTotalDevices
                     value: PRIMEKEY-APPLIANCE-MIB::pkASfpRaidTotalDevices
                     num_oid: '.1.3.6.1.4.1.22408.1.1.2.1.5.114.97.105.100.52.1{{ $index }}'
                     descr: 'RAID Devices'
                     group: 'RAID'
                     index: pkASfpRaidTotalDevices
                 -
-                    oid: PRIMEKEY-APPLIANCE-MIB::pkSfp
+                    oid: PRIMEKEY-APPLIANCE-MIB::pkASfpRaidActiveDevices
                     value: PRIMEKEY-APPLIANCE-MIB::pkASfpRaidActiveDevices
                     num_oid: '.1.3.6.1.4.1.22408.1.1.2.1.5.114.97.105.100.54.1{{ $index }}'
                     descr: 'RAID Active'
@@ -75,28 +71,28 @@ modules:
                 skip_value_lt: 0
             data:
                 -
-                    oid: PRIMEKEY-APPLIANCE-MIB::pkSfp
+                    oid: PRIMEKEY-APPLIANCE-MIB::pkASfpCpuFan
                     value: PRIMEKEY-APPLIANCE-MIB::pkASfpCpuFan
                     num_oid: '.1.3.6.1.4.1.22408.1.1.2.1.4.102.97.110.49.1{{ $index }}'
                     descr: 'CPU Fan'
                     group: 'CPU'
                     index: pkASfpCpuFan
                 -
-                    oid: PRIMEKEY-APPLIANCE-MIB::pkSfp
+                    oid: PRIMEKEY-APPLIANCE-MIB::pkASfpSysFan1
                     value: PRIMEKEY-APPLIANCE-MIB::pkASfpSysFan1
                     num_oid: '.1.3.6.1.4.1.22408.1.1.2.1.4.102.97.110.50.1{{ $index }}'
                     descr: 'System Fan 1'
                     group: 'System'
                     index: pkASfpSysFan1
                 -
-                    oid: PRIMEKEY-APPLIANCE-MIB::pkSfp
+                    oid: PRIMEKEY-APPLIANCE-MIB::pkASfpSysFan2
                     value: PRIMEKEY-APPLIANCE-MIB::pkASfpSysFan2
                     num_oid: '.1.3.6.1.4.1.22408.1.1.2.1.4.102.97.110.51.1{{ $index }}'
                     descr: 'System Fan 2'
                     group: 'System'
                     index: pkASfpSysFan2
                 -
-                    oid: PRIMEKEY-APPLIANCE-MIB::pkSfp
+                    oid: PRIMEKEY-APPLIANCE-MIB::pkASfpSysFan3
                     value: PRIMEKEY-APPLIANCE-MIB::pkASfpSysFan3
                     num_oid: '.1.3.6.1.4.1.22408.1.1.2.1.4.102.97.110.52.1{{ $index }}'
                     descr: 'System Fan 3'
@@ -107,7 +103,7 @@ modules:
                 skip_value_lt: 0
             data:
                 -
-                    oid: PRIMEKEY-APPLIANCE-MIB::pkSfp
+                    oid: PRIMEKEY-APPLIANCE-MIB::pkAVdbUsagePercent
                     value: PRIMEKEY-APPLIANCE-MIB::pkAVdbUsagePercent
                     num_oid: '.1.3.6.1.4.1.22408.1.1.2.1.4.118.100.98.49.1{{ $index }}'
                     descr: 'DB Usage %'
@@ -118,7 +114,7 @@ modules:
         state:
             data:
                 -
-                    oid: PRIMEKEY-APPLIANCE-MIB::pkSfp
+                    oid: PRIMEKEY-APPLIANCE-MIB::pkASfpVmStatus
                     value: PRIMEKEY-APPLIANCE-MIB::pkASfpVmStatus
                     num_oid: '.1.3.6.1.4.1.22408.1.1.2.1.2.118.109.1{{ $index }}'
                     descr: 'Health VMs'
@@ -129,7 +125,7 @@ modules:
                         -  { value: 0, generic: 0, graph: 0, descr: 'All OK' }
                         -  { value: 1, generic: 2, graph: 1, descr: 'Some Inactive' }
                 -
-                    oid: PRIMEKEY-APPLIANCE-MIB::pkSfp
+                    oid: PRIMEKEY-APPLIANCE-MIB::pkAEJBCAHealth
                     value: PRIMEKEY-APPLIANCE-MIB::pkAEJBCAHealth
                     num_oid: '.1.3.6.1.4.1.22408.1.1.2.1.8.104.101.97.108.116.104.101.50.1{{ $index }}'
                     descr: 'Health EJBCA'
@@ -141,6 +137,7 @@ modules:
                         -  { value: 1, generic: 3, graph: 1, descr: 'Not Running or Unhealthy' }
                 -
                     oid: PRIMEKEY-APPLIANCE-MIB::pkASignServerHealth
+                    value: PRIMEKEY-APPLIANCE-MIB::pkASignServerHealth
                     num_oid: '.1.3.6.1.4.1.22408.1.1.2.1.8.104.101.97.108.116.104.115.50.1{{ $index }}'
                     descr: 'Health SignServer'
                     group: 'Health of VMs'
@@ -151,7 +148,7 @@ modules:
                         -  { value: 0, generic: 0, graph: 0, descr: 'All OK' }
                         -  { value: 1, generic: 3, graph: 1, descr: 'Not Running or Unhealthy' }
                 -
-                    oid: PRIMEKEY-APPLIANCE-MIB::pkSfp
+                    oid: PRIMEKEY-APPLIANCE-MIB::pkASfpCpuFanStatus
                     value: PRIMEKEY-APPLIANCE-MIB::pkASfpCpuFanStatus
                     num_oid: '.1.3.6.1.4.1.22408.1.1.2.1.4.102.97.110.53.1{{ $index }}'
                     descr: 'Fan CPU'
@@ -162,7 +159,7 @@ modules:
                         -  { value: 0, generic: 0, graph: 0, descr: 'OK' }
                         -  { value: 1, generic: 2, graph: 1, descr: 'Fail' }
                 -
-                    oid: PRIMEKEY-APPLIANCE-MIB::pkSfp
+                    oid: PRIMEKEY-APPLIANCE-MIB::pkASfpSysFansStatus
                     value: PRIMEKEY-APPLIANCE-MIB::pkASfpSysFansStatus
                     num_oid: '.1.3.6.1.4.1.22408.1.1.2.1.4.102.97.110.54.1'
                     descr: 'Fans System'
@@ -173,7 +170,7 @@ modules:
                         -  { value: 0, generic: 0, graph: 0, descr: 'All OK' }
                         -  { value: 1, generic: 1, graph: 1, descr: 'Fail' }
                 -
-                    oid: PRIMEKEY-APPLIANCE-MIB::pkSfp
+                    oid: PRIMEKEY-APPLIANCE-MIB::pkAVdbStatus
                     value: PRIMEKEY-APPLIANCE-MIB::pkAVdbStatus
                     num_oid: '.1.3.6.1.4.1.22408.1.1.2.1.4.118.100.98.50.1{{ $index }}'
                     descr: 'DB Storage'
@@ -184,7 +181,7 @@ modules:
                         -  { value: 0, generic: 0, graph: 0, descr: '< 80% full' }
                         -  { value: 1, generic: 2, graph: 1, descr: '> 80% full' }
                 -
-                    oid: PRIMEKEY-APPLIANCE-MIB::pkSfp
+                    oid: PRIMEKEY-APPLIANCE-MIB::pkAClusterLocalGaleraState
                     value: PRIMEKEY-APPLIANCE-MIB::pkAClusterLocalGaleraState
                     num_oid: '.1.3.6.1.4.1.22408.1.1.2.1.8.99.108.117.115.116.101.114.52.1{{ $index }}'
                     descr: 'DB Enum'
@@ -211,7 +208,7 @@ modules:
                         -  { value: 5, generic: 2, graph: 5, descr: 'Error' }     # this and above is provider-specific error code
                         -  { value: 6, generic: 2, graph: 6, descr: 'Max' }
                 -
-                    oid: PRIMEKEY-APPLIANCE-MIB::pkSfp
+                    oid: PRIMEKEY-APPLIANCE-MIB::pkASfpRaidStatus
                     value: PRIMEKEY-APPLIANCE-MIB::pkASfpRaidStatus
                     num_oid: '.1.3.6.1.4.1.22408.1.1.2.1.5.114.97.105.100.49.1{{ $index }}'
                     descr: 'RAID Health'
@@ -222,7 +219,7 @@ modules:
                         -  { value: 0, generic: 0, graph: 0, descr: 'Clean or Active' }
                         -  { value: 1, generic: 2, graph: 1, descr: 'Degraded' }
                 -
-                    oid: PRIMEKEY-APPLIANCE-MIB::pkVhsm
+                    oid: PRIMEKEY-APPLIANCE-MIB::pkAHsmStatusEnum
                     value: PRIMEKEY-APPLIANCE-MIB::pkAHsmStatusEnum
                     num_oid: '.1.3.6.1.4.1.22408.1.1.2.2.4.104.115.109.50.1{{ $index }}'
                     descr: 'HSM Enum'
@@ -238,7 +235,7 @@ modules:
                         -  { value: 5, generic: 2, graph: 5, descr: 'STATUS_is_FAIL' }
                         -  { value: 5, generic: 3, graph: 6, descr: 'STATUS_is_OTHER' }
                 -
-                    oid: PRIMEKEY-APPLIANCE-MIB::pkVhsm
+                    oid: PRIMEKEY-APPLIANCE-MIB::pkAHsmStatusBool
                     value: PRIMEKEY-APPLIANCE-MIB::pkAHsmStatusBool
                     num_oid: '.1.3.6.1.4.1.22408.1.1.2.2.4.104.115.109.51.1{{ $index }}'
                     descr: 'HSM Healthy'
@@ -249,7 +246,7 @@ modules:
                         -  { value: 0, generic: 0, graph: 0, descr: 'OK' }
                         -  { value: 1, generic: 2, graph: 1, descr: 'Fail' }
                 -
-                    oid: PRIMEKEY-APPLIANCE-MIB::pkVhsm
+                    oid: PRIMEKEY-APPLIANCE-MIB::pkAHsmBatteryIntStatus
                     value: PRIMEKEY-APPLIANCE-MIB::pkAHsmBatteryIntStatus
                     num_oid: '.1.3.6.1.4.1.22408.1.1.2.2.4.104.115.109.53.1{{ $index }}'
                     descr: 'Battery Int'
@@ -261,6 +258,7 @@ modules:
                         -  { value: 1, generic: 2, graph: 1, descr: 'Low or Fail' }
                 -
                     oid: PRIMEKEY-APPLIANCE-MIB::pkAHsmBatteryExtStatus
+                    value: PRIMEKEY-APPLIANCE-MIB::pkAHsmBatteryExtStatus
                     num_oid: '.1.3.6.1.4.1.22408.1.1.2.2.4.104.115.109.56.1{{ $index }}'
                     descr: 'Battery Ext'
                     group: 'HSM'
@@ -273,7 +271,7 @@ modules:
         temperature:
             data:
                 -
-                    oid: PRIMEKEY-APPLIANCE-MIB::pkSfp
+                    oid: PRIMEKEY-APPLIANCE-MIB::pkASfpCpuTemp
                     value: PRIMEKEY-APPLIANCE-MIB::pkASfpCpuTemp
                     num_oid: '.1.3.6.1.4.1.22408.1.1.2.1.3.99.112.117.1{{ $index }}'
                     descr: 'CPU Temp'
@@ -284,7 +282,7 @@ modules:
                 skip_value_lt: 0
             data:
                 -
-                    oid: PRIMEKEY-APPLIANCE-MIB::pkVhsm
+                    oid: PRIMEKEY-APPLIANCE-MIB::pkAHsmBatteryInt
                     value: PRIMEKEY-APPLIANCE-MIB::pkAHsmBatteryInt
                     num_oid: '.1.3.6.1.4.1.22408.1.1.2.2.4.104.115.109.52.1{{ $index }}'
                     descr: 'Int Battery'
@@ -292,7 +290,7 @@ modules:
                     index: pkAHsmBatteryInt
                     user_func: Number::cast
                 -
-                    oid: PRIMEKEY-APPLIANCE-MIB::pkVhsm
+                    oid: PRIMEKEY-APPLIANCE-MIB::pkAHsmBatteryExt
                     value: PRIMEKEY-APPLIANCE-MIB::pkAHsmBatteryExt
                     num_oid: '.1.3.6.1.4.1.22408.1.1.2.2.4.104.115.109.55.1{{ $index }}'
                     descr: 'Ext Battery'

--- a/includes/definitions/primekey.yaml
+++ b/includes/definitions/primekey.yaml
@@ -4,10 +4,11 @@ type: appliance
 icon: primekey
 group: primekey
 mib_dir: primekey
+snmp_bulk: false
 over:
-    - { graph: device_percent, text: "Database Usage" }
     - { graph: device_voltage, text: "HSM Voltage" }
-    - { graph: device_count, text: "Counters" }
+    - { graph: device_temperature, text: "Temperature" }
+    - { graph: device_fanspeed, text: "Fan Speed" }
 poller_modules:
     bgp-peers: false
     ospf: false


### PR DESCRIPTION
Using bulkwalk on PrimeKey is inefficient, partly because the mibs are not
organised into tables. This means bulkwalk returns a number of unused responses.

Stop using bulk-walk and don't pre-cache oids. Also change the over graphs to something more useful.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
