### PR TITLE
Adding wireguard app to the apps overview page

### DIFF
--- a/includes/html/pages/apps.inc.php
+++ b/includes/html/pages/apps.inc.php
@@ -441,6 +441,10 @@ $graphs['systemd'] = [
     'active',
     'load',
 ];
+$graphs['wireguard'] = [
+    'traffic',
+    'time',
+];
 
 echo '<div class="panel panel-default">';
 echo '<div class="panel-heading">';


### PR DESCRIPTION
Somehow I forgot to copy over apps.inc.php from my test to dev env and it wasn't included in https://github.com/librenms/librenms/pull/14625

Adding it here.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [X] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
