### PR TITLE
FTD: Add more OIDs for determining hardware and serial attributes correctly

### DIFF
--- a/includes/definitions/discovery/ftd.yaml
+++ b/includes/definitions/discovery/ftd.yaml
@@ -4,9 +4,12 @@ modules:
         serial:
             - ENTITY-MIB::entPhysicalSerialNum.1
             - ENTITY-MIB::entPhysicalSerialNum.4
+            - ENTITY-MIB::entPhysicalSerialNum.10
         version:
             - ENTITY-MIB::entPhysicalSoftwareRev.1
             - ENTITY-MIB::entPhysicalSoftwareRev.4
+            - ENTITY-MIB::entPhysicalSoftwareRev.10
         hardware:
             - ENTITY-MIB::entPhysicalModelName.1
             - ENTITY-MIB::entPhysicalModelName.4
+            - ENTITY-MIB::entPhysicalModelName.10


### PR DESCRIPTION
Some FTD systems like 4110 and 4120 (probably more) use a different OID (.10, not .1 or .4) for that, so these were added. The version extension is probably not very helpful as the result is an empty string … but at least that OID exists. Note/Reason: without this change, hardware+serial fields will be empty after a (re)discovery.


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [-] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [-] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [-] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

=> No php code changes; tests … not sure if there is any meaningful test for this
 
#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
