### PR TITLE
rutos-rutx: Map GPS lat and lon to os module

### DIFF
--- a/includes/definitions/discovery/rutos-rutx.yaml
+++ b/includes/definitions/discovery/rutos-rutx.yaml
@@ -4,6 +4,8 @@ modules:
         hardware: TELTONIKA-RUTX-MIB::routerName.0
         serial: TELTONIKA-RUTX-MIB::serial.0
         version: TELTONIKA-RUTX-MIB::fwVersion.0
+        lat: TELTONIKA-RUTX-MIB::latitude.0
+        long: TELTONIKA-RUTX-MIB::longtitude.0
     sensors:
         pre-cache:
             data:


### PR DESCRIPTION
Teltonika routers have GPS hardware and it's discovered by LibreNMS, but for some reason only gets graphed.
This maps the coordinates to the OS module, which makes its position appear on the pretty map.

As the GPS coordinates are already there and discovered by LibreNMS, simply used erroneously, I do not believe updated test data is needed.

Web UI before:

![before](https://github.com/librenms/librenms/assets/6379091/6b689494-b58e-4e3a-969a-4d3350a85828)

Web UI after:

![after](https://github.com/librenms/librenms/assets/6379091/07ec2dbf-0aeb-40b6-8326-704d9ed0695e)

GPS coordinates were available before, but in the form of a graphed count:

![firefox_AzrNaXsovj](https://github.com/librenms/librenms/assets/6379091/b45a0688-c309-49cf-aeba-204fa0afe3e7)

This is still the case and this count has not been removed.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
