### PR TITLE
Jira transport: use template title

### DIFF
--- a/LibreNMS/Alert/Transport/Jira.php
+++ b/LibreNMS/Alert/Transport/Jira.php
@@ -52,7 +52,7 @@ class Jira extends Transport
         $password = $opts['password'];
         $prjkey = $opts['prjkey'];
         $issuetype = $opts['issuetype'];
-        $details = (!empty($obj['title'])) ? $obj['title'] : 'Librenms alert for: ' . $obj['hostname'];
+        $details = empty($obj['title']) ? 'Librenms alert for: ' . $obj['hostname'] : $obj['title'];
         $description = $obj['msg'];
         $url = $opts['url'] . '/rest/api/latest/issue';
         $curl = curl_init();

--- a/LibreNMS/Alert/Transport/Jira.php
+++ b/LibreNMS/Alert/Transport/Jira.php
@@ -52,7 +52,7 @@ class Jira extends Transport
         $password = $opts['password'];
         $prjkey = $opts['prjkey'];
         $issuetype = $opts['issuetype'];
-        $details = ($obj['title'] != '') ? $obj['title'] : 'Librenms alert for: ' . $obj['hostname'];
+        $details = (!empty($obj['title'])) ? $obj['title'] : 'Librenms alert for: ' . $obj['hostname'];
         $description = $obj['msg'];
         $url = $opts['url'] . '/rest/api/latest/issue';
         $curl = curl_init();

--- a/LibreNMS/Alert/Transport/Jira.php
+++ b/LibreNMS/Alert/Transport/Jira.php
@@ -52,7 +52,7 @@ class Jira extends Transport
         $password = $opts['password'];
         $prjkey = $opts['prjkey'];
         $issuetype = $opts['issuetype'];
-        $details = 'Librenms alert for: ' . $obj['hostname'];
+        $details = ($obj['title'] != '') ? $obj['title'] : 'Librenms alert for: ' . $obj['hostname'];
         $description = $obj['msg'];
         $url = $opts['url'] . '/rest/api/latest/issue';
         $curl = curl_init();


### PR DESCRIPTION
Use the title from the Alert Template for the Jira Alert Transport if it's not empty. Else use the default title as it was before the change.
This change gives the flexibility to customize the title of the created Jira issue. This way you can use custom variables in the title like sysLocation, sysName, etc.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
