### PR TITLE
Added basic support for distributing billing

### DIFF
--- a/doc/Extensions/Distributed-Poller.md
+++ b/doc/Extensions/Distributed-Poller.md
@@ -186,6 +186,15 @@ It's not necessary to run discovery services on all pollers. In fact, you should
 only run one discovery process per poller group.
 Designate a single poller to run discovery (or a separate server if required).
 
+If you run billing, you can do this in one of two ways:
+
+1. Run poll-billing.php and calculate-billing.php on a single poller which will 
+create billing information for all bills. Please note this poller must have 
+snmp access to all of your devices which have ports within a bill.
+1. The other option is to enable `$config['distributed_billing'] = true;` in 
+config.php. Then run poll-billing.php on a single poller per group. You can run 
+calculate-billing.php on any poller but only one poller overall.
+
 **Dispatcher service**
 When using the dispatcher service, discovery can run on all nodes.
 
@@ -259,11 +268,12 @@ Running an install of LibreNMS in /opt/librenms
 
 ```php
 $config['distributed_poller_name']           = php_uname('n');
+$config['distributed_poller_group']          = '0';
+$config['distributed_billing']               = true;
 ```
 
 !!! setting "poller/distributed"
     ```bash
-    lnms config:set distributed_poller_group 0
     lnms config:set distributed_poller_memcached_host "example.com"
     lnms config:set distributed_poller_memcached_port 11211
     lnms config:set distributed_poller true
@@ -294,11 +304,12 @@ Running an install of LibreNMS in /opt/librenms
 
 ```php
 $config['distributed_poller_name']           = php_uname('n');
+$config['distributed_poller_group']          = '0';
+$config['distributed_billing']               = true;
 ```
 
 !!! setting "poller/distributed"
     ```bash
-    lnms config:set distributed_poller_group 0
     lnms config:set distributed_poller_memcached_host "example.com"
     lnms config:set distributed_poller_memcached_port 11211
     lnms config:set distributed_poller true
@@ -327,11 +338,12 @@ Running an install of LibreNMS in /opt/librenms
 
 ```php
 $config['distributed_poller_name']           = php_uname('n');
+$config['distributed_poller_group']          = '2,3';
+$config['distributed_billing']               = true;
 ```
 
 !!! setting "poller/distributed"
     ```bash
-    lnms config:set distributed_poller_group '2,3'
     lnms config:set distributed_poller_memcached_host "example.com"
     lnms config:set distributed_poller_memcached_port 11211
     lnms config:set distributed_poller true
@@ -348,6 +360,7 @@ Runs discovery and polling for groups 2 and 3.
 ```conf
 33  */6 * * *   librenms    /opt/librenms/cronic /opt/librenms/discovery-wrapper.py 1
 */5 *   * * *   librenms    /opt/librenms/discovery.php -h new >> /dev/null 2>&1
+*/5 *   * * *   librenms    /opt/librenms/poll-billing.php >> /dev/null 2>&1
 */5 *   * * *   librenms    /opt/librenms/cronic /opt/librenms/poller-wrapper.py 16
 15  0   * * *   librenms    /opt/librenms/daily.sh >> /dev/null 2>&1
 ```

--- a/poll-billing.php
+++ b/poll-billing.php
@@ -41,7 +41,11 @@ foreach ($query->get(['bill_id', 'bill_name']) as $bill) {
     echo 'Bill : ' . $bill->bill_name . "\n";
     $bill_id = $bill->bill_id;
 
-    $port_list = dbFetchRows('SELECT * FROM `bill_ports` as P, `ports` as I, `devices` as D WHERE P.bill_id=? AND I.port_id = P.port_id AND D.device_id = I.device_id', [$bill_id]);
+    if ($config['distributed_poller'] && $config['distributed_billing']) {
+        $port_list = dbFetchRows('SELECT * FROM `bill_ports` as P, `ports` as I, `devices` as D WHERE P.bill_id=? AND I.port_id = P.port_id AND D.device_id = I.device_id AND D.poller_group IN (?)', [$bill_id, $config['distributed_poller_group']]);
+    } else {
+        $port_list = dbFetchRows('SELECT * FROM `bill_ports` as P, `ports` as I, `devices` as D WHERE P.bill_id=? AND I.port_id = P.port_id AND D.device_id = I.device_id', [$bill_id]);
+    }
 
     $now = dbFetchCell('SELECT NOW()');
     $delta = 0;


### PR DESCRIPTION
This adds support to allow distributed poller nodes to poll ports from devices assigned to it's poller group.

A new config option has been used so that it doesn't break current distributed setups. Anyone running it by the dispatcher service or running poll-billing.php across multiple pollers will maintain how it works as of today.

With the new config option enabled though, only ports assigned to devices in that pollers group will be polled.

Docs updated.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
