### PR TITLE
Update XDP string to exclude modern Cisco lightweight APs from discovery

### DIFF
--- a/doc/Extensions/Auto-Discovery.md
+++ b/doc/Extensions/Auto-Discovery.md
@@ -130,6 +130,7 @@ These devices are excluded by default:
 
 ```php
 $config['autodiscovery']['xdp_exclude']['sysdesc_regexp'][] = '/-K9W8-/'; // Cisco Lightweight Access Point
+$config['autodiscovery']['xdp_exclude']['sysdesc_regexp'][] = '/-k9w8 /'; // Cisco Lightweight Access Point
 $config['autodiscovery']['cdp_exclude']['platform_regexp'][] = '/^Cisco IP Phone/'; //Cisco IP Phone
 ```
 

--- a/doc/Extensions/Auto-Discovery.md
+++ b/doc/Extensions/Auto-Discovery.md
@@ -129,8 +129,7 @@ $config['autodiscovery']['cdp_exclude']['platform_regexp'][] = '/WS-C3750G/';
 These devices are excluded by default:
 
 ```php
-$config['autodiscovery']['xdp_exclude']['sysdesc_regexp'][] = '/-K9W8-/'; // Cisco Lightweight Access Point
-$config['autodiscovery']['xdp_exclude']['sysdesc_regexp'][] = '/-k9w8 /'; // Cisco Lightweight Access Point
+$config['autodiscovery']['xdp_exclude']['sysdesc_regexp'][] = '/-K9W8/'; // Cisco Lightweight Access Point
 $config['autodiscovery']['cdp_exclude']['platform_regexp'][] = '/^Cisco IP Phone/'; //Cisco IP Phone
 ```
 

--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -727,8 +727,7 @@
         "autodiscovery.xdp_exclude.sysdesc_regexp": {
             "type": "array",
             "default": [
-                "/-K9W8-/",
-                "/-k9w8 /"                
+                "/-K9W8/"
             ]
         },
         "bad_entity_sensor_regex": {

--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -727,7 +727,8 @@
         "autodiscovery.xdp_exclude.sysdesc_regexp": {
             "type": "array",
             "default": [
-                "/-K9W8-/"
+                "/-K9W8-/",
+                "/-k9w8 /"                
             ]
         },
         "bad_entity_sensor_regex": {


### PR DESCRIPTION
Existing string was not changed, as older APs might use that format.
To verify device string, view: librenms\tests\snmpsim\aos6.snmprec (line 233)

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
