### PR TITLE
Set 0 as integer in loading of graylog.

### DIFF
--- a/includes/html/common/graylog.inc.php
+++ b/includes/html/common/graylog.inc.php
@@ -135,7 +135,7 @@ $tmp_output .= '
             return {
                 stream: "' . (isset($_POST['stream']) ? $_POST['stream'] : '') . '",
                 device: "' . (isset($filter_device) ? $filter_device : '') . '",
-                range: "' . (isset($_POST['range']) ? $_POST['range'] : '') . '",
+                range: "' . (isset($_POST['range']) ? $_POST['range'] : 0) . '",
                 loglevel: "' . (isset($_POST['loglevel']) ? $_POST['loglevel'] : '') . '",
             };
         },


### PR DESCRIPTION
#14476 probably made this require integer instead of empty string as default.

Graylog on device view or global view did not load logs when page is opened.

Resulted in a 500 error:

`GraylogApi::query(): Argument #2  ($range) must be of type int, null given`

Loading with filter button works - so i changed the default value of the initial ajax call, if no other value is given.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
