### PR TITLE
change chunk to chunkById

### DIFF
--- a/app/Observers/DeviceObserver.php
+++ b/app/Observers/DeviceObserver.php
@@ -166,7 +166,7 @@ class DeviceObserver
 
         $device->ports()
             ->select(['port_id', 'device_id', 'ifIndex', 'ifName', 'ifAlias', 'ifDescr'])
-            ->chunk(100, function ($ports) {
+            ->chunkById(100, function ($ports) {
                 foreach ($ports as $port) {
                     $port->delete();
                 }

--- a/daily.php
+++ b/daily.php
@@ -140,7 +140,7 @@ if ($options['f'] === 'ports_purge') {
         if ($lock->get()) {
             \App\Models\Port::query()->with(['device' => function ($query) {
                 $query->select('device_id', 'hostname');
-            }])->isDeleted()->chunk(100, function ($ports) {
+            }])->isDeleted()->chunkById(100, function ($ports) {
                 foreach ($ports as $port) {
                     $port->delete();
                 }
@@ -380,7 +380,7 @@ if ($options['f'] === 'recalculate_device_dependencies') {
     $lock = Cache::lock('recalculate_device_dependencies', 86000);
     if ($lock->get()) {
         // update all root nodes and recurse, chunk so we don't blow up
-        Device::doesntHave('parents')->with('children')->chunk(100, function (Collection $devices) {
+        Device::doesntHave('parents')->with('children')->chunkById(100, function (Collection $devices) {
             // anonymous recursive function
             $recurse = function (Device $device) use (&$recurse) {
                 $device->updateMaxDepth();

--- a/includes/html/pages/ports.inc.php
+++ b/includes/html/pages/ports.inc.php
@@ -236,7 +236,7 @@ if (isset($vars['purge'])) {
     if ($vars['purge'] === 'all') {
         Port::hasAccess(Auth::user())->with(['device' => function ($query) {
             $query->select('device_id', 'hostname');
-        }])->isDeleted()->chunk(100, function ($ports) {
+        }])->isDeleted()->chunkById(100, function ($ports) {
             foreach ($ports as $port) {
                 $port->delete();
             }


### PR DESCRIPTION
Please give a short description what your pull request is for

I noticed when attempting to purge a large quantity of deleted ports that some ports were getting purged but not all ports

On investigation in daily.php I noted the results are chunk'd.   adding some debug around this I see

```
/opt/librenms $ php ./daily.php -f ports_purge
running ports_purge...
before count = 5824
All deleted ports now purged
removed 2924
after count = 2900
```

If I change chunk to chunkById then I see
```
/opt/librenms $ php ./daily.php -f ports_purge
running ports_purge...
before count = 2900
All deleted ports now purged
removed 2900
after count = 0
```

This behaviour seems to be consistent and explored in these links
   https://neutrondev.com/laravel-chunk-database-records/
   https://github.com/laravel/framework/issues/23277 
   https://laravel.com/docs/10.x/queries#chunking-results

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
