### PR TITLE
Fix broken MPLS services for services without a svcID

### DIFF
--- a/LibreNMS/OS/Timos.php
+++ b/LibreNMS/OS/Timos.php
@@ -208,6 +208,10 @@ class Timos extends OS implements MplsDiscovery, MplsPolling
                 unset($key);
                 continue;
             }
+            if ($value['svcId'] == null) {
+                unset($key);
+                continue;
+            }
 
             $svcs->push(new MplsService([
                 'svc_oid' => $value['svcId'],
@@ -449,6 +453,10 @@ class Timos extends OS implements MplsDiscovery, MplsPolling
         foreach ($mplsSvcCache as $key => $value) {
             $garbage = preg_match($filter, $value['svcDescription']);
             if ($garbage) {
+                unset($key);
+                continue;
+            }
+            if ($value['svcId'] == null) {
                 unset($key);
                 continue;
             }


### PR DESCRIPTION
This was done via github.dev; so apologies for the submission styling.  I'm not at my usual workstation so I was forced to make compromises.

we're having issues with mpls discovery and polling failing due to services cropping up with a null svcId.

This was due to things showing up in the svcTlsInfoTable and not in the svcBaseInfoTable.  Its results in an incomplete svcBase record, which causes the insert(s) to fail. Here is some (sanitized output)

```MPLS Services: SNMP['/usr/bin/snmpbulkwalk' '-v2c' '-c' 'SNMPCOMMUNITY' '-OQUst' '-m' 'TIMETRA-SERV-MIB' '-M' '/opt/librenms/mibs:/opt/librenms/mibs/nokia' '-r' '15' 'udp:HOSTNAME:161' 'svcBaseInfoTable']
svcId.123 = 123
svcId.127 = 127
svcRowStatus.123 = active
svcRowStatus.127 = active
svcType.123 = vprn
svcType.127 = tls
svcCustId.123 = 1
svcCustId.127 = 1
svcIpRouting.123 = enabled
svcIpRouting.127 = disabled
svcDescription.123 = "NetMgmt L3VPN"
svcDescription.127 = "Cabinet Mgmt"
svcMtu.123 = 0
svcMtu.127 = 1522
svcAdminStatus.123 = up
svcAdminStatus.127 = up
svcOperStatus.123 = up
svcOperStatus.127 = up
svcNumSaps.123 = 0
svcNumSaps.127 = 2
svcNumSdps.123 = 0
svcNumSdps.127 = 0
svcLastMgmtChange.123 = 1793
svcLastMgmtChange.127 = 3425779
svcVpnId.123 = 0
svcVpnId.127 = 0
svcVRouterId.123 = 2
svcVRouterId.127 = 0
svcLastStatusChange.123 = 1793
svcLastStatusChange.127 = 326005
svcVllType.123 = undef
svcVllType.127 = undef
svcMgmtVpls.123 = false
svcMgmtVpls.127 = false
svcVcSwitching.123 = false
svcVcSwitching.127 = false
svcVplsType.123 = none
svcVplsType.127 = none
svcNumMcStandbySaps.123 = 0
svcNumMcStandbySaps.127 = 0
svcName.123 = "NetMgmt"
svcName.127 = "mgmtCO"
svcHashLabel.123 = false
svcHashLabel.127 = false
svcTmplUsed.123 = ""
svcTmplUsed.127 = ""
svcCreationOrigin.123 = manual
svcCreationOrigin.127 = manual
svcNumMHStandbySaps.123 = 0
svcNumMHStandbySaps.127 = 0
svcVsdDomainName.123 = ""
svcVsdDomainName.127 = ""
svcIsTestSvc.123 = false
svcIsTestSvc.127 = false
svcTlsModeEtree.123 = false
svcTlsModeEtree.127 = false
svcNumEvpnMHStandbySaps.123 = 0
svcNumEvpnMHStandbySaps.127 = 0
svcLogServicesAllEvents.123 = false
svcLogServicesAllEvents.127 = false  
  
SNMP['/usr/bin/snmpbulkwalk' '-v2c' '-c' 'SNMPCOMMUNITY' '-OQUst' '-m' 'TIMETRA-SERV-MIB' '-M' '/opt/librenms/mibs:/opt/librenms/mibs/nokia' '-r' '15' 'udp:HOSTNAME:161' 'svcTlsInfoTable']
svcTlsMacLearning.127 = enabled
svcTlsDiscardUnknownDest.127 = disabled
svcTlsFdbTableSize.127 = 250
svcTlsFdbNumEntries.127 = 2
svcTlsFdbNumStaticEntries.127 = 0
svcTlsStpAdminStatus.127 = disabled
svcTlsStpPriority.127 = 32768
svcTlsStpBridgeAddress.127 = e8:86:cf:3a:a1:24
svcTlsStpTimeSinceTopologyChange.127 = 0
svcTlsStpTopologyChanges.127 = 0
svcTlsStpDesignatedRoot.127 = "00 00 00 00 00 00 00 00 "
svcTlsStpRootCost.127 = 0
svcTlsStpRootPort.127 = 0
svcTlsStpMaxAge.127 = 0
svcTlsStpHelloTime.127 = 0
svcTlsStpForwardDelay.127 = 0
svcTlsStpBridgeMaxAge.127 = 20
svcTlsStpBridgeHelloTime.127 = 2
svcTlsStpBridgeForwardDelay.127 = 15
svcTlsStpOperStatus.127 = down
svcTlsStpVirtualRootBridgeStatus.127 = down
svcTlsMacAgeing.127 = enabled
svcTlsStpTopologyChangeActive.127 = false
svcTlsFdbTableFullHighWatermark.127 = 95
svcTlsFdbTableFullLowWatermark.127 = 90
svcTlsVpnId.127 = 0
svcTlsCustId.127 = 1
svcTlsStpVersion.127 = rstp
svcTlsStpHoldCount.127 = 6
svcTlsStpPrimaryBridge.127 = "00 00 00 00 00 00 00 00 "
svcTlsStpBridgeInstanceId.127 = 0
svcTlsStpVcpOperProtocol.127 = notApplicable
svcTlsMacMoveMaxRate.127 = 2
svcTlsMacMoveRetryTimeout.127 = 10
svcTlsMacMoveAdminStatus.127 = disabled
svcTlsMacRelearnOnly.127 = false
svcTlsMfibTableSize.127 = 0
svcTlsMfibTableFullHighWatermark.127 = 95
svcTlsMfibTableFullLowWatermark.127 = 90
svcTlsMacFlushOnFail.127 = disabled
svcTlsStpRegionName.127 = 
svcTlsStpRegionRevision.127 = 0
svcTlsStpBridgeMaxHops.127 = 20
svcTlsStpCistRegionalRoot.127 = "00 00 00 00 00 00 00 00 "
svcTlsStpCistIntRootCost.127 = 0
svcTlsStpCistRemainingHopCount.127 = 0
svcTlsStpCistRegionalRootPort.127 = 0
svcTlsFdbNumLearnedEntries.127 = 2
svcTlsFdbNumOamEntries.127 = 0
svcTlsFdbNumDhcpEntries.127 = 0
svcTlsFdbNumHostEntries.127 = 0
svcTlsPriPortsCumulativeFactor.127 = 3
svcTlsSecPortsCumulativeFactor.127 = 2
svcTlsL2ptTermEnabled.127 = false
svcTlsPropagateMacFlush.127 = false
svcTlsMacMoveNumRetries.127 = 3
svcTlsMacSubNetLen.127 = 48
svcTlsSendFlushOnBVplsFail.127 = false
svcTlsPropMacFlushFromBVpls.127 = false
svcTlsAllowIpIfBinding.127 = true
svcTlsSelLearnedFdb.127 = false
svcTlsFdbNumEntriesInUse.127 = 2
svcTlsInfoEntry.96.127 = 1794
svcTlsInfoEntry.97.127 = 123
svcTlsInfoEntry.98.127 = 4  
  
Reporting disabled by user setting  
SQL[select * from `mpls_services` where `mpls_services`.`device_id` = ? and `mpls_services`.`device_id` is not null [526] 1.51ms] 
  
..Error polling mpls module for chcg-ch1-pe01.ntwk.mgmt. PDOException: SQLSTATE[23000]: Integrity constraint violation: 1048 Column 'svc_oid' cannot be null in /opt/librenms/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDOStatement.php:117
Stack trace:
#0 /opt/librenms/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDOStatement.php(117): PDOStatement->execute()
#1 /opt/librenms/vendor/laravel/framework/src/Illuminate/Database/Connection.php(501): Doctrine\DBAL\Driver\PDOStatement->execute()
#2 /opt/librenms/vendor/laravel/framework/src/Illuminate/Database/Connection.php(705): Illuminate\Database\Connection->Illuminate\Database\{closure}()
#3 /opt/librenms/vendor/laravel/framework/src/Illuminate/Database/Connection.php(672): Illuminate\Database\Connection->runQueryCallback()
#4 /opt/librenms/vendor/laravel/framework/src/Illuminate/Database/Connection.php(502): Illuminate\Database\Connection->run()
#5 /opt/librenms/vendor/laravel/framework/src/Illuminate/Database/Connection.php(454): Illuminate\Database\Connection->statement()
#6 /opt/librenms/vendor/laravel/framework/src/Illuminate/Database/Query/Processors/Processor.php(32): Illuminate\Database\Connection->insert()
#7 /opt/librenms/vendor/laravel/framework/src/Illuminate/Database/Query/Builder.php(3028): Illuminate\Database\Query\Processors\Processor->processInsertGetId()
#8 /opt/librenms/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Builder.php(1657): Illuminate\Database\Query\Builder->insertGetId()
#9 /opt/librenms/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Model.php(1188): Illuminate\Database\Eloquent\Builder->__call()
#10 /opt/librenms/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Model.php(1153): Illuminate\Database\Eloquent\Model->insertAndSetId()
#11 /opt/librenms/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Model.php(994): Illuminate\Database\Eloquent\Model->performInsert()
#12 /opt/librenms/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php(267): Illuminate\Database\Eloquent\Model->save()
#13 /opt/librenms/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php(279): Illuminate\Database\Eloquent\Relations\HasOneOrMany->save()
#14 /opt/librenms/LibreNMS/DB/SyncsModels.php(72): Illuminate\Database\Eloquent\Relations\HasOneOrMany->saveMany()
#15 /opt/librenms/LibreNMS/Modules/Mpls.php(128): LibreNMS\Modules\Mpls->syncModels()
#16 /opt/librenms/includes/polling/mpls.inc.php(31): LibreNMS\Modules\Mpls->poll()
#17 /opt/librenms/includes/polling/functions.inc.php(340): include('...')
#18 /opt/librenms/poller.php(126): poll_device()
#19 {main}

```