### PR TITLE
Fix unnecessary Updates of DB when values are equal

### DIFF
--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -288,7 +288,7 @@ function discover_sensor(&$valid, $class, $device, $oid, $index, $type, $descr, 
             [$high_limit, $low_limit] = [$low_limit, $high_limit];
         }
 
-        if ($high_limit != $sensor_entry['sensor_limit'] && $sensor_entry['sensor_custom'] == 'No') {
+        if ((string)$high_limit != (string)$sensor_entry['sensor_limit'] && $sensor_entry['sensor_custom'] == 'No') {
             $update = ['sensor_limit' => ($high_limit == null ? ['NULL'] : $high_limit)];
             $updated = dbUpdate($update, 'sensors', '`sensor_id` = ?', [$sensor_entry['sensor_id']]);
             d_echo("( $updated updated )\n");
@@ -297,7 +297,7 @@ function discover_sensor(&$valid, $class, $device, $oid, $index, $type, $descr, 
             log_event('Sensor High Limit Updated: ' . $class . ' ' . $type . ' ' . $index . ' ' . $descr . ' (' . $high_limit . ')', $device, 'sensor', 3, $sensor_entry['sensor_id']);
         }
 
-        if ($sensor_entry['sensor_limit_low'] != $low_limit && $sensor_entry['sensor_custom'] == 'No') {
+        if ((string)$sensor_entry['sensor_limit_low'] != (string)$low_limit && $sensor_entry['sensor_custom'] == 'No') {
             $update = ['sensor_limit_low' => ($low_limit == null ? ['NULL'] : $low_limit)];
             $updated = dbUpdate($update, 'sensors', '`sensor_id` = ?', [$sensor_entry['sensor_id']]);
             d_echo("( $updated updated )\n");
@@ -306,7 +306,7 @@ function discover_sensor(&$valid, $class, $device, $oid, $index, $type, $descr, 
             log_event('Sensor Low Limit Updated: ' . $class . ' ' . $type . ' ' . $index . ' ' . $descr . ' (' . $low_limit . ')', $device, 'sensor', 3, $sensor_entry['sensor_id']);
         }
 
-        if ($warn_limit != $sensor_entry['sensor_limit_warn'] && $sensor_entry['sensor_custom'] == 'No') {
+        if ((string)$warn_limit != (string)$sensor_entry['sensor_limit_warn'] && $sensor_entry['sensor_custom'] == 'No') {
             $update = ['sensor_limit_warn' => ($warn_limit == null ? ['NULL'] : $warn_limit)];
             $updated = dbUpdate($update, 'sensors', '`sensor_id` = ?', [$sensor_entry['sensor_id']]);
             d_echo("( $updated updated )\n");
@@ -315,7 +315,7 @@ function discover_sensor(&$valid, $class, $device, $oid, $index, $type, $descr, 
             log_event('Sensor Warn High Limit Updated: ' . $class . ' ' . $type . ' ' . $index . ' ' . $descr . ' (' . $warn_limit . ')', $device, 'sensor', 3, $sensor_entry['sensor_id']);
         }
 
-        if ($sensor_entry['sensor_limit_low_warn'] != $low_warn_limit && $sensor_entry['sensor_custom'] == 'No') {
+        if ((string)$sensor_entry['sensor_limit_low_warn'] != (string)$low_warn_limit && $sensor_entry['sensor_custom'] == 'No') {
             $update = ['sensor_limit_low_warn' => ($low_warn_limit == null ? ['NULL'] : $low_warn_limit)];
             $updated = dbUpdate($update, 'sensors', '`sensor_id` = ?', [$sensor_entry['sensor_id']]);
             d_echo("( $updated updated )\n");

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -288,7 +288,7 @@ function discover_sensor(&$valid, $class, $device, $oid, $index, $type, $descr, 
             [$high_limit, $low_limit] = [$low_limit, $high_limit];
         }
 
-        if ((string)$high_limit != (string)$sensor_entry['sensor_limit'] && $sensor_entry['sensor_custom'] == 'No') {
+        if ((string) $high_limit != (string) $sensor_entry['sensor_limit'] && $sensor_entry['sensor_custom'] == 'No') {
             $update = ['sensor_limit' => ($high_limit == null ? ['NULL'] : $high_limit)];
             $updated = dbUpdate($update, 'sensors', '`sensor_id` = ?', [$sensor_entry['sensor_id']]);
             d_echo("( $updated updated )\n");
@@ -297,7 +297,7 @@ function discover_sensor(&$valid, $class, $device, $oid, $index, $type, $descr, 
             log_event('Sensor High Limit Updated: ' . $class . ' ' . $type . ' ' . $index . ' ' . $descr . ' (' . $high_limit . ')', $device, 'sensor', 3, $sensor_entry['sensor_id']);
         }
 
-        if ((string)$sensor_entry['sensor_limit_low'] != (string)$low_limit && $sensor_entry['sensor_custom'] == 'No') {
+        if ((string) $sensor_entry['sensor_limit_low'] != (string) $low_limit && $sensor_entry['sensor_custom'] == 'No') {
             $update = ['sensor_limit_low' => ($low_limit == null ? ['NULL'] : $low_limit)];
             $updated = dbUpdate($update, 'sensors', '`sensor_id` = ?', [$sensor_entry['sensor_id']]);
             d_echo("( $updated updated )\n");
@@ -306,7 +306,7 @@ function discover_sensor(&$valid, $class, $device, $oid, $index, $type, $descr, 
             log_event('Sensor Low Limit Updated: ' . $class . ' ' . $type . ' ' . $index . ' ' . $descr . ' (' . $low_limit . ')', $device, 'sensor', 3, $sensor_entry['sensor_id']);
         }
 
-        if ((string)$warn_limit != (string)$sensor_entry['sensor_limit_warn'] && $sensor_entry['sensor_custom'] == 'No') {
+        if ((string) $warn_limit != (string) $sensor_entry['sensor_limit_warn'] && $sensor_entry['sensor_custom'] == 'No') {
             $update = ['sensor_limit_warn' => ($warn_limit == null ? ['NULL'] : $warn_limit)];
             $updated = dbUpdate($update, 'sensors', '`sensor_id` = ?', [$sensor_entry['sensor_id']]);
             d_echo("( $updated updated )\n");
@@ -315,7 +315,7 @@ function discover_sensor(&$valid, $class, $device, $oid, $index, $type, $descr, 
             log_event('Sensor Warn High Limit Updated: ' . $class . ' ' . $type . ' ' . $index . ' ' . $descr . ' (' . $warn_limit . ')', $device, 'sensor', 3, $sensor_entry['sensor_id']);
         }
 
-        if ((string)$sensor_entry['sensor_limit_low_warn'] != (string)$low_warn_limit && $sensor_entry['sensor_custom'] == 'No') {
+        if ((string) $sensor_entry['sensor_limit_low_warn'] != (string) $low_warn_limit && $sensor_entry['sensor_custom'] == 'No') {
             $update = ['sensor_limit_low_warn' => ($low_warn_limit == null ? ['NULL'] : $low_warn_limit)];
             $updated = dbUpdate($update, 'sensors', '`sensor_id` = ?', [$sensor_entry['sensor_id']]);
             d_echo("( $updated updated )\n");


### PR DESCRIPTION
With some devices (Packetlight), we have at each discovery an update of the limits. But the update uses the exact same value. It ends up filling the eventlogs for nothing.

While checking function.inc.php, it appears that the auto-cast of string/int/float does not end up right. This PR forces (string) cast to ensure proper string comparison. 

Here is a capture of the eventlog (with some extra data added during the debug phase).

![image](https://user-images.githubusercontent.com/23125855/182964215-5d87fcf2-4940-4791-a839-36c55a745eac.png)


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
