### PR TITLE
add a flag for adding app data to tests generated via scripts/json-app-tool.php

### DIFF
--- a/scripts/json-app-tool.php
+++ b/scripts/json-app-tool.php
@@ -210,7 +210,7 @@ if (isset($options['t'])) {
             system('jsonlint ' . escapeshellarg($options['j']));
             exit(3);
         }
-        $test_data['applications']['poller']['applications']['data'] = json_encode($app_data);
+        $test_data['applications']['poller']['applications']['0']['data'] = json_encode($app_data);
     }
     echo json_encode($test_data, JSON_PRETTY_PRINT) . "\n";
     exit(0);

--- a/scripts/json-app-tool.php
+++ b/scripts/json-app-tool.php
@@ -210,7 +210,7 @@ if (isset($options['t'])) {
             system('jsonlint ' . escapeshellarg($options['j']));
             exit(3);
         }
-        $test_data['applications']['poller']['applications']['data']=json_encode($app_data);
+        $test_data['applications']['poller']['applications']['data'] = json_encode($app_data);
     }
     echo json_encode($test_data, JSON_PRETTY_PRINT) . "\n";
     exit(0);

--- a/scripts/json-app-tool.php
+++ b/scripts/json-app-tool.php
@@ -34,7 +34,7 @@ function string_to_oid($string)
 }//end string_to_oid()
 
 // Options!
-$short_opts = 'S:sktmlhj:a:';
+$short_opts = 'S:sktmlhj:a:d:';
 $options = getopt($short_opts);
 
 // print the help
@@ -48,6 +48,7 @@ if (isset($options['h'])) {
   -k      If m is specified, just print the keys in tested order.
   -a      The application name for use with -s and -t.
   -S      SNMP extend name. Defaults to the same as -a.
+  -d      JSON file to use for app data.
   -h      Show this help text.
 
 -j must always be specified.
@@ -196,6 +197,20 @@ if (isset($options['t'])) {
             'value_prev' => null,
             'app_type' => $options['a'],
         ];
+    }
+    // if d is specified, try to read it in and add it
+    if (isset($options['d'])) {
+        $raw_app_data = file_get_contents($options['d']);
+        if ($raw_json === false) {
+            exit(2);
+        }
+        $app_data = json_decode(stripslashes($raw_app_data), true);
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            echo "Parsing '" . $options['d'] . "' failed. Running jsonlint...\n\n";
+            system('jsonlint ' . escapeshellarg($options['j']));
+            exit(3);
+        }
+        $test_data['applications']['poller']['applications']['data']=json_encode($app_data);
     }
     echo json_encode($test_data, JSON_PRETTY_PRINT) . "\n";
     exit(0);


### PR DESCRIPTION
`-d` may now be used to specify a JSON file to use for the app data column when writing tests.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
