### PR TITLE
update HV::Monitor support to use generic_stats.inc.php

### DIFF
--- a/includes/html/graphs/application/hv-monitor_cow.inc.php
+++ b/includes/html/graphs/application/hv-monitor_cow.inc.php
@@ -14,15 +14,12 @@ if (isset($vars['vm'])) {
     $rrd_filename = Rrd::name($device['hostname'], ['app', $name, $app->app_id]);
 }
 
-$rrd_list = [];
 if (Rrd::checkRrdExists($rrd_filename)) {
-    $rrd_list[] = [
-        'filename' => $rrd_filename,
-        'descr'    => 'COW',
-        'ds'       => 'cow',
-    ];
+    $filename = $rrd_filename;
+    $descr = 'COW';
+    $ds = 'cow';
 } else {
     d_echo('RRD "' . $rrd_filename . '" not found');
 }
 
-require 'includes/html/graphs/generic_multi_line.inc.php';
+require 'includes/html/graphs/generic_stats.inc.php';

--- a/includes/html/graphs/application/hv-monitor_disk-freqs.inc.php
+++ b/includes/html/graphs/application/hv-monitor_disk-freqs.inc.php
@@ -16,15 +16,12 @@ if (isset($vars['vmdisk']) && isset($vars['vm'])) {
     $rrd_filename = Rrd::name($device['hostname'], ['app', $name, $app->app_id]);
 }
 
-$rrd_list = [];
 if (Rrd::checkRrdExists($rrd_filename)) {
-    $rrd_list[] = [
-        'filename' => $rrd_filename,
-        'descr'    => 'Flushes',
-        'ds'       => 'freqs',
-    ];
+    $filename = $rrd_filename;
+    $descr = 'Flushes';
+    $ds = 'freqs';
 } else {
     d_echo('RRD "' . $rrd_filename . '" not found');
 }
 
-require 'includes/html/graphs/generic_multi_line.inc.php';
+require 'includes/html/graphs/generic_stats.inc.php';

--- a/includes/html/graphs/application/hv-monitor_disk-ftime.inc.php
+++ b/includes/html/graphs/application/hv-monitor_disk-ftime.inc.php
@@ -16,15 +16,12 @@ if (isset($vars['vmdisk']) && isset($vars['vm'])) {
     $rrd_filename = Rrd::name($device['hostname'], ['app', $name, $app->app_id]);
 }
 
-$rrd_list = [];
 if (Rrd::checkRrdExists($rrd_filename)) {
-    $rrd_list[] = [
-        'filename' => $rrd_filename,
-        'descr'    => 'Flush Time',
-        'ds'       => 'ftime',
-    ];
+    $filename = $rrd_filename;
+    $descr = 'Flush Time';
+    $ds = 'ftime';
 } else {
     d_echo('RRD "' . $rrd_filename . '" not found');
 }
 
-require 'includes/html/graphs/generic_multi_line.inc.php';
+require 'includes/html/graphs/generic_stats.inc.php';

--- a/includes/html/graphs/application/hv-monitor_etimes.inc.php
+++ b/includes/html/graphs/application/hv-monitor_etimes.inc.php
@@ -14,15 +14,12 @@ if (isset($vars['vm'])) {
     $rrd_filename = Rrd::name($device['hostname'], ['app', $name, $app->app_id]);
 }
 
-$rrd_list = [];
 if (Rrd::checkRrdExists($rrd_filename)) {
-    $rrd_list[] = [
-        'filename' => $rrd_filename,
-        'descr'    => 'Etimes',
-        'ds'       => 'etimes',
-    ];
+    $filename = $rrd_filename;
+    $descr = 'Etimes';
+    $ds = 'etimes';
 } else {
     d_echo('RRD "' . $rrd_filename . '" not found');
 }
 
-require 'includes/html/graphs/generic_multi_line.inc.php';
+require 'includes/html/graphs/generic_stats.inc.php';

--- a/includes/html/graphs/application/hv-monitor_net-coll.inc.php
+++ b/includes/html/graphs/application/hv-monitor_net-coll.inc.php
@@ -16,15 +16,12 @@ if (isset($vars['vmif'])) {
     $rrd_filename = Rrd::name($device['hostname'], ['app', $name, $app->app_id]);
 }
 
