### PR TITLE
Adding extra variables recovery and invert + adding invert_map direct…

### DIFF
--- a/doc/API/Alerts.md
+++ b/doc/API/Alerts.md
@@ -279,12 +279,14 @@ Input (JSON):
 - mute: If mute is enabled then an alert will never be sent but will
   show up in the Web UI (true or false).
 - invert: This would invert the rules check.
+- recovery: This will set or not the recovery alert.
 - name: This is the name of the rule and is mandatory.
+- invert_map: This will set or not the all devices except in list feature.
 
 Example:
 
 ```curl
-curl -X POST -d '{"devices":[1,2,3], "name": "testrule", "builder":{"condition":"AND","rules":[{"id":"devices.hostname","field":"devices.hostname","type":"string","input":"text","operator":"equal","value":"localhost"}],"valid":true},"severity": "critical","count":15,"delay":"5 m","interval":"5 m","mute":false}' -H 'X-Auth-Token: YOURAPITOKENHERE' https://librenms.org/api/v0/rules
+curl -X POST -d '{"devices":[1,2,3], "name": "testrule", "builder":{"condition":"AND","rules":[{"id":"devices.hostname","field":"devices.hostname","type":"string","input":"text","operator":"equal","value":"localhost"}],"valid":true},"severity": "critical","count":15,"delay":"5 m","interval":"5 m","mute":false,"invert":false,"recovery":true,"invert_map":0}' -H 'X-Auth-Token: YOURAPITOKENHERE' https://librenms.org/api/v0/rules
 ```
 
 Output:
@@ -323,12 +325,14 @@ Input (JSON):
 - mute: If mute is enabled then an alert will never be sent but will
   show up in the Web UI (true or false).
 - invert: This would invert the rules check.
+- recovery: This will set or not the recovery alert.
 - name: This is the name of the rule and is mandatory.
+- invert_map: This will set or not the all devices except in list feature.
 
 Example:
 
 ```curl
-curl -X PUT -d '{"rule_id":1,"device_id":"-1", "name": "testrule", "builder":"{"condition":"AND","rules":[{"id":"devices.hostname","field":"devices.hostname","type":"string","input":"text","operator":"equal","value":"localhost"}],"valid":true}","severity": "critical","count":15,"delay":"5 m","interval":"5 m","mute":false}' -H 'X-Auth-Token: YOURAPITOKENHERE' https://librenms.org/api/v0/rules
+curl -X PUT -d '{"rule_id":1,"device_id":"-1", "name": "testrule", "builder":"{"condition":"AND","rules":[{"id":"devices.hostname","field":"devices.hostname","type":"string","input":"text","operator":"equal","value":"localhost"}],"valid":true}","severity": "critical","count":15,"delay":"5 m","interval":"5 m","mute":false,"invert":false,"recovery":true,"invert_map":0}' -H 'X-Auth-Token: YOURAPITOKENHERE' https://librenms.org/api/v0/rules
 ```
 
 Output:

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -1250,10 +1250,17 @@ function add_edit_rule(Illuminate\Http\Request $request)
         $disabled = 0;
     }
 
+    $invert_map = $data['invert_map'];
+    if ($invert_map != '0' && $invert_map != '1') {
+        $invert_map = 0;
+    }
+
     $count = $data['count'];
     $mute = $data['mute'];
     $delay = $data['delay'];
     $interval = $data['interval'];
+    $recovery = $data['recovery'];
+    $invert = $data['invert'];
     $override_query = $data['override_query'];
     $adv_query = $data['adv_query'];
     $delay_sec = convert_delay($delay);
@@ -1269,6 +1276,8 @@ function add_edit_rule(Illuminate\Http\Request $request)
         'count' => $count,
         'delay' => $delay_sec,
         'interval' => $interval_sec,
+        'recovery' => $recovery,
+        'invert' => $invert,
         'options' => [
             'override_query' => $override_query,
         ],
@@ -1293,10 +1302,10 @@ function add_edit_rule(Illuminate\Http\Request $request)
     }
 
     if (is_numeric($rule_id)) {
-        if (! (dbUpdate(['name' => $name, 'builder' => $builder, 'query' => $query, 'severity' => $severity, 'disabled' => $disabled, 'extra' => $extra_json], 'alert_rules', 'id=?', [$rule_id]) >= 0)) {
+        if (! (dbUpdate(['name' => $name, 'builder' => $builder, 'query' => $query, 'severity' => $severity, 'disabled' => $disabled, 'invert_map' => $invert_map, 'extra' => $extra_json], 'alert_rules', 'id=?', [$rule_id]) >= 0)) {
             return api_error(500, 'Failed to update existing alert rule');
         }
-    } elseif (! $rule_id = dbInsert(['name' => $name, 'builder' => $builder, 'query' => $query, 'severity' => $severity, 'disabled' => $disabled, 'extra' => $extra_json], 'alert_rules')) {
+    } elseif (! $rule_id = dbInsert(['name' => $name, 'builder' => $builder, 'query' => $query, 'severity' => $severity, 'disabled' => $disabled, 'invert_map' => $invert_map, 'extra' => $extra_json], 'alert_rules')) {
         return api_error(500, 'Failed to create new alert rule');
     }
 


### PR DESCRIPTION
…ly in DB for edit alert_rule API request

Hello dear LibreNMS community,

After this PR https://github.com/librenms/librenms/pull/14481, we tried to modify alert rules with the API and found some weird behaviour.
We can't set the extra group fields in the add_edit alert rules API request. Default fields are restored.
We have to break each field of this extra group to put them separately in the PUT request.
The 2 fields recovery and invert were not evaluated so first change I added them.
Another fields was not handled, invert_map but this one is not under extra group, it has his proper fields directly in the DB.
I added it the same way as the field disabled is handled.
I also quickly updated the documentation.

Feel free to challenge me if changes are needed.

Thanks and have a great day!
geg347

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
