### PR TITLE
Alert template example uses incorrect variable

### DIFF
--- a/doc/Alerting/Templates.md
+++ b/doc/Alerting/Templates.md
@@ -272,7 +272,7 @@ email or just the hostname in any other transport:
 
 ```text
 @if ($alert->status == 0)
-    @if ($alert->status == 'icmp')
+    @if ($alert->status_reason == 'icmp')
         {{ $alert->debug['traceroute'] }}
     @endif
 @endif


### PR DESCRIPTION
status_reason hold the monitoring status reason of icmp or snmp.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