-$rrd_list = [];
 if (Rrd::checkRrdExists($rrd_filename)) {
-    $rrd_list[] = [
-        'filename' => $rrd_filename,
-        'descr'    => 'Collisions',
-        'ds'       => 'coll',
-    ];
+    $filename = $rrd_filename;
+    $descr = 'Collisions';
+    $ds = 'coll';
 } else {
     d_echo('RRD "' . $rrd_filename . '" not found');
 }
 
-require 'includes/html/graphs/generic_multi_line.inc.php';
+require 'includes/html/graphs/generic_stats.inc.php';

--- a/includes/html/graphs/application/hv-monitor_pcpu.inc.php
+++ b/includes/html/graphs/application/hv-monitor_pcpu.inc.php
@@ -14,15 +14,12 @@ if (isset($vars['vm'])) {
     $rrd_filename = Rrd::name($device['hostname'], ['app', $name, $app->app_id]);
 }
 
-$rrd_list = [];
 if (Rrd::checkRrdExists($rrd_filename)) {
-    $rrd_list[] = [
-        'filename' => $rrd_filename,
-        'descr'    => 'CPU%',
-        'ds'       => 'pcpu',
-    ];
+    $filename = $rrd_filename;
+    $descr = 'CPU%';
+    $ds = 'pcpu';
 } else {
     d_echo('RRD "' . $rrd_filename . '" not found');
 }
 
-require 'includes/html/graphs/generic_multi_line.inc.php';
+require 'includes/html/graphs/generic_stats.inc.php';

--- a/includes/html/graphs/application/hv-monitor_pcpu.inc.php
+++ b/includes/html/graphs/application/hv-monitor_pcpu.inc.php
@@ -1,7 +1,7 @@
 <?php
 
 $name = 'hv-monitor';
-$unit_text = 'Memory Usage %';
+$unit_text = 'CPU Usage %';
 $colours = 'psychedelic';
 $dostack = 0;
 $printtotal = 0;

--- a/includes/html/graphs/application/hv-monitor_snaps.inc.php
+++ b/includes/html/graphs/application/hv-monitor_snaps.inc.php
@@ -14,15 +14,13 @@ if (isset($vars['vm'])) {
     $rrd_filename = Rrd::name($device['hostname'], ['app', $name, $app->app_id]);
 }
 
-$rrd_list = [];
+
 if (Rrd::checkRrdExists($rrd_filename)) {
-    $rrd_list[] = [
-        'filename' => $rrd_filename,
-        'descr'    => 'Snaps',
-        'ds'       => 'snaps',
-    ];
+    $filename = $rrd_filename;
+    $descr = 'Snaps';
+    $ds = 'snaps';
 } else {
     d_echo('RRD "' . $rrd_filename . '" not found');
 }
 
-require 'includes/html/graphs/generic_multi_line.inc.php';
+require 'includes/html/graphs/generic_stats.inc.php';

--- a/includes/html/graphs/application/hv-monitor_snaps.inc.php
+++ b/includes/html/graphs/application/hv-monitor_snaps.inc.php
@@ -14,7 +14,6 @@ if (isset($vars['vm'])) {
     $rrd_filename = Rrd::name($device['hostname'], ['app', $name, $app->app_id]);
 }
 
-
 if (Rrd::checkRrdExists($rrd_filename)) {
     $filename = $rrd_filename;
     $descr = 'Snaps';

--- a/includes/html/graphs/application/hv-monitor_snaps_size.inc.php
+++ b/includes/html/graphs/application/hv-monitor_snaps_size.inc.php
@@ -14,15 +14,12 @@ if (isset($vars['vm'])) {
     $rrd_filename = Rrd::name($device['hostname'], ['app', $name, $app->app_id]);
 }
 
-$rrd_list = [];
 if (Rrd::checkRrdExists($rrd_filename)) {
-    $rrd_list[] = [
-        'filename' => $rrd_filename,
-        'descr'    => 'Snap Size',
-        'ds'       => 'snaps_size',
-    ];
+    $filename = $rrd_filename;
+    $descr = 'Snaps Size';
+    $ds = 'snaps_size';
 } else {
     d_echo('RRD "' . $rrd_filename . '" not found');
 }
 
-require 'includes/html/graphs/generic_multi_line.inc.php';
+require 'includes/html/graphs/generic_stats.inc.php';


### PR DESCRIPTION
Previously only a single line would be displayed.

Now uses generic_stats.inc.php to show meaningful averages. This is especially handy for the pcpu graph as it gives a lot better indication of CPU usage by giving hour, day, etc stats.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [X] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
