### PR TITLE
SnmpResponse filterBadLines fix

### DIFF
--- a/LibreNMS/Data/Source/SnmpResponse.php
+++ b/LibreNMS/Data/Source/SnmpResponse.php
@@ -227,7 +227,7 @@ class SnmpResponse
      */
     public function filterBadLines(): SnmpResponse
     {
-        $this->raw = preg_replace('/^.*No Such Instance currently exists.*$/', '', $this->raw);
+        $this->raw = preg_replace('/^.*No Such Instance currently exists.*$/m', '', $this->raw);
         $this->raw = preg_replace('/\n[^\r\n]+No more variables left[^\r\n]+$/s', '', $this->raw);
 
         return $this;


### PR DESCRIPTION
Actually filter lines (instead of full responses) with No Such Instance regex

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
