### PR TITLE
Use display name when sending alerts to Sensu

### DIFF
--- a/LibreNMS/Alert/Transport/Sensu.php
+++ b/LibreNMS/Alert/Transport/Sensu.php
@@ -131,7 +131,7 @@ class Sensu extends Transport
                     'namespace' => $opts['namespace'],
                 ],
                 'system' => [
-                    'hostname' => $obj['display'],
+                    'hostname' => $obj['hostname'],
                     'os' => $obj['os'],
                 ],
             ],

--- a/LibreNMS/Alert/Transport/Sensu.php
+++ b/LibreNMS/Alert/Transport/Sensu.php
@@ -131,7 +131,7 @@ class Sensu extends Transport
                     'namespace' => $opts['namespace'],
                 ],
                 'system' => [
-                    'hostname' => $obj['hostname'],
+                    'hostname' => $obj['display'],
                     'os' => $obj['os'],
                 ],
             ],
@@ -177,7 +177,7 @@ class Sensu extends Transport
     public static function getEntityName($obj, $key)
     {
         if ($key === 'shortname') {
-            return Sensu::shortenName($obj['hostname']);
+            return Sensu::shortenName($obj['display']);
         }
 
         return $obj[$key];


### PR DESCRIPTION
Avoids IP addresses being registered as Sensu entities to allow alerts from other systems to be correctly correlated.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
