### PR TITLE
Edgeos picked up as generic device

### DIFF
--- a/includes/definitions/edgeos.yaml
+++ b/includes/definitions/edgeos.yaml
@@ -10,6 +10,7 @@ discovery:
     -
         sysObjectID: .1.3.6.1.4.1.41112.1.5
         sysDescr_regex:
+            - '/^Ubiquiti\ EdgeOS/'
             - '/^EdgeOS/'
             - '/^EdgeRouter/'
         snmpget_except:


### PR DESCRIPTION
Edgeos on EdgeRouter Lite 3-Port (erlite-3) picked up as generic device #14611

Not sure about other edgemax devices but the value of sysDescr for the EdgeRouter Lite running v2.0.9-hotfix.4 is "Ubiquiti EdgeOS", so neither regex matches.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
