### PR TITLE
feat(apps/mysql): add error-state to non-responsive mysql-servers

### DIFF
--- a/database/migrations/2022_05_30_084932_update-app-status-length.php
+++ b/database/migrations/2022_05_30_084932_update-app-status-length.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class UpdateAppStatusLength extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('applications', function (Blueprint $table) {
+            $table->string('app_status', 1024)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('applications', function (Blueprint $table) {
+            $table->string('app_status', 8)->change();
+        });
+    }
+}

--- a/includes/polling/applications/mysql.inc.php
+++ b/includes/polling/applications/mysql.inc.php
@@ -100,7 +100,7 @@ $mapping = [
 
 $data = explode("\n", $mysql);
 if (sizeof($data) > 0 && strpos($data[0], 'ERROR') === 0) {
-    $mysql= 'ERROR';
+    $mysql = 'ERROR';
 }
 
 $map = [];

--- a/includes/polling/applications/mysql.inc.php
+++ b/includes/polling/applications/mysql.inc.php
@@ -99,6 +99,7 @@ $mapping = [
 ];
 
 $data = explode("\n", $mysql);
+if (sizeof($data) > 0 && strpos($data[0], "ERROR") === 0) $mysql= "ERROR";
 
 $map = [];
 foreach ($data as $str) {

--- a/includes/polling/applications/mysql.inc.php
+++ b/includes/polling/applications/mysql.inc.php
@@ -99,7 +99,9 @@ $mapping = [
 ];
 
 $data = explode("\n", $mysql);
-if (sizeof($data) > 0 && strpos($data[0], "ERROR") === 0) $mysql= "ERROR";
+if (sizeof($data) > 0 && strpos($data[0], "ERROR") === 0) {
+    $mysql= "ERROR";
+}
 
 $map = [];
 foreach ($data as $str) {

--- a/includes/polling/applications/mysql.inc.php
+++ b/includes/polling/applications/mysql.inc.php
@@ -99,8 +99,8 @@ $mapping = [
 ];
 
 $data = explode("\n", $mysql);
-if (sizeof($data) > 0 && strpos($data[0], "ERROR") === 0) {
-    $mysql= "ERROR";
+if (sizeof($data) > 0 && strpos($data[0], 'ERROR') === 0) {
+    $mysql= 'ERROR';
 }
 
 $map = [];

--- a/includes/polling/applications/mysql.inc.php
+++ b/includes/polling/applications/mysql.inc.php
@@ -99,9 +99,6 @@ $mapping = [
 ];
 
 $data = explode("\n", $mysql);
-if (sizeof($data) > 0 && strpos($data[0], 'ERROR') === 0) {
-    $mysql = 'ERROR';
-}
 
 $map = [];
 foreach ($data as $str) {

--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -470,7 +470,8 @@ function update_application($app, $response, $metrics = [], $status = '')
             'Traceback (most recent call last):'
         ])) {
             $data['app_status'] = $response;
-            $data['app_state'] = 'ERROR';
+            $has_generic_error = in_array($response, ['ERROR', 'LEGACY', 'UNSUPPORTED']);
+            $data['app_state'] = $has_generic_error ? $has_generic_error : "ERROR";
         } else {
             // should maybe be 'unknown' as state
             $data['app_state'] = 'OK';

--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -459,19 +459,14 @@ function update_application($app, $response, $metrics = [], $status = '')
     ];
 
     if ($response != '' && $response !== false) {
-        /**
-         * check if the response starts with an error and set that in the app_state field
-         * also set app_status to the raw response
-         */
-        if (Str::startsWith($response, [
-            'ERROR',
-            'LEGACY',
-            'UNSUPPORTED',
+        if (Str::contains($response, [
             'Traceback (most recent call last):',
         ])) {
+            $data['app_state'] = 'ERROR';
             $data['app_status'] = $response;
-            $has_generic_error = in_array($response, ['ERROR', 'LEGACY', 'UNSUPPORTED']);
-            $data['app_state'] = $has_generic_error ? $has_generic_error : 'ERROR';
+        } elseif (preg_match('/^(OK|ERROR|LEGACY|UNSUPPORTED)/', $response, $matches)) {
+            $data['app_state'] = $matches[1];
+            $data['app_status'] = $response;
         } else {
             // should maybe be 'unknown' as state
             $data['app_state'] = 'OK';

--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -467,11 +467,11 @@ function update_application($app, $response, $metrics = [], $status = '')
             'ERROR',
             'LEGACY',
             'UNSUPPORTED',
-            'Traceback (most recent call last):'
+            'Traceback (most recent call last):',
         ])) {
             $data['app_status'] = $response;
             $has_generic_error = in_array($response, ['ERROR', 'LEGACY', 'UNSUPPORTED']);
-            $data['app_state'] = $has_generic_error ? $has_generic_error : "ERROR";
+            $data['app_state'] = $has_generic_error ? $has_generic_error : 'ERROR';
         } else {
             // should maybe be 'unknown' as state
             $data['app_state'] = 'OK';

--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -459,12 +459,13 @@ function update_application($app, $response, $metrics = [], $status = '')
     ];
 
     if ($response != '' && $response !== false) {
+        // if the response indicates an error, set it and set app_status to the raw response
         if (Str::contains($response, [
             'Traceback (most recent call last):',
         ])) {
             $data['app_state'] = 'ERROR';
             $data['app_status'] = $response;
-        } elseif (preg_match('/^(OK|ERROR|LEGACY|UNSUPPORTED)/', $response, $matches)) {
+        } elseif (preg_match('/^(ERROR|LEGACY|UNSUPPORTED)/', $response, $matches)) {
             $data['app_state'] = $matches[1];
             $data['app_status'] = $response;
         } else {

--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -459,12 +459,18 @@ function update_application($app, $response, $metrics = [], $status = '')
     ];
 
     if ($response != '' && $response !== false) {
-        if (Str::contains($response, [
-            'Traceback (most recent call last):',
+        /**
+         * check if the response starts with an error and set that in the app_state field
+         * also set app_status to the raw response
+         */
+        if (Str::startsWith($response, [
+            'ERROR',
+            'LEGACY',
+            'UNSUPPORTED',
+            'Traceback (most recent call last):'
         ])) {
+            $data['app_status'] = $response;
             $data['app_state'] = 'ERROR';
-        } elseif (in_array($response, ['OK', 'ERROR', 'LEGACY', 'UNSUPPORTED'])) {
-            $data['app_state'] = $response;
         } else {
             // should maybe be 'unknown' as state
             $data['app_state'] = 'OK';

--- a/misc/alert_rules.json
+++ b/misc/alert_rules.json
@@ -527,5 +527,10 @@
     "rule": "applications.app_type = \"suricata\" && application_metrics.metric = \".total_error_delta\" && application_metrics.value >= \"2\"",
     "name": "Suricata Packet Error >= 2%",
     "severity": "critical"
+  },
+  {
+    "rule": "applications.app_type = \"mysql\" && applications.app_state != \"OK\"",
+    "name": "MySQL Server not responding",
+    "severity":"critical"
   }
 ]

--- a/misc/db_schema.yaml
+++ b/misc/db_schema.yaml
@@ -168,7 +168,7 @@ applications:
     - { Field: app_state, Type: varchar(32), 'Null': false, Extra: '', Default: UNKNOWN }
     - { Field: discovered, Type: tinyint, 'Null': false, Extra: '', Default: '0' }
     - { Field: app_state_prev, Type: varchar(32), 'Null': true, Extra: '' }
-    - { Field: app_status, Type: varchar(8), 'Null': false, Extra: '' }
+    - { Field: app_status, Type: varchar(1024), 'Null': false, Extra: '' }
     - { Field: timestamp, Type: timestamp, 'Null': false, Extra: 'on update CURRENT_TIMESTAMP', Default: CURRENT_TIMESTAMP }
     - { Field: app_instance, Type: varchar(255), 'Null': false, Extra: '' }
   Indexes:


### PR DESCRIPTION
This PR updates the `app_state` field for mysql-Apps that returned an error during polling.
This can be caused by an offline server or invalid user configuration.

I also added an alert template to show how to filter these incidents.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
