### PR TITLE
Set mibs explicitly in SnmpQuery

### DIFF
--- a/LibreNMS/Data/Source/SnmpQueryInterface.php
+++ b/LibreNMS/Data/Source/SnmpQueryInterface.php
@@ -59,6 +59,12 @@ interface SnmpQueryInterface
     public function mibDir(?string $dir): SnmpQueryInterface;
 
     /**
+     * Set MIBs to use for this query. Base mibs are included by default.
+     * They will be appended to existing mibs unless $append is set to false.
+     */
+    public function mibs(array $mibs, bool $append = true): SnmpQueryInterface;
+
+    /**
      * When walking multiple OIDs, stop if one fails. Used when the first OID indicates if the rest are supported.
      * OIDs will be walked in order, so you may want to put your OIDs in a specific order.
      */
@@ -127,5 +133,5 @@ interface SnmpQueryInterface
      * Translate an OID.
      * Call numeric method prior output numeric OID.
      */
-    public function translate(string $oid, ?string $mib = null): string;
+    public function translate(string $oid): string;
 }

--- a/LibreNMS/OS/Junose.php
+++ b/LibreNMS/OS/Junose.php
@@ -37,7 +37,7 @@ class Junose extends \LibreNMS\OS
             return;
         }
 
-        $junose_hardware = \SnmpQuery::translate($device->sysObjectID, 'Juniper-Products-MIB');
+        $junose_hardware = \SnmpQuery::mibs(['Juniper-Products-MIB'])->translate($device->sysObjectID);
         $device->hardware = $this->rewriteHardware($junose_hardware) ?: null;
 
         $junose_version = \SnmpQuery::get('Juniper-System-MIB::juniSystemSwVersion.0')->value();

--- a/LibreNMS/OS/Traits/YamlMempoolsDiscovery.php
+++ b/LibreNMS/OS/Traits/YamlMempoolsDiscovery.php
@@ -113,7 +113,7 @@ trait YamlMempoolsDiscovery
         }
 
         if (isset($this->mempoolsOids[$field])) {
-            return Oid::toNumeric("{$this->mempoolsOids[$field]}.$index", 'ALL');
+            return Oid::toNumeric("{$this->mempoolsOids[$field]}.$index");
         }
 
         return null;

