### PR TITLE
Update devices filter in alert-logs to init_select2

### DIFF
--- a/includes/html/common/alert-log.inc.php
+++ b/includes/html/common/alert-log.inc.php
@@ -54,13 +54,9 @@ $common_output[] = '<div class="panel panel-default panel-condensed">
                 </div>
             ';
 
-if (isset($_POST['device_id'])) {
-    $selected_device = '<option value="' . (int) $_POST['device_id'] . '" selected="selected">';
-    $selected_device .= htmlentities($_POST['hostname']) . '</option>';
-} else {
-    $selected_device = $device_id;
-    $_POST['device_id'] = $device_id;
-}
+$device = DeviceCache::get((int) $vars['device_id']);
+$device_selected = json_encode($device->exists() ? ['id' => $device->device_id, 'text' => $device->displayName()] : '');
+
 if (isset($_POST['state'])) {
     $selected_state = '<option value="' . htmlspecialchars($_POST['state']) . '" selected="selected">';
     $selected_state .= array_search((int) $_POST['state'], $alert_states) . '</option>';
@@ -112,9 +108,7 @@ if (isset($vars['fromdevice']) && ! $vars['fromdevice']) {
                 <label> \
                 <strong>Device&nbsp;</strong> \
                 </label> \
-                <select name="device_id" id="device_id" class="form-control input-sm" style="min-width: 175px;"> \
-                ' . $selected_device . ' \
-               </select> \
+                <select name="device_id" id="device_id" class="form-control input-sm" style="min-width: 175px;"></select> \
                </div> \
                ';
 }
@@ -204,23 +198,6 @@ $common_output[] = '<div class="form-group"> \
         });
     });
 
-    $("#device_id").select2({
-        allowClear: true,
-        placeholder: "All Devices",
-        ajax: {
-            url: \'ajax_list.php\',
-            delay: 250,
-            data: function (params) {
-                return {
-                    type: \'devices\',
-                    search: params.term,
-                    limit: 8,
-                    page: params.page || 1
-                };
-            }
-        }
-    }).on(\'select2:select\', function (e) {
-        $(\'#hostname\').val(e.params.data.text);
-    });
+    init_select2("#device_id", "device", {}, ' . $device_selected . ' , "All Devices");
 </script>
 ';


### PR DESCRIPTION
Added init_select2 to devices filter in alert-logs page
![image](https://user-images.githubusercontent.com/48569093/190712723-9f16f7bb-04aa-4ef3-9108-7a0e4350a070.png)

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
