### PR TITLE
Removing max polling restriction for wireguard traffic RRD data

### DIFF
--- a/includes/polling/applications/wireguard.inc.php
+++ b/includes/polling/applications/wireguard.inc.php
@@ -21,8 +21,8 @@ try {
 
 $rrd_name = [$polling_type, $name, $app->app_id];
 $rrd_def = RrdDefinition::make()
-    ->addDataset('bytes_rcvd', 'DERIVE', 0, 125000000000)
-    ->addDataset('bytes_sent', 'DERIVE', 0, 125000000000)
+    ->addDataset('bytes_rcvd', 'DERIVE', 0)
+    ->addDataset('bytes_sent', 'DERIVE', 0)
     ->addDataset('minutes_since_last_handshake', 'GAUGE', 0);
 
 $metrics = [];


### PR DESCRIPTION
As pointed out in https://github.com/librenms/librenms-agent/issues/445 , there's no real reason to restrict the bytes_rcvd and bytes_sent to a maximum of 125GB.  A long-running Wireguard VPN tunnel (think site-to-site) could easily exceed that.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [X] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
