### PR TITLE
Feature: Add support to REST API for creating Maintenance Schedules for Device Groups

### DIFF
--- a/app/Models/DeviceGroup.php
+++ b/app/Models/DeviceGroup.php
@@ -26,6 +26,7 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use LibreNMS\Alerting\QueryBuilderFluentParser;
 use Permissions;
 
@@ -115,6 +116,11 @@ class DeviceGroup extends BaseModel
     }
 
     // ---- Define Relationships ----
+
+    public function alertSchedules(): MorphToMany
+    {
+        return $this->morphToMany(\App\Models\AlertSchedule::class, 'alert_schedulable', 'alert_schedulables', 'schedule_id', 'schedule_id');
+    }
 
     public function devices(): BelongsToMany
     {

--- a/doc/API/DeviceGroups.md
+++ b/doc/API/DeviceGroups.md
@@ -138,3 +138,31 @@ Output:
      }
 ]
 ```
+
+### `maintenance_devicegroup`
+
+Set a device group into maintenance mode.
+
+Route: `/api/v0/devicesgroups/:name/maintenance`
+
+Input (JSON):
+
+- title: Some title for the Maintenance
+- notes: Some description for the Maintenance
+- start: Start time of Maintenance in format H:m
+- duration: Duration of Maintenance in format H:m
+
+Example:
+
+```curl
+curl -X POST -d '{"title":"Device group Maintenance","notes":"A 2 hour Maintenance triggered via API","start":"04:30","duration":"2:00"}' -H 'X-Auth-Token: YOURAPITOKENHERE' https://librenms.org/api/v0/localhost/maintenance
+```
+
+Output:
+
+```json
+{
+    "status": "ok",
+    "message": "Device group Cisco switches (2) will begin maintenance mode at 5:00 for 2:00 h"
+}
+```

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -2142,7 +2142,7 @@ function maintenance_devicegroup(Illuminate\Http\Request $request)
     $device_group = ctype_digit($name) ? DeviceGroup::find($name) : DeviceGroup::where('name', $name)->first();
 
     if (! $device_group) {
-        return api_error(404, "Device group not found");
+        return api_error(404, 'Device group not found');
     }
 
     $notes = $request->json('notes');

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -2171,7 +2171,6 @@ function maintenance_devicegroup(Illuminate\Http\Request $request)
     return api_success_noresult(201, "Device group {$device_group->name} ({$device_group->id}) will begin maintenance mode at $start" . ($duration ? " for {$duration}h" : ''));
 }
 
-
 function get_devices_by_group(Illuminate\Http\Request $request)
 {
     $name = $request->route('name');

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -2128,6 +2128,50 @@ function get_device_groups(Illuminate\Http\Request $request)
     return api_success($groups->makeHidden('pivot')->toArray(), 'groups', 'Found ' . $groups->count() . ' device groups');
 }
 
+function maintenance_devicegroup(Illuminate\Http\Request $request)
+{
+    if (empty($request->json())) {
+        return api_error(400, 'No information has been provided to set this device into maintenance');
+    }
+
+    $name = $request->route('name');
+    if (! $name) {
+        return api_error(400, 'No device group name provided');
+    }
+
+    $device_group = ctype_digit($name) ? DeviceGroup::find($name) : DeviceGroup::where('name', $name)->first();
+
+    if (! $device_group) {
+        return api_error(404, "Device group not found");
+    }
+
+    $notes = $request->json('notes');
+    $title = $request->json('title') ?? $device_group->name;
+
+    $alert_schedule = new \App\Models\AlertSchedule([
+        'title' => $title,
+        'notes' => $notes,
+        'recurring' => 0,
+    ]);
+
+    $start = $request->json('start') ?? \Carbon\Carbon::now()->format('Y-m-d H:i:00');
+    $alert_schedule->start = $start;
+
+    $duration = $request->json('duration');
+
+    if (Str::contains($duration, ':')) {
+        [$duration_hour, $duration_min] = explode(':', $duration);
+        $alert_schedule->end = \Carbon\Carbon::createFromFormat('Y-m-d H:i:s', $start)
+            ->addHours($duration_hour)->addMinutes($duration_min)
+            ->format('Y-m-d H:i:00');
+    }
+
+    $device_group->alertSchedules()->save($alert_schedule);
+
+    return api_success_noresult(201, "Device group {$device_group->name} ({$device_group->id}) will begin maintenance mode at $start" . ($duration ? " for {$duration}h" : ''));
+}
+
+
 function get_devices_by_group(Illuminate\Http\Request $request)
 {
     $name = $request->route('name');

--- a/routes/api.php
+++ b/routes/api.php
@@ -67,6 +67,10 @@ Route::group(['prefix' => 'v0', 'namespace' => '\App\Api\Controllers'], function
             Route::post('{hostname}/maintenance', 'LegacyApiController@maintenance_device')->name('maintenance_device');
         });
 
+        Route::group(['prefix' => 'devicegroups'], function () {
+            Route::post('{name}/maintenance', 'LegacyApiController@maintenance_devicegroup')->name('maintenance_devicegroup');
+        });
+
         Route::post('bills', 'LegacyApiController@create_edit_bill')->name('create_bill');
         Route::delete('bills/{bill_id}', 'LegacyApiController@delete_bill')->name('delete_bill');
         Route::put('alerts/{id}', 'LegacyApiController@ack_alert')->name('ack_alert');


### PR DESCRIPTION
Adds support to the REST API for creating Maintenance Schedules for Device Groups. Largely based on existing functionality at `/api/v0/devices/:hostname/maintenance`.

New functionality in the `maintenance_devicegroup()` function that isn't present in `maintenance_device()` includes:

* The ability to pass a custom maintenance title in the JSON request body
* The ability to pass a custom start datetime in the JSON request body

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
