### PR TITLE
Fix issue causing error reporting to be incorrectly enabled

### DIFF
--- a/app/Providers/ErrorReportingProvider.php
+++ b/app/Providers/ErrorReportingProvider.php
@@ -46,7 +46,7 @@ class ErrorReportingProvider extends \Facade\Ignition\IgnitionServiceProvider
     public function boot(): void
     {
         Flare::filterExceptionsUsing(function (\Exception $e) {
-            if (Config::get('reporting.error.dump')) {
+            if (Config::get('reporting.dump_errors')) {
                 dump('Exception: ' . $e->getMessage(), $e->getFile() . ':' . $e->getLine());
             }
 

--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -4857,7 +4857,7 @@
             "default": false,
             "type": "boolean"
         },
-        "reporting.error.dump": {
+        "reporting.dump_errors": {
             "default": false,
             "type": "boolean"
         },


### PR DESCRIPTION
for some reason, the reporting.error.dump merged with reporting.error to store an array instead of a bool.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
