### PR TITLE
Email Transport: embed graphs by default

### DIFF
--- a/LibreNMS/Alert/Transport/Mail.php
+++ b/LibreNMS/Alert/Transport/Mail.php
@@ -46,7 +46,7 @@ class Mail extends Transport
             $msg = preg_replace("/(?<!\r)\n/", "\r\n", $obj['msg']);
         }
 
-        return \LibreNMS\Util\Mail::send($email, $obj['title'], $msg, $html);
+        return \LibreNMS\Util\Mail::send($email, $obj['title'], $msg, $html, $this->config['attach-graph']);
     }
 
     public static function configTemplate()
@@ -58,6 +58,13 @@ class Mail extends Transport
                     'name' => 'email',
                     'descr' => 'Email address of contact',
                     'type'  => 'text',
+                ],
+                [
+                    'title' => 'Include Graphs',
+                    'name' => 'attach-graph',
+                    'descr' => 'Include graph image data in the email.  Will be embedded if html5, otherwise attached. Template must use @signedGraphTag',
+                    'type' => 'checkbox',
+                    'default' => false,
                 ],
             ],
             'validation' => [

--- a/LibreNMS/Alert/Transport/Mail.php
+++ b/LibreNMS/Alert/Transport/Mail.php
@@ -64,7 +64,7 @@ class Mail extends Transport
                     'name' => 'attach-graph',
                     'descr' => 'Include graph image data in the email.  Will be embedded if html5, otherwise attached. Template must use @signedGraphTag',
                     'type' => 'checkbox',
-                    'default' => null,
+                    'default' => true,
                 ],
             ],
             'validation' => [

--- a/LibreNMS/Alert/Transport/Mail.php
+++ b/LibreNMS/Alert/Transport/Mail.php
@@ -46,7 +46,7 @@ class Mail extends Transport
             $msg = preg_replace("/(?<!\r)\n/", "\r\n", $obj['msg']);
         }
 
-        return \LibreNMS\Util\Mail::send($email, $obj['title'], $msg, $html, $this->config['attach-graph']);
+        return \LibreNMS\Util\Mail::send($email, $obj['title'], $msg, $html, $this->config['attach-graph'] ?? null);
     }
 
     public static function configTemplate()
@@ -64,7 +64,7 @@ class Mail extends Transport
                     'name' => 'attach-graph',
                     'descr' => 'Include graph image data in the email.  Will be embedded if html5, otherwise attached. Template must use @signedGraphTag',
                     'type' => 'checkbox',
