### PR TITLE
Add more docker stats

### DIFF
--- a/LibreNMS/Util/Number.php
+++ b/LibreNMS/Util/Number.php
@@ -125,4 +125,26 @@ class Number
 
         return round($part / $total * 100, $precision);
     }
+
+    /**
+     * This converts a memory size containing the unit to bytes. example 1 MiB to 1048576 bytes
+     */
+    public static function convertToBytes(string $from): ?int
+    {
+        $units = ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB'];
+        $number = floatval(substr($from, 0, -3));
+        $suffix = substr($from, -3);
+
+        //B or no suffix
+        if (is_numeric(substr($suffix, 0, 1))) {
+            return (int) $from;
+        }
+
+        $exponent = array_flip($units)[$suffix] ?? null;
+        if ($exponent === null) {
+            return null;
+        }
+
+        return (int) ($number * (1024 ** $exponent));
+    }
 }

--- a/doc/Extensions/Applications.md
+++ b/doc/Extensions/Applications.md
@@ -460,30 +460,36 @@ Extend` heading top of page.
 
 ## Docker Stats
 
-It allows you to know which container docker run and their stats.
+It gathers metrics about the docker containers, including:
+- cpu percentage 
+- memory usage 
+- container size
+- uptime 
+- Totals per status
 
-This script require: jq
+This script requires python3 and the pip module python-dateutil 
 
 ### SNMP Extend
 
-1. Install jq
+1. Install pip module
 ```
-sudo apt install jq
+pip3 install python-dateutil
 ```
 
 2. Copy the shell script to the desired host.
+By default, it will only show the status for containers that are running. To include all containers modify the constant in the script at the top of the file and change it to `ONLY_RUNNING_CONTAINERS = False`
 ```
-wget https://github.com/librenms/librenms-agent/raw/master/snmp/docker-stats.sh -O /etc/snmp/docker-stats.sh
+wget https://github.com/librenms/librenms-agent/raw/master/snmp/docker-stats.py -O /etc/snmp/docker-stats.py
 ```
 
 3. Make the script executable
 ```
-chmod +x /etc/snmp/docker-stats.sh
+chmod +x /etc/snmp/docker-stats.py
 ```
 
 4. Edit your snmpd.conf file (usually /etc/snmp/snmpd.conf) and add:
 ```
