### PR TITLE
Fix use of incorrect variable to retrieve current sensor value

### DIFF
--- a/includes/discovery/sensors/temperature/axiscam.inc.php
+++ b/includes/discovery/sensors/temperature/axiscam.inc.php
@@ -12,7 +12,7 @@ foreach ($oids_tmp as $key_oids_tmp => $val_oids_tmp) {
 }
 
 foreach (array_keys($oids) as $index) {
-    $current = $cur_oid[$index]['tempSensorValue'];
+    $current = $oids[$index]['tempSensorValue'];
     $oid = $cur_oid . $index;
 
     discover_sensor($valid['sensor'], 'temperature', $device, $oid, $index, 'axiscam', 'Temperature Sensor ' . $index, '1', '1', '5', '10', '30', '35', $current);


### PR DESCRIPTION
The current Axis sensor discovery uses the wrong variable to retrieve the current sensor value. This results in attempting to perform an array access into a string:

TypeError: Cannot access offset of type string on string in /opt/librenms/includes/discovery/sensors/temperature/axiscam.inc.php:15

This patch discovery to use the correct variable.



DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
