### PR TITLE
Fix Cimc on Overview

### DIFF
--- a/includes/html/pages/device/overview/cimc.inc.php
+++ b/includes/html/pages/device/overview/cimc.inc.php
@@ -6,7 +6,7 @@ $components = $component->getComponents($device['device_id'], ['type'=>'Cisco-CI
 // We only care about our device id.
 $components = $components[$device['device_id']];
 
-if (count($components) > 0) {
+if (! empty($components)) {
     ?>
         <div class="row">
             <div class="col-md-12">


### PR DESCRIPTION
Fixes this:
[2022-12-14T21:21:12.405304+00:00] production.ERROR: count(): Argument #1 ($value) must be of type Countable|array, null given {"userId":3,"exception":"[object] (TypeError(code: 0): count(): Argument #1 ($value) must be of type Countable|array, null given at /opt/librenms/includes/html/pages/device/overview/cimc.inc.php:9)"} 
[2022-12-14T21:21:12.826885+00:00] production.ERROR: count(): Argument #1 ($value) must be of type Countable|array, null given {"userId":3,"exception":"[object] (TypeError(code: 0): count(): Argument #1 ($value) must be of type Countable|array, null given at /opt/librenms/includes/html/pages/device/overview/cimc.inc.php:9)"} 
[2022-12-14T21:21:12.858762+00:00] production.ERROR: count(): Argument #1 ($value) must be of type Countable|array, null given {"userId":3,"exception":"[object] (TypeError(code: 0): count(): Argument #1 ($value) must be of type Countable|array, null given at /opt/librenms/includes/html/pages/device/overview/cimc.inc.php:9)"} 

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
