### PR TITLE
Slightly better OS module test output

### DIFF
--- a/LibreNMS/Util/CiHelper.php
+++ b/LibreNMS/Util/CiHelper.php
@@ -178,7 +178,7 @@ class CiHelper
      */
     public function checkUnit()
     {
-        $phpunit_cmd = [$this->checkPhpExec('phpunit'), '--colors=always', '--debug'];
+        $phpunit_cmd = [$this->checkPhpExec('phpunit'), '--colors=always'];
 
         if ($this->flags['fail-fast']) {
             array_push($phpunit_cmd, '--stop-on-error', '--stop-on-failure');

--- a/tests/OSModulesTest.php
+++ b/tests/OSModulesTest.php
@@ -27,6 +27,7 @@ namespace LibreNMS\Tests;
 
 use DeviceCache;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Arr;
 use LibreNMS\Config;
 use LibreNMS\Data\Source\Fping;
 use LibreNMS\Data\Source\FpingResponse;
@@ -34,6 +35,7 @@ use LibreNMS\Exceptions\FileNotFoundException;
 use LibreNMS\Exceptions\InvalidModuleException;
 use LibreNMS\Util\Debug;
 use LibreNMS\Util\ModuleTestHelper;
+use PHPUnit\Util\Color;
 
 class OSModulesTest extends DBTestCase
 {
@@ -118,34 +120,13 @@ class OSModulesTest extends DBTestCase
         foreach ($modules as $module) {
             $expected = $expected_data[$module]['discovery'] ?? [];
             $actual = $results[$module]['discovery'] ?? [];
-            $this->assertEquals(
-                $expected,
-                $actual,
-                "OS $os: Discovered $module data does not match that found in $filename\n"
-                . print_r(array_diff($expected, $actual), true)
-                . $helper->getDiscoveryOutput($phpunit_debug ? null : $module)
-                . "\nOS $os: Discovered $module data does not match that found in $filename"
-            );
+            $this->checkTestData($expected, $actual, 'Discovered', $os, $module, $filename, $helper, $phpunit_debug);
 
-            if ($module === 'route') {
-                // no route poller module
-                continue;
-            }
-
-            if ($expected_data[$module]['poller'] == 'matches discovery') {
-                $expected = $expected_data[$module]['discovery'];
-            } else {
+            if ($expected_data[$module]['poller'] !== 'matches discovery') {
                 $expected = $expected_data[$module]['poller'] ?? [];
             }
             $actual = $results[$module]['poller'] ?? [];
-            $this->assertEquals(
-                $expected,
-                $actual,
-                "OS $os: Polled $module data does not match that found in $filename\n"
-                . print_r(array_diff($expected, $actual), true)
-                . $helper->getPollerOutput($phpunit_debug ? null : $module)
-                . "\nOS $os: Polled $module data does not match that found in $filename"
-            );
+            $this->checkTestData($expected, $actual, 'Polled', $os, $module, $filename, $helper, $phpunit_debug);
         }
 
         DeviceCache::flush(); // clear cached devices
@@ -183,5 +164,19 @@ class OSModulesTest extends DBTestCase
 
             return $mock;
         });
+    }
+
+    private function checkTestData(array $expected, array $actual, string $type, string $os, mixed $module, string $filename, ModuleTestHelper $helper, bool $phpunit_debug): void
+    {
+        // try simple and fast comparison first, if that fails, do a costly/well formatted comparison
+        if ($expected != $actual) {
+            $message = Color::colorize('bg-red', "OS $os: $type $module data does not match that found in $filename");
+            $message .= PHP_EOL;
+            $message .= ($type == 'Discovered'
+                ? $helper->getDiscoveryOutput($phpunit_debug ? null : $module)
+                : $helper->getPollerOutput($phpunit_debug ? null : $module));
+
+            $this->assertSame(Arr::dot($expected), Arr::dot($actual), $message);
+        }
     }
 }

