### PR TITLE
Allow Custom OIDs to interpret hex output

### DIFF
--- a/includes/polling/customoid.inc.php
+++ b/includes/polling/customoid.inc.php
@@ -18,6 +18,9 @@ foreach (dbFetchRows('SELECT * FROM `customoids` WHERE `customoid_passed` = 1 AN
     if (is_numeric($rawdata)) {
         $os->enableGraph('customoid');
         $oid_value = $rawdata;
+    } elseif (isHexString($rawdata) && is_numeric(string_to_float(snmp_hexstring($rawdata)))) {
+        $os->enableGraph('customoid');
+       $oid_value = string_to_float(snmp_hexstring($rawdata));
     } elseif (
         $customoid['customoid_unit'] &&
         str_i_contains($rawdata, $customoid['customoid_unit']) &&


### PR DESCRIPTION
When a custom OID output is in hexadecimal form, the existing implementation will chop and trim, and usually return the first two characters.  Using the existing `isHexString` and `snmp_hexstring` methods we can check for, and convert this data to accommodate manufacturers who are not playing completely by the rules.

It could be argued that the `is_numeric` check can be broken out, and both string and numeric results could be in, with only numerics getting the `enableGraph`treatment.  I can submit an additional commit for that if there's a desire.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [X] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
