### PR TITLE
Stacked graphs on zoom to speed

### DIFF
--- a/includes/html/functions.inc.php
+++ b/includes/html/functions.inc.php
@@ -1010,9 +1010,9 @@ function get_oxidized_nodes_list()
  * @param  string  $transparency  value of desired transparency applied to rrdtool options (values 01 - 99)
  * @return array containing transparency and stacked setup
  */
-function generate_stacked_graphs(force_stack = false,$transparency = '88')
+function generate_stacked_graphs($force_stack = false ,$transparency = '88')
 {
-    if (Config::get('webui.graph_stacked') == true or force_stack == true) {
+    if (Config::get('webui.graph_stacked') == true or $force_stack == true) {
         return ['transparency' => $transparency, 'stacked' => '1'];
     } else {
         return ['transparency' => '', 'stacked' => '-1'];

--- a/includes/html/functions.inc.php
+++ b/includes/html/functions.inc.php
@@ -1010,7 +1010,7 @@ function get_oxidized_nodes_list()
  * @param  string  $transparency  value of desired transparency applied to rrdtool options (values 01 - 99)
  * @return array containing transparency and stacked setup
  */
-function generate_stacked_graphs($force_stack = false ,$transparency = '88')
+function generate_stacked_graphs($force_stack = false, $transparency = '88')
 {
     if (Config::get('webui.graph_stacked') == true or $force_stack == true) {
         return ['transparency' => $transparency, 'stacked' => '1'];

--- a/includes/html/functions.inc.php
+++ b/includes/html/functions.inc.php
@@ -1012,7 +1012,7 @@ function get_oxidized_nodes_list()
  */
 function generate_stacked_graphs($force_stack = false, $transparency = '88')
 {
-    if (Config::get('webui.graph_stacked') == true or $force_stack == true) {
+    if (Config::get('webui.graph_stacked') == true || $force_stack == true) {
         return ['transparency' => $transparency, 'stacked' => '1'];
     } else {
         return ['transparency' => '', 'stacked' => '-1'];

--- a/includes/html/functions.inc.php
+++ b/includes/html/functions.inc.php
@@ -1010,9 +1010,9 @@ function get_oxidized_nodes_list()
  * @param  string  $transparency  value of desired transparency applied to rrdtool options (values 01 - 99)
  * @return array containing transparency and stacked setup
  */
-function generate_stacked_graphs($transparency = '88')
+function generate_stacked_graphs(force_stack = false,$transparency = '88')
 {
-    if (Config::get('webui.graph_stacked') == true) {
+    if (Config::get('webui.graph_stacked') == true or force_stack == true) {
         return ['transparency' => $transparency, 'stacked' => '1'];
     } else {
         return ['transparency' => '', 'stacked' => '-1'];

--- a/includes/html/graphs/generic_data.inc.php
+++ b/includes/html/graphs/generic_data.inc.php
@@ -18,7 +18,7 @@ use LibreNMS\Util\Number;
 
 require 'includes/html/graphs/common.inc.php';
 
-$stacked = generate_stacked_graphs();
+$stacked = generate_stacked_graphs((!empty($port['ifSpeed']) &&($vars['port_speed_zoom'] ?? Config::get('graphs.port_speed_zoom'))));
 $inverse = $inverse ?? false;
 $multiplier = $multiplier ?? false;
 $format = $format ?? '';

--- a/includes/html/graphs/generic_data.inc.php
+++ b/includes/html/graphs/generic_data.inc.php
@@ -169,7 +169,7 @@ $rrd_options .= ' LINE1:percentile_in#aa0000';
 $rrd_options .= ' LINE1:dpercentile_out#aa0000';
 
 if (! empty($port['ifSpeed'])) {
-    $speed_line_type = ($vars['port_speed_zoom'] ?? Config::get('graphs.port_speed_zoom')) == 1 ? 'LINE2' : 'HRULE';
+    $speed_line_type = ($vars['port_speed_zoom'] ?? Config::get('graphs.port_speed_zoom')) ? 'LINE2' : 'HRULE';
     $rrd_options .= " $speed_line_type:{$port['ifSpeed']}#000000:'Port Speed " . Number::formatSi($port['ifSpeed'], 2, 3, 'bps') . "\\n'";
 }
 

--- a/includes/html/graphs/generic_data.inc.php
+++ b/includes/html/graphs/generic_data.inc.php
@@ -18,7 +18,7 @@ use LibreNMS\Util\Number;
 
 require 'includes/html/graphs/common.inc.php';
 
-$stacked = generate_stacked_graphs(! empty($port['ifSpeed']) && ($vars['port_speed_zoom'] ?? Config::get('graphs.port_speed_zoom')) == 1);
+$stacked = generate_stacked_graphs(! empty($port['ifSpeed']) && ($vars['port_speed_zoom'] ?? Config::get('graphs.port_speed_zoom')));
 $inverse = $inverse ?? false;
 $multiplier = $multiplier ?? false;
 $format = $format ?? '';

--- a/includes/html/graphs/generic_data.inc.php
+++ b/includes/html/graphs/generic_data.inc.php
@@ -18,7 +18,7 @@ use LibreNMS\Util\Number;
 
 require 'includes/html/graphs/common.inc.php';
 
-$stacked = generate_stacked_graphs(! empty($port['ifSpeed']) && ($vars['port_speed_zoom'] ?? Config::get('graphs.port_speed_zoom')));
+$stacked = generate_stacked_graphs(! empty($port['ifSpeed']) && ($vars['port_speed_zoom'] ?? Config::get('graphs.port_speed_zoom')) == 1);
 $inverse = $inverse ?? false;
 $multiplier = $multiplier ?? false;
 $format = $format ?? '';
@@ -169,7 +169,7 @@ $rrd_options .= ' LINE1:percentile_in#aa0000';
 $rrd_options .= ' LINE1:dpercentile_out#aa0000';
 
 if (! empty($port['ifSpeed'])) {
-    $speed_line_type = ($vars['port_speed_zoom'] ?? Config::get('graphs.port_speed_zoom')) ? 'LINE2' : 'HRULE';
+    $speed_line_type = ($vars['port_speed_zoom'] ?? Config::get('graphs.port_speed_zoom')) == 1 ? 'LINE2' : 'HRULE';
     $rrd_options .= " $speed_line_type:{$port['ifSpeed']}#000000:'Port Speed " . Number::formatSi($port['ifSpeed'], 2, 3, 'bps') . "\\n'";
 }
 

--- a/includes/html/graphs/generic_data.inc.php
+++ b/includes/html/graphs/generic_data.inc.php
@@ -18,7 +18,7 @@ use LibreNMS\Util\Number;
 
 require 'includes/html/graphs/common.inc.php';
 
-$stacked = generate_stacked_graphs((!empty($port['ifSpeed']) &&($vars['port_speed_zoom'] ?? Config::get('graphs.port_speed_zoom'))));
+$stacked = generate_stacked_graphs(! empty($port['ifSpeed']) && ($vars['port_speed_zoom'] ?? Config::get('graphs.port_speed_zoom')));
 $inverse = $inverse ?? false;
 $multiplier = $multiplier ?? false;
 $format = $format ?? '';

--- a/includes/html/pages/graphs.inc.php
+++ b/includes/html/pages/graphs.inc.php
@@ -156,7 +156,7 @@ if (! $auth) {
 
     if ($vars['type'] == 'port_bits') {
         echo ' | ';
-        if ($vars['port_speed_zoom'] ?? Config::get('graphs.port_speed_zoom')) {
+        if (($vars['port_speed_zoom'] ?? Config::get('graphs.port_speed_zoom')) == 1) {
             echo generate_link('Zoom to Traffic', $vars, ['page' => 'graphs', 'port_speed_zoom' => 0]);
         } else {
             echo generate_link('Zoom to Port Speed', $vars, ['page' => 'graphs', 'port_speed_zoom' => 1]);

--- a/includes/html/pages/graphs.inc.php
+++ b/includes/html/pages/graphs.inc.php
@@ -156,7 +156,7 @@ if (! $auth) {
 
     if ($vars['type'] == 'port_bits') {
         echo ' | ';
-        if (($vars['port_speed_zoom'] ?? Config::get('graphs.port_speed_zoom'))) {
+        if ($vars['port_speed_zoom'] ?? Config::get('graphs.port_speed_zoom')) {
             echo generate_link('Zoom to Traffic', $vars, ['page' => 'graphs', 'port_speed_zoom' => 0]);
         } else {
             echo generate_link('Zoom to Port Speed', $vars, ['page' => 'graphs', 'port_speed_zoom' => 1]);

--- a/includes/html/pages/graphs.inc.php
+++ b/includes/html/pages/graphs.inc.php
@@ -156,7 +156,7 @@ if (! $auth) {
 
     if ($vars['type'] == 'port_bits') {
         echo ' | ';
-        if (($vars['port_speed_zoom'] ?? Config::get('graphs.port_speed_zoom')) == 1) {
+        if (($vars['port_speed_zoom'] ?? Config::get('graphs.port_speed_zoom'))) {
             echo generate_link('Zoom to Traffic', $vars, ['page' => 'graphs', 'port_speed_zoom' => 0]);
         } else {
             echo generate_link('Zoom to Port Speed', $vars, ['page' => 'graphs', 'port_speed_zoom' => 1]);


### PR DESCRIPTION
Zoom to speed doesn't scale the egress properly on inverse graphs, however if it were to scale it properly, the graphs would be small and unreadable. So best course of action is to stack when Zoomed to speed.

Edit:
While testing this out, I found some issues in the logic, probably from changes in PHP. I fixed them.
Edit2:
First Edit was fixed with #14967
Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
