### PR TITLE
Adding device's field in get_alert_rule and list-alert-rules API function (new)

### DIFF
--- a/app/Http/Resources/AlertRule.php
+++ b/app/Http/Resources/AlertRule.php
@@ -5,9 +5,9 @@ namespace App\Http\Resources;
 use Illuminate\Http\Resources\Json\JsonResource;
 
 /**
- * @property string $devices
- * @property string $groups
- * @property string $locations
+ * @property \App\Models\Device $devices
+ * @property \App\Models\DeviceGroup $groups
+ * @property \App\Models\Location $locations
  */
 class AlertRule extends JsonResource
 {

--- a/app/Http/Resources/AlertRule.php
+++ b/app/Http/Resources/AlertRule.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class AlertRule extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array|\Illuminate\Contracts\Support\Arrayable|\JsonSerializable
+     */
+    public function toArray($request)
+    {
+        $rule = parent::toArray($request);
+        $rule['devices'] = $this->devices->pluck('device_id')->all();
+        $rule['groups'] = $this->groups->pluck('id')->all();
+        $rule['locations'] = $this->locations->pluck('id')->all();
+
+        return $rule;
+    }
+}

--- a/app/Http/Resources/AlertRule.php
+++ b/app/Http/Resources/AlertRule.php
@@ -4,6 +4,11 @@ namespace App\Http\Resources;
 
 use Illuminate\Http\Resources\Json\JsonResource;
 
+/**
+ * @property string $devices
+ * @property string $groups
+ * @property string $locations
+ */
 class AlertRule extends JsonResource
 {
     /**

--- a/app/Models/AlertRule.php
+++ b/app/Models/AlertRule.php
@@ -88,6 +88,16 @@ class AlertRule extends BaseModel
 
     public function devices(): BelongsToMany
     {
-        return $this->belongsToMany(\App\Models\Device::class, 'alert_device_map', 'device_id', 'device_id');
+        return $this->belongsToMany(\App\Models\Device::class, 'alert_device_map', 'rule_id', 'device_id');
+    }
+
+    public function groups(): BelongsToMany
+    {
+        return $this->belongsToMany(\App\Models\DeviceGroup::class, 'alert_group_map', 'rule_id', 'group_id');
+    }
+
+    public function locations(): BelongsToMany
+    {
+        return $this->belongsToMany(\App\Models\Location::class, 'alert_location_map', 'rule_id');
     }
 }

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -1160,7 +1160,7 @@ function list_alert_rules(Illuminate\Http\Request $request)
     $id = $request->route('id');
 
     $rules = \App\Http\Resources\AlertRule::collection(
-        \App\Models\AlertRule::when($id, fn($query) => $query->where('id', $id))
+        \App\Models\AlertRule::when($id, fn ($query) => $query->where('id', $id))
         ->with(['devices:device_id', 'groups:id', 'locations:id'])->get()
     );
 

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -1158,45 +1158,13 @@ function update_device_port_notes(Illuminate\Http\Request $request): \Illuminate
 function list_alert_rules(Illuminate\Http\Request $request)
 {
     $id = $request->route('id');
-    $sql = '';
-    $param = [];
-    if ($id > 0) {
-        $sql = 'WHERE `a`.`id`=?';
-        $param = [$id];
-    }
 
-    $rules = dbFetchRows("SELECT `a`.*,
-        GROUP_CONCAT(DISTINCT `d`.`device_id`) AS `devices`,
-        GROUP_CONCAT(DISTINCT `g`.`group_id`) AS `groups`,
-        GROUP_CONCAT(DISTINCT `l`.`location_id`) AS `locations`
-        FROM `alert_rules`
-        AS `a` LEFT JOIN `alert_device_map`
-        AS `d` ON `a`.`id`=`d`.`rule_id` LEFT JOIN `alert_group_map`
-        AS `g` ON `a`.`id`=`g`.`rule_id` LEFT JOIN `alert_location_map`
-        AS `l` ON `a`.`id`=`l`.`rule_id` $sql
-        GROUP BY `a`.`id`", $param);
+    $rules = \App\Http\Resources\AlertRule::collection(
+        \App\Models\AlertRule::when($id, fn($query) => $query->where('id', $id))
+        ->with(['devices:device_id', 'groups:id', 'locations:id'])->get()
+    );
 
-    $i = 0;
-    foreach ($rules as $rule) {
-        if ($rule['devices'] == null) {
-            unset($rules[$i]['devices']);
-        } else {
-            $rules[$i]['devices'] = array_map('intval', explode(',', $rules[$i]['devices']));
-        }
-        if ($rule['groups'] == null) {
-            unset($rules[$i]['groups']);
-        } else {
-            $rules[$i]['groups'] = array_map('intval', explode(',', $rules[$i]['groups']));
-        }
-        if ($rule['locations'] == null) {
-            unset($rules[$i]['locations']);
-        } else {
-            $rules[$i]['locations'] = array_map('intval', explode(',', $rules[$i]['locations']));
-        }
-        $i++;
-    }
-
-    return api_success($rules, 'rules');
+    return api_success($rules->toArray($request), 'rules');
 }
 
 function list_alerts(Illuminate\Http\Request $request)


### PR DESCRIPTION
Hello dear LibreNMS community,

Sorry for posting twice but here is the same PR as #14376 (I created it on master by mistake)
I am trying to solve the pipeline error by rebasing from upstream master and not creating a PR on my fork master.

Previous text : 

Here I added the ability to retrieve the Devices field in get_alert_rules and list_alert_rules API request either if it is a device, group or location.
Before that nothing was returned.
If one of these 3 variables are set they will be shown as a array of integer.
If there is no such variable nothing will be returned.

I know that the SQL request is quite complex and can maybe add latency on simple query.
I also added some PHP code to reset the variable if empty and to convert the string returned in SQL to an array of integer.


I split the SQL in several lines. Tell me if you really want to use eloquent, but I will need help on this.

Have a nice day!

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
