### PR TITLE
TAIT-Infra93 - Fix state + skip_values for Battery

### DIFF
--- a/includes/definitions/discovery/tait-infra93.yaml
+++ b/includes/definitions/discovery/tait-infra93.yaml
@@ -44,7 +44,7 @@ modules:
                     index: 'healthNetworkConnLogChan1State.{{ $index }}'
                     state_name: healthNetworkConnLogChan1State
                     states:
-                        - { descr: inactive, graph: 1, value: 0, generic: 1 }
+                        - { descr: inactive, graph: 1, value: 0, generic: 3 }
                         - { descr: idle, graph: 1, value: 1, generic: 3 }
                         - { descr: traffic, graph: 1, value: 2, generic: 0 }
                         - { descr: control, graph: 1, value: 3, generic: 0 }
@@ -60,7 +60,7 @@ modules:
                     index: 'healthNetworkConnLogChan2State.{{ $index }}'
                     state_name: healthNetworkConnLogChan2State
                     states:
-                        - { descr: inactive, graph: 1, value: 0, generic: 1 }
+                        - { descr: inactive, graph: 1, value: 0, generic: 3 }
                         - { descr: idle, graph: 1, value: 1, generic: 3 }
                         - { descr: traffic, graph: 1, value: 2, generic: 0 }
                         - { descr: control, graph: 1, value: 3, generic: 0 }
@@ -115,6 +115,11 @@ modules:
                         - { descr: bad, graph: 1, value: 0, generic: 1 }
                         - { descr: good, graph: 1, value: 1, generic: 0 }
                         - { descr: not fitted, graph: 1, value: 2, generic: 3 }
+                    skip_values:
+                        -
+                            oid: pmuStateBusConnect
+                            op: '='
+                            value: '2'
                 -
                     oid: pmuState
                     value: pmuStateBusConnect
@@ -137,11 +142,11 @@ modules:
                     states:
                         - { descr: unconnected, graph: 1, value: 0, generic: 1 }
                         - { descr: deprecatedUnconnected, graph: 1, value: 1, generic: 1 }
-                        - { descr: standby, graph: 1, value: 2, generic: 1 }
+                        - { descr: standby, graph: 1, value: 2, generic: 3 }
                         - { descr: dmr-aligned, graph: 1, value: 3, generic: 0 }
                         - { descr: dmr-offset, graph: 1, value: 4, generic: 3 }
                         - { descr: dmr-two-slot-data, graph: 1, value: 5, generic: 0 }
-                        - { descr: dmr-hibernate, graph: 1, value: 6, generic: 1 }
+                        - { descr: dmr-hibernate, graph: 1, value: 6, generic: 3 }
                         - { descr: analogue, graph: 1, value: 7, generic: 3 }
                         - { descr: test-mode, graph: 1, value: 8, generic: 3 }
                         - { descr: dmr-tier2-aligned, graph: 1, value: 9, generic: 0 }

--- a/tests/data/tait-infra93_tb9300.json
+++ b/tests/data/tait-infra93_tb9300.json
@@ -2044,31 +2044,6 @@
                     "sensor_deleted": 0,
                     "sensor_class": "state",
                     "poller_type": "snmp",
-                    "sensor_oid": ".1.3.6.1.4.1.3570.2.2.2.1.2.4.2.2.0",
-                    "sensor_index": "pmuStateBatteryInState.0",
-                    "sensor_type": "pmuStateBatteryInState",
-                    "sensor_descr": "PMU DC power input state",
-                    "group": "PMUState",
-                    "sensor_divisor": 1,
-                    "sensor_multiplier": 1,
-                    "sensor_current": 0,
-                    "sensor_limit": null,
-                    "sensor_limit_warn": null,
-                    "sensor_limit_low": null,
-                    "sensor_limit_low_warn": null,
-                    "sensor_alert": 1,
-                    "sensor_custom": "No",
-                    "entPhysicalIndex": null,
-                    "entPhysicalIndex_measured": null,
-                    "sensor_prev": null,
-                    "user_func": null,
-                    "rrd_type": "GAUGE",
-                    "state_name": "pmuStateBatteryInState"
-                },
-                {
-                    "sensor_deleted": 0,
-                    "sensor_class": "state",
-                    "poller_type": "snmp",
                     "sensor_oid": ".1.3.6.1.4.1.3570.2.2.2.1.2.4.2.9.0",
                     "sensor_index": "pmuStateBusConnect.0",
                     "sensor_type": "pmuStateBusConnect",
@@ -3214,7 +3189,7 @@
                     "state_descr": "inactive",
                     "state_draw_graph": 1,
                     "state_value": 0,
-                    "state_generic_value": 1
+                    "state_generic_value": 3
                 },
                 {
                     "state_name": "healthNetworkConnLogChan1State",
@@ -3263,7 +3238,7 @@
                     "state_descr": "inactive",
                     "state_draw_graph": 1,
                     "state_value": 0,
-                    "state_generic_value": 1
+                    "state_generic_value": 3
                 },
                 {
                     "state_name": "healthNetworkConnLogChan2State",
@@ -3347,7 +3322,7 @@
                     "state_descr": "standby",
                     "state_draw_graph": 1,
                     "state_value": 2,
-                    "state_generic_value": 1
+                    "state_generic_value": 3
                 },
                 {
                     "state_name": "linkInfoCtrlProtocolStatus",
@@ -3375,7 +3350,7 @@
                     "state_descr": "dmr-hibernate",
                     "state_draw_graph": 1,
                     "state_value": 6,
-                    "state_generic_value": 1
+                    "state_generic_value": 3
                 },
                 {
                     "state_name": "linkInfoCtrlProtocolStatus",
@@ -4226,27 +4201,6 @@
                 },
                 {
                     "state_name": "pmuStateAuxOutState",
-                    "state_descr": "not fitted",
-                    "state_draw_graph": 1,
-                    "state_value": 2,
-                    "state_generic_value": 3
-                },
-                {
-                    "state_name": "pmuStateBatteryInState",
-                    "state_descr": "bad",
-                    "state_draw_graph": 1,
-                    "state_value": 0,
-                    "state_generic_value": 1
-                },
-                {
-                    "state_name": "pmuStateBatteryInState",
-                    "state_descr": "good",
-                    "state_draw_graph": 1,
-                    "state_value": 1,
-                    "state_generic_value": 0
-                },
-                {
-                    "state_name": "pmuStateBatteryInState",
                     "state_descr": "not fitted",
                     "state_draw_graph": 1,
                     "state_value": 2,


### PR DESCRIPTION
- Changed 3 states (from warning to unknown) cause the situation was not a warning after all
- If no battery is connected, avoid discovering the sensor which gives the battery state (cause this one will return an error). 

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
