### PR TITLE
Ondemand popup graphs

### DIFF
--- a/resources/views/components/device-link.blade.php
+++ b/resources/views/components/device-link.blade.php
@@ -17,10 +17,16 @@
         </span>
     </x-slot>
     <x-slot name="body">
-        @foreach($graphs as $graph)
-            @isset($graph['text'], $graph['graph'])
-                <x-graph-row loading="lazy" :device="$device" :type="$graph['graph']" :title="$graph['text']" :graphs="[['from' => '-1d'], ['from' => '-7d']]"></x-graph-row>
-            @endisset
-        @endforeach
+        <div x-data="{loadGraphs: false}" x-init="$watch('popupShow', shown => {if(shown) loadGraphs = true})">
+        <template x-if="loadGraphs">
+            <div>
+            @foreach($graphs as $graph)
+                @isset($graph['text'], $graph['graph'])
+                    <x-graph-row loading="lazy" :device="$device" :type="$graph['graph']" :title="$graph['text']" :graphs="[['from' => '-1d'], ['from' => '-7d']]"></x-graph-row>
+                @endisset
+            @endforeach
+            </div>
+        </template>
+        </div>
     </x-slot>
 </x-popup>

--- a/resources/views/components/device-link.blade.php
+++ b/resources/views/components/device-link.blade.php
@@ -17,8 +17,7 @@
         </span>
     </x-slot>
     <x-slot name="body">
-        <div x-data="{loadGraphs: false}" x-init="$watch('popupShow', shown => {if(shown) loadGraphs = true})">
-        <template x-if="loadGraphs">
+        <template x-if="loadGraphs" x-data="{loadGraphs: false}" x-init="$watch('popupShow', shown => {if(shown) loadGraphs = true})">
             <div>
             @foreach($graphs as $graph)
                 @isset($graph['text'], $graph['graph'])
@@ -27,6 +26,5 @@
             @endforeach
             </div>
         </template>
-        </div>
     </x-slot>
 </x-popup>


### PR DESCRIPTION
Only load popup graphs when popup is shown

Might cause a small delay, but pre-loading all the graphs was causing a lot of unneeded work. Slowing down page loading.

fixes https://github.com/librenms/docker/issues/343

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