-extend docker /etc/snmp/docker-stats.sh
+extend docker /etc/snmp/docker-stats.py
 ```
 
 5. If your run Debian, you need to add the Debian-snmp user to the docker group

--- a/includes/html/graphs/application/docker_size_root_fs.inc.php
+++ b/includes/html/graphs/application/docker_size_root_fs.inc.php
@@ -1,0 +1,6 @@
+<?php
+
+$unit_text = 'Container size root FS';
+$rrdVar = 'size_root_fs';
+
+require 'docker-common.inc.php';

--- a/includes/html/graphs/application/docker_size_rw.inc.php
+++ b/includes/html/graphs/application/docker_size_rw.inc.php
@@ -1,0 +1,6 @@
+<?php
+
+$unit_text = 'Container size RW';
+$rrdVar = 'size_rw';
+
+require 'docker-common.inc.php';

--- a/includes/html/graphs/application/docker_totals.inc.php
+++ b/includes/html/graphs/application/docker_totals.inc.php
@@ -1,0 +1,41 @@
+<?php
+
+require 'includes/html/graphs/common.inc.php';
+$name = 'docker';
+$scale_min = 0;
+$colours = 'mixed';
+$unit_text = 'Status';
+$unitlen = 10;
+$bigdescrlen = 15;
+$smalldescrlen = 15;
+$dostack = 0;
+$printtotal = 0;
+$addarea = 1;
+$transparency = 15;
+
+$rrd_filename = Rrd::name($device['hostname'], ['app', $name, $app->app_id]);
+
+$array = [
+    'created' => ['descr' => 'created', 'colour' => 'FFC107'],
+    'restarting' => ['descr' => 'restarting', 'colour' => '28774F'],
+    'running' => ['descr' => 'running', 'colour' => '4CAf50'],
+    'removing' => ['descr' => 'removing', 'colour' => 'CDDC39'],
+    'paused' => ['descr' => 'paused', 'colour' => 'D46A6A'],
+    'exited' => ['descr' => 'exited', 'colour' => 'E74B00'],
+    'dead' => ['descr' => 'dead', 'colour' => 'E91E63'],
+];
+
+$i = 0;
+if (Rrd::checkRrdExists($rrd_filename)) {
+    foreach ($array as $ds => $var) {
+        $rrd_list[$i]['filename'] = $rrd_filename;
+        $rrd_list[$i]['descr'] = $var['descr'];
+        $rrd_list[$i]['ds'] = $ds;
+        $rrd_list[$i]['colour'] = $var['colour'];
+        $i++;
+    }
+} else {
+    echo "file missing: $rrd_filename";
+}
+
+require 'includes/html/graphs/generic_v3_multiline.inc.php';

--- a/includes/html/graphs/application/docker_uptime.inc.php
+++ b/includes/html/graphs/application/docker_uptime.inc.php
@@ -1,0 +1,6 @@
+<?php
+
+$unit_text = 'Uptime';
+$rrdVar = 'uptime';
+
+require 'docker-common.inc.php';

--- a/includes/html/pages/device/apps/docker.inc.php
+++ b/includes/html/pages/device/apps/docker.inc.php
@@ -28,13 +28,23 @@ foreach ($containers as $index => $container) {
 
 print_optionbar_end();
 
-$graphs = [
+$graphs = [];
+if (! isset($vars['container'])) {
+    $graphs = array_merge($graphs, [
+        'docker_totals' => 'Totals status',
+    ]);
+}
+
+$graphs = array_merge($graphs, [
     'docker_pids' => 'PIDs',
     'docker_mem_limit' => 'Container memory limit',
     'docker_mem_used' => 'Container memory used',
     'docker_cpu_usage' => 'Container CPU usage, %',
     'docker_mem_perc' => 'Container Memory usage, %',
-];
+    'docker_uptime' => 'Container uptime',
+    'docker_size_rw' => 'Container Size RW',
+    'docker_size_root_fs' => 'Container Size Root FS',
+]);
 
 foreach ($graphs as $key => $text) {
     $graph_type = $key;

--- a/includes/polling/applications/docker.inc.php
+++ b/includes/polling/applications/docker.inc.php
@@ -3,31 +3,16 @@
 use LibreNMS\Exceptions\JsonAppException;
 use LibreNMS\Exceptions\JsonAppMissingKeysException;
 use LibreNMS\RRD\RrdDefinition;
+use LibreNMS\Util\Number;
 
 $name = 'docker';
+$version = 1;
 $output = 'OK';
 
-function convertToBytes(string $from): ?int
-{
-    $units = ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB'];
-    $number = substr($from, 0, -3);
-    $suffix = substr($from, -3);
-
-    //B or no suffix
-    if (is_numeric(substr($suffix, 0, 1))) {
-        return (int) $from;
-    }
-
-    $exponent = array_flip($units)[$suffix] ?? null;
-    if ($exponent === null) {
-        return null;
-    }
-
-    return (int) ($number * (1024 ** $exponent));
-}
-
 try {
-    $docker_data = json_app_get($device, $name, 1)['data'];
+    $result = json_app_get($device, $name, 1);
+    $version = $result['version'];
+    $docker_data = $result['data'];
 } catch (JsonAppMissingKeysException $e) {
     $docker_data = $e->getParsedJson();
 } catch (JsonAppException $e) {
@@ -37,33 +22,73 @@ try {
     return;
 }
 
+$version = intval($version);
+
+if ($version == 1) {
+    $output = 'LEGACY';
+} elseif ($version == 2) {
+    $output = 'OK';
+} else {
+    $output = 'UNSUPPORTED';
+}
+
 $rrd_name = ['app', $name, $app->app_id];
 $rrd_def = RrdDefinition::make()
     ->addDataset('cpu_usage', 'GAUGE', 0, 100)
     ->addDataset('pids', 'GAUGE', 0)
     ->addDataset('mem_perc', 'GAUGE', 0, 100)
     ->addDataset('mem_used', 'GAUGE', 0)
-    ->addDataset('mem_limit', 'GAUGE', 0);
+    ->addDataset('mem_limit', 'GAUGE', 0)
+    ->addDataset('uptime', 'GAUGE', 0)
+    ->addDataset('size_rw', 'GAUGE', 0)
+    ->addDataset('size_root_fs', 'GAUGE', 0);
 
+$totals = [
+    'created' => 0,
+    'restarting' => 0,
+    'running' => 0,
+    'removing' => 0,
+    'paused' => 0,
+    'exited' => 0,
+    'dead' => 0,
+];
 $metrics = [];
 $containerNames = [];
 foreach ($docker_data as $data) {
     $containerNames[] = $container = $data['container'];
 
-    $rrd_name = ['app', $name, $app->app_id, $container];
+    $status = isset($data['state']['status']) ? strtolower($data['state']['status']) : null;
+    if ($status) {
+        $totals[$status] += 1;
+    }
 
     $fields = [
         'cpu_usage' => (float) $data['cpu'],
         'pids' => $data['pids'],
         'mem_perc' => (float) $data['memory']['perc'],
-        'mem_used' => convertToBytes($data['memory']['used']),
-        'mem_limit' => convertToBytes($data['memory']['limit']),
+        'mem_used' => Number::convertToBytes($data['memory']['used']),
+        'mem_limit' => Number::convertToBytes($data['memory']['limit']),
+        'uptime' => $data['state']['uptime'],
+        'size_rw' => $data['size']['size_rw'],
+        'size_root_fs' => $data['size']['size_root_fs'],
     ];
 
+    $rrd_name = ['app', $name, $app->app_id, $container];
     $metrics[$container] = $fields;
     $tags = ['name' => $container, 'app_id' => $app->app_id, 'rrd_def' => $rrd_def, 'rrd_name' => $rrd_name];
     data_update($device, 'app', $tags, $fields);
 }
+
+$rrd_def = RrdDefinition::make();
+foreach ($totals as $status => $value) {
+    $rrd_def->addDataset($status, 'GAUGE', 0);
+}
+$rrd_name = ['app', $name, $app->app_id];
+$tags = ['name' => $name, 'app_id' => $app->app_id, 'rrd_def' => $rrd_def, 'rrd_name' => $rrd_name];
+data_update($device, 'app', $tags, $totals);
+
+$metrics['total'] = $totals;
+
 $app->data = ['containers' => $containerNames];
 
 update_application($app, $output, $metrics);

--- a/tests/data/linux_docker-v2.json
+++ b/tests/data/linux_docker-v2.json
@@ -17,10 +17,10 @@
             "applications": [
                 {
                     "app_type": "docker",
-                    "app_state": "LEGACY",
+                    "app_state": "OK",
                     "discovered": 1,
                     "app_state_prev": "UNKNOWN",
-                    "app_status": "LEGACY",
+                    "app_status": "",
                     "app_instance": "",
                     "data": "{\"containers\":[\"foobar_laravel.test_1\",\"foobar_dashboard_1\",\"foobar_meilisearch_1\",\"foobar_mysql_1\",\"foobar_redis_1\"]}"
                 }
@@ -52,25 +52,25 @@
                 },
                 {
                     "metric": "foobar_dashboard_1_pids",
-                    "value": 6.0,
+                    "value": 6,
                     "value_prev": null,
                     "app_type": "docker"
                 },
                 {
                     "metric": "foobar_dashboard_1_size_root_fs",
-                    "value": 0.0,
+                    "value": 538012988,
                     "value_prev": null,
                     "app_type": "docker"
                 },
                 {
                     "metric": "foobar_dashboard_1_size_rw",
-                    "value": 0.0,
+                    "value": 6,
                     "value_prev": null,
                     "app_type": "docker"
                 },
                 {
                     "metric": "foobar_dashboard_1_uptime",
-                    "value": 0.0,
+                    "value": 6490,
                     "value_prev": null,
                     "app_type": "docker"
                 },
@@ -100,31 +100,31 @@
                 },
                 {
                     "metric": "foobar_laravel.test_1_pids",
-                    "value": 4.0,
+                    "value": 4,
                     "value_prev": null,
                     "app_type": "docker"
                 },
                 {
                     "metric": "foobar_laravel.test_1_size_root_fs",
-                    "value": 0.0,
+                    "value": 538012988,
                     "value_prev": null,
                     "app_type": "docker"
                 },
                 {
                     "metric": "foobar_laravel.test_1_size_rw",
-                    "value": 0.0,
+                    "value": 6,
                     "value_prev": null,
                     "app_type": "docker"
                 },
                 {
                     "metric": "foobar_laravel.test_1_uptime",
-                    "value": 0.0,
+                    "value": 6490,
                     "value_prev": null,
                     "app_type": "docker"
                 },
                 {
                     "metric": "foobar_meilisearch_1_cpu_usage",
-                    "value": 0.0,
+                    "value": 0,
                     "value_prev": null,
                     "app_type": "docker"
                 },
@@ -148,25 +148,25 @@
                 },
                 {
                     "metric": "foobar_meilisearch_1_pids",
-                    "value": 15.0,
+                    "value": 15,
                     "value_prev": null,
                     "app_type": "docker"
                 },
                 {
                     "metric": "foobar_meilisearch_1_size_root_fs",
-                    "value": 0.0,
+                    "value": 538012988,
                     "value_prev": null,
                     "app_type": "docker"
                 },
                 {
                     "metric": "foobar_meilisearch_1_size_rw",
-                    "value": 0.0,
+                    "value": 6,
                     "value_prev": null,
                     "app_type": "docker"
                 },
                 {
                     "metric": "foobar_meilisearch_1_uptime",
-                    "value": 0.0,
+                    "value": 6490,
                     "value_prev": null,
                     "app_type": "docker"
                 },
@@ -196,25 +196,25 @@
                 },
                 {
                     "metric": "foobar_mysql_1_pids",
-                    "value": 38.0,
+                    "value": 38,
                     "value_prev": null,
                     "app_type": "docker"
                 },
                 {
                     "metric": "foobar_mysql_1_size_root_fs",
-                    "value": 0.0,
+                    "value": 538012988,
                     "value_prev": null,
                     "app_type": "docker"
                 },
                 {
                     "metric": "foobar_mysql_1_size_rw",
-                    "value": 0.0,
+                    "value": 6,
                     "value_prev": null,
                     "app_type": "docker"
                 },
                 {
                     "metric": "foobar_mysql_1_uptime",
-                    "value": 0.0,
+                    "value": 6490,
                     "value_prev": null,
                     "app_type": "docker"
                 },
@@ -244,25 +244,25 @@
                 },
                 {
                     "metric": "foobar_redis_1_pids",
-                    "value": 5.0,
+                    "value": 5,
                     "value_prev": null,
                     "app_type": "docker"
                 },
                 {
                     "metric": "foobar_redis_1_size_root_fs",
-                    "value": 0.0,
+                    "value": 538012988,
                     "value_prev": null,
                     "app_type": "docker"
                 },
                 {
                     "metric": "foobar_redis_1_size_rw",
-                    "value": 0.0,
+                    "value": 6,
                     "value_prev": null,
                     "app_type": "docker"
                 },
                 {
                     "metric": "foobar_redis_1_uptime",
-                    "value": 0.0,
+                    "value": 6490,
                     "value_prev": null,
                     "app_type": "docker"
                 },
@@ -304,7 +304,7 @@
                 },
                 {
                     "metric": "total_running",
-                    "value": 0,
+                    "value": 5,
                     "value_prev": null,
                     "app_type": "docker"
                 }

--- a/tests/snmpsim/linux_docker-v2.snmprec
+++ b/tests/snmpsim/linux_docker-v2.snmprec
@@ -1,0 +1,9 @@
+1.3.6.1.2.1.1.1.0|4|Linux server 3.10.0-693.5.2.el7.x86_64 #1 SMP Fri Oct 20 20:32:50 UTC 2017 x86_64
+1.3.6.1.2.1.1.2.0|6|1.3.6.1.4.1.8072.3.2.10
+1.3.6.1.2.1.1.3.0|67|77550514
+1.3.6.1.2.1.1.4.0|4|<private>
+1.3.6.1.2.1.1.5.0|4|<private>
+1.3.6.1.2.1.1.6.0|4|<private>
+1.3.6.1.4.1.8072.1.3.2.2.1.21.6.100.111.99.107.101.114|2|1
+1.3.6.1.4.1.8072.1.3.2.3.1.2.6.100.111.99.107.101.114|4|{"version":"2","data":[{"container":"foobar_laravel.test_1","pids":4,"memory":{"used":"26.67MiB","limit":"15.36GiB","perc":"0.17%"},"cpu":"0.09%","size":{"size_rw":6,"size_root_fs":538012988},"state":{"status":"running","started_at":"2023-01-02T11:28:32.611824308Z","finished_at":"2023-01-02T11:28:22.744456652Z","uptime":6490}},{"container":"foobar_dashboard_1","pids":6,"memory":{"used":"6.934MiB","limit":"15.36GiB","perc":"0.04%"},"cpu":"0.01%","size":{"size_rw":6,"size_root_fs":538012988},"state":{"status":"running","started_at":"2023-01-02T11:28:32.611824308Z","finished_at":"2023-01-02T11:28:22.744456652Z","uptime":6490}},{"container":"foobar_meilisearch_1","pids":15,"memory":{"used":"10.86MiB","limit":"15.36GiB","perc":"0.07%"},"cpu":"0.00%","size":{"size_rw":6,"size_root_fs":538012988},"state":{"status":"running","started_at":"2023-01-02T11:28:32.611824308Z","finished_at":"2023-01-02T11:28:22.744456652Z","uptime":6490}},{"container":"foobar_mysql_1","pids":38,"memory":{"used":"141.3MiB","limit":"15.36GiB","perc":"0.90%"},"cpu":"0.33%","size":{"size_rw":6,"size_root_fs":538012988},"state":{"status":"running","started_at":"2023-01-02T11:28:32.611824308Z","finished_at":"2023-01-02T11:28:22.744456652Z","uptime":6490}},{"container":"foobar_redis_1","pids":5,"memory":{"used":"5.055MiB","limit":"15.36GiB","perc":"0.03%"},"cpu":"0.23%","size":{"size_rw":6,"size_root_fs":538012988},"state":{"status":"running","started_at":"2023-01-02T11:28:32.611824308Z","finished_at":"2023-01-02T11:28:22.744456652Z","uptime":6490}}],"error":"0","errorString":""}
+


### PR DESCRIPTION
This pull requests add extra stats for docker.
This includes
- container uptime
- container size
- container filesystem 
- Totals per status

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
