### PR TITLE
Extend filtering of graphs device_bits on cisco ASA

### DIFF
--- a/includes/html/graphs/device/bits.inc.php
+++ b/includes/html/graphs/device/bits.inc.php
@@ -18,8 +18,8 @@ foreach ($ports as $port) {
             if (in_array($iftype, ['/virtual/', '/l2vlan/']) && $device['os'] == 'asa') {
                 // ASA (at least in multicontext) reports interfaces as l2vlan even if they are l3
                 // or propVirtual in 9.16 (like etherchannels) but without the physical ones.
-                // Removing thos types results in empty device_bits graphs in ASAs. 
-                // This patch will ignore l2vlan and propVirtual for ASA.
+                // Filtering those types results in empty device_bits graphs in ASAs.
+                // This patch will avoid filtering l2vlan and propVirtual on ASA devices.
                 continue;
             }
             if (preg_match($iftype . 'i', $port['ifType'])) {

--- a/includes/html/graphs/device/bits.inc.php
+++ b/includes/html/graphs/device/bits.inc.php
@@ -15,10 +15,11 @@ foreach ($ports as $port) {
     $ignore = 0;
     if (is_array(\LibreNMS\Config::get('device_traffic_iftype'))) {
         foreach (\LibreNMS\Config::get('device_traffic_iftype') as $iftype) {
-            if ($iftype == '/l2vlan/' && $device['os'] == 'asa') {
-                // ASA (at least in multicontext) reports all interfaces as l2vlan even if they are l3
-                // so every context has no graph displayed unless l2vlan are accepted for all.
-                // This patch will ignore l2vlan for ASA.
+            if (in_array($iftype, ['/virtual/', '/l2vlan/']) && $device['os'] == 'asa') {
+                // ASA (at least in multicontext) reports interfaces as l2vlan even if they are l3
+                // or propVirtual in 9.16 (like etherchannels) but without the physical ones.
+                // Removing thos types results in empty device_bits graphs in ASAs. 
+                // This patch will ignore l2vlan and propVirtual for ASA.
                 continue;
             }
             if (preg_match($iftype . 'i', $port['ifType'])) {


### PR DESCRIPTION
With upgrade to 9.16, new behaviour on ASA. Type changed from l2vlan to propVirtual, so we need to extend this code as well. 

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
