### PR TITLE
Fix Cisco polling BGP peers in non-default VRF

### DIFF
--- a/includes/polling/bgp-peers.inc.php
+++ b/includes/polling/bgp-peers.inc.php
@@ -48,7 +48,13 @@ if (\LibreNMS\Config::get('enable_bgp')) {
                 echo "Checking BGP peer $peer_ip ";
 
                 // --- Collect BGP data ---
-                if (count($peer_data_check) > 0) {
+                // If a Cisco device has BGP peers in VRF(s),
+                // but no BGP peers in the default VRF,
+                // a SNMP (v3) walk without context will not find any
+                // cbgpPeer2RemoteAs, resulting in empty $peer_data_check.
+                // Without the or clause, we won't see the VRF BGP peers.
+                // ($peer_data_check isn't used in the Cisco code path,)
+                if (count($peer_data_check) > 0 || ($device['os_group'] == 'cisco' && count(DeviceCache::getPrimary()->getVrfContexts()) > 1)) {
                     if ($generic) {
                         echo "\nfallback to default mib";
 


### PR DESCRIPTION
 (comments and commented out code left on purpose)

If a Cisco device has VRFs defined and BGP peers configured in those VRFs, but no BGP sessions/peers in the default VRF, a SNMP (v3) walk without context will not find any cbgpPeer2RemoteAs in the code at the top of `includes/polling/bgp-peers.inc.php`. The line for os_group cisco populating `$peer_data_check` will return an empty Array:
```
$peer_data_check = snmpwalk_cache_oid($device, 'cbgpPeer2RemoteAs', [], 'CISCO-BGP4-MIB');
```
This causes the code further below in the same file to skip reading the BGP peer data for the peers in the VRFs.

We've observed the issue on at least these devices and software:
- Cisco Nexus 9000 series, running NX-OS 9.3.8 and 9.3.9
- Cisco ASR 9901 running IOS-XR 7.3.2

... but the issue will be present on all Cisco devices with BGP peers in VRFs, and no BGP peers in the default VRF.

NB: although the code changes the polling, it doesn't add or change the SNMP queries or parsing thereof. Changing to tests/data/pfsense_frr-bgp.json shouldn't be necessary.

fixes  #14104

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [X] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
