### PR TITLE
VLANs: Ironware workaround for Q-BRIDGE-MIB

### DIFF
--- a/includes/discovery/vlans/q-bridge-mib.inc.php
+++ b/includes/discovery/vlans/q-bridge-mib.inc.php
@@ -36,7 +36,7 @@ if ($vlanversion == 'version1' || $vlanversion == '2') {
     // fetch vlan data
     $vlans = SnmpQuery::walk('Q-BRIDGE-MIB::dot1qVlanCurrentUntaggedPorts')->table(2);
     $vlans = SnmpQuery::walk('Q-BRIDGE-MIB::dot1qVlanCurrentEgressPorts')->table(2, $vlans);
-    // Q-BRIDGE-MIB::dot1qVlanCurrentX returns incorrect data for ICX64XX with v08.0.30uT313 
+    // dot1qVlanCurrentX returns incorrect data on ICX64XX with v08.0.30uT313
     if (empty($vlans) || $device['version'] == '08.0.30uT313') {
         // fall back to static
         $vlans = SnmpQuery::walk('Q-BRIDGE-MIB::dot1qVlanStaticUntaggedPorts')->table(1, $vlans);

--- a/includes/discovery/vlans/q-bridge-mib.inc.php
+++ b/includes/discovery/vlans/q-bridge-mib.inc.php
@@ -36,7 +36,8 @@ if ($vlanversion == 'version1' || $vlanversion == '2') {
     // fetch vlan data
     $vlans = SnmpQuery::walk('Q-BRIDGE-MIB::dot1qVlanCurrentUntaggedPorts')->table(2);
     $vlans = SnmpQuery::walk('Q-BRIDGE-MIB::dot1qVlanCurrentEgressPorts')->table(2, $vlans);
-    if (empty($vlans)) {
+    // Q-BRIDGE-MIB::dot1qVlanCurrentX returns incorrect data for ICX64XX with v08.0.30uT313 
+    if (empty($vlans) || $device['version'] == '08.0.30uT313') {
         // fall back to static
         $vlans = SnmpQuery::walk('Q-BRIDGE-MIB::dot1qVlanStaticUntaggedPorts')->table(1, $vlans);
         $vlans = SnmpQuery::walk('Q-BRIDGE-MIB::dot1qVlanStaticEgressPorts')->table(1, $vlans);


### PR DESCRIPTION
@murrant 

As originally noted in https://github.com/librenms/librenms/pull/14326:

The VLANS tab was populated with incorrect data for my Brocade ICX6450-48P. Specifically, the information coming from Q-BRIDGE-MIB::dot1qVlanCurrentEgressPorts is wrong. It appears to need the data in Q-BRIDGE-MIB::dot1qVlanStaticEgressPorts to be correct. 

This PR modifies q-bridge-mib.inc.php in order to test for ironware version 08.0.30uT313 (which is the last version supported on this device) when polling for vlan data. 

This change fixed the VLANs tab for my switch, but I am not sure if this is an acceptable approach and/or if someone else has a device running this version (or others) that can confirm the issue/fix. The only other thing I can think of would be to compare dot1qVlanCurrentEgressPorts with dot1qVlanStaticEgressPorts and if they differ prefer the latter (possibly again only for version 08.0.30uT313 of the firmware). 

Side note: I'm also having trouble creating testing data in the official docker container. I can create the snmprec in step one, but can't get step two to complete. 



DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
