### PR TITLE
bug - wrong type in ports.inc.php

### DIFF
--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -782,7 +782,7 @@ foreach ($ports as $port) {
 
                 $oid_prev = $oid . '_prev';
                 if (isset($port[$oid])) {
-                    $oid_diff = (($this_port[$oid] ?? 0) - $port[$oid]);
+                    $oid_diff = (intval($this_port[$oid] ?? 0) - intval($port[$oid]));
                     $oid_rate = ($oid_diff / $polled_period);
                     if ($oid_rate < 0) {
                         $oid_rate = '0';


### PR DESCRIPTION
Yet another of these :) 

```
[2023-04-07T19:55:28.777810+02:00] production.ERROR: Error polling ports module for xxxxxxxxxx. TypeError: Unsupported operand types: string - int in /opt/librenms/includes/polling/ports.inc.php:785
Stack trace:
#0 /opt/librenms/includes/polling/functions.inc.php(339): include()
#1 /opt/librenms/poller.php(126): poll_device(Array, false)
#2 {main}  
[2023-04-07T19:55:28.780705+02:00] production.ERROR: Unsupported operand types: string - int {"exception":"[object] (TypeError(code: 0): Unsupported operand types: string - int at /opt/librenms/includes/polling/ports.inc.php:785)"} 
```

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
