### PR TITLE
Fixes #14957 missing IPv6 BGP peers

### DIFF
--- a/includes/polling/bgp-peers.inc.php
+++ b/includes/polling/bgp-peers.inc.php
@@ -39,7 +39,8 @@ if (! empty($peers)) {
     // if it has a switch configured SNMP context.
     // The issues occured on NX-OS (Nexus) and IOS-XR (ASR) devices.
     // Using os_group 'cisco' breaks the 3560g snmpsim tests.
-    $cisco_with_vrf = (($device['os'] == 'iosxr' || $device['os'] == 'nxos') && count(DeviceCache::getPrimary()->getVrfContexts()) > 0);
+    $vrf_contexts = DeviceCache::getPrimary()->getVrfContexts();
+    $cisco_with_vrf = (($device['os'] == 'iosxr' || $device['os'] == 'nxos') &&  (count($vrf_contexts) > 1 || ! empty($vrf_contexts[0])));
     if (empty($peer_data_check) && ! $cisco_with_vrf) {
         $peer_data_check = snmpwalk_cache_oid($device, 'bgpPeerRemoteAs', [], 'BGP4-MIB');
         $generic = true;

--- a/includes/polling/bgp-peers.inc.php
+++ b/includes/polling/bgp-peers.inc.php
@@ -37,7 +37,9 @@ if (! empty($peers)) {
     // e.g. snmp-server context context_name vrf vrf_name
     // "> 0" because the default VRF is only included in the count,
     // if it has a switch configured SNMP context.
-    $cisco_with_vrf = ($device['os_group'] == 'cisco' && count(DeviceCache::getPrimary()->getVrfContexts()) > 0);
+    // The issues occured on NX-OS (Nexus) and IOS-XR (ASR) devices.
+    // Using os_group 'cisco' breaks the 3560g snmpsim tests.
+    $cisco_with_vrf = (($device['os'] == 'iosxr' || $device['os'] == 'nxos') && count(DeviceCache::getPrimary()->getVrfContexts()) > 0);
     if (empty($peer_data_check) && ! $cisco_with_vrf) {
         $peer_data_check = snmpwalk_cache_oid($device, 'bgpPeerRemoteAs', [], 'BGP4-MIB');
         $generic = true;

--- a/includes/polling/bgp-peers.inc.php
+++ b/includes/polling/bgp-peers.inc.php
@@ -40,7 +40,7 @@ if (! empty($peers)) {
     // The issues occured on NX-OS (Nexus) and IOS-XR (ASR) devices.
     // Using os_group 'cisco' breaks the 3560g snmpsim tests.
     $vrf_contexts = DeviceCache::getPrimary()->getVrfContexts();
-    $cisco_with_vrf = (($device['os'] == 'iosxr' || $device['os'] == 'nxos') && (count($vrf_contexts) > 1 || ! empty($vrf_contexts[0])));
+    $cisco_with_vrf = (($device['os'] == 'iosxr' || $device['os'] == 'nxos') && ! empty($vrf_contexts[0]));
     if (empty($peer_data_check) && ! $cisco_with_vrf) {
         $peer_data_check = snmpwalk_cache_oid($device, 'bgpPeerRemoteAs', [], 'BGP4-MIB');
         $generic = true;

--- a/includes/polling/bgp-peers.inc.php
+++ b/includes/polling/bgp-peers.inc.php
@@ -40,7 +40,7 @@ if (! empty($peers)) {
     // The issues occured on NX-OS (Nexus) and IOS-XR (ASR) devices.
     // Using os_group 'cisco' breaks the 3560g snmpsim tests.
     $vrf_contexts = DeviceCache::getPrimary()->getVrfContexts();
-    $cisco_with_vrf = (($device['os'] == 'iosxr' || $device['os'] == 'nxos') &&  (count($vrf_contexts) > 1 || ! empty($vrf_contexts[0])));
+    $cisco_with_vrf = (($device['os'] == 'iosxr' || $device['os'] == 'nxos') && (count($vrf_contexts) > 1 || ! empty($vrf_contexts[0])));
     if (empty($peer_data_check) && ! $cisco_with_vrf) {
         $peer_data_check = snmpwalk_cache_oid($device, 'bgpPeerRemoteAs', [], 'BGP4-MIB');
         $generic = true;


### PR DESCRIPTION
Polling IPv6 peers in VRF(s) on Cisco devices with no IPv6 peers in the
default VRF failed, because the code path will use $generic instead of the
network OS specific if section.  This PR fixes that issue.

NB: although the code changes the polling, it doesn't add or change the SNMP
queries or parsing thereof.  Changing to tests/data/pfsense_frr-bgp.json
shouldn't be necessary.

Fixes #14957 ( related to #14105 , but for IPv6 BGP peers )


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
