### PR TITLE
Fix Oxidized OS Exclude when OS changed in Mapping

### DIFF
--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -1527,8 +1527,8 @@ function list_oxidized(Illuminate\Http\Request $request)
                 }
             }
         }
-        //Exclude groups from being sent to Oxidized
-        if (in_array($output['group'], Config::get('oxidized.ignore_groups'))) {
+        //Exclude groups or os from being sent to Oxidized
+        if (in_array($output['group'], Config::get('oxidized.ignore_groups')) || in_array($output['os'], Config::get('oxidized.ignore_os'))) {
             continue;
         }
 


### PR DESCRIPTION
Currently if the OS is changed via Variable Mapping, the ignore_os setting is not used. This fixes that.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
