### PR TITLE
use lock ports_purge in ports_purge rather than syslog_purge lock

### DIFF
--- a/daily.php
+++ b/daily.php
@@ -136,7 +136,7 @@ if ($options['f'] === 'device_perf') {
 
 if ($options['f'] === 'ports_purge') {
     if (Config::get('ports_purge')) {
-        $lock = Cache::lock('syslog_purge', 86000);
+        $lock = Cache::lock('ports_purge', 86000);
         if ($lock->get()) {
             \App\Models\Port::query()->with(['device' => function ($query) {
                 $query->select('device_id', 'hostname');


### PR DESCRIPTION
Please give a short description what your pull request is for

Noticed ports were not getting purged even through deleted.

Noticed syslog_purge lock used rather than ports_purge lock.  Changed on my system and hey presto purge running

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
