### PR TITLE
Correct logic for recurring alert rules that span UTC days

### DIFF
--- a/tests/Feature/TestScheduledMaintenance.php
+++ b/tests/Feature/TestScheduledMaintenance.php
@@ -48,8 +48,8 @@ class TestScheduledMaintenance extends DBTestCase
         $this->assertScheduleActive(Carbon::parse('2020-09-10 2:00'), $schedule);
         $this->assertScheduleSet(Carbon::parse('2020-09-10 1:59'), $schedule);
         $this->assertScheduleActive(Carbon::parse('2020-09-10 19:59'), $schedule);
-//        $this->assertScheduleSet(Carbon::parse('2020-09-10 20:01'), $schedule); // FIXME broken since end is 1am UTC
-//        $this->assertScheduleSet(Carbon::parse('2020-09-11 01:00'), $schedule);
+        $this->assertScheduleSet(Carbon::parse('2020-09-10 20:01'), $schedule); // FIXME broken since end is 1am UTC
+        $this->assertScheduleSet(Carbon::parse('2020-09-11 01:00'), $schedule);
         $this->assertScheduleActive(Carbon::parse('2020-09-11 11:00'), $schedule);
         $this->assertScheduleSet(Carbon::parse('2020-09-12 11:00'), $schedule);
         $this->assertScheduleActive(Carbon::parse('2020-09-14 10:00'), $schedule);

--- a/tests/Feature/TestScheduledMaintenance.php
+++ b/tests/Feature/TestScheduledMaintenance.php
@@ -48,7 +48,7 @@ class TestScheduledMaintenance extends DBTestCase
         $this->assertScheduleActive(Carbon::parse('2020-09-10 2:00'), $schedule);
         $this->assertScheduleSet(Carbon::parse('2020-09-10 1:59'), $schedule);
         $this->assertScheduleActive(Carbon::parse('2020-09-10 19:59'), $schedule);
-        $this->assertScheduleSet(Carbon::parse('2020-09-10 20:01'), $schedule); // FIXME broken since end is 1am UTC
+        $this->assertScheduleSet(Carbon::parse('2020-09-10 20:01'), $schedule);
         $this->assertScheduleSet(Carbon::parse('2020-09-11 01:00'), $schedule);
         $this->assertScheduleActive(Carbon::parse('2020-09-11 11:00'), $schedule);
         $this->assertScheduleSet(Carbon::parse('2020-09-12 11:00'), $schedule);


### PR DESCRIPTION
This change addresses a bug where the behavior of recurring alert rules that span days (after conversion to UTC) in the polling/alerting processes differs from the status (set or current) reported via the UI.

Specifically in the existing / suspected buggy implementation, the logic for the UI here: https://github.com/librenms/librenms/blob/master/app/Models/AlertSchedule.php#L165

...is not logically/functionally equivalent to the database query at https://github.com/librenms/librenms/blob/master/app/Models/AlertSchedule.php#L192 used when actually dispatching alerts.

Therefore, this change updates the DB query logic to be logically equivalent to what is shown in the UI, under the only assumption that the timezone configured on the poller running the alerting task and the timezone on the UI server are identical.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [X] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
