### PR TITLE
Missing "s" in NsBsd.php

### DIFF
--- a/LibreNMS/OS/NsBsd.php
+++ b/LibreNMS/OS/NsBsd.php
@@ -33,6 +33,6 @@ class NsBsd extends \LibreNMS\OS
     {
         parent::discoverOS($device); // yaml
 
-        $device->sysName = \SnmpQuery::get('STORMSHIELD-PROPERTY-MIB::nsSystemName.0')->value() ?: $device->sysName;
+        $device->sysName = \SnmpQuery::get('STORMSHIELD-PROPERTY-MIB::snsSystemName.0')->value() ?: $device->sysName;
     }
 }


### PR DESCRIPTION
Missing "s" in MIB "snsSystemName" see : https://www.stormshield.com/wp-content/uploads/STORMSHIELD-PROPERTY-MIB-1.txt

Tested on multiples SNS 3.11.5 and 4.2.6

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
