### PR TITLE
syslog-notify-oxidized.php now always notifies Oxidized

### DIFF
--- a/scripts/syslog-notify-oxidized.php
+++ b/scripts/syslog-notify-oxidized.php
@@ -9,22 +9,19 @@ $os = $argv[2];
 $msg = $argv[3];
 
 $oxidized_api = new \App\ApiClients\Oxidized();
-if (preg_match('/(SYS-(SW[0-9]+-)?5-CONFIG_I|VSHD-5-VSHD_SYSLOG_CONFIG_I): Configured from .+ by (?P<user>\S+)( on .*)?$/', $msg, $matches)) {
+if (preg_match('/Configured from .+ by (?P<user>\S+)/', $msg, $matches)) {
     $oxidized_api->updateNode($hostname, $msg, $matches['user']);
-} elseif (preg_match('/GBL-CONFIG-6-DB_COMMIT : Configuration committed by user \\\\\'(?P<user>.+?)\\\\\'..*/', $msg, $matches)) {
+} elseif (preg_match('/Configuration committed by user \\\\\'(?P<user>.+?)\\\\\'/', $msg, $matches)) {
     $oxidized_api->updateNode($hostname, $msg, $matches['user']);
-} elseif (preg_match('/ASA-(config-)?5-111005: (?P<user>.+) end configuration: OK/', $msg, $matches)) {
+} elseif (preg_match('/ASA-(config-)?5-111005: (?P<user>\S+) end configuration: OK/', $msg, $matches)) {
     $oxidized_api->updateNode($hostname, $msg, $matches['user']);
-} elseif (preg_match('/startup-config was changed by (?P<user>.+) from telnet client .*/', $msg, $matches)) {
+} elseif (preg_match('/startup-config was changed by (?P<user>\S+)/', $msg, $matches)) {
     $oxidized_api->updateNode($hostname, $msg, $matches['user']);
-} elseif (preg_match('/HWCM\/4\/CFGCHANGE/', $msg, $matches)) { //Huawei VRP devices CFGCHANGE syslog
-    $oxidized_api->updateNode($hostname, $msg);
-} elseif (preg_match('/UI_COMMIT: User \\\\\'(?P<user>.+?)\\\\\' .*/', $msg, $matches)) {
+} elseif (preg_match('/UI_COMMIT: User \\\\\'(?P<user>.+?)\\\\\'/', $msg, $matches)) {
     $oxidized_api->updateNode($hostname, $msg, $matches['user']);
-} elseif (preg_match('/IMI.+.Startup-config saved on .+ by (?P<user>.+) via .*/', $msg, $matches)) {
+} elseif (preg_match('/IMI.+.Startup-config saved on .+ by (?P<user>\S+)/', $msg, $matches)) {
     $oxidized_api->updateNode($hostname, $msg, $matches['user']); //Alliedware Plus devices. Requires at least V5.4.8-2.1
-} elseif (preg_match('/System configuration saved/', $msg, $matches)) {
-    $oxidized_api->updateNode($hostname, $msg); //ScreenOS
-} elseif (preg_match('/Running Config Change/', $msg, $matches)) {
-    $oxidized_api->updateNode($hostname, $msg); //HPE and Aruba Procurve devices
+} elseif (isset($hostname, $msg)) {
+    // without user detection...
+    $oxidized_api->updateNode($hostname, $msg);
 }


### PR DESCRIPTION
When the script is called, it has already matched a regex.  I saw a user duplicating this script so they could notify oxidized.  That just makes things hard.  The only reason for the extra regex here should be to parse a user from the output.

Also, simplify many of the regex.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
