### PR TITLE
Add a few more graphs for CAPEv2

### DIFF
--- a/includes/html/graphs/application/cape_banned.inc.php
+++ b/includes/html/graphs/application/cape_banned.inc.php
@@ -1,0 +1,23 @@
+<?php
+
+$name = 'cape';
+$app_id = $app['app_id'];
+$unit_text = 'Run Count';
+$colours = 'psychedelic';
+$dostack = 0;
+$printtotal = 1;
+$addarea = 0;
+$transparency = 15;
+$float_precision = 3;
+
+$rrd_filename = Rrd::name($device['hostname'], ['app', $name, $app['app_id']]);
+
+if (Rrd::checkRrdExists($rrd_filename)) {
+    $filename = $rrd_filename;
+    $descr = 'banned';
+    $ds = 'banned';
+} else {
+    d_echo('RRD "' . $rrd_filename . '" not found');
+}
+
+require 'includes/html/graphs/generic_stats.inc.php';

--- a/includes/html/graphs/application/cape_completed.inc.php
+++ b/includes/html/graphs/application/cape_completed.inc.php
@@ -1,0 +1,23 @@
+<?php
+
+$name = 'cape';
+$app_id = $app['app_id'];
+$unit_text = 'Run Count';
+$colours = 'psychedelic';
+$dostack = 0;
+$printtotal = 1;
+$addarea = 0;
+$transparency = 15;
+$float_precision = 3;
+
+$rrd_filename = Rrd::name($device['hostname'], ['app', $name, $app['app_id']]);
+
+if (Rrd::checkRrdExists($rrd_filename)) {
+    $filename = $rrd_filename;
+    $descr = 'completed';
+    $ds = 'completed';
+} else {
+    d_echo('RRD "' . $rrd_filename . '" not found');
+}
+
+require 'includes/html/graphs/generic_stats.inc.php';

--- a/includes/html/graphs/application/cape_distributed.inc.php
+++ b/includes/html/graphs/application/cape_distributed.inc.php
@@ -1,0 +1,23 @@
+<?php
+
+$name = 'cape';
+$app_id = $app['app_id'];
+$unit_text = 'Run Count';
+$colours = 'psychedelic';
+$dostack = 0;
+$printtotal = 1;
+$addarea = 0;
+$transparency = 15;
+$float_precision = 3;
+
+$rrd_filename = Rrd::name($device['hostname'], ['app', $name, $app['app_id']]);
+
+if (Rrd::checkRrdExists($rrd_filename)) {
+    $filename = $rrd_filename;
+    $descr = 'distributed';
+    $ds = 'distributed';
+} else {
+    d_echo('RRD "' . $rrd_filename . '" not found');
+}
+
+require 'includes/html/graphs/generic_stats.inc.php';

--- a/includes/html/graphs/application/cape_failed_analysis.inc.php
+++ b/includes/html/graphs/application/cape_failed_analysis.inc.php
@@ -1,0 +1,23 @@
+<?php
+
+$name = 'cape';
+$app_id = $app['app_id'];
+$unit_text = 'Run Count';
+$colours = 'psychedelic';
+$dostack = 0;
+$printtotal = 1;
+$addarea = 0;
+$transparency = 15;
+$float_precision = 3;
+
+$rrd_filename = Rrd::name($device['hostname'], ['app', $name, $app['app_id']]);
+
+if (Rrd::checkRrdExists($rrd_filename)) {
+    $filename = $rrd_filename;
+    $descr = 'failed_analysis';
+    $ds = 'failed_analysis';
+} else {
+    d_echo('RRD "' . $rrd_filename . '" not found');
+}
+
+require 'includes/html/graphs/generic_stats.inc.php';

--- a/includes/html/graphs/application/cape_failed_processing.inc.php
+++ b/includes/html/graphs/application/cape_failed_processing.inc.php
@@ -1,0 +1,23 @@
+<?php
+
+$name = 'cape';
+$app_id = $app['app_id'];
+$unit_text = 'Run Count';
+$colours = 'psychedelic';
+$dostack = 0;
+$printtotal = 1;
+$addarea = 0;
+$transparency = 15;
+$float_precision = 3;
+
+$rrd_filename = Rrd::name($device['hostname'], ['app', $name, $app['app_id']]);
+
+if (Rrd::checkRrdExists($rrd_filename)) {
+    $filename = $rrd_filename;
+    $descr = 'failed_processing';
+    $ds = 'failed_processing';
+} else {
+    d_echo('RRD "' . $rrd_filename . '" not found');
+}
+
+require 'includes/html/graphs/generic_stats.inc.php';

