### PR TITLE
Check that device exists on update_device API-route

### DIFF
--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -1907,7 +1907,7 @@ function update_device(Illuminate\Http\Request $request)
     $device_id = ctype_digit($hostname) ? $hostname : getidbyname($hostname);
 
     // Check that the device exists before updating fields
-    if (Device::where('device_id', $device_id)->doesntExist()) {
+    if (! DeviceCache::get($device_id)->exists) {
         return api_error(404, 'Device does not exist');
     }
 

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -1905,6 +1905,12 @@ function update_device(Illuminate\Http\Request $request)
     $hostname = $request->route('hostname');
     // use hostname as device_id if it's all digits
     $device_id = ctype_digit($hostname) ? $hostname : getidbyname($hostname);
+
+    // Check that the device exists before updating fields
+    if (Device::where('device_id', $device_id)->doesntExist()) {
+        return api_error(404, 'Device does not exist');
+    }
+
     $data = json_decode($request->getContent(), true);
     $bad_fields = ['device_id', 'hostname'];
     if (empty($data['field'])) {


### PR DESCRIPTION
Checks that the device exists before making update queries on device fields using the API. Currently the API responds with "ok" status even when the device does not exist at all. The issue probably occurs because the update is done using `dbUpdate`-function and only checking that the return value is `>= 0`. 

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
