### PR TITLE
Fix vendor_ouis duplicates in migration

### DIFF
--- a/database/migrations/2023_08_02_120455_vendor_ouis_unique_index.php
+++ b/database/migrations/2023_08_02_120455_vendor_ouis_unique_index.php
@@ -11,6 +11,11 @@ return new class extends Migration
      */
     public function up(): void
     {
+        // if duplicate entries, truncate the table.  Hard to delete due to lacking index.
+       if (DB::table('vendor_ouis')->havingRaw('count(oui) > 1')->groupBy('oui')->exists()) {
+           DB::table('vendor_ouis')->truncate();
+       }
+
         Schema::table('vendor_ouis', function (Blueprint $table) {
             $table->string('oui', 12)->change();
             $table->unique(['oui']);

--- a/database/migrations/2023_08_02_120455_vendor_ouis_unique_index.php
+++ b/database/migrations/2023_08_02_120455_vendor_ouis_unique_index.php
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         // if duplicate entries, truncate the table.  Hard to delete due to lacking index.
-        if (DB::table('vendor_ouis')->havingRaw('count(oui) > 1')->groupBy('oui')->exists()) {
+        if (DB::table('vendor_ouis')->select('oui')->havingRaw('count(oui) > 1')->groupBy('oui')->exists()) {
             DB::table('vendor_ouis')->truncate();
         }
 

--- a/database/migrations/2023_08_02_120455_vendor_ouis_unique_index.php
+++ b/database/migrations/2023_08_02_120455_vendor_ouis_unique_index.php
@@ -12,9 +12,9 @@ return new class extends Migration
     public function up(): void
     {
         // if duplicate entries, truncate the table.  Hard to delete due to lacking index.
-       if (DB::table('vendor_ouis')->havingRaw('count(oui) > 1')->groupBy('oui')->exists()) {
-           DB::table('vendor_ouis')->truncate();
-       }
+        if (DB::table('vendor_ouis')->havingRaw('count(oui) > 1')->groupBy('oui')->exists()) {
+            DB::table('vendor_ouis')->truncate();
+        }
 
         Schema::table('vendor_ouis', function (Blueprint $table) {
             $table->string('oui', 12)->change();


### PR DESCRIPTION
Can't trim the duplicates efficiently due to lacking an index on oui.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
