### PR TITLE
Billing module fix/cleanup

### DIFF
--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -1833,6 +1833,7 @@ function create_edit_bill(Illuminate\Http\Request $request)
             'bill_custid' => $bill['bill_custid'],
             'bill_ref' => $bill['bill_ref'],
             'bill_notes' => $bill['bill_notes'],
+            'dir_95th' => $bill['dir_95th'],
         ];
         $update = dbUpdate($update_data, 'bills', 'bill_id=?', [$bill_id]);
         if ($update === false || $update < 0) {
@@ -1853,6 +1854,7 @@ function create_edit_bill(Illuminate\Http\Request $request)
             'bill_custid',
             'bill_ref',
             'bill_notes',
+            'dir_95th',
         ];
 
         if ($data['bill_type'] == 'quota') {
@@ -1891,6 +1893,7 @@ function create_edit_bill(Illuminate\Http\Request $request)
                 'bill_custid' => $bill['bill_custid'],
                 'bill_ref' => $bill['bill_ref'],
                 'bill_notes' => $bill['bill_notes'],
+                'dir_95th' => $bill['dir_95th'],
             ],
             'bills'
         );

--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -813,18 +813,6 @@
             "default": 1000,
             "type": "integer"
         },
-        "billing.bill_autoadd": {
-            "default": false,
-            "type": "boolean"
-        },
-        "billing.circuit_autoadd": {
-            "default": false,
-            "type": "boolean"
-        },
-        "billing.customer_autoadd": {
-            "default": false,
-            "type": "boolean"
-        },
         "callback_clear": {
             "default": "https://stats.librenms.org/clear.php",
             "type": "text"


### PR DESCRIPTION
Small fix to Billing module API (allows creating aggregate bills via API), and delete some billing module definitions that are never used.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
