### PR TITLE
Add option to disable the send of acknowledgement alerts.

### DIFF
--- a/LibreNMS/Alert/RunAlerts.php
+++ b/LibreNMS/Alert/RunAlerts.php
@@ -271,8 +271,17 @@ class RunAlerts
     public function runAcks()
     {
         foreach ($this->loadAlerts('alerts.state = ' . AlertState::ACKNOWLEDGED . ' && alerts.open = ' . AlertState::ACTIVE) as $alert) {
-            $this->issueAlert($alert);
-            dbUpdate(['open' => AlertState::CLEAR], 'alerts', 'rule_id = ? && device_id = ?', [$alert['rule_id'], $alert['device_id']]);
+            $rextra = json_decode($alert['extra'], true);
+            if (! isset($rextra['acknowledgement'])) {
+                // backwards compatibility check
+                $rextra['acknowledgement'] = true;
+            }
+
+            if ($rextra['acknowledgement']) {
+                // Rule is set to send an acknowledgement alert
+                $this->issueAlert($alert);
+                dbUpdate(['open' => AlertState::CLEAR], 'alerts', 'rule_id = ? && device_id = ?', [$alert['rule_id'], $alert['device_id']]);
+            }
         }
     }
 

--- a/includes/html/forms/alert-rules.inc.php
+++ b/includes/html/forms/alert-rules.inc.php
@@ -59,6 +59,7 @@ $invert = isset($_POST['invert']) ? $_POST['invert'] : null;
 $name = strip_tags($_POST['name']);
 $proc = $_POST['proc'];
 $recovery = $vars['recovery'];
+$acknowledgement = $vars['acknowledgement'];
 $invert_map = isset($_POST['invert_map']) ? $_POST['invert_map'] : null;
 $severity = $_POST['severity'];
 
@@ -82,6 +83,7 @@ if ($invert == 'on') {
 }
 
 $recovery = empty($recovery) ? $recovery = false : true;
