### PR TITLE
Speed up tests

### DIFF
--- a/LibreNMS/Poller.php
+++ b/LibreNMS/Poller.php
@@ -83,7 +83,7 @@ class Poller
         $polled = 0;
         $this->printHeader();
 
-        if (Debug::isEnabled()) {
+        if (Debug::isEnabled() && ! defined('PHPUNIT_RUNNING')) {
             \LibreNMS\Util\OS::updateCache(true); // Force update of OS Cache
         }
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -40,5 +40,6 @@
     <server name="QUEUE_CONNECTION" value="sync"/>
     <server name="SESSION_DRIVER" value="array"/>
     <server name="DB_CONNECTION" value="testing"/>
+    <const name="PHPUNIT_RUNNING" value="true"/>
   </php>
 </phpunit>


### PR DESCRIPTION
Don't re-load os yaml every time

Looks like it saves approximately 5 minutes per run.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
