### PR TITLE
Fix missing device_id from device alert logs

### DIFF
--- a/includes/html/common/alert-log.inc.php
+++ b/includes/html/common/alert-log.inc.php
@@ -147,7 +147,7 @@ $common_output[] = '<div class="form-group"> \
         post: function () {
             return {
                 id: "alertlog",
-                device_id: \'' . htmlspecialchars($_POST['device_id']) . '\',
+                device_id: \'' . htmlspecialchars($_POST['device_id'] ?? $device_id) . '\',
                 state: \'' . htmlspecialchars($_POST['state']) . '\',
                 min_severity: \'' . htmlspecialchars($_POST['min_severity']) . '\'
             };


### PR DESCRIPTION
Recently the alert log filter on device page broke and it seems to be including the whole alert history of all devices instead of the current device.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
