### PR TITLE
Allow save-test-data.php to run all modules explicitely

### DIFF
--- a/scripts/save-test-data.php
+++ b/scripts/save-test-data.php
@@ -53,7 +53,8 @@ Required:
   -v, --variant      The variant of the OS to use, usually the device model
 
 Optional:
-  -m, --modules      The discovery/poller module(s) to collect data for, comma delimited
+  -m, --modules      The discovery/poller module(s) to collect data for, comma delimited.
+                     Use -m 'all' for all modules.
   -n, --no-save      Don't save database entries, print them out instead
   -f, --file         Save data to file instead of the standard location
   -d, --debug        Enable debug output
@@ -73,7 +74,10 @@ if (isset($options['o'])) {
     $os_name = $options['os'];
 }
 
-if (isset($options['m'])) {
+if ((isset($options['m']) && $options['m'] == "all") || (isset($options['modules']) && $options['modules'] == "all")) {
+    $modules_input = 'all';
+    $modules = [];
+} elseif (isset($options['m'])) {
     $modules_input = $options['m'];
     $modules = explode(',', $modules_input);
 } elseif (isset($options['modules'])) {

--- a/scripts/save-test-data.php
+++ b/scripts/save-test-data.php
@@ -74,7 +74,7 @@ if (isset($options['o'])) {
     $os_name = $options['os'];
 }
 
-if ((isset($options['m']) && $options['m'] == "all") || (isset($options['modules']) && $options['modules'] == "all")) {
+if ((isset($options['m']) && $options['m'] == 'all') || (isset($options['modules']) && $options['modules'] == 'all')) {
     $modules_input = 'all';
     $modules = [];
 } elseif (isset($options['m'])) {


### PR DESCRIPTION
This allows to re-run ALL scripts with the following command: 
`./scripts/save-test-data.php -m all`

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
