### PR TITLE
Fix fping 4.0+ prefers IPv6

### DIFF
--- a/LibreNMS/Data/Source/Fping.php
+++ b/LibreNMS/Data/Source/Fping.php
@@ -46,11 +46,13 @@ class Fping
         $interval = max($interval, 20);
 
         $fping = Config::get('fping');
+        $fping6 = Config::get('fping6');
         $fping_tos = Config::get('fping_options.tos', 0);
-        $cmd = [$fping];
+
         if ($address_family == 'ipv6') {
-            $fping6 = Config::get('fping6');
             $cmd = is_executable($fping6) ? [$fping6] : [$fping, '-6'];
+        } else {
+            $cmd = is_executable($fping6) ? [$fping] : [$fping, '-4'];
         }
 
         // build the command


### PR DESCRIPTION
Additionally fping6 is no longer a thing - this breaks IPv4 hosts entirely in a dual stack environment

It's not possible to reconcile these options, so we have to have a toggle until distro's with fping 3.x fall out of support.

Open to other ways to solve this - I couldn't think of anything other than invoking fping to check its version, which doubles the process overhead.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
