### PR TITLE
Fix poller service logging configuration

### DIFF
--- a/LibreNMS/queuemanager.py
+++ b/LibreNMS/queuemanager.py
@@ -493,7 +493,12 @@ class PollerQueueManager(QueueManager):
         if self.lock(device_id, timeout=self.config.poller.frequency):
             logger.info("Polling device {}".format(device_id))
 
-            exit_code, output = LibreNMS.call_script("poller.php", ("-h", device_id))
+            poller_args = ("-h", device_id)
+
+            if self.config.debug:
+                poller_args = ("-d", *poller_args)
+
+            exit_code, output = LibreNMS.call_script("poller.php", poller_args)
             if exit_code == 0:
                 self.unlock(device_id)
             else:
@@ -546,7 +551,13 @@ class DiscoveryQueueManager(TimedQueueManager):
             device_id, timeout=LibreNMS.normalize_wait(self.config.discovery.frequency)
         ):
             logger.info("Discovering device {}".format(device_id))
-            exit_code, output = LibreNMS.call_script("discovery.php", ("-h", device_id))
+
+            discovery_args = ("-h", device_id)
+
+            if self.config.debug:
+                discovery_args = ("-d", *discovery_args)
+
+            exit_code, output = LibreNMS.call_script("discovery.php", discovery_args)
             if exit_code == 0:
                 self.unlock(device_id)
             else:

--- a/LibreNMS/service.py
+++ b/LibreNMS/service.py
@@ -72,7 +72,7 @@ class ServiceConfig(DBConfig):
     group = 0
 
     debug = False
-    log_level = 20
+    log_level = logging.INFO
     max_db_failures = 5
 
     alerting = PollerConfig(1, 60)
@@ -100,10 +100,11 @@ class ServiceConfig(DBConfig):
     watchdog_enabled = False
     watchdog_logfile = "logs/librenms.log"
 
-    def populate(self):
+    def populate(self, min_log_level):
         config = LibreNMS.get_config_data(self.BASE_DIR)
 
         # populate config variables
+        self.min_log_level = min_log_level
         self.node_id = os.getenv("NODE_ID")
         self.set_name(config.get("distributed_poller_name", None))
         self.distributed = config.get("distributed_poller", ServiceConfig.distributed)
@@ -124,7 +125,7 @@ class ServiceConfig(DBConfig):
         self.down_retry = config.get(
             "poller_service_down_retry", ServiceConfig.down_retry
         )
-        self.log_level = config.get("poller_service_loglevel", ServiceConfig.log_level)
+        self.legacy_log_level = config.get("poller_service_loglevel", ServiceConfig.log_level)
 
         # new options
         self.poller.enabled = config.get("service_poller_enabled", True)  # unused
@@ -164,7 +165,7 @@ class ServiceConfig(DBConfig):
         self.down_retry = config.get(
             "service_poller_down_retry", ServiceConfig.down_retry
         )
-        self.log_level = config.get("service_loglevel", ServiceConfig.log_level)
+        self.service_log_level = config.get("service_loglevel", ServiceConfig.log_level)
         self.update_enabled = config.get(
             "service_update_enabled", ServiceConfig.update_enabled
         )
@@ -233,19 +234,29 @@ class ServiceConfig(DBConfig):
         )
         self.watchdog_logfile = config.get("log_file", ServiceConfig.watchdog_logfile)
 
-        # set convenient debug variable
-        self.debug = logging.getLogger().isEnabledFor(logging.DEBUG)
+    def set_log_level(self):
+        if self.poller_log_level:
+            # User has set an explicit log level at the poller level
+            log_level = self.poller_log_level
+        elif self.service_log_level:
+            # User has set an explicit log level at the global level
+            log_level = self.service_log_level
+        elif self.legacy_log_level:
+            # User has set an explicit log level using old variables
+            log_level = self.legacy_log_level
 
