### PR TITLE
Add Eaton PDU environmental sensor support

### DIFF
--- a/includes/definitions/eatonpdu.yaml
+++ b/includes/definitions/eatonpdu.yaml
@@ -9,3 +9,21 @@ over:
 discovery:
     -
         sysObjectID: .1.3.6.1.4.1.534.6.
+        
+temperature:
+    data:
+        -
+            oid: .1.3.6.1.4.1.534.6.8.1.2.3.1.3.1.1
+            value: sensorAgent
+            num_oid: '.1.3.6.1.4.1.534.6.8.1.2.3.1.3.1.1'
+            divisor: 10
+            descr: 'Temperature'
+
+humidity:
+    data:
+        -
+            oid: .1.3.6.1.4.1.534.6.8.1.3.3.1.3.1.1
+            value: sensorAgent
+            num_oid: '.1.3.6.1.4.1.534.6.8.1.3.3.1.3.1.1'
+            divisor: 10
+            descr: 'Humidity'


### PR DESCRIPTION
Add support for environmental sensors on Eaton PDUs (tested with EMA333-10)

Let me know if any more info is needed.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
