### PR TITLE
firebrick bgp polling was broken

### DIFF
--- a/includes/polling/bgp-peers.inc.php
+++ b/includes/polling/bgp-peers.inc.php
@@ -696,7 +696,7 @@ if (\LibreNMS\Config::get('enable_bgp')) {
                         }
                     }
 
-                    if ($devices['os'] == 'firebrick') {
+                    if ($device['os'] == 'firebrick') {
                         foreach ($peer_data_check as $key => $value) {
                             $oid = explode('.', $key);
                             $protocol = $oid[0];


### PR DESCRIPTION
It checked the wrong os variable, so was never run
Other option is to delete the code

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
