### PR TITLE
Update test data to account for new vertiv.svg icon

### DIFF
--- a/tests/data/liebert.json
+++ b/tests/data/liebert.json
@@ -14,7 +14,7 @@
                     "os": "liebert",
                     "type": "power",
                     "serial": null,
-                    "icon": "vertiv.png"
+                    "icon": "vertiv.svg"
                 }
             ]
         },

--- a/tests/data/liebert_weblbds.json
+++ b/tests/data/liebert_weblbds.json
@@ -1696,7 +1696,7 @@
                     "os": "liebert",
                     "type": "power",
                     "serial": null,
-                    "icon": "vertiv.png"
+                    "icon": "vertiv.svg"
                 }
             ]
         },

--- a/tests/data/vertiv-pdu_mn03edr1.json
+++ b/tests/data/vertiv-pdu_mn03edr1.json
@@ -14,7 +14,7 @@
                     "os": "vertiv-pdu",
                     "type": "power",
                     "serial": "<private>",
-                    "icon": "vertiv.png"
+                    "icon": "vertiv.svg"
                 }
             ]
         },


### PR DESCRIPTION
Update test data of devices that use the Vertiv icon. The vertiv.png icon was replaced by vertiv.svg in https://github.com/librenms/librenms/pull/14874

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [X] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
