### PR TITLE
Fixed a zero value data insertion for billing

### DIFF
--- a/poll-billing.php
+++ b/poll-billing.php
@@ -42,7 +42,7 @@ foreach ($query->get(['bill_id', 'bill_name']) as $bill) {
     $bill_id = $bill->bill_id;
 
     if ($config['distributed_poller'] && $config['distributed_billing']) {
-        $port_list = dbFetchRows('SELECT * FROM `bill_ports` as P, `ports` as I, `devices` as D WHERE P.bill_id=? AND I.port_id = P.port_id AND I.ifOperStatus="up" AND D.device_id = I.device_id AND D.status=1 AND D.poller_group IN (?)', [$bill_id, $config['distributed_poller_group']]);
+        $port_list = dbFetchRows('SELECT * FROM `bill_ports` as P, `ports` as I, `devices` as D WHERE P.bill_id=? AND I.port_id = P.port_id AND I.ifOperStatus="up" AND D.device_id = I.device_id AND D.status=1 AND D.poller_group IN ('.$config['distributed_poller_group'].')', [$bill_id]);
     } else {
         $port_list = dbFetchRows('SELECT * FROM `bill_ports` as P, `ports` as I, `devices` as D WHERE P.bill_id=? AND I.port_id = P.port_id AND I.ifOperStatus="up" AND D.device_id = I.device_id AND D.status=1', [$bill_id]);
     }
@@ -143,7 +143,15 @@ foreach ($query->get(['bill_id', 'bill_name']) as $bill) {
         logfile("BILLING: negative period! id:$bill_id period:$period delta:$delta in_delta:$in_delta out_delta:$out_delta");
     } else {
         // NOTE: casting to string for mysqli bug (fixed by mysqlnd)
-        dbInsert(['bill_id' => $bill_id, 'timestamp' => $now, 'period' => $period, 'delta' => (string) $delta, 'in_delta' => (string) $in_delta, 'out_delta' => (string) $out_delta], 'bill_data');
+        if ($config['distributed_poller'] && $config['distributed_billing']) {
+            $port_count = dbFetchCell('SELECT COUNT(*) FROM `bill_ports` as P, `ports` as I, `devices` as D WHERE P.bill_id=? AND I.port_id = P.port_id AND D.device_id = I.device_id AND D.poller_group IN ('.$config['distributed_poller_group'].')', [$bill_id]);
+        } else {
+            $port_count = dbFetchCell('SELECT COUNT(*) FROM `bill_ports` as P, `ports` as I, `devices` as D WHERE P.bill_id=? AND I.port_id = P.port_id AND D.device_id = I.device_id', [$bill_id]);
+        }
+        if ($port_count > 0) {
+            // If no ports are part of this bill then don't insert a zero value entry
+            dbInsert(['bill_id' => $bill_id, 'timestamp' => $now, 'period' => $period, 'delta' => (string) $delta, 'in_delta' => (string) $in_delta, 'out_delta' => (string) $out_delta], 'bill_data');
+        }
     }
 }//end CollectData()
 


### PR DESCRIPTION
Sorry for yet another patch.

Two issues with the previous code:

1. The use of IN for the MySQL was wrong. The `$config['distributed_poller_group']` value can be comma separated so can be used straight within the IN statement.
2. Now that poll-billing.php can run and no ports are polled for data because they aren't assigned to a device in that bill, it will still insert a zero value entry into the bill_data table. This is bad for 95 percentile calculations so now we stop doing that.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
