### PR TITLE
Fix inventory display for Calix AXOS devices

### DIFF
--- a/includes/discovery/entity-physical/axos.inc.php
+++ b/includes/discovery/entity-physical/axos.inc.php
@@ -1,27 +1,33 @@
 <?php
 
-$physical_name = snmpwalk_cache_oid($device, 'sysObjectID.0', $physical_name, 'SNMPv2-MIB:CALIX-PRODUCT-MIB');
-$serial_number = snmpwalk_cache_oid($device, 'axosSystemChassisSerialNumber', $serial_number, 'Axos-System-MIB');
-$entity_array[] = [
-    'entPhysicalIndex' => 0,
-    'entPhysicalName' => $physical_name['sysObjectID.0'],
-    'entPhysicalSerialNum' => $serial_number['axosSystemChassisSerialNumber.0'],
-    'entPhysicalMfgName' => 'Calix',
+$physical_name = snmpwalk_cache_multi_oid($device, 'sysObjectID.0', $physical_name, 'SNMPv2-MIB:CALIX-PRODUCT-MIB');
+$serial_number = snmpwalk_cache_multi_oid($device, 'axosSystemChassisSerialNumber', $serial_number, 'Axos-System-MIB');
+$physical_index = 1;
+$entity_array[1] = [
+    'entPhysicalIndex'        => $physical_index,
+    'entPhysicalDescr' => $physical_name[0]['sysObjectID'],
     'entPhysicalVendorType' => 'Calix',
-    'entPhysicalParentRelPos' => 0,
+    'entPhysicalContainedIn' => '0',
+    'entPhysicalClass'        => 'chassis',
+    'entPhysicalParentRelPos' => '-1',
+    'entPhysicalName' => $physical_name[0]['sysObjectID'],
+    'entPhysicalSerialNum' => $serial_number[0]['axosSystemChassisSerialNumber'],
+    'entPhysicalMfgName' => 'Calix',
+    'entPhysicalModelName' => $physical_name[0]['sysObjectID'],
 ];
 
 $card_array = snmpwalk_cache_multi_oid($device, 'axosCardTable', $card_array, 'Axos-Card-MIB');
-$id = 1;
 foreach ($card_array as $card) {
-    // Discover the card
+    $physical_index++;
+//    Discover the card
     $entity_array[] = [
-        'entPhysicalIndex'        => $id++,
+        'entPhysicalIndex'        => $physical_index,
         'entPhysicalDescr'        => "Calix {$card['axosCardActualType']}",
-        'entPhysicalClass'        => 'card',
+        'entPhysicalClass'        => 'container',
         'entPhysicalModelName'    => $card['axosCardPartNumber'],
         'entPhysicalSerialNum'    => $card['axosCardSerialNumber'],
-        'entPhysicalContainedIn'  => '0',
+        'entPhysicalContainedIn'  => 1,
+        'entPhysicalParentRelPos'  => $card['axosCardSlot'],
         'entPhysicalSoftwareRev'  => $card['axosCardSoftwareVersion'],
         'entPhysicalIsFRU'        => true,
     ];


### PR DESCRIPTION
Fixes inventory display so that chassis information shows up and cards show up properly below.

![image](https://github.com/librenms/librenms/assets/52936/6ad40e56-97bb-4b1e-8751-77cbd6141e93)


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [X] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
