### PR TITLE
Check dot1dBasePortIfIndex exists before using it

### DIFF
--- a/includes/discovery/vlans.inc.php
+++ b/includes/discovery/vlans.inc.php
@@ -26,7 +26,7 @@ foreach ($tmp_base_indexes as $index => $array) {
     // So lets sanity check
     if (! array_key_exists('dot1dBasePortIfIndex', $array)) {
         continue;
-    }    
+    }
     $base_to_index[$index] = $array['dot1dBasePortIfIndex'];
 }
 $index_to_base = array_flip($base_to_index);

--- a/includes/discovery/vlans.inc.php
+++ b/includes/discovery/vlans.inc.php
@@ -25,7 +25,7 @@ foreach ($tmp_base_indexes as $index => $array) {
     // Broken SNMP servers can return the wrong data when OID doesn't exist
     // So lets sanity check
     if (! array_key_exists('dot1dBasePortIfIndex', $array)) {
-      continue;
+        continue;
     }    
     $base_to_index[$index] = $array['dot1dBasePortIfIndex'];
 }

--- a/includes/discovery/vlans.inc.php
+++ b/includes/discovery/vlans.inc.php
@@ -22,6 +22,11 @@ $base_to_index = [];
 $tmp_base_indexes = snmpwalk_cache_oid($device, 'dot1dBasePortIfIndex', [], 'BRIDGE-MIB');
 // flatten the array
 foreach ($tmp_base_indexes as $index => $array) {
+    // Broken SNMP servers can return the wrong data when OID doesn't exist
+    // So lets sanity check
+    if (! array_key_exists('dot1dBasePortIfIndex', $array)) {
+      continue;
+    }    
     $base_to_index[$index] = $array['dot1dBasePortIfIndex'];
 }
 $index_to_base = array_flip($base_to_index);


### PR DESCRIPTION
Fixes: array_flip(): Can only flip STRING and INTEGER values!

From a device returning this from `snmpwalk_cache_oid($device, 'dot1dBasePortIfIndex', [], 'BRIDGE-MIB');`:
```
array:1 [
  0 => array:1 [
    "sysDescr" => "Temperature & Sensor Gateway"
  ]
]
```


#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
