### PR TITLE
Fix the parsing of the temperature unit value (CMCIII devices)

### DIFF
--- a/includes/discovery/sensors/rittal-cmc-iii-sensors.inc.php
+++ b/includes/discovery/sensors/rittal-cmc-iii-sensors.inc.php
@@ -76,8 +76,10 @@ foreach ($cmc_iii_var_table as $index => $entry) {
                 $cmc_iii_sensors[$sensor_id]['multiplier'] = substr($entry['cmcIIIVarScale'], 1);
             }
 
-            $unit = $entry['cmcIIIVarUnit'];
+            // encode string to ensure that degree sign may be used properly for unit comparison
+            $unit = utf8_encode($entry['cmcIIIVarUnit']);
             $type = 'state';
+            $temperature_units = ['degree C', 'degree F', '°C', '°F'];
             if ($unit == 'mA') {
                 //In some cases we get a mA value. However, the cmcIIIVarScale is simply 1.
                 //Therefore, we must hardcode the divisor here to calculate the value into A.
@@ -92,7 +94,7 @@ foreach ($cmc_iii_var_table as $index => $entry) {
                 $type = 'power_consumed';
             } elseif ($unit == 'Hz') {
                 $type = 'frequency';
-            } elseif ($unit == 'degree C' || $unit == 'degree F') {
+            } elseif (in_array($unit, $temperature_units)) {
                 $type = 'temperature';
             } elseif ($unit == 'l/min') {
                 $type = 'waterflow';


### PR DESCRIPTION
CMCIII will yield the temperate unit as '°C' (or °F), which is not
'degree C'. The ° isn’t even encoded properly, so an additional
encoding is included for good measure. Both raw and encoded
values are used for the look up.

Previously these values were stored as 'state' sensor entries,
making them sadly utterly useless.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
