### PR TITLE
AIX: remove extends and hardware detection support

### DIFF
--- a/LibreNMS/OS/Aix.php
+++ b/LibreNMS/OS/Aix.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Aix.php
+ *
+ * -Description-
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * @link       https://www.librenms.org
+ *
+ * @copyright  2022 Tony Murray
+ * @author     Tony Murray <murraytony@gmail.com>
+ */
+
+namespace LibreNMS\OS;
+
+use App\Models\Device;
+use LibreNMS\OS\Shared\Unix;
+
+class Aix extends Unix
+{
+    public function discoverOS(Device $device): void
+    {
+        // don't support server hardware detection or extends
+        $this->discoverYamlOS($device);
+    }
+}


### PR DESCRIPTION
Because the aix snmpd returns NULL instead of a non-existent oid error, remove support for extends and additional hardware detection

https://community.librenms.org/t/aix-discovery-not-working-in-22-10-0-102-g3e6ad9006/20135/4

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
