### PR TITLE
Add possibility to monitor redis application through the unix-agent

### DIFF
--- a/doc/Extensions/Applications.md
+++ b/doc/Extensions/Applications.md
@@ -1911,7 +1911,7 @@ extend rpigpiomonitor /etc/snmp/rpigpiomonitor.php
 
 ## Redis
 
-SNMP extend script to monitor your Redis Server
+Script to monitor your Redis Server
 
 ### SNMP Extend
 
@@ -1929,6 +1929,11 @@ chmod +x /etc/snmp/redis.py
 ```
 extend redis /etc/snmp/redis.py
 ```
+
+### Agent
+
+[Install the agent](Agent-Setup.md) on this device if it isn't already
+and copy the `redis` script to `/usr/lib/check_mk_agent/local/`
 
 ## RRDCached
 

--- a/includes/polling/unix-agent.inc.php
+++ b/includes/polling/unix-agent.inc.php
@@ -59,6 +59,7 @@ if ($device['os_group'] == 'unix' || $device['os'] == 'windows') {
             'powerdns',
             'powerdns-recursor',
             'proxmox',
+            'redis',
             'rrdcached',
             'tinydns',
             'gpsd',


### PR DESCRIPTION
Just update the `redis.inc.php` to allow the use of unix-agent to retrieve data for redis DB monitoring.

Linked to PR https://github.com/librenms/librenms-agent/pull/418 to add the script for `redis` to the agent

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
