### PR TITLE
Fix os_group unset errors

### DIFF
--- a/LibreNMS/OS.php
+++ b/LibreNMS/OS.php
@@ -243,7 +243,7 @@ class OS implements
             if ($os_group = Config::get("os.{$device['os']}.group")) {
                 $device['os_group'] = $os_group;
             } else {
-                unset($device['os_group']);
+                $device['os_group'] = null;
             }
 
             $class = StringHelpers::toClass($device['os'], 'LibreNMS\\OS\\');

--- a/includes/discovery/bgp-peers.inc.php
+++ b/includes/discovery/bgp-peers.inc.php
@@ -28,12 +28,12 @@ if (Config::get('enable_bgp')) {
                 echo 'Updated AS ';
             }
 
-            if (isset($device['os_group']) && $device['os_group'] === 'arista') {
+            if ($device['os_group'] === 'arista') {
                 $peers_data = snmp_walk($device, 'aristaBgp4V2PeerRemoteAs', '-Oq', 'ARISTA-BGP4V2-MIB');
                 $peer2 = true;
             } elseif ($device['os'] == 'junos') {
                 $peers_data = snmp_walk($device, 'jnxBgpM2PeerRemoteAs', '-Onq', 'BGP4-V2-MIB-JUNIPER', 'junos');
-            } elseif (isset($device['os_group']) && $device['os_group'] === 'cisco') {
+            } elseif ($device['os_group'] === 'cisco') {
                 $peers_data = snmp_walk($device, 'cbgpPeer2RemoteAs', '-Oq', 'CISCO-BGP4-MIB');
                 $peer2 = ! empty($peers_data);
             } elseif ($device['os'] === 'cumulus') {

--- a/includes/discovery/cisco-vrf-lite.inc.php
+++ b/includes/discovery/cisco-vrf-lite.inc.php
@@ -21,7 +21,7 @@ if (Config::get('enable_vrf_lite_cisco')) {
     $ids = [];
 
     // For the moment only will be cisco and the version 3
-    if (isset($device['os_group']) && $device['os_group'] == 'cisco' && $device['snmpver'] == 'v3') {
+    if ($device['os_group'] == 'cisco' && $device['snmpver'] == 'v3') {
         $mib = 'SNMP-COMMUNITY-MIB';
         $mib = 'CISCO-CONTEXT-MAPPING-MIB';
         //-Osq because if i put the n the oid from the first command is not the same of this one

--- a/includes/discovery/sensors/cisco-entity-sensor.inc.php
+++ b/includes/discovery/sensors/cisco-entity-sensor.inc.php
@@ -2,7 +2,7 @@
 
 use Illuminate\Support\Str;
 
-if (isset($device['os_group']) && $device['os_group'] == 'cisco') {
+if ($device['os_group'] == 'cisco') {
     echo ' CISCO-ENTITY-SENSOR: ';
 
     $oids = [];

--- a/includes/discovery/storage/hpe-ilo.inc.php
+++ b/includes/discovery/storage/hpe-ilo.inc.php
@@ -1,6 +1,6 @@
 <?php
 
-if (in_array($device['os'], ['windows', 'hpe-ilo']) || (isset($device['os_group']) && $device['os_group'] == 'unix')) {
+if (in_array($device['os'], ['windows', 'hpe-ilo']) || $device['os_group'] == 'unix') {
     $ilo_storage = snmpwalk_group($device, 'cpqHoFileSysEntry', 'CPQHOST-MIB', 1, [], 'hp');
     $units = 1024 * 1024;
 

--- a/includes/discovery/vlans/cisco-vtp.inc.php
+++ b/includes/discovery/vlans/cisco-vtp.inc.php
@@ -1,6 +1,6 @@
 <?php
 
-if (isset($device['os_group']) && $device['os_group'] == 'cisco') {
+if ($device['os_group'] == 'cisco') {
     echo "Cisco VLANs:\n";
 
     $native_vlans = snmpwalk_cache_oid($device, 'vlanTrunkPortNativeVlan', [], 'CISCO-VTP-MIB');

--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -420,7 +420,7 @@ if (Config::get('enable_ports_poe')) {
     }
 }
 
-if (isset($device['os_group']) && $device['os_group'] == 'cisco' && $device['os'] != 'asa') {
+if ($device['os_group'] == 'cisco' && $device['os'] != 'asa') {
     foreach ($pagp_oids as $oid) {
         $pagp_port_stats = snmpwalk_cache_oid($device, $oid, [], 'CISCO-PAGP-MIB');
     }


### PR DESCRIPTION
Instead of requiring an isset check for os_group, just set it, but to null
valid isset checks will still work right since it is now set to null.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
