### PR TITLE
Update ports_purge docs and definitions

### DIFF
--- a/doc/Support/Cleanup-options.md
+++ b/doc/Support/Cleanup-options.md
@@ -21,7 +21,7 @@ $config['authlog_purge']                             = 30;
 $config['ports_fdb_purge']                           = 10;
 $config['device_perf_purge']                         = 7;
 $config['rrd_purge']                                 = 0;
-$config['ports_purge']                               = 10;
+$config['ports_purge']                               = true;
 ```
 
 These options will ensure data within LibreNMS over X days old is

--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -4781,9 +4781,8 @@
             "group": "system",
             "section": "cleanup",
             "order": 9,
-            "units": "days",
-            "default": "10",
-            "type": "integer"
+            "default": true,
+            "type": "boolean"
         },
         "project_home": {
             "default": "https://www.librenms.org/",

--- a/resources/lang/de/settings.php
+++ b/resources/lang/de/settings.php
@@ -595,7 +595,7 @@ return [
             'help' => 'Bereinigung wird erledigt durch daily.sh',
         ],
         'ports_purge' => [
-            'description' => 'Ports älter als',
+            'description' => 'Purge Ports gelöscht',
             'help' => 'Bereinigung wird erledigt durch daily.sh',
         ],
         'public_status' => [

--- a/resources/lang/en/settings.php
+++ b/resources/lang/en/settings.php
@@ -1203,7 +1203,7 @@ return [
             'help' => 'Cleanup done by daily.sh',
         ],
         'ports_purge' => [
-            'description' => 'Ports older than',
+            'description' => 'Purge ports deleted',
             'help' => 'Cleanup done by daily.sh',
         ],
         'prometheus' => [

--- a/resources/lang/fr/settings.php
+++ b/resources/lang/fr/settings.php
@@ -925,7 +925,7 @@ return [
             'help' => 'Nettoyage effectué par daily.sh',
         ],
         'ports_purge' => [
-            'description' => 'Interfaces, entrées plus anciennes que',
+            'description' => 'Purger les ports supprimés',
             'help' => 'Nettoyage effectué par daily.sh',
         ],
         'public_status' => [

--- a/resources/lang/it/settings.php
+++ b/resources/lang/it/settings.php
@@ -1185,7 +1185,7 @@ return [
             'help' => 'Cleanup done by daily.sh',
         ],
         'ports_purge' => [
-            'description' => 'Ports older than',
+            'description' => 'Elimina le porte',
             'help' => 'Cleanup done by daily.sh',
         ],
         'prometheus' => [

--- a/resources/lang/uk/settings.php
+++ b/resources/lang/uk/settings.php
@@ -1176,7 +1176,7 @@ return [
             'help' => 'Очистка виконується daily.sh',
         ],
         'ports_purge' => [
-            'description' => 'Записи портів старші за',
+            'description' => 'Порти очищення видалено',
             'help' => 'Очистка виконується daily.sh',
         ],
         'prometheus' => [

--- a/resources/lang/zh-CN/settings.php
+++ b/resources/lang/zh-CN/settings.php
@@ -602,7 +602,7 @@ return [
             'help' => 'Cleanup done by daily.sh',
         ],
         'ports_purge' => [
-            'description' => '连接埠大于',
+            'description' => '清除端口已删除',
             'help' => 'Cleanup done by daily.sh',
         ],
         'public_status' => [

--- a/resources/lang/zh-TW/settings.php
+++ b/resources/lang/zh-TW/settings.php
@@ -729,7 +729,7 @@ return [
             'help' => 'Cleanup done by daily.sh',
         ],
         'ports_purge' => [
-            'description' => '連接埠大於',
+            'description' => '清除端口已刪除',
             'help' => 'Cleanup done by daily.sh',
         ],
         'prometheus' => [


### PR DESCRIPTION
This PR is reference to issue #14336 
The cron worked so that it validated if the ports definition was true or false, but in the documentation and in the configuration it was as int of days, so I changed it to boolean and updated the documentation.

Before:
![image](https://user-images.githubusercontent.com/48569093/192838086-1646bb72-fcdb-4f2a-a41a-895a2689659d.png)

After:
![image](https://user-images.githubusercontent.com/48569093/192839606-bb9e95c7-130b-4ad2-a96b-f8ddd8ebc6b9.png)

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
