### PR TITLE
Health edit coloring

### DIFF
--- a/app/Http/Controllers/DeviceController.php
+++ b/app/Http/Controllers/DeviceController.php
@@ -201,14 +201,14 @@ class DeviceController extends Controller
         ];
 
         // Mgmt
-        if ($device->attribs->firstWhere('attrib_type', 'ipmi_hostname')){
+        if ($device->attribs->firstWhere('attrib_type', 'ipmi_hostname')) {
             $device_links['ipmi'] = [
                 'icon' => 'fa-microchip',
                 'url' => 'https://' . $device->attribs->firstWhere('attrib_type', 'ipmi_hostname')?->attrib_value,
                 'title' => __('Mgmt'),
                 'external' => true,
                 'onclick' => 'http_fallback(this); return false;',
-              ];
+            ];
         }
 
         // SSH

--- a/app/Http/Controllers/DeviceController.php
+++ b/app/Http/Controllers/DeviceController.php
@@ -201,14 +201,14 @@ class DeviceController extends Controller
         ];
 
         // Mgmt
-        if($device->attribs->firstWhere('attrib_type', 'ipmi_hostname')){
+        if ($device->attribs->firstWhere('attrib_type', 'ipmi_hostname')){
             $device_links['ipmi'] = [
                 'icon' => 'fa-microchip',
                 'url' => 'https://' . $device->attribs->firstWhere('attrib_type', 'ipmi_hostname')?->attrib_value,
                 'title' => __('Mgmt'),
                 'external' => true,
-               'onclick' => 'http_fallback(this); return false;',
-             ];
+                'onclick' => 'http_fallback(this); return false;',
+              ];
         }
 
         // SSH

--- a/app/Http/Controllers/DeviceController.php
+++ b/app/Http/Controllers/DeviceController.php
@@ -204,7 +204,7 @@ class DeviceController extends Controller
         if ($device->attribs->firstWhere('attrib_type', 'ipmi_hostname')) {
             $device_links['ipmi'] = [
                 'icon' => 'fa-microchip',
-                'url' => 'https://' . $device->attribs->firstWhere('attrib_type', 'ipmi_hostname')?->attrib_value,
+                'url' => 'https://' . $device->attribs->firstWhere('attrib_type', 'ipmi_hostname')->attrib_value,
                 'title' => __('Mgmt'),
                 'external' => true,
                 'onclick' => 'http_fallback(this); return false;',

--- a/app/Http/Controllers/DeviceController.php
+++ b/app/Http/Controllers/DeviceController.php
@@ -200,6 +200,17 @@ class DeviceController extends Controller
             'onclick' => 'http_fallback(this); return false;',
         ];
 
+        // Mgmt
+        if($device->attribs->firstWhere('attrib_type', 'ipmi_hostname')){
+            $device_links['ipmi'] = [
+                'icon' => 'fa-microchip',
+                'url' => 'https://' . $device->attribs->firstWhere('attrib_type', 'ipmi_hostname')?->attrib_value,
+                'title' => __('Mgmt'),
+                'external' => true,
+               'onclick' => 'http_fallback(this); return false;',
+             ];
+        }
+
         // SSH
         $ssh_url = Config::has('gateone.server')
             ? Config::get('gateone.server') . '?ssh=ssh://' . (Config::get('gateone.use_librenms_user') ? Auth::user()->username . '@' : '') . $device['hostname'] . '&location=' . $device['hostname']

--- a/includes/html/pages/device/edit/sensors-common.php
+++ b/includes/html/pages/device/edit/sensors-common.php
@@ -54,8 +54,17 @@ foreach (dbFetchRows("SELECT * FROM `$table` WHERE `device_id` = ? AND `sensor_d
         $custom = '';
     }
 
+    if((isset($sensor['sensor_limit']) && $sensor['sensor_current'] > $sensor['sensor_limit'])
+    || (isset($sensor['sensor_limit_low']) && $sensor['sensor_current'] < $sensor['sensor_limit_low'])){
+	$sensor_current_state = 'danger';
+    }else if((isset($sensor['sensor_limit_warn']) && $sensor['sensor_current'] > $sensor['sensor_limit_warn'])
+    || (isset($sensor['sensor_limit_low_warn']) && $sensor['sensor_current'] < $sensor['sensor_limit_low_warn'])){
+        $sensor_current_state = 'warning';
+    }else{
+	$sensor_current_state = '';
+    }
     echo '
-        <tr>
+        <tr class="' . $sensor_current_state . '">
         <td>' . $sensor['sensor_class'] . '</td>
         <td>' . $sensor['sensor_type'] . '</td>
         <td style="white-space: nowrap">' . $sensor['sensor_descr'] . '</td>


### PR DESCRIPTION
Makes sensors in warning or alarm status visible in color even when editing limits. In most cases, these are the most frequently searched sensors for adjusting the values.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
