### PR TITLE
Increase Oxidized reload nodes timeout

### DIFF
--- a/app/ApiClients/BaseApi.php
+++ b/app/ApiClients/BaseApi.php
@@ -39,7 +39,7 @@ class BaseApi
             $this->client = Http::withOptions([
                 'proxy' => Proxy::forGuzzle($this->base_uri),
             ])->baseUrl($this->base_uri)
-            ->timeout(3);
+            ->timeout(10);
         }
 
         return $this->client;


### PR DESCRIPTION
Related to [this](https://community.librenms.org/t/curl-operation-timed-out-oxidized-reload-json/18207). 

With 2500 devices in Oxidized:
```
root@descolfrlibre04v:~# time curl http://127.0.0.1:9003/reload.json > /dev/null
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    24  100    24    0     0      3      0  0:00:08  0:00:06  0:00:02     6

real    0m6.821s
user    0m0.007s
sys     0m0.002s
```

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
