### PR TITLE
Fix MPLS Tab Display for Nokia devices using LDP and not RSVP

### DIFF
--- a/app/Http/Controllers/Device/Tabs/RoutingController.php
+++ b/app/Http/Controllers/Device/Tabs/RoutingController.php
@@ -44,7 +44,7 @@ class RoutingController implements DeviceTab
             'bgp' => $device->bgppeers()->count(),
             'vrf' => $device->vrfs()->count(),
             'cef' => $device->cefSwitching()->count(),
-            'mpls' => $device->mplsLsps()->count(),
+            'mpls' => $device->mplsServices()->count(),
             'cisco-otv' => Component::query()->where('device_id', $device->device_id)->where('type', 'Cisco-OTV')->count(),
             'loadbalancer_rservers' => $device->rServers()->count(),
             'ipsec_tunnels' => $device->ipsecTunnels()->count(),

--- a/includes/html/pages/device/routing/mpls.inc.php
+++ b/includes/html/pages/device/routing/mpls.inc.php
@@ -292,7 +292,7 @@ if ($vars['view'] == 'sdps') {
 } // end sdps view
 
 if ($vars['view'] == 'sdpbinds') {
-    echo '<th><a title="The value of this object specifies the Service identifier. This value should be unique within the service domain.">Service Id</a></th>
+    echo '<th><a title="The value of this object specifies the Service identifier. This value should be unique within the service domain.">Service ID</a></th>
         <th><a title="SDP Binding identifier. SDP identifier : Service identifier">SDP Bind Id</a></th>
         <th><a title="This object specifies whether this Service SDP binding is a spoke or a mesh.">Bind Type</a></th>
         <th><a title="The value of VC Type is an enumerated integer that specifies the type of virtual circuit (VC) associated with the SDP binding">VC Type</a></th>
@@ -358,7 +358,7 @@ sapDown: The SAP associated with the service is down.">Oper State</a></th>
 } // end sdpbinds view
 
 if ($vars['view'] == 'services') {
-    echo '<th><a title="The value of this object specifies the Service identifier. This value should be unique within the service domain.">Service Id</a></th>
+    echo '<th><a title="The value of this object specifies the Service identifier. This value should be unique within the service domain.">Service ID</a></th>
         <th><a title="The value of this object specifies the service type: e.g. epipe, tls, etc.">Type</a></th>
         <th><a title="The value of this object specifies the ID of the customer who owns this service.">Customer</a></th>
         <th><a title="The value of this object specifies the desired state of this service.">Admin Status</a></th>
@@ -436,7 +436,7 @@ vprn services are up when the service is administratively up however routing fun
 } // end services view
 
 if ($vars['view'] == 'saps') {
-    echo '<th><a title="The value of this object specifies the Service identifier.">Service Id</a></th>
+    echo '<th><a title="The value of this object specifies the Service identifier.">Service ID</a></th>
         <th><a title="The ID of the access port where this SAP is defined.">SAP Port</a></th>
         <th><a title="The value of the label used to identify this SAP on the access port specified by sapPortId.">Encapsulation</a></th>
         <th><a title="This object indicates the type of service where this SAP is defined.">Type</a></th>

--- a/includes/html/pages/routing/mpls.inc.php
+++ b/includes/html/pages/routing/mpls.inc.php
@@ -292,7 +292,7 @@ if ($vars['view'] == 'sdps') {
 
 if ($vars['view'] == 'sdpbinds') {
     echo '<tr><th><a title="Device">Device</a></th>
-        <th><a title="The value of this object specifies the Service identifier. This value should be unique within the service domain">Service Id</a></th>
+        <th><a title="The value of this object specifies the Service identifier. This value should be unique within the service domain">Service ID</a></th>
         <th><a title="SDP Binding identifier. SDP identifier : Service identifier">SDP Bind Id</a></th>
         <th><a title="This object specifies whether this Service SDP binding is a spoke or a mesh.">Bind Type</a></th>
         <th><a title="The value of VC Type is an enumerated integer that specifies the type of virtual circuit (VC) associated with the SDP binding">VC Type</a></th>
@@ -361,7 +361,7 @@ sapDown: The SAP associated with the service is down.">Oper State</a></th>
 
 if ($vars['view'] == 'services') {
     echo '<tr><th><a title="Device">Device</a></th>
-        <th><a title="The value of this object specifies the Service identifier. This value should be unique within the service domain.">Service Id</a></th>
+        <th><a title="The value of this object specifies the Service identifier. This value should be unique within the service domain.">Service ID</a></th>
         <th><a title="The value of this object specifies the service type: e.g. epipe, tls, etc.">Type</a></th>
         <th><a title="The value of this object specifies the ID of the customer who owns this service.">Customer</a></th>
         <th><a title="The value of this object specifies the desired state of this service.">Admin Status</a></th>
@@ -442,7 +442,7 @@ vprn services are up when the service is administratively up however routing fun
 
 if ($vars['view'] == 'saps') {
     echo '<tr><th><a title="Device">Device</a></th>
-        <th><a title="The value of this object specifies the Service identifier.">Service Id</a></th>
+        <th><a title="The value of this object specifies the Service identifier.">Service ID</a></th>
         <th><a title="The ID of the access port where this SAP is defined.">SAP Port</a></th>
         <th><a title="The value of the label used to identify this SAP on the access port specified by sapPortId.">Encapsulation</a></th>
         <th><a title="This object indicates the type of service where this SAP is defined.">Type</a></th>


### PR DESCRIPTION
If the device being monitored used did not have any LSP Paths defined, the MPLS tab was not available.  In our cases, many devices just use LDP and therefore have no LSP paths.  Now use the count of services to determine if the tab is shown, instead of the count of LSPs.

Also fixed some text casing issues (`Service Id` vs `Service ID`).

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [X] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
