### PR TITLE
Add option STARTTLS for authentication via AD

### DIFF
--- a/LibreNMS/Authentication/ActiveDirectoryAuthorizer.php
+++ b/LibreNMS/Authentication/ActiveDirectoryAuthorizer.php
@@ -24,12 +24,6 @@ class ActiveDirectoryAuthorizer extends AuthorizerBase
         $this->connect();
 
         if ($this->ldap_connection) {
-            if (Config::get('auth_ad_starttls') && (Config::get('auth_ad_starttls') == 'optional' || Config::get('auth_ad_starttls') == 'required')) {
-                $tls = ldap_start_tls($this->ldap_connection);
-                if (Config::get('auth_ad_starttls') == 'required' && $tls === false) {
-                    throw new AuthenticationException('Fatal error: LDAP TLS required but not successfully negotiated:' . ldap_error($this->ldap_connection));
-                }
-            }
             // bind with sAMAccountName instead of full LDAP DN
             if (! empty($credentials['username']) && ! empty($credentials['password']) && ldap_bind($this->ldap_connection, $credentials['username'] . '@' . Config::get('auth_ad_domain'), $credentials['password'])) {
                 $this->is_bound = true;
@@ -211,6 +205,12 @@ class ActiveDirectoryAuthorizer extends AuthorizerBase
         // disable referrals and force ldap version to 3
         ldap_set_option($this->ldap_connection, LDAP_OPT_REFERRALS, 0);
         ldap_set_option($this->ldap_connection, LDAP_OPT_PROTOCOL_VERSION, 3);
+        if (Config::get('auth_ad_starttls') && (Config::get('auth_ad_starttls') == 'optional' || Config::get('auth_ad_starttls') == 'required')) {
+            $tls = ldap_start_tls($this->ldap_connection);
+            if (Config::get('auth_ad_starttls') == 'required' && $tls === false) {
+                throw new AuthenticationException('Fatal error: LDAP TLS required but not successfully negotiated:' . ldap_error($this->ldap_connection));
+	    }
+        }
     }
 
     public function bind($credentials = [])

--- a/LibreNMS/Authentication/ActiveDirectoryAuthorizer.php
+++ b/LibreNMS/Authentication/ActiveDirectoryAuthorizer.php
@@ -205,9 +205,11 @@ class ActiveDirectoryAuthorizer extends AuthorizerBase
         // disable referrals and force ldap version to 3
         ldap_set_option($this->ldap_connection, LDAP_OPT_REFERRALS, 0);
         ldap_set_option($this->ldap_connection, LDAP_OPT_PROTOCOL_VERSION, 3);
-        if (Config::get('auth_ad_starttls') && (Config::get('auth_ad_starttls') == 'optional' || Config::get('auth_ad_starttls') == 'required')) {
+
+        $starttls = Config::get('auth_ad_starttls');
+        if ($starttls == 'optional' || $starttls == 'required') {
             $tls = ldap_start_tls($this->ldap_connection);
-            if (Config::get('auth_ad_starttls') == 'required' && $tls === false) {
+            if ($starttls == 'required' && $tls === false) {
                 throw new AuthenticationException('Fatal error: LDAP TLS required but not successfully negotiated:' . ldap_error($this->ldap_connection));
             }
         }

--- a/LibreNMS/Authentication/ActiveDirectoryAuthorizer.php
+++ b/LibreNMS/Authentication/ActiveDirectoryAuthorizer.php
@@ -24,6 +24,12 @@ class ActiveDirectoryAuthorizer extends AuthorizerBase
         $this->connect();
 
         if ($this->ldap_connection) {
+            if (Config::get('auth_ad_starttls') && (Config::get('auth_ad_starttls') == 'optional' || Config::get('auth_ad_starttls') == 'required')) {
+                $tls = ldap_start_tls($this->ldap_connection);
+                if (Config::get('auth_ad_starttls') == 'required' && $tls === false) {
+                    throw new AuthenticationException('Fatal error: LDAP TLS required but not successfully negotiated:' . ldap_error($this->ldap_connection));
+                }   
+            }
             // bind with sAMAccountName instead of full LDAP DN
             if (! empty($credentials['username']) && ! empty($credentials['password']) && ldap_bind($this->ldap_connection, $credentials['username'] . '@' . Config::get('auth_ad_domain'), $credentials['password'])) {
                 $this->is_bound = true;

--- a/LibreNMS/Authentication/ActiveDirectoryAuthorizer.php
+++ b/LibreNMS/Authentication/ActiveDirectoryAuthorizer.php
@@ -209,7 +209,7 @@ class ActiveDirectoryAuthorizer extends AuthorizerBase
             $tls = ldap_start_tls($this->ldap_connection);
             if (Config::get('auth_ad_starttls') == 'required' && $tls === false) {
                 throw new AuthenticationException('Fatal error: LDAP TLS required but not successfully negotiated:' . ldap_error($this->ldap_connection));
-	    }
+            }
         }
     }
 

--- a/LibreNMS/Authentication/ActiveDirectoryAuthorizer.php
+++ b/LibreNMS/Authentication/ActiveDirectoryAuthorizer.php
@@ -28,7 +28,7 @@ class ActiveDirectoryAuthorizer extends AuthorizerBase
                 $tls = ldap_start_tls($this->ldap_connection);
                 if (Config::get('auth_ad_starttls') == 'required' && $tls === false) {
                     throw new AuthenticationException('Fatal error: LDAP TLS required but not successfully negotiated:' . ldap_error($this->ldap_connection));
-                }   
+                }
             }
             // bind with sAMAccountName instead of full LDAP DN
             if (! empty($credentials['username']) && ! empty($credentials['password']) && ldap_bind($this->ldap_connection, $credentials['username'] . '@' . Config::get('auth_ad_domain'), $credentials['password'])) {

--- a/html/mix-manifest.json
+++ b/html/mix-manifest.json
@@ -4,12 +4,12 @@
     "/css/vendor.css": "/css/vendor.css?id=2568831af31dbfc3128a",
     "/css/app.css": "/css/app.css?id=bd093a6a2e2682bb59ef",
     "/js/vendor.js": "/js/vendor.js?id=c5fd3d75a63757080dbb",
-    "/js/lang/de.js": "/js/lang/de.js?id=e2912d41c392d8bc4e2c",
-    "/js/lang/en.js": "/js/lang/en.js?id=7aed3226fceb16d522cd",
-    "/js/lang/fr.js": "/js/lang/fr.js?id=bd58747a5439aafb8330",
-    "/js/lang/it.js": "/js/lang/it.js?id=5fdcbbb097408f63d589",
+    "/js/lang/de.js": "/js/lang/de.js?id=613b5ca9cd06ca15e384",
+    "/js/lang/en.js": "/js/lang/en.js?id=a32b81c7156d48489ca3",
+    "/js/lang/fr.js": "/js/lang/fr.js?id=982d149de32e1867610c",
+    "/js/lang/it.js": "/js/lang/it.js?id=8bcb940703f9b010d5e9",
     "/js/lang/ru.js": "/js/lang/ru.js?id=f6b7c078755312a0907c",
-    "/js/lang/uk.js": "/js/lang/uk.js?id=1bba323982918f74fa33",
-    "/js/lang/zh-CN.js": "/js/lang/zh-CN.js?id=0edc19cb25bb6d36861b",
-    "/js/lang/zh-TW.js": "/js/lang/zh-TW.js?id=4d13fc5d8fdd20d417d3"
+    "/js/lang/uk.js": "/js/lang/uk.js?id=510f6f08095080a981a6",
+    "/js/lang/zh-CN.js": "/js/lang/zh-CN.js?id=4e081fbac70d969894bf",
+    "/js/lang/zh-TW.js": "/js/lang/zh-TW.js?id=ed26425647721a42ee9d"
 }

