### PR TITLE
Support for SSL/TLS protected connections to MySQL databases

### DIFF
--- a/LibreNMS/__init__.py
+++ b/LibreNMS/__init__.py
@@ -421,8 +421,8 @@ class ThreadingLock(Lock):
 
 class RedisLock(Lock):
     def __init__(self, namespace="lock", **redis_kwargs):
-        import redis
-        from redis.sentinel import Sentinel
+        import redis  # pylint: disable=import-error
+        from redis.sentinel import Sentinel  # pylint: disable=import-error
 
         redis_kwargs["decode_responses"] = True
         if redis_kwargs.get("sentinel") and redis_kwargs.get("sentinel_service"):
@@ -458,7 +458,7 @@ class RedisLock(Lock):
         :param owner: str a unique name for the locking node
         :param expiration: int in seconds, 0 expiration means forever
         """
-        import redis
+        import redis  # pylint: disable=import-error
 
         try:
             if int(expiration) < 1:
@@ -503,8 +503,8 @@ class RedisLock(Lock):
 
 class RedisUniqueQueue(object):
     def __init__(self, name, namespace="queue", **redis_kwargs):
-        import redis
-        from redis.sentinel import Sentinel
+        import redis  # pylint: disable=import-error
+        from redis.sentinel import Sentinel  # pylint: disable=import-error
 
         redis_kwargs["decode_responses"] = True
         if redis_kwargs.get("sentinel") and redis_kwargs.get("sentinel_service"):

--- a/LibreNMS/__init__.py
+++ b/LibreNMS/__init__.py
@@ -253,7 +253,7 @@ class DB:
                 logger.debug("Using cleartext MySQL connection")
             elif sslmode == "verify_ca":
                 logger.info(
-                    "Using TLS MySQL connection without CA trust validation only"
+                    "Using TLS MySQL connection without CN/SAN check (CA validation only)"
                 )
                 args["ssl"] = {"ca": self.config.db_ssl_ca, "check_hostname": False}
             elif sslmode == "verify_identity":

--- a/LibreNMS/__init__.py
+++ b/LibreNMS/__init__.py
@@ -26,7 +26,7 @@ from .service import Service, ServiceConfig
 
 # Hard limit script execution time so we don't get to "hang"
 DEFAULT_SCRIPT_TIMEOUT = 3600
-MAX_LOGFILE_SIZE = (1024 ** 2) * 10  # 10 Megabytes max log files
+MAX_LOGFILE_SIZE = (1024**2) * 10  # 10 Megabytes max log files
 
 logger = logging.getLogger(__name__)
 
@@ -249,16 +249,21 @@ class DB:
                 args["unix_socket"] = self.config.db_socket
 
             sslmode = self.config.db_sslmode.lower()
-            if sslmode == 'disabled':
+            if sslmode == "disabled":
                 logger.debug("Using cleartext MySQL connection")
-            elif sslmode == 'verify_ca':
-                logger.info("Using TLS MySQL connection without CA trust validation only")
+            elif sslmode == "verify_ca":
+                logger.info(
+                    "Using TLS MySQL connection without CA trust validation only"
+                )
                 args["ssl"] = {"ca": self.config.db_ssl_ca, "check_hostname": False}
-            elif sslmode == 'verify_identity':
+            elif sslmode == "verify_identity":
                 logger.info("Using TLS MySQL connection with full validation")
                 args["ssl"] = {"ca": self.config.db_ssl_ca}
             else:
-                logger.critical("Unsupported MySQL sslmode %s, dispatcher supports DISABLED, VERIFY_CA, and VERIFY_IDENTITY only", self.config.db_sslmode)
+                logger.critical(
+                    "Unsupported MySQL sslmode %s, dispatcher supports DISABLED, VERIFY_CA, and VERIFY_IDENTITY only",
+                    self.config.db_sslmode,
+                )
                 raise SystemExit(2)
 
             conn = MySQLdb.connect(**args)

--- a/LibreNMS/__init__.py
+++ b/LibreNMS/__init__.py
@@ -248,6 +248,19 @@ class DB:
             if self.config.db_socket:
                 args["unix_socket"] = self.config.db_socket
 
+            sslmode = self.config.db_sslmode.lower()
+            if sslmode == 'disabled':
+                logger.debug("Using cleartext MySQL connection")
+            elif sslmode == 'verify_ca':
+                logger.info("Using TLS MySQL connection without CA trust validation only")
+                args["ssl"] = {"ca": self.config.db_ssl_ca, "check_hostname": False}
+            elif sslmode == 'verify_identity':
+                logger.info("Using TLS MySQL connection with full validation")
+                args["ssl"] = {"ca": self.config.db_ssl_ca}
+            else:
+                logger.critical("Unsupported MySQL sslmode %s, dispatcher supports DISABLED, VERIFY_CA, and VERIFY_IDENTITY only", self.config.db_sslmode)
+                raise SystemExit(2)
+
             conn = MySQLdb.connect(**args)
             conn.autocommit(True)
             conn.ping(True)

--- a/LibreNMS/__init__.py
+++ b/LibreNMS/__init__.py
@@ -313,31 +313,6 @@ class DB:
             conn.close()
 
 
-class DBConfig:
-    """
-    Bare minimal config class for LibreNMS.DB class usage
-    """
-
-    # Start with defaults and override
-    db_host = "localhost"
-    db_port = 0
-    db_socket = None
-    db_user = "librenms"
-    db_pass = ""
-    db_name = "librenms"
-    db_sslmode = "disabled"
-    db_ssl_ca = "/etc/ssl/certs/ca-certificates.crt"
-
-    def populate(self, _config):
-        for key, val in _config.items():
-            if key == "db_port":
-                # Special case: port number
-                self.db_port = int(val)
-            elif key.startswith("db_"):
-                # Prevent prototype pollution by enforcing prefix
-                setattr(DBConfig, key, val)
-
-
 class RecurringTimer:
     def __init__(self, duration, target, thread_name=None):
         self.duration = duration

--- a/LibreNMS/__init__.py
+++ b/LibreNMS/__init__.py
@@ -313,6 +313,32 @@ class DB:
             conn.close()
 
 
+class DBConfig:
+    """
+    Bare minimal config class for LibreNMS.DB class usage
+    """
+
+    def __init__(self):
+        # Start with defaults and override
+        self.db_host = "localhost"
+        self.db_port = 0
+        self.db_socket = None
+        self.db_user = "librenms"
+        self.db_pass = ""
+        self.db_name = "librenms"
+        self.db_sslmode = "disabled"
+        self.db_ssl_ca = "/etc/ssl/certs/ca-certificates.crt"
+
+    def populate(self, _config):
+        for key, val in _config.items():
+            if key == "db_port":
+                # Special case: port number
+                self.db_port = int(val)
+            elif key.startswith("db_"):
+                # Prevent prototype pollution by enforcing prefix
+                setattr(self, key, val)
+
+
 class RecurringTimer:
     def __init__(self, duration, target, thread_name=None):
         self.duration = duration

--- a/LibreNMS/__init__.py
+++ b/LibreNMS/__init__.py
@@ -318,16 +318,15 @@ class DBConfig:
     Bare minimal config class for LibreNMS.DB class usage
     """
 
