### PR TITLE
correct squid snmpd.conf proxy host syntax

### DIFF
--- a/doc/Extensions/Applications.md
+++ b/doc/Extensions/Applications.md
@@ -2377,7 +2377,7 @@ snmp_access deny all
 3. Edit your snmpd.conf file and add, making sure you have the same
 community, host, and port as above:
 ```
-proxy -v 2c -Cc -c public 127.0.0.1.3401 1.3.6.1.4.1.3495
+proxy -v 2c -Cc -c public 127.0.0.1:3401 1.3.6.1.4.1.3495
 ```
 
 For more advanced information on Squid and SNMP or setting up proxying


### PR DESCRIPTION
following the current instructions for adding Squid proxy app to LibreNMS produces non-working instal as there is dot instead of colon in the docs. using 127.0.0.1.3401 produces error `snmpget: Unknown host (127.0.0.1.3401)`

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
