### PR TITLE
Ensure irc fifo-file is shared between dispatcher and core containers

### DIFF
--- a/LibreNMS/Alert/Transport/Irc.php
+++ b/LibreNMS/Alert/Transport/Irc.php
@@ -41,7 +41,7 @@ class Irc extends Transport
         if (file_exists($container_dir) and posix_getpwuid(fileowner($container_dir))['name'] == 'librenms') {
             $f = $container_dir . '/.ircbot.alert';
         } else {
-            $f = $this->config['install_dir'] . '/.ircbot.alert';
+            $f = Config::get('install_dir') . '/.ircbot.alert';
         }
         if (file_exists($f) && filetype($f) == 'fifo') {
             $f = fopen($f, 'w+');

--- a/LibreNMS/Alert/Transport/Irc.php
+++ b/LibreNMS/Alert/Transport/Irc.php
@@ -37,7 +37,12 @@ class Irc extends Transport
 
     public function contactIrc($obj, $opts)
     {
-        $f = Config::get('install_dir') . '/.ircbot.alert';
+        $container_dir = '/data';
+        if (file_exists($container_dir) and posix_getpwuid(fileowner($container_dir))['name'] == 'librenms') {
+            $f = $container_dir . '/.ircbot.alert';
+        } else {
+            $f = $this->config['install_dir'] . '/.ircbot.alert';
+        }
         if (file_exists($f) && filetype($f) == 'fifo') {
             $f = fopen($f, 'w+');
             $r = fwrite($f, json_encode($obj) . "\n");

--- a/LibreNMS/IRCBot.php
+++ b/LibreNMS/IRCBot.php
@@ -218,7 +218,12 @@ class IRCBot
 
     private function connectAlert()
     {
-        $f = $this->config['install_dir'] . '/.ircbot.alert';
+        $container_dir = '/data';
+        if (file_exists($container_dir) and posix_getpwuid(fileowner($container_dir))['name'] == 'librenms') {
+            $f = $container_dir . '/.ircbot.alert';
+        } else {
+            $f = $this->config['install_dir'] . '/.ircbot.alert';
+        }
         if ((file_exists($f) && filetype($f) != 'fifo' && ! unlink($f)) || (! file_exists($f) && ! shell_exec("mkfifo $f && echo 1"))) {
             $this->log('Error - Cannot create Alert-File');
 


### PR DESCRIPTION
Please give a short description what your pull request is for

When running as docker containers, we need to share the ircbot.alert-file between the core container and the dispather container to send alerts using the irc-transport.

Here, the fifo-file is moved to the shared /data-folder if it exists and is owned by the user "librenms" which is true for the Docker images.


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