-    def __init__(self):
-        # Start with defaults and override
-        self.db_host = "localhost"
-        self.db_port = 0
-        self.db_socket = None
-        self.db_user = "librenms"
-        self.db_pass = ""
-        self.db_name = "librenms"
-        self.db_sslmode = "disabled"
-        self.db_ssl_ca = "/etc/ssl/certs/ca-certificates.crt"
+    # Start with defaults and override
+    db_host = "localhost"
+    db_port = 0
+    db_socket = None
+    db_user = "librenms"
+    db_pass = ""
+    db_name = "librenms"
+    db_sslmode = "disabled"
+    db_ssl_ca = "/etc/ssl/certs/ca-certificates.crt"
 
     def populate(self, _config):
         for key, val in _config.items():
@@ -336,7 +335,7 @@ class DBConfig:
                 self.db_port = int(val)
             elif key.startswith("db_"):
                 # Prevent prototype pollution by enforcing prefix
-                setattr(self, key, val)
+                setattr(DBConfig, key, val)
 
 
 class RecurringTimer:

--- a/LibreNMS/config.py
+++ b/LibreNMS/config.py
@@ -1,0 +1,23 @@
+class DBConfig:
+    """
+    Bare minimal config class for LibreNMS.DB class usage
+    """
+
+    # Start with defaults and override
+    db_host = "localhost"
+    db_port = 0
+    db_socket = None
+    db_user = "librenms"
+    db_pass = ""
+    db_name = "librenms"
+    db_sslmode = "disabled"
+    db_ssl_ca = "/etc/ssl/certs/ca-certificates.crt"
+
+    def populate(self, _config):
+        for key, val in _config.items():
+            if key == "db_port":
+                # Special case: port number
+                self.db_port = int(val)
+            elif key.startswith("db_"):
+                # Prevent prototype pollution by enforcing prefix
+                setattr(DBConfig, key, val)

--- a/LibreNMS/service.py
+++ b/LibreNMS/service.py
@@ -7,6 +7,7 @@ import time
 import pymysql  # pylint: disable=import-error
 
 import LibreNMS
+from LibreNMS.config import DBConfig
 
 try:
     import psutil
