### PR TITLE
Allow setting of disabled flag via API Resolves #14980

### DIFF
--- a/app/Models/Device.php
+++ b/app/Models/Device.php
@@ -50,6 +50,7 @@ class Device extends BaseModel
         'features',
         'hardware',
         'hostname',
+        'disabled',
         'display',
         'icon',
         'ip',


### PR DESCRIPTION
REF. Issue 14768

Allows the setting of the disabled flag for a device via the API. Currently if you attempt to set this the API returnd 200 Successful but does not actually update the field.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
