### PR TITLE
Add module support for wrapper script calls

### DIFF
--- a/LibreNMS/wrapper.py
+++ b/LibreNMS/wrapper.py
@@ -513,7 +513,7 @@ def wrapper(
                 "log_dir": log_dir,
                 "wrapper_type": wrapper_type,
                 "debug": _debug,
-                "modules": kwargs.get('modules', ""),
+                "modules": kwargs.get("modules", ""),
             },
         )
         worker.setDaemon(True)

--- a/LibreNMS/wrapper.py
+++ b/LibreNMS/wrapper.py
@@ -513,7 +513,7 @@ def wrapper(
                 "log_dir": log_dir,
                 "wrapper_type": wrapper_type,
                 "debug": _debug,
-                "modules": kwargs.get('modules', "")
+                "modules": kwargs.get('modules', ""),
             },
         )
         worker.setDaemon(True)
@@ -683,7 +683,7 @@ if __name__ == "__main__":
     if wrapper_type in ["discovery", "poller"]:
         modules_validated = modules
     else:
-        modules_validated = "" # ignore module parameter
+        modules_validated = ""  # ignore module parameter
 
     wrapper(
         wrapper_type,
@@ -691,5 +691,5 @@ if __name__ == "__main__":
         config,
         log_dir,
         _debug=debug,
-        modules=modules_validated
+        modules=modules_validated,
     )

--- a/LibreNMS/wrapper.py
+++ b/LibreNMS/wrapper.py
@@ -229,7 +229,7 @@ def poll_worker(
     log_dir,  # Type: str
     wrapper_type,  # Type: str
     debug,  # Type: bool
-    modules = '',  # Type: string
+    modules="",  # Type: string
 ):
     """
     This function will fork off single instances of the php process, record
@@ -281,7 +281,7 @@ def poll_worker(
                 )
                 command = "/usr/bin/env php {} -h {}".format(executable, device_id)
                 if modules is not None and len(str(modules).strip()):
-                    module_str = re.sub('\s', "", str(modules).strip())
+                    module_str = re.sub("\s", "", str(modules).strip())
                     command = command + " -m {}".format(module_str)
                 if debug:
                     command = command + " -d"
@@ -513,7 +513,7 @@ def wrapper(
                 "log_dir": log_dir,
                 "wrapper_type": wrapper_type,
                 "debug": _debug,
-                "modules": kwargs.get('modules', '')
+                "modules": kwargs.get('modules', "")
             },
         )
         worker.setDaemon(True)
@@ -637,7 +637,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "-m",
         "--modules",
-        default='',
+        default="",
         help="Enable passing of a module string, modules are separated by comma",
     )
 
@@ -653,7 +653,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     debug = args.debug
-    modules = args.modules or ''
+    modules = args.modules or ""
     wrapper_type = args.wrapper
     amount_of_workers = args.threads
 
@@ -681,6 +681,15 @@ if __name__ == "__main__":
         )
 
     if wrapper_type in ["discovery", "poller"]:
-        wrapper(wrapper_type, amount_of_workers, config, log_dir, _debug=debug, modules=modules)
+        modules_validated = modules
     else:
-        wrapper(wrapper_type, amount_of_workers, config, log_dir, _debug=debug, modules='')
+        modules_validated = "" # ignore module parameter
+
+    wrapper(
+        wrapper_type,
+        amount_of_workers,
+        config,
+        log_dir,
+        _debug=debug,
+        modules=modules_validated
+    )

--- a/LibreNMS/wrapper.py
+++ b/LibreNMS/wrapper.py
@@ -44,6 +44,7 @@
 import logging
 import os
 import queue
+import re
 import sys
 import threading
 import time
@@ -228,6 +229,7 @@ def poll_worker(
     log_dir,  # Type: str
     wrapper_type,  # Type: str
     debug,  # Type: bool
+    modules = '',  # Type: string
 ):
     """
     This function will fork off single instances of the php process, record
@@ -278,6 +280,9 @@ def poll_worker(
                     wrappers[wrapper_type]["executable"],
                 )
                 command = "/usr/bin/env php {} -h {}".format(executable, device_id)
