### PR TITLE
Improve embedded graph title handling

### DIFF
--- a/LibreNMS/Data/Graphing/GraphParameters.php
+++ b/LibreNMS/Data/Graphing/GraphParameters.php
@@ -36,7 +36,7 @@ class GraphParameters
 {
     public readonly array $visibleElements;
 
-    public string $title;
+    public ?string $title;
     public readonly string $type;
     public readonly string $subtype;
     public readonly ImageFormat $imageFormat;
@@ -89,9 +89,9 @@ class GraphParameters
         $this->canvas = Clean::alphaDash($vars['bg'] ?? '');
         $this->background = Clean::alphaDash($vars['bbg'] ?? '');
 
-        $this->title = $vars['graph_title'] ?? $this->defaultTitle();
+        $this->title = $vars['graph_title'] ?? null;
         $this->visibleElements = [
-            'title' => empty($vars['title']) || $vars['title'] !== 'no',
+            'title' => isset($vars['title']) && $vars['title'] !== 'no',
             'legend' => empty($vars['legend']) || $vars['legend'] !== 'no',
             'total' => ! ($vars['nototal'] ?? $this->is_small),
             'details' => ! ($vars['nodetails'] ?? $this->is_small),
@@ -182,8 +182,8 @@ class GraphParameters
             $options[] = '-g';
         }
 
-        if ($this->visible('title') && $this->title) {
-            $options[] = "--title='" . Clean::alphaDashSpace($this->title) . "'";
+        if ($this->visible('title') || $this->title) {
+            $options[] = "--title='" . Clean::alphaDashSpace($this->title ?? $this->defaultTitle()) . "'";
         }
 
         return $options;

--- a/LibreNMS/Data/Graphing/GraphParameters.php
+++ b/LibreNMS/Data/Graphing/GraphParameters.php
@@ -183,7 +183,7 @@ class GraphParameters
         }
 
         if ($this->visible('title') || $this->title) {
-            $options[] = "--title='" . Clean::alphaDashSpace($this->title ?? $this->defaultTitle()) . "'";
+            $options[] = "--title='" . Clean::alphaDashSpace($this->title ?: $this->defaultTitle()) . "'";
         }
 
         return $options;

--- a/LibreNMS/Data/Graphing/GraphParameters.php
+++ b/LibreNMS/Data/Graphing/GraphParameters.php
@@ -248,7 +248,7 @@ class GraphParameters
     {
         $title = DeviceCache::getPrimary()->displayName() ?: ucfirst($this->type);
         $title .= '::';
-        $title .= Str::title(Str::snake($this->subtype));
+        $title .= Str::title(str_replace('_', ' ', $this->subtype));
 
         return $title;
     }

--- a/LibreNMS/Data/Graphing/GraphParameters.php
+++ b/LibreNMS/Data/Graphing/GraphParameters.php
@@ -183,7 +183,7 @@ class GraphParameters
         }
 
         if ($this->visible('title')) {
-            $options[] = "--title='" . Clean::shell($this->defaultTitle()) . "'";
+            $options[] = '--title=' . escapeshellarg($this->title ?: $this->defaultTitle());
         }
 
         return $options;

--- a/LibreNMS/Data/Graphing/GraphParameters.php
+++ b/LibreNMS/Data/Graphing/GraphParameters.php
@@ -183,7 +183,7 @@ class GraphParameters
         }
 
         if ($this->visible('title') || $this->title) {
-            $options[] = "--title='" . Clean::alphaDashSpace($this->title ?: $this->defaultTitle()) . "'";
+            $options[] = "--title='" . Clean::shell($this->title ?: $this->defaultTitle()) . "'";
         }
 
         return $options;

