### PR TITLE
Fix junos rpm probes

### DIFF
--- a/app/Http/Controllers/AboutController.php
+++ b/app/Http/Controllers/AboutController.php
@@ -68,7 +68,7 @@ class AboutController extends Controller
 
             'db_schema' => vsprintf('%s (%s)', $version->database()),
             'git_log' => $version->gitChangelog(),
-            'git_date' => $version->gitDate(),
+            'git_date' => $version->localDate(),
             'project_name' => Config::get('project_name'),
 
             'version_local' => $version->local(),

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -31,6 +31,9 @@ class AppServiceProvider extends ServiceProvider
         $this->app->singleton('device-cache', function ($app) {
             return new \LibreNMS\Cache\Device();
         });
+        $this->app->singleton('version', function ($app) {
+            return new \LibreNMS\Util\Version();
+        });
 
         $this->app->bind(\App\Models\Device::class, function () {
             /** @var \LibreNMS\Cache\Device $cache */

--- a/daily.php
+++ b/daily.php
@@ -175,14 +175,10 @@ if ($options['f'] === 'handle_notifiable') {
 
         // if update is not set to false and version is min or newer
         if (Config::get('update') && $options['r']) {
-            if ($options['r'] === 'php53') {
-                $phpver = '5.6.4';
-                $eol_date = 'January 10th, 2018';
-            } elseif ($options['r'] === 'php56' || $options['r'] === 'php71' || $options['r'] === 'php72') {
+            if (preg_match('/^php\d{2}/', $options['r'])) {
                 $phpver = Php::PHP_MIN_VERSION;
                 $eol_date = Php::PHP_MIN_VERSION_DATE;
-            }
-            if (isset($phpver)) {
+
                 new_notification(
                     $error_title,
                     "PHP version $phpver is the minimum supported version as of $eol_date.  We recommend you update to PHP a supported version of PHP (" . Php::PHP_RECOMMENDED_VERSION . ' suggested) to continue to receive updates.  If you do not update PHP, LibreNMS will continue to function but stop receiving bug fixes and updates.',

--- a/daily.sh
+++ b/daily.sh
@@ -130,28 +130,23 @@ set_notifiable_result() {
 #   Exit-Code: 0 >= min ver, 1 < min ver
 #######################################
 check_dependencies() {
-    local branch ver_56 ver_71 ver_72 ver_73 python3 python_deps phpver pythonver old_branches msg
+    local branch ver_71 ver_72 ver_73 ver_81 python3 python_deps phpver pythonver old_branches msg
 
     branch=$(git rev-parse --abbrev-ref HEAD)
     scripts/check_requirements.py > /dev/null 2>&1 || pip3 install -r requirements.txt > /dev/null 2>&1
 
-    ver_56=$(php -r "echo (int)version_compare(PHP_VERSION, '5.6.4', '<');")
     ver_71=$(php -r "echo (int)version_compare(PHP_VERSION, '7.1.3', '<');")
     ver_72=$(php -r "echo (int)version_compare(PHP_VERSION, '7.2.5', '<');")
     ver_73=$(php -r "echo (int)version_compare(PHP_VERSION, '7.3', '<');")
+    ver_81=$(php -r "echo (int)version_compare(PHP_VERSION, '8.1', '<');")
     python3=$(python3 -c "import sys;print(int(sys.version_info < (3, 4)))" 2> /dev/null)
     python_deps=$("${LIBRENMS_DIR}/scripts/check_requirements.py" > /dev/null 2>&1; echo $?)
     phpver="master"
     pythonver="master"
 
-    old_branches="^(php53|php56|php71-python2|php72)$"
-    if [[ $branch =~ $old_branches ]] && [[ "$ver_73" == "0" && "$python3" == "0" && "$python_deps" == "0" ]]; then
+    old_branches="^(php53|php56|php71-python2|php72|php73)$"
+    if [[ $branch =~ $old_branches ]] && [[ "$ver_81" == "0" && "$python3" == "0" && "$python_deps" == "0" ]]; then
         status_run "Supported PHP and Python version, switched back to master branch." 'git checkout master'
-    elif [[ "$ver_56" != "0" ]]; then
-        phpver="php53"
-        if [[ "$branch" != "php53" ]]; then
-            status_run "Unsupported PHP version, switched to php53 branch." 'git checkout php53'
-        fi
     elif [[ "$ver_71" != "0" ]]; then
         phpver="php56"
         if [[ "$branch" != "php56" ]]; then
@@ -178,6 +173,11 @@ check_dependencies() {
         phpver="php72"
         if [[ "$branch" != "php72" ]]; then
             status_run "Unsupported PHP version, switched to php72 branch." 'git checkout php72'
+        fi
+    elif [[ "$ver_81" != "0" ]]; then
+        phpver="php73"
+        if [[ "$branch" != "php73" ]]; then
+            status_run "Unsupported PHP version, switched to php73 branch." 'git checkout php73'
         fi
     fi
 

--- a/includes/common.php
+++ b/includes/common.php
@@ -541,12 +541,12 @@ function parse_location($location)
 function version_info($remote = false)
 {
     $version = \LibreNMS\Util\Version::get();
-    $local = $version->localCommit();
-    $output = [
+
+    return [
         'local_ver' => $version->local(),
-        'local_sha' => $local['sha'],
-        'local_date' => $local['date'],
-        'local_branch' => $local['branch'],
+        'local_sha' => $version->localCommitSha(),
+        'local_date' => $version->localDate(),
+        'local_branch' => $version->localBranch(),
         'github' => $remote ? $version->remoteCommit() : null,
         'db_schema' => vsprintf('%s (%s)', $version->database()),
         'php_ver' => phpversion(),
@@ -555,8 +555,6 @@ function version_info($remote = false)
         'rrdtool_ver' => $version->rrdtool(),
         'netsnmp_ver' => $version->netSnmp(),
     ];
-
-    return $output;
 }//end version_info()
 
 /**

--- a/includes/definitions/discovery/junos.yaml
+++ b/includes/definitions/discovery/junos.yaml
@@ -149,7 +149,7 @@ modules:
                 -
                     oid: jnxRpmResultsSummaryTable
                     value: jnxRpmResSumPercentLost
-                    num_oid: '.1.3.6.1.4.1.2636.3.50.1.2.1.{{ $index_string }}'
+                    num_oid: '.1.3.6.1.4.1.2636.3.50.1.2.1.{{ $index }}'
                     entPhysicalIndex: '{{ $index }}'
                     group: RPM Probes
                     entPhysicalIndex_measured: 'probes'


### PR DESCRIPTION
When discovering a Juniper SRX with an RPM probe configured, I end up with the following sensors in the database:

```
MariaDB [librenms]> select sensor_class,sensor_oid,sensor_descr,`group`,entPhysicalIndex,entPhysicalIndex_measured from sensors where sensor_id > 1270;

+--------------+--------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------+------------+------------------+---------------------------+

| sensor_class | sensor_oid                                                                                                                                       | sensor_descr                              | group      | entPhysicalIndex | entPhysicalIndex_measured |

+--------------+--------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------+------------+------------------+---------------------------+

| state        | .1.3.6.1.4.1.2636.3.1.15.1.8.8.1.1.0                                                                                                             | PIC: 8xGE,8xGE SFP Base PIC @ 0/0/*       | NULL       | NULL             | NULL                      |

| state        | .1.3.6.1.4.1.2636.3.1.15.1.8.9.1.0.0                                                                                                             | Routing Engine                            | NULL       | NULL             | NULL                      |

| count        | .1.3.6.1.4.1.2636.3.39.1.12.1.1.1.6.0                                                                                                            | Node 0 FPC 0 SPU 0 Flow Count             | Sessions   | NULL             | NULL                      |

| temperature  | .1.3.6.1.4.1.2636.3.1.13.1.7.9.1.0.0                                                                                                             | Routing Engine                            | NULL       | NULL             | NULL                      |

| temperature  | .1.3.6.1.4.1.2636.3.60.1.1.1.1.8.526                                                                                                             | ge-0/0/15 Temperature                     | NULL       | 526              | ports                     |

| loss         | .1.3.6.1.4.1.2636.3.50.1.2.1.24.100.97.103.98.46.117.100.112.116.101.115.116.46.99.117.114.114.101.110.116.84.101.115.116                        | dagb.udptest.currentTest Probe Loss       | RPM Probes | dagb.udptest.cur | probes                    |

| loss         | .1.3.6.1.4.1.2636.3.50.1.2.1.30.100.97.103.98.46.117.100.112.116.101.115.116.46.108.97.115.116.67.111.109.112.108.101.116.101.100.84.101.115.116 | dagb.udptest.lastCompletedTest Probe Loss | RPM Probes | dagb.udptest.las | probes                    |

| loss         | .1.3.6.1.4.1.2636.3.50.1.2.1.21.100.97.103.98.46.117.100.112.116.101.115.116.46.97.108.108.84.101.115.116.115                                    | dagb.udptest.allTests Probe Loss          | RPM Probes | dagb.udptest.all | probes                    |

+--------------+--------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------+------------+------------------+---------------------------+

8 rows in set (0.000 sec)
```

The first 5 OIDs are pollable, the last three are not. The issue appears to be that there is some mixup during discovery with what constitutes the probe OID and the probe description.

The pollable OIDs are:

```
JUNIPER-SMI::jnxRpmMibRoot.1.2.1.4.4.100.97.103.98.7.117.100.112.116.101.115.116
JUNIPER-SMI::jnxRpmMibRoot.1.2.1.4.4.100.97.103.98.7.117.100.112.116.101.115.116.1 = Gauge32: 100000000
JUNIPER-SMI::jnxRpmMibRoot.1.2.1.4.4.100.97.103.98.7.117.100.112.116.101.115.116.2 = Gauge32: 100000000
JUNIPER-SMI::jnxRpmMibRoot.1.2.1.4.4.100.97.103.98.7.117.100.112.116.101.115.116.4 = Gauge32: 78706199
```


The yaml in question (includes/definitions/discovery/junos.yaml) states:
```
       loss:
            data:
                -
                    oid: jnxRpmResultsSummaryTable
                    value: jnxRpmResSumPercentLost
                    num_oid: '.1.3.6.1.4.1.2636.3.50.1.2.1.{{ $index_string }}'
                    entPhysicalIndex: '{{ $index }}'
                    group: RPM Probes
                    entPhysicalIndex_measured: 'probes'
                    descr: '{{ $index }} Probe Loss'
                    index: 'jnxRpmResSumPercentLost.{{ $index }}'
```

With my SRX 340, running Junos 20.4R3-S4.8, I need to modify num_oid to append $index, not $index_string. With this change, my RPM probes return actual probe data.

Also see [this](https://community.librenms.org/t/juniper-loss-not-polling-correctly/16628) for another report regarding this issue.

I need to create a sanitized environment before I can provide test data. Unsure when I can allocate time for this.


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [N/A ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
