### PR TITLE
Fix sensor limit linked port rules in collection

### DIFF
--- a/misc/alert_rules.json
+++ b/misc/alert_rules.json
@@ -198,11 +198,11 @@
     "name": "HP Procurve Fan Fault"
   },
   {
-    "rule": "sensors.sensor_current > sensors.sensor_limit && sensors.sensor_alert = \"1\" && macros.device_up = \"1\" && macros.sensor_port_link = \"1\"",
+    "rule": "sensors.sensor_current > `sensors.sensor_limit` && sensors.sensor_alert = \"1\" && macros.device_up = \"1\" && macros.sensor_port_link = \"1\"",
     "name": "Sensor over limit with linked port"
   },
   {
-    "rule": "sensors.sensor_current < sensors.sensor_limit_low && sensors.sensor_alert = \"1\" && macros.device_up = \"1\" && macros.sensor_port_link = \"1\"",
+    "rule": "sensors.sensor_current < `sensors.sensor_limit_low` && sensors.sensor_alert = \"1\" && macros.device_up = \"1\" && macros.sensor_port_link = \"1\"",
     "name": "Sensor under limit with linked port"
   },
   {


### PR DESCRIPTION
variables currently aren't escaped so they're evaluated as strings.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
