### PR TITLE
Changed sensor state for Loop telecom

### DIFF
--- a/includes/discovery/sensors/state/loop-telecom.inc.php
+++ b/includes/discovery/sensors/state/loop-telecom.inc.php
@@ -9,7 +9,7 @@ if (! empty($oids)) {
         ['value' => 1, 'generic' => 3, 'graph' => 0, 'descr' => 'Empty'],
         ['value' => 2, 'generic' => 1, 'graph' => 0, 'descr' => 'Initializing'],
         ['value' => 3, 'generic' => 0, 'graph' => 0, 'descr' => 'Working'],
-        ['value' => 4, 'generic' => 0, 'graph' => 0, 'descr' => 'Unplugged'],
+        ['value' => 4, 'generic' => 1, 'graph' => 0, 'descr' => 'Unplugged'],
         ['value' => 5, 'generic' => 2, 'graph' => 0, 'descr' => 'Failed'],
         ['value' => 6, 'generic' => 1, 'graph' => 0, 'descr' => 'UnknownCard'],
         ['value' => 11, 'generic' => 1, 'graph' => 0, 'descr' => 'BrandMismatch'],


### PR DESCRIPTION
Update state to warning if a line card is removed.

Please give a short description what your pull request is for:

When unplugging a working card from the chassis no state alarm was triggered. This PR will change it so when unplugging a card it will change the state from OK to Waring. If the system boots up without a card in a slot it will not trigger a Waring state but an unknown state as expected. 

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
