### PR TITLE
Fix v2 plugins

### DIFF
--- a/app/Plugins/PluginManager.php
+++ b/app/Plugins/PluginManager.php
@@ -122,7 +122,7 @@ class PluginManager
                     return 'HOOK FAILED';
                 }
             })->filter(function ($hook) {
-                return $hook === 'HOOK FAILED';
+                return $hook !== 'HOOK FAILED';
             });
     }
 


### PR DESCRIPTION
inverted check caused all v2 plugins to not be shown.

fixes #14491

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
