### PR TITLE
Fix bogus reply from snmpwalk in ipNetToPhysicalPhysAddress

### DIFF
--- a/includes/discovery/arp-table.inc.php
+++ b/includes/discovery/arp-table.inc.php
@@ -49,6 +49,7 @@ foreach (DeviceCache::getPrimary()->getVrfContexts() as $context_name) {
 
         echo "{$interface['ifName']}: \n";
         foreach ($port_arp as $ip => $raw_mac) {
+            $ip = preg_replace('{^\.}', '', $ip, 1);
             if (empty($ip) || empty($raw_mac) || $raw_mac == '0:0:0:0:0:0' || isset($arp_table[$port_id][$ip])) {
                 continue;
             }


### PR DESCRIPTION
Check to catch bogus replies from snmpwalk (bad formatting). Seems that version 5.7.2 at least shows this behaviour.

Here is the wrong reply from snmpwalk :

```
IP-MIB::ipNetToPhysicalPhysAddress[17][ipv4][.10.19.0.9 = 18:94:ef:13:eb:88
```
instead of 
```
IP-MIB::ipNetToPhysicalPhysAddress[17][ipv4][10.19.0.9] = 18:94:ef:13:eb:88
```


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [X] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