--- a/LibreNMS/Data/Graphing/GraphParameters.php
+++ b/LibreNMS/Data/Graphing/GraphParameters.php
@@ -36,7 +36,7 @@ class GraphParameters
 {
     public readonly array $visibleElements;
 
-    public ?string $title = null;
+    public string $title = '';
     public readonly ?string $user_title;
     public readonly string $type;
     public readonly string $subtype;
@@ -185,8 +185,7 @@ class GraphParameters
 
         if ($this->visible('title')) {
             // remove single quotes, because we can't drop out of the string if this is sent to rrdtool stdin
-            $title = str_replace("'", '', $this->user_title ?? $this->title ?: $this->defaultTitle());
-            $options[] = '--title=' . escapeshellarg($title);
+            $options[] = '--title=' . escapeshellarg(str_replace("'", '', $this->getTitle()));
         }
 
         return $options;
@@ -195,6 +194,17 @@ class GraphParameters
     public function __toString(): string
     {
         return implode(' ', $this->toRrdOptions());
+    }
+
+    /**
+     * Get the graph title. In order:
+     * - User set title
+     * - Graph set title
+     * - Fallback default title
+     */
+    public function getTitle(): string
+    {
+        return $this->user_title ?? $this->title ?: $this->defaultTitle();
     }
 
     private function graphColors(): array

--- a/LibreNMS/Data/Graphing/GraphParameters.php
+++ b/LibreNMS/Data/Graphing/GraphParameters.php
@@ -92,7 +92,7 @@ class GraphParameters
 
         $this->user_title = $vars['graph_title'] ?? null; // if the user sets a title, show it
         $this->visibleElements = [
-            'title' => isset($this->user_title)  || (isset($vars['title']) && $vars['title'] !== 'no'),
+            'title' => isset($this->user_title) || (isset($vars['title']) && $vars['title'] !== 'no'),
             'legend' => empty($vars['legend']) || $vars['legend'] !== 'no',
             'total' => ! ($vars['nototal'] ?? $this->is_small),
             'details' => ! ($vars['nodetails'] ?? $this->is_small),

--- a/LibreNMS/Data/Graphing/GraphParameters.php
+++ b/LibreNMS/Data/Graphing/GraphParameters.php
@@ -183,7 +183,7 @@ class GraphParameters
         }
 
         if ($this->visible('title')) {
-            $options[] = "--title='" . Clean::shell($this->title ?: $this->defaultTitle()) . "'";
+            $options[] = "--title='" . Clean::shell($this->defaultTitle()) . "'";
         }
 
         return $options;
@@ -234,8 +234,8 @@ class GraphParameters
     private function defaultTitle(): string
     {
         $title = DeviceCache::getPrimary()->displayName() ?: ucfirst($this->type);
-        $title .= ' - ';
-        $title .= Str::title(str_replace('_', ' ', $this->subtype));
+        $title .= '::';
+        $title .= Str::title(Str::snake($this->subtype));
 
         return $title;
     }

--- a/LibreNMS/Data/Graphing/GraphParameters.php
+++ b/LibreNMS/Data/Graphing/GraphParameters.php
@@ -36,7 +36,7 @@ class GraphParameters
 {
     public readonly array $visibleElements;
 
-    public ?string $title;
+    public ?string $title = null;
     public readonly ?string $user_title;
     public readonly string $type;
     public readonly string $subtype;

--- a/LibreNMS/Data/Graphing/GraphParameters.php
+++ b/LibreNMS/Data/Graphing/GraphParameters.php
@@ -37,6 +37,7 @@ class GraphParameters
     public readonly array $visibleElements;
 
     public ?string $title;
+    public readonly ?string $user_title;
     public readonly string $type;
     public readonly string $subtype;
     public readonly ImageFormat $imageFormat;
@@ -89,9 +90,9 @@ class GraphParameters
         $this->canvas = Clean::alphaDash($vars['bg'] ?? '');
         $this->background = Clean::alphaDash($vars['bbg'] ?? '');
 
-        $this->title = $vars['graph_title'] ?? null;
+        $this->user_title = $vars['graph_title'] ?? null; // if the user sets a title, show it
         $this->visibleElements = [
-            'title' => isset($vars['title']) && $vars['title'] !== 'no',
+            'title' => isset($this->user_title)  || (isset($vars['title']) && $vars['title'] !== 'no'),
             'legend' => empty($vars['legend']) || $vars['legend'] !== 'no',
             'total' => ! ($vars['nototal'] ?? $this->is_small),
             'details' => ! ($vars['nodetails'] ?? $this->is_small),
@@ -183,7 +184,9 @@ class GraphParameters
         }
 
         if ($this->visible('title')) {
-            $options[] = '--title=' . escapeshellarg($this->title ?: $this->defaultTitle());
+            // remove single quotes, because we can't drop out of the string if this is sent to rrdtool stdin
+            $title = str_replace("'", '', $this->user_title ?? $this->title ?: $this->defaultTitle());
+            $options[] = '--title=' . escapeshellarg($title);
         }
 
         return $options;

--- a/LibreNMS/Data/Graphing/GraphParameters.php
+++ b/LibreNMS/Data/Graphing/GraphParameters.php
@@ -182,7 +182,7 @@ class GraphParameters
             $options[] = '-g';
         }
 
-        if ($this->visible('title') || $this->title) {
+        if ($this->visible('title')) {
             $options[] = "--title='" . Clean::shell($this->title ?: $this->defaultTitle()) . "'";
         }
 

--- a/LibreNMS/Util/Clean.php
+++ b/LibreNMS/Util/Clean.php
@@ -55,14 +55,11 @@ class Clean
     }
 
     /**
-     * Sanitize string to only contain alpha, numeric, dashes, underscores, and spaces
-     *
-     * @param  string  $string
-     * @return string
+     * Sanitize string for shell usage.  The string must also be enclosed in quotes.
      */
-    public static function alphaDashSpace($string)
+    public static function shell(string $string): string
     {
-        return preg_replace('/[^a-zA-Z0-9\-_ ]/', '', $string);
+        return preg_replace('#[^a-zA-Z0-9,._+:@%/-]#', '', $string) ?? '';
     }
 
     /**

--- a/LibreNMS/Util/Clean.php
+++ b/LibreNMS/Util/Clean.php
@@ -55,14 +55,6 @@ class Clean
     }
 
     /**
-     * Sanitize string for shell usage.  The string must also be enclosed in quotes.
-     */
-    public static function shell(string $string): string
-    {
-        return preg_replace('#[^a-zA-Z0-9,._+:@%/-]#', '', $string) ?? '';
-    }
-
-    /**
      * Clean a string for display in an html page.
      * For use in non-blade pages
      *

--- a/LibreNMS/Util/Graph.php
+++ b/LibreNMS/Util/Graph.php
@@ -168,7 +168,7 @@ class Graph
         try {
             $image_data = Rrd::graph($rrd_options);
 
-            return new GraphImage($graph_params->imageFormat, $graph_params->title, $image_data);
+            return new GraphImage($graph_params->imageFormat, $graph_params->getTitle(), $image_data);
         } catch (RrdGraphException $e) {
             // preserve original error if debug is enabled, otherwise make it a little more user friendly
             if (Debug::isEnabled()) {


### PR DESCRIPTION
Setting the default title too early cause the titles to always be shown. AFAIK, they should only be shown when:
 - graph_title is set by the user ~~or graph itself (not 100% sure)~~
 - the title variable is set (aka show title)

fixes #14543 

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
