### PR TITLE
Remove asterisk from recurring input

### DIFF
--- a/includes/html/modal/alert_schedule.inc.php
+++ b/includes/html/modal/alert_schedule.inc.php
@@ -51,7 +51,7 @@ if (\Auth::user()->hasGlobalAdmin()) {
                         </div>
                     </div>
                     <div class="form-group">
-                        <label for="recurring" class="col-sm-4 control-label">Recurring <strong class="text-danger">*</strong> </label>
+                        <label for="recurring" class="col-sm-4 control-label">Recurring </label>
                         <div class="col-sm-8">
                             <input type="checkbox" id="recurring" name="recurring" data-size="small" data-on-text="Yes" data-off-text="No" onChange="recurring_switch();" value=0 />
                         </div>


### PR DESCRIPTION
Asterisks are typically used to indicate a required field, however the asterisk next to the recurring input field is red (instead of black) and unnecessary (as the field is a toggle).

![image](https://github.com/librenms/librenms/assets/32306651/a9348ea8-6bdd-44d2-939b-514f9c431db4)


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
