### PR TITLE
Bug in Ciscowlc AP graphs definition

### DIFF
--- a/LibreNMS/OS/Ciscowlc.php
+++ b/LibreNMS/OS/Ciscowlc.php
@@ -109,7 +109,7 @@ class Ciscowlc extends Cisco implements
                     'name' => $ap->name,
                     'radionum' => $ap->radio_number,
                     'rrd_name' => ['arubaap', $ap->name . $ap->radio_number],
-                    'rrd_dev' => $rrd_def,
+                    'rrd_def' => $rrd_def,
                 ], $ap->only([
                     'channel',
                     'txpow',


### PR DESCRIPTION
Took me a while to get this one small little letter. Seems to appear in #13460. Haven't found another OS impacted. 

Symptoms : no new AP graphs on Cisco WLC. Existing one are still updated. 

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
