### PR TITLE
IPv6 Debug typo

### DIFF
--- a/LibreNMS/Util/IPv6.php
+++ b/LibreNMS/Util/IPv6.php
@@ -42,7 +42,7 @@ class IPv6 extends IP
         [$this->ip, $this->cidr] = $this->extractCidr($ipv6);
 
         if (! self::isValid($this->ip)) {
-            throw new InvalidIpException("$ipv6 is not a valid ipv4 address");
+            throw new InvalidIpException("$ipv6 is not a valid ipv6 address");
         }
 
         $this->ip = $this->compressed();  // store in compressed format


### PR DESCRIPTION
Messing arround with some IPv6 stuff
i got a very confusing message

`LibreNMS\Exceptions\InvalidIpException:  is not a valid ipv4 address `
which lead me in very wrong path of debugging

typo corrected

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
(https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
