### PR TITLE
remove round from timeFormat function

### DIFF
--- a/LibreNMS/Alert/RunAlerts.php
+++ b/LibreNMS/Alert/RunAlerts.php
@@ -209,11 +209,11 @@ class RunAlerts
     public function timeFormat($secs)
     {
         $bit = [
-            'y' => round($secs / 31556926) % 12,
-            'w' => round($secs / 604800) % 52,
-            'd' => round($secs / 86400) % 7,
-            'h' => round($secs / 3600) % 24,
-            'm' => round($secs / 60) % 60,
+            'y' => ($secs / 31556926) % 12,
+            'w' => ($secs / 604800) % 52,
+            'd' => ($secs / 86400) % 7,
+            'h' => ($secs / 3600) % 24,
+            'm' => ($secs / 60) % 60,
             's' => $secs % 60,
         ];
         $ret = [];


### PR DESCRIPTION
If we have 16 hours time elapsed should be just 16h not 1d 16h. Using round there is a mistake. 16 hours is 0.67 day. If we round 0.67 we get 1 which is wrong.

This solution probably needs some testing because I am not sure how precise is PHP numerically but all my tests went through.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
