### PR TITLE
Pseudowires refresh

### DIFF
--- a/includes/html/pages/device/pseudowires.inc.php
+++ b/includes/html/pages/device/pseudowires.inc.php
@@ -49,7 +49,7 @@ foreach (dbFetchRows('SELECT * FROM pseudowires AS P, ports AS I WHERE P.port_id
         continue;
     }
 
-    # if the remote device is valid, resolve their pw & port details
+    // if the remote device is valid, resolve their pw & port details
     if ($pw_a['peer_device_id'] != 0) {
         $pw_b = dbFetchRow(
             'SELECT * from `devices` AS D, `ports` AS I, `pseudowires` AS P WHERE D.device_id = ? AND D.device_id = I.device_id
@@ -60,9 +60,7 @@ foreach (dbFetchRows('SELECT * FROM pseudowires AS P, ports AS I WHERE P.port_id
         if (! port_permitted($pw_b['port_id'])) {
             continue;
         }
-    }
-    else
-    {
+    } else {
         unset($pw_b);
     }
 
@@ -72,42 +70,38 @@ foreach (dbFetchRows('SELECT * FROM pseudowires AS P, ports AS I WHERE P.port_id
         $bg = '255,255,255';
     }
 
-    echo '<tr style="background-color: rgb('.$bg.')">
-            <td style="font-size:18px; padding:4px;vertical-align: middle;">' . $pw_a['cpwVcID'] .'</td>
-            <td>'.$pw_a['pw_descr']. '<br/><span class="box-desc">'. $pw_a['pw_type'] .' '. $pw_a['pw_psntype'].'</span></td>
-            <td>' . generate_port_link($pw_a) . ' <i class="fa fa-arrow-'.$pw_a['ifOperStatus'].' report-'.$pw_a['ifOperStatus'].'" aria-hidden="true"></i><br/><span class="interface-desc">'. $pw_a['ifAlias'].'</span>';
-                if ($pw_a['pw_local_mtu'] !=0){
-                    echo '<br/><span class="box-desc">MTU '. $pw_a['ifMtu'].'</span>';
-                    echo '<br/><span class="box-desc">PW MTU '. $pw_a['pw_local_mtu'].'</span>';
-                }
-                else {
-                    echo '<br/><span class="box-desc">MTU '. $pw_a['ifMtu'].'</span>';
-                }
-            echo '</td>
+    echo '<tr style="background-color: rgb(' . $bg . ')">
+            <td style="font-size:18px; padding:4px;vertical-align: middle;">' . $pw_a['cpwVcID'] . '</td>
+            <td>' . $pw_a['pw_descr'] . '<br/><span class="box-desc">' . $pw_a['pw_type'] . ' ' . $pw_a['pw_psntype'] . '</span></td>
+            <td>' . generate_port_link($pw_a) . ' <i class="fa fa-arrow-' . $pw_a['ifOperStatus'] . ' report-' . $pw_a['ifOperStatus'] . '" aria-hidden="true"></i><br/><span class="interface-desc">' . $pw_a['ifAlias'] . '</span>';
+    if ($pw_a['pw_local_mtu'] != 0) {
+        echo '<br/><span class="box-desc">MTU ' . $pw_a['ifMtu'] . '</span>';
+        echo '<br/><span class="box-desc">PW MTU ' . $pw_a['pw_local_mtu'] . '</span>';
+    } else {
+        echo '<br/><span class="box-desc">MTU ' . $pw_a['ifMtu'] . '</span>';
+    }
+    echo '</td>
             <td style="vertical-align: middle;"> <i class="fa fa-times" aria-hidden="true" style="font-size:2em;"></i></span> </td>';
 
-            //Only if b-endpoint was found
-            if ($pw_b){
-                echo '<td>' . generate_device_link($pw_b) . '<br/><span class="box-desc"> '. $pw_b['pw_descr'].'</span></td>
-                <td>' . generate_port_link($pw_b) . ' <i class="fa fa-arrow-'.$pw_b['ifOperStatus'].' report-'.$pw_b['ifOperStatus'].'" aria-hidden="true"></i><br/><span class="interface-desc">'. $pw_b['ifAlias'].'</span>';
+    //Only if b-endpoint was found
+    if ($pw_b) {
+        echo '<td>' . generate_device_link($pw_b) . '<br/><span class="box-desc"> ' . $pw_b['pw_descr'] . '</span></td>
+                <td>' . generate_port_link($pw_b) . ' <i class="fa fa-arrow-' . $pw_b['ifOperStatus'] . ' report-' . $pw_b['ifOperStatus'] . '" aria-hidden="true"></i><br/><span class="interface-desc">' . $pw_b['ifAlias'] . '</span>';
 
-                if ($pw_b['pw_local_mtu'] !=0){
-                    echo '<br/><span class="box-desc">MTU '. $pw_b['ifMtu'].'</span>';
-                    echo '<br/><span class="box-desc">PW MTU '. $pw_b['pw_local_mtu'].'</span>';
-                }
-                else {
-                    echo '<br/><span class="box-desc">MTU '. $pw_b['ifMtu'].'</span>';
-                }
-            }
-            else {
-                echo '<td style="font-style: italic; vertical-align: middle;">unresolved remote device</td><td></td>';
-            }
+        if ($pw_b['pw_local_mtu'] != 0) {
+            echo '<br/><span class="box-desc">MTU ' . $pw_b['ifMtu'] . '</span>';
+            echo '<br/><span class="box-desc">PW MTU ' . $pw_b['pw_local_mtu'] . '</span>';
+        } else {
+            echo '<br/><span class="box-desc">MTU ' . $pw_b['ifMtu'] . '</span>';
+        }
+    } else {
+        echo '<td style="font-style: italic; vertical-align: middle;">unresolved remote device</td><td></td>';
+    }
 
-            echo '</tr>';
-
+    echo '</tr>';
 
     if ($vars['view'] == 'minigraphs') {
-        echo '<tr style="background-color: rgb('.$bg.')"><td></td><td colspan=2>';
+        echo '<tr style="background-color: rgb(' . $bg . ')"><td></td><td colspan=2>';
 
         if ($pw_a) {
             $pw_a['width'] = '150';

--- a/includes/html/pages/device/pseudowires.inc.php
+++ b/includes/html/pages/device/pseudowires.inc.php
@@ -34,7 +34,8 @@ if ($vars['view'] == 'minigraphs') {
 
 print_optionbar_end();
 
-echo '<table cellpadding=5 cellspacing=0 class=devicetable width=100%>';
+echo '<table class="table">';
+echo '<tr><th>PW ID</th><th>Local PW Name</th><th>Local Port</th><td></th><th>Remote Device/PW Name</th><th>Remote Port</th></tr>';
 
 $linkdone = [];
 $bg = '';
@@ -44,35 +45,69 @@ foreach (dbFetchRows('SELECT * FROM pseudowires AS P, ports AS I WHERE P.port_id
     if (in_array($pw_a['device_id'] . $pw_a['port_id'], $linkdone)) {
         continue;
     }
-
-    $pw_b = dbFetchRow(
-        'SELECT * from `devices` AS D, `ports` AS I, `pseudowires` AS P WHERE D.device_id = ? AND D.device_id = I.device_id
-        AND P.cpwVcID = ? AND P.port_id = I.port_id',
-        [$pw_a['peer_device_id'], $pw_a['cpwVcID']]
-    );
-    $pw_b = cleanPort($pw_b);
-
     if (! port_permitted($pw_a['port_id'])) {
         continue;
     }
 
-    if (! port_permitted($pw_b['port_id'])) {
-        continue;
+    # if the remote device is valid, resolve their pw & port details
+    if ($pw_a['peer_device_id'] != 0) {
+        $pw_b = dbFetchRow(
+            'SELECT * from `devices` AS D, `ports` AS I, `pseudowires` AS P WHERE D.device_id = ? AND D.device_id = I.device_id
+            AND P.cpwVcID = ? AND P.port_id = I.port_id',
+            [$pw_a['peer_device_id'], $pw_a['cpwVcID']]
+        );
+        $pw_b = cleanPort($pw_b);
+        if (! port_permitted($pw_b['port_id'])) {
+            continue;
+        }
+    }
+    else
+    {
+        unset($pw_b);
     }
 
-    if ($bg == 'ffffff') {
-        $bg = 'e5e5e5';
+    if ($bg == '255,255,255') {
+        $bg = '238, 238, 238';
     } else {
-        $bg = 'ffffff';
+        $bg = '255,255,255';
     }
 
-    echo "<tr style=\"background-color: #$bg;\"><td rowspan=2 style='font-size:18px; padding:4px;'>" . $pw_a['cpwVcID'] . '</td><td>' . generate_port_link($pw_a) . "</td>
-            <td rowspan=2> <i class='fa fa-arrows-alt fa-lg icon-theme' aria-hidden='true'></i> </td>
-            <td>" . generate_device_link($pw_b) . '</td><td>' . generate_port_link($pw_b) . '</td></tr>';
-    echo "<tr style=\"background-color: #$bg;\"><td colspan=2>" . $pw_a['ifAlias'] . '</td><td>' . $pw_b['ifAlias'] . '</td></tr>';
+    echo '<tr style="background-color: rgb('.$bg.')">
+            <td style="font-size:18px; padding:4px;vertical-align: middle;">' . $pw_a['cpwVcID'] .'</td>
+            <td>'.$pw_a['pw_descr']. '<br/><span class="box-desc">'. $pw_a['pw_type'] .' '. $pw_a['pw_psntype'].'</span></td>
+            <td>' . generate_port_link($pw_a) . ' <i class="fa fa-arrow-'.$pw_a['ifOperStatus'].' report-'.$pw_a['ifOperStatus'].'" aria-hidden="true"></i><br/><span class="interface-desc">'. $pw_a['ifAlias'].'</span>';
+                if ($pw_a['pw_local_mtu'] !=0){
+                    echo '<br/><span class="box-desc">MTU '. $pw_a['ifMtu'].'</span>';
+                    echo '<br/><span class="box-desc">PW MTU '. $pw_a['pw_local_mtu'].'</span>';
+                }
+                else {
+                    echo '<br/><span class="box-desc">MTU '. $pw_a['ifMtu'].'</span>';
+                }
+            echo '</td>
+            <td style="vertical-align: middle;"> <i class="fa fa-times" aria-hidden="true" style="font-size:2em;"></i></span> </td>';
+
+            //Only if b-endpoint was found
+            if ($pw_b){
+                echo '<td>' . generate_device_link($pw_b) . '<br/><span class="box-desc"> '. $pw_b['pw_descr'].'</span></td>
+                <td>' . generate_port_link($pw_b) . ' <i class="fa fa-arrow-'.$pw_b['ifOperStatus'].' report-'.$pw_b['ifOperStatus'].'" aria-hidden="true"></i><br/><span class="interface-desc">'. $pw_b['ifAlias'].'</span>';
+
+                if ($pw_b['pw_local_mtu'] !=0){
+                    echo '<br/><span class="box-desc">MTU '. $pw_b['ifMtu'].'</span>';
+                    echo '<br/><span class="box-desc">PW MTU '. $pw_b['pw_local_mtu'].'</span>';
+                }
+                else {
+                    echo '<br/><span class="box-desc">MTU '. $pw_b['ifMtu'].'</span>';
+                }
+            }
+            else {
+                echo '<td style="font-style: italic; vertical-align: middle;">unresolved remote device</td><td></td>';
+            }
+
+            echo '</tr>';
+
 
     if ($vars['view'] == 'minigraphs') {
-        echo "<tr style=\"background-color: #$bg;\"><td></td><td colspan=2>";
+        echo '<tr style="background-color: rgb('.$bg.')"><td></td><td colspan=2>';
 
         if ($pw_a) {
             $pw_a['width'] = '150';


### PR DESCRIPTION
I did a small refresh on the pseudowire page:

- cut the sql queries in half if the remote endpoint is not known
- proper tables and out put if endpoint is not known
- pseudowire description, class, type and MTU is also visible
- visible port state
- less html table, common CSS styles

Im aware this page needs a general refactoring #13781, I took this as a mid step for how to present the data and check if we have the correct data at all (I assume there is a missing cleanup task for deleted hosts, PR will follow)

Before:
![image](https://user-images.githubusercontent.com/13567009/223440735-3619c6bc-f913-4984-ac0f-afe70ca68a96.png)



After:
![223430454-7e500662-3563-4df3-924f-7a18c9eded90](https://user-images.githubusercontent.com/13567009/223469844-0483db45-af12-4677-82e5-945c427b3945.png)

Question:
- is someone into the minigraph view? (in my opinion this does not make much sense)
- does somebody know why there is no cisco-pw polling module?


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [-] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply 14882`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
