### PR TITLE
remove alert keys from component for Suricata

### DIFF
--- a/includes/polling/applications/suricata.inc.php
+++ b/includes/polling/applications/suricata.inc.php
@@ -207,8 +207,6 @@ if (empty($instance_list)) {
     $id = $component->getFirstComponentID($ourc);
     $ourc[$id]['label'] = 'Suricata';
     $ourc[$id]['instances'] = json_encode($instance_list);
-    $ourc[$id]['alert'] = $suricata['alert'];
-    $ourc[$id]['alertString'] = $suricata['alertString'];
 
     $component->setComponentPrefs($device_id, $ourc);
 }


### PR DESCRIPTION
Not actually using those and alerting is done via metrics.

This removes un-needed updates from device logs.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [X] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