-        if not self.debug and self.log_level:
-            try:
-                logging.getLogger().setLevel(self.log_level)
-            except ValueError:
-                logger.error(
-                    "Unknown log level {}, must be one of 'DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'".format(
-                        self.log_level
-                    )
+        self.log_level = min([log_level, self.min_log_level])
+
+        try:
+            logging.getLogger().setLevel(self.log_level)
+            self.debug = logging.getLogger().isEnabledFor(logging.DEBUG)
+        except ValueError:
+            logger.error(
+                "Unknown log level {}, must be one of 'DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'".format(
+                    self.log_level
                 )
-                logging.getLogger().setLevel(logging.INFO)
+            )
+            logging.getLogger().setLevel(logging.INFO)
 
     def load_poller_config(self, db):
         try:
@@ -303,7 +314,7 @@ class ServiceConfig(DBConfig):
             if settings["update_frequency"] is not None:
                 self.update_frequency = settings["update_frequency"]
             if settings["loglevel"] is not None:
-                self.log_level = settings["loglevel"]
+                self.poller_log_level = settings["loglevel"]
             if settings["watchdog_enabled"] is not None:
                 self.watchdog_enabled = settings["watchdog_enabled"]
             if settings["watchdog_log"] is not None:
@@ -340,12 +351,14 @@ class Service:
     terminate_flag = False
     reload_flag = False
     db_failures = 0
+    min_log_level = None
 
-    def __init__(self):
+    def __init__(self, min_log_level = None):
         self.start_time = time.time()
-        self.config.populate()
+        self.config.populate(min_log_level)
         self._db = LibreNMS.DB(self.config)
         self.config.load_poller_config(self._db)
+        self.set_log_level()
 
         threading.current_thread().name = self.config.name  # rename main thread
         self.attach_signals()

--- a/LibreNMS/service.py
+++ b/LibreNMS/service.py
@@ -247,6 +247,9 @@ class ServiceConfig(DBConfig):
             # User has set an explicit log level using old variables
             log_level = self.legacy_log_level
 
+        if not isinstance(log_level, int):
+            log_level = getattr(logging, log_level)
+
         self.log_level = min([log_level, self.min_log_level])
 
         try:

--- a/LibreNMS/service.py
+++ b/LibreNMS/service.py
@@ -125,7 +125,9 @@ class ServiceConfig(DBConfig):
         self.down_retry = config.get(
             "poller_service_down_retry", ServiceConfig.down_retry
         )
-        self.legacy_log_level = config.get("poller_service_loglevel", ServiceConfig.log_level)
+        self.legacy_log_level = config.get(
+            "poller_service_loglevel", ServiceConfig.log_level
+        )
 
         # new options
         self.poller.enabled = config.get("service_poller_enabled", True)  # unused
@@ -353,12 +355,12 @@ class Service:
     db_failures = 0
     min_log_level = None
 
-    def __init__(self, min_log_level = None):
+    def __init__(self, min_log_level=None):
         self.start_time = time.time()
         self.config.populate(min_log_level)
         self._db = LibreNMS.DB(self.config)
         self.config.load_poller_config(self._db)
-        self.set_log_level()
+        self.config.set_log_level()
 
         threading.current_thread().name = self.config.name  # rename main thread
         self.attach_signals()

--- a/librenms-service.py
+++ b/librenms-service.py
@@ -52,7 +52,7 @@ if __name__ == "__main__":
         logging.getLogger().setLevel(logging.INFO)
        	info("Initial log level was set to INFO")
     else:
-       	logging.getLogger().setLevel(logging.WARNING)
+        logging.getLogger().setLevel(logging.WARNING)
 
     info("Configuring LibreNMS service")
 

--- a/librenms-service.py
+++ b/librenms-service.py
@@ -45,10 +45,10 @@ if __name__ == "__main__":
     else:
         logging.basicConfig(format="%(threadName)s(%(levelname)s):%(message)s")
 
-    if args.verbose:
-        logging.getLogger().setLevel(logging.INFO)
-    elif args.debug:
+    if args.debug:
         logging.getLogger().setLevel(logging.DEBUG)
+    elif args.verbose:
+        logging.getLogger().setLevel(logging.INFO)
     else:
         logging.getLogger().setLevel(logging.WARNING)
 

--- a/librenms-service.py
+++ b/librenms-service.py
@@ -46,11 +46,11 @@ if __name__ == "__main__":
         logging.basicConfig(format="%(threadName)s(%(levelname)s):%(message)s")
 
     if args.debug:
-       	logging.getLogger().setLevel(logging.DEBUG)
+        logging.getLogger().setLevel(logging.DEBUG)
         debug("Initial log level was set to DEBUG")
     elif args.verbose:
         logging.getLogger().setLevel(logging.INFO)
-       	info("Initial log level was set to INFO")
+        info("Initial log level was set to INFO")
     else:
         logging.getLogger().setLevel(logging.WARNING)
 

--- a/librenms-service.py
+++ b/librenms-service.py
@@ -8,7 +8,7 @@ import threading
 
 import LibreNMS
 
-from logging import info
+from logging import info, debug
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
@@ -46,13 +46,16 @@ if __name__ == "__main__":
         logging.basicConfig(format="%(threadName)s(%(levelname)s):%(message)s")
 
     if args.debug:
-        logging.getLogger().setLevel(logging.DEBUG)
+       	logging.getLogger().setLevel(logging.DEBUG)
+        debug("Initial log level was set to DEBUG")
     elif args.verbose:
         logging.getLogger().setLevel(logging.INFO)
+       	info("Initial log level was set to INFO")
     else:
-        logging.getLogger().setLevel(logging.WARNING)
+       	logging.getLogger().setLevel(logging.WARNING)
 
     info("Configuring LibreNMS service")
+
     try:
         service = LibreNMS.Service()
     except Exception as e:

--- a/librenms-service.py
+++ b/librenms-service.py
@@ -27,10 +27,11 @@ if __name__ == "__main__":
         action="count",
         help="Force verbose ouput - log level is forced to INFO",
     )
