### PR TITLE
SnmpQuery walk multiple oids

### DIFF
--- a/LibreNMS/Data/Source/NetSnmpQuery.php
+++ b/LibreNMS/Data/Source/NetSnmpQuery.php
@@ -243,7 +243,7 @@ class NetSnmpQuery implements SnmpQueryInterface
      */
     public function walk($oid): SnmpResponse
     {
-        return $this->exec('snmpwalk', $this->parseOid($oid));
+        return $this->execMultiple('snmpwalk', $this->parseOid($oid));
     }
 
     /**
@@ -328,6 +328,19 @@ class NetSnmpQuery implements SnmpQueryInterface
         } else {
             Log::debug("Unsupported SNMP Version: {$this->device->snmpver}");
         }
+    }
+
+    private function execMultiple(string $command, array $oids): ?SnmpResponse
+    {
+        $combined = null;
+
+        foreach ($oids as $oid) {
+            $response = $this->exec($command, [$oid]);
+
+            $combined = $combined ? $combined->append($response) : $response;
+        }
+
+        return $combined;
     }
 
     private function exec(string $command, array $oids): SnmpResponse

--- a/LibreNMS/Data/Source/SnmpResponse.php
+++ b/LibreNMS/Data/Source/SnmpResponse.php
@@ -232,4 +232,14 @@ class SnmpResponse
 
         return $this;
     }
+
+    public function append(SnmpResponse $response): SnmpResponse
+    {
+        $this->raw .= $response->raw;
+        $this->stderr .= $response->stderr;
+        $this->exitCode = $this->exitCode ?: $response->exitCode;
+        $this->errorMessage = $this->errorMessage ?: $response->errorMessage;
+
+        return $this;
+    }
 }


### PR DESCRIPTION
Makes it easier to walk select oids from a large table.
Walking oids with different indexes will break some logic and is undefined so far.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
