### PR TITLE
Save-test-data to refresh all variants of an OS

### DIFF
--- a/LibreNMS/Util/ModuleTestHelper.php
+++ b/LibreNMS/Util/ModuleTestHelper.php
@@ -259,13 +259,17 @@ class ModuleTestHelper
      *
      * @throws InvalidModuleException
      */
-    public static function findOsWithData($modules = [])
+    public static function findOsWithData($modules = [], string $os_filter = null)
     {
         $os_list = [];
 
         foreach (glob(Config::get('install_dir') . '/tests/data/*.json') as $file) {
             $base_name = basename($file, '.json');
             [$os, $variant] = self::extractVariant($file);
+
+            if ($os_filter != '' && $os_filter != $os) {
+                continue;
+            }
 
             // calculate valid modules
             $decoded = json_decode(file_get_contents($file), true);

--- a/scripts/save-test-data.php
+++ b/scripts/save-test-data.php
@@ -89,7 +89,8 @@ if ((isset($options['m']) && $options['m'] == 'all') || (isset($options['modules
 }
 
 $full_os_name = $os_name;
-$variant = '';
+$variant = null;
+
 if (isset($options['v'])) {
     $variant = $options['v'];
     $full_os_name = $os_name . '_' . $variant;
@@ -100,9 +101,9 @@ if (isset($options['v'])) {
 
 $os_list = [];
 
-if ($os_name && $variant) {
+if (isset($os_name) && isset($variant)) {
     $os_list = [$full_os_name => [$os_name, $variant]];
-} elseif ($os_name) {
+} elseif (isset($os_name)) {
     $os_list = ModuleTestHelper::findOsWithData($modules, $os_name);
 } else {
     $os_list = ModuleTestHelper::findOsWithData($modules);

--- a/scripts/save-test-data.php
+++ b/scripts/save-test-data.php
@@ -40,19 +40,19 @@ if (isset($options['snmpsim'])) {
 
 if (isset($options['h'])
     || isset($options['help'])
-    || (isset($options['o']) || isset($options['os'])) && ! (isset($options['v']) || isset($options['variant']))
     || ! (isset($options['o']) || isset($options['os']) || isset($options['m']) || isset($options['modules']))
 ) {
     echo "Script to update test data. Database data is saved in tests/data.
 
 Usage:
-  You must specify a valid OS (and variant) and/or module(s).
+  - This script can process new test data (by specifying both OS and VARIANT).
+  - This script can refresh test data.
+    -> if an OS is specified, only this OS will be refreshed.
+    -> if MODULES are specified, only these modules will be refreshed.
 
-Required:
-  -o, --os           Name of the OS to save test data for
-  -v, --variant      The variant of the OS to use, usually the device model
-
-Optional:
+Parameters:
+  -o, --os           Name of the OS to save test data for.
+  -v, --variant      The variant of the OS to use, usually the device model.
   -m, --modules      The discovery/poller module(s) to collect data for, comma delimited.
                      Use -m 'all' for all modules.
   -n, --no-save      Don't save database entries, print them out instead
@@ -100,8 +100,10 @@ if (isset($options['v'])) {
 
 $os_list = [];
 
-if ($os_name) {
+if ($os_name && $variant) {
     $os_list = [$full_os_name => [$os_name, $variant]];
+} elseif ($os_name) {
+    $os_list = ModuleTestHelper::findOsWithData($modules, $os_name);
 } else {
     $os_list = ModuleTestHelper::findOsWithData($modules);
 }


### PR DESCRIPTION
Allow save-test-data to refresh all variants for a single OS

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
