### PR TITLE
Added feature to set SNMPv3 context name for device

### DIFF
--- a/database/migrations/2023_04_17_120044_device_add_snmpv3_context_name_field.php
+++ b/database/migrations/2023_04_17_120044_device_add_snmpv3_context_name_field.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class DeviceAddSnmpv3ContextNameField extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('devices', function (Blueprint $table) {
+            $table->string('context_name', 64)->nullable()->after('cryptoalgo');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('devices', function (Blueprint $table) {
+            $table->dropColumn(['context_name']);
+        });
+    }
+}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -322,6 +322,7 @@ function deviceArray($host, $community, $snmpver, $port = 161, $transport = 'udp
         $device['authalgo'] = $v3['authalgo'];
         $device['cryptopass'] = $v3['cryptopass'];
         $device['cryptoalgo'] = $v3['cryptoalgo'];
+        $device['context_name'] = $v3['context_name'];
     }
 
     return $device;

--- a/includes/html/pages/addhost.inc.php
+++ b/includes/html/pages/addhost.inc.php
@@ -65,6 +65,7 @@ if (! empty($_POST['hostname'])) {
                 'authalgo'   => strip_tags($_POST['authalgo']),
                 'cryptopass' => $_POST['cryptopass'],
                 'cryptoalgo' => $_POST['cryptoalgo'],
+                'context_name' => strip_tags($_POST['context_name']),
             ];
 
             $v3_config = Config::get('snmp.v3');
@@ -265,6 +266,12 @@ foreach (PortAssociationMode::getModes() as $mode) {
               <?php if (! \LibreNMS\SNMPCapabilities::supportsAES256()) {?>
               <label class="text-left"><small>Some options are disabled. <a href="https://docs.librenms.org/Support/FAQ/#optional-requirements-for-snmpv3-sha2-auth">Read more here</a></small></label>
               <?php } ?>
+            </div>
+          </div>
+          <div class="form-group">
+            <label for="context_name" class="col-sm-3 control-label">Context Name</label>
+            <div class="col-sm-9">
+              <input type="text" name="context_name" id="context_name" placeholder="Context Name" class="form-control input-sm">
             </div>
           </div>
         </div>

--- a/includes/html/pages/device/edit/snmp.inc.php
+++ b/includes/html/pages/device/edit/snmp.inc.php
@@ -55,6 +55,7 @@ if ($_POST['editing']) {
                 $v3['authpass'] = $_POST['authpass'];
                 $v3['cryptoalgo'] = $_POST['cryptoalgo'];
                 $v3['cryptopass'] = $_POST['cryptopass'];
+                $v3['context_name'] = $_POST['context_name'];
 
                 $update = array_merge($update, $v3);
             }
@@ -383,10 +384,16 @@ echo '</select>
 if (! \LibreNMS\SNMPCapabilities::supportsAES256()) {
     echo '<label class="text-left"><small>Some options are disabled. <a href="https://docs.librenms.org/Support/FAQ/#optional-requirements-for-snmpv3-sha2-auth">Read more here</a></small></label>';
 }
-    echo '
+    echo "
     </div>
     </div>
-    </div>';
+    <div class='form-group'>
+    <label for='context_name' class='col-sm-2 control-label'>Context Name</label>
+    <div class='col-sm-4'>
+    <input type='text' id='context_name' name='context_name' class='form-control' value='".$device['context_name']."'>
+    </div>
+    </div>
+    </div>";
 ?>
 
 </div>

--- a/sql-schema/282.sql
+++ b/sql-schema/282.sql
@@ -1,0 +1,1 @@
+ALTER TABLE  `devices` ADD  `context_name` VARCHAR( 64 ) NULL AFTER  `cryptoalgo` ;


### PR DESCRIPTION
This basically reopens on the abandoned https://github.com/librenms/librenms/pull/2974, allowing to set the SNMPv3 context name for a specific device.

BGP/OSPF polling already use the SNMPv3 context name for VRF support.
The BGP polling code passes the context name by overwriting $device['context_name']. which the current snmp.inc.php already uses, i.e. no changes needed in snmp.inc.php


#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [X] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
