### PR TITLE
Add Oxidized search clarification

### DIFF
--- a/includes/html/pages/oxidized.inc.php
+++ b/includes/html/pages/oxidized.inc.php
@@ -51,7 +51,7 @@ $pagetitle[] = 'Oxidized';
                         <br/>
                         <div class="input-group">
                             <input type="text" class="form-control" id="input-parameter"
-                                   placeholder="service password-encryption etc.">
+                                   placeholder="service password-encryption etc. (Regex)">
                             <span class="input-group-btn">
                                 <button type="submit" name="btn-search" id="btn-search" class="btn btn-primary">Search</button>
                             </span>


### PR DESCRIPTION
Add Webui clarification to Oxidized search.

Libre's Oxidized Search function (Passes it to Oxidized):
https://github.com/librenms/librenms/blob/539ef9ff900ed57d7e0be5ef340c9a7d35d764ad/includes/html/functions.inc.php#L901

Oxidized receiving search and doing Regex:
https://github.com/ytti/oxidized-web/blob/master/lib/oxidized/web/webapp.rb#L50

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
