### PR TITLE
Corrected ICT MPS hardware detection

### DIFF
--- a/includes/definitions/discovery/ict-mps.yaml
+++ b/includes/definitions/discovery/ict-mps.yaml
@@ -1,7 +1,7 @@
 mib: ICT-MODULAR-POWER-SYSTEM-MIB
 modules:
     os:
-        hardware: ICT-MODULAR-POWER-SYSTEM-MIB::deviceHardware.0
+        hardware: ICT-MODULAR-POWER-SYSTEM-MIB::deviceModel.0
         version: ICT-MODULAR-POWER-SYSTEM-MIB::deviceFirmware.0
     sensors:
         current:

--- a/tests/data/ict-mps.json
+++ b/tests/data/ict-mps.json
@@ -8,7 +8,7 @@
                     "sysDescr": "ICT Modular Power System",
                     "sysContact": "Example, Inc",
                     "version": "1.04",
-                    "hardware": "2",
+                    "hardware": "Modular Power Series 48V",
                     "features": null,
                     "location": "my_ict_ups",
                     "os": "ict-mps",


### PR DESCRIPTION
Please give a short description what your pull request is for

ICT MPS devices were using the `deviceHardware.0` MIB, which returns only an integer on these devices. Modified it to use `deviceModel.0` which will give the expected string. An oversight on my part with a PR I submitted a couple years ago.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
