### PR TITLE
lnms device:poll better feedback

### DIFF
--- a/LibreNMS/Poller.php
+++ b/LibreNMS/Poller.php
@@ -154,6 +154,14 @@ class Poller
         return $polled;
     }
 
+    /**
+     * Get the total number of devices to poll.
+     */
+    public function totalDevices(): int
+    {
+        return $this->buildDeviceQuery()->count();
+    }
+
     private function pollModules(): void
     {
         $this->filterModules();

--- a/app/Console/Commands/DevicePoll.php
+++ b/app/Console/Commands/DevicePoll.php
@@ -81,6 +81,7 @@ class DevicePoll extends LnmsCommand
         }
 
         $this->error(trans('commands.device:poll.errors.none_polled'));
+
         return 1; // failed to poll
     }
 }

--- a/resources/lang/en/commands.php
+++ b/resources/lang/en/commands.php
@@ -110,7 +110,7 @@ return [
     'device:poll' => [
         'description' => 'Poll data from device(s) as defined by discovery',
         'arguments' => [
-            'device spec' => 'Device spec to poll: device_id, hostname, wildcard, odd, even, all',
+            'device spec' => 'Device spec to poll: device_id, hostname, wildcard (*), odd, even, all',
         ],
         'options' => [
             'modules' => 'Specify single module to be run. Comma separate modules, submodules may be added with /',

--- a/resources/lang/en/commands.php
+++ b/resources/lang/en/commands.php
@@ -119,7 +119,10 @@ return [
         'errors' => [
             'db_connect' => 'Failed to connect to database. Verify database service is running and connection settings.',
             'db_auth' => 'Failed to connect to database. Verify credentials: :error',
+            'no_devices' => 'No devices found matching your given device specification.',
+            'none_polled' => 'No devices were polled.',
         ],
+        'polled' => 'Polled :count devices in :time',
     ],
     'key:rotate' => [
         'description' => 'Rotate APP_KEY, this decrypts all encrypted data with the given old key and stores it with the new key in APP_KEY.',


### PR DESCRIPTION
Feedback when 0 devices are found to poll or 0 devices are polled.
Make devices polled summary string translatable.
Additional info on what the wildcard is

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
