### PR TITLE
SnmpQuery, respect snmp.max_oid

### DIFF
--- a/includes/definitions/hpe-mapdu.yaml
+++ b/includes/definitions/hpe-mapdu.yaml
@@ -5,9 +5,9 @@ icon: hpe
 group: hpe
 mib_dir: hp
 over:
-    - {graph: device_power, text: Power}  
+    - {graph: device_power, text: Power}
     - {graph: device_current, text: Current}
-snmp_max_oid: '8'
+snmp_max_oid: 8
 discovery:
     -
         sysObjectID:

--- a/includes/definitions/tait-tnadmin.yaml
+++ b/includes/definitions/tait-tnadmin.yaml
@@ -3,7 +3,7 @@ text: 'Tait TN Admin OS'
 type: network
 icon: tait
 mib_dir: tait
-snmp_max_oid: '1'
+snmp_max_oid: 1
 over:
     - { graph: device_temperature, text: 'Temperature' }
 discovery:

--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -5273,6 +5273,13 @@
             "type": "integer",
             "units": "seconds"
         },
+        "snmp.max_oid": {
+            "group": "poller",
+            "section": "snmp",
+            "order": 5,
+            "type": "integer",
+            "default": 10
+        },
         "snmp.max_repeaters": {
             "group": "poller",
             "section": "snmp",

--- a/misc/os_schema.json
+++ b/misc/os_schema.json
@@ -391,7 +391,8 @@
             "type": "boolean"
         },
         "snmp_max_oid": {
-            "type": "string"
+            "type": "integer",
+            "minimum": 1
         },
         "ifXmcbc": {
             "type": "boolean"

--- a/resources/lang/en/settings.php
+++ b/resources/lang/en/settings.php
@@ -1413,6 +1413,10 @@ return [
                 'description' => 'Communities (priority)',
                 'help' => 'Enter community strings for v1 and v2c and order them as you want them to be tried',
             ],
+            'max_oid' => [
+                'description' => 'Max OIDs',
+                'help' => 'Maximum OIDs per query.  Can be overriden at OS and device levels.',
+            ],
             'max_repeaters' => [
                 'description' => 'Max Repeaters',
                 'help' => 'Set repeaters to use for SNMP bulk requests',


### PR DESCRIPTION
Previously, the code would query all the oids it received. Now it will split it up into multiple queries if too many are sent.

Prevents some devices snmp service from crashing.

Fixes: #14889

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
