### PR TITLE
Load device selection dynamically on Ports page

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -217,7 +217,7 @@ LibreNMS contributors:
 - Jason Cheng <sanyu3u@gmail.com> (jasoncheng7115)
 - Daniel Baeza <doctoruve@gmail.com> (TheGreatDoc)
 - Thom Cleary <me@thomcat.rocks> (thomcatdotrocks)
-- Kayck Matias <kayckmatias@gmail.com> [KayckMatias](https://github.com/KayckMatias/)
+- Kayck Matias <kayckmatias04@gmail.com> [KayckMatias](https://github.com/KayckMatias/)
 
 Observium was written by:
 - Adam Armstrong

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -217,6 +217,7 @@ LibreNMS contributors:
 - Jason Cheng <sanyu3u@gmail.com> (jasoncheng7115)
 - Daniel Baeza <doctoruve@gmail.com> (TheGreatDoc)
 - Thom Cleary <me@thomcat.rocks> (thomcatdotrocks)
+- Kayck Matias <kayckmatias@gmail.com> [KayckMatias](https://github.com/KayckMatias/)
 
 Observium was written by:
 - Adam Armstrong

--- a/includes/html/pages/ports.inc.php
+++ b/includes/html/pages/ports.inc.php
@@ -91,32 +91,12 @@ if ((isset($vars['searchbar']) && $vars['searchbar'] != 'hide') || ! isset($vars
     $output .= "<div style='margin-bottom:4px;text-align:left;'>";
     $output .= "<div class='form-group'>";
     $output .= "<select name='device_id' id='device_id' class='form-control input-sm'>";
-    $output .= "<option value=''>All Devices</option>";
-
-//    if (Auth::user()->hasGlobalRead()) {
-    $results = Device::hasAccess(Auth::user())->select('device_id', 'hostname', 'sysName')->orderBy('hostname');
-//    } else {
-//        $results = dbFetchRows('SELECT `D`.`device_id`,`D`.`hostname`, `D`.`sysname` FROM `devices` AS `D`, `devices_perms` AS `P` WHERE `P`.`user_id` = ? AND `P`.`device_id` = `D`.`device_id` ORDER BY `hostname`', [Auth::id()]);
-//    }
-    foreach ($results as $data) {
-        $deviceselected = isset($vars['device_id']) && $data['device_id'] == $vars['device_id'] ? 'selected' : '';
-        $ui_device = strlen(format_hostname($data)) > 15 ? substr(format_hostname($data), 0, 15) . '...' : format_hostname($data);
-        $output .= "<option value='" . $data['device_id'] . "' " . $deviceselected . '>' . $ui_device . '</option>';
-    }
-
-    if (! Auth::user()->hasGlobalRead()) {
-        $results = dbFetchRows('SELECT `D`.`device_id`,`D`.`hostname`, `D`.`sysName` FROM `ports` AS `I` JOIN `devices` AS `D` ON `D`.`device_id`=`I`.`device_id` JOIN `ports_perms` AS `PP` ON `PP`.`port_id`=`I`.`port_id` WHERE `PP`.`user_id` = ? AND `PP`.`port_id` = `I`.`port_id` ORDER BY `hostname`', [Auth::id()]);
-    } else {
-        $results = [];
-    }
-
-    foreach ($results as $data) {
-        if ($data['device_id'] == $vars['device_id']) {
-            $deviceselected = 'selected';
-        } else {
-            $deviceselected = '';
-        }
-        $output .= "<option value='" . $data['device_id'] . "' " . $deviceselected . '>' . format_hostname($data) . '</option>';
+    
+    if(isset($vars['device_id'])){
+        $device = Device::find($vars['device_id']);
+        $device_selected = json_encode(['id' => $vars['device_id'], 'text' => $device->hostname]);
+    }else{
+        $device_selected = '""';
     }
 
     $output .= '</select>&nbsp;';

--- a/includes/html/pages/ports.inc.php
+++ b/includes/html/pages/ports.inc.php
@@ -91,7 +91,7 @@ if ((isset($vars['searchbar']) && $vars['searchbar'] != 'hide') || ! isset($vars
     $output .= "<div style='margin-bottom:4px;text-align:left;'>";
     $output .= "<div class='form-group'>";
     $output .= "<select name='device_id' id='device_id' class='form-control input-sm'>";
-    
+
     if (isset($vars['device_id'])) {
         $device = Device::find($vars['device_id']);
         $device_selected = json_encode(['id' => $vars['device_id'], 'text' => $device->hostname]);

--- a/includes/html/pages/ports.inc.php
+++ b/includes/html/pages/ports.inc.php
@@ -92,10 +92,10 @@ if ((isset($vars['searchbar']) && $vars['searchbar'] != 'hide') || ! isset($vars
     $output .= "<div class='form-group'>";
     $output .= "<select name='device_id' id='device_id' class='form-control input-sm'>";
     
-    if(isset($vars['device_id'])){
+    if (isset($vars['device_id'])) {
         $device = Device::find($vars['device_id']);
         $device_selected = json_encode(['id' => $vars['device_id'], 'text' => $device->hostname]);
-    }else{
+    } else {
         $device_selected = '""';
     }
 

--- a/includes/html/pages/ports.inc.php
+++ b/includes/html/pages/ports.inc.php
@@ -13,7 +13,6 @@
  * @author     LibreNMS Contributors
 */
 
-use App\Models\Device;
 use App\Models\Port;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 
@@ -90,16 +89,7 @@ if ((isset($vars['searchbar']) && $vars['searchbar'] != 'hide') || ! isset($vars
     $output .= addslashes(csrf_field());
     $output .= "<div style='margin-bottom:4px;text-align:left;'>";
     $output .= "<div class='form-group'>";
-    $output .= "<select name='device_id' id='device_id' class='form-control input-sm'>";
-
-    if (isset($vars['device_id'])) {
-        $device = Device::find($vars['device_id']);
-        $device_selected = json_encode(['id' => $vars['device_id'], 'text' => $device->hostname]);
-    } else {
-        $device_selected = '""';
-    }
-
-    $output .= '</select>&nbsp;';
+    $output .= "<select name='device_id' id='device_id' class='form-control input-sm'></select>&nbsp;";
 
     $hasvalue = ! empty($vars['hostname']) ? "value='" . $vars['hostname'] . "'" : '';
 

--- a/includes/html/pages/ports/graph.inc.php
+++ b/includes/html/pages/ports/graph.inc.php
@@ -13,6 +13,10 @@ $param = [];
 $where = '';
 $ignore_filter = 0;
 $disabled_filter = 0;
+$device = DeviceCache::get((int) $vars['device_id']);
+
+$device_selected = json_encode($device->exists ? ['id' => $device->device_id, 'text' => $device->displayName()] : '');
+echo '<script>init_select2("#device_id", "device", {field: "device_id"}, ' . $device_selected . ' , "All Devices")</script>';
 
 foreach ($vars as $var => $value) {
     if ($value != '') {

--- a/includes/html/pages/ports/list.inc.php
+++ b/includes/html/pages/ports/list.inc.php
@@ -128,22 +128,7 @@ var grid = $("#ports").bootgrid({
     url: '<?php echo route('table.ports') ?>'
 });
 
-$("#device_id").select2({
-    allowClear: true,
-    placeholder: "All Devices",
-    ajax: {
-        url: 'ajax_list.php',
-        delay: 250,
-        data: function (params) {
-            return {
-                type: 'devices',
-                search: params.term,
-                limit: 8,
-                page: params.page || 1
-            };
-        }
-    }
-});
+init_select2("#device_id", "device", {field: "device_id"}, <?php echo $device_selected; ?>, "All Devices");
 
 $(".actionBar").append("<div class=\"pull-left\"><?php echo $output; ?></div>");
 

--- a/includes/html/pages/ports/list.inc.php
+++ b/includes/html/pages/ports/list.inc.php
@@ -16,6 +16,8 @@
 $details_visible = var_export($vars['format'] == 'list_detail', 1);
 $errors_visible = var_export($vars['format'] == 'list_detail' || isset($vars['errors']), 1);
 $no_refresh = true;
+$device = DeviceCache::get((int) $vars['device_id']);
+$device_selected = json_encode($device->exists() ? ['id' => $device->device_id, 'text' => $device->displayName()] : '');
 
 if (isset($vars['errors'])) {
     $error_sort = ' data-order="desc"';
@@ -128,8 +130,8 @@ var grid = $("#ports").bootgrid({
     url: '<?php echo route('table.ports') ?>'
 });
 
-init_select2("#device_id", "device", {field: "device_id"}, <?php echo $device_selected; ?>, "All Devices");
-
 $(".actionBar").append("<div class=\"pull-left\"><?php echo $output; ?></div>");
+
+init_select2('#device_id', 'device', {}, <?php echo $device_selected ?>, 'All Devices');
 
 </script>

--- a/includes/html/pages/ports/list.inc.php
+++ b/includes/html/pages/ports/list.inc.php
@@ -128,6 +128,23 @@ var grid = $("#ports").bootgrid({
     url: '<?php echo route('table.ports') ?>'
 });
 
+$("#device_id").select2({
+    allowClear: true,
+    placeholder: "All Devices",
+    ajax: {
+        url: 'ajax_list.php',
+        delay: 250,
+        data: function (params) {
+            return {
+                type: 'devices',
+                search: params.term,
+                limit: 8,
+                page: params.page || 1
+            };
+        }
+    }
+});
+
 $(".actionBar").append("<div class=\"pull-left\"><?php echo $output; ?></div>");
 
 </script>


### PR DESCRIPTION
This pull request is to add the realtime search function for device filter on the ports page, the same function is present on other pages but not on this one.

After add:
![2e9133bd-66ca-4791-bc1e-11a85ec901fb](https://user-images.githubusercontent.com/48569093/190237766-3f59b536-6f51-4920-91fc-0703749d25b4.jpeg)

![2893360d-fe9e-4bca-be9b-af7efcab6f7f](https://user-images.githubusercontent.com/48569093/190237774-a5f29674-f685-4525-aefc-b8f57ccdff1e.jpeg)

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
