### PR TITLE
Revert "Update radius auth to accept permissions attribute"

### DIFF
--- a/LibreNMS/Authentication/RadiusAuthorizer.php
+++ b/LibreNMS/Authentication/RadiusAuthorizer.php
@@ -33,27 +33,7 @@ class RadiusAuthorizer extends MysqlAuthorizer
 
         $password = $credentials['password'] ?? null;
         if ($this->radius->accessRequest($credentials['username'], $password) === true) {
-            if ($this->userExists($credentials['username'])) {
-
-                //attribute 11 is "Filter-Id"
-                //Always set password change to 0 - password resides in AAA, not LibreNMS
-                //If attribute 11 is sent in reply after accept - update user
-                //If user exists - update, not add.
-                //If new user - add user with attribute value if present, or use default from config.
-                if ($this->radius->getAttribute(11)) {
-                    $this->updateUser($this->getUserid($credentials['username']), $credentials['username'], intval($this->radius->getAttribute(11)), 0, '');
-                } else {
-                    $this->updateUser($this->getUserid($credentials['username']), $credentials['username'], Config::get('radius.default_level', 1), 0, '');
-                }
-            }
-
-            if (! $this->userExists($credentials['username'])) {
-                if ($this->radius->getAttribute(11)) {
-                    $this->addUser($credentials['username'], $password, intval($this->radius->getAttribute(11)), '', $credentials['username'], 0, '');
-                } else {
-                    $this->addUser($credentials['username'], $password, Config::get('radius.default_level', 1), '', $credentials['username'], 0, '');
-                }
-            }
+            $this->addUser($credentials['username'], $password, Config::get('radius.default_level', 1));
 
             return true;
         }

--- a/doc/Extensions/Authentication.md
+++ b/doc/Extensions/Authentication.md
@@ -267,18 +267,9 @@ setsebool -P httpd_can_connect_ldap 1
 ## Radius Authentication
 
 Please note that a mysql user is created for each user the logs in
-successfully. User level 1 is assigned by default to those accounts 
-unless radius sends a reply attribute with the correct userlevel. 
-
-You can change the default userlevel by setting
-`$config['radius']['userlevel']` to something other than 1.
-
-The attribute `Filter-ID` is a standard Radius-Reply-Attribute that
-can be assigned a value corresponding to the desired userlevel for 
-the user and/or group (profile) in your radius server. 
-
-Userlevels and corresponding values are described in the third paragraph in this document.
-
+successfully. User level 1 is assigned to those accounts so you will
+then need to assign the relevant permissions unless you set
+`$config['radius']['userlevel']` to be something other than 1.
 
 ```php
 $config['radius']['hostname']      = 'localhost';


### PR DESCRIPTION
Reverts librenms/librenms#14382

This commit is very bad. Filter-ID is a string, not a number. It broke our login.
Please cancel and rework.