### PR TITLE
fix: inconsistency in ldap starttls config parameter

### DIFF
--- a/LibreNMS/Authentication/LdapAuthorizationAuthorizer.php
+++ b/LibreNMS/Authentication/LdapAuthorizationAuthorizer.php
@@ -53,9 +53,9 @@ class LdapAuthorizationAuthorizer extends AuthorizerBase
             ldap_set_option($this->ldap_connection, LDAP_OPT_PROTOCOL_VERSION, Config::get('auth_ldap_version'));
         }
 
-        if (Config::get('auth_ldap_starttls') && (Config::get('auth_ldap_starttls') == 'optional' || Config::get('auth_ldap_starttls') == 'require')) {
+        if (Config::get('auth_ldap_starttls') && (Config::get('auth_ldap_starttls') == 'optional' || Config::get('auth_ldap_starttls') == 'required')) {
             $tls = ldap_start_tls($this->ldap_connection);
-            if (Config::get('auth_ldap_starttls') == 'require' && $tls === false) {
+            if (Config::get('auth_ldap_starttls') == 'required' && $tls === false) {
                 throw new AuthenticationException('Fatal error: LDAP TLS required but not successfully negotiated:' . ldap_error($this->ldap_connection));
             }
         }

--- a/LibreNMS/Authentication/LdapAuthorizer.php
+++ b/LibreNMS/Authentication/LdapAuthorizer.php
@@ -385,9 +385,9 @@ class LdapAuthorizer extends AuthorizerBase
         ldap_set_option($this->ldap_connection, LDAP_OPT_PROTOCOL_VERSION, Config::get('auth_ldap_version', 3));
 
         $use_tls = Config::get('auth_ldap_starttls');
-        if ($use_tls == 'optional' || $use_tls == 'require') {
+        if ($use_tls == 'optional' || $use_tls == 'required') {
             $tls_success = ldap_start_tls($this->ldap_connection);
-            if ($use_tls == 'require' && $tls_success === false) {
+            if ($use_tls == 'required' && $tls_success === false) {
                 $error = ldap_error($this->ldap_connection);
                 throw new AuthenticationException("Fatal error: LDAP TLS required but not successfully negotiated: $error");
             }


### PR DESCRIPTION
Fixes an inconsistency in the value of config parameter `auth_ldap_starttls`.

`lnms` only allows to set `auth_ldap_starttls` to `required` (see. [misc/config_definitions.json](https://github.com/librenms/librenms/blob/c3cf527301c6594321caf7715549fc66f7cd660a/misc/config_definitions.json#L597)) but both [LibreNMS/Authentication/LdapAuthorizationAuthorizer.php](https://github.com/librenms/librenms/blob/c3cf527301c6594321caf7715549fc66f7cd660a/LibreNMS/Authentication/LdapAuthorizationAuthorizer.php) and [LibreNMS/Authentication/LdapAuthorizer.php](https://github.com/librenms/librenms/blob/c3cf527301c6594321caf7715549fc66f7cd660a/LibreNMS/Authentication/LdapAuthorizer.php) only utilize `auth_ldap_starttls` with value `require` (instead of `required`)

This PR now testing  `auth_ldap_starttls` for `required` in both scripts (`Ldap{Authorization}Authorizer.php`), enabling the user to successful authenticate via WebUI if `auth_ldap_starttls` is set to `required`.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
