### PR TITLE
Updated check_dns arguments

### DIFF
--- a/includes/services/check_dns.inc.php
+++ b/includes/services/check_dns.inc.php
@@ -14,4 +14,4 @@ if ($service['service_ip']) {
     $resolver = $service['hostname'];
 }
 
-$check_cmd = \LibreNMS\Config::get('nagios_plugins') . '/check_dns -H ' . $nsquery . ' -s ' . $resolver;
+$check_cmd = \LibreNMS\Config::get('nagios_plugins') . '/check_dns -H ' . $resolver . ' $nsquery';


### PR DESCRIPTION
Normally for a service check LibreNMS will pass -H $HOSTNAME at the beginning of the service check, but for some reason it's passing -s $HOSTNAME at the end for the check_dns plugin. The -s should be for the DNS server, and -H should be the host to resolve. 

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
