### PR TITLE
Fix Raisecom ROS processor collection

### DIFF
--- a/includes/definitions/discovery/raisecom-ros.yaml
+++ b/includes/definitions/discovery/raisecom-ros.yaml
@@ -12,12 +12,11 @@ modules:
     processors:
         data:
             -
-                oid: rosMgmtCpuUtilizationTable
-                value: rosMgmtCpuUtilization.oneMin
+                oid: rosMgmtCpuUtilization.oneMin
+                value: rosMgmtCpuUtilization
                 num_oid: '.1.3.6.1.4.1.8886.60.1.1.1.2.1.1.1.3.{{ $index }}'
-                snmp_flags: ['-OeQUsb'] # workaround for one Min index
+                snmp_flags: ['-OeQUsb'] # workaround for oneMin index
                 descr: 'Processor'
-                index: 3
     sensors:
         state:
             data:

--- a/tests/data/raisecom-ros.json
+++ b/tests/data/raisecom-ros.json
@@ -3606,31 +3606,17 @@
                 {
                     "entPhysicalIndex": 0,
                     "hrDeviceIndex": 0,
-                    "processor_oid": ".1.3.6.1.4.1.8886.60.1.1.1.2.1.1.1.3.5.0",
-                    "processor_index": "3",
+                    "processor_oid": ".1.3.6.1.4.1.8886.60.1.1.1.2.1.1.1.3.3.0",
+                    "processor_index": "3.0",
                     "processor_type": "raisecom-ros",
-                    "processor_usage": 31,
+                    "processor_usage": 21,
                     "processor_descr": "Processor",
                     "processor_precision": 1,
                     "processor_perc_warn": 75
                 }
             ]
         },
-        "poller": {
-            "processors": [
-                {
-                    "entPhysicalIndex": 0,
-                    "hrDeviceIndex": 0,
-                    "processor_oid": ".1.3.6.1.4.1.8886.60.1.1.1.2.1.1.1.3.5.0",
-                    "processor_index": "3",
-                    "processor_type": "raisecom-ros",
-                    "processor_usage": 18,
-                    "processor_descr": "Processor",
-                    "processor_precision": 1,
-                    "processor_perc_warn": 75
-                }
-            ]
-        }
+        "poller": "matches discovery"
     },
     "mempools": {
         "discovery": {


### PR DESCRIPTION
Was originally intended to use the 1 minute values, but was discovering the one second value and polling the twoHour value. It was also restricted to only one CPU.
Now discovers and polls all CPUs at the oneMin avg
Unfortunately, historical data will be lost (but it was wrong anyway).

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
