### PR TITLE
change rrd_prune find command to exlcude `.gitignore`

### DIFF
--- a/daily.php
+++ b/daily.php
@@ -66,7 +66,7 @@ if ($options['f'] === 'rrd_purge') {
         $rrd_dir = Config::get('rrd_dir');
 
         if (is_numeric($rrd_purge) && $rrd_purge > 0) {
-            $cmd = "find $rrd_dir -type f -mtime +$rrd_purge -print -exec rm -f {} +";
+            $cmd = "find $rrd_dir -name .gitignore -prune -o -type f -mtime +$rrd_purge -print -exec rm -f {} +";
             $purge = `$cmd`;
             if (! empty($purge)) {
                 echo "Purged the following RRD files due to old age (over $rrd_purge days old):\n";


### PR DESCRIPTION
the daily job rrd_prune deletes all files older than $rrd_purge, including `.gitignore`
This leads to validation warnings as there are changes to files in git.
So with this change any `.gitignore` file is excluded

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
