### PR TITLE
fix for hrStorageIndex agility

### DIFF
--- a/includes/polling/storage/hrstorage.inc.php
+++ b/includes/polling/storage/hrstorage.inc.php
@@ -22,7 +22,7 @@ $entry = $storage_cache['hrstorage'][$storage['storage_index']];
  *
  */
 
-if( $entry['hrStorageDescr'] !== $descr ){
+if( $entry['hrStorageDescr'] !== $descr && is_array( $storage_cache['hrstorage'] ) ){
     d_echo( '🚨 We are after [' . $descr . '] but hrStorageIndex entry has [' . $entry['hrStorageDescr'] . '] ' );
     d_echo( 'Before: ' . var_export( $entry, true ));
     $entry = array_values( array_filter( $storage_cache['hrstorage'], function($entry) use ($descr) {

--- a/includes/polling/storage/hrstorage.inc.php
+++ b/includes/polling/storage/hrstorage.inc.php
@@ -15,7 +15,6 @@ if (($entry['hrStorageDescr'] ?? null) !== $storage['storage_descr']) {
     // couldn't find a match, check by storage_descr or fall back to data found by index in case descr changed
     $entry = collect($storage_cache['hrstorage'])->firstWhere('hrStorageDescr', $storage['storage_descr']) ?? $entry;
 }
-dump($entry);
 
 if (empty($entry)) {
     Log::error("%rCould not find storage data for {$storage['storage_descr']}%n", ['color' => true]);

--- a/includes/polling/storage/hrstorage.inc.php
+++ b/includes/polling/storage/hrstorage.inc.php
@@ -8,6 +8,31 @@ if (! isset($storage_cache['hrstorage'])) {
 
 $entry = $storage_cache['hrstorage'][$storage['storage_index']];
 
+/*
+ * It is possible that the HOST-RESOURCES-MIB::hrStorageTable has updated between
+ * discovery and polling.    If we assume it hasn't we can end up assigning the
+ * values of the wrong mount point to another mount point.   This can cause
+ * issues with not only display, but also alarming.
+ *
+ * We can compare the description expected with one from the hrStorageIndex entry
+ * and if they are not equal then we can filter the table to return an entry
+ * that does match.
+ *
+ * (example of how to debug --> ./poller.php -h 42 -r -f -m storage -d)
+ *
+ */
+
+if( $entry['hrStorageDescr'] !== $descr ){
+    d_echo( '🚨 We are after [' . $descr . '] but hrStorageIndex entry has [' . $entry['hrStorageDescr'] . '] ' );
+    d_echo( 'Before: ' . var_export( $entry, true ));
+    $entry = array_values( array_filter( $storage_cache['hrstorage'], function($entry) use ($descr) {
+        return $entry['hrStorageDescr'] === $descr;
+    }))[0];
+    d_echo( 'After: ' . var_export( $entry, true ) );
+    d_echo( '🚨 updated to [' . $entry['hrStorageDescr'] . ']' );
+}
+
+
 $storage['units'] = $entry['hrStorageAllocationUnits'];
 $entry['hrStorageUsed'] = fix_integer_value($entry['hrStorageUsed'] ?? 0);
 $entry['hrStorageSize'] = fix_integer_value($entry['hrStorageSize']);

--- a/includes/polling/storage/hrstorage.inc.php
+++ b/includes/polling/storage/hrstorage.inc.php
@@ -9,24 +9,27 @@ if (! isset($storage_cache['hrstorage'])) {
 }
 
 // find storage entry
-if (isset($storage_cache['hrstorage'][$storage['storage_index']]) && $storage_cache['hrstorage'][$storage['storage_index']]['hrStorageDescr'] == $storage['storage_descr']) {
-    $entry = $storage_cache['hrstorage'][$storage['storage_index']];
-} else {
-    // couldn't find a match, check by storage_descr in case the index changed
-    $entry = collect($storage_cache['hrstorage'])->firstWhere('hrStorageDescr', $storage['storage_descr']);
+$entry = $storage_cache['hrstorage'][$storage['storage_index']] ?? null;
 
-    if (empty($entry)) {
-        Log::error('%rCould not find storage data for ' . $storage['storage_descr'] . '%n', ['color' => true]);
-        // keep last known values
-        $storage['units'] = $storage['storage_units'];
-        $storage['used'] = $storage['storage_used'];
-        $storage['size'] = $storage['storage_size'];
-        $storage['free'] = $storage['storage_free'];
+if (($entry['hrStorageDescr'] ?? null) !== $storage['storage_descr']) {
+    // couldn't find a match, check by storage_descr or fall back to data found by index in case descr changed
+    $entry = collect($storage_cache['hrstorage'])->firstWhere('hrStorageDescr', $storage['storage_descr']) ?? $entry;
+}
+dump($entry);
 
-        return;
-    }
+if (empty($entry)) {
+    Log::error("%rCould not find storage data for {$storage['storage_descr']}%n", ['color' => true]);
+    // keep last known values
+    $storage['units'] = $storage['storage_units'];
+    $storage['used'] = $storage['storage_used'];
+    $storage['size'] = $storage['storage_size'];
+    $storage['free'] = $storage['storage_free'];
 
-    Log::debug("Storage changed index {$storage['storage_index']} > {$entry['hrStorageIndex']}, applying quickfix until discovery runs");
+    return;
+}
+
+if ($entry['hrStorageIndex'] !== $storage['storage_index']) {
+    Log::debug("Storage {$storage['storage_descr']} changed index {$storage['storage_index']} > {$entry['hrStorageIndex']}, applying quickfix until discovery runs");
 }
 
 $storage['units'] = $entry['hrStorageAllocationUnits'];


### PR DESCRIPTION
Please give a short description what your pull request is for

It is possible that the HOST-RESOURCES-MIB::hrStorageTable has updated between discovery and polling. If we assume it hasn't we can end up assigning the values of the wrong mount point to another mount point. This can cause
issues with not only display, but also alarming.

We can compare the description expected with one from the hrStorageIndex entry and if they are not equal then we can filter the table to return an entry that does match.

We have found with JunOS EVO when anyone logs into the box it mounts
`tmpfs                   3.1G          0       3.1G        0%  /run/user/{uid}`
which causes the ordering of the HOST-RESOURCES-MIB::hrStorageTable to change which causes all sorts of issues ... (like Storage alarms because some partition just got muddled up with some other suppressed partition (ie a loopback mount) that has 0% free space)

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
