### PR TITLE
Remove traceroute6, it is unused

### DIFF
--- a/LibreNMS/Config.php
+++ b/LibreNMS/Config.php
@@ -458,7 +458,7 @@ class Config
         }
 
         // make sure we have full path to binaries in case PATH isn't set
-        foreach (['fping', 'fping6', 'snmpgetnext', 'rrdtool', 'traceroute', 'traceroute6'] as $bin) {
+        foreach (['fping', 'fping6', 'snmpgetnext', 'rrdtool', 'traceroute'] as $bin) {
             if (! is_executable(self::get($bin))) {
                 self::persist($bin, self::locateBinary($bin));
             }

--- a/doc/Support/Configuration.md
+++ b/doc/Support/Configuration.md
@@ -210,13 +210,12 @@ under Device -> Edit -> Misc -> Disable ICMP Test? On
 
 #### traceroute
 
-LibreNMS uses traceroute / traceroute6 to record debug information
+LibreNMS uses traceroute to record debug information
 when a device is down due to icmp AND you have
 `lnms config:set debug.run_trace true` set.
 
 ```bash
 lnms config:set traceroute /usr/bin/traceroute
-lnms config:set traceroute6 /usr/bin/traceroute6
 ```
 
 #### SNMP

--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -5375,13 +5375,6 @@
             "order": 13,
             "type": "executable"
         },
-        "traceroute6": {
-            "default": "traceroute6",
-            "group": "external",
-            "section": "binaries",
-            "order": 14,
-            "type": "executable"
-        },
         "transit_descr": {
             "default": ["transit"],
             "type": "array",

--- a/resources/lang/de/settings.php
+++ b/resources/lang/de/settings.php
@@ -710,9 +710,6 @@ return [
         'traceroute' => [
             'description' => 'Pfad zu  traceroute',
         ],
-        'traceroute6' => [
-            'description' => 'Pfad zu traceroute6',
-        ],
         'unix-agent' => [
             'connection-timeout' => [
                 'description' => 'Unix-agent Verbindungstimeout',

--- a/resources/lang/en/settings.php
+++ b/resources/lang/en/settings.php
@@ -1471,9 +1471,6 @@ return [
         'traceroute' => [
             'description' => 'Path to traceroute',
         ],
-        'traceroute6' => [
-            'description' => 'Path to traceroute6',
-        ],
         'twofactor' => [
             'description' => 'Two-Factor',
             'help' => 'Allow users to activate and use Timebased (TOTP) or Counterbased (HOTP) One-Time Passwords (OTP)',

--- a/resources/lang/fr/settings.php
+++ b/resources/lang/fr/settings.php
@@ -908,9 +908,6 @@ return [
         'traceroute' => [
             'description' => 'Chemin vers `traceroute`',
         ],
-        'traceroute6' => [
-            'description' => 'Chemin vers `traceroute6`',
-        ],
         'unix-agent' => [
             'connection-timeout' => [
                 'description' => 'Délai d\'attente de connexion Unix-agent',

--- a/resources/lang/it/settings.php
+++ b/resources/lang/it/settings.php
@@ -1459,9 +1459,6 @@ return [
         'traceroute' => [
             'description' => 'Path to traceroute',
         ],
-        'traceroute6' => [
-            'description' => 'Path to traceroute6',
-        ],
         'twofactor' => [
             'description' => 'Two-Factor',
             'help' => 'Allow users to activate and use Timebased (TOTP) or Counterbased (HOTP) One-Time Passwords (OTP)',

--- a/resources/lang/uk/settings.php
+++ b/resources/lang/uk/settings.php
@@ -1459,9 +1459,6 @@ return [
         'traceroute' => [
             'description' => 'Шлях до traceroute',
         ],
-        'traceroute6' => [
-            'description' => 'Шлях до traceroute6',
-        ],
         'twofactor' => [
             'description' => 'Двохфакторна автентифікація',
             'help' => 'Дозволяє користувачам активувати та використовувати Timebased (TOTP) або Counterbased (HOTP) одноразові паролі (OTP)',

--- a/resources/lang/zh-CN/settings.php
+++ b/resources/lang/zh-CN/settings.php
@@ -725,9 +725,6 @@ return [
         'traceroute' => [
             'description' => 'traceroute 路径',
         ],
-        'traceroute6' => [
-            'description' => 'traceroute6 路径',
-        ],
         'unix-agent' => [
             'connection-timeout' => [
                 'description' => 'Unix-agent 联机逾时',

--- a/resources/lang/zh-TW/settings.php
+++ b/resources/lang/zh-TW/settings.php
@@ -890,9 +890,6 @@ return [
         'traceroute' => [
             'description' => 'traceroute 路徑',
         ],
-        'traceroute6' => [
-            'description' => 'traceroute6 路徑',
-        ],
         'twofactor' => [
             'description' => '雙因素驗證',
             'help' => '允許使用者啟用基於時間 (TOTP) 或基於雜湊訊息驗證 (HOTP) 的一次性密碼 (OTP)',


### PR DESCRIPTION
LibreNMS just uses traceroute -6, which is supported on all supported OS, and then some.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
