### PR TITLE
Change state value for unplugged linecard

### DIFF
--- a/includes/discovery/sensors/state/loop-telecom.inc.php
+++ b/includes/discovery/sensors/state/loop-telecom.inc.php
@@ -9,7 +9,7 @@ if (! empty($oids)) {
         ['value' => 1, 'generic' => 3, 'graph' => 0, 'descr' => 'Empty'],
         ['value' => 2, 'generic' => 1, 'graph' => 0, 'descr' => 'Initializing'],
         ['value' => 3, 'generic' => 0, 'graph' => 0, 'descr' => 'Working'],
-        ['value' => 4, 'generic' => 0, 'graph' => 0, 'descr' => 'Unplugged'],
+        ['value' => 4, 'generic' => 1, 'graph' => 0, 'descr' => 'Unplugged'],
         ['value' => 5, 'generic' => 2, 'graph' => 0, 'descr' => 'Failed'],
         ['value' => 6, 'generic' => 1, 'graph' => 0, 'descr' => 'UnknownCard'],
         ['value' => 11, 'generic' => 1, 'graph' => 0, 'descr' => 'BrandMismatch'],

--- a/tests/data/loop-telecom_loop-am3440-ccpb-a.json
+++ b/tests/data/loop-telecom_loop-am3440-ccpb-a.json
@@ -1486,7 +1486,7 @@
                     "state_descr": "Unplugged",
                     "state_draw_graph": 0,
                     "state_value": 4,
-                    "state_generic_value": 0
+                    "state_generic_value": 1
                 },
                 {
                     "state_name": "ccCardState",
@@ -2590,7 +2590,7 @@
                     "state_descr": "Unplugged",
                     "state_draw_graph": 0,
                     "state_value": 4,
-                    "state_generic_value": 0
+                    "state_generic_value": 1
                 },
                 {
                     "state_name": "ccCardState",


### PR DESCRIPTION
Please give a short description what your pull request is for:

I updated the line-card state to change the state from "unknown" to "warning." This change aims to draw attention to potential issues when a line-card transitions from an active/working state to "Unplugged." This state should indicate an unexpected removal of the card or a failure in detecting it. However, if the slot is empty without a line-card inserted, it will be labeled as "Empty" without triggering a warning.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
