### PR TITLE
Solves error in discovering services module

### DIFF
--- a/app/Http/Controllers/ServiceTemplateController.php
+++ b/app/Http/Controllers/ServiceTemplateController.php
@@ -321,10 +321,8 @@ class ServiceTemplateController extends Controller
         ServiceTemplateController::applyDeviceGroups($template);
 
         // remove any remaining services no longer in the correct device group
-        foreach ($template->groups as $group) { // notInDeviceGroup expects a group id, not a collection.
-            foreach (Device::notInServiceTemplate($template->id)->notInDeviceGroup($group->id)->get() as $device) {
-                Service::where('device_id', $device->device_id)->where('service_template_id', $template->id)->delete();
-            }
+        foreach (Device::notInServiceTemplate($template->id)->notInDeviceGroup($template->groups->pluck('id'))->pluck('device_id') as $device_id) {
+            Service::where('device_id', $device_id)->where('service_template_id', $template->id)->delete();
         }
         $msg = __('All Service Templates have been applied');
 

--- a/app/Http/Controllers/ServiceTemplateController.php
+++ b/app/Http/Controllers/ServiceTemplateController.php
@@ -320,7 +320,7 @@ class ServiceTemplateController extends Controller
         ServiceTemplateController::applyDevices($template);
         ServiceTemplateController::applyDeviceGroups($template);
 
-        // remove any remaining services no longer in the correct device group        
+        // remove any remaining services no longer in the correct device group
         foreach ($template->groups as $group) { // notInDeviceGroup expects a group id, not a collection.
             foreach (Device::notInServiceTemplate($template->id)->notInDeviceGroup($group->id)->get() as $device) {
                 Service::where('device_id', $device->device_id)->where('service_template_id', $template->id)->delete();

--- a/app/Http/Controllers/ServiceTemplateController.php
+++ b/app/Http/Controllers/ServiceTemplateController.php
@@ -320,9 +320,11 @@ class ServiceTemplateController extends Controller
         ServiceTemplateController::applyDevices($template);
         ServiceTemplateController::applyDeviceGroups($template);
 
-        // remove any remaining services no longer in the correct device group
-        foreach (Device::notInServiceTemplate($template->id)->notInDeviceGroup($template->groups)->get() as $device) {
-            Service::where('device_id', $device->device_id)->where('service_template_id', $template->id)->delete();
+        // remove any remaining services no longer in the correct device group        
+        foreach ($template->groups as $group) { // notInDeviceGroup expects a group id, not a collection.
+            foreach (Device::notInServiceTemplate($template->id)->notInDeviceGroup($group->id)->get() as $device) {
+                Service::where('device_id', $device->device_id)->where('service_template_id', $template->id)->delete();
+            }
         }
         $msg = __('All Service Templates have been applied');
 

--- a/app/Models/Device.php
+++ b/app/Models/Device.php
@@ -14,6 +14,7 @@ use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Database\Query\JoinClause;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use LibreNMS\Exceptions\InvalidIpException;
 use LibreNMS\Util\IP;
@@ -567,7 +568,7 @@ class Device extends BaseModel
             $query->qualifyColumn('device_id'), function ($query) use ($deviceGroup) {
                 $query->select('device_id')
                 ->from('device_group_device')
-                ->where('device_group_id', $deviceGroup);
+                ->whereIn('device_group_id', Arr::wrap($deviceGroup));
             }
         );
     }
@@ -578,7 +579,7 @@ class Device extends BaseModel
             $query->qualifyColumn('device_id'), function ($query) use ($deviceGroup) {
                 $query->select('device_id')
                 ->from('device_group_device')
-                ->where('device_group_id', $deviceGroup);
+                ->whereIn('device_group_id', Arr::wrap($deviceGroup));
             }
         );
     }


### PR DESCRIPTION
This PR solves the issue described in [Error in log: Error discovering services module](https://community.librenms.org/t/error-in-log-error-discovering-services-module/17555)

The method notInDeviceGroup is expecting a group id, not a group collection, so I used another foreach to get them.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
