### PR TITLE
Added support for Eltek Micropack 1U

### DIFF
--- a/includes/definitions/enexus.yaml
+++ b/includes/definitions/enexus.yaml
@@ -17,7 +17,7 @@ discovery:
         snmpget:
             oid: .1.3.6.1.4.1.12148.10.2.6.0
             op: regex
-            value: '/Micropack System|Smart[Pp]ack S|SmartPack2 Touch|SmartPack2 Syst.|SPS-FPS|Flatpack S/'
+            value: '/Micropack System|Smart[Pp]ack S|SmartPack2 Touch|SmartPack2 Syst.|SPS-FPS|Flatpack S|Micropack 1U/'
 poller_modules:
     entity-physical: false
     hr-mib: false


### PR DESCRIPTION
Added support for Eltek Micropack 1U

```
SNMP['/usr/bin/snmpget' '-M' '/opt/librenms/mibs:/opt/librenms/mibs/eltek' '-v2c' '-c' 'COMMUNITY' '-OQXUte' 'udp:HOSTNAME:161' '.1.3.6.1.4.1.12148.10.2.6.0']  
iso.*.1.12*.0 = "Micropack 1U"
```

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
