### PR TITLE
Update radius auth to accept permissions attribute

### DIFF
--- a/LibreNMS/Authentication/RadiusAuthorizer.php
+++ b/LibreNMS/Authentication/RadiusAuthorizer.php
@@ -33,7 +33,40 @@ class RadiusAuthorizer extends MysqlAuthorizer
 
         $password = $credentials['password'] ?? null;
         if ($this->radius->accessRequest($credentials['username'], $password) === true) {
-            $this->addUser($credentials['username'], $password, Config::get('radius.default_level', 1));
+             if($this->userExists($credentials['username'])){
+    
+                //attribute 11 is "Filter-Id"
+                //Always set password change to 0 - password resides in AAA, not LibreNMS
+                //If attribute 11 is sent in reply after accept - update user
+                //If user exists - update, not add.
+                //If new user - add user with attribute value if present, or use default from config.
+                if($this->radius->getAttribute(11)){
+                  
+    
+                    $this->updateUser($this->getUserid($credentials['username']), $credentials['username'], $this->radius->getAttribute(11), 0, '');
+                }
+                else{
+    
+                   
+                    $this->updateUser($this->getUserid($credentials['username']), $credentials['username'], Config::get('radius.default_level', 1),0, '');
+                
+                }
+                
+                
+            }
+            
+            if(!$this->userExists($credentials['username'])){
+    
+                if($this->radius->getAttribute(11)){
+    
+                    $this->addUser($credentials['username'], $password, $this->radius->getAttribute(11),'',$credentials['username'],0, '');
+                }
+                else{
+                    
+                    $this->addUser($credentials['username'], $password, Config::get('radius.default_level', 1),'',$credentials['username'],0, '');
+                }
+            
+            }
 
             return true;
         }

--- a/LibreNMS/Authentication/RadiusAuthorizer.php
+++ b/LibreNMS/Authentication/RadiusAuthorizer.php
@@ -41,7 +41,7 @@ class RadiusAuthorizer extends MysqlAuthorizer
                 //If user exists - update, not add.
                 //If new user - add user with attribute value if present, or use default from config.
                 if ($this->radius->getAttribute(11)) {
-                    $this->updateUser($this->getUserid($credentials['username']), $credentials['username'], $this->radius->getAttribute(11), 0, '');
+                    $this->updateUser($this->getUserid($credentials['username']), $credentials['username'], intval($this->radius->getAttribute(11)), 0, '');
                 } else {
                     $this->updateUser($this->getUserid($credentials['username']), $credentials['username'], Config::get('radius.default_level', 1), 0, '');
                 }
@@ -49,7 +49,7 @@ class RadiusAuthorizer extends MysqlAuthorizer
 
             if (! $this->userExists($credentials['username'])) {
                 if ($this->radius->getAttribute(11)) {
-                    $this->addUser($credentials['username'], $password, $this->radius->getAttribute(11), '', $credentials['username'], 0, '');
+                    $this->addUser($credentials['username'], $password, intval($this->radius->getAttribute(11)), '', $credentials['username'], 0, '');
                 } else {
                     $this->addUser($credentials['username'], $password, Config::get('radius.default_level', 1), '', $credentials['username'], 0, '');
                 }

--- a/doc/Extensions/Authentication.md
+++ b/doc/Extensions/Authentication.md
@@ -267,9 +267,18 @@ setsebool -P httpd_can_connect_ldap 1
 ## Radius Authentication
 
 Please note that a mysql user is created for each user the logs in
-successfully. User level 1 is assigned to those accounts so you will
-then need to assign the relevant permissions unless you set
-`$config['radius']['userlevel']` to be something other than 1.
+successfully. User level 1 is assigned by default to those accounts 
+unless radius sends a reply attribute with the correct userlevel. 
+
+You can change the default userlevel by setting
+`$config['radius']['userlevel']` to something other than 1.
+
+The attribute `Filter-ID` is a standard Radius-Reply-Attribute that
+can be assigned a value corresponding to the desired userlevel for 
+the user and/or group (profile) in your radius server. 
+
+Userlevels and corresponding values are described in the third paragraph in this document.
+
 
 ```php
 $config['radius']['hostname']      = 'localhost';


### PR DESCRIPTION
Radius auth could only set a single default user permission - which defeats a lot of the purpose using radius.

Utilized the functionality in Dapphp library which was in use, and implemented some checks to see if the accept message contained a specific radius attribute. If it does, it will add or update the users permission level based on the existence of the user.

It will update a existing user instead of calling adduser regardless. New user will be updated.

Radius attribute used is standard "Filter-id" (11) - I believe this is ok to use, and it is a default attrib, no need to create a librenms dictionary. Juniper uses filter-id to get user roles.

Attribute is set on the user/group in radius as a reply attribute, not check. Tested with freeradius, and clear text password, as this was what was originally used, and MSCHAP with MD5 probably would require more changes in other places.

I am not a professional coder; If you want changes, i will try my best to make them.
Tested - and every scenario works as expected.


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
