### PR TITLE
Update Nvidia application - values in wrong charts

### DIFF
--- a/includes/polling/applications/nvidia.inc.php
+++ b/includes/polling/applications/nvidia.inc.php
@@ -33,7 +33,7 @@ $metrics = [];
 foreach ($gpuArray as $index => $gpu) {
     $stats = explode(',', $gpu);
 
-    if (count($stats) == 19) {
+    if (count($stats) == 19 || count($stats) == 20) {
         [$gpu, $pwr, $temp, $memtemp, $sm, $mem, $enc, $dec, $mclk, $pclk, $pviol, $tviol,
         $fb, $bar1, $sbecc, $dbecc, $pci, $rxpci, $txpci] = $stats;
     } else {


### PR DESCRIPTION
Hi,
Nvidia changed something in nvidia-smi which causes table shift and snmp script adds an extra comma. Through this for example encode graph was actually drawing the memory graph.

`nvidia-smi dmon` before:
```
# gpu   pwr gtemp mtemp    sm   mem   enc   dec  mclk  pclk
# Idx     W     C     C     %     %     %     %   MHz   MHz
    0     2    42     -     2     2     7     4  2505  1045
```

After:
```
# gpu   pwr gtemp mtemp    sm   mem   enc   dec  mclk  pclk
# Idx     W     C     C     %     %     %     %   MHz   MHz
    0     96     53      -    10      5     34     34   5005   1885
```

SNMP script output:
```
root@live-transcoder:~# $nvidiasmi dmon -c 1 -s pucvmet -i 0 | $grep -v ^# | $sed 's/^ *//' | $sed 's/  */,/g' | $sed 's/-/0/g'
0,92,53,0,10,5,33,34,5005,1885,0,0,3893,5,0,0,0,41,2,
root@live-transcoder:~#
```

![chrome_YywSUY9kxE](https://user-images.githubusercontent.com/46460263/208255065-83be0aea-dd67-4d72-999f-c5ac96f91173.png)



DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
