### PR TITLE
Fix typo in dispatcher service doc

### DIFF
--- a/doc/Extensions/Dispatcher-Service.md
+++ b/doc/Extensions/Dispatcher-Service.md
@@ -180,8 +180,8 @@ librenms.service`
 
 A systemd unit file can be found in `misc/librenms-watchdog.service`. To
 install run `cp /opt/librenms/misc/librenms-watchdog.service
-/etc/systemd/system/librenms.service && systemctl enable --now
-librenms.service`
+/etc/systemd/system/librenms-watchdog.service && systemctl enable --now
+librenms-watchdog.service`
 
 This requires: python3-systemd (or python-systemd on older systems)
 or https://pypi.org/project/systemd-python/


### PR DESCRIPTION
Please give a short description what your pull request is for

Fixes a minor typo in the documentation for setting up the LibreNMS dispatcher service. Documentation suggests users copy both the librenms.service and librenms-watchdog.service file but the documentation has users overwrite the librenms.service with the librenms-watchdog.service instead.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
