### PR TITLE
Added power supply (PSU) sensor state for Checkpoint Gaia

### DIFF
--- a/includes/discovery/sensors/state/gaia.inc.php
+++ b/includes/discovery/sensors/state/gaia.inc.php
@@ -1,0 +1,39 @@
+<?php
+
+$oids = snmpwalk_group($device, 'PowerSupplyEntry', 'CHECKPOINT-MIB');
+
+if (! empty($oids)) {
+    //Create State Index
+    $state_name = 'CheckpointPowerSupplyStatus';
+
+    $states = [
+        ['value' => 1, 'generic' => 0, 'graph' => 2, 'descr' => 'Up'],
+        ['value' => 2, 'generic' => 1, 'graph' => 0, 'descr' => 'Down'],
+    ];
+
+    create_state_index($state_name, $states);
+
+    $num_oid = '1.3.6.1.4.1.2620.1.6.7.9.1.1.2.';
+    foreach ($oids as $index => $entry) {
+        discover_sensor(
+            $valid['sensor'],
+            'state',
+            $device,
+            '.' . $num_oid . $index . '.0',
+            $index,
+            $state_name,
+            'PowerSupply #' . $entry['powerSupplyIndex'][0],
+            '1',
+            '1',
+            null,
+            null,
+            null,
+            null,
+            $entry['powerSupplyStatus'][0],
+            'snmp',
+            $index);
+
+        //Create Sensor To State Index
+        create_sensor_to_state_index($device, $state_name, $index);
+    }
+}


### PR DESCRIPTION
Adds missing power supply (PSU) sensor state for Checkpoint Gaia

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
