### PR TITLE
Quick fix for cipsec-tunnels Cisco implementation

### DIFF
--- a/includes/polling/cipsec-tunnels.inc.php
+++ b/includes/polling/cipsec-tunnels.inc.php
@@ -22,7 +22,6 @@ if ($device['os_group'] == 'cisco') {
     $valid_tunnels = [];
 
     foreach ($ipsec_array as $index => $tunnel) {
-
         if (isset($tunnel['cipSecTunIkeTunnelIndex']) && isset($ike_array[$tunnel['cipSecTunIkeTunnelIndex']])) {
             $tunnel_full = array_merge($tunnel, $ike_array[$tunnel['cipSecTunIkeTunnelIndex']]);
         } else {

--- a/includes/polling/cipsec-tunnels.inc.php
+++ b/includes/polling/cipsec-tunnels.inc.php
@@ -1,6 +1,7 @@
 <?php
 
 use LibreNMS\RRD\RrdDefinition;
+use LibreNMS\Util\IP;
 
 if ($device['os_group'] == 'cisco') {
     // FIXME - seems to be broken. IPs appear with leading zeroes.
@@ -21,13 +22,26 @@ if ($device['os_group'] == 'cisco') {
     $valid_tunnels = [];
 
     foreach ($ipsec_array as $index => $tunnel) {
-        $tunnel = array_merge($tunnel, $ike_array[$tunnel['cipSecTunIkeTunnelIndex']]);
 
-        echo "Tunnel $index (" . $tunnel['cipSecTunIkeTunnelIndex'] . ")\n";
+        if (isset($tunnel['cipSecTunIkeTunnelIndex']) && isset($ike_array[$tunnel['cipSecTunIkeTunnelIndex']])) {
+            $tunnel_full = array_merge($tunnel, $ike_array[$tunnel['cipSecTunIkeTunnelIndex']]);
+        } else {
+            $tunnel_full = $tunnel;
+            $tunnel_full['cikeTunLocalValue'] = (string) IP::fromHexString($tunnel_full['cipSecTunLocalAddr']);
+            $tunnel_full['cikeTunLocalName'] = (string) IP::fromHexString($tunnel_full['cipSecTunLocalAddr']);
+        }
 
-        echo 'Address ' . $tunnel['cikeTunRemoteValue'] . "\n";
+        d_echo($tunnel_full);
 
-        $address = $tunnel['cikeTunRemoteValue'];
+        echo "Tunnel $index (" . $tunnel_full['cipSecTunIkeTunnelIndex'] . ")\n";
+
+        $address = isset($tunnel_full['cikeTunRemoteValue']) ? $tunnel_full['cikeTunRemoteValue'] : (string) IP::fromHexString($tunnel_full['cipSecTunRemoteAddr']);
+
+        echo 'Address ' . $address . "\n";
+
+        if ($tunnel_full['cipSecTunIkeTunnelAlive'] == 'false') {
+            echo "IKE is not valid anymore, and was replaced on the router by a newer one.\n";
+        }
 
         $oids = [
             'cipSecTunInOctets',
@@ -55,41 +69,41 @@ if ($device['os_group'] == 'cisco') {
             'cikeTunLocalValue' => 'local_addr',
         ];
 
-        if (! is_array($tunnels[$tunnel['cikeTunRemoteValue']]) && ! empty($tunnel['cikeTunRemoteValue'])) {
+        if (! isset($tunnels[$address]) && ! empty($address)) {
             $tunnel_id = dbInsert([
                 'device_id' => $device['device_id'],
-                'peer_addr' => $tunnel['cikeTunRemoteValue'],
-                'local_addr' => $tunnel['cikeTunLocalValue'],
-                'tunnel_name' => $tunnel['cikeTunLocalName'],
+                'peer_addr' => $address,
+                'local_addr' => $tunnel_full['cikeTunLocalValue'],
+                'tunnel_name' => $tunnel_full['cikeTunLocalName'],
             ], 'ipsec_tunnels');
             $valid_tunnels[] = $tunnel_id;
         } else {
             foreach ($db_oids as $db_oid => $db_value) {
-                $db_update[$db_value] = $tunnel[$db_oid];
+                $db_update[$db_value] = isset($tunnel_full[$db_oid]) ? $tunnel_full[$db_oid] : '';
             }
 
-            if (! empty($tunnels[$tunnel['cikeTunRemoteValue']]['tunnel_id'])) {
+            if (! empty($tunnels[$address]['tunnel_id'])) {
                 $updated = dbUpdate(
                     $db_update,
                     'ipsec_tunnels',
                     '`tunnel_id` = ?',
-                    [$tunnels[$tunnel['cikeTunRemoteValue']]['tunnel_id']]
+                    [$tunnels[$address]['tunnel_id']]
                 );
-                $valid_tunnels[] = $tunnels[$tunnel['cikeTunRemoteValue']]['tunnel_id'];
+                $valid_tunnels[] = $tunnels[$address]['tunnel_id'];
             }
         }
 
-        if (is_numeric($tunnel['cipSecTunHcInOctets']) &&
-            is_numeric($tunnel['cipSecTunHcInDecompOctets']) &&
-            is_numeric($tunnel['cipSecTunHcOutOctets']) &&
-            is_numeric($tunnel['cipSecTunHcOutUncompOctets'])
+        if (is_numeric($tunnel_full['cipSecTunHcInOctets']) &&
+            is_numeric($tunnel_full['cipSecTunHcInDecompOctets']) &&
+            is_numeric($tunnel_full['cipSecTunHcOutOctets']) &&
+            is_numeric($tunnel_full['cipSecTunHcOutUncompOctets'])
         ) {
             echo 'HC ';
 
-            $tunnel['cipSecTunInOctets'] = $tunnel['cipSecTunHcInOctets'];
-            $tunnel['cipSecTunInDecompOctets'] = $tunnel['cipSecTunHcInDecompOctets'];
-            $tunnel['cipSecTunOutOctets'] = $tunnel['cipSecTunHcOutOctets'];
-            $tunnel['cipSecTunOutUncompOctets'] = $tunnel['cipSecTunHcOutUncompOctets'];
+            $tunnel_full['cipSecTunInOctets'] = $tunnel_full['cipSecTunHcInOctets'];
+            $tunnel_full['cipSecTunInDecompOctets'] = $tunnel_full['cipSecTunHcInDecompOctets'];
+            $tunnel_full['cipSecTunOutOctets'] = $tunnel_full['cipSecTunHcOutOctets'];
+            $tunnel_full['cipSecTunOutUncompOctets'] = $tunnel_full['cipSecTunHcOutUncompOctets'];
         }
 
         $rrd_name = ['ipsectunnel', $address];
@@ -103,15 +117,15 @@ if ($device['os_group'] == 'cisco') {
         $fields = [];
 
         foreach ($oids as $oid) {
-            if (is_numeric($tunnel[$oid])) {
-                $value = $tunnel[$oid];
+            if (is_numeric($tunnel_full[$oid])) {
+                $value = $tunnel_full[$oid];
             } else {
                 $value = '0';
             }
             $fields[$oid] = $value;
         }
 
-        if (isset($tunnel['cikeTunRemoteValue'])) {
+        if (isset($address)) {
             $tags = compact('address', 'rrd_name', 'rrd_def');
             data_update($device, 'ipsectunnel', $tags, $fields);
 
@@ -124,7 +138,7 @@ if ($device['os_group'] == 'cisco') {
         dbDelete(
             'ipsec_tunnels',
             '`tunnel_id` NOT IN ' . dbGenPlaceholders(count($valid_tunnels)) . ' AND `device_id`=?',
-            array_merge([$device['device_id']], $valid_tunnels)
+            array_merge($valid_tunnels, [$device['device_id']])
         );
     }
 


### PR DESCRIPTION
A lot of errors and warning if IKE session is not available anymore on the SNMP table. This tries to fix it by using available data instead. 
Also fix deleting older tunnels (DbDelete parameters were swapped).

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
