### PR TITLE
Fix Type error

### DIFF
--- a/app/ApiClients/BaseApi.php
+++ b/app/ApiClients/BaseApi.php
@@ -32,7 +32,7 @@ class BaseApi
 {
     protected string $base_uri;
     protected int $timeout = 3;
-    private ?\Illuminate\Http\Client\PendingRequest $client;
+    private ?\Illuminate\Http\Client\PendingRequest $client = null;
 
     protected function getClient(): \Illuminate\Http\Client\PendingRequest
     {


### PR DESCRIPTION
Fix production.ERROR: Typed property App\ApiClients\BaseApi::$client must not be accessed before initialization cf. https://stackoverflow.com/a/59265626/3236342

Solve:
- https://community.librenms.org/t/oxidized-backup-libre-error/20054
- https://community.librenms.org/t/i-have-an-issue-with-integration-oxidized/20059
- https://community.librenms.org/t/error-must-not-be-accessed-before-initialization-at-opt-librenms-app-apiclients-baseapi-php/20060

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
