### PR TITLE
Fixes #14975 Services in Device Groups not displayed correctly in Availability widget

### DIFF
--- a/app/Models/DeviceGroup.php
+++ b/app/Models/DeviceGroup.php
@@ -129,7 +129,9 @@ class DeviceGroup extends BaseModel
 
     public function services(): BelongsToMany
     {
-        return $this->belongsToMany(\App\Models\Service::class, 'device_group_device', 'device_group_id', 'device_id');
+        // $parentKey='id', $relatedKey='device_id' is required to generate the right SQL query.
+        // Otherwise the primaryKey in Service.php will be used
+        return $this->belongsToMany(\App\Models\Service::class, 'device_group_device', 'device_group_id', 'device_id', 'id', 'device_id');
     }
 
     public function users(): BelongsToMany


### PR DESCRIPTION
Fixes #14975
The Availability Map Widget for dashboards fails to filter the device group for devices on which these services are running.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [N/A] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [N/A] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
