### PR TITLE
Clarify Dispatcher-Service.md for systemd

### DIFF
--- a/doc/Extensions/Dispatcher-Service.md
+++ b/doc/Extensions/Dispatcher-Service.md
@@ -169,22 +169,25 @@ Once the LibreNMS service is installed, the cron scripts used by LibreNMS to sta
 A systemd unit file is provided - the sysv and upstart init scripts
 could also be used with a little modification.
 
-### systemd
+### systemd service
 
 A systemd unit file can be found in `misc/librenms.service`. To
 install run `cp /opt/librenms/misc/librenms.service
 /etc/systemd/system/librenms.service && systemctl enable --now
 librenms.service`
 
-### systemd-watchdog
+### systemd service with watchdog
+
+This service file is an alternative to the above service file. It uses the systemd WatchdogSec= option to restart the service if it does not receive a keep-alive from the running process.
 
 A systemd unit file can be found in `misc/librenms-watchdog.service`. To
 install run `cp /opt/librenms/misc/librenms-watchdog.service
-/etc/systemd/system/librenms-watchdog.service && systemctl enable --now
-librenms-watchdog.service`
+/etc/systemd/system/librenms.service && systemctl enable --now
+librenms.service`
 
 This requires: python3-systemd (or python-systemd on older systems)
 or https://pypi.org/project/systemd-python/
+If you run this systemd service without python3-systemd it will restart every 30 seconds.
 
 ### OS-Specific Instructions
 


### PR DESCRIPTION
There are two systemd service files suggested for use, only one should be used. My changes clarify the usage and adjust the librenms-watchdog.service to install as librenms.service as that appears to be the intention from #12188

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