+$acknowledgement = empty($acknowledgement) ? $acknowledgement = false : true;
 
 if ($invert_map == 'on') {
     $invert_map = true;
@@ -90,13 +92,14 @@ if ($invert_map == 'on') {
 }
 
 $extra = [
-    'mute'     => $mute,
-    'count'    => $count,
-    'delay'    => $delay_sec,
-    'invert'   => $invert,
-    'interval' => $interval_sec,
-    'recovery' => $recovery,
-    'options'  => $options,
+    'mute'            => $mute,
+    'count'           => $count,
+    'delay'           => $delay_sec,
+    'invert'          => $invert,
+    'interval'        => $interval_sec,
+    'recovery'        => $recovery,
+    'acknowledgement' => $acknowledgement,
+    'options'         => $options,
 ];
 
 $extra_json = json_encode($extra);

--- a/includes/html/forms/sql-from-alert-collection.inc.php
+++ b/includes/html/forms/sql-from-alert-collection.inc.php
@@ -47,6 +47,7 @@ if (is_numeric($template_id)) {
         'invert' => Config::get('alert_rule.invert_rule_match'),
         'interval' => 60 * Config::get('alert_rule.interval'),
         'recovery' => Config::get('alert_rule.recovery_alerts'),
+        'acknowledgement' => Config::get('alert_rule.acknowledgement_alerts'),
     ];
     $output = [
         'status' => 'ok',

--- a/includes/html/forms/sql-from-alert-rules.inc.php
+++ b/includes/html/forms/sql-from-alert-rules.inc.php
@@ -47,6 +47,7 @@ if (is_numeric($rule_id)) {
         'invert' => Config::get('alert_rule.invert_rule_match'),
         'interval' => 60 * Config::get('alert_rule.interval'),
         'recovery' => Config::get('alert_rule.recovery_alerts'),
+        'acknowledgement' => Config::get('alert_rule.acknowledgement_alerts'),
     ];
     $output = [
         'status' => 'ok',

--- a/includes/html/modal/new_alert_rule.inc.php
+++ b/includes/html/modal/new_alert_rule.inc.php
@@ -22,6 +22,7 @@ $default_interval = Config::get('alert_rule.interval') . 'm';
 $default_mute_alerts = Config::get('alert_rule.mute_alerts');
 $default_invert_rule_match = Config::get('alert_rule.invert_rule_match');
 $default_recovery_alerts = Config::get('alert_rule.recovery_alerts');
+$default_acknowledgement_alerts = Config::get('alert_rule.acknowledgement_alerts');
 $default_invert_map = Config::get('alert_rule.invert_map');
 
 if (Auth::user()->hasGlobalAdmin()) {
@@ -112,10 +113,14 @@ if (Auth::user()->hasGlobalAdmin()) {
                                         <input type='checkbox' name='invert' id='invert'>
                                     </div>
                                 </div>
-                                <div class="form-group" title="Issue recovery notifications.">
-                                    <label for='recovery' class='col-sm-3 col-md-2 control-label'>Recovery alerts </label>
-                                    <div class='col-sm-2'>
+                                <div class="form-group form-inline">
+                                    <label for='recovery' class='col-sm-3 col-md-2 control-label' title="Issue recovery alerts.">Recovery alerts </label>
+                                    <div class='col-sm-2' title="Issue recovery alerts.">
                                         <input type='checkbox' name='recovery' id='recovery'>
+                                    </div>
+                                    <label for='acknowledgement' class='col-sm-3 col-md-3 control-label' title="Issue acknowledgement alerts." style="vertical-align: top;">Acknowledgement alerts </label>
+                                    <div class='col-sm-2' title="Issue acknowledgement alerts.">
+                                        <input type='checkbox' name='acknowledgement' id='acknowledgement'>
                                     </div>
                                 </div>
                                 <div class="form-group form-inline">
@@ -308,6 +313,7 @@ if (Auth::user()->hasGlobalAdmin()) {
                 $("#mute").bootstrapSwitch('state', <?=$default_mute_alerts?>);
                 $("#invert").bootstrapSwitch('state', <?=$default_invert_rule_match?>);
                 $("#recovery").bootstrapSwitch('state', <?=$default_recovery_alerts?>);
+                $("#acknowledgement").bootstrapSwitch('state', <?=$default_acknowledgement_alerts?>);
                 $("#override_query").bootstrapSwitch('state', false);
                 $("#invert_map").bootstrapSwitch('state', <?=$default_invert_map?>);
                 $(this).find("input[type=text]").val("");
@@ -389,6 +395,9 @@ if (Auth::user()->hasGlobalAdmin()) {
                 if (typeof extra.recovery == 'undefined') {
                     extra.recovery = '<?=$default_recovery_alerts?>';
                 }
+                if (typeof extra.acknowledgement == 'undefined') {
+                    extra.acknowledgement = '<?=$default_acknowledgement_alerts?>';
+                }
 
                 if (typeof extra.options == 'undefined') {
                     extra.options = new Array();
@@ -397,6 +406,7 @@ if (Auth::user()->hasGlobalAdmin()) {
                     extra.options.override_query = false;
                 }
                 $("[name='recovery']").bootstrapSwitch('state', extra.recovery);
+                $("[name='acknowledgement']").bootstrapSwitch('state', extra.acknowledgement);
 
                 if (rule.invert_map == 1) {
                     $("[name='invert_map']").bootstrapSwitch('state', true);

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -126,6 +126,10 @@ return [
                 'description' => 'Recovery Alerts',
                 'help' => 'Notify if Alert recovers',
             ],
+            'acknowledgement_alerts' => [
+                'description' => 'Acknowledgement Alerts',
+                'help' => 'Notify if Alert is acknowledged',
+            ],
             'invert_map' => [
                 'description' => 'All devices except in list',
                 'help' => 'Alert only for Devices which are not listed',

--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -226,6 +226,13 @@
             "section": "rules",
             "order": 7
         },
+        "alert_rule.acknowledgement_alerts": {
+            "default": true,
+            "type": "boolean",
+            "group": "alerting",
+            "section": "rules",
+            "order": 7
+        },
         "alert_rule.invert_map": {
             "default": false,
             "type": "boolean",


### PR DESCRIPTION
With some transports, like a ticketing system it is undesirable to send additional alerts after the initial alert because it creates new tickets, etc. This option makes it possible to disable alerts on acknowledgements. The functionality is directly copied from the option to disable recovery alerts so it should be familiar.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
