### PR TITLE
Fix empty output on validation test

### DIFF
--- a/LibreNMS/Validations/Database/CheckSchemaCollation.php
+++ b/LibreNMS/Validations/Database/CheckSchemaCollation.php
@@ -79,7 +79,7 @@ class CheckSchemaCollation implements Validation, ValidationFixer
                 }, $collation_columns));
         }
 
-        return ValidationResult::ok('');
+        return ValidationResult::ok(trans('validation.validations.database.CheckSchemaCollation.ok'));
     }
 
     /**

--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -218,7 +218,7 @@ return [
                 'ok' => 'Database Schema is current',
             ],
             'CheckSchemaCollation' => [
-                'ok' => 'Database and column collations are correct',    
+		    'ok' => 'Database and column collations are correct',
             ],
         ],
         'distributedpoller' => [

--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -217,7 +217,8 @@ return [
                 'warn_legacy_newer' => 'Your database schema (:current) is newer than expected (:latest). If you just switched to the stable release from the daily release, your database is in between releases and this will be resolved with the next release.',
                 'ok' => 'Database Schema is current',
             ],
-            'CheckSchemaCollation' => [
+	    'CheckSchemaCollation' => [
+		'ok' => 'Database and column collations are correct',    
 
             ],
         ],

--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -218,7 +218,7 @@ return [
                 'ok' => 'Database Schema is current',
             ],
 	    'CheckSchemaCollation' => [
-		'ok' => 'Database and column collations are correct',    
+                'ok' => 'Database and column collations are correct',    
 
             ],
         ],

--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -219,7 +219,6 @@ return [
             ],
             'CheckSchemaCollation' => [
                 'ok' => 'Database and column collations are correct',    
-
             ],
         ],
         'distributedpoller' => [

--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -217,7 +217,7 @@ return [
                 'warn_legacy_newer' => 'Your database schema (:current) is newer than expected (:latest). If you just switched to the stable release from the daily release, your database is in between releases and this will be resolved with the next release.',
                 'ok' => 'Database Schema is current',
             ],
-	    'CheckSchemaCollation' => [
+            'CheckSchemaCollation' => [
                 'ok' => 'Database and column collations are correct',    
 
             ],

--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -218,7 +218,7 @@ return [
                 'ok' => 'Database Schema is current',
             ],
             'CheckSchemaCollation' => [
-		    'ok' => 'Database and column collations are correct',
+                'ok' => 'Database and column collations are correct',
             ],
         ],
         'distributedpoller' => [


### PR DESCRIPTION
As per screenshot below, the validate.php has been outputtinga blank line (even with an OK). 

Fixed it for the 'ok' status, **but, I don't know how to handle the output if this validation fails, so I need help with that please!**

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.

![LibreNMS-validate-before](https://user-images.githubusercontent.com/24249616/216052479-41780522-43f4-49f0-9fca-c7f0ce5ecb4e.png)
![LibreNMS-validate-after](https://user-images.githubusercontent.com/24249616/216052484-3fc6ecec-d039-465c-81d6-85a05fdbf097.png)

