### PR TITLE
Port search API search more than one fields

### DIFF
--- a/LibreNMS/Exceptions/ApiClientException.php
+++ b/LibreNMS/Exceptions/ApiClientException.php
@@ -27,15 +27,20 @@ namespace LibreNMS\Exceptions;
 
 class ApiClientException extends \Exception
 {
+    /** @var array */
     private $output;
 
+    /**
+     * @param  string  $message
+     * @param  array  $output
+     */
     public function __construct($message = '', $output = [])
     {
         parent::__construct($message, 0, null);
         $this->output = $output;
     }
 
-    public function getOutput()
+    public function getOutput(): array
     {
         return $this->output;
     }

--- a/LibreNMS/Exceptions/ApiClientException.php
+++ b/LibreNMS/Exceptions/ApiClientException.php
@@ -1,6 +1,6 @@
 <?php
-/*
- * InvalidTableColumnException.php
+/**
+ * ApiException.php
  *
  * -Description-
  *
@@ -15,21 +15,28 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * @package    LibreNMS
- * @link       http://librenms.org
- * @copyright  2022 Tony Murray
+ * @link       https://www.librenms.org
+ *
+ * @copyright  2019 Tony Murray
  * @author     Tony Murray <murraytony@gmail.com>
  */
 
 namespace LibreNMS\Exceptions;
 
-class InvalidTableColumnException extends ApiException
+class ApiClientException extends \Exception
 {
-    public function __construct(
-        public readonly array $columns
-    ) {
-        parent::__construct('Invalid columns: ' . join(',', $this->columns));
+    private $output;
+
+    public function __construct($message = '', $output = [])
+    {
+        parent::__construct($message, 0, null);
+        $this->output = $output;
+    }
+
+    public function getOutput()
+    {
+        return $this->output;
     }
 }

--- a/LibreNMS/Exceptions/ApiException.php
+++ b/LibreNMS/Exceptions/ApiException.php
@@ -1,5 +1,5 @@
 <?php
-/**
+/*
  * ApiException.php
  *
  * -Description-
@@ -15,28 +15,40 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
- * @link       https://www.librenms.org
- *
- * @copyright  2019 Tony Murray
+ * @package    LibreNMS
+ * @link       http://librenms.org
+ * @copyright  2022 Tony Murray
  * @author     Tony Murray <murraytony@gmail.com>
  */
 
 namespace LibreNMS\Exceptions;
 
+use Illuminate\Http\JsonResponse;
+
 class ApiException extends \Exception
 {
-    private $output;
-
-    public function __construct($message = '', $output = [])
+    /**
+     * @param  string  $message
+     * @param  int  $code
+     * @param  \Throwable|null  $previous
+     */
+    public function __construct($message = '', $code = 400, $previous = null)
     {
-        parent::__construct($message, 0, null);
-        $this->output = $output;
+        parent::__construct($message, $code, $previous);
     }
 
-    public function getOutput()
+    /**
+     * Render the exception into an HTTP response.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     */
+    public function render($request): JsonResponse
     {
-        return $this->output;
+        return response()->json([
+            'status'  => 'error',
+            'message' => $this->getMessage(),
+        ], $this->getCode(), [], JSON_PRETTY_PRINT);
     }
 }

--- a/LibreNMS/Exceptions/InvalidTableColumnException.php
+++ b/LibreNMS/Exceptions/InvalidTableColumnException.php
@@ -1,0 +1,49 @@
+<?php
+/*
+ * InvalidTableColumnException.php
+ *
+ * -Description-
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @package    LibreNMS
+ * @link       http://librenms.org
+ * @copyright  2022 Tony Murray
+ * @author     Tony Murray <murraytony@gmail.com>
+ */
+
+namespace LibreNMS\Exceptions;
+
+class InvalidTableColumnException extends \Exception
+{
+    public function __construct(
+        private array $columns,
+        protected $code = 400
+    ) {
+        parent::__construct('Invalid columns: ' . join(',', $this->columns));
+    }
+
+    /**
+     * Render the exception into an HTTP response.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     */
+    public function render($request): \Illuminate\Http\JsonResponse
+    {
+        return response()->json([
+            'status'  => 'error',
+            'message' => $this->getMessage(),
+        ], $this->getCode(), [], JSON_PRETTY_PRINT);
+    }
+}

--- a/app/ApiClients/RipeApi.php
+++ b/app/ApiClients/RipeApi.php
@@ -26,7 +26,7 @@
 namespace App\ApiClients;
 
 use GuzzleHttp\Exception\RequestException;
-use LibreNMS\Exceptions\ApiException;
+use LibreNMS\Exceptions\ApiClientException;
 
 class RipeApi extends BaseApi
 {
@@ -38,7 +38,7 @@ class RipeApi extends BaseApi
     /**
      * Get whois info
      *
-     * @throws ApiException
+     * @throws ApiClientException
      */
     public function getWhois(string $resource): array
     {
@@ -52,7 +52,7 @@ class RipeApi extends BaseApi
     /**
      * Get Abuse contact
      *
-     * @throws ApiException
+     * @throws ApiClientException
      */
     public function getAbuseContact(string $resource): mixed
     {
@@ -64,7 +64,7 @@ class RipeApi extends BaseApi
     }
 
     /**
-     * @throws ApiException
+     * @throws ApiClientException
      */
     private function makeApiCall(string $uri, array $options): mixed
     {
@@ -73,13 +73,13 @@ class RipeApi extends BaseApi
             if (isset($response_data['status']) && $response_data['status'] == 'ok') {
                 return $response_data;
             } else {
-                throw new ApiException('RIPE API call failed', $response_data);
+                throw new ApiClientException('RIPE API call failed', $response_data);
             }
         } catch (RequestException $e) {
             $message = 'RIPE API call to ' . $e->getRequest()->getUri() . ' failed: ';
             $message .= $e->getResponse()->getReasonPhrase() . ' ' . $e->getResponse()->getStatusCode();
 
-            throw new ApiException(
+            throw new ApiClientException(
                 $message,
                 json_decode($e->getResponse()->getBody(), true)
             );

--- a/app/Http/Controllers/Ajax/RipeNccApiController.php
+++ b/app/Http/Controllers/Ajax/RipeNccApiController.php
@@ -28,7 +28,7 @@ namespace App\Http\Controllers\Ajax;
 use App\ApiClients\RipeApi;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
-use LibreNMS\Exceptions\ApiException;
+use LibreNMS\Exceptions\ApiClientException;
 
 class RipeNccApiController extends Controller
 {
@@ -50,7 +50,7 @@ class RipeNccApiController extends Controller
                 'message' => 'Queried',
                 'output' => $output,
             ]);
-        } catch (ApiException $e) {
+        } catch (ApiClientException $e) {
             $response = $e->getOutput();
             $message = $e->getMessage();
 

--- a/doc/API/Ports.md
+++ b/doc/API/Ports.md
@@ -87,13 +87,14 @@ Output:
 }
 ```
 
-### `search_ports in specific column`
+### `search_ports in specific field(s)`
 
 Specific search for ports matching the query.
 
 Route: `/api/v0/ports/search/:field/:search`
 
-- search string to search in field specified by field
+- field: comma separated list of field(s) to search
+- search: string to search in fields
 
 Input:
 

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -972,7 +972,7 @@ function list_available_wireless_graphs(Illuminate\Http\Request $request)
 }
 
 /**
- * @throws \LibreNMS\Exceptions\InvalidTableColumnException
+ * @throws \LibreNMS\Exceptions\ApiException
  */
 function get_port_graphs(Illuminate\Http\Request $request)
 {
@@ -1045,7 +1045,7 @@ function get_port_info(Illuminate\Http\Request $request)
 }
 
 /**
- * @throws \LibreNMS\Exceptions\InvalidTableColumnException
+ * @throws \LibreNMS\Exceptions\ApiException
  */
 function search_ports(Illuminate\Http\Request $request)
 {
@@ -1078,7 +1078,7 @@ function search_ports(Illuminate\Http\Request $request)
 }
 
 /**
- * @throws \LibreNMS\Exceptions\InvalidTableColumnException
+ * @throws \LibreNMS\Exceptions\ApiException
  */
 function get_all_ports(Illuminate\Http\Request $request)
 {
@@ -1144,7 +1144,7 @@ function list_alert_rules(Illuminate\Http\Request $request)
 }
 
 /**
- * @throws \LibreNMS\Exceptions\InvalidTableColumnException
+ * @throws \LibreNMS\Exceptions\ApiException
  */
 function list_alerts(Illuminate\Http\Request $request)
 {
@@ -2610,7 +2610,7 @@ function list_logs(Illuminate\Http\Request $request, Router $router)
 }
 
 /**
- * @throws \LibreNMS\Exceptions\InvalidTableColumnException
+ * @throws \LibreNMS\Exceptions\ApiException
  */
 function validate_column_list(?string $columns, string $table, array $default = []): array
 {

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -1057,12 +1057,14 @@ function search_ports(Illuminate\Http\Request $request)
     $field = $request->route('field');
     $search = $request->route('search');
     $columns = $request->get('columns');
+    $columns = $columns ? explode(',', $columns) : [];
+
     if (($validate = validate_column_list($columns, 'ports')) !== true) {
         return $validate;
     }
 
     $query = Port::hasAccess(Auth::user())
-         ->select(['device_id', 'port_id', 'ifIndex', 'ifName', $columns]);
+         ->select(['device_id', 'port_id', 'ifIndex', 'ifName', ...$columns]);
 
     if (isset($search)) {
         $query->where($field, 'like', "%$search%");

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -1061,7 +1061,7 @@ function search_ports(Illuminate\Http\Request $request)
 
     $ports = Port::hasAccess(Auth::user())
         ->isNotDeleted()
-        ->where(function($query) use ($fields, $search) {
+        ->where(function ($query) use ($fields, $search) {
             foreach ($fields as $field) {
                 $query->orWhere($field, 'like', "%$search%");
             }

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -35,6 +35,7 @@ use Illuminate\Support\Str;
 use LibreNMS\Alerting\QueryBuilderParser;
 use LibreNMS\Config;
 use LibreNMS\Exceptions\InvalidIpException;
+use LibreNMS\Exceptions\InvalidTableColumnException;
 use LibreNMS\Util\Graph;
 use LibreNMS\Util\IP;
 use LibreNMS\Util\IPv4;
@@ -970,25 +971,16 @@ function list_available_wireless_graphs(Illuminate\Http\Request $request)
     });
 }
 
+/**
+ * @throws \LibreNMS\Exceptions\InvalidTableColumnException
+ */
 function get_port_graphs(Illuminate\Http\Request $request)
 {
-    $hostname = $request->route('hostname');
-    $columns = $request->get('columns', 'ifName');
+    $device = DeviceCache::get($request->route('hostname'));
+    $columns = validate_column_list($request->get('columns'), 'ports', ['ifName']);
 
-    if (($validate = validate_column_list($columns, 'ports')) !== true) {
-        return $validate;
-    }
-
-    // use hostname as device_id if it's all digits
-    $device_id = ctype_digit($hostname) ? $hostname : getidbyname($hostname);
-    $sql = '';
-    $params = [$device_id];
-    if (! device_permitted($device_id)) {
-        $sql = 'AND `port_id` IN (select `port_id` from `ports_perms` where `user_id` = ?)';
-        array_push($params, Auth::id());
-    }
-
-    $ports = dbFetchRows("SELECT $columns FROM `ports` WHERE `device_id` = ? AND `deleted` = '0' $sql ORDER BY `ifIndex`", $params);
+    $ports = $device->ports()->isNotDeleted()->hasAccess(Auth::user())
+        ->select($columns)->orderBy('ifIndex')->get();
 
     return api_success($ports, 'ports');
 }
@@ -1052,31 +1044,31 @@ function get_port_info(Illuminate\Http\Request $request)
     });
 }
 
+/**
+ * @throws \LibreNMS\Exceptions\InvalidTableColumnException
+ */
 function search_ports(Illuminate\Http\Request $request)
 {
+    $columns = validate_column_list($request->get('columns'), 'ports', ['device_id', 'port_id', 'ifIndex', 'ifName']);
     $field = $request->route('field');
     $search = $request->route('search');
-    $columns = $request->get('columns');
-    $columns = $columns ? explode(',', $columns) : [];
 
-    if (($validate = validate_column_list($columns, 'ports')) !== true) {
-        return $validate;
+    // if only field is set, swap values
+    if (empty($search)) {
+        [$field, $search] = [$search, $field];
     }
+    $fields = validate_column_list($field, 'ports', ['ifAlias', 'ifDescr', 'ifName']);
 
-    $query = Port::hasAccess(Auth::user())
-         ->select(['device_id', 'port_id', 'ifIndex', 'ifName', ...$columns]);
-
-    if (isset($search)) {
-        $query->where($field, 'like', "%$search%");
-    } else {
-        $value = "%$field%";
-        $query->where('ifAlias', 'like', $value)
-            ->orWhere('ifDescr', 'like', $value)
-            ->orWhere('ifName', 'like', $value);
-    }
-
-    $ports = $query->orderBy('ifName')
-                   ->get();
+    $ports = Port::hasAccess(Auth::user())
+        ->isNotDeleted()
+        ->where(function($query) use ($fields, $search) {
+            foreach ($fields as $field) {
+                $query->orWhere($field, 'like', "%$search%");
+            }
+        })
+        ->select($columns)
+        ->orderBy('ifName')
+        ->get();
 
     if ($ports->isEmpty()) {
         return api_error(404, 'No ports found');
@@ -1085,21 +1077,17 @@ function search_ports(Illuminate\Http\Request $request)
     return api_success($ports, 'ports');
 }
 
+/**
+ * @throws \LibreNMS\Exceptions\InvalidTableColumnException
+ */
 function get_all_ports(Illuminate\Http\Request $request)
 {
-    $columns = $request->get('columns', 'port_id, ifName');
-    if (($validate = validate_column_list($columns, 'ports')) !== true) {
-        return $validate;
-    }
+    $columns = validate_column_list($request->get('columns'), 'ports', ['port_id', 'ifName']);
 
-    $params = [];
-    $sql = '';
-    if (! Auth::user()->hasGlobalRead()) {
-        $sql = ' AND (device_id IN (SELECT device_id FROM devices_perms WHERE user_id = ?) OR port_id IN (SELECT port_id FROM ports_perms WHERE user_id = ?))';
-        array_push($params, Auth::id());
-        array_push($params, Auth::id());
-    }
-    $ports = dbFetchRows("SELECT $columns FROM `ports` WHERE `deleted` = 0 $sql", $params);
+    $ports = Port::hasAccess(Auth::user())
+        ->select($columns)
+        ->isNotDeleted()
+        ->get();
 
     return api_success($ports, 'ports');
 }
@@ -1155,6 +1143,9 @@ function list_alert_rules(Illuminate\Http\Request $request)
     return api_success($rules->toArray($request), 'rules');
 }
 
+/**
+ * @throws \LibreNMS\Exceptions\InvalidTableColumnException
+ */
 function list_alerts(Illuminate\Http\Request $request)
 {
     $id = $request->route('id');
@@ -1193,9 +1184,7 @@ function list_alerts(Illuminate\Http\Request $request)
 
     if ($request->has('order')) {
         [$sort_column, $sort_order] = explode(' ', $request->get('order'), 2);
-        if (($res = validate_column_list($sort_column, 'alerts')) !== true) {
-            return $res;
-        }
+        validate_column_list($sort_column, 'alerts');
         if (in_array($sort_order, ['asc', 'desc'])) {
             $order = $request->get('order');
         }
@@ -2620,22 +2609,29 @@ function list_logs(Illuminate\Http\Request $request, Router $router)
     return api_success($logs, 'logs', null, 200, null, ['total' => $count]);
 }
 
-function validate_column_list($columns, $tableName)
+/**
+ * @throws \LibreNMS\Exceptions\InvalidTableColumnException
+ */
+function validate_column_list(?string $columns, string $table, array $default = []): array
 {
+    if ($columns == '') { // no user input, return default
+        return $default;
+    }
+
     static $schema;
     if (is_null($schema)) {
         $schema = new \LibreNMS\DB\Schema();
     }
 
     $column_names = is_array($columns) ? $columns : explode(',', $columns);
-    $valid_columns = $schema->getColumns($tableName);
+    $valid_columns = $schema->getColumns($table);
     $invalid_columns = array_diff(array_map('trim', $column_names), $valid_columns);
 
     if (count($invalid_columns) > 0) {
-        return api_error(400, 'Invalid columns: ' . join(',', $invalid_columns));
+        throw new InvalidTableColumnException($invalid_columns);
     }
 
-    return true;
+    return $column_names;
 }
 
 function missing_fields($required_fields, $data)

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -27,6 +27,7 @@ use App\Models\Sensor;
 use App\Models\ServiceTemplate;
 use App\Models\UserPref;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Arr;
@@ -42,7 +43,7 @@ use LibreNMS\Util\IPv4;
 use LibreNMS\Util\Number;
 use LibreNMS\Util\Rewrite;
 
-function api_success($result, $result_name, $message = null, $code = 200, $count = null, $extra = null)
+function api_success($result, $result_name, $message = null, $code = 200, $count = null, $extra = null): JsonResponse
 {
     if (isset($result) && ! isset($result_name)) {
         return api_error(500, 'Result name not specified');
@@ -69,12 +70,12 @@ function api_success($result, $result_name, $message = null, $code = 200, $count
     return response()->json($output, $code, [], JSON_PRETTY_PRINT);
 } // end api_success()
 
-function api_success_noresult($code, $message = null)
+function api_success_noresult($code, $message = null): JsonResponse
 {
     return api_success(null, null, $message, $code);
 } // end api_success_noresult
 
-function api_error($statusCode, $message)
+function api_error($statusCode, $message): JsonResponse
 {
     return response()->json([
         'status'  => 'error',
@@ -82,7 +83,7 @@ function api_error($statusCode, $message)
     ], $statusCode, [], JSON_PRETTY_PRINT);
 } // end api_error()
 
-function api_not_found()
+function api_not_found(): JsonResponse
 {
     return api_error(404, "This API route doesn't exist.");
 }
@@ -974,7 +975,7 @@ function list_available_wireless_graphs(Illuminate\Http\Request $request)
 /**
  * @throws \LibreNMS\Exceptions\ApiException
  */
-function get_port_graphs(Illuminate\Http\Request $request)
+function get_port_graphs(Illuminate\Http\Request $request): JsonResponse
 {
     $device = DeviceCache::get($request->route('hostname'));
     $columns = validate_column_list($request->get('columns'), 'ports', ['ifName']);
@@ -1047,7 +1048,7 @@ function get_port_info(Illuminate\Http\Request $request)
 /**
  * @throws \LibreNMS\Exceptions\ApiException
  */
-function search_ports(Illuminate\Http\Request $request)
+function search_ports(Illuminate\Http\Request $request): JsonResponse
 {
     $columns = validate_column_list($request->get('columns'), 'ports', ['device_id', 'port_id', 'ifIndex', 'ifName']);
     $field = $request->route('field');
@@ -1080,7 +1081,7 @@ function search_ports(Illuminate\Http\Request $request)
 /**
  * @throws \LibreNMS\Exceptions\ApiException
  */
-function get_all_ports(Illuminate\Http\Request $request)
+function get_all_ports(Illuminate\Http\Request $request): JsonResponse
 {
     $columns = validate_column_list($request->get('columns'), 'ports', ['port_id', 'ifName']);
 
@@ -1109,7 +1110,7 @@ function get_port_stack(Illuminate\Http\Request $request)
     });
 }
 
-function update_device_port_notes(Illuminate\Http\Request $request): \Illuminate\Http\JsonResponse
+function update_device_port_notes(Illuminate\Http\Request $request): JsonResponse
 {
     $portid = $request->route('portid');
 
@@ -1146,7 +1147,7 @@ function list_alert_rules(Illuminate\Http\Request $request)
 /**
  * @throws \LibreNMS\Exceptions\ApiException
  */
-function list_alerts(Illuminate\Http\Request $request)
+function list_alerts(Illuminate\Http\Request $request): JsonResponse
 {
     $id = $request->route('id');
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2431,26 +2431,6 @@ parameters:
 			path: LibreNMS/Device/YamlDiscovery.php
 
 		-
-			message: "#^Method LibreNMS\\\\Exceptions\\\\ApiException\\:\\:__construct\\(\\) has parameter \\$message with no type specified\\.$#"
-			count: 1
-			path: LibreNMS/Exceptions/ApiException.php
-
-		-
-			message: "#^Method LibreNMS\\\\Exceptions\\\\ApiException\\:\\:__construct\\(\\) has parameter \\$output with no type specified\\.$#"
-			count: 1
-			path: LibreNMS/Exceptions/ApiException.php
-
-		-
-			message: "#^Method LibreNMS\\\\Exceptions\\\\ApiException\\:\\:getOutput\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: LibreNMS/Exceptions/ApiException.php
-
-		-
-			message: "#^Property LibreNMS\\\\Exceptions\\\\ApiException\\:\\:\\$output has no type specified\\.$#"
-			count: 1
-			path: LibreNMS/Exceptions/ApiException.php
-
-		-
 			message: "#^Method LibreNMS\\\\Exceptions\\\\AuthenticationException\\:\\:__construct\\(\\) has parameter \\$code with no type specified\\.$#"
 			count: 1
 			path: LibreNMS/Exceptions/AuthenticationException.php


### PR DESCRIPTION
Fixup port APIs
Change validate_column_list api helper to throw a renderable exception on error and return the valid columns
DeviceCache::get() can handle a bigger range of input

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