--- a/includes/html/graphs/application/cape_failed_reporting.inc.php
+++ b/includes/html/graphs/application/cape_failed_reporting.inc.php
@@ -1,0 +1,23 @@
+<?php
+
+$name = 'cape';
+$app_id = $app['app_id'];
+$unit_text = 'Run Count';
+$colours = 'psychedelic';
+$dostack = 0;
+$printtotal = 1;
+$addarea = 0;
+$transparency = 15;
+$float_precision = 3;
+
+$rrd_filename = Rrd::name($device['hostname'], ['app', $name, $app['app_id']]);
+
+if (Rrd::checkRrdExists($rrd_filename)) {
+    $filename = $rrd_filename;
+    $descr = 'failed_reporting';
+    $ds = 'failed_reporting';
+} else {
+    d_echo('RRD "' . $rrd_filename . '" not found');
+}
+
+require 'includes/html/graphs/generic_stats.inc.php';

--- a/includes/html/graphs/application/cape_recovered.inc.php
+++ b/includes/html/graphs/application/cape_recovered.inc.php
@@ -1,0 +1,23 @@
+<?php
+
+$name = 'cape';
+$app_id = $app['app_id'];
+$unit_text = 'Run Count';
+$colours = 'psychedelic';
+$dostack = 0;
+$printtotal = 1;
+$addarea = 0;
+$transparency = 15;
+$float_precision = 3;
+
+$rrd_filename = Rrd::name($device['hostname'], ['app', $name, $app['app_id']]);
+
+if (Rrd::checkRrdExists($rrd_filename)) {
+    $filename = $rrd_filename;
+    $descr = 'recovered';
+    $ds = 'recovered';
+} else {
+    d_echo('RRD "' . $rrd_filename . '" not found');
+}
+
+require 'includes/html/graphs/generic_stats.inc.php';

--- a/includes/html/graphs/application/cape_reported.inc.php
+++ b/includes/html/graphs/application/cape_reported.inc.php
@@ -1,0 +1,23 @@
+<?php
+
+$name = 'cape';
+$app_id = $app['app_id'];
+$unit_text = 'Run Count';
+$colours = 'psychedelic';
+$dostack = 0;
+$printtotal = 1;
+$addarea = 0;
+$transparency = 15;
+$float_precision = 3;
+
+$rrd_filename = Rrd::name($device['hostname'], ['app', $name, $app['app_id']]);
+
+if (Rrd::checkRrdExists($rrd_filename)) {
+    $filename = $rrd_filename;
+    $descr = 'reported';
+    $ds = 'reported';
+} else {
+    d_echo('RRD "' . $rrd_filename . '" not found');
+}
+
+require 'includes/html/graphs/generic_stats.inc.php';

--- a/includes/html/graphs/application/cape_running.inc.php
+++ b/includes/html/graphs/application/cape_running.inc.php
@@ -1,0 +1,23 @@
+<?php
+
+$name = 'cape';
+$app_id = $app['app_id'];
+$unit_text = 'Run Count';
+$colours = 'psychedelic';
+$dostack = 0;
+$printtotal = 1;
+$addarea = 0;
+$transparency = 15;
+$float_precision = 3;
+
+$rrd_filename = Rrd::name($device['hostname'], ['app', $name, $app['app_id']]);
+
+if (Rrd::checkRrdExists($rrd_filename)) {
+    $filename = $rrd_filename;
+    $descr = 'running';
+    $ds = 'running';
+} else {
+    d_echo('RRD "' . $rrd_filename . '" not found');
+}
+
+require 'includes/html/graphs/generic_stats.inc.php';

