### PR TITLE
Fixes #14957 - Polling IPv6 BGP peers fails for Cisco devices with IP…

### DIFF
--- a/includes/polling/bgp-peers.inc.php
+++ b/includes/polling/bgp-peers.inc.php
@@ -30,7 +30,13 @@ if (! empty($peers)) {
     } else {
         $peer_data_check = snmpwalk_cache_oid($device, 'bgpPeerRemoteAs', [], 'BGP4-MIB');
     }
-    if (empty($peer_data_check)) {
+    $cisco_with_vrf = $device['os_group'] == 'cisco' && count(DeviceCache::getPrimary()->getVrfContexts()) > 1;
+    // If a Cisco device has BGP peers in VRF(s),
+    // but no BGP peers in the default VRF:
+    // don't fall back to the default MIB,
+    // to avoid skipping IPv6 peers.
+    // (CISCO-BGP4-MIB is required)
+    if (empty($peer_data_check) && !$cisco_with_vrf) {
         $peer_data_check = snmpwalk_cache_oid($device, 'bgpPeerRemoteAs', [], 'BGP4-MIB');
         $generic = true;
     }
@@ -53,7 +59,7 @@ if (! empty($peers)) {
             // cbgpPeer2RemoteAs, resulting in empty $peer_data_check.
             // Without the or clause, we won't see the VRF BGP peers.
             // ($peer_data_check isn't used in the Cisco code path,)
-            if (count($peer_data_check) > 0 || ($device['os_group'] == 'cisco' && count(DeviceCache::getPrimary()->getVrfContexts()) > 1)) {
+            if (count($peer_data_check) > 0 || $cisco_with_vrf) {
                 if ($generic) {
                     echo "\nfallback to default mib";
 


### PR DESCRIPTION
…v6 peers in VRF, but no IPv6 peers in default VRF

Polling IPv6 peers in VRF(s) on Cisco devices with no IPv6 peers in the default VRF failed, because the code path will use $generic instead of the network OS specific `if` section. This PR fixes that issue.

NB: although the code changes the polling, it doesn't add or change the SNMP queries or parsing thereof. Changing to tests/data/pfsense_frr-bgp.json shouldn't be necessary.

Fixes #14957 ( related to https://github.com/librenms/librenms/pull/14105 , but for IPv6 BGP peers )

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [X] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
