### PR TITLE
SnmpQuery numeric accept a boolean

### DIFF
--- a/LibreNMS/Data/Source/NetSnmpQuery.php
+++ b/LibreNMS/Data/Source/NetSnmpQuery.php
@@ -188,9 +188,11 @@ class NetSnmpQuery implements SnmpQueryInterface
     /**
      * Output all OIDs numerically
      */
-    public function numeric(): SnmpQueryInterface
+    public function numeric(bool $numeric = true): SnmpQueryInterface
     {
-        $this->options = array_merge($this->options, ['-On']);
+        $this->options = $numeric
+            ? array_merge($this->options, ['-On'])
+            : array_diff($this->options, ['-On']);
 
         return $this;
     }

--- a/LibreNMS/Data/Source/SnmpQueryInterface.php
+++ b/LibreNMS/Data/Source/SnmpQueryInterface.php
@@ -73,7 +73,7 @@ interface SnmpQueryInterface
     /**
      * Output all OIDs numerically
      */
-    public function numeric(): SnmpQueryInterface;
+    public function numeric(bool $numeric = true): SnmpQueryInterface;
 
     /**
      * Hide MIB in output

--- a/app/Console/Commands/SnmpFetch.php
+++ b/app/Console/Commands/SnmpFetch.php
@@ -65,13 +65,9 @@ class SnmpFetch extends LnmsCommand
             $output = $this->option('output')
                 ?: ($type == 'walk' ? 'table' : 'value');
 
-            $query = SnmpQuery::make();
-            if ($this->option('numeric')) {
-                $query->numeric();
-            }
-
             /** @var \LibreNMS\Data\Source\SnmpResponse $res */
-            $res = $query->$type($this->argument('oid'));
+            $res = SnmpQuery::numeric($this->option('numeric'))
+                ->$type($this->argument('oid'));
 
             if (! $res->isValid()) {
                 $this->warn(trans('commands.snmp:fetch.failed'));

--- a/tests/Mocks/SnmpQueryMock.php
+++ b/tests/Mocks/SnmpQueryMock.php
@@ -130,9 +130,9 @@ class SnmpQueryMock implements SnmpQueryInterface
         return $this;
     }
 
-    public function numeric(): SnmpQueryInterface
+    public function numeric(bool $numeric = true): SnmpQueryInterface
     {
-        $this->numeric = true;
+        $this->numeric = $numeric;
 
         return $this;
     }


### PR DESCRIPTION
Allows previously set numeric to be reversed, or to directly input a boolean calculated elsewhere.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x=-] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
