### PR TITLE
Fix LinkUp and LinkDown trap parsing

### DIFF
--- a/LibreNMS/Snmptrap/Handlers/LinkDown.php
+++ b/LibreNMS/Snmptrap/Handlers/LinkDown.php
@@ -52,9 +52,17 @@ class LinkDown implements SnmptrapHandler
             return;
         }
 
-        $port->ifOperStatus = $trap->getOidData("IF-MIB::ifOperStatus.$ifIndex");
-        $port->ifAdminStatus = $trap->getOidData("IF-MIB::ifAdminStatus.$ifIndex");
+        $trapOperStatus = $trap->getOidData("IF-MIB::ifOperStatus.$ifIndex");
+        if ($trapOperStatus) {
+            $port->ifOperStatus = $trapOperStatus;
+        } else {
+            $port->ifOperStatus = "down";
+        }
 
+        $trapAdminStatus = $trap->getOidData("IF-MIB::ifAdminStatus.$ifIndex");
+        if ($trapAdminStatus) {
+            $port->ifAdminStatus = $trapAdminStatus;
+        }
         Log::event("SNMP Trap: linkDown $port->ifAdminStatus/$port->ifOperStatus " . $port->ifDescr, $device->device_id, 'interface', 5, $port->port_id);
 
         if ($port->isDirty('ifAdminStatus')) {

--- a/LibreNMS/Snmptrap/Handlers/LinkUp.php
+++ b/LibreNMS/Snmptrap/Handlers/LinkUp.php
@@ -52,8 +52,16 @@ class LinkUp implements SnmptrapHandler
             return;
         }
 
-        $port->ifOperStatus = $trap->getOidData("IF-MIB::ifAdminStatus.$ifIndex");
-        $port->ifAdminStatus = $trap->getOidData("IF-MIB::ifOperStatus.$ifIndex");
+        $trapOperStatus = $trap->getOidData("IF-MIB::ifAdminStatus.$ifIndex");
+        if ($trapOperStatus) {
+            $port->ifOperStatus = $trapOperStatus;
+        } else {
+            $port->ifOperStatus = "up";
+        }
+        $trapAdminStatus = $trap->getOidData("IF-MIB::ifOperStatus.$ifIndex");
+        if ($trapAdminStatus) {
+            $port->ifAdminStatus = $trapAdminStatus;
+        }
 
         Log::event("SNMP Trap: linkUp $port->ifAdminStatus/$port->ifOperStatus " . $port->ifDescr, $device->device_id, 'interface', 1, $port->port_id);
 


### PR DESCRIPTION
These traps do not always include 'ifAdminStatus' and 'ifOperStatus' from IF-MIB, which causes the fields to become NULL when traps are received.

Add checks that values exist, and add default value for ifOperStatus.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
