### PR TITLE
Apply service templates on a per-device basis

### DIFF
--- a/app/Http/Controllers/ServiceTemplateController.php
+++ b/app/Http/Controllers/ServiceTemplateController.php
@@ -370,6 +370,7 @@ class ServiceTemplateController extends Controller
                     'service_ignore' => $template->ignore,
                 ]
             );
+
             return response('Service template ' . $template->id . ' applied to device ID ' . $device_id, 200);
         }
 
@@ -390,6 +391,7 @@ class ServiceTemplateController extends Controller
                         'service_ignore' => $template->ignore,
                     ]
                 );
+
                 return response('Service template ' . $template->id . ' applied to device ID ' . $device_id, 200);
             }
         }

--- a/app/Http/Controllers/ServiceTemplateController.php
+++ b/app/Http/Controllers/ServiceTemplateController.php
@@ -310,6 +310,21 @@ class ServiceTemplateController extends Controller
     }
 
     /**
+     * Apply all Service Templates for a device
+     *
+     * @return \Illuminate\Http\RedirectResponse|\Illuminate\Http\Response|\Illuminate\View\View
+     */
+    public function applyDeviceAll(int $device_id)
+    {
+        foreach (ServiceTemplate::all() as $template) {
+            $this->applyDevice($template, $device_id);
+        }
+        $msg = __('All Service Templates have been applied to device ' . $device_id);
+
+        return response($msg, 200);
+    }
+
+    /**
      * Apply specified Service Template.
      *
      * @param  \App\Models\ServiceTemplate  $template
@@ -327,6 +342,64 @@ class ServiceTemplateController extends Controller
         $msg = __('All Service Templates have been applied');
 
         return response($msg, 200);
+    }
+
+    /**
+     * Apply specified Service Template to a device.
+     *
+     * @param  \App\Models\ServiceTemplate  $template
+     * @param  int  $device_id
+     * @return \Illuminate\Http\RedirectResponse|\Illuminate\Http\Response|\Illuminate\View\View
+     */
+    public function applyDevice(ServiceTemplate $template, int $device_id)
+    {
+        // Check if the device needs to be added
+        foreach (Device::inServiceTemplate($template->id)->where('device_id', $device_id)->get() as $device) {
+            $device->services()->updateOrCreate(
+                [
+                    'service_template_id' => $template->id,
+                ],
+                [
+                    'service_name' => $template->name,
+                    'service_type' => $template->check,
+                    'service_template_id' => $template->id,
+                    'service_param' => $template->param,
+                    'service_ip' => $template->ip,
+                    'service_desc' => $template->desc,
+                    'service_disabled' => $template->disabled,
+                    'service_ignore' => $template->ignore,
+                ]
+            );
+            return response('Service template ' . $template->id . ' applied to device ID ' . $device_id, 200);
+        }
+
+        foreach (DeviceGroup::inServiceTemplate($template->id)->get() as $device_group) {
+            foreach (Device::inDeviceGroup($device_group->id)->where('device_id', $device_id)->get() as $device) {
+                $device->services()->updateOrCreate(
+                    [
+                        'service_template_id' => $template->id,
+                    ],
+                    [
+                        'service_name' => $template->name,
+                        'service_type' => $template->check,
+                        'service_template_id' => $template->id,
+                        'service_param' => $template->param,
+                        'service_ip' => $template->ip,
+                        'service_desc' => $template->desc,
+                        'service_disabled' => $template->disabled,
+                        'service_ignore' => $template->ignore,
+                    ]
+                );
+                return response('Service template ' . $template->id . ' applied to device ID ' . $device_id, 200);
+            }
+        }
+
+        // remove if this template no longer applies
+        foreach (Device::notInServiceTemplate($template->id)->notInDeviceGroup($template->groups->pluck('id'))->where('device_id', $device_id)->pluck('device_id') as $device_id) {
+            Service::where('device_id', $device_id)->where('service_template_id', $template->id)->delete();
+        }
+
+        return response('Service template ' . $template->id . ' applied to device ID ' . $device_id, 200);
     }
 
     /**

--- a/includes/discovery/services.inc.php
+++ b/includes/discovery/services.inc.php
@@ -4,7 +4,7 @@ use App\Http\Controllers\ServiceTemplateController;
 use LibreNMS\Config;
 
 if (Config::get('discover_services_templates')) {
-    (new ServiceTemplateController())->applyAll(); // FIXME applyAll() should not be on a controller
+    (new ServiceTemplateController())->applyDeviceAll($device['device_id']); // FIXME applyAll() should not be on a controller
 }
 if (Config::get('discover_services')) {
     // FIXME: use /etc/services?


### PR DESCRIPTION
We recently started using service templates, and I noticed that during discovery there are a lot of log messages saying services are being deleted from devices.  I traced the issue to the use of the applyAll() function, which was causing the service template to evaluate the template apply rules for every device every time each device is discovered.  This adds about 5s to the discovery time per device.

The proposed pull request replaces the applyAll() function call with an applyDeviceAll() function call, which only evaluates the service template rules for the device being discovered.