### PR TITLE
Update Radius auth to accept permissions attributes

### DIFF
--- a/LibreNMS/Authentication/RadiusAuthorizer.php
+++ b/LibreNMS/Authentication/RadiusAuthorizer.php
@@ -33,7 +33,46 @@ class RadiusAuthorizer extends MysqlAuthorizer
 
         $password = $credentials['password'] ?? null;
         if ($this->radius->accessRequest($credentials['username'], $password) === true) {
-            $this->addUser($credentials['username'], $password, Config::get('radius.default_level', 1));
+            if ($this->userExists($credentials['username'])) {
+
+
+
+                //attribute 11 is "Filter-Id"
+                //Always set password change to 0 - password resides in AAA, not LibreNMS
+                //If attribute 11 is sent in reply after accept - update user
+                //If user exists - update, not add.
+                //If new user - add user with attribute value if present, or use default from config.
+                if ($this->radius->getAttribute(11)) {
+                    switch($this->radius->getAttribute(11)){
+                        case "lnms_admin":
+                            $attribute = 10;
+                            break;
+                        case "lnms_normal":
+                            $attribute = 1;
+                            break;
+                        case "lnms_globalRead":
+                            $attribute = 5;
+                            break;
+                        case "lnms_demo":
+                            $attribute = 11;
+                            break;
+                    }
+                }
+
+                if ($attribute) {
+                    $this->updateUser($this->getUserid($credentials['username']), $credentials['username'], $attribute, 0, '');
+                } else {
+                    $this->updateUser($this->getUserid($credentials['username']), $credentials['username'], Config::get('radius.default_level', 1), 0, '');
+                }
+            }
+
+            if (! $this->userExists($credentials['username'])) {
+                if ($attribute) {
+                    $this->addUser($credentials['username'], $password, $attribute, '', $credentials['username'], 0, '');
+                } else {
+                    $this->addUser($credentials['username'], $password, Config::get('radius.default_level', 1), '', $credentials['username'], 0, '');
+                }
+            }
 
             return true;
         }

--- a/doc/Extensions/Authentication.md
+++ b/doc/Extensions/Authentication.md
@@ -267,9 +267,24 @@ setsebool -P httpd_can_connect_ldap 1
 ## Radius Authentication
 
 Please note that a mysql user is created for each user the logs in
-successfully. User level 1 is assigned to those accounts so you will
-then need to assign the relevant permissions unless you set
-`$config['radius']['userlevel']` to be something other than 1.
+uccessfully. User level 1 is assigned by default to those accounts 
+unless radius sends a reply attribute with the correct userlevel. 
+
+You can change the default userlevel by setting
+`$config['radius']['userlevel']` to something other than 1.
+
+The attribute `Filter-ID` is a standard Radius-Reply-Attribute (string) that
+can be assigned a value which translates into a userlevel in LibreNMS. 
+
+The strings to send in `Filter-ID` reply attribute is *one* of the following:
+
+`lnms_normal` - Sets the value `1`, which is the normal user level.
+`lnms_admin` - Sets the value `5`, which is the administrator level.
+`lnms_globalRead` - Sets the value `10`, which is the global read level.
+`lnms_admin` - Sets the value `11`, which is the demo level.
+
+LibreNMS will ignore any other strings sent in `Filter-ID` and revert to default userlevel that is set in `config.php`.
+
 
 ```php
 $config['radius']['hostname']      = 'localhost';
@@ -279,6 +294,11 @@ $config['radius']['timeout']       = 3;
 $config['radius']['users_purge']   = 14;  // Purge users who haven't logged in for 14 days.
 $config['radius']['default_level'] = 1;  // Set the default user level when automatically creating a user.
 ```
+
+### Radius Huntgroup
+
+Freeradius has a function called `Radius Huntgroup` which allows to send different attributes based on NAS.
+This may be utilized if you already use `Filter-ID` in your environment and also want to use radius with LibreNMS.
 
 ### Old account cleanup
 


### PR DESCRIPTION
This is a new approach to PR #14382

This enables the user to send a radius attribute called "Filter-ID" with a string that RadiusAuthorizer.php interprets to a valid userlevel, or ignores.

As this requires "Filter-ID" to be a predetermined string, it will not break login for users that have "Filter-ID" in use for other purposes, as the authenticator will ignore it and revert to default value defined in config.php.

Updated docs, and also gave a hint for using Radius Huntgroups in Freeradius if someone already uses the attribute, but also want to use the new functionality this PR gives.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
