### PR TITLE
Docs: Debian 11 Sury DPA provides PHP 8.2

### DIFF
--- a/doc/Installation/Install-LibreNMS.md
+++ b/doc/Installation/Install-LibreNMS.md
@@ -133,8 +133,8 @@ Ensure date.timezone is set in php.ini to your preferred time zone.
 
 === "Debian 11"
     ```bash
-    vi /etc/php/8.1/fpm/php.ini
-    vi /etc/php/8.1/cli/php.ini
+    vi /etc/php/8.2/fpm/php.ini
+    vi /etc/php/8.2/cli/php.ini
     ```
 
 Remember to set the system timezone as well.
@@ -214,8 +214,8 @@ exit
 
 === "Debian 11"
     ```bash
-    cp /etc/php/8.1/fpm/pool.d/www.conf /etc/php/8.1/fpm/pool.d/librenms.conf
-    vi /etc/php/8.1/fpm/pool.d/librenms.conf
+    cp /etc/php/8.2/fpm/pool.d/www.conf /etc/php/8.2/fpm/pool.d/librenms.conf
+    vi /etc/php/8.2/fpm/pool.d/librenms.conf
     ```
 
 Change `[www]` to `[librenms]`:
@@ -470,7 +470,7 @@ Feel free to tune the performance settings in librenms.conf to meet your needs.
         ```bash
         rm /etc/nginx/sites-enabled/default
         systemctl reload nginx
-        systemctl restart php8.1-fpm
+        systemctl restart php8.2-fpm
         ```
 
 ## SELinux


### PR DESCRIPTION
Default PHP version of Debian 11 (following this documentation) is 8.2 currently, instead of 8.1

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
