### PR TITLE
Fix cisco-flash

### DIFF
--- a/includes/discovery/storage/cisco-flash.inc.php
+++ b/includes/discovery/storage/cisco-flash.inc.php
@@ -29,7 +29,7 @@ if ($device['os_group'] == 'cisco') {
     $ciscoFlashPartitionName = snmpwalk_cache_oid($device, 'ciscoFlashPartitionName', null, 'CISCO-FLASH-MIB');
     $ciscoFlashDeviceName = snmpwalk_cache_oid($device, 'ciscoFlashDeviceName', null, 'CISCO-FLASH-MIB');
     foreach ($ciscoFlashPartitionName as $index => $partitionName) {
-        $name = is_array($ciscoFlashDeviceName)? array_shift($ciscoFlashDeviceName[$index[0]]) . '(' . array_shift($partitionName) . '):':'(' . array_shift($partitionName) . '):';
+        $name = is_array($ciscoFlashDeviceName)? array_shift($ciscoFlashDeviceName[$index[0]]) . '(' . array_shift($partitionName) . '): array_shift($partitionName);
         $oids = array('ciscoFlashPartitionSize.' . $index, 'ciscoFlashPartitionFreeSpace.' . $index, 'ciscoFlashPartitionSizeExtended.' . $index, 'ciscoFlashPartitionFreeSpaceExtended.' . $index);
         $entry = snmp_get_multi($device, $oids, '-OQUs', 'CISCO-FLASH-MIB');
         $entry = array_shift($entry);

--- a/includes/discovery/storage/cisco-flash.inc.php
+++ b/includes/discovery/storage/cisco-flash.inc.php
@@ -29,7 +29,7 @@ if ($device['os_group'] == 'cisco') {
     $ciscoFlashPartitionName = snmpwalk_cache_oid($device, 'ciscoFlashPartitionName', null, 'CISCO-FLASH-MIB');
     $ciscoFlashDeviceName = snmpwalk_cache_oid($device, 'ciscoFlashDeviceName', null, 'CISCO-FLASH-MIB');
     foreach ($ciscoFlashPartitionName as $index => $partitionName) {
-        $name = is_array($ciscoFlashDeviceName)? array_shift($ciscoFlashDeviceName[$index[0]]) . '(' . array_shift($partitionName) . '): array_shift($partitionName);
+        $name = is_array($ciscoFlashDeviceName)? array_shift($ciscoFlashDeviceName[$index[0]]) . '(' . array_shift($partitionName) . '):': array_shift($partitionName);
         $oids = array('ciscoFlashPartitionSize.' . $index, 'ciscoFlashPartitionFreeSpace.' . $index, 'ciscoFlashPartitionSizeExtended.' . $index, 'ciscoFlashPartitionFreeSpaceExtended.' . $index);
         $entry = snmp_get_multi($device, $oids, '-OQUs', 'CISCO-FLASH-MIB');
         $entry = array_shift($entry);

--- a/includes/discovery/storage/cisco-flash.inc.php
+++ b/includes/discovery/storage/cisco-flash.inc.php
@@ -29,7 +29,7 @@ if ($device['os_group'] == 'cisco') {
     $ciscoFlashPartitionName = snmpwalk_cache_oid($device, 'ciscoFlashPartitionName', null, 'CISCO-FLASH-MIB');
     $ciscoFlashDeviceName = snmpwalk_cache_oid($device, 'ciscoFlashDeviceName', null, 'CISCO-FLASH-MIB');
     foreach ($ciscoFlashPartitionName as $index => $partitionName) {
-        $name = array_shift($ciscoFlashDeviceName[$index[0]]) . '(' . array_shift($partitionName) . '):';
+        $name = is_array($ciscoFlashDeviceName)? array_shift($ciscoFlashDeviceName[$index[0]]) . '(' . array_shift($partitionName) . '):':'(' . array_shift($partitionName) . '):';
         $oids = array('ciscoFlashPartitionSize.' . $index, 'ciscoFlashPartitionFreeSpace.' . $index, 'ciscoFlashPartitionSizeExtended.' . $index, 'ciscoFlashPartitionFreeSpaceExtended.' . $index);
         $entry = snmp_get_multi($device, $oids, '-OQUs', 'CISCO-FLASH-MIB');
         $entry = array_shift($entry);


### PR DESCRIPTION
Please give a short description what your pull request is for

Trying to fix this:

[librenms@librenms ~]$  tail logs/librenms.log
[2023-01-04T17:04:58.723428+00:00] production.ERROR: Error discovering storage module for <IP>. TypeError: array_shift(): Argument #1 ($array) must be of type array, null given in /opt/librenms/includes/discovery/storage/cisco-flash.inc.php:32
Stack trace:
#0 /opt/librenms/includes/discovery/storage/cisco-flash.inc.php(32): array_shift()
#1 /opt/librenms/includes/include-dir.inc.php(6): include('...')
#2 /opt/librenms/includes/discovery/storage.inc.php(7): require('...')
#3 /opt/librenms/includes/discovery/functions.inc.php(153): include('...')
#4 /opt/librenms/discovery.php(106): discover_device()
#5 {main}  
[2023-01-04T17:04:58.730823+00:00] production.ERROR: array_shift(): Argument #1 ($array) must be of type array, null given {"exception":"[object] (TypeError(code: 0): array_shift(): Argument #1 ($array) must be of type array, null given at /opt/librenms/includes/discovery/storage/cisco-flash.inc.php:32)"} 

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