-    parser.add_argument("-d",
+    parser.add_argument(
+        "-d",
         "--debug",
         action="store_true",
-        help="Show debug output - log level is forced to DEBUG and PHP debug messages are captured."
+        help="Show debug output - log level is forced to DEBUG and PHP debug messages are captured.",
     )
     parser.add_argument(
         "-m",

--- a/librenms-service.py
+++ b/librenms-service.py
@@ -21,8 +21,8 @@ if __name__ == "__main__":
         type=int,
         help="Set the poller group for this poller",
     )
-    parser.add_argument("-v", "--verbose", action="count", help="Show verbose output.")
-    parser.add_argument("-d", "--debug", action="store_true", help="Show debug output.")
+    parser.add_argument("-v", "--verbose", action="count", help="Force verbose ouput - log level is forced to INFO")
+    parser.add_argument("-d", "--debug", action="store_true", help="Show debug output - log level is forced to DEBUG and PHP debug messages are captured.")
     parser.add_argument(
         "-m",
         "--multiple",
@@ -45,19 +45,23 @@ if __name__ == "__main__":
     else:
         logging.basicConfig(format="%(threadName)s(%(levelname)s):%(message)s")
 
+    min_log_level = logging.WARNING
+
     if args.debug:
         logging.getLogger().setLevel(logging.DEBUG)
         debug("Initial log level was set to DEBUG")
+        min_log_level = logging.DEBUG
     elif args.verbose:
         logging.getLogger().setLevel(logging.INFO)
         info("Initial log level was set to INFO")
+        min_log_level = logging.INFO
     else:
         logging.getLogger().setLevel(logging.WARNING)
 
     info("Configuring LibreNMS service")
 
     try:
-        service = LibreNMS.Service()
+        service = LibreNMS.Service(min_log_level)
     except Exception as e:
         # catch any initialization errors and print the message instead of a stack trace
         print(e)

--- a/librenms-service.py
+++ b/librenms-service.py
@@ -21,8 +21,17 @@ if __name__ == "__main__":
         type=int,
         help="Set the poller group for this poller",
     )
-    parser.add_argument("-v", "--verbose", action="count", help="Force verbose ouput - log level is forced to INFO")
-    parser.add_argument("-d", "--debug", action="store_true", help="Show debug output - log level is forced to DEBUG and PHP debug messages are captured.")
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="count",
+        help="Force verbose ouput - log level is forced to INFO",
+    )
+    parser.add_argument("-d",
+        "--debug",
+        action="store_true",
+        help="Show debug output - log level is forced to DEBUG and PHP debug messages are captured."
+    )
     parser.add_argument(
         "-m",
         "--multiple",


### PR DESCRIPTION
A previous code cleanup moved these parameters into an 'if' block, but didn't account for the order they needed to be in to function.

This change re-orders the parameters so they work as intended again.

In addition, there were 3 ways logging could be set, with the hierarchy between them being something like

* Legacy Config
* Global Config
* CLI args
* Default

With per poller config being defined, but unused as it was parsed after the log level was set.

This change should also implement the following behaviour, which is opinionated, but I feel reasonable.

* CLI args set a minimum threshold - i.e. if you set -v, attempting to set the log filter to WARN, ERROR or CRIT via config will be ignored. If you don't want verbose output, don't set the flag.

Log level configuration will be parsed in this order:
* CLI Args
* Per-poller
* Global (new)
* Global (legacy)
* Default

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
