### PR TITLE
Adding Devices field in get_alert_rules and list_alert_rules API request

### DIFF
--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -1169,20 +1169,20 @@ function list_alert_rules(Illuminate\Http\Request $request)
 
     $i = 0;
     foreach ($rules as $rule) {
-        if ($rule["devices"] == null) {
-            unset($rules[$i]["devices"]);
+        if ($rule['devices'] == null) {
+            unset($rules[$i]['devices']);
         } else {
-            $rules[$i]["devices"] = array_map('intval', explode(',', $rules[$i]["devices"]));
+            $rules[$i]['devices'] = array_map('intval', explode(',', $rules[$i]['devices']));
         }
-        if ($rule["groups"] == null) {
-            unset($rules[$i]["groups"]);
+        if ($rule['groups'] == null) {
+            unset($rules[$i]['groups']);
         } else {
-            $rules[$i]["groups"] = array_map('intval', explode(',', $rules[$i]["groups"]));
+            $rules[$i]['groups'] = array_map('intval', explode(',', $rules[$i]['groups']));
         }
-        if ($rule["locations"] == null) {
-            unset($rules[$i]["locations"]);
+        if ($rule['locations'] == null) {
+            unset($rules[$i]['locations']);
         } else {
-            $rules[$i]["locations"] = array_map('intval', explode(',', $rules[$i]["locations"]));
+            $rules[$i]['locations'] = array_map('intval', explode(',', $rules[$i]['locations']));
         }
         $i++;
     }

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -1165,7 +1165,16 @@ function list_alert_rules(Illuminate\Http\Request $request)
         $param = [$id];
     }
 
-    $rules = dbFetchRows("SELECT `a`.*, GROUP_CONCAT(DISTINCT `d`.`device_id`) AS `devices`, GROUP_CONCAT(DISTINCT `g`.`group_id`) AS `groups`, GROUP_CONCAT(DISTINCT `l`.`location_id`) AS `locations` FROM `alert_rules` AS `a` LEFT JOIN `alert_device_map` AS `d` ON `a`.`id`=`d`.`rule_id` LEFT JOIN `alert_group_map` AS `g` ON `a`.`id`=`g`.`rule_id` LEFT JOIN `alert_location_map` AS `l` ON `a`.`id`=`l`.`rule_id` $sql GROUP BY `a`.`id`", $param);
+    $rules = dbFetchRows("SELECT `a`.*, 
+        GROUP_CONCAT(DISTINCT `d`.`device_id`) AS `devices`,
+        GROUP_CONCAT(DISTINCT `g`.`group_id`) AS `groups`,
+        GROUP_CONCAT(DISTINCT `l`.`location_id`) AS `locations`
+        FROM `alert_rules`
+        AS `a` LEFT JOIN `alert_device_map`
+        AS `d` ON `a`.`id`=`d`.`rule_id` LEFT JOIN `alert_group_map`
+        AS `g` ON `a`.`id`=`g`.`rule_id` LEFT JOIN `alert_location_map`
+        AS `l` ON `a`.`id`=`l`.`rule_id` $sql
+        GROUP BY `a`.`id`", $param);
 
     $i = 0;
     foreach ($rules as $rule) {

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -1161,11 +1161,31 @@ function list_alert_rules(Illuminate\Http\Request $request)
     $sql = '';
     $param = [];
     if ($id > 0) {
-        $sql = 'WHERE id=?';
+        $sql = 'WHERE `a`.`id`=?';
         $param = [$id];
     }
 
-    $rules = dbFetchRows("SELECT * FROM `alert_rules` $sql", $param);
+    $rules = dbFetchRows("SELECT `a`.*, GROUP_CONCAT(DISTINCT `d`.`device_id`) AS `devices`, GROUP_CONCAT(DISTINCT `g`.`group_id`) AS `groups`, GROUP_CONCAT(DISTINCT `l`.`location_id`) AS `locations` FROM `alert_rules` AS `a` LEFT JOIN `alert_device_map` AS `d` ON `a`.`id`=`d`.`rule_id` LEFT JOIN `alert_group_map` AS `g` ON `a`.`id`=`g`.`rule_id` LEFT JOIN `alert_location_map` AS `l` ON `a`.`id`=`l`.`rule_id` $sql GROUP BY `a`.`id`", $param);
+
+    $i = 0;
+    foreach ($rules as $rule) {
+        if ($rule["devices"] == null) {
+            unset($rules[$i]["devices"]);
+        } else {
+            $rules[$i]["devices"] = array_map('intval', explode(',', $rules[$i]["devices"]));
+        }
+        if ($rule["groups"] == null) {
+            unset($rules[$i]["groups"]);
+        } else {
+            $rules[$i]["groups"] = array_map('intval', explode(',', $rules[$i]["groups"]));
+        }
+        if ($rule["locations"] == null) {
+            unset($rules[$i]["locations"]);
+        } else {
+            $rules[$i]["locations"] = array_map('intval', explode(',', $rules[$i]["locations"]));
+        }
+        $i++;
+    }
 
     return api_success($rules, 'rules');
 }


### PR DESCRIPTION
Hello dear LibreNMS Community,

Here I added the ability to retrieve the Devices field in get_alert_rules and list_alert_rules API request either if it is a device, group or location.
Before that nothing was returned.
If one of these 3 variables are set they will be shown as a array of integer.
If there is no such variable nothing will be returned.

I know that the SQL request is quite complex and can maybe add latency on simple query.
I also added some PHP code to reset the variable if empty and to convert the string returned in SQL to an array of integer.

Do not hesitate to challenge me if you see some possible improvements.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