+                if modules is not None and len(str(modules).strip()):
+                    module_str = re.sub('\s', "", str(modules).strip())
+                    command = command + " -m {}".format(module_str)
                 if debug:
                     command = command + " -d"
                 exit_code, output = command_runner(
@@ -340,6 +345,7 @@ def wrapper(
     config,  # Type: dict
     log_dir,  # Type: str
     _debug=False,  # Type: bool
+    **kwargs,  # Type: dict, may contain modules
 ):  # -> None
     """
     Actual code that runs various php scripts, in single node mode or distributed poller mode
@@ -507,6 +513,7 @@ def wrapper(
                 "log_dir": log_dir,
                 "wrapper_type": wrapper_type,
                 "debug": _debug,
+                "modules": kwargs.get('modules', '')
             },
         )
         worker.setDaemon(True)
@@ -627,6 +634,12 @@ if __name__ == "__main__":
         default=False,
         help="Enable debug output. WARNING: Leaving this enabled will consume a lot of disk space.",
     )
+    parser.add_argument(
+        "-m",
+        "--modules",
+        default='',
+        help="Enable passing of a module string, modules are separated by comma",
+    )
 
     parser.add_argument(
         dest="wrapper",
@@ -640,6 +653,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     debug = args.debug
+    modules = args.modules or ''
     wrapper_type = args.wrapper
     amount_of_workers = args.threads
 
@@ -666,4 +680,7 @@ if __name__ == "__main__":
             )
         )
 
-    wrapper(wrapper_type, amount_of_workers, config, log_dir, _debug=debug)
+    if wrapper_type in ["discovery", "poller"]:
+        wrapper(wrapper_type, amount_of_workers, config, log_dir, _debug=debug, modules=modules)
+    else:
+        wrapper(wrapper_type, amount_of_workers, config, log_dir, _debug=debug, modules='')

--- a/discovery-wrapper.py
+++ b/discovery-wrapper.py
@@ -37,7 +37,7 @@ parser.add_argument(
     "-m",
     "--modules",
     dest="modules",
-    default='',
+    default="",
     help="Enable passing of a module string, modules are separated by comma",
 )
 args = parser.parse_args()
@@ -66,6 +66,6 @@ wrapper.wrapper(
     amount_of_workers=amount_of_workers,
     config=config,
     log_dir=log_dir,
-    modules=args.modules or '',
+    modules=args.modules or "",
     _debug=args.debug,
 )

--- a/discovery-wrapper.py
+++ b/discovery-wrapper.py
@@ -33,6 +33,13 @@ parser.add_argument(
     default=False,
     help="Enable debug output. WARNING: Leaving this enabled will consume a lot of disk space.",
 )
+parser.add_argument(
+    "-m",
+    "--modules",
+    dest="modules",
+    default='',
+    help="Enable passing of a module string, modules are separated by comma",
+)
 args = parser.parse_args()
 
 config = LibreNMS.get_config_data(os.path.dirname(os.path.realpath(__file__)))
@@ -59,5 +66,6 @@ wrapper.wrapper(
     amount_of_workers=amount_of_workers,
     config=config,
     log_dir=log_dir,
+    modules=args.modules or '',
     _debug=args.debug,
 )

--- a/doc/Support/Discovery Support.md
+++ b/doc/Support/Discovery Support.md
@@ -48,6 +48,10 @@ If you need to debug the output of discovery-wrapper.py then you can
 add `-d` to the end of the command - it is NOT recommended to do this
 in cron.
 
+You also may use `-m` to pass a list of comma-separated modules.
+Please refer to [Command options](#command-options) of discovery.php.
+Example: `/opt/librenms/discovery-wrapper.py 1 -m bgp-peers`
+
 If you want to switch back to discovery.php then you can replace:
 
 `33  */6   * * *   librenms    /opt/librenms/discovery-wrapper.py 1 >> /dev/null 2>&1`

--- a/poller-wrapper.py
+++ b/poller-wrapper.py
@@ -37,7 +37,7 @@ parser.add_argument(
     "-m",
     "--modules",
     dest="modules",
-    default='',
+    default="",
     help="Enable passing of a module string, modules are separated by comma",
 )
 args = parser.parse_args()
@@ -66,6 +66,6 @@ wrapper.wrapper(
     amount_of_workers=amount_of_workers,
     config=config,
     log_dir=log_dir,
-    modules=args.modules or '',
+    modules=args.modules or "",
     _debug=args.debug,
 )

--- a/poller-wrapper.py
+++ b/poller-wrapper.py
@@ -33,6 +33,13 @@ parser.add_argument(
     default=False,
     help="Enable debug output. WARNING: Leaving this enabled will consume a lot of disk space.",
 )
+parser.add_argument(
+    "-m",
+    "--modules",
+    dest="modules",
+    default='',
+    help="Enable passing of a module string, modules are separated by comma",
+)
 args = parser.parse_args()
 
 config = LibreNMS.get_config_data(os.path.dirname(os.path.realpath(__file__)))
@@ -59,5 +66,6 @@ wrapper.wrapper(
     amount_of_workers=amount_of_workers,
     config=config,
     log_dir=log_dir,
+    modules=args.modules or '',
     _debug=args.debug,
 )


### PR DESCRIPTION
The scripts poller.php and discovery.php offer a module
option (-m), which may be used to specify specific modules
for polling/discovery, possibly for special (and thus faster) testing
or for example rediscovering the fdb table (on all hosts).

Until now, this was not possible with the python wrapper scripts.
Now they support a '-m' option, where comma separated module names
may be passed. This will currently only work with poller and discovery, though.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
