### PR TITLE
Fix migrations failing one time after dashboard cleanup

### DIFF
--- a/database/seeders/DefaultWidgetSeeder.php
+++ b/database/seeders/DefaultWidgetSeeder.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+
+class DefaultWidgetSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        // dummy to prevent race condition blocking migrations
+    }
+}


### PR DESCRIPTION
The seeder tries to run the DefaultWidgetSeeder, but it doesn't exist anymore, so it fails. Add a skeleton so the migrations run right away instead of the next update.

This won't help anyone on the daily update channel, it is for the monthly release.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
