### PR TITLE
Fix SnmpQuery and max_oid

### DIFF
--- a/LibreNMS/Data/Source/NetSnmpQuery.php
+++ b/LibreNMS/Data/Source/NetSnmpQuery.php
@@ -506,7 +506,7 @@ class NetSnmpQuery implements SnmpQueryInterface
             return array_chunk($oids, $max_oids);
         }
 
-        return $oids;
+        return [$oids]; // wrap in array for execMultiple so they are all done at once
     }
 
     private function parseOid(array|string $oid): array


### PR DESCRIPTION
If the snmpget had less oids than the max, it would run them one at a time instead of all together.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