--- a/LibreNMS/Util/Oid.php
+++ b/LibreNMS/Util/Oid.php
@@ -70,7 +70,13 @@ class Oid
         $key = 'Oid:toNumeric:' . $oid . '/' . $mib;
 
         $numeric_oid = Cache::remember($key, $cache, function () use ($oid, $mib) {
-            return \SnmpQuery::numeric()->translate($oid, $mib);
+            $snmpQuery = \SnmpQuery::numeric();
+
+            if ($mib) {
+                $snmpQuery->mibs([$mib], append: $mib !== 'ALL'); // append to base mibs unless using ALL
+            }
+
+            return $snmpQuery->translate($oid);
         });
 
         if (empty($numeric_oid)) {

--- a/tests/Mocks/SnmpQueryMock.php
+++ b/tests/Mocks/SnmpQueryMock.php
@@ -38,46 +38,24 @@ use Log;
 
 class SnmpQueryMock implements SnmpQueryInterface
 {
-    /**
-     * @var array
-     */
-    private static $cache;
+    private static ?array $cache = null;
+    private Device $device;
+    private string $context = '';
+    private ?string $mibDir = null;
+    private array $mibs = [];
+    private bool $numeric = false;
+    private bool $hideMib = false;
+    private array $options = [];
+    private bool $abort = false;
 
-    /**
-     * @var Device
-     */
-    private $device;
-    /**
-     * @var string
-     */
-    private $context;
-    /**
-     * @var string|null
-     */
-    private $mibDir;
-    /**
-     * @var bool
-     */
-    private $numeric = false;
-    /**
-     * @var bool
-     */
-    private $hideMib = false;
-    /**
-     * @var array|mixed
-     */
-    private $options = [];
-    /**
-     * @var bool
-     */
-    private $abort = false;
+    public function __construct()
+    {
+        $new->device = DeviceCache::getPrimary();
+    }
 
     public static function make(): SnmpQueryInterface
     {
-        $new = new static;
-        $new->device = DeviceCache::getPrimary();
-
-        return $new;
+        return new static;
     }
 
     public function device(Device $device): SnmpQueryInterface
@@ -101,7 +79,7 @@ class SnmpQueryMock implements SnmpQueryInterface
         return $this;
     }
 
-    public function translate(string $oid, ?string $mib = null): string
+    public function translate(string $oid): string
     {
         // call real snmptranslate
         $options = $this->options;
@@ -114,8 +92,9 @@ class SnmpQueryMock implements SnmpQueryInterface
 
         return NetSnmpQuery::make()
             ->mibDir($this->mibDir)
+            ->mibs($this->mibs)
             ->options($options)
-            ->translate($oid, $mib);
+            ->translate($oid);
     }
 
     public function abortOnFailure(): SnmpQueryInterface
@@ -155,6 +134,17 @@ class SnmpQueryMock implements SnmpQueryInterface
     public function options($options = []): SnmpQueryInterface
     {
         $this->options = $options === null ? [] : Arr::wrap($options);
+
+        return $this;
+    }
+
+    /**
+     * Set MIBs to use for this query. Base mibs are included by default.
+     * They will be appended to existing mibs unless $append is set to false.
+     */
+    public function mibs(array $mibs, bool $append = true): SnmpQueryInterface
+    {
+        $this->mibs = $append ? array_merge($this->mibs, $mibs) : $mibs;
 
         return $this;
     }
@@ -288,7 +278,7 @@ class SnmpQueryMock implements SnmpQueryInterface
     private function outputLine(string $oid, string $num_oid, string $type, string $data): string
     {
         if ($type == 6) {
-            $data = $this->numeric ? ".$data" : $this->translate($data, $this->extractMib($oid));
+            $data = $this->numeric ? ".$data" : $this->mibs($this->extractMib($oid))->translate($data);
         }
 
         if ($this->numeric) {
@@ -312,7 +302,7 @@ class SnmpQueryMock implements SnmpQueryInterface
      *
      * @throws Exception Could not translate the oid
      */
-    private function translateNumber($oid, $mib = null)
+    private function translateNumber($oid)
     {
         // optimizations (35s -> 1.6s on my laptop)
         switch ($oid) {
@@ -337,11 +327,9 @@ class SnmpQueryMock implements SnmpQueryInterface
         }
 
         $options = ['-IR'];
-        if ($mib) {
-            $options[] = "-m $mib";
-        }
 
         $number = NetSnmpQuery::make()->mibDir($this->mibDir)
+            ->mibs($this->mibs)
             ->options(array_merge($options, $this->options))->numeric()->translate($oid);
 
         if (empty($number)) {
@@ -362,12 +350,12 @@ class SnmpQueryMock implements SnmpQueryInterface
         return $community;
     }
 
-    private function extractMib(string $oid): ?string
+    private function extractMib(string $oid): array
     {
         if (Str::contains($oid, '::')) {
-            return explode('::', $oid, 2)[0];
+            return [explode('::', $oid, 2)[0]];
         }
 
-        return null;
+        return [];
     }
 }

--- a/tests/Mocks/SnmpQueryMock.php
+++ b/tests/Mocks/SnmpQueryMock.php
@@ -50,7 +50,7 @@ class SnmpQueryMock implements SnmpQueryInterface
 
     public function __construct()
     {
-        $new->device = DeviceCache::getPrimary();
+        $this->device = DeviceCache::getPrimary();
     }
 
     public static function make(): SnmpQueryInterface
@@ -297,7 +297,6 @@ class SnmpQueryMock implements SnmpQueryInterface
      * The leading dot is ommited by default to be compatible with snmpsim
      *
      * @param  string  $oid  the oid to tranlslate
-     * @param  string  $mib  mib to use
      * @return string the oid in numeric format (1.3.4.5)
      *
      * @throws Exception Could not translate the oid

--- a/tests/Unit/SnmpTranslateTest.php
+++ b/tests/Unit/SnmpTranslateTest.php
@@ -59,7 +59,7 @@ class SnmpTranslateTest extends TestCase
         $actual = \SnmpQuery::numeric()->mibs(['IP-MIB'])->translate('ifTable');
         $this->assertEquals('.1.3.6.1.2.1.2.2', $actual);
 
-        $actual = \SnmpQuery::translate('ifTable', 'IP-MIB');
+        $actual = \SnmpQuery::mibs(['IP-MIB'])->translate('ifTable');
         $this->assertEquals('IF-MIB::ifTable', $actual);
 
         // with index

--- a/tests/Unit/SnmpTranslateTest.php
+++ b/tests/Unit/SnmpTranslateTest.php
@@ -35,10 +35,10 @@ class SnmpTranslateTest extends TestCase
         $actual = \SnmpQuery::numeric()->translate('IF-MIB::ifTable');
         $this->assertEquals('.1.3.6.1.2.1.2.2', $actual);
 
-        $actual = \SnmpQuery::numeric()->translate('ifTable', 'IF-MIB');
+        $actual = \SnmpQuery::numeric()->mibs(['IF-MIB'], append: false)->translate('ifTable');
         $this->assertEquals('.1.3.6.1.2.1.2.2', $actual);
 
-        $actual = \SnmpQuery::numeric()->translate('ifTable', 'ALL');
+        $actual = \SnmpQuery::numeric()->mibs(['ALL'], append: false)->translate('ifTable');
         $this->assertEquals('.1.3.6.1.2.1.2.2', $actual);
 
         $actual = \SnmpQuery::translate('IF-MIB::ifTable');
@@ -47,16 +47,16 @@ class SnmpTranslateTest extends TestCase
         $actual = \SnmpQuery::numeric()->translate('.1.3.6.1.2.1.2.2');
         $this->assertEquals('.1.3.6.1.2.1.2.2', $actual);
 
-        $actual = \SnmpQuery::translate('.1.3.6.1.2.1.2.2', 'IF-MIB');
+        $actual = \SnmpQuery::mibs(['IF-MIB'])->translate('.1.3.6.1.2.1.2.2');
         $this->assertEquals('IF-MIB::ifTable', $actual);
 
         $actual = \SnmpQuery::numeric()->translate('1.3.6.1.2.1.2.2');
         $this->assertEquals('.1.3.6.1.2.1.2.2', $actual);
 
-        $actual = \SnmpQuery::translate('.1.3.6.1.2.1.2.2', 'ALL');
+        $actual = \SnmpQuery::mibs(['ALL'], append: false)->translate('.1.3.6.1.2.1.2.2');
         $this->assertEquals('RFC1213-MIB::ifTable', $actual);
 
-        $actual = \SnmpQuery::numeric()->translate('ifTable', 'IP-MIB');
+        $actual = \SnmpQuery::numeric()->mibs(['IP-MIB'])->translate('ifTable');
         $this->assertEquals('.1.3.6.1.2.1.2.2', $actual);
 
         $actual = \SnmpQuery::translate('ifTable', 'IP-MIB');
@@ -66,10 +66,10 @@ class SnmpTranslateTest extends TestCase
         $actual = \SnmpQuery::numeric()->translate('IF-MIB::ifTable.0');
         $this->assertEquals('.1.3.6.1.2.1.2.2.0', $actual);
 
-        $actual = \SnmpQuery::numeric()->translate('ifTable.0', 'IF-MIB');
+        $actual = \SnmpQuery::numeric()->mibs(['IF-MIB'])->translate('ifTable.0');
         $this->assertEquals('.1.3.6.1.2.1.2.2.0', $actual);
 
-        $actual = \SnmpQuery::numeric()->translate('ifTable.0', 'ALL');
+        $actual = \SnmpQuery::numeric()->mibs(['ALL'], append: false)->translate('ifTable.0');
         $this->assertEquals('.1.3.6.1.2.1.2.2.0', $actual);
 
         $actual = \SnmpQuery::translate('IF-MIB::ifTable.0');
@@ -78,66 +78,72 @@ class SnmpTranslateTest extends TestCase
         $actual = \SnmpQuery::numeric()->translate('.1.3.6.1.2.1.2.2.0');
         $this->assertEquals('.1.3.6.1.2.1.2.2.0', $actual);
 
-        $actual = \SnmpQuery::translate('.1.3.6.1.2.1.2.2.0', 'IF-MIB');
+        $actual = \SnmpQuery::mibs(['IF-MIB'])->translate('.1.3.6.1.2.1.2.2.0');
         $this->assertEquals('IF-MIB::ifTable.0', $actual);
 
         $actual = \SnmpQuery::numeric()->translate('1.3.6.1.2.1.2.2.0');
         $this->assertEquals('.1.3.6.1.2.1.2.2.0', $actual);
 
-        $actual = \SnmpQuery::translate('.1.3.6.1.2.1.2.2.0', 'ALL');
+        $actual = \SnmpQuery::mibs(['ALL'], append: false)->translate('.1.3.6.1.2.1.2.2.0');
         $this->assertEquals('RFC1213-MIB::ifTable.0', $actual);
 
-        $actual = \SnmpQuery::translate('ifTable.0', 'IP-MIB');
+        $actual = \SnmpQuery::mibs(['IP-MIB'])->translate('ifTable.0');
         $this->assertEquals('IF-MIB::ifTable.0', $actual);
 
-        $actual = \SnmpQuery::translate('iso.3.6.1.2.1.1.1.0', 'SNMPv2-MIB');
+        $actual = \SnmpQuery::mibs(['SNMPv2-MIB'])->translate('iso.3.6.1.2.1.1.1.0');
         $this->assertEquals('SNMPv2-MIB::sysDescr.0', $actual);
 
-        $actual = \SnmpQuery::numeric()->translate('iso.3.6.1.2.1.1.1.0', 'SNMPv2-MIB');
+        $actual = \SnmpQuery::numeric()->mibs(['SNMPv2-MIB'])->translate('iso.3.6.1.2.1.1.1.0');
         $this->assertEquals('.1.3.6.1.2.1.1.1.0', $actual);
     }
 
     public function testFailedInput(): void
     {
-        $actual = \SnmpQuery::numeric()->translate('ifTable');
-        $this->assertEquals('', $actual);
-
         $actual = \SnmpQuery::translate('ifTable');
+        $this->assertEquals('IF-MIB::ifTable', $actual);
+
+        $actual = \SnmpQuery::numeric()->mibs([], append: false)->translate('ifTable');
         $this->assertEquals('', $actual);
 
-        $actual = \SnmpQuery::numeric()->translate('ifTable', 'ASDF-MIB:SNMPv2-MIB');
+        $actual = \SnmpQuery::mibs([], append: false)->translate('ifTable');
         $this->assertEquals('', $actual);
 
-        $actual = \SnmpQuery::translate('ifTable');
+        $actual = \SnmpQuery::numeric()->mibs(['ASDF-MIB', 'SNMPv2-MIB'], append: false)->translate('ifTable');
         $this->assertEquals('', $actual);
 
-        $actual = \SnmpQuery::numeric()->translate('ifTable');
+        $actual = \SnmpQuery::mibs([], append: false)->translate('ifTable');
         $this->assertEquals('', $actual);
 
-        $actual = \SnmpQuery::translate('ifTable');
+        $actual = \SnmpQuery::numeric()->mibs([], append: false)->translate('ifTable');
+        $this->assertEquals('', $actual);
+
+        $actual = \SnmpQuery::mibs([], append: false)->translate('ifTable');
         $this->assertEquals('', $actual);
     }
 
     public function testComplexInput(): void
     {
-        $actual = \SnmpQuery::translate('.1.3.6.1.2.1.2.2', 'RFC1213-MIB:IF-MIB');
+        $actual = \SnmpQuery::mibs(['RFC1213-MIB', 'IF-MIB'], append: false)->translate('.1.3.6.1.2.1.2.2');
         $this->assertEquals('RFC1213-MIB::ifTable', $actual);
 
-        $actual = \SnmpQuery::translate('.1.3.6.1.2.1.2.2', 'IF-MIB:RFC1213-MIB');
+        $actual = \SnmpQuery::mibs(['IF-MIB', 'RFC1213-MIB'], append: false)->translate('.1.3.6.1.2.1.2.2');
         $this->assertEquals('IF-MIB::ifTable', $actual);
 
-        $actual = \SnmpQuery::translate('ifTable', 'RFC1213-MIB:IF-MIB');
+        $actual = \SnmpQuery::translate('ifTable');
+        $this->assertEquals('IF-MIB::ifTable', $actual);
+
+        $actual = \SnmpQuery::mibs(['RFC1213-MIB', 'IF-MIB'], append: false)->translate('ifTable');
         $this->assertEquals('RFC1213-MIB::ifTable', $actual);
 
-        $actual = \SnmpQuery::translate('ifTable', 'IF-MIB:RFC1213-MIB');
+        $actual = \SnmpQuery::mibs(['IF-MIB', 'RFC1213-MIB'], append: false)->translate('ifTable');
         $this->assertEquals('IF-MIB::ifTable', $actual);
 
         // partial numeric
         $device = Device::factory()->make(['os' => 'dlink']);
-        $actual = \SnmpQuery::device($device)->numeric()->translate('.1.3.6.1.4.1.171.14.5.1.4.1.4.1.dram', 'EQUIPMENT-MIB:DLINKSW-ENTITY-EXT-MIB');
+        $actual = \SnmpQuery::device($device)->numeric()->mibs(['EQUIPMENT-MIB', 'DLINKSW-ENTITY-EXT-MIB'], append: false)->translate('.1.3.6.1.4.1.171.14.5.1.4.1.4.1.dram');
         $this->assertEquals('.1.3.6.1.4.1.171.14.5.1.4.1.4.1.1', $actual);
 
-        $actual = \SnmpQuery::device($device)->numeric()->translate('iso.3.6.1.4.1.171.14.5.1.4.1.4.1.dram', 'EQUIPMENT-MIB:DLINKSW-ENTITY-EXT-MIB');
+        $actual = \SnmpQuery::device($device)->numeric()->mibs(['EQUIPMENT-MIB', 'DLINKSW-ENTITY-EXT-MIB'], append: false)->translate('iso.3.6.1.4.1.171.14.5.1.4.1.4.1.dram');
         $this->assertEquals('.1.3.6.1.4.1.171.14.5.1.4.1.4.1.1', $actual);
     }
 }


### PR DESCRIPTION
Always override system mibs, so we have consistency
New method to control mibs

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
