### PR TITLE
User bgp peer remote addr instead of identifier where possible

### DIFF
--- a/includes/html/pages/routing/bgp.inc.php
+++ b/includes/html/pages/routing/bgp.inc.php
@@ -259,8 +259,7 @@ if (! Auth::user()->hasGlobalRead()) {
         } catch (InvalidIpException $e) {
             $local_addr = $peer['bgpLocalAddr'];
         }
-
-
+        
         try {
             $peer_addr = new IPv6($peer['bgpPeerRemoteAddr'] != '0.0.0.0' ? $peer['bgpPeerRemoteAddr'] : $peer['bgpPeerIdentifier']);
         } catch (InvalidIpException $e) {

--- a/includes/html/pages/routing/bgp.inc.php
+++ b/includes/html/pages/routing/bgp.inc.php
@@ -259,7 +259,7 @@ if (! Auth::user()->hasGlobalRead()) {
         } catch (InvalidIpException $e) {
             $local_addr = $peer['bgpLocalAddr'];
         }
-        
+
         try {
             $peer_addr = new IPv6($peer['bgpPeerRemoteAddr'] != '0.0.0.0' ? $peer['bgpPeerRemoteAddr'] : $peer['bgpPeerIdentifier']);
         } catch (InvalidIpException $e) {

--- a/includes/html/pages/routing/bgp.inc.php
+++ b/includes/html/pages/routing/bgp.inc.php
@@ -255,15 +255,16 @@ if (! Auth::user()->hasGlobalRead()) {
         }
 
         try {
-            $peer_ip = new IPv6($peer['bgpLocalAddr']);
+            $local_addr = new IPv6($peer['bgpLocalAddr']);
         } catch (InvalidIpException $e) {
-            $peer_ip = $peer['bgpLocalAddr'];
+            $local_addr = $peer['bgpLocalAddr'];
         }
 
+
         try {
-            $peer_ident = new IPv6($peer['bgpPeerIdentifier']);
+            $peer_addr = new IPv6($peer['bgpPeerRemoteAddr'] != '0.0.0.0' ? $peer['bgpPeerRemoteAddr'] : $peer['bgpPeerIdentifier']);
         } catch (InvalidIpException $e) {
-            $peer_ident = $peer['bgpPeerIdentifier'];
+            $peer_addr = $peer['bgpPeerRemoteAddr'] != '0.0.0.0' ? $peer['bgpPeerRemoteAddr'] : $peer['bgpPeerIdentifier'];
         }
 
         // display overlib graphs
@@ -280,7 +281,7 @@ if (! Auth::user()->hasGlobalRead()) {
         $graph_array_zoom['height'] = '150';
         $graph_array_zoom['width'] = '500';
         $overlib_link = 'device/device=' . $peer['device_id'] . '/tab=routing/proto=bgp/';
-        $peeraddresslink = '<span class=list-large>' . \LibreNMS\Util\Url::overlibLink($overlib_link, $peer_ident, \LibreNMS\Util\Url::graphTag($graph_array_zoom)) . '</span>';
+        $peeraddresslink = '<span class=list-large>' . \LibreNMS\Util\Url::overlibLink($overlib_link, $peer_addr, \LibreNMS\Util\Url::graphTag($graph_array_zoom)) . '</span>';
 
         // Local Address
         $graph_array['afi'] = 'ipv4';
@@ -288,7 +289,7 @@ if (! Auth::user()->hasGlobalRead()) {
         $graph_array_zoom['afi'] = 'ipv4';
         $graph_array_zoom['safi'] = 'unicast';
         $overlib_link = 'device/device=' . $peer['device_id'] . '/tab=routing/proto=bgp/';
-        $localaddresslink = '<span class=list-large>' . \LibreNMS\Util\Url::overlibLink($overlib_link, $peer_ip, \LibreNMS\Util\Url::graphTag($graph_array_zoom)) . '</span>';
+        $localaddresslink = '<span class=list-large>' . \LibreNMS\Util\Url::overlibLink($overlib_link, $local_addr, \LibreNMS\Util\Url::graphTag($graph_array_zoom)) . '</span>';
 
         if ($peer['bgpPeerLastErrorCode'] == 0 && $peer['bgpPeerLastErrorSubCode'] == 0) {
             $last_error = $peer['bgpPeerLastErrorText'];


### PR DESCRIPTION
Historically, the BGP "Peer IP" section was only showing the BGP "identifier" which the peer can set to any Ipv4 they wish (regardless if its a v4 or v6 session) Now some SNMP implementation dont return `peerRemoteAddr` properly, so what this PR does is simply try to use `bgpRemoteAddr` and if that isnt set in DB then it will fall back to `bgpPeerIdentifier`

Also small adjustment of variable names to clarify their purpose

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [X] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
