### PR TITLE
Fix hrStorageType being undefined

### DIFF
--- a/includes/discovery/storage/hrstorage.inc.php
+++ b/includes/discovery/storage/hrstorage.inc.php
@@ -25,7 +25,7 @@ if (is_array($hrstorage_array)) {
     ];
 
     foreach ($hrstorage_array as $index => $storage) {
-        $fstype = $storage['hrStorageType'];
+        $fstype = $storage['hrStorageType'] ?? null;
         $descr = $storage['hrStorageDescr'];
         $storage['hrStorageSize'] = fix_integer_value($storage['hrStorageSize']);
         $storage['hrStorageUsed'] = fix_integer_value($storage['hrStorageUsed']);


### PR DESCRIPTION
There is at least one reported case of `Illegal string offset 'hrStorageType'`, our test-data for canonprinter_tm got it also.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