--- a/includes/html/pages/device/apps/cape.inc.php
+++ b/includes/html/pages/device/apps/cape.inc.php
@@ -109,7 +109,7 @@ if (sizeof($packages) > 0) {
     if (! isset($vars['package'])) {
         echo '  |  ';
         echo '<b>Run Statuses Averages:</b> ';
-        if ($vars['bypkg'] == 'on') {
+        if ($vars['runstats'] == 'on') {
             $label = '<span class="pagemenu-selected">On</span>';
             echo generate_link($label, $link_array, ['app'=>'cape', 'bypkg'=>$vars['bypkg'], 'bytimeslot'=>$vars['bytimeslot'], 'stddev'=>$vars['stddev'], 'package'=>$vars['package'], 'statsavg'=>$vars['statsavg'], 'runstats'=>'on']) . ', ' .
             generate_link('Off', $link_array, ['app'=>'cape', 'bypkg'=>$vars['bypkg'], 'bytimeslot'=>$vars['bytimeslot'], 'stddev'=>$vars['stddev'], 'package'=>$vars['package'], 'statsavg'=>$vars['statsavg'], 'runstats'=>'off']);

--- a/includes/html/pages/device/apps/cape.inc.php
+++ b/includes/html/pages/device/apps/cape.inc.php
@@ -11,6 +11,7 @@ $vars_to_check = [
     'bytimeslot',
     'bypkg',
     'statsavg',
+    'runstats',
 ];
 foreach ($vars_to_check as $index => $value) {
     if (isset($vars[$value])) {
@@ -26,10 +27,10 @@ if (sizeof($packages) > 0) {
     print_optionbar_start();
 
     if (isset($vars['package'])) {
-        echo generate_link('General', $link_array, ['app'=>'cape', 'stddev'=>$vars['stddev'], 'bypkg'=>$vars['bypkg'], 'bytimeslot'=>$vars['bytimeslot'], 'statsavg'=>$vars['statsavg']]);
+        echo generate_link('General', $link_array, ['app'=>'cape', 'stddev'=>$vars['stddev'], 'bypkg'=>$vars['bypkg'], 'bytimeslot'=>$vars['bytimeslot'], 'statsavg'=>$vars['statsavg'], 'runstats'=>$vars['runstats']]);
     } else {
         $label = '<span class="pagemenu-selected">General</span>';
-        echo generate_link($label, $link_array, ['app'=>'cape', 'stddev'=>$vars['stddev'], 'bypkg'=>$vars['bypkg'], 'bytimeslot'=>$vars['bytimeslot'], 'statsavg'=>$vars['statsavg']]);
+        echo generate_link($label, $link_array, ['app'=>'cape', 'stddev'=>$vars['stddev'], 'bypkg'=>$vars['bypkg'], 'bytimeslot'=>$vars['bytimeslot'], 'statsavg'=>$vars['statsavg'], 'runstats'=>$vars['runstats']]);
     }
 
     echo ' | <b>Packages:</b> ';
@@ -49,7 +50,7 @@ if (sizeof($packages) > 0) {
             $append = ', ';
         }
 
-        echo generate_link($label, $link_array, ['app'=>'cape', 'stddev'=>$vars['stddev'], 'bypkg'=>$vars['bypkg'], 'bytimeslot'=>$vars['bytimeslot'], 'package'=>$package, 'statsavg'=>$vars['statsavg']]) . $append;
+        echo generate_link($label, $link_array, ['app'=>'cape', 'stddev'=>$vars['stddev'], 'bypkg'=>$vars['bypkg'], 'bytimeslot'=>$vars['bytimeslot'], 'package'=>$package, 'statsavg'=>$vars['statsavg'], 'runstats'=>$vars['runstats']]) . $append;
     }
 
     echo "<br>\n";
@@ -57,12 +58,12 @@ if (sizeof($packages) > 0) {
     echo '<b>Run Stats Averages:</b> ';
     if ($vars['statsavg'] == 'on') {
         $label = '<span class="pagemenu-selected">On</span>';
-        echo generate_link($label, $link_array, ['app'=>'cape', 'bytimeslot'=>$vars['bytimeslot'], 'bypkg'=>$vars['bypkg'], 'stddev'=>$vars['stddev'], 'package'=>$vars['package'], 'statsavg'=>'on']) . ', ' .
-        generate_link('Off', $link_array, ['app'=>'cape', 'bytimeslot'=>$vars['bytimeslot'], 'bypkg'=>$vars['bypkg'], 'stddev'=>$vars['stddev'], 'package'=>$vars['package'], 'statsavg'=>'off']);
+        echo generate_link($label, $link_array, ['app'=>'cape', 'bytimeslot'=>$vars['bytimeslot'], 'bypkg'=>$vars['bypkg'], 'stddev'=>$vars['stddev'], 'package'=>$vars['package'], 'statsavg'=>'on', 'runstats'=>$vars['runstats']]) . ', ' .
+        generate_link('Off', $link_array, ['app'=>'cape', 'bytimeslot'=>$vars['bytimeslot'], 'bypkg'=>$vars['bypkg'], 'stddev'=>$vars['stddev'], 'package'=>$vars['package'], 'statsavg'=>'off', 'runstats'=>$vars['runstats']]);
     } else {
         $label = '<span class="pagemenu-selected">Off</span>';
-        echo generate_link('On', $link_array, ['app'=>'cape', 'bytimeslot'=>$vars['bytimeslot'], 'bypkg'=>$vars['bypkg'], 'stddev'=>$vars['stddev'], 'package'=>$vars['package'], 'statsavg'=>'on']) . ', ' .
-        generate_link($label, $link_array, ['app'=>'cape', 'bytimeslot'=>$vars['bytimeslot'], 'bypkg'=>$vars['bypkg'], 'stddev'=>$vars['stddev'], 'package'=>$vars['package'], 'statsavg'=>'off']);
+        echo generate_link('On', $link_array, ['app'=>'cape', 'bytimeslot'=>$vars['bytimeslot'], 'bypkg'=>$vars['bypkg'], 'stddev'=>$vars['stddev'], 'package'=>$vars['package'], 'statsavg'=>'on', 'runstats'=>$vars['runstats']]) . ', ' .
+        generate_link($label, $link_array, ['app'=>'cape', 'bytimeslot'=>$vars['bytimeslot'], 'bypkg'=>$vars['bypkg'], 'stddev'=>$vars['stddev'], 'package'=>$vars['package'], 'statsavg'=>'off', 'runstats'=>$vars['runstats']]);
     }
 
     echo '  |  ';
@@ -70,12 +71,12 @@ if (sizeof($packages) > 0) {
     echo '<b>By Time Slot:</b> ';
     if ($vars['bytimeslot'] == 'on') {
         $label = '<span class="pagemenu-selected">On</span>';
-        echo generate_link($label, $link_array, ['app'=>'cape', 'bytimeslot'=>'on', 'bypkg'=>$vars['bypkg'], 'stddev'=>$vars['stddev'], 'package'=>$vars['package'], 'statsavg'=>$vars['statsavg']]) . ', ' .
-        generate_link('Off', $link_array, ['app'=>'cape', 'bytimeslot'=>'off', 'bypkg'=>$vars['bypkg'], 'stddev'=>$vars['stddev'], 'package'=>$vars['package'], 'statsavg'=>$vars['statsavg']]);
+        echo generate_link($label, $link_array, ['app'=>'cape', 'bytimeslot'=>'on', 'bypkg'=>$vars['bypkg'], 'stddev'=>$vars['stddev'], 'package'=>$vars['package'], 'statsavg'=>$vars['statsavg'], 'runstats'=>$vars['runstats']]) . ', ' .
+        generate_link('Off', $link_array, ['app'=>'cape', 'bytimeslot'=>'off', 'bypkg'=>$vars['bypkg'], 'stddev'=>$vars['stddev'], 'package'=>$vars['package'], 'statsavg'=>$vars['statsavg'], 'runstats'=>$vars['runstats']]);
     } else {
         $label = '<span class="pagemenu-selected">Off</span>';
-        echo generate_link('On', $link_array, ['app'=>'cape', 'bytimeslot'=>'on', 'bypkg'=>$vars['bypkg'], 'stddev'=>$vars['stddev'], 'package'=>$vars['package'], 'statsavg'=>$vars['statsavg']]) . ', ' .
-        generate_link($label, $link_array, ['app'=>'cape', 'bytimeslot'=>'off', 'bypkg'=>$vars['bypkg'], 'stddev'=>$vars['stddev'], 'package'=>$vars['package'], 'statsavg'=>$vars['statsavg']]);
+        echo generate_link('On', $link_array, ['app'=>'cape', 'bytimeslot'=>'on', 'bypkg'=>$vars['bypkg'], 'stddev'=>$vars['stddev'], 'package'=>$vars['package'], 'statsavg'=>$vars['statsavg'], 'runstats'=>$vars['runstats']]) . ', ' .
+        generate_link($label, $link_array, ['app'=>'cape', 'bytimeslot'=>'off', 'bypkg'=>$vars['bypkg'], 'stddev'=>$vars['stddev'], 'package'=>$vars['package'], 'statsavg'=>$vars['statsavg'], 'runstats'=>$vars['runstats']]);
     }
 
     if (! isset($vars['package'])) {
@@ -83,12 +84,12 @@ if (sizeof($packages) > 0) {
         echo '<b>By Package:</b> ';
         if ($vars['bypkg'] == 'on') {
             $label = '<span class="pagemenu-selected">On</span>';
-            echo generate_link($label, $link_array, ['app'=>'cape', 'bypkg'=>'on', 'bytimeslot'=>$vars['bytimeslot'], 'stddev'=>$vars['stddev'], 'package'=>$vars['package'], 'statsavg'=>$vars['statsavg']]) . ', ' .
-            generate_link('Off', $link_array, ['app'=>'cape', 'bypkg'=>'off', 'bytimeslot'=>$vars['bytimeslot'], 'stddev'=>$vars['stddev'], 'package'=>$vars['package'], 'statsavg'=>$vars['statsavg']]);
+            echo generate_link($label, $link_array, ['app'=>'cape', 'bypkg'=>'on', 'bytimeslot'=>$vars['bytimeslot'], 'stddev'=>$vars['stddev'], 'package'=>$vars['package'], 'statsavg'=>$vars['statsavg'], 'runstats'=>$vars['runstats']]) . ', ' .
+            generate_link('Off', $link_array, ['app'=>'cape', 'bypkg'=>'off', 'bytimeslot'=>$vars['bytimeslot'], 'stddev'=>$vars['stddev'], 'package'=>$vars['package'], 'statsavg'=>$vars['statsavg'], 'runstats'=>$vars['runstats']]);
         } else {
             $label = '<span class="pagemenu-selected">Off</span>';
-            echo generate_link('On', $link_array, ['app'=>'cape', 'bypkg'=>'on', 'bytimeslot'=>$vars['bytimeslot'], 'stddev'=>$vars['stddev'], 'package'=>$vars['package'], 'statsavg'=>$vars['statsavg']]) . ', ' .
-            generate_link($label, $link_array, ['app'=>'cape', 'bypkg'=>'off', 'bytimeslot'=>$vars['bytimeslot'], 'stddev'=>$vars['stddev'], 'package'=>$vars['package'], 'statsavg'=>$vars['statsavg']]);
+            echo generate_link('On', $link_array, ['app'=>'cape', 'bypkg'=>'on', 'bytimeslot'=>$vars['bytimeslot'], 'stddev'=>$vars['stddev'], 'package'=>$vars['package'], 'statsavg'=>$vars['statsavg'], 'runstats'=>$vars['runstats']]) . ', ' .
+            generate_link($label, $link_array, ['app'=>'cape', 'bypkg'=>'off', 'bytimeslot'=>$vars['bytimeslot'], 'stddev'=>$vars['stddev'], 'package'=>$vars['package'], 'statsavg'=>$vars['statsavg'], 'runstats'=>$vars['runstats']]);
         }
     }
 
@@ -97,13 +98,28 @@ if (sizeof($packages) > 0) {
     echo '<b>Standard Deviation:</b> ';
     if ($vars['stddev'] == 'on') {
         $label = '<span class="pagemenu-selected">On</span>';
-        echo generate_link($label, $link_array, ['app'=>'cape', 'stddev'=>'on', 'bypkg'=>$vars['bypkg'], 'bytimeslot'=>$vars['bytimeslot'], 'package'=>$vars['package'], 'statsavg'=>$vars['statsavg']]) . ', ' .
-        generate_link('Off', $link_array, ['app'=>'cape', 'stddev'=>'off', 'bypkg'=>$vars['bypkg'], 'bytimeslot'=>$vars['bytimeslot'], 'package'=>$vars['package'], 'statsavg'=>$vars['statsavg']]);
+        echo generate_link($label, $link_array, ['app'=>'cape', 'stddev'=>'on', 'bypkg'=>$vars['bypkg'], 'bytimeslot'=>$vars['bytimeslot'], 'package'=>$vars['package'], 'statsavg'=>$vars['statsavg'], 'runstats'=>$vars['runstats']]) . ', ' .
+        generate_link('Off', $link_array, ['app'=>'cape', 'stddev'=>'off', 'bypkg'=>$vars['bypkg'], 'bytimeslot'=>$vars['bytimeslot'], 'package'=>$vars['package'], 'statsavg'=>$vars['statsavg'], 'runstats'=>$vars['runstats']]);
     } else {
         $label = '<span class="pagemenu-selected">Off</span>';
-        echo generate_link('On', $link_array, ['app'=>'cape', 'stddev'=>'on', 'bypkg'=>$vars['bypkg'], 'bytimeslot'=>$vars['bytimeslot'], 'package'=>$vars['package'], 'statsavg'=>$vars['statsavg']]) . ', ' .
-        generate_link($label, $link_array, ['app'=>'cape', 'stddev'=>'off', 'bypkg'=>$vars['bypkg'], 'bytimeslot'=>$vars['bytimeslot'], 'package'=>$vars['package'], 'statsavg'=>$vars['statsavg']]);
+        echo generate_link('On', $link_array, ['app'=>'cape', 'stddev'=>'on', 'bypkg'=>$vars['bypkg'], 'bytimeslot'=>$vars['bytimeslot'], 'package'=>$vars['package'], 'statsavg'=>$vars['statsavg'], 'runstats'=>$vars['runstats']]) . ', ' .
+        generate_link($label, $link_array, ['app'=>'cape', 'stddev'=>'off', 'bypkg'=>$vars['bypkg'], 'bytimeslot'=>$vars['bytimeslot'], 'package'=>$vars['package'], 'statsavg'=>$vars['statsavg'], 'runstats'=>$vars['runstats']]);
     }
+
+    if (! isset($vars['package'])) {
+        echo '  |  ';
+        echo '<b>Run Statuses Averages:</b> ';
+        if ($vars['bypkg'] == 'on') {
+            $label = '<span class="pagemenu-selected">On</span>';
+            echo generate_link($label, $link_array, ['app'=>'cape', 'bypkg'=>$vars['bypkg'], 'bytimeslot'=>$vars['bytimeslot'], 'stddev'=>$vars['stddev'], 'package'=>$vars['package'], 'statsavg'=>$vars['statsavg'], 'runstats'=>'on']) . ', ' .
+            generate_link('Off', $link_array, ['app'=>'cape', 'bypkg'=>$vars['bypkg'], 'bytimeslot'=>$vars['bytimeslot'], 'stddev'=>$vars['stddev'], 'package'=>$vars['package'], 'statsavg'=>$vars['statsavg'], 'runstats'=>'off']);
+        } else {
+            $label = '<span class="pagemenu-selected">Off</span>';
+            echo generate_link('On', $link_array, ['app'=>'cape', 'bypkg'=>$vars['bypkg'], 'bytimeslot'=>$vars['bytimeslot'], 'stddev'=>$vars['stddev'], 'package'=>$vars['package'], 'statsavg'=>$vars['statsavg'], 'runstats'=>'on']) . ', ' .
+            generate_link($label, $link_array, ['app'=>'cape', 'bypkg'=>$vars['bypkg'], 'bytimeslot'=>$vars['bytimeslot'], 'stddev'=>$vars['stddev'], 'package'=>$vars['package'], 'statsavg'=>$vars['statsavg'], 'runstats'=>'off']);
+        }
+    }
+
     print_optionbar_end();
 }
 
@@ -148,6 +164,18 @@ if (isset($vars['package'])) {
             'cape_malscore_stats' => 'Malscore Averages',
             'cape_pkg_tasks_all' => 'Package Tasks',
         ];
+
+        if ($vars['runstats'] == 'on') {
+            $graphs['cape_banned'] = 'Banned Run Statuses Averages';
+            $graphs['cape_running'] = 'Running Run Statuses Averages';
+            $graphs['cape_completed'] = 'Completed Run Statuses Averages';
+            $graphs['cape_distributed'] = 'Distributed Run Statuses Averages';
+            $graphs['cape_reported'] = 'Reported Run Statuses Averages';
+            $graphs['cape_recovered'] = 'Recovered Run Statuses Averages';
+            $graphs['cape_failed_analysis'] = 'Failed Analysis Run Statuses Averages';
+            $graphs['cape_failed_processing'] = 'Failed Processing Run Statuses Averages';
+            $graphs['cape_failed_reporting'] = 'Failed Reporting  Run Statuses Averages';
+        }
 
         if ($vars['bypkg'] == 'on') {
             $graphs['cape_anti_issues_pkg'] = 'Anti Issues Per Run Stats During Time Slot By Package';


### PR DESCRIPTION
Found my self wanting a more detailed graph for reported. Went though and add stats graphs for all the run statuses.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [X] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
