### PR TITLE
Dont set mempool percent to null

### DIFF
--- a/app/Models/Mempool.php
+++ b/app/Models/Mempool.php
@@ -63,7 +63,6 @@ class Mempool extends DeviceRelatedModel implements Keyable
         $this->mempool_used = $used * $this->mempool_precision;
         $this->mempool_free = $free * $this->mempool_precision;
         $percent = $this->normalizePercent($percent); // don't assign to model or it loses precision
-        $this->mempool_perc = $percent;
 
         if (! $this->mempool_total) {
             if (! $percent && $percent !== 0.0) {
@@ -87,6 +86,8 @@ class Mempool extends DeviceRelatedModel implements Keyable
 
         if ($percent == null) {
             $this->mempool_perc = $this->mempool_used / $this->mempool_total * 100;
+        } else {
+            $this->mempool_perc = $percent;
         }
 
         return $this;

--- a/app/Models/Mempool.php
+++ b/app/Models/Mempool.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Support\Str;
 use LibreNMS\Interfaces\Models\Keyable;
+use LibreNMS\Util\Number;
 
 class Mempool extends DeviceRelatedModel implements Keyable
 {

--- a/app/Models/Mempool.php
+++ b/app/Models/Mempool.php
@@ -63,6 +63,7 @@ class Mempool extends DeviceRelatedModel implements Keyable
         $this->mempool_used = $used * $this->mempool_precision;
         $this->mempool_free = $free * $this->mempool_precision;
         $percent = $this->normalizePercent($percent); // don't assign to model or it loses precision
+        $this->mempool_perc = $percent;
 
         if (! $this->mempool_total) {
             if (! $percent && $percent !== 0.0) {
@@ -85,9 +86,7 @@ class Mempool extends DeviceRelatedModel implements Keyable
         }
 
         if ($percent == null) {
-            $this->mempool_perc = $this->mempool_used / $this->mempool_total * 100;
-        } else {
-            $this->mempool_perc = $percent;
+            $this->mempool_perc = Number::calculatePercent($this->mempool_used, $this->mempool_total);
         }
 
         return $this;


### PR DESCRIPTION
`normalizePercent()` can return null, `setMempoolPercAttribute()` applies `round()` and throws deprecation warning 

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
