### PR TITLE
API update_device, make location field work (as does location_id)

### DIFF
--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -1922,7 +1922,7 @@ function update_device(Illuminate\Http\Request $request)
     // use hostname as device_id if it's all digits
     $device_id = ctype_digit($hostname) ? $hostname : getidbyname($hostname);
     $data = json_decode($request->getContent(), true);
-    $bad_fields = ['device_id', 'hostname'];
+    $bad_fields = ['device_id', 'hostname', 'location'];
     if (empty($data['field'])) {
         return api_error(400, 'Device field to patch has not been supplied');
     } elseif (in_array($data['field'], $bad_fields)) {

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -1922,7 +1922,7 @@ function update_device(Illuminate\Http\Request $request)
     // use hostname as device_id if it's all digits
     $device_id = ctype_digit($hostname) ? $hostname : getidbyname($hostname);
     $data = json_decode($request->getContent(), true);
-    $bad_fields = ['device_id', 'hostname', 'location'];
+    $bad_fields = ['device_id', 'hostname'];
     if (empty($data['field'])) {
         return api_error(400, 'Device field to patch has not been supplied');
     } elseif (in_array($data['field'], $bad_fields)) {
@@ -1938,7 +1938,15 @@ function update_device(Illuminate\Http\Request $request)
         if (count($data['field']) == count($data['data'])) {
             $update = [];
             for ($x = 0; $x < count($data['field']); $x++) {
-                $update[$data['field'][$x]] = $data['data'][$x];
+                $field = $data['field'][$x];
+                $field_data = $data['data'][$x];
+
+                if ($field == 'location') {
+                    $field = 'location_id';
+                    $field_data = \App\Models\Location::firstOrCreate(['location' => $field_data])->id;
+                }
+
+                $update[$field] = $field_data;
             }
             if (dbUpdate($update, 'devices', '`device_id`=?', [$device_id]) >= 0) {
                 return api_success_noresult(200, 'Device fields have been updated');


### PR DESCRIPTION
The field 'location' can't be changed using API update_device_field, even when used with 'override_sysLocation'. It should not return success, with the "Device fields have been updated" message that is untrue.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
