### PR TITLE
Option discovery_remove_domain to strip domainname from FQDN 

### DIFF
--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -44,6 +44,9 @@ function discover_new_device($hostname, $device = [], $method = '', $interface =
                 $hostname = $full_host;
             }
         }
+        if (Config::get('discovery_remove_domain', true)) {
+            if (str_contains($hostname,".") ) $hostname = substr($hostname,0,strpos($hostname,".") );
+        }
 
         $ip = gethostbyname($hostname);
         if ($ip == $hostname) {

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -45,7 +45,7 @@ function discover_new_device($hostname, $device = [], $method = '', $interface =
             }
         }
         if (Config::get('discovery_remove_domain', true)) {
-            if (str_contains($hostname,".") ) $hostname = substr($hostname,0,strpos($hostname,".") );
+            if (str_contains($hostname, '.')) $hostname = substr($hostname, 0 , strpos($hostname, '.'));
         }
 
         $ip = gethostbyname($hostname);

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -45,7 +45,9 @@ function discover_new_device($hostname, $device = [], $method = '', $interface =
             }
         }
         if (Config::get('discovery_remove_domain', true)) {
-            if (str_contains($hostname, '.')) $hostname = substr($hostname, 0 , strpos($hostname, '.'));
+            if (str_contains($hostname, '.')) {
+                $hostname = substr($hostname, 0 , strpos($hostname, '.'));
+            }
         }
 
         $ip = gethostbyname($hostname);


### PR DESCRIPTION
Please give a short description what your pull request is for

Added an extra option discovery_remove_domain to strip the domainname port from a FQDN hostname to only have the short hostname be added as hostname.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