@@ -37,7 +38,7 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 
-class ServiceConfig(LibreNMS.DBConfig):
+class ServiceConfig(DBConfig):
     def __init__(self):
         """
         Stores all of the configuration variables for the LibreNMS service in a common object

--- a/LibreNMS/service.py
+++ b/LibreNMS/service.py
@@ -4,7 +4,7 @@ import sys
 import threading
 import time
 
-import pymysql
+import pymysql  # pylint: disable=import-error
 
 import LibreNMS
 

--- a/LibreNMS/service.py
+++ b/LibreNMS/service.py
@@ -102,6 +102,8 @@ class ServiceConfig:
     db_user = "librenms"
     db_pass = ""
     db_name = "librenms"
+    db_sslmode = "disabled"
+    db_ssl_ca = "/etc/ssl/certs/ca-certificates.crt"
 
     watchdog_enabled = False
     watchdog_logfile = "logs/librenms.log"
@@ -226,6 +228,12 @@ class ServiceConfig:
         )
         self.db_user = os.getenv(
             "DB_USERNAME", config.get("db_user", ServiceConfig.db_user)
+        )
+        self.db_sslmode = os.getenv(
+            "DB_SSLMODE", config.get("db_sslmode", ServiceConfig.db_sslmode)
+        )
+        self.db_ssl_ca = os.getenv(
+            "MYSQL_ATTR_SSL_CA", config.get("db_ssl_ca", ServiceConfig.db_ssl_ca)
         )
 
         self.watchdog_enabled = config.get(

--- a/LibreNMS/service.py
+++ b/LibreNMS/service.py
@@ -43,7 +43,6 @@ class ServiceConfig(LibreNMS.DBConfig):
         Stores all of the configuration variables for the LibreNMS service in a common object
         Starts with defaults, but can be populated with variables from config.php by calling populate()
         """
-        super().__init__()
         self._uuid = str(uuid1())
         self.set_name(gethostname())
 

--- a/LibreNMS/service.py
+++ b/LibreNMS/service.py
@@ -37,12 +37,13 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 
-class ServiceConfig:
+class ServiceConfig(LibreNMS.DBConfig):
     def __init__(self):
         """
         Stores all of the configuration variables for the LibreNMS service in a common object
         Starts with defaults, but can be populated with variables from config.php by calling populate()
         """
+        super().__init__()
         self._uuid = str(uuid1())
         self.set_name(gethostname())
 
@@ -95,15 +96,6 @@ class ServiceConfig:
     redis_sentinel = None
     redis_sentinel_service = None
     redis_timeout = 60
-
-    db_host = "localhost"
-    db_port = 0
-    db_socket = None
-    db_user = "librenms"
-    db_pass = ""
-    db_name = "librenms"
-    db_sslmode = "disabled"
-    db_ssl_ca = "/etc/ssl/certs/ca-certificates.crt"
 
     watchdog_enabled = False
     watchdog_logfile = "logs/librenms.log"

--- a/LibreNMS/wrapper.py
+++ b/LibreNMS/wrapper.py
@@ -52,6 +52,7 @@ from argparse import ArgumentParser
 
 import LibreNMS
 from LibreNMS.command_runner import command_runner
+from LibreNMS.config import DBConfig
 
 
 logger = logging.getLogger(__name__)
@@ -445,7 +446,7 @@ def wrapper(
         logger.critical("Bogus wrapper type called")
         sys.exit(3)
 
-    sconfig = LibreNMS.DBConfig()
+    sconfig = DBConfig()
     sconfig.populate(config)
     db_connection = LibreNMS.DB(sconfig)
     cursor = db_connection.query(query)

--- a/LibreNMS/wrapper.py
+++ b/LibreNMS/wrapper.py
@@ -320,20 +320,6 @@ def poll_worker(
         poll_queue.task_done()
 
 
-class DBConfig:
-    """
-    Bare minimal config class for LibreNMS.service.DB class usage
-    """
-
-    def __init__(self, _config):
-        self.db_socket = _config["db_socket"]
-        self.db_host = _config["db_host"]
-        self.db_port = int(_config["db_port"])
-        self.db_user = _config["db_user"]
-        self.db_pass = _config["db_pass"]
-        self.db_name = _config["db_name"]
-
-
 def wrapper(
     wrapper_type,  # Type: str
     amount_of_workers,  # Type: int
@@ -459,7 +445,8 @@ def wrapper(
         logger.critical("Bogus wrapper type called")
         sys.exit(3)
 
-    sconfig = DBConfig(config)
+    sconfig = LibreNMS.DBConfig()
+    sconfig.populate(config)
     db_connection = LibreNMS.DB(sconfig)
     cursor = db_connection.query(query)
     devices = cursor.fetchall()

--- a/config/database.php
+++ b/config/database.php
@@ -66,7 +66,7 @@ return [
             'prefix_indexes' => true,
             'strict' => true,
             'engine' => null,
-            'sslmode' => env('DB_SSLMODE', 'prefer'),
+            'sslmode' => env('DB_SSLMODE', 'disabled'),
             'options' => extension_loaded('pdo_mysql') ? array_filter([
                 PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
             ]) : [],

--- a/config/database.php
+++ b/config/database.php
@@ -66,6 +66,7 @@ return [
             'prefix_indexes' => true,
             'strict' => true,
             'engine' => null,
+            'sslmode' => env('DB_SSLMODE', 'prefer'),
             'options' => extension_loaded('pdo_mysql') ? array_filter([
                 PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
             ]) : [],


### PR DESCRIPTION
This changeset enables the use of SSL/TLS protected connections to MySQL databases in both the UI/poller as well as the dispatcher service.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [NA] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [NA] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
