### PR TITLE
Oxidized API to return groups based on device purpose or notes

### DIFF
--- a/doc/Extensions/Oxidized.md
+++ b/doc/Extensions/Oxidized.md
@@ -135,7 +135,7 @@ check for the validity of these attributes but will deliver them to
 Oxidized as defined.
 
 Matching of hosts can be done using `hostname`, `sysname`, `os`,
-`location`, `sysDescr` or `hardware` and including either a 'match'
+`location`, `sysDescr`, `hardware`, `purpose` or `notes` and including either a 'match'
 key and value, or a 'regex' key and value. The order of matching is:
 
 - `hostname`
@@ -145,6 +145,8 @@ key and value, or a 'regex' key and value. The order of matching is:
 - `os`
 - `location`
 - `ip`
+- `purpose`
+- `notes`
 
 To match on the device hostnames or sysNames that contain 'lon-sw' or
 if the location contains 'London' then you would set the following:
@@ -165,6 +167,14 @@ To match on a device os of edgeos then please use the following:
 
 Matching on OS requires system name of the OS. For example, "match": "RouterOS"
 will not work, while "match": "routeros" will.
+
+To match on a device purpose or device notes that contains 'lon-net' then you would set the following:
+
+!!! setting "external/oxidized"
+    ```bash
+    lnms config:set oxidized.maps.group.purpose.+ '{"regex": "/^lon-sw/", "value": "london-network"}'
+    lnms config:set oxidized.maps.group.notes.+ '{"regex": "/^lon-sw/", "value": "london-network"}'
+    ```
 
 To edit an existing map, you must use the index to override it.
 

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -1465,7 +1465,7 @@ function list_oxidized(Illuminate\Http\Request $request)
              ->whereNotIn('type', Config::get('oxidized.ignore_types', []))
              ->whereNotIn('os', Config::get('oxidized.ignore_os', []))
              ->whereAttributeDisabled('override_Oxidized_disable')
-             ->select(['hostname', 'sysName', 'sysDescr', 'sysObjectID', 'hardware', 'os', 'ip', 'location_id'])
+             ->select(['hostname', 'sysName', 'sysDescr', 'sysObjectID', 'hardware', 'os', 'ip', 'location_id', 'purpose', 'notes'])
              ->get();
 
     /** @var Device $device */


### PR DESCRIPTION
Oxidized API to group matching allows only - hostname, sysName, sysDescr, hardware, os, location, ip

This will extend it so that we can return groups on two additional fields - device purpose or device notes.

For testting - Set for a device  
device.purpose=lon-net
device.notes=lon.net

Then in config.php

$config['oxidized']['maps']['group']['purpose'][] = array('match' => 'lon-net', 'group' => 'lon-net');
$config['oxidized']['maps']['group']['notes'][] = array('match' => 'lon-net', 'group' => 'lon-net');

After that api for oxidized will return group value = lon-net for devices which have purpose or notes set as lon-net.

//Regards