### PR TITLE
Add download button to device config page

### DIFF
--- a/includes/html/pages/device/showconfig.inc.php
+++ b/includes/html/pages/device/showconfig.inc.php
@@ -206,9 +206,9 @@ if (Auth::user()->hasGlobalAdmin()) {
                 $download_uri = Config::get('oxidized.url') . $uri;
             }
         } else {  // just fetch the only version
-		    $uri = '/node/fetch/' . (! empty($node_info['group']) ? $node_info['group'] . '/' : '') . $oxidized_hostname;
+            $uri = '/node/fetch/' . (! empty($node_info['group']) ? $node_info['group'] . '/' : '') . $oxidized_hostname;
             $text = (new \App\ApiClients\Oxidized())->getContent($uri);
-			$download_uri = Config::get('oxidized.url') . $uri;
+            $download_uri = Config::get('oxidized.url') . $uri;
         }
 
         if (is_array($node_info) || $config_total > 1) {

--- a/includes/html/pages/device/showconfig.inc.php
+++ b/includes/html/pages/device/showconfig.inc.php
@@ -201,10 +201,14 @@ if (Auth::user()->hasGlobalAdmin()) {
                 $text = (new \App\ApiClients\Oxidized())->getContent($uri); // fetch diff
             } else {
                 // fetch current_version
-                $text = (new \App\ApiClients\Oxidized())->getContent('/node/version/view?node=' . $oxidized_hostname . (! empty($node_info['group']) ? '&group=' . $node_info['group'] : '') . '&oid=' . urlencode($current_config['oid']) . '&date=' . urlencode($current_config['date']) . '&num=' . urlencode($current_config['version']) . '&format=text');
+                $uri = '/node/version/view?node=' . $oxidized_hostname . (! empty($node_info['group']) ? '&group=' . $node_info['group'] : '') . '&oid=' . urlencode($current_config['oid']) . '&date=' . urlencode($current_config['date']) . '&num=' . urlencode($current_config['version']) . '&format=text';
+                $text = (new \App\ApiClients\Oxidized())->getContent($uri);
+                $download_uri = Config::get('oxidized.url') . $uri;
             }
         } else {  // just fetch the only version
-            $text = (new \App\ApiClients\Oxidized())->getContent('/node/fetch/' . (! empty($node_info['group']) ? $node_info['group'] . '/' : '') . $oxidized_hostname);
+		    $uri = '/node/fetch/' . (! empty($node_info['group']) ? $node_info['group'] . '/' : '') . $oxidized_hostname;
+            $text = (new \App\ApiClients\Oxidized())->getContent($uri);
+			$download_uri = Config::get('oxidized.url') . $uri;
         }
 
         if (is_array($node_info) || $config_total > 1) {
@@ -240,8 +244,8 @@ if (Auth::user()->hasGlobalAdmin()) {
                 ';
 
                 $i = $config_total;
-                foreach ($config_versions as $version) {
-                    echo '<option value="' . $version['oid'] . '|' . $version['date'] . '|' . $config_total . '" ';
+                foreach ($config_versions as $key=>$version) {
+                    echo '<option value="' . $version['oid'] . '|' . $version['date'] . '|' . $config_total - $key . '" ';
                     if ($current_config['oid'] == $version['oid']) {
                         $author = $version['author']['name'];
                         $msg = $version['message'];
@@ -306,6 +310,9 @@ if (Auth::user()->hasGlobalAdmin()) {
         // $geshi->set_line_style('color: #999999');
         echo '<div class="config">';
         echo '<input id="linenumbers" class="btn btn-primary" type="submit" value="Hide line numbers"/>';
+        if ($download_uri) {
+            echo '<a class="btn btn-primary" href="' . $download_uri . '">Download</a>';
+        }
         echo $geshi->parse_code();
         echo '</div>';
     }

--- a/includes/html/pages/device/showconfig.inc.php
+++ b/includes/html/pages/device/showconfig.inc.php
@@ -311,7 +311,7 @@ if (Auth::user()->hasGlobalAdmin()) {
         echo '<div class="config">';
         echo '<input id="linenumbers" class="btn btn-primary" type="submit" value="Hide line numbers"/>';
         if ($download_uri) {
-            echo '<a class="btn btn-primary" href="' . $download_uri . '">Download</a>';
+            echo '<a class="btn btn-primary" href="' . $download_uri . '" download target="_blank">Download</a>';
         }
         echo $geshi->parse_code();
         echo '</div>';


### PR DESCRIPTION
Adds a button to the device configuration page to download the viewed config version from oxidized.

On modern browsers this will just open the raw config in a new tab, since the 'download' attribute on the link doesn't apply for security reasons when linking to another domain. This could be fixed by adding an endpoint to librenms to proxy the raw config, but it didn't seem worth it since you can just right click the link and do a save as, or save from the resulting tab.

This also fixes a small bug where the version number passed in oxidized url parameters was always equal to the maximum version number. Seems oxidized ignored this argument though, so it doesn't matter much.

Feature request here:
https://community.librenms.org/t/oxidized-configuration-download-button/11780

![image](https://user-images.githubusercontent.com/187133/206299142-6b679e40-e68b-4cc5-8b66-a4fa904c3aad.png)

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
