### PR TITLE
Convert string references to `::class`

### DIFF
--- a/LibreNMS/Modules/Isis.php
+++ b/LibreNMS/Modules/Isis.php
@@ -68,7 +68,7 @@ class Isis implements Module
             ? $os->discoverIsIs()
             : $this->discoverIsIsMib($os);
 
-        ModuleModelObserver::observe('\App\Models\IsisAdjacency');
+        ModuleModelObserver::observe(\App\Models\IsisAdjacency::class);
         $this->syncModels($os->getDevice(), 'isisAdjacencies', $adjacencies);
     }
 

--- a/LibreNMS/Modules/Mempools.php
+++ b/LibreNMS/Modules/Mempools.php
@@ -61,7 +61,7 @@ class Mempools implements Module
         });
         $this->calculateAvailable($mempools);
 
-        MempoolObserver::observe('\App\Models\Mempool');
+        MempoolObserver::observe(\App\Models\Mempool::class);
         $this->syncModels($os->getDevice(), 'mempools', $mempools);
 
         echo PHP_EOL;

--- a/LibreNMS/Modules/Mpls.php
+++ b/LibreNMS/Modules/Mpls.php
@@ -57,35 +57,35 @@ class Mpls implements Module
     {
         if ($os instanceof MplsDiscovery) {
             echo "\nMPLS LSPs: ";
-            ModuleModelObserver::observe('\App\Models\MplsLsp');
+            ModuleModelObserver::observe(\App\Models\MplsLsp::class);
             $lsps = $this->syncModels($os->getDevice(), 'mplsLsps', $os->discoverMplsLsps());
 
             echo "\nMPLS LSP Paths: ";
-            ModuleModelObserver::observe('\App\Models\MplsLspPath');
+            ModuleModelObserver::observe(\App\Models\MplsLspPath::class);
             $paths = $this->syncModels($os->getDevice(), 'mplsLspPaths', $os->discoverMplsPaths($lsps));
 
             echo "\nMPLS SDPs: ";
-            ModuleModelObserver::observe('\App\Models\MplsSdp');
+            ModuleModelObserver::observe(\App\Models\MplsSdp::class);
             $sdps = $this->syncModels($os->getDevice(), 'mplsSdps', $os->discoverMplsSdps());
 
             echo "\nMPLS Services: ";
-            ModuleModelObserver::observe('\App\Models\MplsService');
+            ModuleModelObserver::observe(\App\Models\MplsService::class);
             $svcs = $this->syncModels($os->getDevice(), 'mplsServices', $os->discoverMplsServices());
 
             echo "\nMPLS SAPs: ";
-            ModuleModelObserver::observe('\App\Models\MplsSap');
+            ModuleModelObserver::observe(\App\Models\MplsSap::class);
             $this->syncModels($os->getDevice(), 'mplsSaps', $os->discoverMplsSaps($svcs));
 
             echo "\nMPLS SDP Bindings: ";
-            ModuleModelObserver::observe('\App\Models\MplsSdpBind');
+            ModuleModelObserver::observe(\App\Models\MplsSdpBind::class);
             $this->syncModels($os->getDevice(), 'mplsSdpBinds', $os->discoverMplsSdpBinds($sdps, $svcs));
 
             echo "\nMPLS Tunnel Active Routing Hops: ";
-            ModuleModelObserver::observe('\App\Models\MplsTunnelArHop');
+            ModuleModelObserver::observe(\App\Models\MplsTunnelArHop::class);
             $this->syncModels($os->getDevice(), 'mplsTunnelArHops', $os->discoverMplsTunnelArHops($paths));
 
             echo "\nMPLS Tunnel Constrained Shortest Path First Hops: ";
-            ModuleModelObserver::observe('\App\Models\MplsTunnelCHop');
+            ModuleModelObserver::observe(\App\Models\MplsTunnelCHop::class);
             $this->syncModels($os->getDevice(), 'mplsTunnelCHops', $os->discoverMplsTunnelCHops($paths));
 
             echo PHP_EOL;
@@ -106,49 +106,49 @@ class Mpls implements Module
 
             if ($device->mplsLsps()->exists()) {
                 echo "\nMPLS LSPs: ";
-                ModuleModelObserver::observe('\App\Models\MplsLsp');
+                ModuleModelObserver::observe(\App\Models\MplsLsp::class);
                 $lsps = $this->syncModels($device, 'mplsLsps', $os->pollMplsLsps());
             }
 
             if ($device->mplsLspPaths()->exists()) {
                 echo "\nMPLS LSP Paths: ";
-                ModuleModelObserver::observe('\App\Models\MplsLspPath');
+                ModuleModelObserver::observe(\App\Models\MplsLspPath::class);
                 $paths = $this->syncModels($device, 'mplsLspPaths', $os->pollMplsPaths($lsps));
             }
 
             if ($device->mplsSdps()->exists()) {
                 echo "\nMPLS SDPs: ";
-                ModuleModelObserver::observe('\App\Models\MplsSdp');
+                ModuleModelObserver::observe(\App\Models\MplsSdp::class);
                 $sdps = $this->syncModels($device, 'mplsSdps', $os->pollMplsSdps());
             }
 
             if ($device->mplsServices()->exists()) {
                 echo "\nMPLS Services: ";
-                ModuleModelObserver::observe('\App\Models\MplsService');
+                ModuleModelObserver::observe(\App\Models\MplsService::class);
                 $svcs = $this->syncModels($device, 'mplsServices', $os->pollMplsServices());
             }
 
             if ($device->mplsSaps()->exists()) {
                 echo "\nMPLS SAPs: ";
-                ModuleModelObserver::observe('\App\Models\MplsSap');
+                ModuleModelObserver::observe(\App\Models\MplsSap::class);
                 $this->syncModels($device, 'mplsSaps', $os->pollMplsSaps($svcs));
             }
 
             if ($device->mplsSdpBinds()->exists()) {
                 echo "\nMPLS SDP Bindings: ";
-                ModuleModelObserver::observe('\App\Models\MplsSdpBind');
+                ModuleModelObserver::observe(\App\Models\MplsSdpBind::class);
                 $this->syncModels($device, 'mplsSdpBinds', $os->pollMplsSdpBinds($sdps, $svcs));
             }
 
             if ($device->mplsTunnelArHops()->exists()) {
                 echo "\nMPLS Tunnel Active Routing Hops: ";
-                ModuleModelObserver::observe('\App\Models\MplsTunnelArHop');
+                ModuleModelObserver::observe(\App\Models\MplsTunnelArHop::class);
                 $this->syncModels($device, 'mplsTunnelArHops', $os->pollMplsTunnelArHops($paths));
             }
 
             if ($device->mplsTunnelCHops()->exists()) {
                 echo "\nMPLS Tunnel Constrained Shortest Path First Hops: ";
-                ModuleModelObserver::observe('\App\Models\MplsTunnelCHop');
+                ModuleModelObserver::observe(\App\Models\MplsTunnelCHop::class);
                 $this->syncModels($device, 'mplsTunnelCHops', $os->pollMplsTunnelCHops($paths));
             }
 

--- a/app/Models/Vminfo.php
+++ b/app/Models/Vminfo.php
@@ -54,6 +54,6 @@ class Vminfo extends DeviceRelatedModel
 
     public function parentDevice(): HasOne
     {
-        return $this->hasOne('App\Models\Device', 'hostname', 'vmwVmDisplayName');
+        return $this->hasOne(\App\Models\Device::class, 'hostname', 'vmwVmDisplayName');
     }
 }


### PR DESCRIPTION
PHP 5.5.9 adds the new static `class` property which provides the fully qualified class name. This is preferred over using strings for class names since the `class` property references are checked by PHP.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
