### PR TITLE
add type checking to generic_stats.inc.php for $vars['to'] and $vars['from']

### DIFF
--- a/includes/html/graphs/generic_stats.inc.php
+++ b/includes/html/graphs/generic_stats.inc.php
@@ -119,8 +119,14 @@ if ($height > 25) {
     $rrd_options .= ' VDEF:' . $id . '25th=' . $id . ',25,PERCENTNAN';
     $rrd_options .= ' VDEF:' . $id . '75th=' . $id . ',75,PERCENTNAN';
 
+    // the if is needed as with out it the group page will case an error
+    // devices/group=1/format=graph_poller_perf/from=-24hour/to=now/
+    if ( is_numeric($vars['to']) && is_numeric($vars['from']) ) {
+        $time_diff = $vars['to'] - $vars['from'];
+    } else {
+        $time_diff = 1;
+    }
     // displays nan if less than 17 hours
-    $time_diff = $vars['to'] - $vars['from'];
     if ($time_diff >= 61200) {
         $rrd_options .= ' DEF:' . $id . "1d=$filename:$ds:AVERAGE:step=86400";
     }

--- a/includes/html/graphs/generic_stats.inc.php
+++ b/includes/html/graphs/generic_stats.inc.php
@@ -121,7 +121,7 @@ if ($height > 25) {
 
     // the if is needed as with out it the group page will case an error
     // devices/group=1/format=graph_poller_perf/from=-24hour/to=now/
-    if ( is_numeric($vars['to']) && is_numeric($vars['from']) ) {
+    if (is_numeric($vars['to']) && is_numeric($vars['from'])) {
         $time_diff = $vars['to'] - $vars['from'];
     } else {
         $time_diff = 1;


### PR DESCRIPTION
This resolves the issues with generic_stats.inc.php passing it from=-24hour/to=now instead of integers.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
