### PR TITLE
Allow dispatcher service master timeout to be set

### DIFF
--- a/LibreNMS/service.py
+++ b/LibreNMS/service.py
@@ -115,6 +115,9 @@ class ServiceConfig(DBConfig):
         )
 
         # backward compatible options
+        self.update_frequency = config.get(
+            "service_master_timeout", ServiceConfig.master_timeout
+        )
         self.poller.workers = config.get(
             "poller_service_workers", ServiceConfig.poller.workers
         )

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -1312,6 +1312,10 @@ return [
             'description' => 'Enable Polling',
             'help' => 'Enable poller workers. Sets the default value for all nodes.',
         ],
+        'service_master_timeout' => [
+            'description' => 'Master Dispatcher Timeout',
+            'help' => 'The amount of time before the master lock expires.  If master goes away, it will take this much time for another node to take over.  However if it takes longer than the timeout to dispatch the work, you will have multiple masters',
+        ],
         'service_poller_workers' => [
             'description' => 'Poller Workers',
             'help' => 'Amount of poller workers to spawn. Sets the default value for all nodes.',

--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -5390,11 +5390,19 @@
                 "CRITICAL": "CRITICAL"
             }
         },
+        "service_master_timeout": {
+            "default": 20,
+            "group": "poller",
+            "section": "distributed",
+            "order": 25,
+            "type": "integer",
+            "units": "seconds"
+        },
         "service_watchdog_enabled": {
             "default": false,
             "group": "poller",
             "section": "distributed",
-            "order": 25,
+            "order": 26,
             "type": "boolean"
         },
         "sfdp": {


### PR DESCRIPTION
and increase default to 20s from 10s
20s should still be fast enough to prevent gaps, but larger installs can take longer than 10s (or even 20s) to do dispatch work.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
