### PR TITLE
actually use the stats graph for ntp-server_freq now, which as missed in #14834

### DIFF
--- a/includes/html/graphs/application/ntp-server_freq.inc.php
+++ b/includes/html/graphs/application/ntp-server_freq.inc.php
@@ -8,4 +8,4 @@ if (! Rrd::checkRrdExists($filename)) {
     d_echo('RRD "' . $filename . '" not found');
 }
 
-require 'includes/html/graphs/generic_simplex.inc.php';
+require 'includes/html/graphs/generic_stats.inc.php';


### PR DESCRIPTION
Derp! Updated the graph include for the client graph in https://github.com/librenms/librenms/pull/14834 , but I forgot to update that line for ntp-server_freq.

This fixes that.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [X] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
