### PR TITLE
Update junos discovery yaml to reference total memory instead of buff…

### DIFF
--- a/includes/definitions/discovery/junos.yaml
+++ b/includes/definitions/discovery/junos.yaml
@@ -30,7 +30,7 @@ modules:
                 descr: jnxOperatingDescr
                 skip_values:
                     -
-                        oid: jnxOperatingBuffer
+                        oid: jnxOperatingMemory
                         op: '='
                         value: 0
                     -

--- a/tests/data/junos_vmx.json
+++ b/tests/data/junos_vmx.json
@@ -12216,6 +12216,17 @@
                 {
                     "entPhysicalIndex": 0,
                     "hrDeviceIndex": 0,
+                    "processor_oid": ".1.3.6.1.4.1.2636.3.1.13.1.8.7.1.0.0",
+                    "processor_index": "7.1.0.0",
+                    "processor_type": "junos",
+                    "processor_usage": 7,
+                    "processor_descr": "FPC: Virtual FPC @ 0/*/*",
+                    "processor_precision": 1,
+                    "processor_perc_warn": 75
+                },
+                {
+                    "entPhysicalIndex": 0,
+                    "hrDeviceIndex": 0,
                     "processor_oid": ".1.3.6.1.4.1.2636.3.1.13.1.8.9.1.0.0",
                     "processor_index": "9.1.0.0",
                     "processor_type": "junos",


### PR DESCRIPTION
…er memory used

Please give a short description what your pull request is for

This fixes issue 14917 where Juniper linecards that have a great deal of memory show buffer usage (jnxOperatingBuffer) as 0%. Discovery for processors is changed to use a check for non-zero jnxOperatingMemory instead which is much more reliable.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
