### PR TITLE
Fix PTOPO mib in module discovery-protocols

### DIFF
--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -314,7 +314,7 @@ if (($device['os'] == 'routeros')) {
                     $remote_device_id = discover_new_device($lldp['lldpRemSysName'], $device, 'LLDP', $interface);
 
                     if (! $remote_device_id && Config::get('discovery_by_ip', false)) {
-                        $ptopo_array = snmpwalk_group($device, 'ptopoConnEntry', 'PTOPO-MIB');
+                        $ptopo_array = snmpwalk_cache_multi_oid($device, 'ptopoConnEntry', [], 'PTOPO-MIB');
                         d_echo($ptopo_array);
                         foreach ($ptopo_array as $ptopo) {
                             if (strcmp(trim($ptopo['ptopoConnRemoteChassis']), trim($lldp['lldpRemChassisId'])) == 0) {


### PR DESCRIPTION
Changing snmpwalk mode to get only a simple array. Each row of this array should contain a hash as expected by the MIB. 

fixes #14474

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 14564`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
