### PR TITLE
Allow specifying the background colour in graph images

### DIFF
--- a/includes/html/graphs/common.inc.php
+++ b/includes/html/graphs/common.inc.php
@@ -94,11 +94,14 @@ if ($_GET['bg']) {
     $rrd_options .= ' -c CANVAS#' . Clean::alphaDash($_GET['bg']) . ' ';
 }
 
+if ($_GET['bbg']) {
+    $rrd_options .= ' -c BACK#' . Clean::alphaDash($_GET['bbg']) . ' ';
+}
+
 if ($_GET['font']) {
     $rrd_options .= ' -c FONT#' . Clean::alphaDash($_GET['font']) . ' ';
 }
 
-// $rrd_options .= " -c BACK#FFFFFF";
 if ($height < '99') {
     $rrd_options .= ' --only-graph';
 }


### PR DESCRIPTION
As per title, otherwise the background of the graph image is transparent which may not be desirable.

(extreme example - yellow background)

![image](https://user-images.githubusercontent.com/1866176/183774034-47a8afa8-9aea-4bef-95bd-1c1dc9a721e1.png)

bg is still graph background, new bbg parameter controls the back-background

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
