### PR TITLE
Add possibility to monitor the php-fpm service with the unix agent

### DIFF
--- a/doc/Extensions/Applications.md
+++ b/doc/Extensions/Applications.md
@@ -1320,6 +1320,10 @@ The application should be auto-discovered as described at the top of
 the page. If it is not, please follow the steps set out under `SNMP
 Extend` heading top of page.
 
+### Agent
+[Install the agent](Agent-Setup.md) on this device if it isn't already 
+and copy the `phpfpmsp` script to `/usr/lib/check_mk_agent/local/`
+
 ## Pi-hole
 
 ### SNMP Extend

--- a/includes/polling/applications/php-fpm.inc.php
+++ b/includes/polling/applications/php-fpm.inc.php
@@ -3,9 +3,14 @@
 use LibreNMS\RRD\RrdDefinition;
 
 $name = 'php-fpm';
-$options = '-Oqv';
-$oid = '.1.3.6.1.4.1.8072.1.3.2.3.1.2.8.112.104.112.102.112.109.115.112';
-$phpfpm = snmp_walk($device, $oid, $options);
+
+if (! empty($agent_data['app'][$name])) {
+    $phpfpm = $agent_data['app'][$name];
+} else {
+    $options = '-Oqv';
+    $oid = '.1.3.6.1.4.1.8072.1.3.2.3.1.2.8.112.104.112.102.112.109.115.112';
+    $phpfpm = snmp_walk($device, $oid, $options);
+}
 
 [$pool,$start_time,$start_since,$accepted_conn,$listen_queue,$max_listen_queue,$listen_queue_len,$idle_processes,
      $active_processes,$total_processes,$max_active_processes,$max_children_reached,$slow_requests] = explode("\n", $phpfpm);

--- a/includes/polling/unix-agent.inc.php
+++ b/includes/polling/unix-agent.inc.php
@@ -55,6 +55,7 @@ if ($device['os_group'] == 'unix' || $device['os'] == 'windows') {
             'ceph',
             'mysql',
             'nginx',
+            'php-fpm',
             'powerdns',
             'powerdns-recursor',
             'proxmox',


### PR DESCRIPTION
Currently, the module php-fpm is only available through SNMP.
It could be great to be available too through unix-agent (like nginx or mysql).

The module itself is not modified

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
