### PR TITLE
Check if service_name is empty or equal to service_type

### DIFF
--- a/includes/html/pages/device/overview/services.inc.php
+++ b/includes/html/pages/device/overview/services.inc.php
@@ -13,8 +13,9 @@ if (ObjectCache::serviceCounts(['total'], $device['device_id'])['total'] > 0) {
             $color = $colors->get($service->service_status, 'grey');
             $type = strtolower($service->service_type);
             $name = $service->service_name;
+            $name_type = ($name == "" || $name == $type) ? $type : $name . " (" . $type . ")";
 
-            return "<span title='$message' class='$color'>$name ($type)</span>";
+            return "<span title='$message' class='$color'>$name_type</span>";
         })->implode(', ');
 
     $services = ObjectCache::serviceCounts(['total', 'ok', 'warning', 'critical'], $device['device_id']); ?>

--- a/includes/html/pages/device/overview/services.inc.php
+++ b/includes/html/pages/device/overview/services.inc.php
@@ -13,7 +13,7 @@ if (ObjectCache::serviceCounts(['total'], $device['device_id'])['total'] > 0) {
             $color = $colors->get($service->service_status, 'grey');
             $type = strtolower($service->service_type);
             $name = $service->service_name;
-            $name_type = ($name == "" || $name == $type) ? $type : $name . " (" . $type . ")";
+            $name_type = ($name == '' || $name == $type) ? $type : $name . ' (' . $type . ')';
 
             return "<span title='$message' class='$color'>$name_type</span>";
         })->implode(', ');


### PR DESCRIPTION
Please give a short description what your pull request is for

This is a quick follow up on my previous [PR](https://github.com/librenms/librenms/pull/14410) regarding service names. It checks wether a) service_name is empty or b) service_name equals service_type and generates the text accordingly:
- name == type: `name (type)` → `type`
- name == "": `(type)` → `type`
- name != "" && name != type: `name (type)`


![Bildschirm­foto 2022-10-23 um 15 06 46](https://user-images.githubusercontent.com/3263257/197393902-0e898dd8-331c-4fb3-a9bb-537cd3ec7890.jpg)

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
