### PR TITLE
Do not allow sysDescr to be fetched in os module yaml

### DIFF
--- a/misc/discovery_schema.json
+++ b/misc/discovery_schema.json
@@ -365,7 +365,8 @@
         "oids": {
             "type": ["string", "array"],
             "items": {
-                "type": "string"
+                "type": "string",
+                "pattern": "^((?!sysDescr\\.0|1\\.3\\.6\\.1\\.2\\.1\\.1\\.1\\.0).)*$"
             }
         },
         "pre-cache": {


### PR DESCRIPTION
It has already been fetched, use sysDescr_regex

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
