### PR TITLE
Prevent spurious MAC changes on multi-interface devices

### DIFF
--- a/includes/discovery/arp-table.inc.php
+++ b/includes/discovery/arp-table.inc.php
@@ -36,9 +36,6 @@ foreach (DeviceCache::getPrimary()->getVrfContexts() as $context_name) {
     $sql = 'SELECT * from `ipv4_mac` WHERE `device_id`=? AND `context_name`=?';
     $existing_data = dbFetchRows($sql, [$device['device_id'], $context_name]);
 
-    $ipv4_addresses = array_map(function ($data) {
-        return $data['ipv4_address'];
-    }, $existing_data);
     $arp_table = [];
     $insert_data = [];
     foreach ($arp_data as $ifIndex => $data) {
@@ -59,7 +56,14 @@ foreach (DeviceCache::getPrimary()->getVrfContexts() as $context_name) {
             $mac = implode(array_map('zeropad', explode(':', $raw_mac)));
             $arp_table[$port_id][$ip] = $mac;
 
-            $index = array_search($ip, $ipv4_addresses);
+            $index = false;
+            foreach ($existing_data as $existing_key => $existing_value) {
+                if ($existing_value['ipv4_address'] == $ip && $existing_value['port_id'] == $port_id) {
+                    $index = $existing_key;
+                    break;
+                }
+            }
+
             if ($index !== false) {
                 $old_mac = $existing_data[$index]['mac_address'];
                 if ($mac != $old_mac && $mac != '') {


### PR DESCRIPTION
When a complex device has duplicate addresses visible in the arp table - e.g. VRF's with logical tunnels, the arp module creates spurious "MAC change" messages because it only considers the IP address when looking for existing data.

This means that if the same IP address appears multiple times in the arp table with different MAC's, only the first entry is correctly handled - subsequent entries will generate 'MAC change' messages with the MAC of the first entry, even though no rows in the database are updated.

This change simply makes the arp module consider the port id as well as the ip address when looking for existing data.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
