### PR TITLE
fix issue with new firmware requiring new MIB. Iss#10449

### DIFF
--- a/includes/definitions/discovery/geist-watchdog.yaml
+++ b/includes/definitions/discovery/geist-watchdog.yaml
@@ -1,9 +1,36 @@
-mib: GEIST-V4-MIB:GEIST-MIB-V3
+mib: VERTIV-BB-MIB
 modules:
     os:
         version: GEIST-MIB-V3::productVersion.0
         serial: GEIST-MIB-V3::climateSerial.1
     sensors:
+      state:
+         data:
+             -
+                 oid: InternalTable
+                 value: internalIO1
+                 num_oid: '.1.3.6.1.4.1.21239.5.1.2.1.8.1'
+                 descr: 'Door Position'
+                 group: Switch Sensors
+                 index: 'doorSwitchSensor.{{ $index }}'
+                 state_name: doorSwitchSensor
+                 states:
+                     - { value: -1, generic: 3, graph: 0, descr: 'null' }
+                     - { value:  1, generic: 2, graph: 0, descr: Open }
+                     - { value:  0, generic: 0, graph: 0, descr: Closed }
+             -
+                 oid: InternalTable
+                 value: internalIO2
+                 num_oid: '.1.3.6.1.4.1.21239.5.1.2.1.9.1'
+                 descr: 'Flood Sensor'
+                 group: Switch Sensors
+                 index: 'floodSwitchSensor.{{ $index }}'
+                 state_name: floodSwitchSensor
+                 states:
+                     - { value: -1, generic: 3, graph: 0, descr: 'null' }
+                     - { value:  0, generic: 2, graph: 0, descr: 'Wet' }
+                     - { value:  1, generic: 0, graph: 0, descr: 'Dry' }
+
         temperature:
             options:
                 divisor: 10
@@ -12,7 +39,8 @@ modules:
                     oid: internalTable
                     value: internalTemp
                     num_oid: '.1.3.6.1.4.1.21239.5.1.2.1.5.{{ $index }}'
-                    descr: internalName
+                    index: 'watchdogMainTempSensor.{{ $index }}'
+                    descr: "Main Temp Sensor"
                 -
                     oid: tempSensorTable
                     value: tempSensorTemp
@@ -32,7 +60,35 @@ modules:
                     oid: t3hdSensorTable
                     value: t3hdSensorIntTemp
                     num_oid: '.1.3.6.1.4.1.21239.5.1.8.1.6.{{ $index }}'
-                    descr: t3hdSensorIntName
+                    descr: "GTHD Main Temp Sensor"
+                    index: 'gthdMainTempSensor.{{ $index }}'
+                    skip_values:
+                        -
+                           oid: t3hdSensorAvail
+                           op: '!='
+                           value: 1
+                -
+                    oid: t3hdSensorTable
+                    value:  t3hdSensorExtATemp
+                    num_oid: '.1.3.6.1.4.1.21239.5.1.8.1.11.{{ $index }}'
+                    descr: "GTHD ExtA Temp Sensor"
+                    index: 'gthdExtATemp.{{ $index }}'
+                    skip_values:
+                        -
+                            oid: t3hdSensorExtAAvail
+                            op: '!='
+                            value: 1
+                -
+                    oid: t3hdSensorTable
+                    value:  t3hdSensorExtBTemp
+                    num_oid: '.1.3.6.1.4.1.21239.5.1.8.1.14.{{ $index }}'
+                    descr: "GTHD ExtB Temp Sensor"
+                    index: 'gthdExtBTemp.{{ $index }}'
+                    skip_values:
+                        -
+                            oid: t3hdSensorExtBAvail
+                            op: '!='
+                            value: 1
                 -
                     oid: thdSensorTable
                     value: thdSensorTemp
@@ -339,8 +395,9 @@ modules:
                 -
                     oid: internalTable
                     value: internalHumidity
-                    num_oid: '.1.3.6.1.4.1.21239.5.1.2.1.6.{{ $index }}'
-                    descr: internalName
+                    num_oid: '.1.3.6.1.4.1.21239.5.1.2.1.6.1'
+                    index: 'watchdogHumiditySensor.{{ $index }}'
+                    descr: "Main Humidity Sensor"
                 -
                     oid: thdSensorTable
                     value: thdSensorHumidity
@@ -355,8 +412,9 @@ modules:
                     oid: t3hdSensorTable
                     value: t3hdSensorIntHumidity
                     divisor: 1
-                    num_oid: '.1.3.6.1.4.1.21239.2.31.1.8.{{ $index }}'
-                    descr: t3hdSensorName
+                    num_oid: '.1.3.6.1.4.1.21239.5.1.8.1.7.1'
+                    descr: "GTHD Main Humidity Sensor"
+                    index: 'gthdHumiditySensor.{{ $index }}'
                     skip_values:
                         -
                             oid: t3hdSensorAvail

--- a/includes/definitions/discovery/geist-watchdog.yaml
+++ b/includes/definitions/discovery/geist-watchdog.yaml
@@ -31,7 +31,7 @@ modules:
                      - { value:  0, generic: 2, graph: 0, descr: 'Wet' }
                      - { value:  1, generic: 0, graph: 0, descr: 'Dry' }
 
-        temperature:
+      temperature:
             options:
                 divisor: 10
             data:

--- a/includes/definitions/geist-watchdog.yaml
+++ b/includes/definitions/geist-watchdog.yaml
@@ -14,4 +14,5 @@ discovery:
             - RCM-O
 mib_dir: geist
 over:
-    - { graph: device_bits, text: 'Device Traffic' }
+    - { graph: device_temperature, text: 'Temperatures' }
+    - { graph: device_humidity, text: 'Humidities' }

--- a/includes/polling/sensors/pre-cache/geist-watchdog.inc.php
+++ b/includes/polling/sensors/pre-cache/geist-watchdog.inc.php
@@ -23,5 +23,5 @@
  * @author     Neil Lathwood <gh+n@laf.io>
  */
 if ($type == 'temperature') {
-    $sensor_cache['geist_temp_unit'] = snmp_get($device, 'temperatureUnits.0', '-Oqv', 'GEIST-V4-MIB');
+    $sensor_cache['geist_temp_unit'] = snmp_get($device, 'temperatureUnits.0', '-Oqv', 'VERTIV-BB-MIB');
 }

--- a/includes/polling/sensors/temperature/geist-watchdog.inc.php
+++ b/includes/polling/sensors/temperature/geist-watchdog.inc.php
@@ -22,6 +22,6 @@
  * @copyright  2017 Neil Lathwood
  * @author     Neil Lathwood <gh+n@laf.io>
  */
-if ($sensor_cache['geist_temp_unit'] === '0') {
+if ($sensor_cache['geist_temp_unit'] == '0') {
     $sensor_value = fahrenheit_to_celsius($sensor_value / 10) * 10;
 }


### PR DESCRIPTION
The new Vertiv Geist Watchdog devices come with firmware version 3.4.0 which requires a new MIB "VERTIV-BB-MIB". I don't have the ability to run snmpsim in my environment, however, since I installed these modules and needed support, I figured I would send the changes upstream. I noticed there was a stale issue regarding the sensor support and this PR happens to address their concerns.

Additionally, I added two dry contact sensors. This is what I am using, but it also gives the user a starting point for adding or changing according to their environment. The documentation around this part isn't very clear, I think this will help future users of geist.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
