### PR TITLE
Workaround issues with lldp information from GS108Tv1

### DIFF
--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -347,6 +347,18 @@ if (($device['os'] == 'routeros')) {
                     $remote_port_name = (string) ($n_slot * 1000 + $n_port);
                 }
 
+                if ($remote_device['os'] == 'netgear' &&
+                    $remote_device['sysDescr'] == 'GS108T' &&
+                    $lldp['lldpRemSysDesc'] == 'Smart Switch') {
+                    // Some netgear switches, as Netgear GS108Tv1 presents it's port name over snmp as
+                    // "Port 1 Gigabit Ethernet" but as 'lldpRemPortId' => 'g1' and
+                    // 'lldpRemPortDesc' => 'Port #1' over lldp.
+                    // So remap g1 to 1 so it matches ifIndex
+                    if (preg_match("/^g(\d+)$/", $lldp['lldpRemPortId'], $matches)) {
+                        $remote_port_name = $matches[1];
+                    }
+                }
+
                 $remote_port_id = find_port_id(
                     $lldp['lldpRemPortDesc'],
                     $remote_port_name,


### PR DESCRIPTION
The GS108Tv1 doesn't present the same information over snmp as they do
over lldp. This tries to detect such a remote device and figure out
which remote port we actually should map it to.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
