### PR TITLE
Allow the use of a custom URL for accessing the PagerDuty API and correct API schema violation

### DIFF
--- a/LibreNMS/Alert/Transport/Pagerduty.php
+++ b/LibreNMS/Alert/Transport/Pagerduty.php
@@ -53,12 +53,13 @@ class Pagerduty extends Transport
      */
     public function contactPagerduty($obj, $config)
     {
+        $custom_details = [ 'message' => strip_tags($obj['msg']) ?: 'Test' ];
         $data = [
             'routing_key'  => $config['service_key'],
             'event_action' => $obj['event_type'],
             'dedup_key'    => (string) $obj['alert_id'],
             'payload'    => [
-                'custom_details'  => strip_tags($obj['msg']) ?: 'Test',
+                'custom_details'  => $custom_details,
                 'group'   => (string) \DeviceCache::get($obj['device_id'])->groups->pluck('name'),
                 'source'   => $obj['hostname'],
                 'severity' => $obj['severity'],

--- a/LibreNMS/Alert/Transport/Pagerduty.php
+++ b/LibreNMS/Alert/Transport/Pagerduty.php
@@ -69,12 +69,10 @@ class Pagerduty extends Transport
         // EU service region
         if ($config['region'] == 'EU') {
             $url = 'https://events.eu.pagerduty.com/v2/enqueue';
-        }
-        else if ($config['region'] == 'US') {
-        // US service region
+        } elseif ($config['region'] == 'US') {
+            // US service region
             $url = 'https://events.pagerduty.com/v2/enqueue';
-        }
-        else {
+        } else {
             $url = $config['custom-url'];
         }
 
@@ -108,7 +106,7 @@ class Pagerduty extends Transport
                     'options' => [
                         'EU' => 'EU',
                         'US' => 'US',
-			'Custom URL' => 'CUSTOM',
+                        'Custom URL' => 'CUSTOM',
                     ],
                 ],
                 [
@@ -121,7 +119,7 @@ class Pagerduty extends Transport
                     'type' => 'text',
                     'name' => 'custom-url',
                     'descr' => 'Custom PagerDuty API URL',
-                ]
+                ],
             ],
             'validation' => [
                 'region' => 'in:EU,US,CUSTOM',

--- a/LibreNMS/Alert/Transport/Pagerduty.php
+++ b/LibreNMS/Alert/Transport/Pagerduty.php
@@ -70,10 +70,12 @@ class Pagerduty extends Transport
         if ($config['region'] == 'EU') {
             $url = 'https://events.eu.pagerduty.com/v2/enqueue';
         }
-
+        else if ($config['region'] == 'US') {
         // US service region
-        else {
             $url = 'https://events.pagerduty.com/v2/enqueue';
+        }
+        else {
+            $url = $config['custom-url'];
         }
 
         $client = new Client();
@@ -106,6 +108,7 @@ class Pagerduty extends Transport
                     'options' => [
                         'EU' => 'EU',
                         'US' => 'US',
+			'Custom URL' => 'CUSTOM',
                     ],
                 ],
                 [
@@ -113,9 +116,16 @@ class Pagerduty extends Transport
                     'type'  => 'text',
                     'name'  => 'service_key',
                 ],
+                [
+                    'title' => 'Custom API URL',
+                    'type' => 'text',
+                    'name' => 'custom-url',
+                    'descr' => 'Custom PagerDuty API URL',
+                ]
             ],
             'validation' => [
-                'region' => 'in:EU,US',
+                'region' => 'in:EU,US,CUSTOM',
+                'custom-url' => 'url',
             ],
         ];
     }

--- a/LibreNMS/Alert/Transport/Pagerduty.php
+++ b/LibreNMS/Alert/Transport/Pagerduty.php
@@ -53,7 +53,7 @@ class Pagerduty extends Transport
      */
     public function contactPagerduty($obj, $config)
     {
-        $custom_details = [ 'message' => strip_tags($obj['msg']) ?: 'Test' ];
+        $custom_details = ['message' => strip_tags($obj['msg']) ?: 'Test'];
         $data = [
             'routing_key'  => $config['service_key'],
             'event_action' => $obj['event_type'],


### PR DESCRIPTION
This change allows the usage of a custom URL for accessing the PagerDuty API to enable access via reverse proxies as well as PagerDuty API-compatible vendor products. 

Additionally, this change ensures that the message provided to PagerDuty in the custom_details field is provided as an object in order to adhere to the API definition per https://developer.pagerduty.com/docs/ZG9jOjExMDI5NTgx-send-an-alert-event.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [NA] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

<img width="1526" alt="LNMS PD Screenshot" src="https://user-images.githubusercontent.com/36900518/171960746-28c34dc6-03ce-4879-80d6-844c16125726.png">

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
