### PR TITLE
Fix graphs for a search query

### DIFF
--- a/includes/html/pages/devices.inc.php
+++ b/includes/html/pages/devices.inc.php
@@ -134,7 +134,7 @@ if ($format == 'graph') {
 
     if (! empty($vars['searchquery'])) {
         $where .= ' AND (sysName LIKE ? OR hostname LIKE ? OR display LIKE ? OR hardware LIKE ? OR os LIKE ? OR location LIKE ?)';
-        $sql_param += array_fill(count($param), 6, '%' . $vars['searchquery'] . '%');
+        $sql_param += array_fill(0, 6, '%' . $vars['searchquery'] . '%');
     }
     if (! empty($vars['os'])) {
         $where .= ' AND os = ?';


### PR DESCRIPTION
This `count` was introduced in #8509, but most probably never worked since `$param` was not a defined variable.
Before PHP 8 this threw a WARNING, thus not bothering the user.
Since PHP 8 the behavior was changed to throw an ERROR, thus also making LibreNMS trhow an error.

I'm not sure why the count was needed anyway since we can safely start the array counting at 0.

This MR fixes #14859

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
