### PR TITLE
add poller_groups (served) to the poller_cluster table

### DIFF
--- a/LibreNMS/service.py
+++ b/LibreNMS/service.py
@@ -814,12 +814,13 @@ class Service:
         try:
             # Report on the poller instance as a whole
             self._db.query(
-                "INSERT INTO poller_cluster(node_id, poller_name, poller_version, last_report, master) "
-                'values("{0}", "{1}", "{2}", NOW(), {3}) '
-                'ON DUPLICATE KEY UPDATE poller_version="{2}", last_report=NOW(), master={3}; '.format(
+                "INSERT INTO poller_cluster(node_id, poller_name, poller_version, poller_groups, last_report, master) "
+                'values("{0}", "{1}", "{2}", "{3}", NOW(), {4}) '
+                'ON DUPLICATE KEY UPDATE poller_version="{2}", poller_groups="{3}", last_report=NOW(), master={4}; '.format(
                     self.config.node_id,
                     self.config.name,
                     "librenms-service",
+                    ",".join(str(i) for i in self.config.group),
                     1 if self.is_master else 0,
                 )
             )


### PR DESCRIPTION
The Poller Cluster Health table has a column for 'Groups Served'.

If `librenms-service.py` is called with `-g | --group` giving a single group, or list of groups, this overwrites any existing setting read in from the `poller_groups` column of the `poller_cluster` table (if there is one), and the service operates on these groups ( as expected ).

Adding this small patch writes the 'running' groups into the `poller_groups` column.

This aids in visibility of what the service for that node is actually doing.

<img width="830" alt="LibreNMS Poller Cluster Health Groups Served" src="https://user-images.githubusercontent.com/11673421/223898579-f1b18857-2c97-4f2e-9fc2-9832b5220671.png">


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
