### PR TITLE
Number Casting allow preceding space

### DIFF
--- a/LibreNMS/Util/Number.php
+++ b/LibreNMS/Util/Number.php
@@ -97,7 +97,7 @@ class Number
     {
         if (! is_numeric($number)) {
             // match pre-PHP8 behavior
-            if (! preg_match('/^-?\d+(\.\d+)?/', $number ?? '', $matches)) {
+            if (! preg_match('/^\s*-?\d+(\.\d+)?/', $number ?? '', $matches)) {
                 return 0;
             }
             $number = $matches[0];


### PR DESCRIPTION
Preceding spaces are allowed when casting, so include them in the regex.
This will improve casting for some snmp output.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
