### PR TITLE
Fix billing graph divide by zero when the period is zero or doesn't exist

### DIFF
--- a/includes/billing.php
+++ b/includes/billing.php
@@ -192,9 +192,9 @@ function getRates($bill_id, $datefrom, $dateto, $dir_95th)
     $data['total_data'] = $mtot;
     $data['total_data_in'] = $mtot_in;
     $data['total_data_out'] = $mtot_out;
-    $data['rate_average'] = ($mtot / $ptot * 8);
-    $data['rate_average_in'] = ($mtot_in / $ptot * 8);
-    $data['rate_average_out'] = ($mtot_out / $ptot * 8);
+    $data['rate_average'] = ! empty($ptot) ? ($mtot / $ptot * 8) : 0;
+    $data['rate_average_in'] = ! empty($ptot) ? ($mtot_in / $ptot * 8) : 0;
+    $data['rate_average_out'] = ! empty($ptot) ? ($mtot_out / $ptot * 8) : 0;
 
     // print_r($data);
     return $data;


### PR DESCRIPTION
Fix billing graph when the period is zero or doesn't exits, before the fix a divide by zero error was happening when the billing api was being call for an image

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
