### PR TITLE
APC UPS UIO sensor discovery bug

### DIFF
--- a/includes/discovery/sensors/state/apc.inc.php
+++ b/includes/discovery/sensors/state/apc.inc.php
@@ -159,7 +159,7 @@ foreach ($pre_cache['mem_sensors_status'] as $index => $data) {
 
 // Monitor contact switches via the UIO ports.
 $apcContactData = snmpwalk_cache_oid($device, 'uioInputContact', $apcContactData, 'PowerNet-MIB', null, '-OQUse');
-if ($apcContactData["uioInputContactStatusTableSize"] > 0) {
+if ($apcContactData['uioInputContactStatusTableSize'] > 0) {
     // NMC2/NMC3/etc Universal Input Output
     foreach (array_keys($apcContactData) as $index) {
         // APC disabled (1), enabled (2)

--- a/includes/discovery/sensors/state/apc.inc.php
+++ b/includes/discovery/sensors/state/apc.inc.php
@@ -159,7 +159,7 @@ foreach ($pre_cache['mem_sensors_status'] as $index => $data) {
 
 // Monitor contact switches via the UIO ports.
 $apcContactData = snmpwalk_cache_oid($device, 'uioInputContact', $apcContactData, 'PowerNet-MIB', null, '-OQUse');
-if ($apcContactData) {
+if ($apcContactData["uioInputContactStatusTableSize"] > 0) {
     // NMC2/NMC3/etc Universal Input Output
     foreach (array_keys($apcContactData) as $index) {
         // APC disabled (1), enabled (2)


### PR DESCRIPTION
Please give a short description what your pull request is for

closes #14941 

After adding the check for `uioInputContactStatusTableSize`, dummy sensors are no longer created after each discovery.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
