### PR TITLE
Do not include _token in legacy vars

### DIFF
--- a/includes/html/vars.inc.php
+++ b/includes/html/vars.inc.php
@@ -10,5 +10,5 @@ foreach ($_POST as $name => $value) {
     $vars[$name] = ($value);
 }
 
-// don't leak login data
-unset($vars['username'], $vars['password'], $uri, $base_url);
+// don't leak login and other data
+unset($vars['username'], $vars['password'], $vars['_token']);


### PR DESCRIPTION
Stops the legacy ui from inserting _token into urls all over the place...

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
