### PR TITLE
Fix Netscaler VServer database updates during polling

### DIFF
--- a/includes/polling/netscaler-vsvr.inc.php
+++ b/includes/polling/netscaler-vsvr.inc.php
@@ -128,7 +128,7 @@ if ($device['os'] == 'netscaler') {
     foreach ($vsvrs as $db_name => $db_id) {
         if (! $vsvr_exist[$db_name]) {
             echo '-' . $db_name;
-            dbDelete('netscaler_vservers', '`vsvr_id` =  ?', [$db_id]);
+            dbDelete('netscaler_vservers', '`vsvr_id` =  ?', [$db_id['vsvr_id']]);
         }
     }
 }//end if


### PR DESCRIPTION
When a VServer is removed/renamed in NetScaler Librenms doesn't remove it automatically, it seems to have a bug in the netscaler-vsvr.inc.php file. 

The vserver ID isn't sent to the dbdelete function and he doesn't know what to delete

Original line:

dbDelete('netscaler_vservers', '`vsvr_id` =  ?', [$db_id]);

Modified line:

dbDelete('netscaler_vservers', '`vsvr_id` =  ?', [$db_id['vsvr_id']]);

Thanks

Dave


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
