### PR TITLE
Fix bgp_peer array_merge error

### DIFF
--- a/includes/polling/bgp-peers.inc.php
+++ b/includes/polling/bgp-peers.inc.php
@@ -158,14 +158,11 @@ if (\LibreNMS\Config::get('enable_bgp')) {
                                 if ($oid[2] > 4) { //ipv6 so we have to translate
                                     $address = IP::fromSnmpString($oid[3])->compressed();
                                 }
-                                $bgpPeers[$address][$vrfInstance] = array_merge($bgpPeers[$address][$vrfInstance], $value);
-                                //d_echo("$vrfInstance -- $address \t-- $value");
-                                //d_echo($value);
+                                if (is_array($bgpPeers[$address]) && is_array($bgpPeers[$address][$vrfInstance])) {
+                                    $bgpPeers[$address][$vrfInstance] = array_merge($bgpPeers[$address][$vrfInstance], $value);
+                                }
                             }
-                            //d_echo($bgpPeersCache);
-                            //d_echo($bgpPeersStats);
                         }
-                        //d_echo($bgpPeers);
                         $address = (string) $peer_ip;
                         $bgpPeer = $bgpPeers[$address];
                         $peer_data = [];


### PR DESCRIPTION
`[2022-10-03T13:22:21.421462+02:00] production.ERROR: Error polling bgp-peers module for 10.19.25.2. TypeError: array_merge(): Argument #1 must be of type array, null given in /opt/librenms/includes/polling/bgp-peers.inc.php:161`

`[2022-10-03T13:22:21.426229+02:00] production.ERROR: array_merge(): Argument #1 must be of type array, null given {"exception":"[object] (TypeError(code: 0): array_merge(): Argument #1 must be of type array, null given at /opt/librenms/includes/polling/bgp-peers.inc.php:161)"}`

`[2022-10-03T13:22:27.934557+02:00] production.ERROR: Error polling bgp-peers module for 10.19.25.1. TypeError: array_merge(): Argument #1 must be of type array, null given in /opt/librenms/includes/polling/bgp-peers.inc.php:161`

`[2022-10-03T13:22:27.948272+02:00] production.ERROR: array_merge(): Argument #1 must be of type array, null given {"exception":"[object] (TypeError(code: 0): array_merge(): Argument #1 must be of type array, null given at /opt/librenms/includes/polling/bgp-peers.inc.php:161)"}`
 
DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
