### PR TITLE
empty Outages table

### DIFF
--- a/includes/html/common/outages.inc.php
+++ b/includes/html/common/outages.inc.php
@@ -38,7 +38,7 @@ var outages_grid = $("#outages").bootgrid({
     post: function ()
     {
         return {
-            device: "' . (int) ($vars['device']) . '",
+            device: ' . (empty($vars['device']) ? 'null' : (int) $vars['device']) . ',
             to: "' . addcslashes($vars['to'], '"') . '",
             from: "' . addcslashes($vars['from'], '"') . '",
         };


### PR DESCRIPTION
same fix as 
https://github.com/librenms/librenms/pull/14136

https://community.librenms.org/t/outages-page-is-empty/19251


#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
