### PR TITLE
Don't send zeros to Graphite for missing metrics

### DIFF
--- a/LibreNMS/Data/Store/Graphite.php
+++ b/LibreNMS/Data/Store/Graphite.php
@@ -113,9 +113,9 @@ class Graphite extends BaseDatastore
         }
 
         foreach ($fields as $k => $v) {
-            // Send zero for fields without values
-            if (empty($v)) {
-                $v = 0;
+            // Skip fields without values
+            if (is_null($v)) {
+                continue;
             }
             $metric = implode('.', array_filter([$this->prefix, $hostname, $measurement, $ms_name, $k]));
             $this->writeData($metric, $v, $timestamp);


### PR DESCRIPTION
Fix #14258 - Graphite logic checking for empty metrics sends them as zeros instead of skipping them

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
