### PR TITLE
Cleanup enable bgp setting

### DIFF
--- a/app/Http/Controllers/OverviewController.php
+++ b/app/Http/Controllers/OverviewController.php
@@ -63,14 +63,12 @@ class OverviewController extends Controller
             ->get();
 
         // TODO: is inAlarm() equal to: bgpPeerAdminStatus != 'start' AND bgpPeerState != 'established' AND bgpPeerState != ''  ?
-        if (Config::get('enable_bgp')) {
             $bgp_down = BgpPeer::hasAccess(Auth::user())
                 ->inAlarm()
                 ->limit(Config::get('front_page_down_box_limit'))
                 ->with('device')
                 ->get();
-        }
-
+        
         if (filter_var(Config::get('uptime_warning'), FILTER_VALIDATE_FLOAT) !== false
             && Config::get('uptime_warning') > 0
         ) {

--- a/app/Http/Controllers/OverviewController.php
+++ b/app/Http/Controllers/OverviewController.php
@@ -63,11 +63,11 @@ class OverviewController extends Controller
             ->get();
 
         // TODO: is inAlarm() equal to: bgpPeerAdminStatus != 'start' AND bgpPeerState != 'established' AND bgpPeerState != ''  ?
-            $bgp_down = BgpPeer::hasAccess(Auth::user())
-                ->inAlarm()
-                ->limit(Config::get('front_page_down_box_limit'))
-                ->with('device')
-                ->get();
+        $bgp_down = BgpPeer::hasAccess(Auth::user())
+            ->inAlarm()
+            ->limit(Config::get('front_page_down_box_limit'))
+            ->with('device')
+            ->get();
         
         if (filter_var(Config::get('uptime_warning'), FILTER_VALIDATE_FLOAT) !== false
             && Config::get('uptime_warning') > 0

--- a/app/Http/Controllers/OverviewController.php
+++ b/app/Http/Controllers/OverviewController.php
@@ -68,7 +68,7 @@ class OverviewController extends Controller
             ->limit(Config::get('front_page_down_box_limit'))
             ->with('device')
             ->get();
-        
+
         if (filter_var(Config::get('uptime_warning'), FILTER_VALIDATE_FLOAT) !== false
             && Config::get('uptime_warning') > 0
         ) {

--- a/doc/Support/Configuration.md
+++ b/doc/Support/Configuration.md
@@ -657,7 +657,6 @@ Please refer to [Billing](../Extensions/Billing-Module.md)
 ## Global module support
 
 ```bash
-lnms config:set enable_bgp true # Enable BGP session collection and display
 lnms config:set enable_syslog false # Enable Syslog
 lnms config:set enable_inventory true # Enable Inventory
 lnms config:set enable_pseudowires true # Enable Pseudowires

--- a/includes/discovery/bgp-peers.inc.php
+++ b/includes/discovery/bgp-peers.inc.php
@@ -4,196 +4,196 @@ use LibreNMS\Config;
 use LibreNMS\Exceptions\InvalidIpException;
 use LibreNMS\Util\IP;
 
-    //
-    // Load OS specific file
-    //
-    if (file_exists(Config::get('install_dir') . "/includes/discovery/bgp-peers/{$device['os']}.inc.php")) {
-        include Config::get('install_dir') . "/includes/discovery/bgp-peers/{$device['os']}.inc.php";
-    }
+//
+// Load OS specific file
+//
+if (file_exists(Config::get('install_dir') . "/includes/discovery/bgp-peers/{$device['os']}.inc.php")) {
+    include Config::get('install_dir') . "/includes/discovery/bgp-peers/{$device['os']}.inc.php";
+}
 
-    if (empty($bgpLocalAs)) {
-        $bgpLocalAs = snmp_getnext($device, 'bgpLocalAs', '-OQUsv', 'BGP4-MIB');
-    }
+if (empty($bgpLocalAs)) {
+    $bgpLocalAs = snmp_getnext($device, 'bgpLocalAs', '-OQUsv', 'BGP4-MIB');
+}
 
-    foreach (DeviceCache::getPrimary()->getVrfContexts() as $context_name) {
-        $device['context_name'] = $context_name;
-        $peer2 = false;
-        $peers_data = '';
-        $bgp4_mib = false;
+foreach (DeviceCache::getPrimary()->getVrfContexts() as $context_name) {
+    $device['context_name'] = $context_name;
+    $peer2 = false;
+    $peers_data = '';
+    $bgp4_mib = false;
 
-        if (is_numeric($bgpLocalAs)) {
-            echo "AS$bgpLocalAs ";
-            if ($bgpLocalAs != $device['bgpLocalAs']) {
-                dbUpdate(['bgpLocalAs' => $bgpLocalAs], 'devices', 'device_id=?', [$device['device_id']]);
-                echo 'Updated AS ';
-            }
-
-            if ($device['os_group'] === 'arista') {
-                $peers_data = snmp_walk($device, 'aristaBgp4V2PeerRemoteAs', '-Oq', 'ARISTA-BGP4V2-MIB');
-                $peer2 = true;
-            } elseif ($device['os'] == 'junos') {
-                $peers_data = snmp_walk($device, 'jnxBgpM2PeerRemoteAs', '-Onq', 'BGP4-V2-MIB-JUNIPER', 'junos');
-            } elseif ($device['os_group'] === 'cisco') {
-                $peers_data = snmp_walk($device, 'cbgpPeer2RemoteAs', '-Oq', 'CISCO-BGP4-MIB');
-                $peer2 = ! empty($peers_data);
-            } elseif ($device['os'] === 'cumulus') {
-                $peers_data = snmp_walk($device, 'bgpPeerRemoteAs', '-Oq', 'CUMULUS-BGPUN-MIB');
-                $peer2 = ! empty($peers_data);
-            }
-
-            if (empty($peers_data)) {
-                $bgp4_mib = true;
-                $peers_data = preg_replace('/= /', '', snmp_walk($device, 'bgpPeerRemoteAs', '-OQ', 'BGP4-MIB'));
-            }
-        } else {
-            echo 'No BGP on host';
-            if ($device['bgpLocalAs']) {
-                dbUpdate(['bgpLocalAs' => ['NULL']], 'devices', 'device_id=?', [$device['device_id']]);
-                echo ' (Removed ASN) ';
-            }
+    if (is_numeric($bgpLocalAs)) {
+        echo "AS$bgpLocalAs ";
+        if ($bgpLocalAs != $device['bgpLocalAs']) {
+            dbUpdate(['bgpLocalAs' => $bgpLocalAs], 'devices', 'device_id=?', [$device['device_id']]);
+            echo 'Updated AS ';
         }
 
-        $peerlist = build_bgp_peers($device, $peers_data, $peer2);
+        if ($device['os_group'] === 'arista') {
+            $peers_data = snmp_walk($device, 'aristaBgp4V2PeerRemoteAs', '-Oq', 'ARISTA-BGP4V2-MIB');
+            $peer2 = true;
+        } elseif ($device['os'] == 'junos') {
+            $peers_data = snmp_walk($device, 'jnxBgpM2PeerRemoteAs', '-Onq', 'BGP4-V2-MIB-JUNIPER', 'junos');
+        } elseif ($device['os_group'] === 'cisco') {
+            $peers_data = snmp_walk($device, 'cbgpPeer2RemoteAs', '-Oq', 'CISCO-BGP4-MIB');
+            $peer2 = ! empty($peers_data);
+        } elseif ($device['os'] === 'cumulus') {
+            $peers_data = snmp_walk($device, 'bgpPeerRemoteAs', '-Oq', 'CUMULUS-BGPUN-MIB');
+            $peer2 = ! empty($peers_data);
+        }
 
-        // Process discovered peers
-        if (! empty($peerlist)) {
-            $af_data = [];
-            $af_list = [];
+        if (empty($peers_data)) {
+            $bgp4_mib = true;
+            $peers_data = preg_replace('/= /', '', snmp_walk($device, 'bgpPeerRemoteAs', '-OQ', 'BGP4-MIB'));
+        }
+    } else {
+        echo 'No BGP on host';
+        if ($device['bgpLocalAs']) {
+            dbUpdate(['bgpLocalAs' => ['NULL']], 'devices', 'device_id=?', [$device['device_id']]);
+            echo ' (Removed ASN) ';
+        }
+    }
 
-            foreach ($peerlist as $peer) {
-                $peer['astext'] = get_astext($peer['as']);
+    $peerlist = build_bgp_peers($device, $peers_data, $peer2);
 
-                add_bgp_peer($device, $peer);
+    // Process discovered peers
+    if (! empty($peerlist)) {
+        $af_data = [];
+        $af_list = [];
 
-                if (empty($af_data)) {
-                    if ($device['os_group'] == 'cisco') {
-                        if ($peer2 === true) {
-                            $af_data = snmpwalk_cache_oid($device, 'cbgpPeer2AddrFamilyEntry', [], 'CISCO-BGP4-MIB');
+        foreach ($peerlist as $peer) {
+            $peer['astext'] = get_astext($peer['as']);
+
+            add_bgp_peer($device, $peer);
+
+            if (empty($af_data)) {
+                if ($device['os_group'] == 'cisco') {
+                    if ($peer2 === true) {
+                        $af_data = snmpwalk_cache_oid($device, 'cbgpPeer2AddrFamilyEntry', [], 'CISCO-BGP4-MIB');
+                    }
+                    if (empty($af_data)) {
+                        $af_data = snmpwalk_cache_oid($device, 'cbgpPeerAddrFamilyEntry', [], 'CISCO-BGP4-MIB');
+                        $peer2 = false;
+                    }
+                } elseif ($device['os_group'] === 'arista') {
+                    $af_data = snmpwalk_cache_oid($device, 'aristaBgp4V2PrefixInPrefixes', $af_data, 'ARISTA-BGP4V2-MIB');
+                } elseif ($device['os'] === 'aos7') {
+                    $af_data = snmpwalk_cache_oid($device, 'alaBgpPeerRcvdPrefixes', $af_data, 'ALCATEL-IND1-BGP-MIB');
+                }
+            }
+
+            // build the list
+            if (! empty($af_data)) {
+                $af_list = build_cbgp_peers($device, $peer, $af_data, $peer2);
+            }
+
+            if (! $bgp4_mib && $device['os'] == 'junos') {
+                $afis['ipv4'] = 'ipv4';
+                $afis['ipv6'] = 'ipv6';
+                $afis[25] = 'l2vpn';
+                $safis[1] = 'unicast';
+                $safis[2] = 'multicast';
+                $safis[3] = 'unicastAndMulticast';
+                $safis[4] = 'labeledUnicast';
+                $safis[5] = 'mvpn';
+                $safis[65] = 'vpls';
+                $safis[70] = 'evpn';
+                $safis[128] = 'vpn';
+                $safis[132] = 'rtfilter';
+                $safis[133] = 'flow';
+
+                if (! isset($j_peerIndexes)) {
+                    $j_bgp = snmpwalk_cache_multi_oid($device, 'jnxBgpM2PeerTable', [], 'BGP4-V2-MIB-JUNIPER', 'junos');
+                    d_echo($j_bgp);
+                    $j_peerIndexes = [];
+                    foreach ($j_bgp as $index => $entry) {
+                        $peer_index = $entry['jnxBgpM2PeerIndex'];
+                        try {
+                            $ip = IP::fromHexString($entry['jnxBgpM2PeerRemoteAddr']);
+                            d_echo('peerindex for ' . $ip->getFamily() . " $ip is $peer_index\n");
+                            $j_peerIndexes[(string) $ip] = $peer_index;
+                        } catch (InvalidIpException $e) {
+                            d_echo("Unable to parse IP for peer $peer_index: " . $entry['jnxBgpM2PeerRemoteAddr'] . PHP_EOL);
                         }
-                        if (empty($af_data)) {
-                            $af_data = snmpwalk_cache_oid($device, 'cbgpPeerAddrFamilyEntry', [], 'CISCO-BGP4-MIB');
-                            $peer2 = false;
-                        }
-                    } elseif ($device['os_group'] === 'arista') {
-                        $af_data = snmpwalk_cache_oid($device, 'aristaBgp4V2PrefixInPrefixes', $af_data, 'ARISTA-BGP4V2-MIB');
-                    } elseif ($device['os'] === 'aos7') {
-                        $af_data = snmpwalk_cache_oid($device, 'alaBgpPeerRcvdPrefixes', $af_data, 'ALCATEL-IND1-BGP-MIB');
                     }
                 }
 
-                // build the list
-                if (! empty($af_data)) {
-                    $af_list = build_cbgp_peers($device, $peer, $af_data, $peer2);
-                }
-
-                if (! $bgp4_mib && $device['os'] == 'junos') {
-                    $afis['ipv4'] = 'ipv4';
-                    $afis['ipv6'] = 'ipv6';
-                    $afis[25] = 'l2vpn';
-                    $safis[1] = 'unicast';
-                    $safis[2] = 'multicast';
-                    $safis[3] = 'unicastAndMulticast';
-                    $safis[4] = 'labeledUnicast';
-                    $safis[5] = 'mvpn';
-                    $safis[65] = 'vpls';
-                    $safis[70] = 'evpn';
-                    $safis[128] = 'vpn';
-                    $safis[132] = 'rtfilter';
-                    $safis[133] = 'flow';
-
-                    if (! isset($j_peerIndexes)) {
-                        $j_bgp = snmpwalk_cache_multi_oid($device, 'jnxBgpM2PeerTable', [], 'BGP4-V2-MIB-JUNIPER', 'junos');
-                        d_echo($j_bgp);
-                        $j_peerIndexes = [];
-                        foreach ($j_bgp as $index => $entry) {
-                            $peer_index = $entry['jnxBgpM2PeerIndex'];
-                            try {
-                                $ip = IP::fromHexString($entry['jnxBgpM2PeerRemoteAddr']);
-                                d_echo('peerindex for ' . $ip->getFamily() . " $ip is $peer_index\n");
-                                $j_peerIndexes[(string) $ip] = $peer_index;
-                            } catch (InvalidIpException $e) {
-                                d_echo("Unable to parse IP for peer $peer_index: " . $entry['jnxBgpM2PeerRemoteAddr'] . PHP_EOL);
-                            }
-                        }
-                    }
-
-                    if (! isset($j_afisafi)) {
-                        $j_prefixes = snmpwalk_cache_multi_oid($device, 'jnxBgpM2PrefixCountersTable', [], 'BGP4-V2-MIB-JUNIPER', 'junos');
-                        $j_afisafi = [];
-                        foreach (array_keys($j_prefixes) as $key) {
-                            [$index,$afisafi] = explode('.', $key, 2);
-                            $j_afisafi[$index][] = $afisafi;
-                        }
-                    }
-
-                    foreach ($j_afisafi[$j_peerIndexes[$peer['ip']]] ?? [] as $afisafi) {
-                        [$afi,$safi] = explode('.', $afisafi);
-                        $afi = $afis[$afi];
-                        $safi = $safis[$safi];
-                        $af_list[$peer['ip']][$afi][$safi] = 1;
-                        add_cbgp_peer($device, $peer, $afi, $safi);
+                if (! isset($j_afisafi)) {
+                    $j_prefixes = snmpwalk_cache_multi_oid($device, 'jnxBgpM2PrefixCountersTable', [], 'BGP4-V2-MIB-JUNIPER', 'junos');
+                    $j_afisafi = [];
+                    foreach (array_keys($j_prefixes) as $key) {
+                        [$index,$afisafi] = explode('.', $key, 2);
+                        $j_afisafi[$index][] = $afisafi;
                     }
                 }
 
-                $af_query = 'SELECT bgpPeerIdentifier, afi, safi FROM bgpPeers_cbgp WHERE `device_id`=? AND bgpPeerIdentifier=? AND context_name=?';
-                foreach (dbFetchRows($af_query, [$device['device_id'], $peer['ip'], $device['context_name']]) as $entry) {
-                    $afi = $entry['afi'];
-                    $safi = $entry['safi'];
-                    if (! $af_list[$entry['bgpPeerIdentifier']][$afi][$safi]) {
-                        dbDelete(
-                            'bgpPeers_cbgp',
-                            '`device_id`=? AND `bgpPeerIdentifier`=? AND context_name=? AND afi=? AND safi=?',
-                            [$device['device_id'], $peer['ip'], $device['context_name'], $afi, $safi]
-                        );
-                    }
+                foreach ($j_afisafi[$j_peerIndexes[$peer['ip']]] ?? [] as $afisafi) {
+                    [$afi,$safi] = explode('.', $afisafi);
+                    $afi = $afis[$afi];
+                    $safi = $safis[$safi];
+                    $af_list[$peer['ip']][$afi][$safi] = 1;
+                    add_cbgp_peer($device, $peer, $afi, $safi);
                 }
             }
-            unset($j_afisafi);
-            unset($j_prefixes);
-            unset($j_bgp);
-            unset($j_peerIndexes);
+
+            $af_query = 'SELECT bgpPeerIdentifier, afi, safi FROM bgpPeers_cbgp WHERE `device_id`=? AND bgpPeerIdentifier=? AND context_name=?';
+            foreach (dbFetchRows($af_query, [$device['device_id'], $peer['ip'], $device['context_name']]) as $entry) {
+                $afi = $entry['afi'];
+                $safi = $entry['safi'];
+                if (! $af_list[$entry['bgpPeerIdentifier']][$afi][$safi]) {
+                    dbDelete(
+                        'bgpPeers_cbgp',
+                        '`device_id`=? AND `bgpPeerIdentifier`=? AND context_name=? AND afi=? AND safi=?',
+                        [$device['device_id'], $peer['ip'], $device['context_name'], $afi, $safi]
+                    );
+                }
+            }
         }
-
-        // clean up peers
-        $params = [$device['device_id'], $device['context_name']];
-        $query = 'device_id=? AND context_name=?';
-        if (! empty($peerlist)) {
-            $query .= ' AND bgpPeerIdentifier NOT IN ' . dbGenPlaceholders(count($peerlist));
-            $params = array_merge($params, array_column($peerlist, 'ip'));
-        }
-
-        $deleted = dbDelete('bgpPeers', $query, $params);
-        dbDelete('bgpPeers_cbgp', $query, $params);
-
-        echo str_repeat('-', $deleted);
-        echo PHP_EOL;
-
-        unset(
-            $device['context_name'],
-            $peerlist,
-            $af_data
-        );
+        unset($j_afisafi);
+        unset($j_prefixes);
+        unset($j_bgp);
+        unset($j_peerIndexes);
     }
 
-    // delete unknown contexts
-    $contexts = dbFetchColumn(
-        'SELECT DISTINCT context_name FROM bgpPeers WHERE device_id=?',
-        [$device['device_id']]
-    );
-
-    $existing_contexts = DeviceCache::getPrimary()->getVrfContexts();
-    foreach ($contexts as $context) {
-        if (! in_array($context, $existing_contexts)) {
-            dbDelete('bgpPeers', 'device_id=? and context_name=?', [$device['device_id'], $context]);
-            dbDelete('bgpPeers_cbgp', 'device_id=? and context_name=?', [$device['device_id'], $context]);
-            echo '-';
-        }
+    // clean up peers
+    $params = [$device['device_id'], $device['context_name']];
+    $query = 'device_id=? AND context_name=?';
+    if (! empty($peerlist)) {
+        $query .= ' AND bgpPeerIdentifier NOT IN ' . dbGenPlaceholders(count($peerlist));
+        $params = array_merge($params, array_column($peerlist, 'ip'));
     }
+
+    $deleted = dbDelete('bgpPeers', $query, $params);
+    dbDelete('bgpPeers_cbgp', $query, $params);
+
+    echo str_repeat('-', $deleted);
+    echo PHP_EOL;
 
     unset(
         $device['context_name'],
-        $peers_data,
-        $af_data,
-        $contexts
+        $peerlist,
+        $af_data
     );
+}
+
+// delete unknown contexts
+$contexts = dbFetchColumn(
+    'SELECT DISTINCT context_name FROM bgpPeers WHERE device_id=?',
+    [$device['device_id']]
+);
+
+$existing_contexts = DeviceCache::getPrimary()->getVrfContexts();
+foreach ($contexts as $context) {
+    if (! in_array($context, $existing_contexts)) {
+        dbDelete('bgpPeers', 'device_id=? and context_name=?', [$device['device_id'], $context]);
+        dbDelete('bgpPeers_cbgp', 'device_id=? and context_name=?', [$device['device_id'], $context]);
+        echo '-';
+    }
+}
+
+unset(
+    $device['context_name'],
+    $peers_data,
+    $af_data,
+    $contexts
+);
 

--- a/includes/discovery/bgp-peers.inc.php
+++ b/includes/discovery/bgp-peers.inc.php
@@ -4,7 +4,6 @@ use LibreNMS\Config;
 use LibreNMS\Exceptions\InvalidIpException;
 use LibreNMS\Util\IP;
 
-if (Config::get('enable_bgp')) {
     //
     // Load OS specific file
     //
@@ -197,4 +196,4 @@ if (Config::get('enable_bgp')) {
         $af_data,
         $contexts
     );
-}
+

--- a/includes/discovery/bgp-peers.inc.php
+++ b/includes/discovery/bgp-peers.inc.php
@@ -196,4 +196,3 @@ unset(
     $af_data,
     $contexts
 );
-

--- a/includes/discovery/bgp-peers/dell-os10.inc.php
+++ b/includes/discovery/bgp-peers/dell-os10.inc.php
@@ -29,7 +29,6 @@ use App\Models\Vrf;
 use LibreNMS\Config;
 use LibreNMS\Util\IP;
 
-if (Config::get('enable_bgp')) {
     if ($device['os'] == 'dell-os10') {
         $bgpPeersCache = snmpwalk_cache_multi_oid($device, 'os10bgp4V2PeerTable', [], 'DELLEMC-OS10-BGP4V2-MIB', 'dell');
         foreach ($bgpPeersCache as $key => $value) {
@@ -117,4 +116,3 @@ if (Config::get('enable_bgp')) {
         unset($bgpPeers);
         // No return statement here, so standard BGP mib will still be polled after this file is executed.
     }
-}

--- a/includes/discovery/bgp-peers/dell-os10.inc.php
+++ b/includes/discovery/bgp-peers/dell-os10.inc.php
@@ -29,90 +29,90 @@ use App\Models\Vrf;
 use LibreNMS\Config;
 use LibreNMS\Util\IP;
 
-    if ($device['os'] == 'dell-os10') {
-        $bgpPeersCache = snmpwalk_cache_multi_oid($device, 'os10bgp4V2PeerTable', [], 'DELLEMC-OS10-BGP4V2-MIB', 'dell');
-        foreach ($bgpPeersCache as $key => $value) {
-            $oid = explode('.', $key);
-            $vrfInstance = array_shift($oid);       // os10bgp4V2PeerInstance
-            $remoteAddressType = array_shift($oid); // os10bgp4V2PeerRemoteAddrType
-            $address = IP::fromSnmpString(implode(' ', $oid))->compressed(); // os10bgp4V2PeerRemoteAddr
-            $bgpPeers[$vrfInstance][$address] = $value;
-        }
-        unset($bgpPeersCache);
-
-        $vrfs = DeviceCache::getPrimary()->vrfs->pluck('vrf_id', 'vrf_oid');
-
-        foreach ($bgpPeers as $vrfInstance => $peer) {
-            $vrfId = $vrfs->get($vrfInstance, 1); // According to the MIB
-
-            foreach ($peer as $address => $value) {
-                // resolve AS number by DNS_TXT record
-                $astext = get_astext($value['os10bgp4V2PeerRemoteAs']);
-
-                // FIXME - the `devices` table gets updated in the main bgp-peers.inc.php
-                // Setting it here avoids the code that resets it to null if not found in BGP4-MIB.
-                $bgpLocalAs = $value['os10bgp4V2PeerLocalAs'];
-
-                if (! DeviceCache::getPrimary()->bgppeers()->where('bgpPeerIdentifier', $address)->where('vrf_id', $vrfId)->exists()) {
-                    $row = [
-                        'vrf_id' => $vrfId,
-                        'bgpPeerIdentifier' => $address,
-                        'bgpPeerRemoteAs' => $value['os10bgp4V2PeerRemoteAs'],
-                        'bgpPeerState' => 'idle',
-                        'bgpPeerAdminStatus' => 'stop',
-                        'bgpLocalAddr' => '0.0.0.0',
-                        'bgpPeerRemoteAddr' => '0.0.0.0',
-                        'bgpPeerInUpdates' => 0,
-                        'bgpPeerOutUpdates' => 0,
-                        'bgpPeerInTotalMessages' => 0,
-                        'bgpPeerOutTotalMessages' => 0,
-                        'bgpPeerFsmEstablishedTime' => 0,
-                        'bgpPeerInUpdateElapsedTime' => 0,
-                        'astext' => $astext,
-                    ];
-                    DeviceCache::getPrimary()->bgppeers()->create($row);
-
-                    if (Config::get('autodiscovery.bgp')) {
-                        $name = gethostbyaddr($address);
-                        discover_new_device($name, $device, 'BGP');
-                    }
-                    echo '+';
-                } else {
-                    BgpPeer::where('bgpPeerRemoteAs', $value['os10bgp4V2PeerRemoteAs'])->where('astext', $astext)->update(['bgpPeerIdentifier' => $address, 'device_id' => $device['device_id'], 'vrf_id' => $vrfId]);
-                    echo '.';
-                }
-            }
-        }
-
-        $af_data = snmpwalk_cache_oid($device, 'os10bgp4V2PrefixInPrefixes', [], 'DELLEMC-OS10-BGP4V2-MIB', 'dell');
-        foreach ($af_data as $key => $value) {
-            $oid = explode('.', $key);
-            $vrfInstance = array_shift($oid);       // os10bgp4V2PeerInstance
-            $remoteAddressType = array_shift($oid); // os10bgp4V2PeerRemoteAddrType
-            $safi = array_pop($oid);                // os10bgp4V2PrefixGaugesSafi
-            $afi = array_pop($oid);                 // os10bgp4V2PrefixGaugesAfi
-            $address = IP::fromSnmpString(implode(' ', $oid))->compressed(); // os10bgp4V2PeerRemoteAddr
-            // add to `bgpPeers_cbgp` table
-            add_cbgp_peer($device, ['ip' => $address], $afi, $safi);
-        }
-
-        // clean up peers
-        if (Vrf::where('device_id', $device['device_id'])->count() == 0) {
-            $peers = BgpPeer::select('vrf_id', 'bgpPeerIdentifier')->where('device_id', $device['device_id']);
-        } else {
-            $peers = dbFetchRows('SELECT `B`.`vrf_id` AS `vrf_id`, `bgpPeerIdentifier` FROM `bgpPeers` AS B LEFT JOIN `vrfs` AS V ON `B`.`vrf_id` = `V`.`vrf_id` WHERE `B`.`device_id` = ?', [$device['device_id']]);
-        }
-        foreach ($peers as $peer) {
-            $vrfId = $peer['vrf_id'];
-            $address = $peer['bgpPeerIdentifier'];
-
-            if (empty($bgpPeers[$vrfInstance][$address])) {
-                $deleted = BgpPeer::where('device_id', $device['device_id'])->where('bgpPeerIdentifier', $address)->where('vrf_id', $vrfId)->delete();
-
-                echo str_repeat('-', $deleted);
-                echo PHP_EOL;
-            }
-        }
-        unset($bgpPeers);
-        // No return statement here, so standard BGP mib will still be polled after this file is executed.
+if ($device['os'] == 'dell-os10') {
+    $bgpPeersCache = snmpwalk_cache_multi_oid($device, 'os10bgp4V2PeerTable', [], 'DELLEMC-OS10-BGP4V2-MIB', 'dell');
+    foreach ($bgpPeersCache as $key => $value) {
+        $oid = explode('.', $key);
+        $vrfInstance = array_shift($oid);       // os10bgp4V2PeerInstance
+        $remoteAddressType = array_shift($oid); // os10bgp4V2PeerRemoteAddrType
+        $address = IP::fromSnmpString(implode(' ', $oid))->compressed(); // os10bgp4V2PeerRemoteAddr
+        $bgpPeers[$vrfInstance][$address] = $value;
     }
+    unset($bgpPeersCache);
+
+    $vrfs = DeviceCache::getPrimary()->vrfs->pluck('vrf_id', 'vrf_oid');
+
+    foreach ($bgpPeers as $vrfInstance => $peer) {
+        $vrfId = $vrfs->get($vrfInstance, 1); // According to the MIB
+
+        foreach ($peer as $address => $value) {
+            // resolve AS number by DNS_TXT record
+            $astext = get_astext($value['os10bgp4V2PeerRemoteAs']);
+
+            // FIXME - the `devices` table gets updated in the main bgp-peers.inc.php
+            // Setting it here avoids the code that resets it to null if not found in BGP4-MIB.
+            $bgpLocalAs = $value['os10bgp4V2PeerLocalAs'];
+
+            if (! DeviceCache::getPrimary()->bgppeers()->where('bgpPeerIdentifier', $address)->where('vrf_id', $vrfId)->exists()) {
+                $row = [
+                    'vrf_id' => $vrfId,
+                    'bgpPeerIdentifier' => $address,
+                    'bgpPeerRemoteAs' => $value['os10bgp4V2PeerRemoteAs'],
+                    'bgpPeerState' => 'idle',
+                    'bgpPeerAdminStatus' => 'stop',
+                    'bgpLocalAddr' => '0.0.0.0',
+                    'bgpPeerRemoteAddr' => '0.0.0.0',
+                    'bgpPeerInUpdates' => 0,
+                    'bgpPeerOutUpdates' => 0,
+                    'bgpPeerInTotalMessages' => 0,
+                    'bgpPeerOutTotalMessages' => 0,
+                    'bgpPeerFsmEstablishedTime' => 0,
+                    'bgpPeerInUpdateElapsedTime' => 0,
+                    'astext' => $astext,
+                ];
+                DeviceCache::getPrimary()->bgppeers()->create($row);
+
+                if (Config::get('autodiscovery.bgp')) {
+                    $name = gethostbyaddr($address);
+                    discover_new_device($name, $device, 'BGP');
+                }
+                echo '+';
+            } else {
+                BgpPeer::where('bgpPeerRemoteAs', $value['os10bgp4V2PeerRemoteAs'])->where('astext', $astext)->update(['bgpPeerIdentifier' => $address, 'device_id' => $device['device_id'], 'vrf_id' => $vrfId]);
+                echo '.';
+            }
+        }
+    }
+
+    $af_data = snmpwalk_cache_oid($device, 'os10bgp4V2PrefixInPrefixes', [], 'DELLEMC-OS10-BGP4V2-MIB', 'dell');
+    foreach ($af_data as $key => $value) {
+        $oid = explode('.', $key);
+        $vrfInstance = array_shift($oid);       // os10bgp4V2PeerInstance
+        $remoteAddressType = array_shift($oid); // os10bgp4V2PeerRemoteAddrType
+        $safi = array_pop($oid);                // os10bgp4V2PrefixGaugesSafi
+        $afi = array_pop($oid);                 // os10bgp4V2PrefixGaugesAfi
+        $address = IP::fromSnmpString(implode(' ', $oid))->compressed(); // os10bgp4V2PeerRemoteAddr
+        // add to `bgpPeers_cbgp` table
+        add_cbgp_peer($device, ['ip' => $address], $afi, $safi);
+    }
+
+    // clean up peers
+    if (Vrf::where('device_id', $device['device_id'])->count() == 0) {
+        $peers = BgpPeer::select('vrf_id', 'bgpPeerIdentifier')->where('device_id', $device['device_id']);
+    } else {
+        $peers = dbFetchRows('SELECT `B`.`vrf_id` AS `vrf_id`, `bgpPeerIdentifier` FROM `bgpPeers` AS B LEFT JOIN `vrfs` AS V ON `B`.`vrf_id` = `V`.`vrf_id` WHERE `B`.`device_id` = ?', [$device['device_id']]);
+    }
+    foreach ($peers as $peer) {
+        $vrfId = $peer['vrf_id'];
+        $address = $peer['bgpPeerIdentifier'];
+
+        if (empty($bgpPeers[$vrfInstance][$address])) {
+            $deleted = BgpPeer::where('device_id', $device['device_id'])->where('bgpPeerIdentifier', $address)->where('vrf_id', $vrfId)->delete();
+
+            echo str_repeat('-', $deleted);
+            echo PHP_EOL;
+        }
+    }
+    unset($bgpPeers);
+    // No return statement here, so standard BGP mib will still be polled after this file is executed.
+}

--- a/includes/discovery/bgp-peers/timos.inc.php
+++ b/includes/discovery/bgp-peers/timos.inc.php
@@ -27,73 +27,73 @@
 use LibreNMS\Config;
 use LibreNMS\Util\IP;
 
-    if ($device['os'] == 'timos') {
-        $bgpPeersCache = snmpwalk_cache_multi_oid($device, 'tBgpPeerNgTable', [], 'TIMETRA-BGP-MIB', 'nokia');
-        foreach ($bgpPeersCache as $key => $value) {
-            $oid = explode('.', $key);
-            $vrfInstance = $oid[0];
-            $address = str_replace($oid[0] . '.' . $oid[1] . '.', '', $key);
-            if (strlen($address) > 15) {
-                $address = IP::fromHexString($address)->compressed();
-            }
-            $bgpPeers[$vrfInstance][$address] = $value;
+if ($device['os'] == 'timos') {
+    $bgpPeersCache = snmpwalk_cache_multi_oid($device, 'tBgpPeerNgTable', [], 'TIMETRA-BGP-MIB', 'nokia');
+    foreach ($bgpPeersCache as $key => $value) {
+        $oid = explode('.', $key);
+        $vrfInstance = $oid[0];
+        $address = str_replace($oid[0] . '.' . $oid[1] . '.', '', $key);
+        if (strlen($address) > 15) {
+            $address = IP::fromHexString($address)->compressed();
         }
-        unset($bgpPeersCache);
-
-        foreach ($bgpPeers as $vrfOid => $vrf) {
-            $vrfId = dbFetchCell('SELECT vrf_id from `vrfs` WHERE vrf_oid = ?', [$vrfOid]);
-            d_echo($vrfId);
-            foreach ($vrf as $address => $value) {
-                $astext = get_astext($value['tBgpPeerNgPeerAS4Byte']);
-
-                if (dbFetchCell('SELECT COUNT(*) from `bgpPeers` WHERE device_id = ? AND bgpPeerIdentifier = ? AND vrf_id = ?', [$device['device_id'], $address, $vrfId]) < '1') {
-                    $peers = [
-                        'device_id' => $device['device_id'],
-                        'vrf_id' => $vrfId,
-                        'bgpPeerIdentifier' => $address,
-                        'bgpPeerRemoteAs' => $value['tBgpPeerNgPeerAS4Byte'],
-                        'bgpPeerState' => 'idle',
-                        'bgpPeerAdminStatus' => 'stop',
-                        'bgpLocalAddr' => '0.0.0.0',
-                        'bgpPeerRemoteAddr' => '0.0.0.0',
-                        'bgpPeerInUpdates' => 0,
-                        'bgpPeerOutUpdates' => 0,
-                        'bgpPeerInTotalMessages' => 0,
-                        'bgpPeerOutTotalMessages' => 0,
-                        'bgpPeerFsmEstablishedTime' => 0,
-                        'bgpPeerInUpdateElapsedTime' => 0,
-                        'astext' => $astext,
-                    ];
-                    dbInsert($peers, 'bgpPeers');
-                    if (Config::get('autodiscovery.bgp')) {
-                        $name = gethostbyaddr($address);
-                        discover_new_device($name, $device, 'BGP');
-                    }
-                    echo '+';
-                } else {
-                    dbUpdate(['bgpPeerRemoteAs' => $value['tBgpPeerNgPeerAS4Byte'], 'astext' => $astext], 'bgpPeers', 'device_id = ? AND bgpPeerIdentifier = ? AND vrf_id = ?', [$device['device_id'], $address, $vrfId]);
-                    echo '.';
-                }
-            }
-        }
-        // clean up peers
-        $peers = dbFetchRows('SELECT `B`.`vrf_id` AS `vrf_id`, `bgpPeerIdentifier`, `vrf_oid` FROM `bgpPeers` AS B LEFT JOIN `vrfs` AS V ON `B`.`vrf_id` = `V`.`vrf_id` WHERE `B`.`device_id` = ?', [$device['device_id']]);
-        foreach ($peers as $value) {
-            $vrfId = $value['vrf_id'];
-            $checkVrf = ' AND vrf_id = ? ';
-            if (empty($vrfId)) {
-                $checkVrf = ' AND `vrf_id` IS NULL ';
-            }
-            $vrfOid = $value['vrf_oid'];
-            $address = $value['bgpPeerIdentifier'];
-
-            if (empty($bgpPeers[$vrfOid][$address])) {
-                $deleted = dbDelete('bgpPeers', 'device_id = ? AND bgpPeerIdentifier = ? ' . $checkVrf, [$device['device_id'], $address, $vrfId]);
-
-                echo str_repeat('-', $deleted);
-                echo PHP_EOL;
-            }
-        }
-        unset($bgpPeers);
-        // No return statement here, so standard BGP mib will still be polled after this file is executed.
+        $bgpPeers[$vrfInstance][$address] = $value;
     }
+    unset($bgpPeersCache);
+
+    foreach ($bgpPeers as $vrfOid => $vrf) {
+        $vrfId = dbFetchCell('SELECT vrf_id from `vrfs` WHERE vrf_oid = ?', [$vrfOid]);
+        d_echo($vrfId);
+        foreach ($vrf as $address => $value) {
+            $astext = get_astext($value['tBgpPeerNgPeerAS4Byte']);
+
+            if (dbFetchCell('SELECT COUNT(*) from `bgpPeers` WHERE device_id = ? AND bgpPeerIdentifier = ? AND vrf_id = ?', [$device['device_id'], $address, $vrfId]) < '1') {
+                $peers = [
+                    'device_id' => $device['device_id'],
+                    'vrf_id' => $vrfId,
+                    'bgpPeerIdentifier' => $address,
+                    'bgpPeerRemoteAs' => $value['tBgpPeerNgPeerAS4Byte'],
+                    'bgpPeerState' => 'idle',
+                    'bgpPeerAdminStatus' => 'stop',
+                    'bgpLocalAddr' => '0.0.0.0',
+                    'bgpPeerRemoteAddr' => '0.0.0.0',
+                    'bgpPeerInUpdates' => 0,
+                    'bgpPeerOutUpdates' => 0,
+                    'bgpPeerInTotalMessages' => 0,
+                    'bgpPeerOutTotalMessages' => 0,
+                    'bgpPeerFsmEstablishedTime' => 0,
+                    'bgpPeerInUpdateElapsedTime' => 0,
+                    'astext' => $astext,
+                ];
+                dbInsert($peers, 'bgpPeers');
+                if (Config::get('autodiscovery.bgp')) {
+                    $name = gethostbyaddr($address);
+                    discover_new_device($name, $device, 'BGP');
+                }
+                echo '+';
+            } else {
+                dbUpdate(['bgpPeerRemoteAs' => $value['tBgpPeerNgPeerAS4Byte'], 'astext' => $astext], 'bgpPeers', 'device_id = ? AND bgpPeerIdentifier = ? AND vrf_id = ?', [$device['device_id'], $address, $vrfId]);
+                echo '.';
+            }
+        }
+    }
+    // clean up peers
+    $peers = dbFetchRows('SELECT `B`.`vrf_id` AS `vrf_id`, `bgpPeerIdentifier`, `vrf_oid` FROM `bgpPeers` AS B LEFT JOIN `vrfs` AS V ON `B`.`vrf_id` = `V`.`vrf_id` WHERE `B`.`device_id` = ?', [$device['device_id']]);
+    foreach ($peers as $value) {
+        $vrfId = $value['vrf_id'];
+        $checkVrf = ' AND vrf_id = ? ';
+        if (empty($vrfId)) {
+            $checkVrf = ' AND `vrf_id` IS NULL ';
+        }
+        $vrfOid = $value['vrf_oid'];
+        $address = $value['bgpPeerIdentifier'];
+
+        if (empty($bgpPeers[$vrfOid][$address])) {
+            $deleted = dbDelete('bgpPeers', 'device_id = ? AND bgpPeerIdentifier = ? ' . $checkVrf, [$device['device_id'], $address, $vrfId]);
+
+            echo str_repeat('-', $deleted);
+            echo PHP_EOL;
+        }
+    }
+    unset($bgpPeers);
+    // No return statement here, so standard BGP mib will still be polled after this file is executed.
+}

--- a/includes/discovery/bgp-peers/timos.inc.php
+++ b/includes/discovery/bgp-peers/timos.inc.php
@@ -27,7 +27,6 @@
 use LibreNMS\Config;
 use LibreNMS\Util\IP;
 
-if (Config::get('enable_bgp')) {
     if ($device['os'] == 'timos') {
         $bgpPeersCache = snmpwalk_cache_multi_oid($device, 'tBgpPeerNgTable', [], 'TIMETRA-BGP-MIB', 'nokia');
         foreach ($bgpPeersCache as $key => $value) {
@@ -98,4 +97,3 @@ if (Config::get('enable_bgp')) {
         unset($bgpPeers);
         // No return statement here, so standard BGP mib will still be polled after this file is executed.
     }
-}

--- a/includes/discovery/bgp-peers/vrp.inc.php
+++ b/includes/discovery/bgp-peers/vrp.inc.php
@@ -27,145 +27,145 @@
 use LibreNMS\Config;
 use LibreNMS\Util\IP;
 
-    $bgpPeersCache = snmpwalk_cache_oid($device, 'hwBgpPeerRemoteAs', [], 'HUAWEI-BGP-VPN-MIB');
+$bgpPeersCache = snmpwalk_cache_oid($device, 'hwBgpPeerRemoteAs', [], 'HUAWEI-BGP-VPN-MIB');
 
-    if (count($bgpPeersCache) == 0) {
-        //Either we have no BGP peer, or this VRP device does not support Huawei's own BGP MIB
-        //Let's compare with standard BGP4-MIB.
-        $bgpPeersCache_ietf = snmpwalk_cache_oid($device, 'bgpPeerRemoteAs', [], 'BGP4-MIB');
+if (count($bgpPeersCache) == 0) {
+    //Either we have no BGP peer, or this VRP device does not support Huawei's own BGP MIB
+    //Let's compare with standard BGP4-MIB.
+    $bgpPeersCache_ietf = snmpwalk_cache_oid($device, 'bgpPeerRemoteAs', [], 'BGP4-MIB');
+}
+
+// So if we have HUAWEI BGP entries or if we don't have anything from HUAWEI nor BGP4-MIB
+if (count($bgpPeersCache) > 0 || count($bgpPeersCache_ietf) == 0) {
+    $vrfs = DeviceCache::getPrimary()->vrfs()->select('vrf_id', 'vrf_name')->get();
+    foreach ($vrfs as $vrf) {
+        $map_vrf['byId'][$vrf['vrf_id']]['vrf_name'] = $vrf['vrf_name'];
+        $map_vrf['byName'][$vrf['vrf_name']]['vrf_id'] = $vrf['vrf_id'];
     }
 
-    // So if we have HUAWEI BGP entries or if we don't have anything from HUAWEI nor BGP4-MIB
-    if (count($bgpPeersCache) > 0 || count($bgpPeersCache_ietf) == 0) {
-        $vrfs = DeviceCache::getPrimary()->vrfs()->select('vrf_id', 'vrf_name')->get();
-        foreach ($vrfs as $vrf) {
-            $map_vrf['byId'][$vrf['vrf_id']]['vrf_name'] = $vrf['vrf_name'];
-            $map_vrf['byName'][$vrf['vrf_name']]['vrf_id'] = $vrf['vrf_id'];
+    $bgpPeersCache = snmpwalk_cache_oid($device, 'hwBgpPeerAddrFamilyTable', $bgpPeersCache, 'HUAWEI-BGP-VPN-MIB');
+    $bgpPeersCache = snmpwalk_cache_oid($device, 'hwBgpPeerTable', $bgpPeersCache, 'HUAWEI-BGP-VPN-MIB');
+    $bgpPeersCache = snmpwalk_cache_oid($device, 'hwBgpPeerRouteTable', $bgpPeersCache, 'HUAWEI-BGP-VPN-MIB');
+    $bgpPeersCache = snmpwalk_cache_oid($device, 'hwBgpPeerSessionTable', $bgpPeersCache, 'HUAWEI-BGP-VPN-MIB');
+
+    $bgpPeersDesc = snmpwalk_cache_oid($device, 'hwBgpPeerSessionExtDescription', [], 'HUAWEI-BGP-VPN-MIB');
+
+    foreach ($bgpPeersCache as $key => $value) {
+        $oid = explode('.', $key);
+        $vrfInstance = $value['hwBgpPeerVrfName'];
+        if ($oid[0] == 0) {
+            $vrfInstance = '';
+            $value['hwBgpPeerVrfName'] = '';
+        }
+        $oid_address = str_replace($oid[0] . '.' . $oid[1] . '.' . $oid[2] . '.' . $oid[3] . '.', '', $key);
+        if ($oid[3] == 'ipv4') {
+            $address = $oid_address;
+        } elseif ($oid[3] == 'ipv6') {
+            $address = IP::fromHexString($oid_address)->compressed();
+        } else {
+            // we have a malformed OID reply, let's skip it
+            continue;
         }
 
-        $bgpPeersCache = snmpwalk_cache_oid($device, 'hwBgpPeerAddrFamilyTable', $bgpPeersCache, 'HUAWEI-BGP-VPN-MIB');
-        $bgpPeersCache = snmpwalk_cache_oid($device, 'hwBgpPeerTable', $bgpPeersCache, 'HUAWEI-BGP-VPN-MIB');
-        $bgpPeersCache = snmpwalk_cache_oid($device, 'hwBgpPeerRouteTable', $bgpPeersCache, 'HUAWEI-BGP-VPN-MIB');
-        $bgpPeersCache = snmpwalk_cache_oid($device, 'hwBgpPeerSessionTable', $bgpPeersCache, 'HUAWEI-BGP-VPN-MIB');
+        $bgpPeers[$vrfInstance][$address] = $value;
+        $bgpPeers[$vrfInstance][$address]['vrf_id'] = $map_vrf['byName'][$vrfInstance]['vrf_id'] ?? null;
+        $bgpPeers[$vrfInstance][$address]['afi'] = $oid[1];
+        $bgpPeers[$vrfInstance][$address]['safi'] = $oid[2];
+        $bgpPeers[$vrfInstance][$address]['typePeer'] = $oid[3];
+        $bgpPeers[$vrfInstance][$address]['bgpPeerDescr'] = '';
+        if (array_key_exists('0.' . $oid[3] . '.' . $oid_address, $bgpPeersDesc)) {
+            // We may have a description
+            $bgpPeers[$vrfInstance][$address]['bgpPeerDescr'] = $bgpPeersDesc['0.' . $oid[3] . '.' . $oid_address]['hwBgpPeerSessionExtDescription'];
+        }
+    }
 
-        $bgpPeersDesc = snmpwalk_cache_oid($device, 'hwBgpPeerSessionExtDescription', [], 'HUAWEI-BGP-VPN-MIB');
+    foreach ($bgpPeers as $vrfName => $vrf) {
+        $vrfId = $map_vrf['byName'][$vrfName]['vrf_id'];
 
-        foreach ($bgpPeersCache as $key => $value) {
-            $oid = explode('.', $key);
-            $vrfInstance = $value['hwBgpPeerVrfName'];
-            if ($oid[0] == 0) {
-                $vrfInstance = '';
-                $value['hwBgpPeerVrfName'] = '';
-            }
-            $oid_address = str_replace($oid[0] . '.' . $oid[1] . '.' . $oid[2] . '.' . $oid[3] . '.', '', $key);
-            if ($oid[3] == 'ipv4') {
-                $address = $oid_address;
-            } elseif ($oid[3] == 'ipv6') {
-                $address = IP::fromHexString($oid_address)->compressed();
+        foreach ($vrf as $address => $value) {
+            $astext = get_astext($value['hwBgpPeerRemoteAs']);
+            if (! DeviceCache::getPrimary()->bgppeers()->where('bgpPeerIdentifier', $address)->where('vrf_id', $vrfId)->exists()) {
+                $peers = [
+                    'device_id' => $device['device_id'],
+                    'vrf_id' => $vrfId,
+                    'bgpPeerIdentifier' => $address,
+                    'bgpPeerRemoteAs' => $value['hwBgpPeerRemoteAs'] ?? '',
+                    'bgpPeerState' => $value['hwBgpPeerState'] ?? '',
+                    'bgpPeerAdminStatus' => $value['hwBgpPeerAdminStatus'] ?? '',
+                    'bgpLocalAddr' => '0.0.0.0',
+                    'bgpPeerRemoteAddr' => $value['hwBgpPeerRemoteAddr'],
+                    'bgpPeerInUpdates' => 0,
+                    'bgpPeerOutUpdates' => 0,
+                    'bgpPeerInTotalMessages' => 0,
+                    'bgpPeerOutTotalMessages' => 0,
+                    'bgpPeerFsmEstablishedTime' => $value['hwBgpPeerFsmEstablishedTime'],
+                    'bgpPeerInUpdateElapsedTime' => 0,
+                    'bgpPeerDescr' => $value['bgpPeerDescr'] ?? '',
+                    'astext' => $astext,
+                ];
+                if (empty($vrfId)) {
+                    unset($peers['vrf_id']);
+                }
+                $seenPeerID[] = DeviceCache::getPrimary()->bgppeers()->create($peers)->bgpPeer_id;
+
+                if (Config::get('autodiscovery.bgp')) {
+                    $name = gethostbyaddr($address);
+                    discover_new_device($name, $device, 'BGP');
+                }
+                echo '+';
+                $vrp_bgp_peer_count++;
             } else {
-                // we have a malformed OID reply, let's skip it
-                continue;
+                $peers = [
+                    'bgpPeerRemoteAs' => $value['hwBgpPeerRemoteAs'],
+                    'astext' => $astext,
+                    'bgpPeerDescr' => $value['bgpPeerDescr'] ?? '',
+                ];
+                $affected = DeviceCache::getPrimary()->bgppeers()->where('bgpPeerIdentifier', $address)->where('vrf_id', $vrfId)->update($peers);
+                $seenPeerID[] = DeviceCache::getPrimary()->bgppeers()->where('bgpPeerIdentifier', $address)->where('vrf_id', $vrfId)->select('bgpPeer_id')->orderBy('bgpPeer_id', 'ASC')->first()->bgpPeer_id;
+
+                echo str_repeat('.', $affected);
+                $vrp_bgp_peer_count += $affected;
             }
-
-            $bgpPeers[$vrfInstance][$address] = $value;
-            $bgpPeers[$vrfInstance][$address]['vrf_id'] = $map_vrf['byName'][$vrfInstance]['vrf_id'] ?? null;
-            $bgpPeers[$vrfInstance][$address]['afi'] = $oid[1];
-            $bgpPeers[$vrfInstance][$address]['safi'] = $oid[2];
-            $bgpPeers[$vrfInstance][$address]['typePeer'] = $oid[3];
-            $bgpPeers[$vrfInstance][$address]['bgpPeerDescr'] = '';
-            if (array_key_exists('0.' . $oid[3] . '.' . $oid_address, $bgpPeersDesc)) {
-                // We may have a description
-                $bgpPeers[$vrfInstance][$address]['bgpPeerDescr'] = $bgpPeersDesc['0.' . $oid[3] . '.' . $oid_address]['hwBgpPeerSessionExtDescription'];
-            }
-        }
-
-        foreach ($bgpPeers as $vrfName => $vrf) {
-            $vrfId = $map_vrf['byName'][$vrfName]['vrf_id'];
-
-            foreach ($vrf as $address => $value) {
-                $astext = get_astext($value['hwBgpPeerRemoteAs']);
-                if (! DeviceCache::getPrimary()->bgppeers()->where('bgpPeerIdentifier', $address)->where('vrf_id', $vrfId)->exists()) {
-                    $peers = [
-                        'device_id' => $device['device_id'],
-                        'vrf_id' => $vrfId,
-                        'bgpPeerIdentifier' => $address,
-                        'bgpPeerRemoteAs' => $value['hwBgpPeerRemoteAs'] ?? '',
-                        'bgpPeerState' => $value['hwBgpPeerState'] ?? '',
-                        'bgpPeerAdminStatus' => $value['hwBgpPeerAdminStatus'] ?? '',
-                        'bgpLocalAddr' => '0.0.0.0',
-                        'bgpPeerRemoteAddr' => $value['hwBgpPeerRemoteAddr'],
-                        'bgpPeerInUpdates' => 0,
-                        'bgpPeerOutUpdates' => 0,
-                        'bgpPeerInTotalMessages' => 0,
-                        'bgpPeerOutTotalMessages' => 0,
-                        'bgpPeerFsmEstablishedTime' => $value['hwBgpPeerFsmEstablishedTime'],
-                        'bgpPeerInUpdateElapsedTime' => 0,
-                        'bgpPeerDescr' => $value['bgpPeerDescr'] ?? '',
-                        'astext' => $astext,
-                    ];
-                    if (empty($vrfId)) {
-                        unset($peers['vrf_id']);
-                    }
-                    $seenPeerID[] = DeviceCache::getPrimary()->bgppeers()->create($peers)->bgpPeer_id;
-
-                    if (Config::get('autodiscovery.bgp')) {
-                        $name = gethostbyaddr($address);
-                        discover_new_device($name, $device, 'BGP');
-                    }
-                    echo '+';
-                    $vrp_bgp_peer_count++;
-                } else {
-                    $peers = [
-                        'bgpPeerRemoteAs' => $value['hwBgpPeerRemoteAs'],
-                        'astext' => $astext,
-                        'bgpPeerDescr' => $value['bgpPeerDescr'] ?? '',
-                    ];
-                    $affected = DeviceCache::getPrimary()->bgppeers()->where('bgpPeerIdentifier', $address)->where('vrf_id', $vrfId)->update($peers);
-                    $seenPeerID[] = DeviceCache::getPrimary()->bgppeers()->where('bgpPeerIdentifier', $address)->where('vrf_id', $vrfId)->select('bgpPeer_id')->orderBy('bgpPeer_id', 'ASC')->first()->bgpPeer_id;
-
-                    echo str_repeat('.', $affected);
-                    $vrp_bgp_peer_count += $affected;
+            if (dbFetchCell('SELECT COUNT(*) from `bgpPeers_cbgp` WHERE device_id = ? AND bgpPeerIdentifier = ? AND afi=? AND safi=?', [$device['device_id'], $value['hwBgpPeerRemoteAddr'], $value['afi'], $value['safi']]) < 1) {
+                if ($vrfName != '') {
+                    $device['context_name'] = $vrfName;
                 }
-                if (dbFetchCell('SELECT COUNT(*) from `bgpPeers_cbgp` WHERE device_id = ? AND bgpPeerIdentifier = ? AND afi=? AND safi=?', [$device['device_id'], $value['hwBgpPeerRemoteAddr'], $value['afi'], $value['safi']]) < 1) {
-                    if ($vrfName != '') {
-                        $device['context_name'] = $vrfName;
-                    }
-                    add_cbgp_peer($device, ['ip' => $value['hwBgpPeerRemoteAddr']], $value['afi'], $value['safi']);
-                    unset($device['context_name']);
-                } else {
-                    //nothing to update
-                }
+                add_cbgp_peer($device, ['ip' => $value['hwBgpPeerRemoteAddr']], $value['afi'], $value['safi']);
+                unset($device['context_name']);
+            } else {
+                //nothing to update
             }
-        }
-        // clean up peers
-
-        if (! is_null($seenPeerID)) {
-            $deleted = DeviceCache::getPrimary()->bgppeers()->whereNotIn('bgpPeer_id', $seenPeerID)->delete();
-            echo str_repeat('-', $deleted);
-        }
-
-        $af_query = 'SELECT bgpPeerIdentifier, afi, safi FROM bgpPeers_cbgp WHERE `device_id`=? AND bgpPeerIdentifier=?';
-        foreach (dbFetchRows($af_query, [$device['device_id'], $peer['ip']]) as $entry) {
-            $afi = $entry['afi'];
-            $safi = $entry['safi'];
-            $vrfName = $entry['context_name'];
-            if (! isset($bgpPeersCache[$vrfName]) ||
-                    ! isset($bgpPeersCache[$vrfName][$entry['bgpPeerIdentifier']]) ||
-                    $bgpPeersCache[$vrfName][$entry['bgpPeerIdentifier']][$entry['afi']] != $afi ||
-                    $bgpPeersCache[$vrfName][$entry['bgpPeerIdentifier']][$entry['safi']] != $safi) {
-                dbDelete(
-                    'bgpPeers_cbgp',
-                    '`device_id`=? AND `bgpPeerIdentifier`=? AND context_name=? AND afi=? AND safi=?',
-                    [$device['device_id'], $address, $vrfName, $afi, $safi]
-                );
-            }
-        }
-
-        unset($bgpPeersCache);
-        unset($bgpPeers);
-        if ($vrp_bgp_peer_count > 0) {
-            return; //Finish BGP discovery here, cause we already collected data with Huawei MIBs
         }
     }
-    // If not, we continue with standard BGP4 MIB
+    // clean up peers
+
+    if (! is_null($seenPeerID)) {
+        $deleted = DeviceCache::getPrimary()->bgppeers()->whereNotIn('bgpPeer_id', $seenPeerID)->delete();
+        echo str_repeat('-', $deleted);
+    }
+
+    $af_query = 'SELECT bgpPeerIdentifier, afi, safi FROM bgpPeers_cbgp WHERE `device_id`=? AND bgpPeerIdentifier=?';
+    foreach (dbFetchRows($af_query, [$device['device_id'], $peer['ip']]) as $entry) {
+        $afi = $entry['afi'];
+        $safi = $entry['safi'];
+        $vrfName = $entry['context_name'];
+        if (! isset($bgpPeersCache[$vrfName]) ||
+                ! isset($bgpPeersCache[$vrfName][$entry['bgpPeerIdentifier']]) ||
+                $bgpPeersCache[$vrfName][$entry['bgpPeerIdentifier']][$entry['afi']] != $afi ||
+                $bgpPeersCache[$vrfName][$entry['bgpPeerIdentifier']][$entry['safi']] != $safi) {
+            dbDelete(
+                'bgpPeers_cbgp',
+                '`device_id`=? AND `bgpPeerIdentifier`=? AND context_name=? AND afi=? AND safi=?',
+                [$device['device_id'], $address, $vrfName, $afi, $safi]
+            );
+        }
+    }
+
+    unset($bgpPeersCache);
+    unset($bgpPeers);
+    if ($vrp_bgp_peer_count > 0) {
+        return; //Finish BGP discovery here, cause we already collected data with Huawei MIBs
+    }
+}
+// If not, we continue with standard BGP4 MIB
 

--- a/includes/discovery/bgp-peers/vrp.inc.php
+++ b/includes/discovery/bgp-peers/vrp.inc.php
@@ -27,7 +27,6 @@
 use LibreNMS\Config;
 use LibreNMS\Util\IP;
 
-if (Config::get('enable_bgp')) {
     $bgpPeersCache = snmpwalk_cache_oid($device, 'hwBgpPeerRemoteAs', [], 'HUAWEI-BGP-VPN-MIB');
 
     if (count($bgpPeersCache) == 0) {
@@ -169,4 +168,4 @@ if (Config::get('enable_bgp')) {
         }
     }
     // If not, we continue with standard BGP4 MIB
-}
+

--- a/includes/discovery/bgp-peers/vrp.inc.php
+++ b/includes/discovery/bgp-peers/vrp.inc.php
@@ -168,4 +168,3 @@ if (count($bgpPeersCache) > 0 || count($bgpPeersCache_ietf) == 0) {
     }
 }
 // If not, we continue with standard BGP4 MIB
-

--- a/includes/polling/bgp-peers.inc.php
+++ b/includes/polling/bgp-peers.inc.php
@@ -5,7 +5,6 @@ use LibreNMS\Exceptions\InvalidIpException;
 use LibreNMS\RRD\RrdDefinition;
 use LibreNMS\Util\IP;
 
-if (\LibreNMS\Config::get('enable_bgp')) {
     $peers = dbFetchRows('SELECT * FROM `bgpPeers` AS B LEFT JOIN `vrfs` AS V ON `B`.`vrf_id` = `V`.`vrf_id` WHERE `B`.`device_id` = ?', [$device['device_id']]);
 
     if (! empty($peers)) {
@@ -788,6 +787,5 @@ if (\LibreNMS\Config::get('enable_bgp')) {
             echo "\n";
         } //end foreach
     } //end if
-} //end if
 
 unset($peers, $peer_data_tmp, $j_prefixes);

--- a/includes/polling/bgp-peers.inc.php
+++ b/includes/polling/bgp-peers.inc.php
@@ -79,8 +79,8 @@ if (! empty($peers)) {
                             $peer_ip_snmp = ltrim($index['orig'], '.');
                             $exploded_ip = explode('.', $peer_ip_snmp);
                             if (count($exploded_ip) > 11) {
-                                 // ipv6
-                                 $tmp_peer_ip = (string) IP::parse(snmp2ipv6($peer_ip_snmp), true);
+                                // ipv6
+                                $tmp_peer_ip = (string) IP::parse(snmp2ipv6($peer_ip_snmp), true);
                             } else {
                                 // ipv4
                                 $tmp_peer_ip = implode('.', array_slice($exploded_ip, -4));
@@ -418,7 +418,7 @@ if (! empty($peers)) {
                         } catch (InvalidIpException $e) {
                             // if parsing fails, leave the data as-is
                         }
-                     }
+                    }
                     $peer_data[$target] = $v;
                 }
                 if (strpos($peer_data['bgpPeerLastErrorCode'], ' ')) {
@@ -447,7 +447,7 @@ if (! empty($peers)) {
                     $peer_data['bgpPeerIface'] = null;
                 }
             }
-             d_echo($peer_data);
+            d_echo($peer_data);
         } catch (InvalidIpException $e) {
             // ignore
         }
@@ -763,7 +763,7 @@ if (! empty($peers)) {
                     ->addDataset('AdvertisedPrefixes', 'GAUGE', null, 100000000000)
                     ->addDataset('SuppressedPrefixes', 'GAUGE', null, 100000000000)
                     ->addDataset('WithdrawnPrefixes', 'GAUGE', null, 100000000000);
-                 $fields = [
+                $fields = [
                     'AcceptedPrefixes'    => $cbgpPeerAcceptedPrefixes,
                     'DeniedPrefixes'      => $cbgpPeerDeniedPrefixes,
                     'AdvertisedPrefixes'  => $cbgpPeerAdvertisedPrefixes,

--- a/includes/polling/bgp-peers.inc.php
+++ b/includes/polling/bgp-peers.inc.php
@@ -5,58 +5,380 @@ use LibreNMS\Exceptions\InvalidIpException;
 use LibreNMS\RRD\RrdDefinition;
 use LibreNMS\Util\IP;
 
-    $peers = dbFetchRows('SELECT * FROM `bgpPeers` AS B LEFT JOIN `vrfs` AS V ON `B`.`vrf_id` = `V`.`vrf_id` WHERE `B`.`device_id` = ?', [$device['device_id']]);
+$peers = dbFetchRows('SELECT * FROM `bgpPeers` AS B LEFT JOIN `vrfs` AS V ON `B`.`vrf_id` = `V`.`vrf_id` WHERE `B`.`device_id` = ?', [$device['device_id']]);
 
-    if (! empty($peers)) {
-        $generic = false;
-        if ($device['os'] == 'junos') {
-            $peer_data_check = snmpwalk_cache_long_oid($device, 'jnxBgpM2PeerIndex', '.1.3.6.1.4.1.2636.5.1.1.2.1.1.1.14', [], 'BGP4-V2-MIB-JUNIPER', 'junos');
-        } elseif ($device['os_group'] === 'arista') {
-            $peer_data_check = snmpwalk_cache_oid($device, 'aristaBgp4V2PeerRemoteAs', [], 'ARISTA-BGP4V2-MIB');
-        } elseif ($device['os'] === 'dell-os10') {
-            $peer_data_check = snmpwalk_cache_oid($device, 'os10bgp4V2PeerRemoteAs', [], 'DELLEMC-OS10-BGP4V2-MIB', 'dell'); // practically identical MIB as arista
-        } elseif ($device['os'] === 'timos') {
-            $peer_data_check = snmpwalk_cache_multi_oid($device, 'tBgpInstanceRowStatus', [], 'TIMETRA-BGP-MIB', 'nokia');
-        } elseif ($device['os'] === 'firebrick') {
-            $peer_data_check = snmpwalk_cache_multi_oid($device, 'fbBgpPeerTable', [], 'FIREBRICK-BGP-MIB', 'firebrick');
-        } elseif ($device['os'] === 'aos7') {
-            $peer_data_check = snmpwalk_cache_multi_oid($device, 'alaBgpPeerAS', [], 'ALCATEL-IND1-BGP-MIB', 'aos7');
-        } elseif ($device['os'] === 'vrp') {
-            $peer_data_check = snmpwalk_cache_multi_oid($device, 'hwBgpPeerEntry', [], 'HUAWEI-BGP-VPN-MIB', 'huawei');
-        } elseif ($device['os_group'] == 'cisco') {
-            $peer_data_check = snmpwalk_cache_oid($device, 'cbgpPeer2RemoteAs', [], 'CISCO-BGP4-MIB');
-        } elseif ($device['os'] == 'cumulus') {
-            $peer_data_check = snmpwalk_cache_oid($device, 'bgpPeerRemoteAs', [], 'CUMULUS-BGPUN-MIB');
-        } else {
-            $peer_data_check = snmpwalk_cache_oid($device, 'bgpPeerRemoteAs', [], 'BGP4-MIB');
-        }
-        if (empty($peer_data_check)) {
-            $peer_data_check = snmpwalk_cache_oid($device, 'bgpPeerRemoteAs', [], 'BGP4-MIB');
-            $generic = true;
-        }
+if (! empty($peers)) {
+    $generic = false;
+    if ($device['os'] == 'junos') {
+        $peer_data_check = snmpwalk_cache_long_oid($device, 'jnxBgpM2PeerIndex', '.1.3.6.1.4.1.2636.5.1.1.2.1.1.1.14', [], 'BGP4-V2-MIB-JUNIPER', 'junos');
+    } elseif ($device['os_group'] === 'arista') {
+        $peer_data_check = snmpwalk_cache_oid($device, 'aristaBgp4V2PeerRemoteAs', [], 'ARISTA-BGP4V2-MIB');
+    } elseif ($device['os'] === 'dell-os10') {
+        $peer_data_check = snmpwalk_cache_oid($device, 'os10bgp4V2PeerRemoteAs', [], 'DELLEMC-OS10-BGP4V2-MIB', 'dell'); // practically identical MIB as arista
+    } elseif ($device['os'] === 'timos') {
+        $peer_data_check = snmpwalk_cache_multi_oid($device, 'tBgpInstanceRowStatus', [], 'TIMETRA-BGP-MIB', 'nokia');
+    } elseif ($device['os'] === 'firebrick') {
+        $peer_data_check = snmpwalk_cache_multi_oid($device, 'fbBgpPeerTable', [], 'FIREBRICK-BGP-MIB', 'firebrick');
+    } elseif ($device['os'] === 'aos7') {
+        $peer_data_check = snmpwalk_cache_multi_oid($device, 'alaBgpPeerAS', [], 'ALCATEL-IND1-BGP-MIB', 'aos7');
+    } elseif ($device['os'] === 'vrp') {
+        $peer_data_check = snmpwalk_cache_multi_oid($device, 'hwBgpPeerEntry', [], 'HUAWEI-BGP-VPN-MIB', 'huawei');
+    } elseif ($device['os_group'] == 'cisco') {
+        $peer_data_check = snmpwalk_cache_oid($device, 'cbgpPeer2RemoteAs', [], 'CISCO-BGP4-MIB');
+    } elseif ($device['os'] == 'cumulus') {
+        $peer_data_check = snmpwalk_cache_oid($device, 'bgpPeerRemoteAs', [], 'CUMULUS-BGPUN-MIB');
+    } else {
+        $peer_data_check = snmpwalk_cache_oid($device, 'bgpPeerRemoteAs', [], 'BGP4-MIB');
+    }
+    if (empty($peer_data_check)) {
+        $peer_data_check = snmpwalk_cache_oid($device, 'bgpPeerRemoteAs', [], 'BGP4-MIB');
+        $generic = true;
+    }
 
-        foreach ($peers as $peer) {
-            //add context if exist
-            $device['context_name'] = $peer['context_name'];
-            $vrfOid = $peer['vrf_oid'];
-            $vrfId = $peer['vrf_id'];
+    foreach ($peers as $peer) {
+        //add context if exist
+        $device['context_name'] = $peer['context_name'];
+        $vrfOid = $peer['vrf_oid'];
+        $vrfId = $peer['vrf_id'];
 
-            try {
-                $peer_ip = IP::parse($peer['bgpPeerIdentifier']);
+        try {
+            $peer_ip = IP::parse($peer['bgpPeerIdentifier']);
 
-                echo "Checking BGP peer $peer_ip ";
+            echo "Checking BGP peer $peer_ip ";
 
-                // --- Collect BGP data ---
-                // If a Cisco device has BGP peers in VRF(s),
-                // but no BGP peers in the default VRF,
-                // a SNMP (v3) walk without context will not find any
-                // cbgpPeer2RemoteAs, resulting in empty $peer_data_check.
-                // Without the or clause, we won't see the VRF BGP peers.
-                // ($peer_data_check isn't used in the Cisco code path,)
-                if (count($peer_data_check) > 0 || ($device['os_group'] == 'cisco' && count(DeviceCache::getPrimary()->getVrfContexts()) > 1)) {
-                    if ($generic) {
-                        echo "\nfallback to default mib";
+            // --- Collect BGP data ---
+            // If a Cisco device has BGP peers in VRF(s),
+            // but no BGP peers in the default VRF,
+            // a SNMP (v3) walk without context will not find any
+            // cbgpPeer2RemoteAs, resulting in empty $peer_data_check.
+            // Without the or clause, we won't see the VRF BGP peers.
+            // ($peer_data_check isn't used in the Cisco code path,)
+            if (count($peer_data_check) > 0 || ($device['os_group'] == 'cisco' && count(DeviceCache::getPrimary()->getVrfContexts()) > 1)) {
+                if ($generic) {
+                    echo "\nfallback to default mib";
 
+                    $peer_identifier = $peer['bgpPeerIdentifier'];
+                    $mib = 'BGP4-MIB';
+                    $oid_map = [
+                        'bgpPeerState' => 'bgpPeerState',
+                        'bgpPeerAdminStatus' => 'bgpPeerAdminStatus',
+                        'bgpPeerInUpdates' => 'bgpPeerInUpdates',
+                        'bgpPeerOutUpdates' => 'bgpPeerOutUpdates',
+                        'bgpPeerInTotalMessages' => 'bgpPeerInTotalMessages',
+                        'bgpPeerOutTotalMessages' => 'bgpPeerOutTotalMessages',
+                        'bgpPeerFsmEstablishedTime' => 'bgpPeerFsmEstablishedTime',
+                        'bgpPeerInUpdateElapsedTime' => 'bgpPeerInUpdateElapsedTime',
+                        'bgpPeerLocalAddr' => 'bgpLocalAddr', // silly db field name
+                        'bgpPeerLastError' => 'bgpPeerLastErrorCode',
+                    ];
+                } elseif ($device['os'] == 'junos') {
+                    if (! isset($junos)) {
+                        echo "\nCaching Oids...";
+
+                        foreach ($peer_data_check as $hash => $index) {
+                            $peer_ip_snmp = ltrim($index['orig'], '.');
+                            $exploded_ip = explode('.', $peer_ip_snmp);
+                            if (count($exploded_ip) > 11) {
+                                 // ipv6
+                                 $tmp_peer_ip = (string) IP::parse(snmp2ipv6($peer_ip_snmp), true);
+                            } else {
+                                // ipv4
+                                $tmp_peer_ip = implode('.', array_slice($exploded_ip, -4));
+                            }
+                            $junos[$tmp_peer_ip]['hash'] = $hash;
+                            $junos[$tmp_peer_ip]['index'] = $index['jnxBgpM2PeerIndex'];
+                        }
+                    }
+
+                    if (! isset($peer_data_tmp)) {
+                        $peer_data_tmp = snmpwalk_cache_long_oid($device, 'jnxBgpM2PeerState', '.1.3.6.1.4.1.2636.5.1.1.2.1.1.1.2', $peer_data_tmp, 'BGP4-V2-MIB-JUNIPER', 'junos');
+                        $peer_data_tmp = snmpwalk_cache_long_oid($device, 'jnxBgpM2PeerStatus', '.1.3.6.1.4.1.2636.5.1.1.2.1.1.1.3', $peer_data_tmp, 'BGP4-V2-MIB-JUNIPER', 'junos');
+                        $peer_data_tmp = snmpwalk_cache_long_oid($device, 'jnxBgpM2PeerInUpdates', '.1.3.6.1.4.1.2636.5.1.1.2.6.1.1.1', $peer_data_tmp, 'BGP4-V2-MIB-JUNIPER', 'junos');
+                        $peer_data_tmp = snmpwalk_cache_long_oid($device, 'jnxBgpM2PeerOutUpdates', '.1.3.6.1.4.1.2636.5.1.1.2.6.1.1.2', $peer_data_tmp, 'BGP4-V2-MIB-JUNIPER', 'junos');
+                        $peer_data_tmp = snmpwalk_cache_long_oid($device, 'jnxBgpM2PeerInTotalMessages', '.1.3.6.1.4.1.2636.5.1.1.2.6.1.1.3', $peer_data_tmp, 'BGP4-V2-MIB-JUNIPER', 'junos');
+                        $peer_data_tmp = snmpwalk_cache_long_oid($device, 'jnxBgpM2PeerOutTotalMessages', '.1.3.6.1.4.1.2636.5.1.1.2.6.1.1.4', $peer_data_tmp, 'BGP4-V2-MIB-JUNIPER', 'junos');
+                        $peer_data_tmp = snmpwalk_cache_long_oid($device, 'jnxBgpM2PeerFsmEstablishedTime', '.1.3.6.1.4.1.2636.5.1.1.2.4.1.1.1', $peer_data_tmp, 'BGP4-V2-MIB-JUNIPER', 'junos');
+                        $peer_data_tmp = snmpwalk_cache_long_oid($device, 'jnxBgpM2PeerInUpdatesElapsedTime', '.1.3.6.1.4.1.2636.5.1.1.2.4.1.1.2', $peer_data_tmp, 'BGP4-V2-MIB-JUNIPER', 'junos');
+                        $peer_data_tmp = snmpwalk_cache_long_oid($device, 'jnxBgpM2PeerLocalAddr', '.1.3.6.1.4.1.2636.5.1.1.2.1.1.1.7', $peer_data_tmp, 'BGP4-V2-MIB-JUNIPER', 'junos');
+                        $peer_data_tmp = snmpwalk_cache_long_oid($device, 'jnxBgpM2PeerRemoteAddrType', '.1.3.6.1.4.1.2636.5.1.1.2.1.1.1.10', $peer_data_tmp, 'BGP4-V2-MIB-JUNIPER', 'junos');
+                        $peer_data_tmp = snmpwalk_cache_long_oid($device, 'jnxBgpM2PeerLastErrorReceived', '.1.3.6.1.4.1.2636.5.1.1.2.2.1.1.1', $peer_data_tmp, 'BGP4-V2-MIB-JUNIPER', 'junos');
+                        $peer_data_tmp = snmpwalk_cache_long_oid($device, 'jnxBgpM2PeerLastErrorReceivedText', '.1.3.6.1.4.1.2636.5.1.1.2.2.1.1.5', $peer_data_tmp, 'BGP4-V2-MIB-JUNIPER', 'junos');
+                        d_echo($peer_data_tmp);
+                    }
+
+                    $peer_hash = $junos[(string) $peer_ip]['hash'];
+                    $peer_data = [];
+                    $peer_data['bgpPeerState'] = $peer_data_tmp[$peer_hash]['jnxBgpM2PeerState'];
+                    $peer_data['bgpPeerAdminStatus'] = $peer_data_tmp[$peer_hash]['jnxBgpM2PeerStatus'];
+                    $peer_data['bgpPeerInUpdates'] = $peer_data_tmp[$peer_hash]['jnxBgpM2PeerInUpdates'];
+                    $peer_data['bgpPeerOutUpdates'] = $peer_data_tmp[$peer_hash]['jnxBgpM2PeerOutUpdates'];
+                    $peer_data['bgpPeerInTotalMessages'] = $peer_data_tmp[$peer_hash]['jnxBgpM2PeerInTotalMessages'];
+                    $peer_data['bgpPeerOutTotalMessages'] = $peer_data_tmp[$peer_hash]['jnxBgpM2PeerOutTotalMessages'];
+                    $peer_data['bgpPeerFsmEstablishedTime'] = $peer_data_tmp[$peer_hash]['jnxBgpM2PeerFsmEstablishedTime'];
+                    $peer_data['bgpPeerLastErrorText'] = $peer_data_tmp[$peer_hash]['jnxBgpM2PeerLastErrorReceivedText'];
+
+                    $error_data = explode(' ', $peer_data_tmp[$peer_hash]['jnxBgpM2PeerLastErrorReceived']);
+                    $peer_data['bgpPeerLastErrorCode'] = intval($error_data[0]);
+                    $peer_data['bgpPeerLastErrorSubCode'] = intval($error_data[1]);
+
+                    try {
+                        $peer_data['bgpLocalAddr'] = IP::fromHexString($peer_data_tmp[$peer_hash]['jnxBgpM2PeerLocalAddr'])->uncompressed();
+                    } catch (InvalidIpException $e) {
+                        $peer_data['bgpLocalAddr'] = '';
+                    }
+                    d_echo("State = {$peer_data['bgpPeerState']} - AdminStatus: {$peer_data['bgpPeerAdminStatus']}\n");
+                } elseif ($device['os'] == 'vrp') {
+                    echo "\nCaching Oids VRP...";
+                    if (! isset($bgpPeers)) {
+                        //if not available, we timeout each time, to be fixed when split
+                        $bgpPeersCache = snmpwalk_cache_oid($device, 'hwBgpPeerEntry', [], 'HUAWEI-BGP-VPN-MIB', 'huawei');
+                        $bgpPeersStats = snmpwalk_cache_oid($device, 'hwBgpPeerStatisticTable', [], 'HUAWEI-BGP-VPN-MIB', 'huawei', '-OQUbs');
+                        $bgp4updates = snmpwalk_cache_oid($device, 'bgpPeerEntry', [], 'BGP4-MIB', 'huawei', '-OQUbs');
+                        foreach ($bgpPeersCache as $key => $value) {
+                            $oid = explode('.', $key, 5);
+                            $vrfInstance = $oid[0];
+                            $afi = $oid[1];
+                            $safi = $oid[2];
+                            $transp = $oid[3];
+                            $address = $oid[4];
+                            if (strlen($address) > 15) {
+                                $address = IP::fromHexString($address)->compressed();
+                            }
+                            if (! isset($bgpPeers[$address][$vrfInstance])) {
+                                $bgpPeers[$address][$vrfInstance] = [];
+                            }
+                            $bgpPeers[$address][$vrfInstance] = array_merge($bgpPeers[$address][$vrfInstance], $value);
+                            //d_echo("$vrfInstance -- $address \t-- $value");
+                        }
+                        foreach ($bgpPeersStats as $key => $value) {
+                            $oid = explode('.', $key, 4);
+                            $vrfInstance = $oid[1];
+                            $address = $oid[3];
+                            if ($oid[2] > 4) { //ipv6 so we have to translate
+                                $address = IP::fromSnmpString($oid[3])->compressed();
+                            }
+                            if (is_array($bgpPeers[$address]) && is_array($bgpPeers[$address][$vrfInstance])) {
+                                $bgpPeers[$address][$vrfInstance] = array_merge($bgpPeers[$address][$vrfInstance], $value);
+                            }
+                        }
+                    }
+                    $address = (string) $peer_ip;
+                    $bgpPeer = $bgpPeers[$address];
+                    $peer_data = [];
+                    if (count(array_keys($bgpPeer)) == 1) { // We have only one vrf with a peer with this IP
+                        $vrfInstance = array_keys($bgpPeer)[0];
+                        $peer_data['bgpPeerState'] = $bgpPeers[$address][$vrfInstance]['hwBgpPeerState'];
+                        $peer_data['bgpPeerAdminStatus'] = $bgpPeers[$address][$vrfInstance]['hwBgpPeerAdminStatus'];
+                        $peer_data['bgpPeerInUpdates'] = $bgpPeers[$address][$vrfInstance]['hwBgpPeerInUpdateMsgs'];
+                        $peer_data['bgpPeerOutUpdates'] = $bgpPeers[$address][$vrfInstance]['hwBgpPeerOutUpdateMsgs'];
+                        $peer_data['bgpPeerInTotalMessages'] = $bgpPeers[$address][$vrfInstance]['hwBgpPeerInTotalMsgs'];
+                        $peer_data['bgpPeerOutTotalMessages'] = $bgpPeers[$address][$vrfInstance]['hwBgpPeerOutTotalMsgs'];
+                        $peer_data['bgpPeerFsmEstablishedTime'] = $bgpPeers[$address][$vrfInstance]['hwBgpPeerFsmEstablishedTime'];
+                        $peer_data['bgpPeerLastError'] = $bgpPeers[$address][$vrfInstance]['hwBgpPeerLastError'];
+                    }
+                    d_echo("VPN : $vrfInstance for $address :\n");
+                    d_echo($peer_data);
+                    if (empty($peer_data['bgpPeerInUpdates']) || empty($peer_data['bgpPeerOutUpdates'])) {
+                        $peer_data['bgpPeerInUpdates'] = $bgp4updates[$address]['bgpPeerInUpdates'];
+                        $peer_data['bgpPeerOutUpdates'] = $bgp4updates[$address]['bgpPeerOutUpdates'];
+                    }
+                    if (empty($peer_data['bgpPeerInTotalMessages']) || empty($peer_data['bgpPeerOutTotalMessages'])) {
+                        $peer_data['bgpPeerInTotalMessages'] = $bgp4updates[$address]['bgpPeerInTotalMessages'];
+                        $peer_data['bgpPeerOutTotalMessages'] = $bgp4updates[$address]['bgpPeerOutTotalMessages'];
+                    }
+                    if (empty($peer_data['bgpPeerState'])) {
+                        $peer_data['bgpPeerState'] = $bgp4updates[$address]['bgpPeerState'];
+                    }
+                    if (empty($peer_data['bgpPeerAdminStatus'])) {
+                        $peer_data['bgpPeerAdminStatus'] = $bgp4updates[$address]['bgpPeerAdminStatus'];
+                    }
+                    if (empty($peer_data['bgpPeerLastError'])) {
+                        $peer_data['bgpPeerLastError'] = $bgp4updates[$address]['bgpPeerLastError'];
+                    }
+                    $error_data = explode(' ', $peer_data['bgpPeerLastError']);
+                    $peer_data['bgpPeerLastErrorCode'] = intval($error_data[0]);
+                    $peer_data['bgpPeerLastErrorSubCode'] = intval($error_data[1]);
+                    unset($peer_data['bgpPeerLastError']);
+                } elseif ($device['os'] == 'timos') {
+                    if (! isset($bgpPeers)) {
+                        echo "\nCaching Oids...";
+                        $bgpPeersCache = snmpwalk_cache_multi_oid($device, 'tBgpPeerNgTable', [], 'TIMETRA-BGP-MIB', 'nokia');
+                        $bgpPeersCache = snmpwalk_cache_multi_oid($device, 'tBgpPeerNgOperEntry', $bgpPeersCache, 'TIMETRA-BGP-MIB', 'nokia');
+                        foreach ($bgpPeersCache as $key => $value) {
+                            $oid = explode('.', $key);
+                            $vrfInstance = $oid[0];
+                            $address = str_replace($oid[0] . '.' . $oid[1] . '.', '', $key);
+                            if (strlen($address) > 15) {
+                                $address = IP::fromHexString($address)->compressed();
+                            }
+                            $bgpPeers[$vrfInstance][$address] = $value;
+                        }
+                    }
+                    $address = (string) $peer_ip;
+                    $tmpTime = $bgpPeers[$vrfOid][$address]['tBgpPeerNgLastChanged'];
+                    $tmpTime = explode('.', $tmpTime);
+                    $tmpTime = explode(':', $tmpTime[0]);
+                    $establishedTime = ($tmpTime[0] * 86400) + ($tmpTime[1] * 3600) + ($tmpTime[2] * 60) + $tmpTime[3];
+
+                    $peer_data = [];
+                    $peer_data['bgpPeerState'] = $bgpPeers[$vrfOid][$address]['tBgpPeerNgConnState'];
+                    if ($bgpPeers[$vrfOid][$address]['tBgpPeerNgShutdown'] == '1') {
+                        $peer_data['bgpPeerAdminStatus'] = 'adminShutdown';
+                    } else {
+                        $peer_data['bgpPeerAdminStatus'] = $bgpPeers[$vrfOid][$address]['tBgpPeerNgOperLastEvent'];
+                    }
+                    $peer_data['bgpPeerInTotalMessages'] = $bgpPeers[$vrfOid][$address]['tBgpPeerNgOperMsgOctetsRcvd'];  // That are actually only octets available,
+                    $peer_data['bgpPeerOutTotalMessages'] = $bgpPeers[$vrfOid][$address]['tBgpPeerNgOperMsgOctetsSent']; // not messages
+                    $peer_data['bgpPeerFsmEstablishedTime'] = $establishedTime;
+                } elseif ($device['os'] == 'firebrick') {
+                    // ToDo, It seems that bgpPeer(In|Out)Updates and bgpPeerInUpdateElapsedTime are actually not available over SNMP
+                    $bgpPeer = null;
+                    foreach ($peer_data_check as $key => $value) {
+                        $oid = explode('.', $key);
+                        $protocol = $oid[0];
+                        $address = str_replace($oid[0] . '.', '', $key);
+                        if (strlen($address) > 15) {
+                            $address = IP::fromHexString($address)->compressed();
+                        }
+
+                        // Some older Firebrick software versions don't have this field
+                        if (isset($value['fbBgpPeerLocalAddress'])) {
+                            $peer_data['bgpLocalAddr'] = IP::fromHexString($value['fbBgpPeerLocalAddress'])->uncompressed();
+                        }
+
+                        if ($address == $peer_ip) {
+                            switch ($value['fbBgpPeerState']) {
+                                case 0:
+                                    $peer_data['bgpPeerState'] = 'idle';
+                                    break;
+                                case 1:
+                                case 2:
+                                    $peer_data['bgpPeerState'] = 'active';
+                                    break;
+                                case 3:
+                                    $peer_data['bgpPeerState'] = 'opensent';
+                                    break;
+                                case 4:
+                                    $peer_data['bgpPeerState'] = 'openconfig';
+                                    break;
+                                case 5:
+                                    $peer_data['bgpPeerState'] = 'established';
+                                    break;
+                                case 6:
+                                    $peer_data['bgpPeerState'] = 'closed';
+                                    break;
+                                case 7:
+                                    $peer_data['bgpPeerState'] = 'free';
+                                    break;
+                            }
+                            $peer_data['bgpPeerRemoteAddr'] = $address;
+                            $peer_data['bgpPeerRemoteAs'] = $value['fbBgpPeerRemoteAS'];
+                            $peer_data['bgpPeerAdminStatus'] = 'start';
+                            $peer_data['bgpPeerInUpdates'] = 0;
+                            $peer_data['bgpPeerOutUpdates'] = 0;
+                            $peer_data['bgpPeerInTotalMessages'] = 0;
+                            $peer_data['bgpPeerOutTotalMessages'] = 0;
+                            $peer_data['bgpPeerFsmEstablishedTime'] = 0;
+                            break;
+                        }
+                    }
+                } else {
+                    $bgp_peer_ident = $peer_ip->toSnmpIndex();
+                    $ip_ver = $peer_ip->getFamily();
+                    if ($ip_ver == 'ipv6') {
+                        $ip_type = 2;
+                        $ip_len = 16;
+                    } else {
+                        $ip_type = 1;
+                        $ip_len = 4;
+                    }
+
+                    if ($device['os_group'] === 'arista') {
+                        $peer_identifier = '1.' . $ip_type . '.' . $ip_len . '.' . $bgp_peer_ident;
+                        $mib = 'ARISTA-BGP4V2-MIB';
+                        $oid_map = [
+                            'aristaBgp4V2PeerState' => 'bgpPeerState',
+                            'aristaBgp4V2PeerAdminStatus' => 'bgpPeerAdminStatus',
+                            'aristaBgp4V2PeerInUpdates' => 'bgpPeerInUpdates',
+                            'aristaBgp4V2PeerOutUpdates' => 'bgpPeerOutUpdates',
+                            'aristaBgp4V2PeerInTotalMessages' => 'bgpPeerInTotalMessages',
+                            'aristaBgp4V2PeerOutTotalMessages' => 'bgpPeerOutTotalMessages',
+                            'aristaBgp4V2PeerFsmEstablishedTime' => 'bgpPeerFsmEstablishedTime',
+                            'aristaBgp4V2PeerInUpdatesElapsedTime' => 'bgpPeerInUpdateElapsedTime',
+                            'aristaBgp4V2PeerLocalAddr' => 'bgpLocalAddr',
+                            'aristaBgp4V2PeerDescription' => 'bgpPeerDescr',
+                            'aristaBgp4V2PeerLastErrorCodeReceived' => 'bgpPeerLastErrorCode',
+                            'aristaBgp4V2PeerLastErrorSubCodeReceived' => 'bgpPeerLastErrorSubCode',
+                            'aristaBgp4V2PeerLastErrorReceivedText' => 'bgpPeerLastErrorText',
+                        ];
+                    } elseif ($device['os'] == 'dell-os10') {
+                        $peer_identifier = '1.' . $ip_type . '.' . $ip_len . '.' . $bgp_peer_ident;
+                        $mib = 'DELLEMC-OS10-BGP4V2-MIB';
+                        $oid_map = [
+                            'os10bgp4V2PeerState' => 'bgpPeerState',
+                            'os10bgp4V2PeerAdminStatus' => 'bgpPeerAdminStatus',
+                            'os10bgp4V2PeerInUpdates' => 'bgpPeerInUpdates',
+                            'os10bgp4V2PeerOutUpdates' => 'bgpPeerOutUpdates',
+                            'os10bgp4V2PeerInTotalMessages' => 'bgpPeerInTotalMessages',
+                            'os10bgp4V2PeerOutTotalMessages' => 'bgpPeerOutTotalMessages',
+                            'os10bgp4V2PeerFsmEstablishedTime' => 'bgpPeerFsmEstablishedTime',
+                            'os10bgp4V2PeerInUpdatesElapsedTime' => 'bgpPeerInUpdateElapsedTime',
+                            'os10bgp4V2PeerLocalAddr' => 'bgpLocalAddr',
+                            'os10bgp4V2PeerDescription' => 'bgpPeerDescr',
+                            'os10bgp4V2PeerLastErrorCodeReceived' => 'bgpPeerLastErrorCode',
+                            'os10bgp4V2PeerLastErrorSubCodeReceived' => 'bgpPeerLastErrorSubCode',
+                            'os10bgp4V2PeerLastErrorReceivedText' => 'bgpPeerLastErrorText',
+                        ];
+                    } elseif ($device['os'] == 'aos7') {
+                        $peer_identifier = $peer['bgpPeerIdentifier'];
+                        $peer_data = [];
+                        $al_descr = snmpwalk_cache_multi_oid($device, 'alaBgpPeerName', $al_descr, 'ALCATEL-IND1-BGP-MIB', 'aos7', '-OQUs');
+                        $al_peer = snmpwalk_cache_multi_oid($device, 'BgpPeerEntry', [], 'BGP4-MIB', 'aos7', '-OQUs');
+                        $peer_data['bgpPeerDescr'] = $al_descr[$peer_identifier]['alaBgpPeerName'];
+                        $peer_data['bgpPeerState'] = $al_peer[$peer_identifier]['bgpPeerState'];
+                        $peer_data['bgpPeerAdminStatus'] = $al_peer[$peer_identifier]['bgpPeerAdminStatus'];
+                        $peer_data['bgpPeerInUpdates'] = $al_peer[$peer_identifier]['bgpPeerInUpdates'];
+                        $peer_data['bgpPeerOutUpdates'] = $al_peer[$peer_identifier]['bgpPeerOutUpdates'];
+                        $peer_data['bgpPeerInTotalMessages'] = $al_peer[$peer_identifier]['bgpPeerInTotalMessages'];
+                        $peer_data['bgpPeerOutTotalMessages'] = $al_peer[$peer_identifier]['bgpPeerOutTotalMessages'];
+                        $peer_data['bgpPeerFsmEstablishedTime'] = $al_peer[$peer_identifier]['bgpPeerFsmEstablishedTime'];
+                        $peer_data['bgpPeerInUpdateElapsedTime'] = $al_peer[$peer_identifier]['bgpPeerInUpdateElapsedTime'];
+                        $error_data = explode(' ', $al_peer[$peer_identifier]['bgpPeerLastError']);
+                        $peer_data['bgpPeerLastErrorCode'] = intval($error_data[0]);
+                        $peer_data['bgpPeerLastErrorSubCode'] = intval($error_data[1]);
+                    } elseif ($device['os_group'] == 'cisco') {
+                        $peer_identifier = $ip_type . '.' . $ip_len . '.' . $bgp_peer_ident;
+                        $mib = 'CISCO-BGP4-MIB';
+                        $oid_map = [
+                            'cbgpPeer2State' => 'bgpPeerState',
+                            'cbgpPeer2AdminStatus' => 'bgpPeerAdminStatus',
+                            'cbgpPeer2InUpdates' => 'bgpPeerInUpdates',
+                            'cbgpPeer2OutUpdates' => 'bgpPeerOutUpdates',
+                            'cbgpPeer2InTotalMessages' => 'bgpPeerInTotalMessages',
+                            'cbgpPeer2OutTotalMessages' => 'bgpPeerOutTotalMessages',
+                            'cbgpPeer2FsmEstablishedTime' => 'bgpPeerFsmEstablishedTime',
+                            'cbgpPeer2InUpdateElapsedTime' => 'bgpPeerInUpdateElapsedTime',
+                            'cbgpPeer2LocalAddr' => 'bgpLocalAddr',
+                            'cbgpPeer2LastError' => 'bgpPeerLastErrorCode',
+                            'cbgpPeer2LastErrorTxt' => 'bgpPeerLastErrorText',
+                        ];
+                    } elseif ($device['os'] == 'cumulus') {
+                        $peer_identifier = $peer['bgpPeerIdentifier'];
+                        $mib = 'CUMULUS-BGPUN-MIB';
+                        $oid_map = [
+                            'bgpPeerState' => 'bgpPeerState',
+                            'bgpPeerAdminStatus' => 'bgpPeerAdminStatus',
+                            'bgpPeerInUpdates' => 'bgpPeerInUpdates',
+                            'bgpPeerOutUpdates' => 'bgpPeerOutUpdates',
+                            'bgpPeerInTotalMessages' => 'bgpPeerInTotalMessages',
+                            'bgpPeerOutTotalMessages' => 'bgpPeerOutTotalMessages',
+                            'bgpPeerFsmEstablishedTime' => 'bgpPeerFsmEstablishedTime',
+                            'bgpPeerInUpdateElapsedTime' => 'bgpPeerInUpdateElapsedTime',
+                            'bgpPeerLocalAddr' => 'bgpLocalAddr',
+                            'bgpPeerLastError' => 'bgpPeerLastErrorCode',
+                            'bgpPeerIface' => 'bgpPeerIface',
+                        ];
+                    } else {
                         $peer_identifier = $peer['bgpPeerIdentifier'];
                         $mib = 'BGP4-MIB';
                         $oid_map = [
@@ -71,721 +393,396 @@ use LibreNMS\Util\IP;
                             'bgpPeerLocalAddr' => 'bgpLocalAddr', // silly db field name
                             'bgpPeerLastError' => 'bgpPeerLastErrorCode',
                         ];
-                    } elseif ($device['os'] == 'junos') {
-                        if (! isset($junos)) {
-                            echo "\nCaching Oids...";
-
-                            foreach ($peer_data_check as $hash => $index) {
-                                $peer_ip_snmp = ltrim($index['orig'], '.');
-                                $exploded_ip = explode('.', $peer_ip_snmp);
-                                if (count($exploded_ip) > 11) {
-                                    // ipv6
-                                    $tmp_peer_ip = (string) IP::parse(snmp2ipv6($peer_ip_snmp), true);
-                                } else {
-                                    // ipv4
-                                    $tmp_peer_ip = implode('.', array_slice($exploded_ip, -4));
-                                }
-                                $junos[$tmp_peer_ip]['hash'] = $hash;
-                                $junos[$tmp_peer_ip]['index'] = $index['jnxBgpM2PeerIndex'];
-                            }
-                        }
-
-                        if (! isset($peer_data_tmp)) {
-                            $peer_data_tmp = snmpwalk_cache_long_oid($device, 'jnxBgpM2PeerState', '.1.3.6.1.4.1.2636.5.1.1.2.1.1.1.2', $peer_data_tmp, 'BGP4-V2-MIB-JUNIPER', 'junos');
-                            $peer_data_tmp = snmpwalk_cache_long_oid($device, 'jnxBgpM2PeerStatus', '.1.3.6.1.4.1.2636.5.1.1.2.1.1.1.3', $peer_data_tmp, 'BGP4-V2-MIB-JUNIPER', 'junos');
-                            $peer_data_tmp = snmpwalk_cache_long_oid($device, 'jnxBgpM2PeerInUpdates', '.1.3.6.1.4.1.2636.5.1.1.2.6.1.1.1', $peer_data_tmp, 'BGP4-V2-MIB-JUNIPER', 'junos');
-                            $peer_data_tmp = snmpwalk_cache_long_oid($device, 'jnxBgpM2PeerOutUpdates', '.1.3.6.1.4.1.2636.5.1.1.2.6.1.1.2', $peer_data_tmp, 'BGP4-V2-MIB-JUNIPER', 'junos');
-                            $peer_data_tmp = snmpwalk_cache_long_oid($device, 'jnxBgpM2PeerInTotalMessages', '.1.3.6.1.4.1.2636.5.1.1.2.6.1.1.3', $peer_data_tmp, 'BGP4-V2-MIB-JUNIPER', 'junos');
-                            $peer_data_tmp = snmpwalk_cache_long_oid($device, 'jnxBgpM2PeerOutTotalMessages', '.1.3.6.1.4.1.2636.5.1.1.2.6.1.1.4', $peer_data_tmp, 'BGP4-V2-MIB-JUNIPER', 'junos');
-                            $peer_data_tmp = snmpwalk_cache_long_oid($device, 'jnxBgpM2PeerFsmEstablishedTime', '.1.3.6.1.4.1.2636.5.1.1.2.4.1.1.1', $peer_data_tmp, 'BGP4-V2-MIB-JUNIPER', 'junos');
-                            $peer_data_tmp = snmpwalk_cache_long_oid($device, 'jnxBgpM2PeerInUpdatesElapsedTime', '.1.3.6.1.4.1.2636.5.1.1.2.4.1.1.2', $peer_data_tmp, 'BGP4-V2-MIB-JUNIPER', 'junos');
-                            $peer_data_tmp = snmpwalk_cache_long_oid($device, 'jnxBgpM2PeerLocalAddr', '.1.3.6.1.4.1.2636.5.1.1.2.1.1.1.7', $peer_data_tmp, 'BGP4-V2-MIB-JUNIPER', 'junos');
-                            $peer_data_tmp = snmpwalk_cache_long_oid($device, 'jnxBgpM2PeerRemoteAddrType', '.1.3.6.1.4.1.2636.5.1.1.2.1.1.1.10', $peer_data_tmp, 'BGP4-V2-MIB-JUNIPER', 'junos');
-                            $peer_data_tmp = snmpwalk_cache_long_oid($device, 'jnxBgpM2PeerLastErrorReceived', '.1.3.6.1.4.1.2636.5.1.1.2.2.1.1.1', $peer_data_tmp, 'BGP4-V2-MIB-JUNIPER', 'junos');
-                            $peer_data_tmp = snmpwalk_cache_long_oid($device, 'jnxBgpM2PeerLastErrorReceivedText', '.1.3.6.1.4.1.2636.5.1.1.2.2.1.1.5', $peer_data_tmp, 'BGP4-V2-MIB-JUNIPER', 'junos');
-                            d_echo($peer_data_tmp);
-                        }
-
-                        $peer_hash = $junos[(string) $peer_ip]['hash'];
-                        $peer_data = [];
-                        $peer_data['bgpPeerState'] = $peer_data_tmp[$peer_hash]['jnxBgpM2PeerState'];
-                        $peer_data['bgpPeerAdminStatus'] = $peer_data_tmp[$peer_hash]['jnxBgpM2PeerStatus'];
-                        $peer_data['bgpPeerInUpdates'] = $peer_data_tmp[$peer_hash]['jnxBgpM2PeerInUpdates'];
-                        $peer_data['bgpPeerOutUpdates'] = $peer_data_tmp[$peer_hash]['jnxBgpM2PeerOutUpdates'];
-                        $peer_data['bgpPeerInTotalMessages'] = $peer_data_tmp[$peer_hash]['jnxBgpM2PeerInTotalMessages'];
-                        $peer_data['bgpPeerOutTotalMessages'] = $peer_data_tmp[$peer_hash]['jnxBgpM2PeerOutTotalMessages'];
-                        $peer_data['bgpPeerFsmEstablishedTime'] = $peer_data_tmp[$peer_hash]['jnxBgpM2PeerFsmEstablishedTime'];
-                        $peer_data['bgpPeerLastErrorText'] = $peer_data_tmp[$peer_hash]['jnxBgpM2PeerLastErrorReceivedText'];
-
-                        $error_data = explode(' ', $peer_data_tmp[$peer_hash]['jnxBgpM2PeerLastErrorReceived']);
-                        $peer_data['bgpPeerLastErrorCode'] = intval($error_data[0]);
-                        $peer_data['bgpPeerLastErrorSubCode'] = intval($error_data[1]);
-
-                        try {
-                            $peer_data['bgpLocalAddr'] = IP::fromHexString($peer_data_tmp[$peer_hash]['jnxBgpM2PeerLocalAddr'])->uncompressed();
-                        } catch (InvalidIpException $e) {
-                            $peer_data['bgpLocalAddr'] = '';
-                        }
-                        d_echo("State = {$peer_data['bgpPeerState']} - AdminStatus: {$peer_data['bgpPeerAdminStatus']}\n");
-                    } elseif ($device['os'] == 'vrp') {
-                        echo "\nCaching Oids VRP...";
-                        if (! isset($bgpPeers)) {
-                            //if not available, we timeout each time, to be fixed when split
-                            $bgpPeersCache = snmpwalk_cache_oid($device, 'hwBgpPeerEntry', [], 'HUAWEI-BGP-VPN-MIB', 'huawei');
-                            $bgpPeersStats = snmpwalk_cache_oid($device, 'hwBgpPeerStatisticTable', [], 'HUAWEI-BGP-VPN-MIB', 'huawei', '-OQUbs');
-                            $bgp4updates = snmpwalk_cache_oid($device, 'bgpPeerEntry', [], 'BGP4-MIB', 'huawei', '-OQUbs');
-                            foreach ($bgpPeersCache as $key => $value) {
-                                $oid = explode('.', $key, 5);
-                                $vrfInstance = $oid[0];
-                                $afi = $oid[1];
-                                $safi = $oid[2];
-                                $transp = $oid[3];
-                                $address = $oid[4];
-                                if (strlen($address) > 15) {
-                                    $address = IP::fromHexString($address)->compressed();
-                                }
-                                if (! isset($bgpPeers[$address][$vrfInstance])) {
-                                    $bgpPeers[$address][$vrfInstance] = [];
-                                }
-                                $bgpPeers[$address][$vrfInstance] = array_merge($bgpPeers[$address][$vrfInstance], $value);
-                                //d_echo("$vrfInstance -- $address \t-- $value");
-                            }
-                            foreach ($bgpPeersStats as $key => $value) {
-                                $oid = explode('.', $key, 4);
-                                $vrfInstance = $oid[1];
-                                $address = $oid[3];
-                                if ($oid[2] > 4) { //ipv6 so we have to translate
-                                    $address = IP::fromSnmpString($oid[3])->compressed();
-                                }
-                                if (is_array($bgpPeers[$address]) && is_array($bgpPeers[$address][$vrfInstance])) {
-                                    $bgpPeers[$address][$vrfInstance] = array_merge($bgpPeers[$address][$vrfInstance], $value);
-                                }
-                            }
-                        }
-                        $address = (string) $peer_ip;
-                        $bgpPeer = $bgpPeers[$address];
-                        $peer_data = [];
-                        if (count(array_keys($bgpPeer)) == 1) { // We have only one vrf with a peer with this IP
-                            $vrfInstance = array_keys($bgpPeer)[0];
-                            $peer_data['bgpPeerState'] = $bgpPeers[$address][$vrfInstance]['hwBgpPeerState'];
-                            $peer_data['bgpPeerAdminStatus'] = $bgpPeers[$address][$vrfInstance]['hwBgpPeerAdminStatus'];
-                            $peer_data['bgpPeerInUpdates'] = $bgpPeers[$address][$vrfInstance]['hwBgpPeerInUpdateMsgs'];
-                            $peer_data['bgpPeerOutUpdates'] = $bgpPeers[$address][$vrfInstance]['hwBgpPeerOutUpdateMsgs'];
-                            $peer_data['bgpPeerInTotalMessages'] = $bgpPeers[$address][$vrfInstance]['hwBgpPeerInTotalMsgs'];
-                            $peer_data['bgpPeerOutTotalMessages'] = $bgpPeers[$address][$vrfInstance]['hwBgpPeerOutTotalMsgs'];
-                            $peer_data['bgpPeerFsmEstablishedTime'] = $bgpPeers[$address][$vrfInstance]['hwBgpPeerFsmEstablishedTime'];
-                            $peer_data['bgpPeerLastError'] = $bgpPeers[$address][$vrfInstance]['hwBgpPeerLastError'];
-                        }
-                        d_echo("VPN : $vrfInstance for $address :\n");
-                        d_echo($peer_data);
-                        if (empty($peer_data['bgpPeerInUpdates']) || empty($peer_data['bgpPeerOutUpdates'])) {
-                            $peer_data['bgpPeerInUpdates'] = $bgp4updates[$address]['bgpPeerInUpdates'];
-                            $peer_data['bgpPeerOutUpdates'] = $bgp4updates[$address]['bgpPeerOutUpdates'];
-                        }
-                        if (empty($peer_data['bgpPeerInTotalMessages']) || empty($peer_data['bgpPeerOutTotalMessages'])) {
-                            $peer_data['bgpPeerInTotalMessages'] = $bgp4updates[$address]['bgpPeerInTotalMessages'];
-                            $peer_data['bgpPeerOutTotalMessages'] = $bgp4updates[$address]['bgpPeerOutTotalMessages'];
-                        }
-                        if (empty($peer_data['bgpPeerState'])) {
-                            $peer_data['bgpPeerState'] = $bgp4updates[$address]['bgpPeerState'];
-                        }
-                        if (empty($peer_data['bgpPeerAdminStatus'])) {
-                            $peer_data['bgpPeerAdminStatus'] = $bgp4updates[$address]['bgpPeerAdminStatus'];
-                        }
-                        if (empty($peer_data['bgpPeerLastError'])) {
-                            $peer_data['bgpPeerLastError'] = $bgp4updates[$address]['bgpPeerLastError'];
-                        }
-                        $error_data = explode(' ', $peer_data['bgpPeerLastError']);
-                        $peer_data['bgpPeerLastErrorCode'] = intval($error_data[0]);
-                        $peer_data['bgpPeerLastErrorSubCode'] = intval($error_data[1]);
-                        unset($peer_data['bgpPeerLastError']);
-                    } elseif ($device['os'] == 'timos') {
-                        if (! isset($bgpPeers)) {
-                            echo "\nCaching Oids...";
-                            $bgpPeersCache = snmpwalk_cache_multi_oid($device, 'tBgpPeerNgTable', [], 'TIMETRA-BGP-MIB', 'nokia');
-                            $bgpPeersCache = snmpwalk_cache_multi_oid($device, 'tBgpPeerNgOperEntry', $bgpPeersCache, 'TIMETRA-BGP-MIB', 'nokia');
-                            foreach ($bgpPeersCache as $key => $value) {
-                                $oid = explode('.', $key);
-                                $vrfInstance = $oid[0];
-                                $address = str_replace($oid[0] . '.' . $oid[1] . '.', '', $key);
-                                if (strlen($address) > 15) {
-                                    $address = IP::fromHexString($address)->compressed();
-                                }
-                                $bgpPeers[$vrfInstance][$address] = $value;
-                            }
-                        }
-                        $address = (string) $peer_ip;
-                        $tmpTime = $bgpPeers[$vrfOid][$address]['tBgpPeerNgLastChanged'];
-                        $tmpTime = explode('.', $tmpTime);
-                        $tmpTime = explode(':', $tmpTime[0]);
-                        $establishedTime = ($tmpTime[0] * 86400) + ($tmpTime[1] * 3600) + ($tmpTime[2] * 60) + $tmpTime[3];
-
-                        $peer_data = [];
-                        $peer_data['bgpPeerState'] = $bgpPeers[$vrfOid][$address]['tBgpPeerNgConnState'];
-                        if ($bgpPeers[$vrfOid][$address]['tBgpPeerNgShutdown'] == '1') {
-                            $peer_data['bgpPeerAdminStatus'] = 'adminShutdown';
-                        } else {
-                            $peer_data['bgpPeerAdminStatus'] = $bgpPeers[$vrfOid][$address]['tBgpPeerNgOperLastEvent'];
-                        }
-                        $peer_data['bgpPeerInTotalMessages'] = $bgpPeers[$vrfOid][$address]['tBgpPeerNgOperMsgOctetsRcvd'];  // That are actually only octets available,
-                        $peer_data['bgpPeerOutTotalMessages'] = $bgpPeers[$vrfOid][$address]['tBgpPeerNgOperMsgOctetsSent']; // not messages
-                        $peer_data['bgpPeerFsmEstablishedTime'] = $establishedTime;
-                    } elseif ($device['os'] == 'firebrick') {
-                        // ToDo, It seems that bgpPeer(In|Out)Updates and bgpPeerInUpdateElapsedTime are actually not available over SNMP
-                        $bgpPeer = null;
-                        foreach ($peer_data_check as $key => $value) {
-                            $oid = explode('.', $key);
-                            $protocol = $oid[0];
-                            $address = str_replace($oid[0] . '.', '', $key);
-                            if (strlen($address) > 15) {
-                                $address = IP::fromHexString($address)->compressed();
-                            }
-
-                            // Some older Firebrick software versions don't have this field
-                            if (isset($value['fbBgpPeerLocalAddress'])) {
-                                $peer_data['bgpLocalAddr'] = IP::fromHexString($value['fbBgpPeerLocalAddress'])->uncompressed();
-                            }
-
-                            if ($address == $peer_ip) {
-                                switch ($value['fbBgpPeerState']) {
-                                    case 0:
-                                        $peer_data['bgpPeerState'] = 'idle';
-                                        break;
-                                    case 1:
-                                    case 2:
-                                        $peer_data['bgpPeerState'] = 'active';
-                                        break;
-                                    case 3:
-                                        $peer_data['bgpPeerState'] = 'opensent';
-                                        break;
-                                    case 4:
-                                        $peer_data['bgpPeerState'] = 'openconfig';
-                                        break;
-                                    case 5:
-                                        $peer_data['bgpPeerState'] = 'established';
-                                        break;
-                                    case 6:
-                                        $peer_data['bgpPeerState'] = 'closed';
-                                        break;
-                                    case 7:
-                                        $peer_data['bgpPeerState'] = 'free';
-                                        break;
-                                }
-                                $peer_data['bgpPeerRemoteAddr'] = $address;
-                                $peer_data['bgpPeerRemoteAs'] = $value['fbBgpPeerRemoteAS'];
-                                $peer_data['bgpPeerAdminStatus'] = 'start';
-                                $peer_data['bgpPeerInUpdates'] = 0;
-                                $peer_data['bgpPeerOutUpdates'] = 0;
-                                $peer_data['bgpPeerInTotalMessages'] = 0;
-                                $peer_data['bgpPeerOutTotalMessages'] = 0;
-                                $peer_data['bgpPeerFsmEstablishedTime'] = 0;
-                                break;
-                            }
-                        }
-                    } else {
-                        $bgp_peer_ident = $peer_ip->toSnmpIndex();
-                        $ip_ver = $peer_ip->getFamily();
-                        if ($ip_ver == 'ipv6') {
-                            $ip_type = 2;
-                            $ip_len = 16;
-                        } else {
-                            $ip_type = 1;
-                            $ip_len = 4;
-                        }
-
-                        if ($device['os_group'] === 'arista') {
-                            $peer_identifier = '1.' . $ip_type . '.' . $ip_len . '.' . $bgp_peer_ident;
-                            $mib = 'ARISTA-BGP4V2-MIB';
-                            $oid_map = [
-                                'aristaBgp4V2PeerState' => 'bgpPeerState',
-                                'aristaBgp4V2PeerAdminStatus' => 'bgpPeerAdminStatus',
-                                'aristaBgp4V2PeerInUpdates' => 'bgpPeerInUpdates',
-                                'aristaBgp4V2PeerOutUpdates' => 'bgpPeerOutUpdates',
-                                'aristaBgp4V2PeerInTotalMessages' => 'bgpPeerInTotalMessages',
-                                'aristaBgp4V2PeerOutTotalMessages' => 'bgpPeerOutTotalMessages',
-                                'aristaBgp4V2PeerFsmEstablishedTime' => 'bgpPeerFsmEstablishedTime',
-                                'aristaBgp4V2PeerInUpdatesElapsedTime' => 'bgpPeerInUpdateElapsedTime',
-                                'aristaBgp4V2PeerLocalAddr' => 'bgpLocalAddr',
-                                'aristaBgp4V2PeerDescription' => 'bgpPeerDescr',
-                                'aristaBgp4V2PeerLastErrorCodeReceived' => 'bgpPeerLastErrorCode',
-                                'aristaBgp4V2PeerLastErrorSubCodeReceived' => 'bgpPeerLastErrorSubCode',
-                                'aristaBgp4V2PeerLastErrorReceivedText' => 'bgpPeerLastErrorText',
-                            ];
-                        } elseif ($device['os'] == 'dell-os10') {
-                            $peer_identifier = '1.' . $ip_type . '.' . $ip_len . '.' . $bgp_peer_ident;
-                            $mib = 'DELLEMC-OS10-BGP4V2-MIB';
-                            $oid_map = [
-                                'os10bgp4V2PeerState' => 'bgpPeerState',
-                                'os10bgp4V2PeerAdminStatus' => 'bgpPeerAdminStatus',
-                                'os10bgp4V2PeerInUpdates' => 'bgpPeerInUpdates',
-                                'os10bgp4V2PeerOutUpdates' => 'bgpPeerOutUpdates',
-                                'os10bgp4V2PeerInTotalMessages' => 'bgpPeerInTotalMessages',
-                                'os10bgp4V2PeerOutTotalMessages' => 'bgpPeerOutTotalMessages',
-                                'os10bgp4V2PeerFsmEstablishedTime' => 'bgpPeerFsmEstablishedTime',
-                                'os10bgp4V2PeerInUpdatesElapsedTime' => 'bgpPeerInUpdateElapsedTime',
-                                'os10bgp4V2PeerLocalAddr' => 'bgpLocalAddr',
-                                'os10bgp4V2PeerDescription' => 'bgpPeerDescr',
-                                'os10bgp4V2PeerLastErrorCodeReceived' => 'bgpPeerLastErrorCode',
-                                'os10bgp4V2PeerLastErrorSubCodeReceived' => 'bgpPeerLastErrorSubCode',
-                                'os10bgp4V2PeerLastErrorReceivedText' => 'bgpPeerLastErrorText',
-                            ];
-                        } elseif ($device['os'] == 'aos7') {
-                            $peer_identifier = $peer['bgpPeerIdentifier'];
-                            $peer_data = [];
-                            $al_descr = snmpwalk_cache_multi_oid($device, 'alaBgpPeerName', $al_descr, 'ALCATEL-IND1-BGP-MIB', 'aos7', '-OQUs');
-                            $al_peer = snmpwalk_cache_multi_oid($device, 'BgpPeerEntry', [], 'BGP4-MIB', 'aos7', '-OQUs');
-                            $peer_data['bgpPeerDescr'] = $al_descr[$peer_identifier]['alaBgpPeerName'];
-                            $peer_data['bgpPeerState'] = $al_peer[$peer_identifier]['bgpPeerState'];
-                            $peer_data['bgpPeerAdminStatus'] = $al_peer[$peer_identifier]['bgpPeerAdminStatus'];
-                            $peer_data['bgpPeerInUpdates'] = $al_peer[$peer_identifier]['bgpPeerInUpdates'];
-                            $peer_data['bgpPeerOutUpdates'] = $al_peer[$peer_identifier]['bgpPeerOutUpdates'];
-                            $peer_data['bgpPeerInTotalMessages'] = $al_peer[$peer_identifier]['bgpPeerInTotalMessages'];
-                            $peer_data['bgpPeerOutTotalMessages'] = $al_peer[$peer_identifier]['bgpPeerOutTotalMessages'];
-                            $peer_data['bgpPeerFsmEstablishedTime'] = $al_peer[$peer_identifier]['bgpPeerFsmEstablishedTime'];
-                            $peer_data['bgpPeerInUpdateElapsedTime'] = $al_peer[$peer_identifier]['bgpPeerInUpdateElapsedTime'];
-                            $error_data = explode(' ', $al_peer[$peer_identifier]['bgpPeerLastError']);
-                            $peer_data['bgpPeerLastErrorCode'] = intval($error_data[0]);
-                            $peer_data['bgpPeerLastErrorSubCode'] = intval($error_data[1]);
-                        } elseif ($device['os_group'] == 'cisco') {
-                            $peer_identifier = $ip_type . '.' . $ip_len . '.' . $bgp_peer_ident;
-                            $mib = 'CISCO-BGP4-MIB';
-                            $oid_map = [
-                                'cbgpPeer2State' => 'bgpPeerState',
-                                'cbgpPeer2AdminStatus' => 'bgpPeerAdminStatus',
-                                'cbgpPeer2InUpdates' => 'bgpPeerInUpdates',
-                                'cbgpPeer2OutUpdates' => 'bgpPeerOutUpdates',
-                                'cbgpPeer2InTotalMessages' => 'bgpPeerInTotalMessages',
-                                'cbgpPeer2OutTotalMessages' => 'bgpPeerOutTotalMessages',
-                                'cbgpPeer2FsmEstablishedTime' => 'bgpPeerFsmEstablishedTime',
-                                'cbgpPeer2InUpdateElapsedTime' => 'bgpPeerInUpdateElapsedTime',
-                                'cbgpPeer2LocalAddr' => 'bgpLocalAddr',
-                                'cbgpPeer2LastError' => 'bgpPeerLastErrorCode',
-                                'cbgpPeer2LastErrorTxt' => 'bgpPeerLastErrorText',
-                            ];
-                        } elseif ($device['os'] == 'cumulus') {
-                            $peer_identifier = $peer['bgpPeerIdentifier'];
-                            $mib = 'CUMULUS-BGPUN-MIB';
-                            $oid_map = [
-                                'bgpPeerState' => 'bgpPeerState',
-                                'bgpPeerAdminStatus' => 'bgpPeerAdminStatus',
-                                'bgpPeerInUpdates' => 'bgpPeerInUpdates',
-                                'bgpPeerOutUpdates' => 'bgpPeerOutUpdates',
-                                'bgpPeerInTotalMessages' => 'bgpPeerInTotalMessages',
-                                'bgpPeerOutTotalMessages' => 'bgpPeerOutTotalMessages',
-                                'bgpPeerFsmEstablishedTime' => 'bgpPeerFsmEstablishedTime',
-                                'bgpPeerInUpdateElapsedTime' => 'bgpPeerInUpdateElapsedTime',
-                                'bgpPeerLocalAddr' => 'bgpLocalAddr',
-                                'bgpPeerLastError' => 'bgpPeerLastErrorCode',
-                                'bgpPeerIface' => 'bgpPeerIface',
-                            ];
-                        } else {
-                            $peer_identifier = $peer['bgpPeerIdentifier'];
-                            $mib = 'BGP4-MIB';
-                            $oid_map = [
-                                'bgpPeerState' => 'bgpPeerState',
-                                'bgpPeerAdminStatus' => 'bgpPeerAdminStatus',
-                                'bgpPeerInUpdates' => 'bgpPeerInUpdates',
-                                'bgpPeerOutUpdates' => 'bgpPeerOutUpdates',
-                                'bgpPeerInTotalMessages' => 'bgpPeerInTotalMessages',
-                                'bgpPeerOutTotalMessages' => 'bgpPeerOutTotalMessages',
-                                'bgpPeerFsmEstablishedTime' => 'bgpPeerFsmEstablishedTime',
-                                'bgpPeerInUpdateElapsedTime' => 'bgpPeerInUpdateElapsedTime',
-                                'bgpPeerLocalAddr' => 'bgpLocalAddr', // silly db field name
-                                'bgpPeerLastError' => 'bgpPeerLastErrorCode',
-                            ];
-                        }
                     }
                 }
+            }
 
-                // --- Build peer data if it is not already filled in ---
-                if (empty($peer_data) && isset($peer_identifier, $oid_map, $mib)) {
-                    echo "Fetching $mib data... \n";
+            // --- Build peer data if it is not already filled in ---
+            if (empty($peer_data) && isset($peer_identifier, $oid_map, $mib)) {
+                echo "Fetching $mib data... \n";
 
-                    $get_oids = array_map(function ($oid) use ($peer_identifier) {
-                        return "$oid.$peer_identifier";
-                    }, array_keys($oid_map));
-                    $peer_data_raw = snmp_get_multi($device, $get_oids, '-OQUs', $mib);
-                    $peer_data_raw = reset($peer_data_raw);  // get the first element of the array
+                $get_oids = array_map(function ($oid) use ($peer_identifier) {
+                    return "$oid.$peer_identifier";
+                }, array_keys($oid_map));
+                $peer_data_raw = snmp_get_multi($device, $get_oids, '-OQUs', $mib);
+                $peer_data_raw = reset($peer_data_raw);  // get the first element of the array
 
-                    $peer_data = [];
+                $peer_data = [];
 
-                    foreach ($oid_map as $source => $target) {
-                        $v = isset($peer_data_raw[$source]) ? $peer_data_raw[$source] : '';
+                foreach ($oid_map as $source => $target) {
+                    $v = isset($peer_data_raw[$source]) ? $peer_data_raw[$source] : '';
 
-                        if (Str::contains($source, 'LocalAddr')) {
-                            try {
-                                $v = IP::fromHexString($v)->uncompressed();
-                            } catch (InvalidIpException $e) {
-                                // if parsing fails, leave the data as-is
-                            }
-                        }
-                        $peer_data[$target] = $v;
-                    }
-                    if (strpos($peer_data['bgpPeerLastErrorCode'], ' ')) {
-                        // Some device return both Code and SubCode in the same snmp field, we need to split it
-                        $splitted_codes = explode(' ', $peer_data['bgpPeerLastErrorCode']);
-                        $error_code = intval($splitted_codes[0]);
-                        $error_subcode = intval($splitted_codes[1]);
-                        $peer_data['bgpPeerLastErrorCode'] = $error_code;
-                        $peer_data['bgpPeerLastErrorSubCode'] = $error_subcode;
-                    }
-
-                    // --- Fill the bgpPeerIface column ---
-                    if (isset($peer_data['bgpPeerIface']) && ! IP::isValid($peer_data['bgpPeerIface'])) {
-                        // The column is already filled with the ifName, we change it to ifIndex
-                        $peer_data['bgpPeerIface'] = DeviceCache::getPrimary()->ports()->where('ifName', '=', $peer_data['bgpPeerIface'])->value('ifIndex');
-                    } elseif (isset($peer_data['bgpLocalAddr']) && IP::isValid($peer_data['bgpLocalAddr'])) {
-                        // else we use the bgpLocalAddr to find ifIndex
+                    if (Str::contains($source, 'LocalAddr')) {
                         try {
-                            $ip_address = IP::parse($peer_data['bgpLocalAddr']);
-                            $family = $ip_address->getFamily();
-                            $peer_data['bgpPeerIface'] = DB::table('ports')->join("{$family}_addresses", 'ports.port_id', '=', "{$family}_addresses.port_id")->where("{$family}_address", '=', $ip_address->uncompressed())->value('ifIndex');
+                            $v = IP::fromHexString($v)->uncompressed();
                         } catch (InvalidIpException $e) {
-                            $peer_data['bgpPeerIface'] = null;
+                            // if parsing fails, leave the data as-is
                         }
-                    } else {
+                     }
+                    $peer_data[$target] = $v;
+                }
+                if (strpos($peer_data['bgpPeerLastErrorCode'], ' ')) {
+                    // Some device return both Code and SubCode in the same snmp field, we need to split it
+                    $splitted_codes = explode(' ', $peer_data['bgpPeerLastErrorCode']);
+                    $error_code = intval($splitted_codes[0]);
+                    $error_subcode = intval($splitted_codes[1]);
+                    $peer_data['bgpPeerLastErrorCode'] = $error_code;
+                    $peer_data['bgpPeerLastErrorSubCode'] = $error_subcode;
+                }
+
+                // --- Fill the bgpPeerIface column ---
+                if (isset($peer_data['bgpPeerIface']) && ! IP::isValid($peer_data['bgpPeerIface'])) {
+                    // The column is already filled with the ifName, we change it to ifIndex
+                    $peer_data['bgpPeerIface'] = DeviceCache::getPrimary()->ports()->where('ifName', '=', $peer_data['bgpPeerIface'])->value('ifIndex');
+                } elseif (isset($peer_data['bgpLocalAddr']) && IP::isValid($peer_data['bgpLocalAddr'])) {
+                    // else we use the bgpLocalAddr to find ifIndex
+                    try {
+                        $ip_address = IP::parse($peer_data['bgpLocalAddr']);
+                        $family = $ip_address->getFamily();
+                        $peer_data['bgpPeerIface'] = DB::table('ports')->join("{$family}_addresses", 'ports.port_id', '=', "{$family}_addresses.port_id")->where("{$family}_address", '=', $ip_address->uncompressed())->value('ifIndex');
+                    } catch (InvalidIpException $e) {
                         $peer_data['bgpPeerIface'] = null;
                     }
-                }
-
-                d_echo($peer_data);
-            } catch (InvalidIpException $e) {
-                // ignore
-            }
-            // --- Send event log notices ---
-            if ($peer_data['bgpPeerFsmEstablishedTime']) {
-                if (! (is_array(\LibreNMS\Config::get('alerts.bgp.whitelist'))
-                        && ! in_array($peer['bgpPeerRemoteAs'], \LibreNMS\Config::get('alerts.bgp.whitelist')))
-                    && ($peer_data['bgpPeerFsmEstablishedTime'] < $peer['bgpPeerFsmEstablishedTime']
-                        || $peer_data['bgpPeerState'] != $peer['bgpPeerState'])
-                ) {
-                    if ($peer['bgpPeerState'] == $peer_data['bgpPeerState']) {
-                        log_event('BGP Session Flap: ' . $peer['bgpPeerIdentifier'] . ' (AS' . $peer['bgpPeerRemoteAs'] . ' ' . $peer['bgpPeerDescr'] . '), last error: ' . describe_bgp_error_code($peer['bgpPeerLastErrorCode'], $peer['bgpPeerLastErrorSubCode']), $device, 'bgpPeer', 4, $peer_ip);
-                    } elseif ($peer_data['bgpPeerState'] == 'established') {
-                        log_event('BGP Session Up: ' . $peer['bgpPeerIdentifier'] . ' (AS' . $peer['bgpPeerRemoteAs'] . ' ' . $peer['bgpPeerDescr'] . ')', $device, 'bgpPeer', 1, $peer_ip);
-                    } elseif ($peer['bgpPeerState'] == 'established') {
-                        log_event('BGP Session Down: ' . $peer['bgpPeerIdentifier'] . ' (AS' . $peer['bgpPeerRemoteAs'] . ' ' . $peer['bgpPeerDescr'] . '), last error: ' . describe_bgp_error_code($peer['bgpPeerLastErrorCode'], $peer['bgpPeerLastErrorSubCode']), $device, 'bgpPeer', 5, $peer_ip);
-                    }
-                }
-            }
-
-            // --- Update rrd data ---
-            $peer_rrd_name = \LibreNMS\Data\Store\Rrd::safeName('bgp-' . $peer['bgpPeerIdentifier']);
-            $peer_rrd_def = RrdDefinition::make()
-                ->addDataset('bgpPeerOutUpdates', 'COUNTER', null, 100000000000)
-                ->addDataset('bgpPeerInUpdates', 'COUNTER', null, 100000000000)
-                ->addDataset('bgpPeerOutTotal', 'COUNTER', null, 100000000000)
-                ->addDataset('bgpPeerInTotal', 'COUNTER', null, 100000000000)
-                ->addDataset('bgpPeerEstablished', 'GAUGE', 0);
-            // Validate data
-            $peer_data['bgpPeerFsmEstablishedTime'] = set_numeric($peer_data['bgpPeerFsmEstablishedTime']);
-            $peer_data['bgpPeerInUpdates'] = set_numeric($peer_data['bgpPeerInUpdates']);
-            $peer_data['bgpPeerOutUpdates'] = set_numeric($peer_data['bgpPeerOutUpdates']);
-            $peer_data['bgpPeerInTotalMessages'] = set_numeric($peer_data['bgpPeerInTotalMessages']);
-            $peer_data['bgpPeerOutTotalMessages'] = set_numeric($peer_data['bgpPeerOutTotalMessages']);
-
-            $fields = [
-                'bgpPeerOutUpdates' => $peer_data['bgpPeerOutUpdates'],
-                'bgpPeerInUpdates' => $peer_data['bgpPeerInUpdates'],
-                'bgpPeerOutTotal' => $peer_data['bgpPeerOutTotalMessages'],
-                'bgpPeerInTotal' => $peer_data['bgpPeerInTotalMessages'],
-                'bgpPeerEstablished' => $peer_data['bgpPeerFsmEstablishedTime'],
-            ];
-
-            $tags = [
-                'bgpPeerIdentifier' => $peer['bgpPeerIdentifier'],
-                'rrd_name' => $peer_rrd_name,
-                'rrd_def' => $peer_rrd_def,
-            ];
-            data_update($device, 'bgp', $tags, $fields);
-
-            // --- Update Database data ---
-            $peer['update'] = array_diff_assoc($peer_data, $peer);
-            unset($peer_data);
-
-            if ($peer['update']) {
-                if ($vrfId) {
-                    dbUpdate($peer['update'], 'bgpPeers', '`device_id` = ? AND `bgpPeerIdentifier` = ? AND `vrf_id` = ?', [$device['device_id'], $peer['bgpPeerIdentifier'], $vrfId]);
                 } else {
-                    dbUpdate($peer['update'], 'bgpPeers', '`device_id` = ? AND `bgpPeerIdentifier` = ?', [$device['device_id'], $peer['bgpPeerIdentifier']]);
+                    $peer_data['bgpPeerIface'] = null;
                 }
             }
+             d_echo($peer_data);
+        } catch (InvalidIpException $e) {
+            // ignore
+        }
+        // --- Send event log notices ---
+        if ($peer_data['bgpPeerFsmEstablishedTime']) {
+            if (! (is_array(\LibreNMS\Config::get('alerts.bgp.whitelist'))
+                    && ! in_array($peer['bgpPeerRemoteAs'], \LibreNMS\Config::get('alerts.bgp.whitelist')))
+                && ($peer_data['bgpPeerFsmEstablishedTime'] < $peer['bgpPeerFsmEstablishedTime']
+                    || $peer_data['bgpPeerState'] != $peer['bgpPeerState'])
+            ) {
+                if ($peer['bgpPeerState'] == $peer_data['bgpPeerState']) {
+                    log_event('BGP Session Flap: ' . $peer['bgpPeerIdentifier'] . ' (AS' . $peer['bgpPeerRemoteAs'] . ' ' . $peer['bgpPeerDescr'] . '), last error: ' . describe_bgp_error_code($peer['bgpPeerLastErrorCode'], $peer['bgpPeerLastErrorSubCode']), $device, 'bgpPeer', 4, $peer_ip);
+                } elseif ($peer_data['bgpPeerState'] == 'established') {
+                    log_event('BGP Session Up: ' . $peer['bgpPeerIdentifier'] . ' (AS' . $peer['bgpPeerRemoteAs'] . ' ' . $peer['bgpPeerDescr'] . ')', $device, 'bgpPeer', 1, $peer_ip);
+                } elseif ($peer['bgpPeerState'] == 'established') {
+                    log_event('BGP Session Down: ' . $peer['bgpPeerIdentifier'] . ' (AS' . $peer['bgpPeerRemoteAs'] . ' ' . $peer['bgpPeerDescr'] . '), last error: ' . describe_bgp_error_code($peer['bgpPeerLastErrorCode'], $peer['bgpPeerLastErrorSubCode']), $device, 'bgpPeer', 5, $peer_ip);
+                }
+            }
+        }
 
-            // --- Populate cbgp data ---
-            if ($device['os_group'] == 'vrp' || $device['os_group'] == 'cisco' || $device['os'] == 'junos' || $device['os'] == 'aos7' || $device['os_group'] === 'arista' || $device['os'] == 'dell-os10' || $device['os'] == 'firebrick') {
-                // Poll each AFI/SAFI for this peer (using CISCO-BGP4-MIB or BGP4-V2-JUNIPER MIB)
-                $peer_afis = dbFetchRows('SELECT * FROM bgpPeers_cbgp WHERE `device_id` = ? AND bgpPeerIdentifier = ?', [$device['device_id'], $peer['bgpPeerIdentifier']]);
-                foreach ($peer_afis as $peer_afi) {
-                    $afi = $peer_afi['afi'];
-                    $safi = $peer_afi['safi'];
-                    d_echo("$afi $safi\n");
-                    if ($device['os_group'] == 'cisco') {
-                        $bgp_peer_ident = $peer_ip->toSnmpIndex();
+        // --- Update rrd data ---
+        $peer_rrd_name = \LibreNMS\Data\Store\Rrd::safeName('bgp-' . $peer['bgpPeerIdentifier']);
+        $peer_rrd_def = RrdDefinition::make()
+            ->addDataset('bgpPeerOutUpdates', 'COUNTER', null, 100000000000)
+            ->addDataset('bgpPeerInUpdates', 'COUNTER', null, 100000000000)
+            ->addDataset('bgpPeerOutTotal', 'COUNTER', null, 100000000000)
+            ->addDataset('bgpPeerInTotal', 'COUNTER', null, 100000000000)
+            ->addDataset('bgpPeerEstablished', 'GAUGE', 0);
+        // Validate data
+        $peer_data['bgpPeerFsmEstablishedTime'] = set_numeric($peer_data['bgpPeerFsmEstablishedTime']);
+        $peer_data['bgpPeerInUpdates'] = set_numeric($peer_data['bgpPeerInUpdates']);
+        $peer_data['bgpPeerOutUpdates'] = set_numeric($peer_data['bgpPeerOutUpdates']);
+        $peer_data['bgpPeerInTotalMessages'] = set_numeric($peer_data['bgpPeerInTotalMessages']);
+        $peer_data['bgpPeerOutTotalMessages'] = set_numeric($peer_data['bgpPeerOutTotalMessages']);
 
-                        $ip_ver = $peer_ip->getFamily();
-                        if ($ip_ver == 'ipv6') {
-                            $ip_type = 2;
-                            $ip_len = 16;
-                        } else {
-                            $ip_type = 1;
-                            $ip_len = 4;
-                        }
+        $fields = [
+            'bgpPeerOutUpdates' => $peer_data['bgpPeerOutUpdates'],
+            'bgpPeerInUpdates' => $peer_data['bgpPeerInUpdates'],
+            'bgpPeerOutTotal' => $peer_data['bgpPeerOutTotalMessages'],
+            'bgpPeerInTotal' => $peer_data['bgpPeerInTotalMessages'],
+            'bgpPeerEstablished' => $peer_data['bgpPeerFsmEstablishedTime'],
+        ];
 
-                        $ip_cast = 1;
-                        if ($peer_afi['safi'] == 'multicast') {
-                            $ip_cast = 2;
-                        } elseif ($peer_afi['safi'] == 'unicastAndMulticast') {
-                            $ip_cast = 3;
-                        } elseif ($peer_afi['safi'] == 'vpn') {
-                            $ip_cast = 128;
-                        }
+        $tags = [
+            'bgpPeerIdentifier' => $peer['bgpPeerIdentifier'],
+            'rrd_name' => $peer_rrd_name,
+            'rrd_def' => $peer_rrd_def,
+        ];
+        data_update($device, 'bgp', $tags, $fields);
 
-                        $check = snmp_get($device, 'cbgpPeer2AcceptedPrefixes.' . $ip_type . '.' . $ip_len . '.' . $bgp_peer_ident . '.' . $ip_type . '.' . $ip_cast, '', 'CISCO-BGP4-MIB');
+        // --- Update Database data ---
+        $peer['update'] = array_diff_assoc($peer_data, $peer);
+        unset($peer_data);
 
-                        if (! empty($check)) {
-                            $cgp_peer_identifier = $ip_type . '.' . $ip_len . '.' . $bgp_peer_ident . '.' . $ip_type . '.' . $ip_cast;
-                            $cbgp2_oids = [
-                                'cbgpPeer2AcceptedPrefixes.' . $cgp_peer_identifier,
-                                'cbgpPeer2DeniedPrefixes.' . $cgp_peer_identifier,
-                                'cbgpPeer2PrefixAdminLimit.' . $cgp_peer_identifier,
-                                'cbgpPeer2PrefixThreshold.' . $cgp_peer_identifier,
-                                'cbgpPeer2PrefixClearThreshold.' . $cgp_peer_identifier,
-                                'cbgpPeer2AdvertisedPrefixes.' . $cgp_peer_identifier,
-                                'cbgpPeer2SuppressedPrefixes.' . $cgp_peer_identifier,
-                                'cbgpPeer2WithdrawnPrefixes.' . $cgp_peer_identifier,
-                            ];
-                            $cbgp_data_tmp = snmp_get_multi($device, $cbgp2_oids, '-OQUs', 'CISCO-BGP4-MIB');
-                            $ident = "$ip_ver.\"" . $peer['bgpPeerIdentifier'] . '"' . '.' . $ip_type . '.' . $ip_cast;
+        if ($peer['update']) {
+            if ($vrfId) {
+                dbUpdate($peer['update'], 'bgpPeers', '`device_id` = ? AND `bgpPeerIdentifier` = ? AND `vrf_id` = ?', [$device['device_id'], $peer['bgpPeerIdentifier'], $vrfId]);
+            } else {
+                dbUpdate($peer['update'], 'bgpPeers', '`device_id` = ? AND `bgpPeerIdentifier` = ?', [$device['device_id'], $peer['bgpPeerIdentifier']]);
+            }
+        }
 
-                            $key = key($cbgp_data_tmp); // get key of item
-                            $cbgp_data = [
-                                'cbgpPeerAcceptedPrefixes' => $cbgp_data_tmp[$key]['cbgpPeer2AcceptedPrefixes'],
-                                'cbgpPeerDeniedPrefixes' => $cbgp_data_tmp[$key]['cbgpPeer2DeniedPrefixes'],
-                                'cbgpPeerPrefixAdminLimit' => $cbgp_data_tmp[$key]['cbgpPeer2PrefixAdminLimit'],
-                                'cbgpPeerPrefixThreshold' => $cbgp_data_tmp[$key]['cbgpPeer2PrefixThreshold'],
-                                'cbgpPeerPrefixClearThreshold' => $cbgp_data_tmp[$key]['cbgpPeer2PrefixClearThreshold'],
-                                'cbgpPeerAdvertisedPrefixes' => $cbgp_data_tmp[$key]['cbgpPeer2AdvertisedPrefixes'],
-                                'cbgpPeerSuppressedPrefixes' => $cbgp_data_tmp[$key]['cbgpPeer2SuppressedPrefixes'],
-                                'cbgpPeerWithdrawnPrefixes' => $cbgp_data_tmp[$key]['cbgpPeer2WithdrawnPrefixes'],
-                            ];
-                        } else {
-                            $cbgp_oids = [
-                                'cbgpPeerAcceptedPrefixes.' . $peer['bgpPeerIdentifier'] . ".$afi.$safi",
-                                'cbgpPeerDeniedPrefixes.' . $peer['bgpPeerIdentifier'] . ".$afi.$safi",
-                                'cbgpPeerPrefixAdminLimit.' . $peer['bgpPeerIdentifier'] . ".$afi.$safi",
-                                'cbgpPeerPrefixThreshold.' . $peer['bgpPeerIdentifier'] . ".$afi.$safi",
-                                'cbgpPeerPrefixClearThreshold.' . $peer['bgpPeerIdentifier'] . ".$afi.$safi",
-                                'cbgpPeerAdvertisedPrefixes.' . $peer['bgpPeerIdentifier'] . ".$afi.$safi",
-                                'cbgpPeerSuppressedPrefixes.' . $peer['bgpPeerIdentifier'] . ".$afi.$safi",
-                                'cbgpPeerWithdrawnPrefixes.' . $peer['bgpPeerIdentifier'] . ".$afi.$safi",
-                            ];
+        // --- Populate cbgp data ---
+        if ($device['os_group'] == 'vrp' || $device['os_group'] == 'cisco' || $device['os'] == 'junos' || $device['os'] == 'aos7' || $device['os_group'] === 'arista' || $device['os'] == 'dell-os10' || $device['os'] == 'firebrick') {
+            // Poll each AFI/SAFI for this peer (using CISCO-BGP4-MIB or BGP4-V2-JUNIPER MIB)
+            $peer_afis = dbFetchRows('SELECT * FROM bgpPeers_cbgp WHERE `device_id` = ? AND bgpPeerIdentifier = ?', [$device['device_id'], $peer['bgpPeerIdentifier']]);
+            foreach ($peer_afis as $peer_afi) {
+                $afi = $peer_afi['afi'];
+                $safi = $peer_afi['safi'];
+                d_echo("$afi $safi\n");
+                if ($device['os_group'] == 'cisco') {
+                    $bgp_peer_ident = $peer_ip->toSnmpIndex();
 
-                            $cbgp_data = snmp_get_multi($device, $cbgp_oids, '-OUQs', 'CISCO-BGP4-MIB');
-                            $cbgp_data = reset($cbgp_data); // get first entry
-                        }
-                        d_echo($cbgp_data);
+                    $ip_ver = $peer_ip->getFamily();
+                    if ($ip_ver == 'ipv6') {
+                        $ip_type = 2;
+                        $ip_len = 16;
+                    } else {
+                        $ip_type = 1;
+                        $ip_len = 4;
+                    }
 
-                        $cbgpPeerAcceptedPrefixes = $cbgp_data['cbgpPeerAcceptedPrefixes'];
-                        $cbgpPeerDeniedPrefixes = $cbgp_data['cbgpPeerDeniedPrefixes'];
-                        $cbgpPeerPrefixAdminLimit = $cbgp_data['cbgpPeerPrefixAdminLimit'];
-                        $cbgpPeerPrefixThreshold = $cbgp_data['cbgpPeerPrefixThreshold'];
-                        $cbgpPeerPrefixClearThreshold = $cbgp_data['cbgpPeerPrefixClearThreshold'];
-                        $cbgpPeerAdvertisedPrefixes = $cbgp_data['cbgpPeerAdvertisedPrefixes'];
-                        $cbgpPeerSuppressedPrefixes = $cbgp_data['cbgpPeerSuppressedPrefixes'];
-                        $cbgpPeerWithdrawnPrefixes = $cbgp_data['cbgpPeerWithdrawnPrefixes'];
-                        unset($cbgp_data);
-                    } //end if
+                    $ip_cast = 1;
+                    if ($peer_afi['safi'] == 'multicast') {
+                        $ip_cast = 2;
+                    } elseif ($peer_afi['safi'] == 'unicastAndMulticast') {
+                        $ip_cast = 3;
+                    } elseif ($peer_afi['safi'] == 'vpn') {
+                        $ip_cast = 128;
+                    }
 
-                    if ($device['os'] == 'junos') {
-                        $safis = [
-                            'unicast' => 1,
-                            'multicast' => 2,
-                            'unicastAndMulticast' => 3,
-                            'labeledUnicast' => 4,
-                            'mvpn' => 5,
-                            'vpls' => 65,
-                            'evpn' => 70,
-                            'vpn' => 128,
-                            'rtfilter' => 132,
-                            'flow' => 133,
+                    $check = snmp_get($device, 'cbgpPeer2AcceptedPrefixes.' . $ip_type . '.' . $ip_len . '.' . $bgp_peer_ident . '.' . $ip_type . '.' . $ip_cast, '', 'CISCO-BGP4-MIB');
+
+                    if (! empty($check)) {
+                        $cgp_peer_identifier = $ip_type . '.' . $ip_len . '.' . $bgp_peer_ident . '.' . $ip_type . '.' . $ip_cast;
+                        $cbgp2_oids = [
+                            'cbgpPeer2AcceptedPrefixes.' . $cgp_peer_identifier,
+                            'cbgpPeer2DeniedPrefixes.' . $cgp_peer_identifier,
+                            'cbgpPeer2PrefixAdminLimit.' . $cgp_peer_identifier,
+                            'cbgpPeer2PrefixThreshold.' . $cgp_peer_identifier,
+                            'cbgpPeer2PrefixClearThreshold.' . $cgp_peer_identifier,
+                            'cbgpPeer2AdvertisedPrefixes.' . $cgp_peer_identifier,
+                            'cbgpPeer2SuppressedPrefixes.' . $cgp_peer_identifier,
+                            'cbgpPeer2WithdrawnPrefixes.' . $cgp_peer_identifier,
+                        ];
+                        $cbgp_data_tmp = snmp_get_multi($device, $cbgp2_oids, '-OQUs', 'CISCO-BGP4-MIB');
+                        $ident = "$ip_ver.\"" . $peer['bgpPeerIdentifier'] . '"' . '.' . $ip_type . '.' . $ip_cast;
+
+                        $key = key($cbgp_data_tmp); // get key of item
+                        $cbgp_data = [
+                            'cbgpPeerAcceptedPrefixes' => $cbgp_data_tmp[$key]['cbgpPeer2AcceptedPrefixes'],
+                            'cbgpPeerDeniedPrefixes' => $cbgp_data_tmp[$key]['cbgpPeer2DeniedPrefixes'],
+                            'cbgpPeerPrefixAdminLimit' => $cbgp_data_tmp[$key]['cbgpPeer2PrefixAdminLimit'],
+                            'cbgpPeerPrefixThreshold' => $cbgp_data_tmp[$key]['cbgpPeer2PrefixThreshold'],
+                            'cbgpPeerPrefixClearThreshold' => $cbgp_data_tmp[$key]['cbgpPeer2PrefixClearThreshold'],
+                            'cbgpPeerAdvertisedPrefixes' => $cbgp_data_tmp[$key]['cbgpPeer2AdvertisedPrefixes'],
+                            'cbgpPeerSuppressedPrefixes' => $cbgp_data_tmp[$key]['cbgpPeer2SuppressedPrefixes'],
+                            'cbgpPeerWithdrawnPrefixes' => $cbgp_data_tmp[$key]['cbgpPeer2WithdrawnPrefixes'],
+                        ];
+                    } else {
+                        $cbgp_oids = [
+                            'cbgpPeerAcceptedPrefixes.' . $peer['bgpPeerIdentifier'] . ".$afi.$safi",
+                            'cbgpPeerDeniedPrefixes.' . $peer['bgpPeerIdentifier'] . ".$afi.$safi",
+                            'cbgpPeerPrefixAdminLimit.' . $peer['bgpPeerIdentifier'] . ".$afi.$safi",
+                            'cbgpPeerPrefixThreshold.' . $peer['bgpPeerIdentifier'] . ".$afi.$safi",
+                            'cbgpPeerPrefixClearThreshold.' . $peer['bgpPeerIdentifier'] . ".$afi.$safi",
+                            'cbgpPeerAdvertisedPrefixes.' . $peer['bgpPeerIdentifier'] . ".$afi.$safi",
+                            'cbgpPeerSuppressedPrefixes.' . $peer['bgpPeerIdentifier'] . ".$afi.$safi",
+                            'cbgpPeerWithdrawnPrefixes.' . $peer['bgpPeerIdentifier'] . ".$afi.$safi",
                         ];
 
-                        if (! isset($j_prefixes)) {
-                            $j_prefixes = SnmpQuery::walk([
-                                'BGP4-V2-MIB-JUNIPER::jnxBgpM2PrefixInPrefixesAccepted',
-                                'BGP4-V2-MIB-JUNIPER::jnxBgpM2PrefixInPrefixesRejected',
-                                'BGP4-V2-MIB-JUNIPER::jnxBgpM2PrefixOutPrefixes',
-                            ])->table(3);
-                        }
+                        $cbgp_data = snmp_get_multi($device, $cbgp_oids, '-OUQs', 'CISCO-BGP4-MIB');
+                        $cbgp_data = reset($cbgp_data); // get first entry
+                    }
+                    d_echo($cbgp_data);
 
-                        $current_peer_data = $j_prefixes[$junos[(string) $peer_ip]['index']][$afi][$safis[$safi]];
-                        $cbgpPeerAcceptedPrefixes = $current_peer_data['BGP4-V2-MIB-JUNIPER::jnxBgpM2PrefixInPrefixesAccepted'];
-                        $cbgpPeerDeniedPrefixes = $current_peer_data['BGP4-V2-MIB-JUNIPER::jnxBgpM2PrefixInPrefixesRejected'];
-                        $cbgpPeerAdvertisedPrefixes = $current_peer_data['BGP4-V2-MIB-JUNIPER::jnxBgpM2PrefixOutPrefixes'];
-                    }//end if
+                    $cbgpPeerAcceptedPrefixes = $cbgp_data['cbgpPeerAcceptedPrefixes'];
+                    $cbgpPeerDeniedPrefixes = $cbgp_data['cbgpPeerDeniedPrefixes'];
+                    $cbgpPeerPrefixAdminLimit = $cbgp_data['cbgpPeerPrefixAdminLimit'];
+                    $cbgpPeerPrefixThreshold = $cbgp_data['cbgpPeerPrefixThreshold'];
+                    $cbgpPeerPrefixClearThreshold = $cbgp_data['cbgpPeerPrefixClearThreshold'];
+                    $cbgpPeerAdvertisedPrefixes = $cbgp_data['cbgpPeerAdvertisedPrefixes'];
+                    $cbgpPeerSuppressedPrefixes = $cbgp_data['cbgpPeerSuppressedPrefixes'];
+                    $cbgpPeerWithdrawnPrefixes = $cbgp_data['cbgpPeerWithdrawnPrefixes'];
+                    unset($cbgp_data);
+                } //end if
 
-                    if ($device['os_group'] === 'arista') {
-                        $safis['unicast'] = 1;
-                        $safis['multicast'] = 2;
-                        $afis['ipv4'] = 1;
-                        $afis['ipv6'] = 2;
-                        if (preg_match('/:/', $peer['bgpPeerIdentifier'])) {
-                            $tmp_peer = str_replace(':', '', $peer['bgpPeerIdentifier']);
-                            $tmp_peer = preg_replace('/([\w\d]{2})/', '\1:', $tmp_peer);
-                            $tmp_peer = rtrim($tmp_peer, ':');
-                        } else {
-                            $tmp_peer = $peer['bgpPeerIdentifier'];
-                        }
-                        $a_prefixes = snmpwalk_cache_multi_oid($device, 'aristaBgp4V2PrefixInPrefixesAccepted', $a_prefixes, 'ARISTA-BGP4V2-MIB', null, '-OQUs');
-                        $out_prefixes = snmpwalk_cache_multi_oid($device, 'aristaBgp4V2PrefixOutPrefixes', $out_prefixes, 'ARISTA-BGP4V2-MIB', null, '-OQUs');
+                if ($device['os'] == 'junos') {
+                    $safis = [
+                        'unicast' => 1,
+                        'multicast' => 2,
+                        'unicastAndMulticast' => 3,
+                        'labeledUnicast' => 4,
+                        'mvpn' => 5,
+                        'vpls' => 65,
+                        'evpn' => 70,
+                        'vpn' => 128,
+                        'rtfilter' => 132,
+                        'flow' => 133,
+                    ];
 
-                        $cbgpPeerAcceptedPrefixes = $a_prefixes["1.$afi.$tmp_peer.$afi.$safi"]['aristaBgp4V2PrefixInPrefixesAccepted'];
-                        $cbgpPeerAdvertisedPrefixes = $out_prefixes["1.$afi.$tmp_peer.$afi.$safi"]['aristaBgp4V2PrefixOutPrefixes'];
+                    if (! isset($j_prefixes)) {
+                        $j_prefixes = SnmpQuery::walk([
+                            'BGP4-V2-MIB-JUNIPER::jnxBgpM2PrefixInPrefixesAccepted',
+                            'BGP4-V2-MIB-JUNIPER::jnxBgpM2PrefixInPrefixesRejected',
+                            'BGP4-V2-MIB-JUNIPER::jnxBgpM2PrefixOutPrefixes',
+                        ])->table(3);
                     }
 
-                    if ($device['os'] == 'dell-os10') {
-                        $safis['unicast'] = 1;
-                        $safis['multicast'] = 2;
-                        $afis['ipv4'] = 1;
-                        $afis['ipv6'] = 2;
-                        if (preg_match('/:/', $peer['bgpPeerIdentifier'])) {
-                            $tmp_peer = str_replace(':', '', $peer['bgpPeerIdentifier']);
-                            $tmp_peer = preg_replace('/([\w\d]{2})/', '\1:', $tmp_peer);
-                            $tmp_peer = rtrim($tmp_peer, ':');
-                        } else {
-                            $tmp_peer = $peer['bgpPeerIdentifier'];
-                        }
-                        $a_prefixes = snmpwalk_cache_multi_oid($device, 'os10bgp4V2PrefixInPrefixesAccepted', $a_prefixes, 'DELLEMC-OS10-BGP4V2-MIB', null, '-OQUs');
-                        $out_prefixes = snmpwalk_cache_multi_oid($device, 'os10bgp4V2PrefixOutPrefixes', $out_prefixes, 'DELLEMC-OS10-BGP4V2-MIB', null, '-OQUs');
+                    $current_peer_data = $j_prefixes[$junos[(string) $peer_ip]['index']][$afi][$safis[$safi]];
+                    $cbgpPeerAcceptedPrefixes = $current_peer_data['BGP4-V2-MIB-JUNIPER::jnxBgpM2PrefixInPrefixesAccepted'];
+                    $cbgpPeerDeniedPrefixes = $current_peer_data['BGP4-V2-MIB-JUNIPER::jnxBgpM2PrefixInPrefixesRejected'];
+                    $cbgpPeerAdvertisedPrefixes = $current_peer_data['BGP4-V2-MIB-JUNIPER::jnxBgpM2PrefixOutPrefixes'];
+                }//end if
 
-                        $cbgpPeerAcceptedPrefixes = $a_prefixes["1.$afi.$tmp_peer.$afi.$safi"]['os10bgp4V2PrefixInPrefixesAccepted'];
-                        $cbgpPeerAdvertisedPrefixes = $out_prefixes["1.$afi.$tmp_peer.$afi.$safi"]['os10bgp4V2PrefixOutPrefixes'];
-                    }
-
-                    if ($device['os'] === 'aos7') {
+                if ($device['os_group'] === 'arista') {
+                    $safis['multicast'] = 2;
+                    $afis['ipv4'] = 1;
+                    $afis['ipv6'] = 2;
+                    if (preg_match('/:/', $peer['bgpPeerIdentifier'])) {
+                        $tmp_peer = str_replace(':', '', $peer['bgpPeerIdentifier']);
+                        $tmp_peer = preg_replace('/([\w\d]{2})/', '\1:', $tmp_peer);
+                        $tmp_peer = rtrim($tmp_peer, ':');
+                    } else {
                         $tmp_peer = $peer['bgpPeerIdentifier'];
-                        $al_prefixes = snmpwalk_cache_multi_oid($device, 'alaBgpPeerRcvdPrefixes', $al_prefixes, 'ALCATEL-IND1-BGP-MIB', 'aos7', '-OQUs');
-                        $cbgpPeerAcceptedPrefixes = $al_prefixes[$tmp_peer]['alaBgpPeerRcvdPrefixes'];
                     }
+                    $a_prefixes = snmpwalk_cache_multi_oid($device, 'aristaBgp4V2PrefixInPrefixesAccepted', $a_prefixes, 'ARISTA-BGP4V2-MIB', null, '-OQUs');
+                    $out_prefixes = snmpwalk_cache_multi_oid($device, 'aristaBgp4V2PrefixOutPrefixes', $out_prefixes, 'ARISTA-BGP4V2-MIB', null, '-OQUs');
 
-                    if ($device['os_group'] === 'vrp') {
-                        $vrpPrefixes = snmpwalk_cache_multi_oid($device, 'hwBgpPeerPrefixRcvCounter', $vrpPrefixes, 'HUAWEI-BGP-VPN-MIB', null, '-OQUs');
-                        $vrpPrefixes = snmpwalk_cache_multi_oid($device, 'hwBgpPeerPrefixAdvCounter', $vrpPrefixes, 'HUAWEI-BGP-VPN-MIB', null, '-OQUs');
+                    $cbgpPeerAcceptedPrefixes = $a_prefixes["1.$afi.$tmp_peer.$afi.$safi"]['aristaBgp4V2PrefixInPrefixesAccepted'];
+                    $cbgpPeerAdvertisedPrefixes = $out_prefixes["1.$afi.$tmp_peer.$afi.$safi"]['aristaBgp4V2PrefixOutPrefixes'];
+                }
 
-                        // only works in global routing table, as the vpnInstanceId is not available
-                        // for now in the VRF discovery of VRP devices
-                        $key4 = $vrfInstance . '.' . $afi . '.' . $safi . '.ipv4.' . $peer['bgpPeerIdentifier'];
-                        $key6 = $vrfInstance . '.' . $afi . '.' . $safi . '.ipv6.' . $peer['bgpPeerIdentifier'];
-
-                        if (isset($vrpPrefixes[$key4])) {
-                            $cbgpPeerAcceptedPrefixes = $vrpPrefixes[$key4]['hwBgpPeerPrefixRcvCounter'];
-                            $cbgpPeerAdvertisedPrefixes = $vrpPrefixes[$key4]['hwBgpPeerPrefixAdvCounter'];
-                        }
-                        if (isset($vrpPrefixes[$key6])) {
-                            $cbgpPeerAcceptedPrefixes = $vrpPrefixes[$key6]['hwBgpPeerPrefixRcvCounter'];
-                            $cbgpPeerAdvertisedPrefixes = $vrpPrefixes[$key6]['hwBgpPeerPrefixAdvCounter'];
-                        }
+                if ($device['os'] == 'dell-os10') {
+                    $safis['unicast'] = 1;
+                    $safis['multicast'] = 2;
+                    $afis['ipv4'] = 1;
+                    $afis['ipv6'] = 2;
+                    if (preg_match('/:/', $peer['bgpPeerIdentifier'])) {
+                        $tmp_peer = str_replace(':', '', $peer['bgpPeerIdentifier']);
+                        $tmp_peer = preg_replace('/([\w\d]{2})/', '\1:', $tmp_peer);
+                        $tmp_peer = rtrim($tmp_peer, ':');
+                    } else {
+                        $tmp_peer = $peer['bgpPeerIdentifier'];
                     }
+                    $a_prefixes = snmpwalk_cache_multi_oid($device, 'os10bgp4V2PrefixInPrefixesAccepted', $a_prefixes, 'DELLEMC-OS10-BGP4V2-MIB', null, '-OQUs');
+                    $out_prefixes = snmpwalk_cache_multi_oid($device, 'os10bgp4V2PrefixOutPrefixes', $out_prefixes, 'DELLEMC-OS10-BGP4V2-MIB', null, '-OQUs');
 
-                    if ($device['os'] == 'firebrick') {
-                        foreach ($peer_data_check as $key => $value) {
-                            $oid = explode('.', $key);
-                            $protocol = $oid[0];
-                            $address = str_replace($oid[0] . '.', '', $key);
-                            if (strlen($address) > 15) {
-                                $address = IP::fromHexString($address)->compressed();
-                            }
-                            if ($address == $peer['bgpPeerIdentifier']) {
-                                $cbgpPeerAcceptedPrefixes = $value['fbBgpPeerReceivedIpv4Prefixes'] + $value['fbBgpPeerReceivedIpv6Prefixes'];
-                                $cbgpPeerAdvertisedPrefixes = $value['fbBgpPeerExported'];
-                                break;
-                            }
-                        }
+                    $cbgpPeerAcceptedPrefixes = $a_prefixes["1.$afi.$tmp_peer.$afi.$safi"]['os10bgp4V2PrefixInPrefixesAccepted'];
+                    $cbgpPeerAdvertisedPrefixes = $out_prefixes["1.$afi.$tmp_peer.$afi.$safi"]['os10bgp4V2PrefixOutPrefixes'];
+                }
+
+                if ($device['os'] === 'aos7') {
+                    $tmp_peer = $peer['bgpPeerIdentifier'];
+                    $al_prefixes = snmpwalk_cache_multi_oid($device, 'alaBgpPeerRcvdPrefixes', $al_prefixes, 'ALCATEL-IND1-BGP-MIB', 'aos7', '-OQUs');
+                    $cbgpPeerAcceptedPrefixes = $al_prefixes[$tmp_peer]['alaBgpPeerRcvdPrefixes'];
+                }
+
+                if ($device['os_group'] === 'vrp') {
+                    $vrpPrefixes = snmpwalk_cache_multi_oid($device, 'hwBgpPeerPrefixRcvCounter', $vrpPrefixes, 'HUAWEI-BGP-VPN-MIB', null, '-OQUs');
+                    $vrpPrefixes = snmpwalk_cache_multi_oid($device, 'hwBgpPeerPrefixAdvCounter', $vrpPrefixes, 'HUAWEI-BGP-VPN-MIB', null, '-OQUs');
+
+                    // only works in global routing table, as the vpnInstanceId is not available
+                    // for now in the VRF discovery of VRP devices
+                    $key4 = $vrfInstance . '.' . $afi . '.' . $safi . '.ipv4.' . $peer['bgpPeerIdentifier'];
+                    $key6 = $vrfInstance . '.' . $afi . '.' . $safi . '.ipv6.' . $peer['bgpPeerIdentifier'];
+
+                    if (isset($vrpPrefixes[$key4])) {
+                        $cbgpPeerAcceptedPrefixes = $vrpPrefixes[$key4]['hwBgpPeerPrefixRcvCounter'];
+                        $cbgpPeerAdvertisedPrefixes = $vrpPrefixes[$key4]['hwBgpPeerPrefixAdvCounter'];
                     }
-
-                    // Validate data
-                    $cbgpPeerAcceptedPrefixes = set_numeric($cbgpPeerAcceptedPrefixes);
-                    $cbgpPeerDeniedPrefixes = set_numeric($cbgpPeerDeniedPrefixes);
-                    $cbgpPeerPrefixAdminLimit = set_numeric($cbgpPeerPrefixAdminLimit);
-                    $cbgpPeerPrefixThreshold = set_numeric($cbgpPeerPrefixThreshold);
-                    $cbgpPeerPrefixClearThreshold = set_numeric($cbgpPeerPrefixClearThreshold);
-                    $cbgpPeerAdvertisedPrefixes = set_numeric($cbgpPeerAdvertisedPrefixes);
-                    $cbgpPeerSuppressedPrefixes = set_numeric($cbgpPeerSuppressedPrefixes);
-                    $cbgpPeerWithdrawnPrefixes = set_numeric($cbgpPeerWithdrawnPrefixes);
-
-                    $cbgpPeers_cbgp_fields = [
-                        'AcceptedPrefixes'     => $cbgpPeerAcceptedPrefixes,
-                        'DeniedPrefixes'       => $cbgpPeerDeniedPrefixes,
-                        'PrefixAdminLimit'     => $cbgpPeerPrefixAdminLimit,
-                        'PrefixThreshold'      => $cbgpPeerPrefixThreshold,
-                        'PrefixClearThreshold' => $cbgpPeerPrefixClearThreshold,
-                        'AdvertisedPrefixes'   => $cbgpPeerAdvertisedPrefixes,
-                        'SuppressedPrefixes'   => $cbgpPeerSuppressedPrefixes,
-                        'WithdrawnPrefixes'    => $cbgpPeerWithdrawnPrefixes,
-                    ];
-
-                    foreach ($cbgpPeers_cbgp_fields as $field => $value) {
-                        if ($peer_afi[$field] != $value) {
-                            $peer['c_update'][$field] = $value;
-                        }
+                    if (isset($vrpPrefixes[$key6])) {
+                        $cbgpPeerAcceptedPrefixes = $vrpPrefixes[$key6]['hwBgpPeerPrefixRcvCounter'];
+                        $cbgpPeerAdvertisedPrefixes = $vrpPrefixes[$key6]['hwBgpPeerPrefixAdvCounter'];
                     }
+                }
 
-                    $oids = [
-                        'AcceptedPrefixes',
-                        'DeniedPrefixes',
-                        'AdvertisedPrefixes',
-                        'SuppressedPrefixes',
-                        'WithdrawnPrefixes',
-                    ];
-
-                    foreach ($oids as $oid) {
-                        $tmp_prev = set_numeric($peer_afi[$oid]);
-                        $tmp_delta = $cbgpPeers_cbgp_fields[$oid] - $tmp_prev;
-                        if ($peer_afi[$oid . '_delta'] != $tmp_delta) {
-                            $peer['c_update'][$oid . '_delta'] = $tmp_delta;
+                if ($device['os'] == 'firebrick') {
+                    foreach ($peer_data_check as $key => $value) {
+                        $oid = explode('.', $key);
+                        $protocol = $oid[0];
+                        $address = str_replace($oid[0] . '.', '', $key);
+                        if (strlen($address) > 15) {
+                            $address = IP::fromHexString($address)->compressed();
                         }
-                        if ($peer_afi[$oid . '_prev'] != $tmp_prev) {
-                            $peer['c_update'][$oid . '_prev'] = $tmp_prev;
+                        if ($address == $peer['bgpPeerIdentifier']) {
+                            $cbgpPeerAcceptedPrefixes = $value['fbBgpPeerReceivedIpv4Prefixes'] + $value['fbBgpPeerReceivedIpv6Prefixes'];
+                            $cbgpPeerAdvertisedPrefixes = $value['fbBgpPeerExported'];
+                            break;
                         }
                     }
+                }
 
-                    if ($peer['c_update']) {
-                        dbUpdate(
-                            $peer['c_update'],
-                            'bgpPeers_cbgp',
-                            '`device_id` = ? AND bgpPeerIdentifier = ? AND afi = ? AND safi = ?',
-                            [$device['device_id'], $peer['bgpPeerIdentifier'], $afi, $safi]
-                        );
+                // Validate data
+                $cbgpPeerAcceptedPrefixes = set_numeric($cbgpPeerAcceptedPrefixes);
+                $cbgpPeerDeniedPrefixes = set_numeric($cbgpPeerDeniedPrefixes);
+                $cbgpPeerPrefixAdminLimit = set_numeric($cbgpPeerPrefixAdminLimit);
+                $cbgpPeerPrefixThreshold = set_numeric($cbgpPeerPrefixThreshold);
+                $cbgpPeerPrefixClearThreshold = set_numeric($cbgpPeerPrefixClearThreshold);
+                $cbgpPeerAdvertisedPrefixes = set_numeric($cbgpPeerAdvertisedPrefixes);
+                $cbgpPeerSuppressedPrefixes = set_numeric($cbgpPeerSuppressedPrefixes);
+                $cbgpPeerWithdrawnPrefixes = set_numeric($cbgpPeerWithdrawnPrefixes);
+
+                $cbgpPeers_cbgp_fields = [
+                    'AcceptedPrefixes'     => $cbgpPeerAcceptedPrefixes,
+                    'DeniedPrefixes'       => $cbgpPeerDeniedPrefixes,
+                    'PrefixAdminLimit'     => $cbgpPeerPrefixAdminLimit,
+                    'PrefixThreshold'      => $cbgpPeerPrefixThreshold,
+                    'PrefixClearThreshold' => $cbgpPeerPrefixClearThreshold,
+                    'AdvertisedPrefixes'   => $cbgpPeerAdvertisedPrefixes,
+                    'SuppressedPrefixes'   => $cbgpPeerSuppressedPrefixes,
+                    'WithdrawnPrefixes'    => $cbgpPeerWithdrawnPrefixes,
+                ];
+
+                foreach ($cbgpPeers_cbgp_fields as $field => $value) {
+                    if ($peer_afi[$field] != $value) {
+                        $peer['c_update'][$field] = $value;
                     }
+                }
 
-                    $cbgp_rrd_name = \LibreNMS\Data\Store\Rrd::safeName('cbgp-' . $peer['bgpPeerIdentifier'] . ".$afi.$safi");
-                    $cbgp_rrd_def = RrdDefinition::make()
-                        ->addDataset('AcceptedPrefixes', 'GAUGE', null, 100000000000)
-                        ->addDataset('DeniedPrefixes', 'GAUGE', null, 100000000000)
-                        ->addDataset('AdvertisedPrefixes', 'GAUGE', null, 100000000000)
-                        ->addDataset('SuppressedPrefixes', 'GAUGE', null, 100000000000)
-                        ->addDataset('WithdrawnPrefixes', 'GAUGE', null, 100000000000);
+                $oids = [
+                    'AcceptedPrefixes',
+                    'DeniedPrefixes',
+                    'AdvertisedPrefixes',
+                    'SuppressedPrefixes',
+                    'WithdrawnPrefixes',
+                ];
 
-                    $fields = [
-                        'AcceptedPrefixes'    => $cbgpPeerAcceptedPrefixes,
-                        'DeniedPrefixes'      => $cbgpPeerDeniedPrefixes,
-                        'AdvertisedPrefixes'  => $cbgpPeerAdvertisedPrefixes,
-                        'SuppressedPrefixes'  => $cbgpPeerSuppressedPrefixes,
-                        'WithdrawnPrefixes'   => $cbgpPeerWithdrawnPrefixes,
-                    ];
+                foreach ($oids as $oid) {
+                    $tmp_prev = set_numeric($peer_afi[$oid]);
+                    $tmp_delta = $cbgpPeers_cbgp_fields[$oid] - $tmp_prev;
+                    if ($peer_afi[$oid . '_delta'] != $tmp_delta) {
+                        $peer['c_update'][$oid . '_delta'] = $tmp_delta;
+                    }
+                    if ($peer_afi[$oid . '_prev'] != $tmp_prev) {
+                        $peer['c_update'][$oid . '_prev'] = $tmp_prev;
+                    }
+                }
 
-                    $tags = [
-                        'bgpPeerIdentifier' => $peer['bgpPeerIdentifier'],
-                        'afi' => $afi,
-                        'safi' => $safi,
-                        'rrd_name' => $cbgp_rrd_name,
-                        'rrd_def' => $cbgp_rrd_def,
-                    ];
-                    data_update($device, 'cbgp', $tags, $fields);
-                } //end foreach
-            } //end if
-            echo "\n";
-        } //end foreach
-    } //end if
+                if ($peer['c_update']) {
+                    dbUpdate(
+                        $peer['c_update'],
+                        'bgpPeers_cbgp',
+                        '`device_id` = ? AND bgpPeerIdentifier = ? AND afi = ? AND safi = ?',
+                        [$device['device_id'], $peer['bgpPeerIdentifier'], $afi, $safi]
+                    );
+                }
+
+                $cbgp_rrd_name = \LibreNMS\Data\Store\Rrd::safeName('cbgp-' . $peer['bgpPeerIdentifier'] . ".$afi.$safi");
+                $cbgp_rrd_def = RrdDefinition::make()
+                    ->addDataset('AcceptedPrefixes', 'GAUGE', null, 100000000000)
+                    ->addDataset('DeniedPrefixes', 'GAUGE', null, 100000000000)
+                    ->addDataset('AdvertisedPrefixes', 'GAUGE', null, 100000000000)
+                    ->addDataset('SuppressedPrefixes', 'GAUGE', null, 100000000000)
+                    ->addDataset('WithdrawnPrefixes', 'GAUGE', null, 100000000000);
+                 $fields = [
+                    'AcceptedPrefixes'    => $cbgpPeerAcceptedPrefixes,
+                    'DeniedPrefixes'      => $cbgpPeerDeniedPrefixes,
+                    'AdvertisedPrefixes'  => $cbgpPeerAdvertisedPrefixes,
+                    'SuppressedPrefixes'  => $cbgpPeerSuppressedPrefixes,
+                    'WithdrawnPrefixes'   => $cbgpPeerWithdrawnPrefixes,
+                ];
+
+                $tags = [
+                    'bgpPeerIdentifier' => $peer['bgpPeerIdentifier'],
+                    'afi' => $afi,
+                    'safi' => $safi,
+                    'rrd_name' => $cbgp_rrd_name,
+                    'rrd_def' => $cbgp_rrd_def,
+                ];
+                data_update($device, 'cbgp', $tags, $fields);
+            } //end foreach
+        } //end if
+        echo "\n";
+    } //end foreach
+} //end if
 
 unset($peers, $peer_data_tmp, $j_prefixes);

--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -1584,10 +1584,6 @@
             "order": 1,
             "type": "text"
         },
-        "enable_bgp": {
-            "default": true,
-            "type": "boolean"
-        },
         "enable_billing": {
             "default": false,
             "type": "boolean"


### PR DESCRIPTION
enable_bgp setting is redundant to the newer polling/discovery module bgp-peers setting.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