-                    'default' => false,
+                    'default' => null,
                 ],
             ],
             'validation' => [

--- a/LibreNMS/Exceptions/RrdGraphException.php
+++ b/LibreNMS/Exceptions/RrdGraphException.php
@@ -26,19 +26,48 @@
 namespace LibreNMS\Exceptions;
 
 use Exception;
+use LibreNMS\Util\Graph;
 
 class RrdGraphException extends Exception
 {
+    /** @var string */
     protected $image_output;
+    /** @var string|null */
+    private $short_text;
+    /** @var int|string|null */
+    private $width;
+    /** @var int|string|null */
+    private $height;
 
-    public function __construct($error, $exit_code, $image_output)
+    /**
+     * @param  string  $error
+     * @param  string|null  $short_text
+     * @param  int|string|null  $width
+     * @param  int|string|null  $height
+     * @param  int  $exit_code
+     * @param  string  $image_output
+     */
+    public function __construct($error, $short_text = null, $width = null, $height = null, $exit_code = 0, $image_output = '')
     {
         parent::__construct($error, $exit_code);
+        $this->short_text = $short_text;
         $this->image_output = $image_output;
+        $this->width = $width;
+        $this->height = $height;
     }
 
-    public function getImage()
+    public function getImage(): string
     {
         return $this->image_output;
+    }
+
+    public function generateErrorImage(): string
+    {
+        return Graph::error(
+            $this->getMessage(),
+            $this->short_text,
+            empty($this->width) ? 300 : (int) $this->width,
+            empty($this->height) ? null : (int) $this->height,
+        );
     }
 }

--- a/LibreNMS/Util/Graph.php
+++ b/LibreNMS/Util/Graph.php
@@ -25,6 +25,7 @@
 
 namespace LibreNMS\Util;
 
+use App\Facades\DeviceCache;
 use App\Models\Device;
 use Illuminate\Support\Facades\Auth;
 use LibreNMS\Config;
@@ -46,7 +47,7 @@ class Graph
      *
      * @throws \LibreNMS\Exceptions\RrdGraphException
      */
-    public static function get($vars, $flags = 0): string
+    public static function get($vars, int $flags = 0): string
     {
         define('IGNORE_ERRORS', true);
         chdir(base_path());
@@ -63,13 +64,13 @@ class Graph
 
         [$type, $subtype] = extract_graph_type($vars['type']);
 
+        $graph_title = '';
         if (isset($vars['device'])) {
-            $device = is_numeric($vars['device'])
-                ? device_by_id_cache($vars['device'])
-                : device_by_name($vars['device']);
+            $device = device_by_id_cache(is_numeric($vars['device']) ? $vars['device'] : getidbyname($vars['device']));
+            DeviceCache::setPrimary($device['device_id']);
 
             //set default graph title
-            $graph_title = format_hostname($device);
+            $graph_title = DeviceCache::getPrimary()->displayName();
         }
 
         // variables for included graphs

--- a/LibreNMS/Util/Graph.php
+++ b/LibreNMS/Util/Graph.php
@@ -26,6 +26,7 @@
 namespace LibreNMS\Util;
 
 use App\Models\Device;
+use Illuminate\Support\Facades\Auth;
 use LibreNMS\Config;
 use Rrd;
 
@@ -64,7 +65,7 @@ class Graph
         $graph_image_type = $vars['graph_type'] ?? Config::get('webui.graph_type');
         $rrd_options = '';
 
-        $auth = null; // FIXME correct?
+        $auth = Auth::guest();
         require base_path("/includes/html/graphs/$type/auth.inc.php");
 
         //set default graph title

--- a/LibreNMS/Util/Graph.php
+++ b/LibreNMS/Util/Graph.php
@@ -33,16 +33,20 @@ use Rrd;
 
 class Graph
 {
+    const BASE64_OUTPUT = 1;
+    const COMMAND_ONLY = 2;
+
     /**
      * Fetch a graph image (as string) based on the given $vars
      * Optionally, override the output format to base64
      *
      * @param  array|string  $vars
-     * @param  bool  $base64
+     * @param  int  $flags  Flags for controlling graph generating options.
      * @return string
+     *
      * @throws \LibreNMS\Exceptions\RrdGraphException
      */
-    public static function get($vars, $base64 = false): string
+    public static function get($vars, $flags = 0): string
     {
         define('IGNORE_ERRORS', true);
         chdir(base_path());
@@ -63,6 +67,9 @@ class Graph
             $device = is_numeric($vars['device'])
                 ? device_by_id_cache($vars['device'])
                 : device_by_name($vars['device']);
+
+            //set default graph title
+            $graph_title = format_hostname($device);
         }
 
         // variables for included graphs
@@ -71,7 +78,7 @@ class Graph
         $title = $vars['title'] ?? '';
         $vertical = $vars['vertical'] ?? '';
         $legend = $vars['legend'] ?? false;
-        $output = $base64 ? 'base64' : $vars['output'] ?? 'default';
+        $output = $flags & self::BASE64_OUTPUT ? 'base64' : $vars['output'] ?? 'default';
         $from = parse_at_time($vars['from'] ?? '-1d');
         $to = empty($vars['to']) ? time() : parse_at_time($vars['to']);
         $period = ($to - $from);
@@ -79,25 +86,22 @@ class Graph
         $graph_image_type = $vars['graph_type'] ?? Config::get('webui.graph_type');
         Config::set('webui.graph_type', $graph_image_type); // set in case accessed elsewhere
         $rrd_options = '';
+        $rrd_filename = null;
+
         $auth = Auth::guest(); // if user not logged in, assume we authenticated via signed url, allow_unauth_graphs or allow_unauth_graphs_cidr
-
         require base_path("/includes/html/graphs/$type/auth.inc.php");
-
-        //set default graph title
-        $graph_title = format_hostname($device);
-
-        if ($auth && is_customoid_graph($type, $subtype)) {
-            $unit = $vars['unit'];
-            require base_path('/includes/html/graphs/customoid/customoid.inc.php');
-        } elseif ($auth && is_file(base_path("/includes/html/graphs/$type/$subtype.inc.php"))) {
-            require base_path("/includes/html/graphs/$type/$subtype.inc.php");
-        } else {
-            throw new RrdGraphException("{$type}_$subtype template missing", "{$type}_$subtype missing", $width, $height);
-        }
-
         if (! $auth) {
             // We are unauthenticated :(
             throw new RrdGraphException('No Authorization', 'No Auth', $width, $height);
+        }
+
+        if (is_customoid_graph($type, $subtype)) {
+            $unit = $vars['unit'];
+            require base_path('/includes/html/graphs/customoid/customoid.inc.php');
+        } elseif (is_file(base_path("/includes/html/graphs/$type/$subtype.inc.php"))) {
+            require base_path("/includes/html/graphs/$type/$subtype.inc.php");
+        } else {
+            throw new RrdGraphException("{$type}_$subtype template missing", "{$type}_$subtype missing", $width, $height);
         }
 
         if ($graph_image_type === 'svg') {
@@ -108,7 +112,7 @@ class Graph
         }
 
         // command output requested
-        if (! empty($command_only)) {
+        if ($flags & self::COMMAND_ONLY) {
             $cmd_output = "<div class='infobox'>";
             $cmd_output .= "<p style='font-size: 16px; font-weight: bold;'>RRDTool Command</p>";
             $cmd_output .= "<pre class='rrd-pre'>";
@@ -116,7 +120,7 @@ class Graph
             $cmd_output .= '</pre>';
             try {
                 $cmd_output .= Rrd::graph($rrd_options);
-            } catch (\LibreNMS\Exceptions\RrdGraphException $e) {
+            } catch (RrdGraphException $e) {
                 $cmd_output .= "<p style='font-size: 16px; font-weight: bold;'>RRDTool Output</p>";
                 $cmd_output .= "<pre class='rrd-pre'>";
                 $cmd_output .= $e->getMessage();
@@ -125,11 +129,6 @@ class Graph
             $cmd_output .= '</div>';
 
             return $cmd_output;
-        }
-
-        // graph sent file not found flag
-        if (! empty($no_file)) {
-            throw new RrdGraphException('No Data file', 'No Data', $width, $height);
         }
 
         if (empty($rrd_options)) {
@@ -141,24 +140,23 @@ class Graph
             $image_data = Rrd::graph($rrd_options);
 
             // output the graph
-            if (\LibreNMS\Util\Debug::isEnabled()) {
+            if (Debug::isEnabled()) {
                 return '<img src="data:' . get_image_type($graph_image_type) . ';base64,' . base64_encode($image_data) . '" alt="graph" />';
             } else {
                 return $output === 'base64' ? base64_encode($image_data) : $image_data;
             }
-        } catch (\LibreNMS\Exceptions\RrdGraphException $e) {
+        } catch (RrdGraphException $e) {
             // preserve original error if debug is enabled, otherwise make it a little more user friendly
-            if (\LibreNMS\Util\Debug::isEnabled()) {
+            if (Debug::isEnabled()) {
                 throw $e;
             }
 
-            if (isset($rrd_filename) && ! Rrd::checkRrdExists($rrd_filename)) {
+            if (! empty($rrd_filename) && ! Rrd::checkRrdExists($rrd_filename)) {
                 throw new RrdGraphException('No Data file' . basename($rrd_filename), 'No Data', $width, $height, $e->getCode(), $e->getImage());
             }
 
             throw new RrdGraphException('Error: ' . $e->getMessage(), 'Draw Error', $width, $height, $e->getCode(), $e->getImage());
         }
-
     }
 
     public static function getTypes(): array
@@ -233,11 +231,11 @@ class Graph
     /**
      * Create image to output text instead of a graph.
      *
-     * @param  string  $text Error message to display
-     * @param  string|null  $short_text Error message for smaller graph images
+     * @param  string  $text  Error message to display
+     * @param  string|null  $short_text  Error message for smaller graph images
      * @param  int  $width  Width of graph image (defaults to 300)
-     * @param  int|null  $height Height of graph image (defaults to width / 3)
-     * @param  int[]  $color Color of text, defaults to dark red
+     * @param  int|null  $height  Height of graph image (defaults to width / 3)
+     * @param  int[]  $color  Color of text, defaults to dark red
      * @return string the generated image
      */
     public static function error(string $text, ?string $short_text, int $width = 300, ?int $height = null, array $color = [128, 0, 0]): string
@@ -251,6 +249,7 @@ class Graph
 
         if ($type === 'svg') {
             $rgb = implode(', ', $color);
+
             return <<<SVG
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xhtml="http://www.w3.org/1999/xhtml"
@@ -270,7 +269,7 @@ SVG;
         $img = imagecreate($width, $height);
         imagecolorallocatealpha($img, 255, 255, 255, 127); // transparent background
 
-        $px = ((imagesx($img) - 7.5 * strlen($text)) / 2);
+        $px = (int) ((imagesx($img) - 7.5 * strlen($text)) / 2);
         $font = $width < 200 ? 3 : 5;
         imagestring($img, $font, $px, ($height / 2 - 8), $text, imagecolorallocate($img, ...$color));
 
@@ -283,5 +282,4 @@ SVG;
 
         return $output;
     }
-
 }

--- a/LibreNMS/Util/Graph.php
+++ b/LibreNMS/Util/Graph.php
@@ -151,7 +151,7 @@ class Graph
                 throw $e;
             }
 
-            if (! empty($rrd_filename) && ! Rrd::checkRrdExists($rrd_filename)) {
+            if (isset($rrd_filename) && ! Rrd::checkRrdExists($rrd_filename)) {
                 throw new RrdGraphException('No Data file' . basename($rrd_filename), 'No Data', $width, $height, $e->getCode(), $e->getImage());
             }
 

--- a/LibreNMS/Util/Graph.php
+++ b/LibreNMS/Util/Graph.php
@@ -27,9 +27,128 @@ namespace LibreNMS\Util;
 
 use App\Models\Device;
 use LibreNMS\Config;
+use Rrd;
 
 class Graph
 {
+    public static function get($vars): string
+    {
+        global $debug;
+        define('IGNORE_ERRORS', true);
+
+        include_once base_path('includes/dbFacile.php');
+        include_once base_path('includes/common.php');
+        include_once base_path('includes/html/functions.inc.php');
+        include_once base_path('includes/rewrites.php');
+
+        [$type, $subtype] = extract_graph_type($vars['type']);
+
+        if (isset($vars['device'])) {
+            $device = is_numeric($vars['device'])
+                ? device_by_id_cache($vars['device'])
+                : device_by_name($vars['device']);
+        }
+
+        // FIXME -- remove these
+        $width = $vars['width'];
+        $height = $vars['height'];
+        $title = $vars['title'] ?? '';
+        $vertical = $vars['vertical'] ?? '';
+        $legend = $vars['legend'] ?? false;
+        $output = (! empty($vars['output']) ? $vars['output'] : 'default');
+        $from = empty($vars['from']) ? Config::get('time.day') : parse_at_time($vars['from']);
+        $to = empty($vars['to']) ? Config::get('time.now') : parse_at_time($vars['to']);
+        $period = ($to - $from);
+        $prev_from = ($from - $period);
+
+        $graph_image_type = $vars['graph_type'] ?? Config::get('webui.graph_type');
+        $rrd_options = '';
+
+        $auth = null; // FIXME correct?
+        require base_path("/includes/html/graphs/$type/auth.inc.php");
+
+        //set default graph title
+        $graph_title = format_hostname($device);
+
+        if ($auth && is_customoid_graph($type, $subtype)) {
+            $unit = $vars['unit'];
+            require base_path('/includes/html/graphs/customoid/customoid.inc.php');
+        } elseif ($auth && is_file(base_path("/includes/html/graphs/$type/$subtype.inc.php"))) {
+            require base_path("/includes/html/graphs/$type/$subtype.inc.php");
+        } else {
+            return self::error("$type*$subtype template missing", $vars);
+        }
+
+        if (! empty($error_msg)) {
+            // We have an error :(
+            return self::error($error_msg, $vars);
+        }
+
+        if ($auth === null) {
+            // We are unauthenticated :(
+            return self::error($width < 200 ? 'No Auth' : 'No Authorization', $vars);
+        }
+
+        if ($graph_image_type === 'svg') {
+            $rrd_options .= ' --imgformat=SVG';
+            if ($width < 350) {
+                $rrd_options .= ' -m 0.75 -R light';
+            }
+        }
+
+        // command output requested
+        if (! empty($command_only)) {
+            $cmd_output = "<div class='infobox'>";
+            $cmd_output .= "<p style='font-size: 16px; font-weight: bold;'>RRDTool Command</p>";
+            $cmd_output .= "<pre class='rrd-pre'>";
+            $cmd_output .= escapeshellcmd('rrdtool ' . Rrd::buildCommand('graph', Config::get('temp_dir') . '/' . strgen(), $rrd_options));
+            $cmd_output .= '</pre>';
+            try {
+                $cmd_output .= Rrd::graph($rrd_options);
+            } catch (\LibreNMS\Exceptions\RrdGraphException $e) {
+                $cmd_output .= "<p style='font-size: 16px; font-weight: bold;'>RRDTool Output</p>";
+                $cmd_output .= "<pre class='rrd-pre'>";
+                $cmd_output .= $e->getMessage();
+                $cmd_output .= '</pre>';
+            }
+            $cmd_output .= '</div>';
+
+            return $cmd_output;
+        }
+
+        // graph sent file not found flag
+        if (! empty($no_file)) {
+            return self::error($width < 200 ? 'No Data' : 'No Data file ' . $no_file, $vars);
+        }
+
+        if (empty($rrd_options)) {
+            return self::error($width < 200 ? 'Def Error' : 'Graph Definition Error', $vars);
+        }
+
+        // Generating the graph!
+        try {
+            $image_data = Rrd::graph($rrd_options);
+
+            // output the graph
+            if (\LibreNMS\Util\Debug::isEnabled()) {
+                return '<img src="data:' . get_image_type($graph_image_type) . ';base64,' . base64_encode($image_data) . '" alt="graph" />';
+            } else {
+                return $output === 'base64' ? base64_encode($image_data) : $image_data;
+            }
+        } catch (\LibreNMS\Exceptions\RrdGraphException $e) {
+            if (\LibreNMS\Util\Debug::isEnabled()) {
+                throw $e;
+            }
+
+            if (isset($rrd_filename) && ! Rrd::checkRrdExists($rrd_filename)) {
+                return self::error($width < 200 ? 'No Data' : 'No Data file ' . basename($rrd_filename), $vars);
+            }
+
+            return self::error($width < 200 ? 'Draw Error' : 'Error Drawing Graph: ' . $e->getMessage(), $vars);
+        }
+
+    }
+
     public static function getTypes()
     {
         return ['device', 'port', 'application', 'munin', 'service'];
@@ -98,4 +217,54 @@ class Graph
 
         return Config::get("os_group.$os_group.over", Config::get('os.default.over'));
     }
+
+    /**
+     * Create image to output text instead of a graph.
+     *
+     * @param  string  $text
+     * @param  array  $vars
+     * @param  int[]  $color
+     */
+    public static function error($text, $vars = [], $color = [128, 0, 0]): string
+    {
+        $type = Config::get('webui.graph_type');
+
+        $width = (int) ($vars['width'] ?? 150);
+        $height = (int) ($vars['height'] ?? 60);
+
+        if ($type === 'svg') {
+            $rgb = implode(', ', $color);
+            return <<<SVG
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xhtml="http://www.w3.org/1999/xhtml"
+viewBox="0 0 $width $height"
+preserveAspectRatio="xMinYMin">
+<foreignObject x="0" y="0" width="$width" height="$height" transform="translate(0,0)">
+      <xhtml:div style="display:table; width:{$width}px; height:{$height}px; overflow:hidden;">
+         <xhtml:div style="display:table-cell; vertical-align:middle;">
+            <xhtml:div style="color:rgb($rgb); text-align:center; font-family:sans-serif; font-size:0.6em;">$text</xhtml:div>
+         </xhtml:div>
+      </xhtml:div>
+   </foreignObject>
+</svg>
+SVG;
+        }
+
+        $img = imagecreate($width, $height);
+        imagecolorallocatealpha($img, 255, 255, 255, 127); // transparent background
+
+        $px = ((imagesx($img) - 7.5 * strlen($text)) / 2);
+        $font = $width < 200 ? 3 : 5;
+        imagestring($img, $font, $px, ($height / 2 - 8), $text, imagecolorallocate($img, ...$color));
+
+        // Output the image
+        ob_start();
+        imagepng($img);
+        $output = ob_get_clean();
+        ob_end_clean();
+        imagedestroy($img);
+
+        return $output;
+    }
+
 }

--- a/LibreNMS/Util/Mail.php
+++ b/LibreNMS/Util/Mail.php
@@ -71,7 +71,7 @@ class Mail
      * @param  bool  $html
      * @return bool|string
      */
-    public static function send($emails, $subject, $message, bool $html = false)
+    public static function send($emails, $subject, $message, bool $html = false, ?bool $embedGraphs = null)
     {
         if (is_array($emails) || ($emails = self::parseEmails($emails))) {
             d_echo("Attempting to email $subject to: " . implode('; ', array_keys($emails)) . PHP_EOL);
@@ -90,7 +90,7 @@ class Mail
                 $mail->CharSet = 'utf-8';
                 $mail->WordWrap = 76;
                 $mail->Body = $message;
-                if (Config::get('email_attach_graphs')) {
+                if ($embedGraphs ?? Config::get('email_attach_graphs')) {
                     self::embedGraphs($mail);
                 }
                 if ($html) {

--- a/app/Http/Controllers/GraphController.php
+++ b/app/Http/Controllers/GraphController.php
@@ -5,39 +5,37 @@ namespace App\Http\Controllers;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use LibreNMS\Config;
+use LibreNMS\Exceptions\RrdGraphException;
 use LibreNMS\Util\Debug;
+use LibreNMS\Util\Graph;
 use LibreNMS\Util\Url;
 
 class GraphController extends Controller
 {
+    /**
+     * @throws \LibreNMS\Exceptions\RrdGraphException
+     */
     public function __invoke(Request $request, string $path = ''): Response
     {
-        define('IGNORE_ERRORS', true);
-
-        include_once base_path('includes/dbFacile.php');
-        include_once base_path('includes/common.php');
-        include_once base_path('includes/html/functions.inc.php');
-        include_once base_path('includes/rewrites.php');
-
-        $auth = \Auth::guest(); // if user not logged in, assume we authenticated via signed url, allow_unauth_graphs or allow_unauth_graphs_cidr
         $vars = array_merge(Url::parseLegacyPathVars($request->path()), $request->except(['username', 'password']));
+
         if (\Auth::check()) {
             // only allow debug for logged in users
             Debug::set(! empty($vars['debug']));
         }
 
-        // TODO, import graph.inc.php code and call Rrd::graph() directly
-        chdir(base_path());
-        ob_start();
-        include base_path('includes/html/graphs/graph.inc.php');
-        $output = ob_get_clean();
-        ob_end_clean();
+        $headers = [
+            'Content-type' => Config::get('webui.graph_type') == 'svg' ? 'image/svg+xml' : 'image/png',
+        ];
 
-        $headers = [];
-        if (! Debug::isEnabled()) {
-            $headers['Content-type'] = (Config::get('webui.graph_type') == 'svg' ? 'image/svg+xml' : 'image/png');
+        try {
+            return response(Graph::get($vars), 200, Debug::isEnabled() ? [] : $headers);
+        } catch (RrdGraphException $e) {
+            if (Debug::isEnabled()) {
+                throw $e;
+            }
+
+            return response($e->generateErrorImage(), 500, $headers);
         }
-
-        return response($output, 200, $headers);
     }
 }

--- a/app/Http/Controllers/GraphController.php
+++ b/app/Http/Controllers/GraphController.php
@@ -18,6 +18,7 @@ class GraphController extends Controller
     public function __invoke(Request $request, string $path = ''): Response
     {
         $vars = array_merge(Url::parseLegacyPathVars($request->path()), $request->except(['username', 'password']));
+        $vars['graph_type'] = $vars['graph_type'] ?? Config::get('webui.graph_type');
 
         if (\Auth::check()) {
             // only allow debug for logged in users
@@ -25,7 +26,7 @@ class GraphController extends Controller
         }
 
         $headers = [
-            'Content-type' => Config::get('webui.graph_type') == 'svg' ? 'image/svg+xml' : 'image/png',
+            'Content-type' => Graph::imageType($vars['graph_type']),
         ];
 
         try {

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -80,8 +80,8 @@ class AppServiceProvider extends ServiceProvider
             return "<?php echo '<img class=\"librenms-graph\" src=\"' . \LibreNMS\Util\Url::forExternalGraph($vars) . '\" />'; ?>";
         });
 
-        Blade::directive('graphImage', function ($vars, $base64 = false) {
-            return "<?php echo \LibreNMS\Util\Graph::get($vars, $base64); ?>";
+        Blade::directive('graphImage', function ($vars, $flags = 0) {
+            return "<?php echo \LibreNMS\Util\Graph::get($vars, $flags); ?>";
         });
     }
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -81,7 +81,7 @@ class AppServiceProvider extends ServiceProvider
         });
 
         Blade::directive('graphImage', function ($vars, $base64 = false) {
-            return "<?php echo \LibreNMS\Util\Graph::get(is_array($vars) ? $vars : \LibreNMS\Util\Url::parseLegacyPathVars($vars), $base64); ?>";
+            return "<?php echo \LibreNMS\Util\Graph::get($vars, $base64); ?>";
         });
     }
 

--- a/doc/Alerting/Transports.md
+++ b/doc/Alerting/Transports.md
@@ -385,10 +385,12 @@ The E-Mail transports uses the same email-configuration as the rest of LibreNMS.
 As a small reminder, here is its configuration directives including defaults:
 
 Emails will attach all graphs included with the @signedGraphTag directive.
+If the email format is set to html, they will be embedded.
 To disable attaching images, set email_attach_graphs to false.
 
 !!! setting "alerting/email"
 ```bash
+lnms config:set email_html true
 lnms config:set email_attach_graphs false
 ```
 

--- a/doc/Alerting/Transports.md
+++ b/doc/Alerting/Transports.md
@@ -381,8 +381,16 @@ LibreNMS database.
 
 ## Mail
 
-The E-Mail transports uses the same email-configuration like the rest of LibreNMS.
-As a small reminder, here is it's configuration directives including defaults:
+The E-Mail transports uses the same email-configuration as the rest of LibreNMS.
+As a small reminder, here is its configuration directives including defaults:
+
+Emails will attach all graphs included with the @signedGraphTag directive.
+To disable attaching images, set email_attach_graphs to false.
+
+!!! setting "alerting/email"
+```bash
+lnms config:set email_attach_graphs false
+```
 
 **Example:**
 

--- a/html/mix-manifest.json
+++ b/html/mix-manifest.json
@@ -5,12 +5,12 @@
     "/css/app.css": "/css/app.css?id=bd093a6a2e2682bb59ef",
     "/js/vendor.js": "/js/vendor.js?id=c5fd3d75a63757080dbb",
     "/js/lang/de.js": "/js/lang/de.js?id=613b5ca9cd06ca15e384",
-    "/js/lang/en.js": "/js/lang/en.js?id=6b3807ebe10e3fa9fa40",
+    "/js/lang/en.js": "/js/lang/en.js?id=b4dc5539b25bf7a31718",
     "/js/lang/fr.js": "/js/lang/fr.js?id=982d149de32e1867610c",
     "/js/lang/it.js": "/js/lang/it.js?id=e24bb9bad83e288b4617",
     "/js/lang/ru.js": "/js/lang/ru.js?id=f6b7c078755312a0907c",
+    "/js/lang/sr.js": "/js/lang/sr.js?id=388e38b41f63e3517506",
     "/js/lang/uk.js": "/js/lang/uk.js?id=34f8698ff09b869db2f5",
     "/js/lang/zh-CN.js": "/js/lang/zh-CN.js?id=4e081fbac70d969894bf",
-    "/js/lang/zh-TW.js": "/js/lang/zh-TW.js?id=ed26425647721a42ee9d",
-    "/js/lang/sr.js": "/js/lang/sr.js?id=17585a0e001293ade0e1"
+    "/js/lang/zh-TW.js": "/js/lang/zh-TW.js?id=ed26425647721a42ee9d"
 }

--- a/includes/html/functions.inc.php
+++ b/includes/html/functions.inc.php
@@ -438,7 +438,7 @@ function generate_port_image($args)
  */
 function graph_error($text, $color = [128, 0, 0])
 {
-    echo \LibreNMS\Util\Graph::error($text, $color);
+    echo \LibreNMS\Util\Graph::error($text, null, 300, null, $color);
 }
 
 /**

--- a/includes/html/functions.inc.php
+++ b/includes/html/functions.inc.php
@@ -11,7 +11,6 @@
  */
 
 use LibreNMS\Config;
-use LibreNMS\Util\Debug;
 use LibreNMS\Util\Number;
 use LibreNMS\Util\Rewrite;
 
@@ -439,44 +438,7 @@ function generate_port_image($args)
  */
 function graph_error($text, $color = [128, 0, 0])
 {
-    global $vars;
-
-    $type = Config::get('webui.graph_type');
-    if (! Debug::isEnabled()) {
-        header('Content-type: ' . get_image_type($type));
-    }
-
-    $width = (int) ($vars['width'] ?? 150);
-    $height = (int) ($vars['height'] ?? 60);
-
-    if ($type === 'svg') {
-        $rgb = implode(', ', $color);
-        echo <<<SVG
-<svg xmlns="http://www.w3.org/2000/svg"
-xmlns:xhtml="http://www.w3.org/1999/xhtml"
-viewBox="0 0 $width $height"
-preserveAspectRatio="xMinYMin">
-<foreignObject x="0" y="0" width="$width" height="$height" transform="translate(0,0)">
-      <xhtml:div style="display:table; width:{$width}px; height:{$height}px; overflow:hidden;">
-         <xhtml:div style="display:table-cell; vertical-align:middle;">
-            <xhtml:div style="color:rgb($rgb); text-align:center; font-family:sans-serif; font-size:0.6em;">$text</xhtml:div>
-         </xhtml:div>
-      </xhtml:div>
-   </foreignObject>
-</svg>
-SVG;
-    } else {
-        $img = imagecreate($width, $height);
-        imagecolorallocatealpha($img, 255, 255, 255, 127); // transparent background
-
-        $px = ((imagesx($img) - 7.5 * strlen($text)) / 2);
-        $font = $width < 200 ? 3 : 5;
-        imagestring($img, $font, $px, ($height / 2 - 8), $text, imagecolorallocate($img, ...$color));
-
-        // Output the image
-        imagepng($img);
-        imagedestroy($img);
-    }
+    echo \LibreNMS\Util\Graph::error($text, $color);
 }
 
 /**

--- a/includes/html/functions.inc.php
+++ b/includes/html/functions.inc.php
@@ -997,7 +997,7 @@ function eventlog_severity($eventlog_severity)
  */
 function get_image_type(string $type)
 {
-    return $type === 'svg' ? 'image/svg+xml' : 'image/png';
+    return \LibreNMS\Util\Graph::imageType($type);
 }
 
 function get_oxidized_nodes_list()

--- a/includes/html/graphs/application/nginx_req.inc.php
+++ b/includes/html/graphs/application/nginx_req.inc.php
@@ -16,6 +16,4 @@ if (Rrd::checkRrdExists($rrd_filename)) {
     $rrd_options .= " GPRINT:a:LAST:'%6.2lf %s'";
     $rrd_options .= " GPRINT:a:AVERAGE:'%6.2lf %s'";
     $rrd_options .= " GPRINT:a:MAX:'%6.2lf %s\\n'";
-} else {
-    $error_msg = 'Missing RRD';
 }

--- a/includes/html/graphs/graph.inc.php
+++ b/includes/html/graphs/graph.inc.php
@@ -42,13 +42,6 @@ if ($auth && is_customoid_graph($type, $subtype)) {
     // Graph Template Missing");
 }
 
-if (! empty($error_msg)) {
-    // We have an error :(
-    graph_error($error_msg);
-
-    return;
-}
-
 if ($auth === null) {
     // We are unauthenticated :(
     graph_error($width < 200 ? 'No Auth' : 'No Authorization');

--- a/includes/html/graphs/graph.inc.php
+++ b/includes/html/graphs/graph.inc.php
@@ -76,13 +76,6 @@ if (! empty($command_only)) {
     return;
 }
 
-// graph sent file not found flag
-if (! empty($no_file)) {
-    graph_error($width < 200 ? 'No Data' : 'No Data file ' . $no_file);
-
-    return;
-}
-
 if (empty($rrd_options)) {
     graph_error($width < 200 ? 'Def Error' : 'Graph Definition Error');
 

--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -1427,6 +1427,13 @@
                 "value": "smtp"
             }
         },
+        "email_attach_graphs": {
+            "default": true,
+            "group": "alerting",
+            "section": "email",
+            "order": 4,
+            "type": "boolean"
+        },
         "email_backend": {
             "default": "mail",
             "group": "alerting",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2741,31 +2741,6 @@ parameters:
 			path: LibreNMS/Exceptions/JsonAppWrongVersionException.php
 
 		-
-			message: "#^Method LibreNMS\\\\Exceptions\\\\RrdGraphException\\:\\:__construct\\(\\) has parameter \\$error with no type specified\\.$#"
-			count: 1
-			path: LibreNMS/Exceptions/RrdGraphException.php
-
-		-
-			message: "#^Method LibreNMS\\\\Exceptions\\\\RrdGraphException\\:\\:__construct\\(\\) has parameter \\$exit_code with no type specified\\.$#"
-			count: 1
-			path: LibreNMS/Exceptions/RrdGraphException.php
-
-		-
-			message: "#^Method LibreNMS\\\\Exceptions\\\\RrdGraphException\\:\\:__construct\\(\\) has parameter \\$image_output with no type specified\\.$#"
-			count: 1
-			path: LibreNMS/Exceptions/RrdGraphException.php
-
-		-
-			message: "#^Method LibreNMS\\\\Exceptions\\\\RrdGraphException\\:\\:getImage\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: LibreNMS/Exceptions/RrdGraphException.php
-
-		-
-			message: "#^Property LibreNMS\\\\Exceptions\\\\RrdGraphException\\:\\:\\$image_output has no type specified\\.$#"
-			count: 1
-			path: LibreNMS/Exceptions/RrdGraphException.php
-
-		-
 			message: "#^Method LibreNMS\\\\Exceptions\\\\UnserializableRouteCache\\:\\:__construct\\(\\) has parameter \\$cli_php_version with no type specified\\.$#"
 			count: 1
 			path: LibreNMS/Exceptions/UnserializableRouteCache.php
@@ -5612,11 +5587,6 @@ parameters:
 
 		-
 			message: "#^Method LibreNMS\\\\Util\\\\Graph\\:\\:getOverviewGraphsForDevice\\(\\) has parameter \\$device with no type specified\\.$#"
-			count: 1
-			path: LibreNMS/Util/Graph.php
-
-		-
-			message: "#^Method LibreNMS\\\\Util\\\\Graph\\:\\:getTypes\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: LibreNMS/Util/Graph.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -5596,7 +5596,7 @@ parameters:
 			path: LibreNMS/Util/Graph.php
 
 		-
-			message: "#^Variable \\$rrd_filename in empty\\(\\) always exists and is always falsy\\.$#"
+			message: "#^Variable \\$rrd_filename in isset\\(\\) always exists and is always null\\.$#"
 			count: 1
 			path: LibreNMS/Util/Graph.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -5591,6 +5591,16 @@ parameters:
 			path: LibreNMS/Util/Graph.php
 
 		-
+			message: "#^Result of && is always false\\.$#"
+			count: 1
+			path: LibreNMS/Util/Graph.php
+
+		-
+			message: "#^Variable \\$rrd_filename in empty\\(\\) always exists and is always falsy\\.$#"
+			count: 1
+			path: LibreNMS/Util/Graph.php
+
+		-
 			message: "#^Method LibreNMS\\\\Util\\\\Html\\:\\:percentageBar\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: LibreNMS/Util/Html.php

--- a/resources/lang/en/settings.php
+++ b/resources/lang/en/settings.php
@@ -625,6 +625,10 @@ return [
             'description' => 'Auto TLS support',
             'help' => 'Tries to use TLS before falling back to un-encrypted',
         ],
+        'email_attach_graphs' => [
+            'description' => 'Attach graph images',
+            'help' => 'This will generate a graph when the alert is raised and attach it and embed it in the email.',
+        ],
         'email_backend' => [
             'description' => 'How to deliver mail',
             'help' => 'The backend to use for sending email, can be mail, sendmail or SMTP',


### PR DESCRIPTION
This will attach images included with the @signedGraphTag directive in the template.
If the email is html, they will be embedded, otherwise, they will only be attached.
Also includes some graphing cleanups, prep for removing the legacy graph.php entry point.

 - [x] Add docs

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
