### PR TITLE
Fixes #14975 - Availability Map: Services in Device Groups not displayed correctly

### DIFF
--- a/app/Models/DeviceGroup.php
+++ b/app/Models/DeviceGroup.php
@@ -129,7 +129,9 @@ class DeviceGroup extends BaseModel
 
     public function services(): BelongsToMany
     {
-        return $this->belongsToMany(\App\Models\Service::class, 'device_group_device', 'device_group_id', 'device_id');
+        // $parentKey='id', $relatedKey='device_id' is required to generate the right SQL query.
+        // Otherwise the primaryKey in Service.php will be used
+        return $this->belongsToMany(\App\Models\Service::class, 'device_group_device', 'device_group_id', 'device_id', 'id', 'device_id');
     }
 
     public function users(): BelongsToMany

--- a/includes/html/common/availability-map.inc.php
+++ b/includes/html/common/availability-map.inc.php
@@ -351,7 +351,7 @@ if (defined('SHOW_SETTINGS')) {
         </div>
         <div class="page-availability-title-right">';
 
-        if ((Config::get('webui.availability_map_use_device_groups') != 0) && ($mode == 0 || $mode == 1 || $mode == 2)) {
+        if ((Config::get('webui.availability_map_use_device_groups') != 0)) {
             $sql = 'SELECT `G`.`id`, `G`.`name` FROM `device_groups` AS `G`';
             $dev_groups = dbFetchRows($sql);
 

--- a/includes/html/common/availability-map.inc.php
+++ b/includes/html/common/availability-map.inc.php
@@ -351,7 +351,7 @@ if (defined('SHOW_SETTINGS')) {
         </div>
         <div class="page-availability-title-right">';
 
-        if ((Config::get('webui.availability_map_use_device_groups') != 0)) {
+        if (Config::get('webui.availability_map_use_device_groups') != 0) {
             $sql = 'SELECT `G`.`id`, `G`.`name` FROM `device_groups` AS `G`';
             $dev_groups = dbFetchRows($sql);
 

--- a/includes/html/common/availability-map.inc.php
+++ b/includes/html/common/availability-map.inc.php
@@ -171,7 +171,6 @@ if (defined('SHOW_SETTINGS')) {
 
     // Only show devices if mode is 0 or 2 (Only Devices or both)
     if ($mode == 0 || $mode == 2) {
-
         $sql = 'SELECT `D`.`hostname`, `D`.`sysName`, `D`.`display`, `D`.`device_id`, `D`.`status`, `D`.`uptime`, `D`.`last_polled`, `D`.`os`, `D`.`icon`, `D`.`disable_notify`, `D`.`disabled` FROM `devices` AS `D`';
 
         if (! Auth::user()->hasGlobalRead()) {


### PR DESCRIPTION
Fixes #14975 
Both Maps -> Availability and the Availability Map Widget for dashboards fail to filter the device group for devices on which these services are running.

Maps -> Availability misses the option to filter on device group for all options/modes (only devices, only services, devices and services). And if a device group is selected, no filtering is applied on the device group for the devices on which these services are running.

The Availability Map Widget uses different code, but has the same issue: services aren't filtered by device group.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ X] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
