### PR TITLE
Add support for Okta Group claims to set user role

### DIFF
--- a/app/Http/Controllers/Auth/SocialiteController.php
+++ b/app/Http/Controllers/Auth/SocialiteController.php
@@ -168,7 +168,7 @@ class SocialiteController extends Controller
             foreach ($scopes as $scope) {
                 foreach (Arr::wrap($attributes[$scope] ?? []) as $scope_data) {
                     $user->level = max($user->level,
-                        $this->getRoleAsLevel($groups[$scope_data]['role'] ?? 'none')
+                        $this->getRoleAsLevel($groups[$scope_data]['role'] ?? null)
                     );
                 }
             }
@@ -213,7 +213,7 @@ class SocialiteController extends Controller
         return ! empty($name) ? $name : '';
     }
 
-    private function getRoleAsLevel(string $role = 'none'): int
+    private function getRoleAsLevel(?string $role): int
     {
         return match ($role) {
             'admin' => 10,

--- a/app/Http/Controllers/Auth/SocialiteController.php
+++ b/app/Http/Controllers/Auth/SocialiteController.php
@@ -134,7 +134,7 @@ class SocialiteController extends Controller
         $user->email = $this->socialite_user->getEmail();
         $user->realname = $this->buildRealName();
 
-        $user->level = $this->getRoleAsLevel( LibreNMSConfig::get('auth.socialite.default_level', 'none' ));
+        $user->level = $this->getRoleAsLevel( LibreNMSConfig::get('auth.socialite.default_role', 'none' ));
         $this->setLevelFromGroupsClaim( $provider, $user );
 
         $user->save();
@@ -143,7 +143,7 @@ class SocialiteController extends Controller
     private function setLevelFromGroupsClaim(string $provider, $user)
     {
         if( $provider == "okta" && LibreNMSConfig::get('auth.socialite.configs.okta.group_claim', false) ){
-            $user->level = $this->getRoleAsLevel( LibreNMSConfig::get('auth.socialite.default_level', 'none' ));
+            $user->level = $this->getRoleAsLevel( LibreNMSConfig::get('auth.socialite.default_role', 'none' ));
 
             if( in_array('ArrayAccess', class_implements($this->socialite_user)) &&
                 isset( $this->socialite_user->user ) &&

--- a/app/Http/Controllers/Auth/SocialiteController.php
+++ b/app/Http/Controllers/Auth/SocialiteController.php
@@ -157,6 +157,7 @@ class SocialiteController extends Controller
     {
         $scopes = LibreNMSConfig::get('auth.socialite.scopes');
         $groups = LibreNMSConfig::get('auth.socialite.groups');
+
         if (is_array($scopes) &&
             $this->socialite_user instanceof AbstractUser &&
             ! empty($groups)

--- a/app/Http/Controllers/Auth/SocialiteController.php
+++ b/app/Http/Controllers/Auth/SocialiteController.php
@@ -68,7 +68,6 @@ class SocialiteController extends Controller
             }
         }
         return $driver->redirect();
-
     }
 
     public function callback(Request $request, string $provider): RedirectResponse
@@ -154,7 +153,7 @@ class SocialiteController extends Controller
         $user->save();
     }
 
-    private function setLevelFromClaim(string $provider, $user)
+    private function setLevelFromClaim(string $provider, $user): void
     {
         if( LibreNMSConfig::has('auth.socialite.scopes') )
         {

--- a/app/Http/Controllers/Auth/SocialiteController.php
+++ b/app/Http/Controllers/Auth/SocialiteController.php
@@ -159,7 +159,7 @@ class SocialiteController extends Controller
         $groups = LibreNMSConfig::get('auth.socialite.groups');
 
         if (is_array($scopes) &&
-            $this->socialite_user instanceof AbstractUser &&
+            $this->socialite_user instanceof \Laravel\Socialite\AbstractUser &&
             ! empty($groups)
         ) {
             $user->level = $this->getRoleAsLevel(LibreNMSConfig::get('auth.socialite.default_role'));

--- a/app/Http/Controllers/Auth/SocialiteController.php
+++ b/app/Http/Controllers/Auth/SocialiteController.php
@@ -73,6 +73,14 @@ class SocialiteController extends Controller
 
     public function callback(Request $request, string $provider): RedirectResponse
     {
+        /* If we get an error in the callback then attempt to handle nicely  */
+        if( array_key_exists('error', $request->query() )) {
+            $error = $request->query('error');
+            $error_description = $request->query('error_description') ;
+            flash()->addError( $error . ": " . $error_description );
+            return redirect()->route('login');
+        }
+        
         $this->socialite_user = Socialite::driver($provider)->user();
 
         // If we already have a valid session, user is trying to pair their account

--- a/app/Http/Controllers/Auth/SocialiteController.php
+++ b/app/Http/Controllers/Auth/SocialiteController.php
@@ -206,16 +206,12 @@ class SocialiteController extends Controller
         switch($role) {
           case 'admin':
             return 10;
-            break;
           case 'global-read':
             return 5;
-            break;
           case 'normal':
             return 1;
-            break;
           default:
             return 0;
-            break;
         }
       }
 

--- a/doc/Extensions/OAuth-SAML.md
+++ b/doc/Extensions/OAuth-SAML.md
@@ -263,6 +263,43 @@ The final step is to now add an event listener.
         ```
     Don't forget the initial backslack (\\) !
 
+### Default User level
+
+    Since most Socialite Providers don't provide Authorization only Authentication it is possible to set
+    the default User level for Authorized users.   Appropriate care should be taken.
+
+- 1: **Normal User**: You will need to assign device / port
+      permissions for users at this level.
+
+- 5: **Global Read**: Read only Administrator.
+
+- 10: **Administrator**: This is a global read/write admin account.
+
+- 11: **Demo Account**: Provides full read/write with certain
+    restrictions (i.e can't delete devices).
+
+    !!! setting "settings/auth/socialite"
+        ```bash
+        lnms config:set auth.socialite.defaultlevel 5
+        ```
+
+### Okta Group Claims
+
+    If Okta is configured to expose group(s) it is possible to use these groups to configure User levels
+
+    First enable sending the 'groups' claim (along with the normal openid, profile, and email claims )
+    !!! setting "settings/auth/socialite"
+        ```bash
+        lnms config:set auth.socialite.configs.okta.group_claim true
+        ```
+    
+    Then setup mappings from the returned groups to the User levels you want
+    !!! setting "settings/auth/socialite"
+        ```bash
+        lnms config:set auth.socialite.groups.MY_ADMIN_GROUP.level 10
+        lnms config:set auth.socialite.groups.MY_READ_GROUP.level 5
+        ```
+
 Now you are done with setting up the OAuth provider!
 If it doesn't work, please double check your configuration values by using the `config:get` command below.
 

--- a/doc/Extensions/OAuth-SAML.md
+++ b/doc/Extensions/OAuth-SAML.md
@@ -282,21 +282,25 @@ The final step is to now add an event listener.
         lnms config:set auth.socialite.default_role global-read
         ```
 
-### Okta Group Claims
+###  Claims / Access Scopes
 
-    If Okta is configured to expose group(s) it is possible to use these groups to configure User Roles
+    Socialite can specifiy scopes that should be included with in the authentication request.
+    (see https://laravel.com/docs/10.x/socialite#access-scopes )
+
+    For example, if Okta is configured to expose group information it is possible to use these group
+    names to configure User Roles.
 
     First enable sending the 'groups' claim (along with the normal openid, profile, and email claims )
     !!! setting "settings/auth/socialite"
         ```bash
-        lnms config:set auth.socialite.configs.okta.group_claim true
+        lnms config:set auth.socialite.scopes.+ groups
         ```
     
-    Then setup mappings from the returned groups to the User levels you want
+    Then setup mappings from the returned claim arrays to the User levels you want
     !!! setting "settings/auth/socialite"
         ```bash
-        lnms config:set auth.socialite.groups.MY_ADMIN_GROUP.role admin
-        lnms config:set auth.socialite.groups.MY_READ_GROUP.role global-read
+        lnms config:set auth.socialite.groups.RETURN_FROM_CLAIM.role admin
+        lnms config:set auth.socialite.groups.OTHER_RETURN_FROM_CLAIM.role global-read
         ```
 
 Now you are done with setting up the OAuth provider!

--- a/doc/Extensions/OAuth-SAML.md
+++ b/doc/Extensions/OAuth-SAML.md
@@ -263,29 +263,28 @@ The final step is to now add an event listener.
         ```
     Don't forget the initial backslack (\\) !
 
-### Default User level
+### Default Role
 
     Since most Socialite Providers don't provide Authorization only Authentication it is possible to set
-    the default User level for Authorized users.   Appropriate care should be taken.
+    the default User Role for Authorized users.   Appropriate care should be taken.
 
-- 1: **Normal User**: You will need to assign device / port
+- none: **No Access**: User has no access
+
+- normal: **Normal User**: You will need to assign device / port
       permissions for users at this level.
 
-- 5: **Global Read**: Read only Administrator.
+- global-read: **Global Read**: Read only Administrator.
 
-- 10: **Administrator**: This is a global read/write admin account.
-
-- 11: **Demo Account**: Provides full read/write with certain
-    restrictions (i.e can't delete devices).
+- admin: **Administrator**: This is a global read/write admin account.
 
     !!! setting "settings/auth/socialite"
         ```bash
-        lnms config:set auth.socialite.defaultlevel 5
+        lnms config:set auth.socialite.default_role global-read
         ```
 
 ### Okta Group Claims
 
-    If Okta is configured to expose group(s) it is possible to use these groups to configure User levels
+    If Okta is configured to expose group(s) it is possible to use these groups to configure User Roles
 
     First enable sending the 'groups' claim (along with the normal openid, profile, and email claims )
     !!! setting "settings/auth/socialite"
@@ -296,8 +295,8 @@ The final step is to now add an event listener.
     Then setup mappings from the returned groups to the User levels you want
     !!! setting "settings/auth/socialite"
         ```bash
-        lnms config:set auth.socialite.groups.MY_ADMIN_GROUP.level 10
-        lnms config:set auth.socialite.groups.MY_READ_GROUP.level 5
+        lnms config:set auth.socialite.groups.MY_ADMIN_GROUP.role admin
+        lnms config:set auth.socialite.groups.MY_READ_GROUP.role global-read
         ```
 
 Now you are done with setting up the OAuth provider!

--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -404,10 +404,17 @@
             }
         },
 
-        "auth.socialite.default_role": {
+        "auth.socialite.scopes": {
             "group": "auth",
             "section": "socialite",
             "order": 4,
+            "type": "array"
+        },
+
+        "auth.socialite.default_role": {
+            "group": "auth",
+            "section": "socialite",
+            "order": 5,
             "type": "select",
             "default": "none",
             "options" : {
@@ -422,14 +429,14 @@
             "default": {},
             "group": "auth",
             "section": "socialite",
-            "order": 5,
+            "order": 6,
             "type": "ldap-groups",
             "validate": {
                 "value": "array",
                 "value.*": "array"
             }
         },
-
+        
         "auth_ad_check_certificates": {
             "default": false,
             "group": "auth",

--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -404,6 +404,26 @@
             }
         },
 
+        "auth.socialite.defaultlevel": {
+            "group": "auth",
+            "section": "socialite",
+            "order": 4,
+            "type": "integer",
+            "default": 0
+        },
+
+        "auth.socialite.groups": {
+            "default": {},
+            "group": "auth",
+            "section": "socialite",
+            "order": 5,
+            "type": "ldap-groups",
+            "validate": {
+                "value": "array",
+                "value.*": "array"
+            }
+        },
+
         "auth_ad_check_certificates": {
             "default": false,
             "group": "auth",

--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -404,12 +404,18 @@
             }
         },
 
-        "auth.socialite.defaultlevel": {
+        "auth.socialite.default_role": {
             "group": "auth",
             "section": "socialite",
             "order": 4,
-            "type": "integer",
-            "default": 0
+            "type": "select",
+            "default": "none",
+            "options" : {
+                "none" : "No Access",
+                "normal" : "Normal Access",
+                "global-read" : "Global Viewing Access",
+                "admin" : "Global Administrative Access"
+            }
         },
 
         "auth.socialite.groups": {


### PR DESCRIPTION
Please give a short description what your pull request is for

Allow the Socialite Okta support to ask for groups claim, and then use those okta groups to map to User level's

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
