### PR TITLE
XSS sanitize pwrstatd application script inputs

### DIFF
--- a/includes/polling/applications/pwrstatd.inc.php
+++ b/includes/polling/applications/pwrstatd.inc.php
@@ -31,15 +31,22 @@ $rrd_def = RrdDefinition::make()
 
 $metrics = [];
 foreach ($pwrstatd_data as $data) {
-    $sn = $data['sn'];
-    $mruntime = $data['mruntime'];
-    $pcapacity = $data['pcapacity'];
-    $pload = $data['pload'];
-    $voutput = $data['voutput'];
-    $vrating = $data['vrating'];
-    $vutility = $data['vutility'];
-    $wload = $data['wload'];
-    $wrating = $data['wrating'];
+    $sn = is_string($data['sn']) ? filter_var($data['sn'], FILTER_SANITIZE_STRING) : null;
+
+    if (is_null($data['sn'])) {
+        echo PHP_EOL . $name . ':' . ' Invalid or no psu serial number found.' . PHP_EOL;
+
+        continue;
+    }
+
+    $mruntime = is_int($data['mruntime']) ? $data['mruntime'] : null;
+    $pcapacity = is_int($data['pcapacity']) ? $data['pcapacity'] : null;
+    $pload = is_int($data['pload']) ? $data['pload'] : null;
+    $voutput = is_int($data['voutput']) ? $data['voutput'] : null;
+    $vrating = is_int($data['vrating']) ? $data['vrating'] : null;
+    $vutility = is_int($data['vutility']) ? $data['vutility'] : null;
+    $wload = is_int($data['wload']) ? $data['wload'] : null;
+    $wrating = is_int($data['wrating']) ? $data['wrating'] : null;
 
     $rrd_name = ['app', $name, $app->app_id, $sn];
 

--- a/includes/polling/applications/pwrstatd.inc.php
+++ b/includes/polling/applications/pwrstatd.inc.php
@@ -39,14 +39,14 @@ foreach ($pwrstatd_data as $data) {
         continue;
     }
 
-    $mruntime = is_int($data['mruntime']) ? $data['mruntime'] : null;
-    $pcapacity = is_int($data['pcapacity']) ? $data['pcapacity'] : null;
-    $pload = is_int($data['pload']) ? $data['pload'] : null;
-    $voutput = is_int($data['voutput']) ? $data['voutput'] : null;
-    $vrating = is_int($data['vrating']) ? $data['vrating'] : null;
-    $vutility = is_int($data['vutility']) ? $data['vutility'] : null;
-    $wload = is_int($data['wload']) ? $data['wload'] : null;
-    $wrating = is_int($data['wrating']) ? $data['wrating'] : null;
+    $mruntime = $data['mruntime'];
+    $pcapacity = $data['pcapacity'];
+    $pload = $data['pload'];
+    $voutput = $data['voutput'];
+    $vrating = $data['vrating'];
+    $vutility = $data['vutility'];
+    $wload = $data['wload'];
+    $wrating = $data['wrating'];
 
     $rrd_name = ['app', $name, $app->app_id, $sn];
 


### PR DESCRIPTION
Sanitizing and validating input for the pwrstatd application's script's data.  We expect integers for all data except the serial number which is a string.

A bad actor could, in theory, construct a pwrstatd application that returned a serial number with "<script>..." in its name to arbitrarily execute on the pwrstatd application page.  filter_var has been added to negate this possibility.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [X] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