--- a/tests/OSModulesTest.php
+++ b/tests/OSModulesTest.php
@@ -92,6 +92,8 @@ class OSModulesTest extends DBTestCase
      */
     public function testOS($os, $variant, $modules)
     {
+        $this->expectNotToPerformAssertions(); // successful tests will make no assertions due to checkTestData()
+
         // Lock testing time
         $this->travelTo(new \DateTime('2022-01-01 00:00:00'));
         $this->requireSnmpsim();  // require snmpsim for tests

--- a/tests/OSModulesTest.php
+++ b/tests/OSModulesTest.php
@@ -121,6 +121,11 @@ class OSModulesTest extends DBTestCase
             $expected = $expected_data[$module]['discovery'] ?? [];
             $actual = $results[$module]['discovery'] ?? [];
             $this->checkTestData($expected, $actual, 'Discovered', $os, $module, $filename, $helper, $phpunit_debug);
+            
+            if ($module === 'route') {
+                // no route poller module
+                continue;
+            }
 
             if ($expected_data[$module]['poller'] !== 'matches discovery') {
                 $expected = $expected_data[$module]['poller'] ?? [];

--- a/tests/OSModulesTest.php
+++ b/tests/OSModulesTest.php
@@ -121,7 +121,7 @@ class OSModulesTest extends DBTestCase
             $expected = $expected_data[$module]['discovery'] ?? [];
             $actual = $results[$module]['discovery'] ?? [];
             $this->checkTestData($expected, $actual, 'Discovered', $os, $module, $filename, $helper, $phpunit_debug);
-            
+
             if ($module === 'route') {
                 // no route poller module
                 continue;

--- a/tests/OSModulesTest.php
+++ b/tests/OSModulesTest.php
@@ -92,8 +92,6 @@ class OSModulesTest extends DBTestCase
      */
     public function testOS($os, $variant, $modules)
     {
-        $this->expectNotToPerformAssertions(); // successful tests will make no assertions due to checkTestData()
-
         // Lock testing time
         $this->travelTo(new \DateTime('2022-01-01 00:00:00'));
         $this->requireSnmpsim();  // require snmpsim for tests
@@ -130,6 +128,8 @@ class OSModulesTest extends DBTestCase
             $actual = $results[$module]['poller'] ?? [];
             $this->checkTestData($expected, $actual, 'Polled', $os, $module, $filename, $helper, $phpunit_debug);
         }
+
+        $this->assertTrue(true, "Tested $os successfully"); // avoid no asserts error
 
         DeviceCache::flush(); // clear cached devices
         $this->travelBack();


### PR DESCRIPTION
Maybe faster
Remove forced --debug in phpunit

```
1) LibreNMS\Tests\OSModulesTest::testOS with data set "quantum_scalari6000" ('quantum', 'scalari6000', array('os', 'ports', 'sensors'))
OS quantum: Discovered ports data does not match that found in tests/data/quantum_scalari6000.json
#### Load disco module ports ####
SNMP['/usr/bin/snmpbulkwalk' '-v2c' '-c' 'quantum_scalari6000' '-OQUs' '-m' 'IF-MIB' '-M' '.../librenms/mibs:.../librenms/mibs/adic' 'udp:127.1.6.2:1162' 'ifDescr']
SNMP['/usr/bin/snmpbulkwalk' '-v2c' '-c' 'quantum_scalari6000' '-OQUs' '-m' 'IF-MIB' '-M' '.../librenms/mibs:.../librenms/mibs/adic' 'udp:127.1.6.2:1162' 'ifName']
SNMP['/usr/bin/snmpbulkwalk' '-v2c' '-c' 'quantum_scalari6000' '-OQUs' '-m' 'IF-MIB' '-M' '.../librenms/mibs:.../librenms/mibs/adic' 'udp:127.1.6.2:1162' 'ifAlias']
SNMP['/usr/bin/snmpbulkwalk' '-v2c' '-c' 'quantum_scalari6000' '-OQUs' '-m' 'IF-MIB' '-M' '.../mibs:.../librenms/mibs/adic' 'udp:127.1.6.2:1162' 'ifType']
SNMP['/usr/bin/snmpbulkwalk' '-v2c' '-c' 'quantum_scalari6000' '-OQUs' '-m' 'IF-MIB' '-M' '.../librenms/mibs:.../librenms/mibs/adic' 'udp:127.1.6.2:1162' 'ifOperStatus']
Adding: lo(1)(171)Adding: dummy0(2)(172)Adding: eth0(3)(173)Adding: eth2(4)(174)Adding: eth1(5)(175)

>> Runtime for discovery module 'ports': 0.0510 seconds with 65456 bytes
#### Unload disco module ports ####
Failed asserting that two arrays are identical.
--- Expected
+++ Actual
@@ @@
     'ports.0.ifSpeed' => null
     'ports.0.ifSpeed_prev' => null
     'ports.0.ifConnectorPresent' => null
-    'ports.0.ifPromiscuousMode' => null
     'ports.0.ifOperStatus' => 'up'
     'ports.0.ifOperStatus_prev' => null
     'ports.0.ifAdminStatus' => null
@@ @@
     'ports.0.ifType' => 'softwareLoopback'
     'ports.0.ifAlias' => 'lo'
     'ports.0.ifPhysAddress' => null
-    'ports.0.ifHardType' => null
     'ports.0.ifLastChange' => 0
-    'ports.0.ifVlan' => ''
+    'ports.0.ifVlan' => null
     'ports.0.ifTrunk' => null
-    'ports.0.counter_in' => null
-    'ports.0.counter_out' => null
     'ports.0.ignore' => 0
     'ports.0.disabled' => 0
-    'ports.0.detailed' => 0
     'ports.0.deleted' => 0
     'ports.0.pagpOperationMode' => null
     'ports.0.pagpPortState' => null
@@ @@
     'ports.1.ifSpeed' => null
     'ports.1.ifSpeed_prev' => null
     'ports.1.ifConnectorPresent' => null
-    'ports.1.ifPromiscuousMode' => null
     'ports.1.ifOperStatus' => 'down'
     'ports.1.ifOperStatus_prev' => null
     'ports.1.ifAdminStatus' => null
@@ @@
     'ports.1.ifType' => 'ethernetCsmacd'
     'ports.1.ifAlias' => 'dummy0'
     'ports.1.ifPhysAddress' => null
-    'ports.1.ifHardType' => null
     'ports.1.ifLastChange' => 0
-    'ports.1.ifVlan' => ''
+    'ports.1.ifVlan' => null
     'ports.1.ifTrunk' => null
-    'ports.1.counter_in' => null
-    'ports.1.counter_out' => null
     'ports.1.ignore' => 0
     'ports.1.disabled' => 0
-    'ports.1.detailed' => 0
     'ports.1.deleted' => 0
     'ports.1.pagpOperationMode' => null
     'ports.1.pagpPortState' => null
@@ @@
     'ports.2.ifSpeed' => null
     'ports.2.ifSpeed_prev' => null
     'ports.2.ifConnectorPresent' => null
-    'ports.2.ifPromiscuousMode' => null
     'ports.2.ifOperStatus' => 'up'
     'ports.2.ifOperStatus_prev' => null
     'ports.2.ifAdminStatus' => null
@@ @@
     'ports.2.ifType' => 'ethernetCsmacd'
     'ports.2.ifAlias' => 'eth0'
     'ports.2.ifPhysAddress' => null
-    'ports.2.ifHardType' => null
     'ports.2.ifLastChange' => 0
-    'ports.2.ifVlan' => ''
+    'ports.2.ifVlan' => null
     'ports.2.ifTrunk' => null
-    'ports.2.counter_in' => null
-    'ports.2.counter_out' => null
     'ports.2.ignore' => 0
     'ports.2.disabled' => 0
-    'ports.2.detailed' => 0
     'ports.2.deleted' => 0
     'ports.2.pagpOperationMode' => null
     'ports.2.pagpPortState' => null
@@ @@
     'ports.3.ifSpeed' => null
     'ports.3.ifSpeed_prev' => null
     'ports.3.ifConnectorPresent' => null
-    'ports.3.ifPromiscuousMode' => null
     'ports.3.ifOperStatus' => 'down'
     'ports.3.ifOperStatus_prev' => null
     'ports.3.ifAdminStatus' => null
@@ @@
     'ports.3.ifType' => 'ethernetCsmacd'
     'ports.3.ifAlias' => 'eth2'
     'ports.3.ifPhysAddress' => null
-    'ports.3.ifHardType' => null
     'ports.3.ifLastChange' => 0
-    'ports.3.ifVlan' => ''
+    'ports.3.ifVlan' => null
     'ports.3.ifTrunk' => null
-    'ports.3.counter_in' => null
-    'ports.3.counter_out' => null
     'ports.3.ignore' => 0
     'ports.3.disabled' => 0
-    'ports.3.detailed' => 0
     'ports.3.deleted' => 0
     'ports.3.pagpOperationMode' => null
     'ports.3.pagpPortState' => null
@@ @@
     'ports.4.ifSpeed' => null
     'ports.4.ifSpeed_prev' => null
     'ports.4.ifConnectorPresent' => null
-    'ports.4.ifPromiscuousMode' => null
     'ports.4.ifOperStatus' => 'up'
     'ports.4.ifOperStatus_prev' => null
     'ports.4.ifAdminStatus' => null
@@ @@
     'ports.4.ifType' => 'ethernetCsmacd'
     'ports.4.ifAlias' => 'eth1'
     'ports.4.ifPhysAddress' => null
-    'ports.4.ifHardType' => null
     'ports.4.ifLastChange' => 0
-    'ports.4.ifVlan' => ''
+    'ports.4.ifVlan' => null
     'ports.4.ifTrunk' => null
-    'ports.4.counter_in' => null
-    'ports.4.counter_out' => null
     'ports.4.ignore' => 0
     'ports.4.disabled' => 0
-    'ports.4.detailed' => 0
     'ports.4.deleted' => 0
     'ports.4.pagpOperationMode' => null
     'ports.4.pagpPortState' => null

.../librenms/tests/OSModulesTest.php:183
.../librenms/tests/OSModulesTest.php:127
```

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
