### PR TITLE
Cisco QFP polling fixes

### DIFF
--- a/includes/html/graphs/qfp/memory.inc.php
+++ b/includes/html/graphs/qfp/memory.inc.php
@@ -33,7 +33,7 @@ if ($width > '500') {
 
 $descr = \LibreNMS\Data\Store\Rrd::fixedSafeDescr(short_hrDeviceDescr($components['name']), $descr_len);
 
-$perc = $components['memory_used'] * 100 / $components['memory_total'];
+$perc = \LibreNMS\Util\Number::calculatePercent((int) $components['memory_used'], (int) $tmp_component['memory_total']);
 
 $background = \LibreNMS\Util\Color::percentage($perc, 75);
 

--- a/includes/html/pages/device/health/qfp.inc.php
+++ b/includes/html/pages/device/health/qfp.inc.php
@@ -187,7 +187,8 @@ foreach ($components as $component_id => $tmp_component) {
     /*
      * QFP Memory resources
      */
-    $mem_prec = $tmp_component['memory_used'] * 100 / $tmp_component['memory_total'];
+    $mem_prec = Number::calculatePercent((int)$tmp_component['memory_used'],(int)$tmp_component['memory_total']);
+    
     if ($mem_prec < 75) {
         $mem_label = 'label-success';
     } elseif ($mem_prec < 90) {

--- a/includes/html/pages/device/health/qfp.inc.php
+++ b/includes/html/pages/device/health/qfp.inc.php
@@ -187,8 +187,8 @@ foreach ($components as $component_id => $tmp_component) {
     /*
      * QFP Memory resources
      */
-    $mem_prec = Number::calculatePercent((int)$tmp_component['memory_used'],(int)$tmp_component['memory_total']);
-    
+    $mem_prec = Number::calculatePercent((int) $tmp_component['memory_used'], (int) $tmp_component['memory_total']);
+
     if ($mem_prec < 75) {
         $mem_label = 'label-success';
     } elseif ($mem_prec < 90) {

--- a/includes/polling/cisco-qfp.inc.php
+++ b/includes/polling/cisco-qfp.inc.php
@@ -101,7 +101,7 @@ if (! empty($components) && is_array($components)) {
         if (! empty($util_data) && ! empty($memory_data)) {
             $total_packets = $util_data[$util_oids['InTotalPps']] + $util_data[$util_oids['OutTotalPps']];
             $throughput = $util_data[$util_oids['InTotalBps']] + $util_data[$util_oids['OutTotalBps']];
-            $average_packet = $throughput / 8 / ($total_packets ?: 1);
+            $average_packet = floor($throughput / 8 / ($total_packets ?: 1));
             /*
              * Create component data array for `component_prefs`
              * and update components

--- a/includes/polling/cisco-qfp.inc.php
+++ b/includes/polling/cisco-qfp.inc.php
@@ -101,7 +101,7 @@ if (! empty($components) && is_array($components)) {
         if (! empty($util_data) && ! empty($memory_data)) {
             $total_packets = $util_data[$util_oids['InTotalPps']] + $util_data[$util_oids['OutTotalPps']];
             $throughput = $util_data[$util_oids['InTotalBps']] + $util_data[$util_oids['OutTotalBps']];
-            $average_packet = floor($throughput / 8 / ($total_packets ?: 1));
+            $average_packet = $total_packets ? ($throughput / 8 / $total_packets) : 0;
             /*
              * Create component data array for `component_prefs`
              * and update components

--- a/includes/polling/cisco-qfp.inc.php
+++ b/includes/polling/cisco-qfp.inc.php
@@ -101,7 +101,7 @@ if (! empty($components) && is_array($components)) {
         if (! empty($util_data) && ! empty($memory_data)) {
             $total_packets = $util_data[$util_oids['InTotalPps']] + $util_data[$util_oids['OutTotalPps']];
             $throughput = $util_data[$util_oids['InTotalBps']] + $util_data[$util_oids['OutTotalBps']];
-            $average_packet = $throughput / 8 / $total_packets;
+            $average_packet = $throughput / 8 / ($total_packets ?: 1);
             /*
              * Create component data array for `component_prefs`
              * and update components

--- a/includes/polling/cisco-qfp.inc.php
+++ b/includes/polling/cisco-qfp.inc.php
@@ -101,7 +101,7 @@ if (! empty($components) && is_array($components)) {
         if (! empty($util_data) && ! empty($memory_data)) {
             $total_packets = $util_data[$util_oids['InTotalPps']] + $util_data[$util_oids['OutTotalPps']];
             $throughput = $util_data[$util_oids['InTotalBps']] + $util_data[$util_oids['OutTotalBps']];
-            $average_packet = $total_packets ? ($throughput / 8 / $total_packets) : 0;
+            $average_packet = $total_packets ? floor($throughput / 8 / $total_packets) : 0;
             /*
              * Create component data array for `component_prefs`
              * and update components


### PR DESCRIPTION
Fixing this Poller Error:

```
./poller.php -h foobardevice -m cisco-qfp
production.ERROR: Error polling cisco-qfp module for foobardevice DivisionByZeroError:
 Division by zero in /opt/librenms/includes/polling/cisco-qfp.inc.php:104
Stack trace:
#0 /opt/librenms/includes/polling/functions.inc.php(339): include()
#1 /opt/librenms/poller.php(126): poll_device()
#2 {main}  
```
and a this possible consequential error:

```
[2023-04-14T10:52:25.859439+02:00] production.ERROR: Unsupported operand types: string * int {"userId":9,"exception":"[object] (TypeError(code:
 0): Unsupported operand types: string * int at /opt/librenms/includes/html/pages/device/health/qfp.inc.php:190)"} 

```

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
