### PR TITLE
set focus to Global Search on Ctrl-F

### DIFF
--- a/resources/views/layouts/menu.blade.php
+++ b/resources/views/layouts/menu.blade.php
@@ -760,4 +760,22 @@
             });
         }
     @endif
+
+    $(document).ready(function(){
+    // Function to focus Global Search on Ctrl-F 
+    window.addEventListener("keydown",function (e) {
+        if (e.keyCode === 114 || (e.ctrlKey && e.keyCode === 70)){
+            if($('#gsearch').is(":focus")) {
+                //allow normal Ctrl-F on a 2nd Hit
+                return true;
+            } else {
+                //set Focus on Global Search and ignore Browsers defaults
+                e.preventDefault();
+                $('#gsearch').focus();
+            }
+        }
+        })
+    
+
+    })
 </script>


### PR DESCRIPTION
Simple set the focus the Global Search form in the upper right corner if the user press Ctrl-F.
As this is the main search field and many of my users hits the search function when entering LibreNMS - this should make sense. 
Other option would be a `autofocus` attribute on the field but this might clash with other forms. 

As java is not my native language any feedback or better ideas are welcome. 

Tested with
- Brave Browser 111.1.49.132 
- Mozilla Firefox 111.0.1
- Google Chrome 112.0.5615.49 


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [-] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [-] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
