### PR TITLE
add os check in discovery for aix/freenas storage and cisco cdp

### DIFF
--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -41,46 +41,49 @@ if ($device['os'] == 'ironware') {
     echo PHP_EOL;
 }//end if
 
-echo ' CISCO-CDP-MIB: ';
-$cdp_array = snmpwalk_group($device, 'cdpCache', 'CISCO-CDP-MIB', 2);
+if ($device['os'] == 'ios' || $device['os'] == 'iosxe' || $device['os'] == 'nxos') {
+    echo ' CISCO-CDP-MIB: ';
+    $cdp_array = snmpwalk_group($device, 'cdpCache', 'CISCO-CDP-MIB', 2);
 
-foreach ($cdp_array as $key => $cdp_if_array) {
-    $interface = get_port_by_ifIndex($device['device_id'], $key);
+    foreach ($cdp_array as $key => $cdp_if_array) {
+        $interface = get_port_by_ifIndex($device['device_id'], $key);
 
-    foreach ($cdp_if_array as $entry_key => $cdp) {
-        d_echo($cdp);
+        foreach ($cdp_if_array as $entry_key => $cdp) {
+            d_echo($cdp);
 
-        $cdp_ip = IP::fromHexString($cdp['cdpCacheAddress'], true);
-        $remote_device_id = find_device_id($cdp['cdpCacheDeviceId'], $cdp_ip);
+            $cdp_ip = IP::fromHexString($cdp['cdpCacheAddress'], true);
+            $remote_device_id = find_device_id($cdp['cdpCacheDeviceId'], $cdp_ip);
 
-        if (! $remote_device_id &&
-            ! can_skip_discovery($cdp['cdpCacheDeviceId'], $cdp['cdpCacheVersion'], $cdp['cdpCachePlatform']) &&
-            Config::get('autodiscovery.xdp') === true
-        ) {
-            $remote_device_id = discover_new_device($cdp['cdpCacheDeviceId'], $device, 'CDP', $interface);
+            if (
+                ! $remote_device_id &&
+                ! can_skip_discovery($cdp['cdpCacheDeviceId'], $cdp['cdpCacheVersion'], $cdp['cdpCachePlatform']) &&
+                Config::get('autodiscovery.xdp') === true
+            ) {
+                $remote_device_id = discover_new_device($cdp['cdpCacheDeviceId'], $device, 'CDP', $interface);
 
-            if (! $remote_device_id && Config::get('discovery_by_ip', false)) {
-                $remote_device_id = discover_new_device($cdp_ip, $device, 'CDP', $interface);
+                if (! $remote_device_id && Config::get('discovery_by_ip', false)) {
+                    $remote_device_id = discover_new_device($cdp_ip, $device, 'CDP', $interface);
+                }
             }
-        }
 
-        if ($interface['port_id'] && $cdp['cdpCacheDeviceId'] && $cdp['cdpCacheDevicePort']) {
-            $remote_port_id = find_port_id($cdp['cdpCacheDevicePort'], '', $remote_device_id);
-            discover_link(
-                $interface['port_id'],
-                'cdp',
-                $remote_port_id,
-                $cdp['cdpCacheDeviceId'],
-                $cdp['cdpCacheDevicePort'],
-                $cdp['cdpCachePlatform'],
-                $cdp['cdpCacheVersion'],
-                $device['device_id'],
-                $remote_device_id
-            );
-        }
-    }//end foreach
-}//end foreach
-echo PHP_EOL;
+            if ($interface['port_id'] && $cdp['cdpCacheDeviceId'] && $cdp['cdpCacheDevicePort']) {
+                $remote_port_id = find_port_id($cdp['cdpCacheDevicePort'], '', $remote_device_id);
+                discover_link(
+                    $interface['port_id'],
+                    'cdp',
+                    $remote_port_id,
+                    $cdp['cdpCacheDeviceId'],
+                    $cdp['cdpCacheDevicePort'],
+                    $cdp['cdpCachePlatform'],
+                    $cdp['cdpCacheVersion'],
+                    $device['device_id'],
+                    $remote_device_id
+                );
+            }
+        } //end foreach
+    } //end foreach
+    echo PHP_EOL;
+}//end if
 
 if (($device['os'] == 'routeros') && ($device['version'] <= '7.6')) {
     echo ' LLDP-MIB: ';

--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -41,7 +41,7 @@ if ($device['os'] == 'ironware') {
     echo PHP_EOL;
 }//end if
 
-if ($device['os'] == 'ios' || $device['os'] == 'iosxe' || $device['os'] == 'nxos') {
+if (isset($device['os_group']) && $device['os_group'] == 'cisco') {
     echo ' CISCO-CDP-MIB: ';
     $cdp_array = snmpwalk_group($device, 'cdpCache', 'CISCO-CDP-MIB', 2);
 

--- a/includes/discovery/storage/aix.inc.php
+++ b/includes/discovery/storage/aix.inc.php
@@ -8,20 +8,22 @@
  * the source code distribution for details.
  */
 
-$aix_filesystem = snmpwalk_cache_oid($device, 'aixFsTableEntry', [], 'IBM-AIX-MIB');
+if ($device['os'] == 'aix') {
+    $aix_filesystem = snmpwalk_cache_oid($device, 'aixFsTableEntry', [], 'IBM-AIX-MIB');
 
-if (is_array($aix_filesystem)) {
-    echo 'aix_filesystem : ';
-    foreach ($aix_filesystem as $aix_fs) {
-        if (isset($aix_fs['aixFsMountPoint'])) {
-            if ($aix_fs['aixFsType'] == 'jfs' || $aix_fs['aixFsType'] == 'jfs2') { // Only JFS or JFS2
-                $aix_fs['aixFsSize'] = $aix_fs['aixFsSize'] * 1024 * 1024;
-                $aix_fs['aixFsFree'] = $aix_fs['aixFsFree'] * 1024 * 1024;
-                $aix_fs['aixFsUsed'] = $aix_fs['aixFsSize'] - $aix_fs['aixFsFree'];
+    if (is_array($aix_filesystem)) {
+        echo 'aix_filesystem : ';
+        foreach ($aix_filesystem as $aix_fs) {
+            if (isset($aix_fs['aixFsMountPoint'])) {
+                if ($aix_fs['aixFsType'] == 'jfs' || $aix_fs['aixFsType'] == 'jfs2') { // Only JFS or JFS2
+                    $aix_fs['aixFsSize'] = $aix_fs['aixFsSize'] * 1024 * 1024;
+                    $aix_fs['aixFsFree'] = $aix_fs['aixFsFree'] * 1024 * 1024;
+                    $aix_fs['aixFsUsed'] = $aix_fs['aixFsSize'] - $aix_fs['aixFsFree'];
 
-                discover_storage($valid_storage, $device, $aix_fs['aixFsIndex'], 'aixFileSystem', 'aix', $aix_fs['aixFsMountPoint'], $aix_fs['aixFsSize'], 1024 * 1024, $aix_fs['aixFsUsed']);
+                    discover_storage($valid_storage, $device, $aix_fs['aixFsIndex'], 'aixFileSystem', 'aix', $aix_fs['aixFsMountPoint'], $aix_fs['aixFsSize'], 1024 * 1024, $aix_fs['aixFsUsed']);
+                }
             }
-        }
-    } // end foreach
-} // endif
-unset($aix_fs);
+        } // end foreach
+    } // endif
+    unset($aix_fs);
+}

--- a/includes/discovery/storage/freenas-dataset.inc.php
+++ b/includes/discovery/storage/freenas-dataset.inc.php
@@ -1,20 +1,22 @@
 <?php
 
-$datasetTable_array = snmpwalk_cache_oid($device, 'datasetTable', null, 'FREENAS-MIB');
+if ($device['os'] == 'truenas') {
+    $datasetTable_array = snmpwalk_cache_oid($device, 'datasetTable', null, 'FREENAS-MIB');
 
-$sql = "SELECT `storage_descr` FROM `storage` WHERE `device_id`  = '" . $device['device_id'] . "' AND `storage_type` != 'dataset'";
-$tmp_storage = dbFetchColumn($sql);
+    $sql = "SELECT `storage_descr` FROM `storage` WHERE `device_id`  = '" . $device['device_id'] . "' AND `storage_type` != 'dataset'";
+    $tmp_storage = dbFetchColumn($sql);
 
-if (is_array($datasetTable_array)) {
-    foreach ($datasetTable_array as $index => $dataset) {
-        if (isset($dataset['datasetDescr'])) {
-            if (! in_array($dataset['datasetDescr'], $tmp_storage)) {
-                $dataset['datasetIndex'] = $index;
-                $dataset['datasetTotal'] = $dataset['datasetSize'] * $dataset['datasetAllocationUnits'];
-                $dataset['datasetAvail'] = ($dataset['datasetAvailable'] * $dataset['datasetAllocationUnits']);
-                $dataset['datasetUsed'] = $dataset['datasetTotal'] - $dataset['datasetAvail'];
+    if (is_array($datasetTable_array)) {
+        foreach ($datasetTable_array as $index => $dataset) {
+            if (isset($dataset['datasetDescr'])) {
+                if (!in_array($dataset['datasetDescr'], $tmp_storage)) {
+                    $dataset['datasetIndex'] = $index;
+                    $dataset['datasetTotal'] = $dataset['datasetSize'] * $dataset['datasetAllocationUnits'];
+                    $dataset['datasetAvail'] = ($dataset['datasetAvailable'] * $dataset['datasetAllocationUnits']);
+                    $dataset['datasetUsed'] = $dataset['datasetTotal'] - $dataset['datasetAvail'];
 
-                discover_storage($valid_storage, $device, $dataset['datasetIndex'], 'dataset', 'freenas-dataset', $dataset['datasetDescr'], $dataset['datasetTotal'], $dataset['datasetAllocationUnits'], $dataset['datasetUsed']);
+                    discover_storage($valid_storage, $device, $dataset['datasetIndex'], 'dataset', 'freenas-dataset', $dataset['datasetDescr'], $dataset['datasetTotal'], $dataset['datasetAllocationUnits'], $dataset['datasetUsed']);
+                }
             }
         }
     }

--- a/includes/discovery/storage/freenas-zpool.inc.php
+++ b/includes/discovery/storage/freenas-zpool.inc.php
@@ -1,20 +1,22 @@
 <?php
 
-$zpooltable_array = snmpwalk_cache_oid($device, 'zpoolTable', null, 'FREENAS-MIB');
+if ($device['os'] == 'truenas') {
+    $zpooltable_array = snmpwalk_cache_oid($device, 'zpoolTable', null, 'FREENAS-MIB');
 
-$sql = "SELECT `storage_descr` FROM `storage` WHERE `device_id`  = '" . $device['device_id'] . "' AND `storage_type` != 'zpool'";
-$tmp_storage = dbFetchColumn($sql);
+    $sql = "SELECT `storage_descr` FROM `storage` WHERE `device_id`  = '" . $device['device_id'] . "' AND `storage_type` != 'zpool'";
+    $tmp_storage = dbFetchColumn($sql);
 
-if (is_array($zpooltable_array)) {
-    foreach ($zpooltable_array as $index => $zpool) {
-        if (isset($zpool['zpoolDescr'])) {
-            if (! in_array($zpool['zpoolDescr'], $tmp_storage)) {
-                $zpool['zpoolIndex'] = $index;
-                $zpool['zpoolTotal'] = $zpool['zpoolSize'] * $zpool['zpoolAllocationUnits'];
-                $zpool['zpoolAvail'] = ($zpool['zpoolAvailable'] * $zpool['zpoolAllocationUnits']);
-                $zpool['zpoolUsed'] = $zpool['zpoolTotal'] - $zpool['zpoolAvail'];
+    if (is_array($zpooltable_array)) {
+        foreach ($zpooltable_array as $index => $zpool) {
+            if (isset($zpool['zpoolDescr'])) {
+                if (!in_array($zpool['zpoolDescr'], $tmp_storage)) {
+                    $zpool['zpoolIndex'] = $index;
+                    $zpool['zpoolTotal'] = $zpool['zpoolSize'] * $zpool['zpoolAllocationUnits'];
+                    $zpool['zpoolAvail'] = ($zpool['zpoolAvailable'] * $zpool['zpoolAllocationUnits']);
+                    $zpool['zpoolUsed'] = $zpool['zpoolTotal'] - $zpool['zpoolAvail'];
 
-                discover_storage($valid_storage, $device, $zpool['zpoolIndex'], 'zpool', 'freenas-zpool', $zpool['zpoolDescr'], $zpool['zpoolTotal'], $zpool['zpoolAllocationUnits'], $zpool['zpoolUsed']);
+                    discover_storage($valid_storage, $device, $zpool['zpoolIndex'], 'zpool', 'freenas-zpool', $zpool['zpoolDescr'], $zpool['zpoolTotal'], $zpool['zpoolAllocationUnits'], $zpool['zpoolUsed']);
+                }
             }
         }
     }


### PR DESCRIPTION
Please give a short description what your pull request is for

When investigating another issue found errors caused by discovery trying to do things to JunOS hosts

```{"command" : ["\/usr\/bin\/snmpbulkwalk","-v2c","-c","redacted","-OQUs","-m","IBM-AIX-MIB","-M","\/opt\/librenms\/mibs:\/opt\/librenms\/mibs\/junos",
"-t",2,"udp:redacted.host.net:161","aixFsTableEntry"]}
{"exitcode" : 1}
{"errorOutput" : "MIB search path: \/opt\/librenms\/mibs:\/opt\/librenms\/mibs\/junos\nCannot find module (IBM-AIX-MIB): At line 1 in (none)\naixFsTableEntry: Unknown Object Identifier (Sub-id not found: (top) -> aixFsTableEntry)\n"}

{"command" : ["\/usr\/bin\/snmpbulkwalk","-v2c","-c","redacted","-OQUs","-m","FREENAS-MIB","-M","\/opt\/librenms\/mibs:\/opt\/librenms\/mibs\/junos",
"-t",2,"udp:redacted.host.net:161","datasetTable"]}
{"exitcode" : 1}
{"errorOutput" : "MIB search path: \/opt\/librenms\/mibs:\/opt\/librenms\/mibs\/junos\nCannot find module (FREENAS-MIB): At line 1 in (none)\ndatasetTable: Unknown Object Identifier (Sub-id not found: (top) -> datasetTable)\n"}

{"command" : ["\/usr\/bin\/snmpbulkwalk","-v2c","-c","redacted","-OQUs","-m","FREENAS-MIB","-M","\/opt\/librenms\/mibs:\/opt\/librenms\/mibs\/junos",
"-t",2,"udp:redacted.host.net:161","zpoolTable"]}
{"exitcode" : 1}
{"errorOutput" : "MIB search path: \/opt\/librenms\/mibs:\/opt\/librenms\/mibs\/junos\nCannot find module (FREENAS-MIB): At line 1 in (none)\nzpoolTable:
 Unknown Object Identifier (Sub-id not found: (top) -> zpoolTable)\n"}

{"command" : ["\/usr\/bin\/snmpbulkwalk","-v2c","-c","redacted","-OQUsetX","-m","CISCO-CDP-MIB","-M","\/opt\/librenms\/mibs:\/opt\/librenms\/mibs\/junos","udp:redacted.host.net:161","cdpCache"]}
{"exitcode" : 1}
{"errorOutput" : "MIB search path: \/opt\/librenms\/mibs:\/opt\/librenms\/mibs\/junos\nCannot find module (CISCO-CDP-MIB): At line 1 in (none)\ncdpCache: Unknown Object Identifier (Sub-id not found: (top) -> cdpCache)\n"}
```
Added device os checks

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
