### PR TITLE
Increase traceroute timeout

### DIFF
--- a/LibreNMS/Polling/ConnectivityHelper.php
+++ b/LibreNMS/Polling/ConnectivityHelper.php
@@ -146,6 +146,7 @@ class ConnectivityHelper
         }
 
         $process = new Process($command);
+        $process->setTimeout(120);
         $process->run();
 
         return [


### PR DESCRIPTION
traceroute going to 30hops with a 3s timeout was exceeding the default execution time and throwing an exception.
https://community.librenms.org/t/possible-bug-in-polling/19061

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
