### PR TITLE
Fix config seeder will never run

### DIFF
--- a/database/seeders/ConfigSeeder.php
+++ b/database/seeders/ConfigSeeder.php
@@ -57,11 +57,15 @@ class ConfigSeeder extends Seeder
             return; // nothing to do
         }
 
-        if (\App\Models\Config::exists() && ! getenv('REAPPLY_YAML_CONFIG')) {
+        $reapply = getenv('REAPPLY_YAML_CONFIG');
+
+        if (Config::get('config_seeded') && ! $reapply) {
             if (! app()->runningInConsole() || ! $this->command->confirm(trans('commands.db:seed.existing_config'), false)) {
                 return; // don't overwrite existing settings.
             }
         }
+
+        $skipped_existing = false;
 
         foreach ($files as $file) {
             $settings = Yaml::parse(file_get_contents($file));
@@ -71,8 +75,22 @@ class ConfigSeeder extends Seeder
                     continue;
                 }
 
+                if (! $reapply && \App\Models\Config::where('config_name', $key)->exists()) {
+                    if (! \App\Models\Config::where('config_name', $key)->value('config_value') == $value) {
+                        echo 'Skipped existing config key: ' . json_encode($key) . PHP_EOL;
+                        $skipped_existing = true;
+                    }
+                    continue;
+                }
+
                 Config::persist($key, $value);
             }
+        }
+
+        Config::persist('config_seeded', true);
+
+        if ($skipped_existing) {
+            echo 'Skipped overwritting existing config settings.  To overwrite them, run: REAPPLY_YAML_CONFIG=1 lnms db:seed' . PHP_EOL;
         }
     }
 }

--- a/database/seeders/ConfigSeeder.php
+++ b/database/seeders/ConfigSeeder.php
@@ -90,7 +90,7 @@ class ConfigSeeder extends Seeder
         Config::persist('config_seeded', true);
 
         if ($skipped_existing) {
-            echo 'Skipped overwritting existing config settings.  To overwrite them, run: REAPPLY_YAML_CONFIG=1 lnms db:seed' . PHP_EOL;
+            echo 'Skipped overwriting existing config settings.  To overwrite them, run: REAPPLY_YAML_CONFIG=1 lnms db:seed' . PHP_EOL;
         }
     }
 }


### PR DESCRIPTION
Because of startup processes, the config database is never empty.
Use config_seeded variable to detect if the config has been seeded.
But don't clobber settings that already exist in the database unless REAPPLY_YAML_CONFIG is set
Don't notify for existing settings that match, give tip that REAPPLY_YAML_CONFIG exists

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
