### PR TITLE
replace git show --no-patch option with --quiet

### DIFF
--- a/LibreNMS/Util/Version.php
+++ b/LibreNMS/Util/Version.php
@@ -76,7 +76,7 @@ class Version
     {
         if ($this->is_git_install) {
             $install_dir = base_path();
-            $version_process = new Process(['git', 'show', '--no-patch', '--pretty=%H|%ct'], $install_dir);
+            $version_process = new Process(['git', 'show', '--quiet', '--pretty=%H|%ct'], $install_dir);
             $version_process->run();
 
             // failed due to permissions issue

--- a/LibreNMS/Validations/Updates.php
+++ b/LibreNMS/Validations/Updates.php
@@ -66,7 +66,7 @@ class Updates extends BaseValidation
             $remote_ver = Version::get()->remoteCommit();
             if ($local_ver['sha'] != ($remote_ver['sha'] ?? null)) {
                 if (empty($local_ver['date'])) {
-                    $process = new Process(['git', 'show', '--no-patch', '--pretty=%H|%ct'], base_path());
+                    $process = new Process(['git', 'show', '--queit', '--pretty=%H|%ct'], base_path());
                     $process->run();
                     $error = rtrim($process->getErrorOutput());
 


### PR DESCRIPTION
Older versions of git do not support --no-patch or -q, but both older and modern versions support --quiet.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
