### PR TITLE
Prevent duplicate plugin table entries

### DIFF
--- a/app/Plugins/PluginManager.php
+++ b/app/Plugins/PluginManager.php
@@ -189,7 +189,11 @@ class PluginManager
 
         if (! $plugin) {
             try {
-                $plugin = Plugin::create([
+                // plugin should not exist, but check for safety
+                $plugin = Plugin::firstOrCreate([
+                    'version' => 2,
+                    'plugin_name' => $name,
+                ], [
                     'plugin_name' => $name,
                     'plugin_active' => $name !== 'ExamplePlugin',
                     'version' => 2,

--- a/database/migrations/2022_07_19_081224_plugins_unique_index.php
+++ b/database/migrations/2022_07_19_081224_plugins_unique_index.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class PluginsUniqueIndex extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // cleanup duplicates
+        $plugins = DB::table('plugins')->groupBy(['version', 'plugin_name'])->select(['version', 'plugin_name'])->get();
+        $valid_plugins = [];
+        foreach ($plugins as $plugin) {
+            // find the newest id with settings
+            $valid_plugins[] = DB::table('plugins')
+                ->where(['version' => $plugin->version, 'plugin_name' => $plugin->plugin_name])
+                ->orderBy('settings', 'DESC')
+                ->orderBy('plugin_id', 'DESC')
+                ->value('plugin_id');
+        }
+        DB::table('plugins')->whereNotIn('plugin_id', $valid_plugins)->delete();
+
+        Schema::table('plugins', function (Blueprint $table) {
+            $table->unique(['version', 'plugin_name']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('plugins', function (Blueprint $table) {
+            $table->dropUnique('plugins_version_plugin_name_unique');
+        });
+    }
+}

--- a/misc/db_schema.yaml
+++ b/misc/db_schema.yaml
@@ -1356,6 +1356,7 @@ plugins:
     - { Field: settings, Type: longtext, 'Null': true, Extra: '' }
   Indexes:
     PRIMARY: { Name: PRIMARY, Columns: [plugin_id], Unique: true, Type: BTREE }
+    plugins_version_plugin_name_unique: { Name: plugins_version_plugin_name_unique, Columns: [version, plugin_name], Unique: true, Type: BTREE }
 pollers:
   Columns:
     - { Field: id, Type: 'int unsigned', 'Null': false, Extra: auto_increment }


### PR DESCRIPTION
Some sort of race condition.
Add a unique index, this will cause the create query to fail when it tries to add a new entry for an existing plugin.

fixes #14032 

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
