### PR TITLE
Fix Doc Link for Canopsis transport

### DIFF
--- a/doc/Alerting/Transports.md
+++ b/doc/Alerting/Transports.md
@@ -213,7 +213,7 @@ alerts on a browser on the user preferences page.
 Canopsis is a hypervision tool. LibreNMS can send alerts to Canopsis
 which are then converted to canopsis events.
 
-[Canopsis Docs](https://doc.canopsis.net/guide-developpement/struct-event/)
+[Canopsis Docs](https://doc.canopsis.net/guide-developpement/structures/#structure-des-evenements)
 
 **Example:**
 


### PR DESCRIPTION
Inside Transports page, link to Canopsis documentation was not correct anymore. It has been fixed with that PR

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
