### PR TITLE
Adding sample alert for systemd application

### DIFF
--- a/misc/alert_rules.json
+++ b/misc/alert_rules.json
@@ -587,5 +587,10 @@
     "rule": "storage.storage_deleted = 0 AND storage.storage_descr = \"/\" AND storage.storage_perc >= 95",
     "name": "Space on / is >= 95% in use",
     "severity":"critical"
+  },
+  {
+    "rule": "applications.app_type = \"systemd\" && application_metrics.metric = \"sub_service_failed\" && application_metrics.value > \"0\"",
+    "name": "Systemd Services Failed > 0",
+    "severity": "warning"
   }
 ]


### PR DESCRIPTION
Adding a sample alert that will trigger if any services on a system running the systemd application have failed.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [X] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
