### PR TITLE
Store discover/polled time in whole seconds

### DIFF
--- a/app/Jobs/PingCheck.php
+++ b/app/Jobs/PingCheck.php
@@ -123,7 +123,6 @@ class PingCheck implements ShouldQueue
                 continue;
             }
 
-            dump($line);
             if (preg_match_all(
                 '/^(?<hostname>[^\s]+) is (?<status>alive|unreachable)(?: \((?<rtt>[\d.]+) ms\))?/m',
                 $line,
@@ -230,7 +229,6 @@ class PingCheck implements ShouldQueue
      */
     private function recordData(string $hostname, string $status, float $rtt = 0): void
     {
-        dump(get_defined_vars());
         if (Debug::isVerbose()) {
             echo "Attempting to record data for $hostname... ";
         }
@@ -247,7 +245,7 @@ class PingCheck implements ShouldQueue
             // mark up only if snmp is not down too
             $device->status = ($status == 'alive' && $device->status_reason != 'snmp');
             $device->last_ping = Carbon::now();
-            $device->last_ping_timetaken = $rtt;
+            $device->last_ping_timetaken = round($rtt, 2);
 
             if ($device->isDirty('status')) {
                 // if changed, update reason

--- a/database/migrations/2023_05_11_122222_store_polled_time_in_seconds.php
+++ b/database/migrations/2023_05_11_122222_store_polled_time_in_seconds.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('devices', function (Blueprint $table) {
+            $table->unsignedSmallInteger('last_polled_timetaken')->nullable()->change();
+            $table->unsignedSmallInteger('last_discovered_timetaken')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('devices', function (Blueprint $table) {
+            $table->float('last_polled_timetaken', 5)->nullable()->change();
+            $table->float('last_discovered_timetaken', 5)->nullable()->change();
+        });
+    }
+};

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -179,7 +179,7 @@ function discover_device(&$device, $force_module = false)
         }
     }
 
-    $device_time = round(microtime(true) - $device_start, 3);
+    $device_time = round(microtime(true) - $device_start);
 
     dbUpdate(['last_discovered' => ['NOW()'], 'last_discovered_timetaken' => $device_time], 'devices', '`device_id` = ?', [$device['device_id']]);
 

--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -387,7 +387,7 @@ function poll_device($device, $force_module = false)
             $os->enableGraph('ping_perf');
         }
 
-        $device_time = round(microtime(true) - $device_start, 3);
+        $device_time = round(microtime(true) - $device_start);
 
         // Poller performance
         if (! empty($device_time)) {

--- a/misc/db_schema.yaml
+++ b/misc/db_schema.yaml
@@ -530,8 +530,8 @@ devices:
     - { Field: agent_uptime, Type: 'int unsigned', 'Null': false, Extra: '', Default: '0' }
     - { Field: last_polled, Type: timestamp, 'Null': true, Extra: '' }
     - { Field: last_poll_attempted, Type: timestamp, 'Null': true, Extra: '' }
-    - { Field: last_polled_timetaken, Type: 'double(5,2)', 'Null': true, Extra: '' }
-    - { Field: last_discovered_timetaken, Type: 'double(5,2)', 'Null': true, Extra: '' }
+    - { Field: last_polled_timetaken, Type: 'smallint unsigned', 'Null': true, Extra: '' }
+    - { Field: last_discovered_timetaken, Type: 'smallint unsigned', 'Null': true, Extra: '' }
     - { Field: last_discovered, Type: timestamp, 'Null': true, Extra: '' }
     - { Field: last_ping, Type: timestamp, 'Null': true, Extra: '' }
     - { Field: last_ping_timetaken, Type: 'double(8,2)', 'Null': true, Extra: '' }


### PR DESCRIPTION
Fixes 
```
[2023-05-11T09:36:00.864994+02:00] production.ERROR: SQLSTATE[22003]: Numeric value out of range:
1264 Out of range value for column 'last_discovered_timetaken' at row 1 (SQL: UPDATE `devices` set `last_discovered`=NOW(),`last_discovered_timetaken`=1831.653 WHERE `device_id` = 6788) (SQL: UPDATE `devices` set `last_discovered`=NOW(),`last_discovered_timetaken`=1831.653 WHERE `device_id` = 6788)
#0 /opt/librenms/includes/discovery/functions.inc.php(184): dbUpdate()
```

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
