### PR TITLE
Fix MS Teams alert transport, correct HTTP header

### DIFF
--- a/LibreNMS/Alert/Transport/Msteams.php
+++ b/LibreNMS/Alert/Transport/Msteams.php
@@ -41,7 +41,7 @@ class Msteams extends Transport
         Proxy::applyToCurl($curl);
         curl_setopt($curl, CURLOPT_URL, $url);
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
-        curl_setopt($curl, CURLOPT_HTTPHEADER, array('Content-Type:application/json', 'Expect:'));
+        curl_setopt($curl, CURLOPT_HTTPHEADER, ['Content-Type:application/json', 'Expect:']);
         curl_setopt($curl, CURLOPT_POSTFIELDS, json_encode($data));
         if ($this->config['use-json'] === 'on' && $obj['uid'] !== '000') {
             curl_setopt($curl, CURLOPT_POSTFIELDS, $obj['msg']);

--- a/LibreNMS/Alert/Transport/Msteams.php
+++ b/LibreNMS/Alert/Transport/Msteams.php
@@ -41,10 +41,7 @@ class Msteams extends Transport
         Proxy::applyToCurl($curl);
         curl_setopt($curl, CURLOPT_URL, $url);
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
-        curl_setopt($curl, CURLOPT_HTTPHEADER, [
-            'Content-type' => 'application/json',
-            'Expect:',
-        ]);
+        curl_setopt($curl, CURLOPT_HTTPHEADER, array('Content-Type:application/json', 'Expect:'));
         curl_setopt($curl, CURLOPT_POSTFIELDS, json_encode($data));
         if ($this->config['use-json'] === 'on' && $obj['uid'] !== '000') {
             curl_setopt($curl, CURLOPT_POSTFIELDS, $obj['msg']);


### PR DESCRIPTION
Microsoft rejects webhooks without correct Content-Type since beginning of January. This PR fixes the behaviour and makes Teams webhooks working again.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
