### PR TITLE
autodiscovery fix

### DIFF
--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -83,14 +83,7 @@ function discover_new_device($hostname, $device = [], $method = '', $interface =
         device_by_id_cache($remote_device_id, 1);
 
         if ($remote_device_id && is_array($device) && ! empty($method)) {
-            $extra_log = '';
-            // cleanPort expect array
-            $ifArray = ['ifName' => $interface, 'ifDescr' => $interface, 'ifAlias' => $interface, 'device_id' => $device['device_id']];
-            $int = cleanPort($ifArray);
-            if (is_array($int)) {
-                $extra_log = ' (port ' . $int['label'] . ') ';
-            }
-
+            $extra_log = isset($interface) ? ' (port ' . htmlentities($interface) . ') ' : '';
             log_event('Device ' . $remote_device['hostname'] . " ($ip) $extra_log autodiscovered through $method on " . $device['hostname'], $remote_device_id, 'discovery', 1);
         } else {
             log_event("$method discovery of " . $remote_device['hostname'] . " ($ip) failed - Check ping and SNMP access", $device['device_id'], 'discovery', 5);

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -83,11 +83,7 @@ function discover_new_device($hostname, $device = [], $method = '', $interface =
         device_by_id_cache($remote_device_id, 1);
 
         if ($remote_device_id && is_array($device) && ! empty($method)) {
-            $extra_log = '';
-            if (is_array($interface)) {
-                $int = cleanPort($interface);
-                $extra_log = ' (port ' . $int['label'] . ') ';
-            }
+            $extra_log = is_array($interface) ? ' (port ' . cleanPort($interface)['label'] . ') ' : '';
 
             log_event('Device ' . $remote_device['hostname'] . " ($ip) $extra_log autodiscovered through $method on " . $device['hostname'], $remote_device_id, 'discovery', 1);
         } else {

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -76,7 +76,7 @@ function discover_new_device($hostname, $device = [], $method = '', $interface =
     }
 
     try {
-        $remote_device_id = addHost($hostname, '', '161', 'udp', Config::get('default_poller_group'));
+        $remote_device_id = addHost($hostname, '', '161', 'udp', $device['poller_group']); // discover with actual poller group
         $remote_device = device_by_id_cache($remote_device_id, 1);
         echo '+[' . $remote_device['hostname'] . '(' . $remote_device['device_id'] . ')]';
         discover_device($remote_device);
@@ -84,7 +84,9 @@ function discover_new_device($hostname, $device = [], $method = '', $interface =
 
         if ($remote_device_id && is_array($device) && ! empty($method)) {
             $extra_log = '';
-            $int = cleanPort($interface);
+            // cleanPort expect array
+            $ifArray = ['ifName' => $interface, 'ifDescr' => $interface, 'ifAlias' => $interface, 'device_id' => $device['device_id']];
+            $int = cleanPort($ifArray);
             if (is_array($int)) {
                 $extra_log = ' (port ' . $int['label'] . ') ';
             }

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -83,7 +83,12 @@ function discover_new_device($hostname, $device = [], $method = '', $interface =
         device_by_id_cache($remote_device_id, 1);
 
         if ($remote_device_id && is_array($device) && ! empty($method)) {
-            $extra_log = isset($interface) ? ' (port ' . htmlentities($interface) . ') ' : '';
+            $extra_log = '';
+            if (is_array($interface)) {
+                $int = cleanPort($interface);
+                $extra_log = ' (port ' . $int['label'] . ') ';
+            }
+
             log_event('Device ' . $remote_device['hostname'] . " ($ip) $extra_log autodiscovered through $method on " . $device['hostname'], $remote_device_id, 'discovery', 1);
         } else {
             log_event("$method discovery of " . $remote_device['hostname'] . " ($ip) failed - Check ping and SNMP access", $device['device_id'], 'discovery', 5);

--- a/includes/rewrites.php
+++ b/includes/rewrites.php
@@ -41,9 +41,10 @@ function cleanPort($interface, $device = null)
     if (! $interface) {
         return $interface;
     }
-    $interface['ifAlias'] = htmlentities($interface['ifAlias']);
-    $interface['ifName'] = htmlentities($interface['ifName']);
-    $interface['ifDescr'] = htmlentities($interface['ifDescr']);
+
+    $interface['ifAlias'] = isset($interface['ifAlias']) ? htmlentities($interface['ifAlias']) : '';
+    $interface['ifName'] = isset($interface['ifName']) ? htmlentities($interface['ifName']) : '';
+    $interface['ifDescr'] = isset($interface['ifDescr']) ? htmlentities($interface['ifDescr']) : '';
 
     if (! $device) {
         $device = device_by_id_cache($interface['device_id']);

--- a/includes/rewrites.php
+++ b/includes/rewrites.php
@@ -42,9 +42,9 @@ function cleanPort($interface, $device = null)
         return $interface;
     }
 
-    $interface['ifAlias'] = isset($interface['ifAlias']) ? htmlentities($interface['ifAlias']) : '';
-    $interface['ifName'] = isset($interface['ifName']) ? htmlentities($interface['ifName']) : '';
-    $interface['ifDescr'] = isset($interface['ifDescr']) ? htmlentities($interface['ifDescr']) : '';
+    $interface['ifAlias'] = htmlentities($interface['ifAlias'] ?? '');
+    $interface['ifName'] = htmlentities($interface['ifName'] ?? '');
+    $interface['ifDescr'] = htmlentities($interface['ifDescr'] ?? '');
 
     if (! $device) {
         $device = device_by_id_cache($interface['device_id']);


### PR DESCRIPTION
Two fix:

1. function cleanPort expect array, but simple variable is passed

[2022-08-18T05:48:54.991362+02:00] production.ERROR: Error discovering discovery-protocols module for 169.254.101.12. TypeError: Cannot access offset of type string on string in /opt/librenms/includes/rewrites.php:45
Stack trace:
#0 /opt/librenms/includes/discovery/functions.inc.php(88): cleanPort()
#1 /opt/librenms/includes/discovery/discovery-protocols.inc.php(233): discover_new_device()
#2 /opt/librenms/includes/discovery/functions.inc.php(158): include('...')
#3 /opt/librenms/discovery.php(118): discover_device()
#4 {main}

2. autodiscovery put new device in default poller group, which is not correct. 
if we have poller/discovery for group 99 and this group is unreachable from main LNMS, then polling will fail until newly discovered device is not changed manualy to poller_group 99
so it is best to inherit poller_group from device which discovered NEW device


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
