### PR TITLE
add graph_stat_percentile_disable config item to disable percentile lines/value printing

### DIFF
--- a/includes/html/graphs/generic_stats.inc.php
+++ b/includes/html/graphs/generic_stats.inc.php
@@ -98,6 +98,8 @@ if (! isset($colour1w)) {
     $iter++;
 }
 
+$graph_stat_percentile_disable = \LibreNMS\Config::get("graph_stat_percentile_disable");
+
 $descr = \LibreNMS\Data\Store\Rrd::fixedSafeDescr($descr, $descr_len);
 
 if ($height > 25) {
@@ -155,14 +157,16 @@ if ($height > 25) {
         $rrd_optionsb .= ' GPRINT:' . $id . '1w:MAX:%5.' . $float_precision . 'lf%s' . $units . ' GPRINT:' . $id . "1w:AVERAGE:'%5." . $float_precision . "lf%s$units\\n'";
     }
 
-    $rrd_optionsb .= ' HRULE:' . $id . '25th#' . $colour25th . ':25th_Percentile';
-    $rrd_optionsb .= ' GPRINT:' . $id . '25th:%' . $float_precision . 'lf%s\n';
+    if (!$graph_stat_percentile_disable){
+        $rrd_optionsb .= ' HRULE:' . $id . '25th#' . $colour25th . ':25th_Percentile';
+        $rrd_optionsb .= ' GPRINT:' . $id . '25th:%' . $float_precision . 'lf%s\n';
 
-    $rrd_optionsb .= ' HRULE:' . $id . '50th#' . $colour50th . ':50th_Percentile';
-    $rrd_optionsb .= ' GPRINT:' . $id . '50th:%' . $float_precision . 'lf%s\n';
+        $rrd_optionsb .= ' HRULE:' . $id . '50th#' . $colour50th . ':50th_Percentile';
+        $rrd_optionsb .= ' GPRINT:' . $id . '50th:%' . $float_precision . 'lf%s\n';
 
-    $rrd_optionsb .= ' HRULE:' . $id . '75th#' . $colour75th . ':75th_Percentile';
-    $rrd_optionsb .= ' GPRINT:' . $id . '75th:%' . $float_precision . 'lf%s\n';
+        $rrd_optionsb .= ' HRULE:' . $id . '75th#' . $colour75th . ':75th_Percentile';
+        $rrd_optionsb .= ' GPRINT:' . $id . '75th:%' . $float_precision . 'lf%s\n';
+    }
 }
 $rrd_options .= $rrd_optionsb;
 $rrd_options .= ' HRULE:0#555555';

--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -1776,6 +1776,13 @@
             "default": null,
             "type": "array"
         },
+        "graph_stat_percentile_disable": {
+            "default": false,
+            "group": "webui",
+            "section": "graph",
+            "order": 7,
+            "type": "boolean"
+        },
         "graph_colours.blues": {
             "default": [
                 "A9A9F2",

--- a/resources/lang/en/settings.php
+++ b/resources/lang/en/settings.php
@@ -1580,6 +1580,10 @@ return [
                 'description' => 'Set the minimum graph height',
                 'help' => 'Minimum Graph Height (default: 300)',
             ],
+            'graph_stat_percentile_disable' => [
+                'description' => 'Disable Percentile for stats graphs globally',
+                'help' => 'Disables display of the percentile values and lines for graphs that display those',
+            ],
         ],
         'device_display_default' => [
             'description' => 'Default device display name template',

--- a/resources/lang/it/settings.php
+++ b/resources/lang/it/settings.php
@@ -1547,6 +1547,10 @@ return [
                 'description' => 'Set the minimum graph height',
                 'help' => 'Minimum Graph Height (default: 300)',
             ],
+            'graph_stat_percentile_disable' => [
+                'description' => 'Disable Percentile for stats graphs globally',
+                'help' => 'Disables display of the percentile values and lines for graphs that display those',
+            ],
         ],
         'device_display_default' => [
             'description' => 'Default device display name template',


### PR DESCRIPTION
This was requested by some one who does not like them.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [X] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
