### PR TITLE
Handle Division by 0 error for SvcFdbTableSize

### DIFF
--- a/includes/html/pages/routing/mpls.inc.php
+++ b/includes/html/pages/routing/mpls.inc.php
@@ -406,7 +406,7 @@ vprn services are up when the service is administratively up however routing fun
             $operstate_status_color = 'danger';
         }
 
-        $fdb_usage_perc = $svc['svcTlsFdbNumEntries'] / $svc['svcTlsFdbTableSize'] * 100;
+        $fdb_usage_perc = Number::calculatePercent($svc['svcTlsFdbNumEntries'], $svc['svcTlsFdbTableSize']);
         if ($fdb_usage_perc > 95) {
             $fdb_status_color = 'danger';
         } elseif ($fdb_usage_perc > 75) {


### PR DESCRIPTION
Some SROS Devices do not provide any data for the svcTlsFdbTableSize. This caused "division by 0 errors" on the MPLS services page. Used the existing "Number::calculatePercent" function to avoid that to happen so the webpage is rendered anyhow. 

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
