### PR TITLE
Alert transport slack config

### DIFF
--- a/LibreNMS/Alert/Transport/Slack.php
+++ b/LibreNMS/Alert/Transport/Slack.php
@@ -92,8 +92,8 @@ class Slack extends Transport
             ],
             'validation' => [
                 'slack-url' => 'required|url',
+                'slack-channel' => 'string',
                 'slack-author' => 'string',
-                'slack-username' => 'string',
                 'slack-icon_emoji' => 'string',
             ],
         ];

--- a/LibreNMS/Alert/Transport/Slack.php
+++ b/LibreNMS/Alert/Transport/Slack.php
@@ -92,7 +92,7 @@ class Slack extends Transport
             ],
             'validation' => [
                 'slack-url' => 'required|url',
-                'slack-channel' => 'string',
+                'slack-author' => 'string',
                 'slack-username' => 'string',
                 'slack-icon_emoji' => 'string',
             ],

--- a/LibreNMS/Alert/Transport/Slack.php
+++ b/LibreNMS/Alert/Transport/Slack.php
@@ -85,7 +85,7 @@ class Slack extends Transport
                 ],
                 [
                     'title' => 'Icon',
-                    'name' => 'slack-author',
+                    'name' => 'slack-icon_emoji',
                     'descr' => 'Name of emoji for icon',
                     'type' => 'text',
                 ],


### PR DESCRIPTION
These are two small fixes to the slack alert transport which fix the webform (related to using the wrong name for emoji)
as well as to fix the validation (related to using the wrong name for slack-author).

Tested and validated both fixes from the UI.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
