### PR TITLE
Add rich (=html) support for messages via Matrix

### DIFF
--- a/LibreNMS/Alert/Transport/Matrix.php
+++ b/LibreNMS/Alert/Transport/Matrix.php
@@ -54,7 +54,7 @@ class Matrix extends Transport
 
         $message = SimpleTemplate::parse($message, $obj);
 
-        $body = ['body'=>$message, 'msgtype'=>'m.text'];
+        $body = ['body'=>strip_tags($message), 'formatted_body'=>"$message", 'msgtype'=>'m.text', 'format'=>'org.matrix.custom.html'];
 
         $client = new \GuzzleHttp\Client();
         $request_opts['proxy'] = Proxy::forGuzzle();
@@ -102,7 +102,7 @@ class Matrix extends Transport
                     'title' => 'Message',
                     'name' => 'matrix-message',
                     'descr' => 'Enter the message',
-                    'type' => 'textarea',
+                    'type' => 'text',
                 ],
             ],
             'validation' => [


### PR DESCRIPTION
Enable colouring and other html stuff for messages sent to Matrix chatrooms.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
