### PR TITLE
Fix 500 error in validation when UI containers and poller containers have differing node_ids

### DIFF
--- a/LibreNMS/Validations/DistributedPoller.php
+++ b/LibreNMS/Validations/DistributedPoller.php
@@ -99,7 +99,7 @@ class DistributedPoller extends BaseValidation
         }
 
         $node = PollerCluster::firstWhere('node_id', config('librenms.node_id'));
-        if (is_null($node) || (! $node->exists)) {
+        if (is_null($node)) {
             $validator->fail('Dispatcher service is enabled on your cluster, but not in use on this node');
 
             return;

--- a/LibreNMS/Validations/DistributedPoller.php
+++ b/LibreNMS/Validations/DistributedPoller.php
@@ -99,7 +99,7 @@ class DistributedPoller extends BaseValidation
         }
 
         $node = PollerCluster::firstWhere('node_id', config('librenms.node_id'));
-        if (! $node->exists) {
+        if (is_null($node) || (! $node->exists)) {
             $validator->fail('Dispatcher service is enabled on your cluster, but not in use on this node');
 
             return;


### PR DESCRIPTION
This change fixes a 500 error during validation that is observed in containerized deployments of LibreNMS where the node_id field of UI/API server containers is unique and not equal to the poller containers.

Expected behavior in this case would be for the message "Dispatcher service is enabled on your cluster, but not in use on this node" to be printed.


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
