### PR TITLE
Fix the case of 'Ungrouped' in smokeping integration

### DIFF
--- a/LibreNMS/Util/Smokeping.php
+++ b/LibreNMS/Util/Smokeping.php
@@ -78,7 +78,7 @@ class Smokeping
     public function generateFileName($file = '')
     {
         if (Config::get('smokeping.integration') === true) {
-            return Config::get('smokeping.dir') . '/' . ($this->device->type ?: 'ungrouped') . '/' . $file;
+            return Config::get('smokeping.dir') . '/' . ($this->device->type ?: 'Ungrouped') . '/' . $file;
         } else {
             return Config::get('smokeping.dir') . '/' . $file;
         }


### PR DESCRIPTION
The last commit of https://github.com/librenms/librenms/pull/14341 before merging did break the fix because Ungrouped became ungrouped, I'm fixing this here.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
