### PR TITLE
 Add check_hetzner_storagebox to includes/services

### DIFF
--- a/includes/services/check_hetzner_storagebox.inc.php
+++ b/includes/services/check_hetzner_storagebox.inc.php
@@ -1,0 +1,3 @@
+<?php
+
+$check_cmd = \LibreNMS\Config::get('nagios_plugins') . '/check_hetzner_storagebox ' . $service['service_param'];


### PR DESCRIPTION
When using check_hetzner_storagebox (https://github.com/muensmedia/check_hetzner_storagebox) the -H can not be passed.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
