### PR TITLE
Fix 500 error in validations when capabilities are not supported or set

### DIFF
--- a/LibreNMS/Validations/Programs.php
+++ b/LibreNMS/Validations/Programs.php
@@ -105,9 +105,9 @@ class Programs extends BaseValidation
 
         if ($getcap = $this->findExecutable('getcap')) {
             $getcap_out = shell_exec("$getcap $cmd");
-            $found = preg_match("#^$cmd = (.*)$#", $getcap_out, $matches);
+            preg_match("#^$cmd = (.*)$#", $getcap_out, $matches);
 
-            if (! $found || ! Str::contains($matches[1], 'cap_net_raw+ep')) {
+            if (empty($matches) || ! Str::contains($matches[1], 'cap_net_raw+ep')) {
                 $validator->fail(
                     "$cmd should have CAP_NET_RAW!",
                     "setcap cap_net_raw+ep $cmd"

--- a/LibreNMS/Validations/Programs.php
+++ b/LibreNMS/Validations/Programs.php
@@ -107,7 +107,7 @@ class Programs extends BaseValidation
             $getcap_out = shell_exec("$getcap $cmd");
             $found = preg_match("#^$cmd = (.*)$#", $getcap_out, $matches);
 
-            if ($found != 1 || ! Str::contains($matches[1], 'cap_net_raw+ep')) {
+            if (! $found || ! Str::contains($matches[1], 'cap_net_raw+ep')) {
                 $validator->fail(
                     "$cmd should have CAP_NET_RAW!",
                     "setcap cap_net_raw+ep $cmd"

--- a/LibreNMS/Validations/Programs.php
+++ b/LibreNMS/Validations/Programs.php
@@ -105,9 +105,9 @@ class Programs extends BaseValidation
 
         if ($getcap = $this->findExecutable('getcap')) {
             $getcap_out = shell_exec("$getcap $cmd");
-            preg_match("#^$cmd = (.*)$#", $getcap_out, $matches);
+            $found = preg_match("#^$cmd = (.*)$#", $getcap_out, $matches);
 
-            if (is_null($matches) || ! Str::contains($matches[1], 'cap_net_raw+ep')) {
+            if ($found != 1 || ! Str::contains($matches[1], 'cap_net_raw+ep')) {
                 $validator->fail(
                     "$cmd should have CAP_NET_RAW!",
                     "setcap cap_net_raw+ep $cmd"


### PR DESCRIPTION
This change addresses a 500 error that may occur when validate.php is invoked via the UI if the fping executable lacks the appropriate capabilities, such as in a container lacking support for capabilities.

I believe this behavior occurs as a result of the matches array returned by preg_match being an empty array (not null) if the regex is valid but fails to match the provided string. Therefore, I have updated the match/no-match check to instead use the return value of preg_match which returns 1 (per the PHP API docs) if the regex matches the provided string.


#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [NA] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [NA] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
