### PR TITLE
Added Filterable Interface OperStatus and ifAlias to Overall Traffic

### DIFF
--- a/includes/html/graphs/device/bits.inc.php
+++ b/includes/html/graphs/device/bits.inc.php
@@ -14,7 +14,7 @@ foreach (dbFetchRows('SELECT * FROM `ports` WHERE `device_id` = ? AND `disabled`
                 // This patch will ignore l2vlan for ASA.
                 continue;
             }
-            if (preg_match($iftype.'i', $port['ifType'])) {
+            if (preg_match($iftype . 'i', $port['ifType']) || preg_match($iftype . 'i', $port['ifOperStatus'])) {
                 $ignore = 1;
             }
         }
@@ -22,7 +22,7 @@ foreach (dbFetchRows('SELECT * FROM `ports` WHERE `device_id` = ? AND `disabled`
 
     if (is_array(\LibreNMS\Config::get('device_traffic_descr'))) {
         foreach (\LibreNMS\Config::get('device_traffic_descr') as $ifdescr) {
-            if (preg_match($ifdescr.'i', $port['ifDescr']) || preg_match($ifdescr.'i', $port['ifName'])) {
+            if (preg_match($ifdescr . 'i', $port['ifDescr']) || preg_match($ifdescr . 'i', $port['ifName']) || preg_match($ifdescr . 'i', $port['ifAlias'])) {
                 $ignore = 1;
             }
         }

--- a/includes/html/graphs/global/bits.inc.php
+++ b/includes/html/graphs/global/bits.inc.php
@@ -7,7 +7,7 @@ foreach (dbFetchRows('SELECT * FROM `ports` AS P, `devices` AS D WHERE D.device_
     $ignore = 0;
     if (is_array(\LibreNMS\Config::get('device_traffic_iftype'))) {
         foreach (\LibreNMS\Config::get('device_traffic_iftype') as $iftype) {
-            if (preg_match($iftype.'i', $port['ifType'])) {
+            if (preg_match($iftype.'i', $port['ifType']) || preg_match($iftype.'i', $port['ifOperStatus'])) {
                 $ignore = 1;
             }
         }
@@ -15,7 +15,7 @@ foreach (dbFetchRows('SELECT * FROM `ports` AS P, `devices` AS D WHERE D.device_
 
     if (is_array(\LibreNMS\Config::get('device_traffic_descr'))) {
         foreach (\LibreNMS\Config::get('device_traffic_descr') as $ifdescr) {
-            if (preg_match($ifdescr.'i', $port['ifDescr']) || preg_match($ifdescr.'i', $port['ifName'])) {
+            if (preg_match($ifdescr.'i', $port['ifDescr']) || preg_match($ifdescr.'i', $port['ifName']) || preg_match($ifdescr.'i', $port['ifAlias'])) {
                 $ignore = 1;
             }
         }

--- a/includes/html/graphs/location/bits.inc.php
+++ b/includes/html/graphs/location/bits.inc.php
@@ -10,7 +10,7 @@ foreach ($devices as $device) {
         $ignore = 0;
         if (is_array(\LibreNMS\Config::get('device_traffic_iftype'))) {
             foreach (\LibreNMS\Config::get('device_traffic_iftype') as $iftype) {
-                if (preg_match($iftype.'i', $int['ifType'])) {
+                if (preg_match($iftype.'i', $int['ifType']) || preg_match($iftype.'i', $int['ifOperStatus'])) {
                     $ignore = 1;
                 }
             }
@@ -18,7 +18,7 @@ foreach ($devices as $device) {
 
         if (is_array(\LibreNMS\Config::get('device_traffic_descr'))) {
             foreach (\LibreNMS\Config::get('device_traffic_descr') as $ifdescr) {
-                if (preg_match($ifdescr.'i', $int['ifDescr']) || preg_match($ifdescr.'i', $int['ifName'])) {
+                if (preg_match($ifdescr.'i', $int['ifDescr']) || preg_match($ifdescr.'i', $int['ifName']) || preg_match($ifdescr.'i', $int['ifAlias'])) {
                     $ignore = 1;
                 }
             }


### PR DESCRIPTION
"**Overall Traffic**" adaptation to reduce the number of Interfaces and Site Load Time for large Devices e.g. Backbone Layer 3 Routers with over +100 Interfaces and a librenms Installation with +10k Devices

example for routers with ifAdminStatus up and many ifOperStatus down Interfaces

possibility for **device_traffic_iftype** 

- ifOperStatus -> up/down
config.php:
```
unset($config['device_traffic_iftype']);
$config['device_traffic_iftype'][] = '/^down$/';
```


possibility for **device_traffic_descr**

- ifAlias -> configured Interface description in the Device
config.php:
```
unset($config['device_traffic_descr']);
$config['device_traffic_descr'][] = '/Customer-/';
```

Cisco Router Config:
!
interface GigabitEthernet0/0/0
 description UPLINK
!
interface GigabitEthernet0/1/0
 **description Customer-1234**
!
interface GigabitEthernet0/1/1
 **description Customer-5678**
!
etc.


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
