### PR TITLE
Fix legacy os extends

### DIFF
--- a/LibreNMS/OS/Shared/Unix.php
+++ b/LibreNMS/OS/Shared/Unix.php
@@ -117,8 +117,7 @@ class Unix extends \LibreNMS\OS implements MempoolsDiscovery
             $device->hardware = $hardware;
         }
 
-        $serial = SnmpQuery::mibDir('dell')->get([
-            'MIB-Dell-10892::chassisServiceTagName.1', // Dell
+        $serial = SnmpQuery::get([
             'NET-SNMP-EXTEND-MIB::nsExtendOutput1Line."serial"',
             '.1.3.6.1.4.1.2021.7890.4.4.1.2.6.115.101.114.105.97.108.1', // legacy nsExtendOutLine.1 UCD-SNMP-MIB prefix with extend "serial"
             '.1.3.6.1.4.1.2021.7890.4.101.1', // legacy UCD-SNMP-MIB exec

--- a/LibreNMS/OS/Shared/Unix.php
+++ b/LibreNMS/OS/Shared/Unix.php
@@ -82,8 +82,8 @@ class Unix extends \LibreNMS\OS implements MempoolsDiscovery
         // Distro "extend" support
         $features_extend = snmp_get_multi_oid($this->getDeviceArray(), [
             '.1.3.6.1.4.1.8072.1.3.2.3.1.1.6.100.105.115.116.114.111', // NET-SNMP-EXTEND-MIB::nsExtendOutput1Line.\"distro\"
-            '.1.3.6.1.4.1.2021.7890.1.3.1.1.6.100.105.115.116.114.111', // UCD-MIB shell
-            '.1.3.6.1.4.1.2021.7890.1.101.1', // exec
+            '.1.3.6.1.4.1.2021.7890.1.3.1.1.6.100.105.115.116.114.111', // legacy UCD-SNMP-MIB prefix with extend "distro"
+            '.1.3.6.1.4.1.2021.7890.1.101.1', // legacy UCD-SNMP-MIB exec
         ], '-OUQn', 'NET-SNMP-EXTEND-MIB');
         $features = reset($features_extend);
         $device->features = $features ?: $device->features;
@@ -91,22 +91,27 @@ class Unix extends \LibreNMS\OS implements MempoolsDiscovery
         // Try detect using the extended option (dmidecode)
         $hardware_extend = snmp_get_multi_oid($this->getDeviceArray(), [
             '.1.3.6.1.4.1.8072.1.3.2.3.1.1.8.104.97.114.100.119.97.114.101', // NET-SNMP-EXTEND-MIB::nsExtendOutput1Line.\"hardware\"
-            '.1.3.6.1.4.1.2021.7890.3.4.1.2.12.109.97.110.117.102.97.99.116.117.114.101.114.1', // UCD-MIB shell
-            '.1.3.6.1.4.1.2021.7890.3.101.1', // UCD-MIB exec
+            '.1.3.6.1.4.1.2021.7890.2.4.1.2.8.104.97.114.100.119.97.114.101.1', // legacy UCD-SNMP-MIB prefix with extend "hardware"
+            '.1.3.6.1.4.1.2021.7890.2.101.2', // legacy UCD-SNMP-MIB exec
         ], '-OUQn', 'NET-SNMP-EXTEND-MIB');
         $hardware = reset($hardware_extend);
 
         if ($hardware) {
-            //  NET-SNMP-EXTEND-MIB::nsExtendOutput1Line.\"manufacturer\"
-            $manufacturer = snmp_get($this->getDeviceArray(), '.1.3.6.1.4.1.8072.1.3.2.3.1.1.12.109.97.110.117.102.97.99.116.117.114.101.114', '-Oqv', 'NET-SNMP-EXTEND-MIB');
+            // Add manufacturer if we have it
+            $manufacturer_extend = snmp_get_multi_oid($this->getDeviceArray(), [
+                '.1.3.6.1.4.1.8072.1.3.2.3.1.1.12.109.97.110.117.102.97.99.116.117.114.101.114', // NET-SNMP-EXTEND-MIB::nsExtendOutput1Line.\"manufacturer\"
+                '.1.3.6.1.4.1.2021.7890.3.4.1.2.12.109.97.110.117.102.97.99.116.117.114.101.114.1', // legacy UCD-SNMP-MIB prefix with extend "manufacturer"
+                '.1.3.6.1.4.1.2021.7890.3.4.1.2.6.118.101.110.100.111.114.1', // legacy UCD-SNMP-MIB prefix with extend "vendor"
+                '.1.3.6.1.4.1.2021.7890.3.101.1', // legacy UCD-SNMP-MIB exec
+            ],'-OUQn', 'NET-SNMP-EXTEND-MIB');
+            $manufacturer = reset($manufacturer_extend);
             if ($manufacturer) {
                 $hardware = Str::start($hardware, $manufacturer . ' ');
             }
 
+            // add version if we have it
             $version_extend = snmp_get_multi_oid($this->getDeviceArray(), [
                 '.1.3.6.1.4.1.8072.1.3.2.3.1.1.7.118.101.114.115.105.111.110', // NET-SNMP-EXTEND-MIB::nsExtendOutput1Line.\"version\"
-                '.1.3.6.1.4.1.2021.7890.2.4.1.2.8.104.97.114.100.119.97.114.101.1', // UCD-MIB shell
-                '.1.3.6.1.4.1.2021.7890.2.101.1', // UCD-MIB exec
             ], '-OUQn', 'NET-SNMP-EXTEND-MIB');
             $version = reset($version_extend);
             if ($version) {
@@ -118,7 +123,8 @@ class Unix extends \LibreNMS\OS implements MempoolsDiscovery
         $serial_extend = snmp_get_multi_oid($this->getDeviceArray(), [
             '.1.3.6.1.4.1.674.10892.1.300.10.1.11.1', // Dell
             '.1.3.6.1.4.1.8072.1.3.2.3.1.1.6.115.101.114.105.97.108', // NET-SNMP-EXTEND-MIB::nsExtendOutput1Line.\"serial\"
-            '.1.3.6.1.4.1.2021.7890.4.4.1.2.6.115.101.114.105.97.108.1', // UCD-MIB shell
+            '.1.3.6.1.4.1.2021.7890.4.4.1.2.6.115.101.114.105.97.108.1', // legacy UCD-SNMP-MIB prefix with extend "serial"
+            '.1.3.6.1.4.1.2021.7890.4.101.1', // legacy UCD-SNMP-MIB exec
         ], '-OUQn', 'NET-SNMP-EXTEND-MIB:MIB-Dell-10892', 'dell');
         $serial = reset($serial_extend);
         $device->serial = $serial ?: $device->serial;

--- a/LibreNMS/OS/Shared/Unix.php
+++ b/LibreNMS/OS/Shared/Unix.php
@@ -30,6 +30,7 @@ use Illuminate\Support\Str;
 use LibreNMS\Interfaces\Discovery\MempoolsDiscovery;
 use LibreNMS\OS\Traits\ServerHardware;
 use LibreNMS\OS\Traits\YamlOSDiscovery;
+use SnmpQuery;
 
 class Unix extends \LibreNMS\OS implements MempoolsDiscovery
 {
@@ -80,53 +81,48 @@ class Unix extends \LibreNMS\OS implements MempoolsDiscovery
     protected function discoverExtends(Device $device)
     {
         // Distro "extend" support
-        $features_extend = snmp_get_multi_oid($this->getDeviceArray(), [
-            '.1.3.6.1.4.1.8072.1.3.2.3.1.1.6.100.105.115.116.114.111', // NET-SNMP-EXTEND-MIB::nsExtendOutput1Line.\"distro\"
-            '.1.3.6.1.4.1.2021.7890.1.3.1.1.6.100.105.115.116.114.111', // legacy UCD-SNMP-MIB prefix with extend "distro"
+        $features = SnmpQuery::get([
+            'NET-SNMP-EXTEND-MIB::nsExtendOutput1Line."distro"',
+            '.1.3.6.1.4.1.2021.7890.1.3.1.1.6.100.105.115.116.114.111', // legacy nsExtendOutput1Line UCD-SNMP-MIB prefix with extend "distro"
             '.1.3.6.1.4.1.2021.7890.1.101.1', // legacy UCD-SNMP-MIB exec
-        ], '-OUQn', 'NET-SNMP-EXTEND-MIB');
-        $features = reset($features_extend);
+        ])->value();
         $device->features = $features ?: $device->features;
 
         // Try detect using the extended option (dmidecode)
-        $hardware_extend = snmp_get_multi_oid($this->getDeviceArray(), [
-            '.1.3.6.1.4.1.8072.1.3.2.3.1.1.8.104.97.114.100.119.97.114.101', // NET-SNMP-EXTEND-MIB::nsExtendOutput1Line.\"hardware\"
-            '.1.3.6.1.4.1.2021.7890.2.4.1.2.8.104.97.114.100.119.97.114.101.1', // legacy UCD-SNMP-MIB prefix with extend "hardware"
+        $hardware = SnmpQuery::get([
+            'NET-SNMP-EXTEND-MIB::nsExtendOutput1Line."hardware"',
+            '.1.3.6.1.4.1.2021.7890.2.4.1.2.8.104.97.114.100.119.97.114.101.1', // legacy nsExtendOutLine.1 UCD-SNMP-MIB prefix with extend "hardware"
             '.1.3.6.1.4.1.2021.7890.2.101.2', // legacy UCD-SNMP-MIB exec
-        ], '-OUQn', 'NET-SNMP-EXTEND-MIB');
-        $hardware = reset($hardware_extend);
+        ])->value();
 
         if ($hardware) {
             // Add manufacturer if we have it
-            $manufacturer_extend = snmp_get_multi_oid($this->getDeviceArray(), [
-                '.1.3.6.1.4.1.8072.1.3.2.3.1.1.12.109.97.110.117.102.97.99.116.117.114.101.114', // NET-SNMP-EXTEND-MIB::nsExtendOutput1Line.\"manufacturer\"
-                '.1.3.6.1.4.1.2021.7890.3.4.1.2.12.109.97.110.117.102.97.99.116.117.114.101.114.1', // legacy UCD-SNMP-MIB prefix with extend "manufacturer"
-                '.1.3.6.1.4.1.2021.7890.3.4.1.2.6.118.101.110.100.111.114.1', // legacy UCD-SNMP-MIB prefix with extend "vendor"
+            $manufacturer = SnmpQuery::get([
+                'NET-SNMP-EXTEND-MIB::nsExtendOutput1Line."manufacturer"',
+                '.1.3.6.1.4.1.2021.7890.3.4.1.2.12.109.97.110.117.102.97.99.116.117.114.101.114.1', // legacy nsExtendOutLine.1 UCD-SNMP-MIB prefix with extend "manufacturer"
+                '.1.3.6.1.4.1.2021.7890.3.4.1.2.6.118.101.110.100.111.114.1', // legacy nsExtendOutLine.1 UCD-SNMP-MIB prefix with extend "vendor"
                 '.1.3.6.1.4.1.2021.7890.3.101.1', // legacy UCD-SNMP-MIB exec
-            ],'-OUQn', 'NET-SNMP-EXTEND-MIB');
-            $manufacturer = reset($manufacturer_extend);
+            ])->value();
             if ($manufacturer) {
                 $hardware = Str::start($hardware, $manufacturer . ' ');
             }
 
             // add version if we have it
-            $version_extend = snmp_get_multi_oid($this->getDeviceArray(), [
-                '.1.3.6.1.4.1.8072.1.3.2.3.1.1.7.118.101.114.115.105.111.110', // NET-SNMP-EXTEND-MIB::nsExtendOutput1Line.\"version\"
-            ], '-OUQn', 'NET-SNMP-EXTEND-MIB');
-            $version = reset($version_extend);
+            $version = SnmpQuery::get([
+                'NET-SNMP-EXTEND-MIB::nsExtendOutput1Line."version"',
+            ])->value();
             if ($version) {
                 $hardware .= " [$version]";
             }
             $device->hardware = $hardware;
         }
 
-        $serial_extend = snmp_get_multi_oid($this->getDeviceArray(), [
-            '.1.3.6.1.4.1.674.10892.1.300.10.1.11.1', // Dell
-            '.1.3.6.1.4.1.8072.1.3.2.3.1.1.6.115.101.114.105.97.108', // NET-SNMP-EXTEND-MIB::nsExtendOutput1Line.\"serial\"
-            '.1.3.6.1.4.1.2021.7890.4.4.1.2.6.115.101.114.105.97.108.1', // legacy UCD-SNMP-MIB prefix with extend "serial"
+        $serial = SnmpQuery::mibDir('dell')->get([
+            'MIB-Dell-10892::chassisServiceTagName.1', // Dell
+            'NET-SNMP-EXTEND-MIB::nsExtendOutput1Line."serial"',
+            '.1.3.6.1.4.1.2021.7890.4.4.1.2.6.115.101.114.105.97.108.1', // legacy nsExtendOutLine.1 UCD-SNMP-MIB prefix with extend "serial"
             '.1.3.6.1.4.1.2021.7890.4.101.1', // legacy UCD-SNMP-MIB exec
-        ], '-OUQn', 'NET-SNMP-EXTEND-MIB:MIB-Dell-10892', 'dell');
-        $serial = reset($serial_extend);
+        ])->value();
         $device->serial = $serial ?: $device->serial;
     }
 }

--- a/tests/data/freebsd.json
+++ b/tests/data/freebsd.json
@@ -8,7 +8,7 @@
                     "sysDescr": "FreeBSD some.example.org 9.2-RELEASE FreeBSD 9.2-RELEASE #0 r255898: Thu Sep 26 22:50:31 UTC 2013     root@bake.isc.freebsd.org:/usr/obj/usr/src/sys/GENERIC amd64",
                     "sysContact": "<private>",
                     "version": "9.2-RELEASE",
-                    "hardware": "Red Hat [KVM]",
+                    "hardware": "Red Hat KVM",
                     "features": "FreeBSD 12.1-RELEASE-p3",
                     "os": "freebsd",
                     "type": "server",

--- a/tests/data/recoveryos.json
+++ b/tests/data/recoveryos.json
@@ -8,7 +8,7 @@
                     "sysDescr": "Linux unitrends 3.10.0-862.14.4.el7.x86_64 #1 SMP Wed Sep 26 15:12:11 UTC 2018 x86_64",
                     "sysContact": "<private>",
                     "version": "3.10.0-862.14.4.el7.x86_64",
-                    "hardware": "VMware, Inc. [VMware Virtual Platform]",
+                    "hardware": "VMware, Inc. VMware Virtual Platform",
                     "features": "RecoveryOS 7",
                     "os": "recoveryos",
                     "type": "server",


### PR DESCRIPTION
Now compatible with oids that could have been used by older software:
extend .1.3.6.1.4.1.2021.7890.2 hardware
extend .1.3.6.1.4.1.2021.7890.3 manufacturer
extend .1.3.6.1.4.1.2021.7890.3 vendor
extend .1.3.6.1.4.1.2021.7890.4 serial

Correct the oids for VERY old exec options
Update to SnmpQuery
Could not find evidence of legacy version extends
Dell service tag is already discovered, don't fetch twice.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
