### PR TITLE
Split out lnms snmp convenience commands

### DIFF
--- a/LibreNMS/Data/Source/NetSnmpQuery.php
+++ b/LibreNMS/Data/Source/NetSnmpQuery.php
@@ -442,14 +442,14 @@ class NetSnmpQuery implements SnmpQueryInterface
         $dirs = [$base];
 
         // os group
-        if ($os_group = Config::get("os.{$this->device->os}.group")) {
+        if ($os_group = Config::getOsSetting($this->device->os, 'group')) {
             if (file_exists("$base/$os_group")) {
                 $dirs[] = "$base/$os_group";
             }
         }
 
         // os directory
-        if ($os_mibdir = Config::get("os.{$this->device->os}.mib_dir")) {
+        if ($os_mibdir = Config::getOsSetting($this->device->os, 'mib_dir')) {
             $dirs[] = "$base/$os_mibdir";
         } elseif (file_exists($base . '/' . $this->device->os)) {
             $dirs[] = $base . '/' . $this->device->os;

--- a/app/Console/Commands/SnmpFetch.php
+++ b/app/Console/Commands/SnmpFetch.php
@@ -31,7 +31,7 @@ abstract class SnmpFetch extends LnmsCommand
     {
         parent::__construct();
         $this->addArgument('device spec', InputArgument::REQUIRED, trans('commands.snmp:fetch.arguments.device spec'));
-        $this->addArgument('oid(s)', InputArgument::OPTIONAL|InputArgument::IS_ARRAY, trans('commands.snmp:fetch.arguments.oid(s)'));
+        $this->addArgument('oid(s)', InputArgument::OPTIONAL | InputArgument::IS_ARRAY, trans('commands.snmp:fetch.arguments.oid(s)'));
         $this->addOption('output', 'o', InputOption::VALUE_REQUIRED, trans('commands.snmp:fetch.options.output', ['formats' => '[value, values, table]']));
         $this->addOption('depth', 'd', InputOption::VALUE_REQUIRED, trans('commands.snmp:fetch.options.depth'), 1);
         $this->addOption('numeric', 'i', InputOption::VALUE_NONE, trans('commands.snmp:fetch.options.numeric'));
@@ -106,7 +106,8 @@ abstract class SnmpFetch extends LnmsCommand
                 case 'index-table':
                     $this->printYamlCombinedKey($res->valuesByIndex());
 
-                    continue 2;            }
+                    continue 2;
+            }
         }
 
         return $return;
@@ -159,6 +160,7 @@ abstract class SnmpFetch extends LnmsCommand
     protected function fetchData(): SnmpResponse
     {
         $type = $this->type;
+
         return SnmpQuery::make()
             ->numeric($this->numeric)
             ->$type($this->oids);

--- a/app/Console/Commands/SnmpFetch.php
+++ b/app/Console/Commands/SnmpFetch.php
@@ -6,14 +6,21 @@ use App\Console\LnmsCommand;
 use App\Models\Device;
 use DeviceCache;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Arr;
 use Illuminate\Validation\Rule;
+use LibreNMS\Data\Source\SnmpResponse;
 use SnmpQuery;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 
-class SnmpFetch extends LnmsCommand
+abstract class SnmpFetch extends LnmsCommand
 {
-    protected $name = 'snmp:fetch';
+    protected string $type;
+    protected array $oids;
+    protected bool|null $numeric;
+    private string $outputFormat;
+    protected int $depth;
+    protected string $deviceSpec;
 
     /**
      * Create a new command instance.
@@ -23,12 +30,11 @@ class SnmpFetch extends LnmsCommand
     public function __construct()
     {
         parent::__construct();
-        $this->addArgument('device spec', InputArgument::REQUIRED);
-        $this->addArgument('oid', InputArgument::REQUIRED);
-        $this->addOption('type', 't', InputOption::VALUE_REQUIRED, trans('commands.snmp:fetch.options.type', ['types' => '[get, walk, next, translate]']), 'get');
+        $this->addArgument('device spec', InputArgument::REQUIRED, trans('commands.snmp:fetch.arguments.device spec'));
+        $this->addArgument('oid(s)', InputArgument::OPTIONAL|InputArgument::IS_ARRAY, trans('commands.snmp:fetch.arguments.oid(s)'));
         $this->addOption('output', 'o', InputOption::VALUE_REQUIRED, trans('commands.snmp:fetch.options.output', ['formats' => '[value, values, table]']));
-        $this->addOption('depth', 'd', InputOption::VALUE_REQUIRED, null, 1);
-        $this->addOption('numeric', 'i', InputOption::VALUE_NONE);
+        $this->addOption('depth', 'd', InputOption::VALUE_REQUIRED, trans('commands.snmp:fetch.options.depth'), 1);
+        $this->addOption('numeric', 'i', InputOption::VALUE_NONE, trans('commands.snmp:fetch.options.numeric'));
     }
 
     /**
@@ -39,39 +45,36 @@ class SnmpFetch extends LnmsCommand
     public function handle()
     {
         $this->validate([
-            'type' => Rule::in(['walk', 'get', 'next', 'translate']),
-            'output' => ['nullable', Rule::in(['value', 'values', 'table'])],
+            'output' => ['nullable', Rule::in(['value', 'values', 'table', 'index-table'])],
         ]);
 
-        $spec = $this->argument('device spec');
-        $device_ids = Device::query()->when($spec !== 'all', function (Builder $query) use ($spec) {
-            return $query->where('device_id', $spec)
-                ->orWhere('hostname', 'regexp', "^$spec$");
-        })->pluck('device_id');
+        $this->type = substr($this->name, 5); // 'snmp:<type>'
+        $this->deviceSpec = $this->argument('device spec');
+        $this->oids = $this->argument('oid(s)') ?: [];
+        $this->numeric = $this->option('numeric');
+        $this->outputFormat = $this->option('output') ?: ($this->type == 'walk' ? 'table' : 'value');
+        $this->depth = (int) $this->option('depth');
 
-        if ($device_ids->isEmpty()) {
+        $devices = $this->getDevices();
+
+        if ($devices->isEmpty()) {
             $this->error(trans('commands.snmp:fetch.not_found'));
 
             return 1;
         }
 
         $return = 0;
-        $type = $this->option('type');
-        $output = $this->option('output') ?: ($type == 'walk' ? 'table' : 'value');
 
-        foreach ($device_ids as $device_id) {
-            DeviceCache::setPrimary($device_id);
-            $this->info(DeviceCache::getPrimary()->displayName() . ':');
-
-            /** @var \LibreNMS\Data\Source\SnmpResponse $res */
-            $res = SnmpQuery::numeric($this->option('numeric'))
-                ->$type($this->argument('oid'));
-
-            if ($type == 'translate') {
-                $this->line($res);
-
-                return 0;
+        foreach ($devices as $device) {
+            if ($device->exists) {
+                DeviceCache::setPrimary($device->device_id);
             }
+            $device_name = $device->displayName();
+            if ($device_name) {
+                $this->info($device_name . ':');
+            }
+
+            $res = $this->fetchData();
 
             if (! $res->isValid()) {
                 $this->warn(trans('commands.snmp:fetch.failed'));
@@ -82,7 +85,7 @@ class SnmpFetch extends LnmsCommand
                 continue;
             }
 
-            switch ($output) {
+            switch ($this->outputFormat) {
                 case 'value':
                     $this->line($res->value());
 
@@ -90,7 +93,7 @@ class SnmpFetch extends LnmsCommand
                 case 'values':
                     $values = [];
                     foreach ($res->values() as $oid => $value) {
-                        $values[] = [$oid, $value];
+                        $values[] = ["<fg=bright-blue>$oid</>", $value];
                     }
                     $this->table(
                         [trans('commands.snmp:fetch.oid'), trans('commands.snmp:fetch.value')],
@@ -99,12 +102,72 @@ class SnmpFetch extends LnmsCommand
 
                     continue 2;
                 case 'table':
-                    dump($res->table((int) $this->option('depth')));
+                    $this->printYamlLike($res->table($this->depth));
 
                     continue 2;
-            }
+                case 'index-table':
+                    $this->printYamlCombinedKey($res->table(999));
+
+                    continue 2;            }
         }
 
         return $return;
+    }
+
+    protected function printYamlLike(array $data, int $indent = 0): void
+    {
+        foreach ($data as $key => $item) {
+            if (is_array($item)) {
+                // recurse
+                $this->printDataLine($key, '', $indent, 'blue');
+                $this->printYamlLike($item, $indent + 2);
+                continue;
+            }
+
+            // data items
+            $this->printDataLine($key, $item, $indent, 'bright-blue');
+        }
+    }
+
+    protected function printYamlCombinedKey(array $data, string $carry = ''): void
+    {
+        // we found the full key, print it
+        if (! is_array(Arr::first($data))) {
+            $this->printDataLine($carry, '', 0, 'blue');
+        }
+
+        foreach ($data as $key => $item) {
+            if (is_array($item)) {
+                // recurse
+                $this->printYamlCombinedKey($item, $carry ? "$carry.$key" : $key);
+                continue;
+            }
+
+            // data items
+            $this->printDataLine($key, $item, 2, 'bright-blue');
+        }
+    }
+
+    protected function getDevices(): \Illuminate\Support\Collection
+    {
+        return Device::query()->when($this->deviceSpec !== 'all', function (Builder $query) {
+            return $query->where('device_id', $this->deviceSpec)
+                ->orWhere('hostname', 'regexp', "^$this->deviceSpec$");
+        })->pluck('device_id')->map(function ($device_id) {
+            return DeviceCache::get($device_id);
+        });
+    }
+
+    protected function fetchData(): SnmpResponse
+    {
+        $type = $this->type;
+        return SnmpQuery::make()
+            ->numeric($this->numeric)
+            ->$type($this->oids);
+    }
+
+    protected function printDataLine(string $key, string $data, int $indent, string $color): void
+    {
+        $this->line(str_repeat(' ', $indent) . "<fg=$color>$key</>: $data");
     }
 }

--- a/app/Console/Commands/SnmpFetch.php
+++ b/app/Console/Commands/SnmpFetch.php
@@ -39,10 +39,8 @@ abstract class SnmpFetch extends LnmsCommand
 
     /**
      * Execute the console command.
-     *
-     * @return int
      */
-    public function handle()
+    public function handle(): int
     {
         $this->validate([
             'output' => ['nullable', Rule::in(['value', 'values', 'table', 'index-table'])],
@@ -106,7 +104,7 @@ abstract class SnmpFetch extends LnmsCommand
 
                     continue 2;
                 case 'index-table':
-                    $this->printYamlCombinedKey($res->table(999));
+                    $this->printYamlCombinedKey($res->valuesByIndex());
 
                     continue 2;            }
         }

--- a/app/Console/Commands/SnmpGet.php
+++ b/app/Console/Commands/SnmpGet.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Console\Commands;
+
+class SnmpGet extends SnmpFetch
+{
+    protected $name = 'snmp:get';
+}

--- a/app/Console/Commands/SnmpNext.php
+++ b/app/Console/Commands/SnmpNext.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Console\Commands;
+
+class SnmpNext extends SnmpFetch
+{
+    protected $name = 'snmp:next';
+}

--- a/app/Console/Commands/SnmpTranslate.php
+++ b/app/Console/Commands/SnmpTranslate.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Device;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+use LibreNMS\Data\Source\SnmpResponse;
+use SnmpQuery;
+
+class SnmpTranslate extends SnmpFetch
+{
+    protected $name = 'snmp:translate';
+    protected array $oids;
+
+    protected function getDevices(): \Illuminate\Support\Collection
+    {
+        if (empty($this->oids)) {
+            $this->oids = [$this->deviceSpec];
+
+            return new Collection([new Device]); // no device needed, supply dummy
+        }
+
+        $devices = parent::getDevices();
+
+        if ($devices->isEmpty()) {
+            $this->oids = [$this->deviceSpec, ...$this->oids];
+
+            return new Collection([new Device]); // no device needed, supply dummy
+        }
+
+        return $devices;
+    }
+
+    protected function fetchData(): SnmpResponse
+    {
+        $res = new SnmpResponse('');
+        // translate does not support multiple oids (should it?)
+        foreach ($this->oids as $oid) {
+            $translated = SnmpQuery::numeric($this->numeric)->translate($oid);
+
+            // if we got the same back (ignoring . prefix) swap numeric
+            if (empty($translated) || Str::start($oid, '.') == Str::start($translated, '.')) {
+                $translated = SnmpQuery::numeric(! $this->numeric)->translate($oid);
+            }
+
+            $res->append(new SnmpResponse($translated . PHP_EOL));
+        }
+
+        return $res;
+    }
+}

--- a/app/Console/Commands/SnmpWalk.php
+++ b/app/Console/Commands/SnmpWalk.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Console\Commands;
+
+class SnmpWalk extends SnmpFetch
+{
+    protected $name = 'snmp:walk';
+}

--- a/resources/lang/en/commands.php
+++ b/resources/lang/en/commands.php
@@ -198,14 +198,14 @@ return [
         'description' => 'Run snmp query against a device',
         'arguments' => [
             'device spec' => 'Device to query: device_id, hostname/ip, hostname regex, or all',
-            'oid' => 'SNMP OID to fetch.  Should be either MIB::oid or a numeric oid',
+            'oid(s)' => 'One or more SNMP OID to fetch.  Should be either MIB::oid or a numeric oid',
         ],
         'failed' => 'SNMP command failed!',
         'oid' => 'OID',
         'options' => [
-            'type' => 'The type of snmp query to perform :types',
             'output' => 'Specify the output format :formats',
             'numeric' => 'Numeric OIDs',
+            'depth' => 'Depth to group the snmp table at. Usually the same number as the items in the index of the table',
         ],
         'not_found' => 'Device not found',
         'value' => 'Value',


### PR DESCRIPTION
lnms snmp:walk
lnms snmp:get
lnms snmp:next
lnms snmp:translate

basically wrappers around net-snmp, but never having to set options (like snmp credentials)

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
