### PR TITLE
Option discovery_remove_domain to strip domainname from FQDN

### DIFF
--- a/doc/Extensions/Auto-Discovery.md
+++ b/doc/Extensions/Auto-Discovery.md
@@ -72,6 +72,12 @@ If your devices only return a short hostname such as lax-fa0-dc01 but
 the full name should be lax-fa0-dc01.example.com then you can
 set `$config['mydomain'] = 'example.com';`
 
+### Remove domainname from full hostname
+
+If you want to add the devices by short hostname but may have a domainname defined
+then you can strip the domainname with this setting:
+set `$config['discovery_remove_domain'] = 'true`
+
 ### Allow Duplicate sysName
 
 By default we require unique sysNames when adding devices (this is

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -44,7 +44,13 @@ function discover_new_device($hostname, $device = [], $method = '', $interface =
                 $hostname = $full_host;
             }
         }
-
+        
+        if (Config::get('discovery_remove_domain', true)) {
+            if (str_contains($hostname, '.')) {
+                $hostname = substr($hostname, 0 , strpos($hostname, '.'));
+            }
+        }
+        
         $ip = gethostbyname($hostname);
         if ($ip == $hostname) {
             d_echo("name lookup of $hostname failed\n");

--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -226,6 +226,13 @@
             "section": "general",
             "order": 1
         },
+        "discovery_remove_domain": {
+            "default": false,
+            "type": "boolean",
+            "group": "discovery",
+            "section": "general",
+            "order": 0
+        },
         "allow_entity_sensor.amperes": {
             "default": true,
             "type": "boolean"


### PR DESCRIPTION
Added an extra option discovery_remove_domain to strip the domainname port from a FQDN hostname to only have the short hostname be added as hostname.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
