### PR TITLE
Add new option to discover rebooted devices

### DIFF
--- a/discovery.php
+++ b/discovery.php
@@ -37,6 +37,10 @@ if (isset($options['h'])) {
         $new_discovery_lock = Cache::lock('new-discovery', 300);
         $where = 'AND `last_discovered` IS NULL';
         $doing = 'new';
+    } elseif ($options['h'] == 'rebooted') {
+        $new_discovery_lock = Cache::lock('rebooted-discovery', 300);
+        $where = 'AND TIMESTAMPDIFF(SECOND, `last_discovered`, NOW()) > `uptime` and `status`<>0';
+        $doing = 'rebooted';
     } elseif ($options['h']) {
         if (is_numeric($options['h'])) {
             $where = "AND `device_id` = '" . $options['h'] . "'";
@@ -124,7 +128,7 @@ if (! isset($options['q'])) {
 
 logfile($string);
 
-if ($doing !== 'new' && $discovered_devices == 0) {
+if ($doing !== 'new' && $doing !== 'rebooted' && $discovered_devices == 0) {
     // No discoverable devices, either down or disabled
     exit(5);
 }

--- a/dist/librenms.cron
+++ b/dist/librenms.cron
@@ -1,5 +1,6 @@
 33   */6  * * *   librenms    /opt/librenms/cronic /opt/librenms/discovery-wrapper.py 1
 */5  *    * * *   librenms    /opt/librenms/discovery.php -h new >> /dev/null 2>&1
+*/5  *    * * *   librenms    /opt/librenms/discovery.php -h rebooted >> /dev/null 2>&1
 
 */5  *    * * *   librenms    /opt/librenms/cronic /opt/librenms/poller-wrapper.py 16
 *    *    * * *   librenms    /opt/librenms/alerts.php >> /dev/null 2>&1


### PR DESCRIPTION
I noticed that LibreNMS fails to correctly poll some resources after a device has been rebooted because some of the OIDs change.  This patch adds another option to the discovery php script to allow discovery of rebooted devices, which are detected by looking for devices that are online where the time since the last discovery was run is greater than the current uptime.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
