### PR TITLE
Misc errors cleanup

### DIFF
--- a/LibreNMS/Plugins.php
+++ b/LibreNMS/Plugins.php
@@ -183,12 +183,12 @@ class Plugins
 
         ob_start();
         if (! empty(self::$plugins[$hook])) {
-            foreach (self::$plugins[$hook] as $name) {
+            foreach (self::$plugins[$hook] as $plugin) {
                 try {
                     if (! is_array($params)) {
-                        @call_user_func([$name, $hook]);
+                        @call_user_func([$plugin, $hook]);
                     } else {
-                        @call_user_func_array([$name, $hook], $params);
+                        @call_user_func_array([$plugin, $hook], $params);
                     }
                 } catch (\Exception $e) {
                     Log::error($e);

--- a/LibreNMS/Plugins.php
+++ b/LibreNMS/Plugins.php
@@ -109,7 +109,7 @@ class Plugins
 
             foreach ((array) $hooks as $hookName) {
                 if ($hookName[0] != '_') {
-                    self::$plugins[$hookName][] = $class;
+                    self::$plugins[$hookName][] = $plugin;
                 }
             }
         }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1289,7 +1289,7 @@ function cache_peeringdb()
                     $ix_json = $get_ix->body();
                     $ix_data = json_decode($ix_json);
                     $peers = $ix_data->{'data'};
-                    foreach ($peers as $index => $peer) {
+                    foreach ($peers ?? [] as $index => $peer) {
                         $peer_name = get_astext($peer->{'asn'});
                         $tmp_peer = dbFetchRow('SELECT * FROM `pdb_ix_peers` WHERE `peer_id` = ? AND `ix_id` = ?', [$peer->{'id'}, $ixid]);
                         if ($tmp_peer) {


### PR DESCRIPTION
Prevents error such as:
> call_user_func() expects parameter 1 to be a valid callback, non-static method Vlan_Search::menu() should not be called statically

By calling the hook methods with an instance of the class instead. The plugins should have static methods, but this prevents the error anyway.

Also prevents another case of
> Invalid argument supplied for foreach()

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