--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -466,6 +466,18 @@
             "order": 12,
             "type": "text"
         },
+        "auth_ad_starttls": {
+            "default": "disabled",
+            "group": "auth",
+            "section": "ad",
+            "order": 13,
+            "type": "select",
+            "options": {
+                "disabled": "Disabled",
+                "optional": "Optional",
+                "required": "Required"
+            }
+        },
         "auth_ldap_attr.uid": {
             "default": "uid",
             "group": "auth",

--- a/resources/lang/de/settings.php
+++ b/resources/lang/de/settings.php
@@ -210,6 +210,15 @@ return [
             'description' => 'Active Directory Benutzername',
             'help' => 'Benutzt zum durchsuchen des AD Server wenn kein Nutzer eingeloggt ist in (alerts, API, etc)',
         ],
+        'auth_ad_starttls' => [
+            'description' => 'Benutze STARTTLS',
+            'help' => 'Benutze STARTTLS um Verbindungen abzusichern.  Alternative zu LDAPS.',
+            'options' => [
+                'disabled' => 'Deaktiviert',
+                'optional' => 'Optional',
+                'required' => 'Benötigt',
+            ],
+        ],
         'auth_ldap_cache_ttl' => [
             'description' => 'LDAP Cache Gültigkeit',
             'help' => 'Speichert temporär LDAP Suchergebnisse.  Erhöht die Geschwindigkeit, aber die Daten können veraltet sein.',

--- a/resources/lang/en/settings.php
+++ b/resources/lang/en/settings.php
@@ -331,6 +331,15 @@ return [
             'description' => 'Bind username',
             'help' => 'Used to query the AD server when no user is logged in (alerts, API, etc)',
         ],
+        'auth_ad_starttls' => [
+            'description' => 'Use STARTTLS',
+            'help' => 'Use STARTTLS to secure the connection.  Alternative to LDAPS.',
+            'options' => [
+                'disabled' => 'Disabled',
+                'optional' => 'Optional',
+                'required' => 'Required',
+            ],
+        ],
         'auth_ldap_cache_ttl' => [
             'description' => 'LDAP cache expiration',
             'help' => 'Temporarily stores LDAP query results.  Improves speeds, but the data may be stale.',

--- a/resources/lang/fr/settings.php
+++ b/resources/lang/fr/settings.php
@@ -257,6 +257,15 @@ return [
             'description' => 'Utilisateur AD "bind"',
             'help' => 'Utilisé pour questionner l\'AD quand aucun autre utilisateur n\'est dans le contexte (alerts, API, etc)',
         ],
+        'auth_ad_starttls' => [
+            'description' => 'Utiliser STARTTLS',
+            'help' => 'Utiliser STARTTLS pour sécuriser la connexion.  Alternative à LDAPS.',
+            'options' => [
+                'disabled' => 'Désactivé',
+                'optional' => 'Optionnel',
+                'required' => 'Obligatoire',
+            ],
+        ],
         'auth_ldap_cache_ttl' => [
             'description' => 'Expiration du cache LDAP',
             'help' => 'Durée du cache LDAP conservant les résultats des requêtes. Meilleure réactivité mais risque de données imprécises/en retard',

--- a/resources/lang/it/settings.php
+++ b/resources/lang/it/settings.php
@@ -331,6 +331,15 @@ return [
             'description' => 'Bind username',
             'help' => 'Used to query the AD server when no user is logged in (alerts, API, etc)',
         ],
+        'auth_ad_starttls' => [
+            'description' => 'Use STARTTLS',
+            'help' => 'Use STARTTLS to secure the connection.  Alternative to LDAPS.',
+            'options' => [
+                'disabled' => 'Disabled',
+                'optional' => 'Optional',
+                'required' => 'Required',
+            ],
+        ],
         'auth_ldap_cache_ttl' => [
             'description' => 'LDAP cache expiration',
             'help' => 'Temporarily stores LDAP query results.  Improves speeds, but the data may be stale.',

--- a/resources/lang/zh-CN/settings.php
+++ b/resources/lang/zh-CN/settings.php
@@ -211,6 +211,15 @@ return [
             'description' => '系结使用者名称',
             'help' => 'Used to query the AD server when no user is logged in (alerts, API, etc)',
         ],
+        'auth_ad_starttls' => [
+            'description' => '使用 STARTTLS',
+            'help' => 'Use STARTTLS to secure the connection.  Alternative to LDAPS.',
+            'options' => [
+                'disabled' => '停用',
+                'optional' => '选用',
+                'required' => '必要',
+            ],
+        ],
         'auth_ldap_cache_ttl' => [
             'description' => 'LDAP 快取有效期',
             'help' => 'Temporarily stores LDAP query results.  Improves speeds, but the data may be stale.',

--- a/resources/lang/zh-TW/settings.php
+++ b/resources/lang/zh-TW/settings.php
@@ -265,6 +265,15 @@ return [
             'description' => '繫結使用者名稱',
             'help' => 'Used to query the AD server when no user is logged in (alerts, API, etc)',
         ],
+        'auth_ad_starttls' => [
+            'description' => '使用 STARTTLS',
+            'help' => 'Use STARTTLS to secure the connection.  Alternative to LDAPS.',
+            'options' => [
+                'disabled' => '停用',
+                'optional' => '選用',
+                'required' => '必要',
+            ],
+        ],
         'auth_ldap_cache_ttl' => [
             'description' => 'LDAP 快取有效期',
             'help' => 'Temporarily stores LDAP query results.  Improves speeds, but the data may be stale.',


### PR DESCRIPTION
This PR permits authentication method AD to upgrade to TLS by way of STARTTLS. The code is pretty much 1:1 copy/paste from the LDAP code, just with auth_ad_starttls instead of auth_ldap_starttls.

Language resources are extended with verbatim copies of the correspondig resources for auth_ldap_starttls.


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.



