### PR TITLE
Fix Argument #2 ($array) must be of type array in cache

### DIFF
--- a/includes/common.php
+++ b/includes/common.php
@@ -502,7 +502,7 @@ function object_add_cache($section, $obj)
 function object_is_cached($section, $obj)
 {
     global $object_cache;
-    if (array_key_exists($obj, $object_cache)) {
+    if (is_array($object_cache) && array_key_exists($obj, $object_cache)) {
         return $object_cache[$section][$obj];
     } else {
         return false;


### PR DESCRIPTION
```
[2022-08-24T23:35:16.192206+02:00] production.ERROR: Error discovering discovery-arp module for 192.168.168.3. TypeError: array_key_exists(): Argument #2 ($array) must be of type array, null given in /opt/librenms/includes/common.php:505
Stack trace:
#0 /opt/librenms/includes/discovery/discovery-arp.inc.php(60): object_is_cached()
#1 /opt/librenms/includes/discovery/functions.inc.php(153): include('...')
#2 /opt/librenms/discovery.php(118): discover_device()
#3 {main}  
[2022-08-24T23:35:16.202398+02:00] production.ERROR: array_key_exists(): Argument #2 ($array) must be of type array, null given {"exception":"[object] (TypeError(code: 0): array_key_exists(): Argument #2 ($array) must be of type array, null given at /opt/librenms/includes/common.php:505)"} 


```
DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
