### PR TITLE
Improvements to PagerDuty alert formatting

### DIFF
--- a/LibreNMS/Alert/Transport/Pagerduty.php
+++ b/LibreNMS/Alert/Transport/Pagerduty.php
@@ -53,7 +53,8 @@ class Pagerduty extends Transport
      */
     public function contactPagerduty($obj, $config)
     {
-        $custom_details = ['message' => strip_tags($obj['msg']) ?: 'Test'];
+        $safe_message = strip_tags($obj['msg']) ?: 'Test';
+        $custom_details = ['message' => explode("\n", $safe_message)];
         $data = [
             'routing_key'  => $config['service_key'],
             'event_action' => $obj['event_type'],

--- a/LibreNMS/Alert/Transport/Pagerduty.php
+++ b/LibreNMS/Alert/Transport/Pagerduty.php
@@ -54,7 +54,7 @@ class Pagerduty extends Transport
     public function contactPagerduty($obj, $config)
     {
         $safe_message = strip_tags($obj['msg']) ?: 'Test';
-        $custom_details = ['message' => explode("\n", $safe_message)];
+        $custom_details = ['message' => array_filter(explode("\n", $safe_message), 'strlen')];
         $data = [
             'routing_key'  => $config['service_key'],
             'event_action' => $obj['event_type'],


### PR DESCRIPTION
This change makes the following general usability improvements to alerts dispatched to PagerDuty:

- Alert body is formatted as JSON list in the request to PagerDuty. This causes the PD webUI and mobile app to render the alert as a 1-column table with one line of the original alert per row. Otherwise, the PD webUI and mobile app simply suppresses newlines leading to a rather difficult to comprehend alert, especially in the case of longer outputs.

- Empty (zero-length) lines are removed in alert payloads sent to PagerDuty.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
