### PR TITLE
Fix select2 search field focus

### DIFF
--- a/html/js/librenms.js
+++ b/html/js/librenms.js
@@ -212,6 +212,15 @@ $(document).ready(function() {
     });
 });
 
+// Fix select2 search focus bug
+$(document).on('select2:open', (e) => {
+    const selectId = e.target.id
+
+    $(".select2-search__field[aria-controls='select2-" + selectId + "-results']").each(function (key, value){
+        value.focus();
+    })
+})
+
 function refresh_oxidized_node(device_hostname){
     $.ajax({
         type: 'POST',

--- a/resources/views/layouts/librenmsv1.blade.php
+++ b/resources/views/layouts/librenmsv1.blade.php
@@ -76,7 +76,7 @@
         });
         var ajax_url = "{{ url('/ajax') }}";
     </script>
-    <script src="{{ asset('js/librenms.js?ver=01112022') }}"></script>
+    <script src="{{ asset('js/librenms.js?ver=07312023') }}"></script>
     <script type="text/javascript" src="{{ asset('js/overlib_mini.js') }}"></script>
     <script type="text/javascript" src="{{ asset('js/flasher.min.js?ver=0.6.1') }}"></script>
     <script type="text/javascript" src="{{ asset('js/toastr.min.js?ver=05072021') }}"></script>


### PR DESCRIPTION
Some jQuery version broke the focus search field on open, this should fix that.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
