### PR TITLE
Store empty user_func as null

### DIFF
--- a/database/migrations/2023_03_14_130653_migrate_empty_user_funcs_to_null.php
+++ b/database/migrations/2023_03_14_130653_migrate_empty_user_funcs_to_null.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+
+class MigrateEmptyUserFuncsToNull extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        \App\Models\Sensor::where('user_func', '')->update(['user_func' => null]);
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+    }
+}


### PR DESCRIPTION
Turns out there are a few user_func saved as empty strings, these bubbled up as errors after https://github.com/librenms/librenms/pull/14653

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
