### PR TITLE
add generic stats graph munging support and make uptime optional between seconds and days

### DIFF
--- a/includes/html/graphs/device/uptime.inc.php
+++ b/includes/html/graphs/device/uptime.inc.php
@@ -9,8 +9,13 @@ $ds = 'uptime';
 $colours = 'greens';
 $float_precision = 3;
 
-$munge=TRUE;
+$descr = 'Uptime';
 
-$descr = '';
+$munge=\LibreNMS\Config::get('graph_uptime_days');
+
+$unit_text='Days';
+if (!$munge) {
+    $unit_text='Seconds';
+}
 
 require 'includes/html/graphs/generic_stats.inc.php';

--- a/includes/html/graphs/device/uptime.inc.php
+++ b/includes/html/graphs/device/uptime.inc.php
@@ -9,6 +9,8 @@ $ds = 'uptime';
 $colours = 'greens';
 $float_precision = 3;
 
+$munge=TRUE;
+
 $descr = '';
 
 require 'includes/html/graphs/generic_stats.inc.php';

--- a/includes/html/graphs/generic_stats.inc.php
+++ b/includes/html/graphs/generic_stats.inc.php
@@ -17,6 +17,10 @@ require 'includes/html/graphs/common.inc.php';
 
 $stacked = generate_stacked_graphs();
 
+if (! isset($munge)) {
+    $munge = FALSE;
+}
+
 if (! isset($colours)) {
     $colours = 'rainbow_stats_purple';
 }
@@ -108,15 +112,30 @@ if ($height > 25) {
     $descr_1w = \LibreNMS\Data\Store\Rrd::fixedSafeDescr('1 week avg', $descr_len);
 }
 
-$id = 'ds' . $i;
+$id = 'ds0';
+if ($munge) {
+    $id='dsm0';
+}
 
-$rrd_options .= ' DEF:' . $id . "=$filename:$ds:AVERAGE";
+$rrd_options .= ' DEF:ds0' . "=$filename:$ds:AVERAGE";
+
+$munge_helper='';
+if ($munge) {
+    if (!isset($munge_opts)) {
+        $munge_opts='86400,/';
+    }
+    $rrd_options .= ' CDEF:dsm0=ds0,' . $munge_opts;
+    $munge_helper='ds';
+}
 
 $rrd_optionsb .= ' AREA:' . $id . '#' . $colourA . $colourAalpha;
 $rrd_optionsb .= ' LINE1.25:' . $id . '#' . $colour . ":'$descr'";
 
 if ($height > 25) {
-    $rrd_options .= ' DEF:' . $id . "1h=$filename:$ds:AVERAGE:step=3600";
+    $rrd_options .= ' DEF:' . $id . "1h$munge_helper=$filename:$ds:AVERAGE:step=3600";
+    if ($munge) {
+        $rrd_options .= ' CDEF:dsm01h=dsm01hds,' . $munge_opts;
+    }
     $rrd_options .= ' VDEF:' . $id . '50th=' . $id . ',50,PERCENTNAN';
     $rrd_options .= ' VDEF:' . $id . '25th=' . $id . ',25,PERCENTNAN';
     $rrd_options .= ' VDEF:' . $id . '75th=' . $id . ',75,PERCENTNAN';
@@ -130,12 +149,18 @@ if ($height > 25) {
     }
     // displays nan if less than 17 hours
     if ($time_diff >= 61200) {
-        $rrd_options .= ' DEF:' . $id . "1d=$filename:$ds:AVERAGE:step=86400";
+        $rrd_options .= ' DEF:' . $id . "1d$munge_helper=$filename:$ds:AVERAGE:step=86400";
+        if ($munge) {
+            $rrd_options .= ' CDEF:dsm01d=dsm01dds,' . $munge_opts;
+        }
     }
 
     // weekly breaks and causes issues if it is less than 8 days
     if ($time_diff >= 691200) {
-        $rrd_options .= ' DEF:' . $id . "1w=$filename:$ds:AVERAGE:step=604800";
+        $rrd_options .= ' DEF:' . $id . "1w$munge_helper=$filename:$ds:AVERAGE:step=604800";
+        if ($munge) {
+            $rrd_options .= ' CDEF:dsm01w=dsm01wds,' . $munge_opts;
+        }
     }
 
     $rrd_optionsb .= ' GPRINT:' . $id . ':LAST:%5.' . $float_precision . 'lf%s' . $units . ' GPRINT:' . $id . ':MIN:%5.' . $float_precision . 'lf%s' . $units;

--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -1779,6 +1779,13 @@
             "order": 7,
             "type": "boolean"
         },
+        "graph_uptime_days": {
+            "default": true,
+            "group": "webui",
+            "section": "graph",
+            "order": 8,
+            "type": "boolean"
+        },
         "graph_colours.blues": {
             "default": [
                 "A9A9F2",


### PR DESCRIPTION
This adds in munging to the generic stats graph.

Also revert uptime back to being days again and make it able to optionally show in graphs as either days or seconds via a new config def.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [X] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
