### PR TITLE
Include Samsung X Series printers

### DIFF
--- a/includes/definitions/samsungprinter.yaml
+++ b/includes/definitions/samsungprinter.yaml
@@ -11,6 +11,7 @@ discovery:
             - 'Samsung S'
             - 'Samsung ML'
             - 'Samsung M4080FX'
+            - 'Samsung X'
 discovery_modules:
     printer-supplies:   true
 poller_modules:


### PR DESCRIPTION
Amends the Samsung printer definition to include Samsung X series.

Tested against X7600 and X4300. Both of which change from being a generic device to a Samsung printer device. Subsequent poller.php runs result in toner, fuser, impressions counts, etc data being returned. RRD graphs of supplies data starts being populated

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
