### PR TITLE
Remove ungrouped devices panel

### DIFF
--- a/app/Http/Controllers/DeviceGroupController.php
+++ b/app/Http/Controllers/DeviceGroupController.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers;
 
-use App\Models\Device;
 use App\Models\DeviceGroup;
 use Flasher\Prime\FlasherInterface;
 use Illuminate\Http\Request;
@@ -26,13 +25,8 @@ class DeviceGroupController extends Controller
     {
         $this->authorize('manage', DeviceGroup::class);
 
-        $ungrouped_devices = Device::orderBy('hostname')->whereNotIn('device_id', function ($query) {
-            $query->select('device_id')->from('device_group_device');
-        })->get();
-
         return view('device-group.index', [
             'device_groups' => DeviceGroup::orderBy('name')->withCount('devices')->get(),
-            'ungrouped_devices' => $ungrouped_devices,
         ]);
     }
 

--- a/app/Http/Controllers/Table/DeviceController.php
+++ b/app/Http/Controllers/Table/DeviceController.php
@@ -54,7 +54,7 @@ class DeviceController extends TableController
             'disabled' => 'nullable|in:0,1',
             'ignore' => 'nullable|in:0,1',
             'disable_notify' => 'nullable|in:0,1',
-            'group' => 'nullable|int',
+            'group' => ['nullable', 'regex:/^(\d+|none)$/'],
             'poller_group' => 'nullable|int',
             'device_id' => 'nullable|int',
         ];
@@ -102,9 +102,13 @@ class DeviceController extends TableController
 
         // filter device group, not sure this is the most efficient query
         if ($group = $request->get('group')) {
-            $query->whereHas('groups', function ($query) use ($group) {
-                $query->where('id', $group);
-            });
+            if ($group == 'none') {
+                $query->whereDoesntHave('groups');
+            } else {
+                $query->whereHas('groups', function ($query) use ($group) {
+                    $query->where('id', $group);
+                });
+            }
         }
 
         if ($request->get('poller_group') !== null) {

--- a/resources/views/device-group/index.blade.php
+++ b/resources/views/device-group/index.blade.php
@@ -14,6 +14,9 @@
                     <a type="button" class="btn btn-primary" href="{{ route('device-groups.create') }}">
                         <i class="fa fa-plus"></i> {{ __('New Device Group') }}
                     </a>
+                    <a type="button" class="btn btn-default" href="{{ url('devices/group=none')  }}">
+                        <i class="fas fa-border-none"></i> {{ __('View Ungrouped Devices') }}
+                    </a>
                 </div>
             </div>
             <div class="table-responsive">
@@ -55,31 +58,6 @@
                                     <i
                                         class="fa fa-trash" aria-hidden="true"></i></button>
                             </td>
-                        </tr>
-                    @endforeach
-                    </tbody>
-                </table>
-            </div>
-        </x-panel>
-
-        <x-panel id="unmanaged-devices-panel" title="{{ __('Ungrouped Devices') }} ({{ $ungrouped_devices->count() }})">
-            <div class="table-responsive">
-                <table id="ungrouped-devices-table" class="table table-condensed table-hover">
-                    <thead>
-                    <tr>
-                        <th style="width:32px">{{ __('Vendor') }}</th>
-                        <th>{{ __('Device') }}</th>
-                        <th>{{ __('Platform') }}</th>
-                        <th>{{ __('Operating System') }}</th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    @foreach($ungrouped_devices as $device)
-                        <tr id="row_{{ $device->device_id }}">
-                            <td><img alt="{{ $device->os }}" src="{{ asset($device->icon) }}" width="32px" height="32px" title="{{ $device->os }}"></td>
-                            <td><x-device-link :device="$device" /><br />{{ $device->sysName }}</td>
-                            <td>{{ $device->hardware }}</td>
-                            <td>{{ $device->os }} {{ $device->version }} @if($device->features) ({{ $device->features }}) @endif </td>
                         </tr>
                     @endforeach
                     </tbody>


### PR DESCRIPTION
The panel destroyed the page performance on larger installs.
Now has a link to the devices list with new group=none

![image](https://user-images.githubusercontent.com/39462/203372459-00177563-5caa-4f07-bf42-933facf5017f.png)

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
