### PR TITLE
fixing the mac/vendor database download from wireshark, updated file …

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1233,6 +1233,7 @@ function mac_oui_to_database()
         }
     } else {
         echo 'Not able to acquire lock, skipping mac database update' . PHP_EOL;
+
         return 1;
     }
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1182,7 +1182,8 @@ function mac_oui_to_database()
     if ($lock->get()) {
         echo 'Storing Mac OUI in the database' . PHP_EOL;
         try {
-            $mac_oui_url = 'https://gitlab.com/wireshark/wireshark/-/raw/master/manuf';
+            $mac_oui_url = 'https://www.wireshark.org/download/automated/data/manuf';
+            //$mac_oui_url = 'https://gitlab.com/wireshark/wireshark/-/raw/master/manuf';
             //$mac_oui_url_mirror = 'https://raw.githubusercontent.com/wireshark/wireshark/master/manuf';
 
             echo '  -> Downloading ...' . PHP_EOL;
@@ -1197,12 +1198,12 @@ function mac_oui_to_database()
 
                 $length = strlen($entry[0]);
                 $prefix = strtolower(str_replace(':', '', $entry[0]));
-                $vendor = $entry[2];
+                $vendor = $entry[1];
 
-                if (is_array($entry) && count($entry) >= 3 && $length == 8) {
+                if (is_array($entry) && count($entry) >= 2 && $length == 8) {
                     // We have a standard OUI xx:xx:xx
                     $oui = $prefix;
-                } elseif (is_array($entry) && count($entry) >= 3 && $length == 20) {
+                } elseif (is_array($entry) && count($entry) >= 2 && $length == 20) {
                     // We have a smaller range (xx:xx:xx:X or xx:xx:xx:xx:X)
                     if (substr($prefix, -2) == '28') {
                         $oui = substr($prefix, 0, 7);
@@ -1230,6 +1231,9 @@ function mac_oui_to_database()
 
             return 1;
         }
+    } else {
+        echo 'Not able to acquire lock, skipping mac database update' . PHP_EOL;
+        return 1;
     }
 
     return 0;


### PR DESCRIPTION
…location and format

LibreNMS depends on Wireshark repository for vendor information resolution by Mac address. Recent change in Wireshark data (location and format) broke the feature. 

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
