### PR TITLE
Search device by MAC via URL

### DIFF
--- a/includes/html/pages/search/mac.inc.php
+++ b/includes/html/pages/search/mac.inc.php
@@ -77,7 +77,7 @@ if ($_POST['interface'] == 'Vlan%') {
                "<div class=\"form-group\">"+
                "<input type=\"text\" name=\"address\" id=\"address\" value=\""+
 <?php
-echo '"' . htmlspecialchars($_REQUEST['address']) . '"+';
+echo '"' . htmlspecialchars($vars['address']) . '"+';
 ?>
 
                "\" class=\"form-control input-sm\" placeholder=\"Mac Address\"/>"+
@@ -93,7 +93,7 @@ echo '"' . htmlspecialchars($_REQUEST['address']) . '"+';
             search_type: "mac",
             device_id: '<?php echo htmlspecialchars($_POST['device_id']); ?>',
             interface: '<?php echo htmlspecialchars($_POST['interface']); ?>',
-            address: '<?php echo htmlspecialchars($_REQUEST['address']); ?>'
+            address: '<?php echo htmlspecialchars($vars['address']); ?>'
         };
     },
     url: "ajax_table.php",

--- a/includes/html/pages/search/mac.inc.php
+++ b/includes/html/pages/search/mac.inc.php
@@ -77,7 +77,7 @@ if ($_POST['interface'] == 'Vlan%') {
                "<div class=\"form-group\">"+
                "<input type=\"text\" name=\"address\" id=\"address\" value=\""+
 <?php
-echo '"' . htmlspecialchars($_POST['address']) . '"+';
+echo '"' . htmlspecialchars($_REQUEST['address']) . '"+';
 ?>
 
                "\" class=\"form-control input-sm\" placeholder=\"Mac Address\"/>"+
@@ -93,7 +93,7 @@ echo '"' . htmlspecialchars($_POST['address']) . '"+';
             search_type: "mac",
             device_id: '<?php echo htmlspecialchars($_POST['device_id']); ?>',
             interface: '<?php echo htmlspecialchars($_POST['interface']); ?>',
-            address: '<?php echo htmlspecialchars($_POST['address']); ?>'
+            address: '<?php echo htmlspecialchars($_REQUEST['address']); ?>'
         };
     },
     url: "ajax_table.php",

--- a/includes/html/table/address-search.inc.php
+++ b/includes/html/table/address-search.inc.php
@@ -37,7 +37,7 @@ if ($vars['search_type'] == 'ipv4') {
     }
 } elseif ($vars['search_type'] == 'mac') {
     $sql = ' FROM `ports` AS I, `devices` AS D';
-    $sql .= " WHERE I.device_id = D.device_id AND `ifPhysAddress` LIKE '%" . str_replace([':', ' ', '-', '.', '0x'], '', $vars['address']) . "%' $where ";
+    $sql .= " WHERE I.device_id = D.device_id AND `ifPhysAddress` LIKE '%" . trim(str_replace([':', ' ', '-', '.', '0x'], '', $vars['address'])) . "%' $where ";
 }//end if
 if (is_numeric($vars['device_id'])) {
     $sql .= ' AND I.device_id = ?';


### PR DESCRIPTION
This change allows to perform a MAC search via URL by adding **variable** `address`, instead of having to provide a form with the information. For example:

```
https://librenms.local/search/search=mac/address=60:01:01:11:22:33
```

This allows to directly show the device list (usually with a single device).

ℹ️ Also a minor filter: `address` is **filtered** with `trim` to remove trailing spaces (tabs).
When copying MAC address from table and pasting, chances are the user is also copying a "tab character".
By adding `trim`, this space gets removed, and the query is returned successfully.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
