### PR TITLE
Show which host marked a device as down.

### DIFF
--- a/app/Observers/DeviceObserver.php
+++ b/app/Observers/DeviceObserver.php
@@ -42,7 +42,7 @@ class DeviceObserver
         if ($device->isDirty(['status', 'status_reason'])) {
             $type = $device->status ? 'up' : 'down';
             $reason = $device->status ? $device->getOriginal('status_reason') : $device->status_reason;
-            $actor = Config::get('distributed_poller_name', gethostname());
+            $actor = \config('librenms.node_id', gethostname());
             Eventlog::log(sprintf('Device status changed to %s from %s check%s.', ucfirst($type), $reason, Config::get('distributed_poller') ? " by $actor" : ''), $device, $type);
         }
 

--- a/app/Observers/DeviceObserver.php
+++ b/app/Observers/DeviceObserver.php
@@ -41,7 +41,8 @@ class DeviceObserver
         if ($device->isDirty(['status', 'status_reason'])) {
             $type = $device->status ? 'up' : 'down';
             $reason = $device->status ? $device->getOriginal('status_reason') : $device->status_reason;
-            Eventlog::log('Device status changed to ' . ucfirst($type) . " from $reason check.", $device, $type);
+            $actor = gethostname();
+            Eventlog::log('Device status changed to ' . ucfirst($type) . " from $reason check by $actor.", $device, $type);
         }
 
         // key attribute changes

--- a/app/Observers/DeviceObserver.php
+++ b/app/Observers/DeviceObserver.php
@@ -7,6 +7,7 @@ use App\ApiClients\Oxidized;
 use App\Models\Device;
 use App\Models\Eventlog;
 use File;
+use LibreNMS\Config;
 use LibreNMS\Enum\Severity;
 use Log;
 
@@ -42,7 +43,7 @@ class DeviceObserver
             $type = $device->status ? 'up' : 'down';
             $reason = $device->status ? $device->getOriginal('status_reason') : $device->status_reason;
             $actor = gethostname();
-            Eventlog::log('Device status changed to ' . ucfirst($type) . " from $reason check by $actor.", $device, $type);
+            Eventlog::log(sprintf('Device status changed to %s from %s check%s.', ucfirst($type), $reason, Config::get('distributed_poller') ? " by $actor" : ''), $device, $type);
         }
 
         // key attribute changes

--- a/app/Observers/DeviceObserver.php
+++ b/app/Observers/DeviceObserver.php
@@ -42,8 +42,12 @@ class DeviceObserver
         if ($device->isDirty(['status', 'status_reason'])) {
             $type = $device->status ? 'up' : 'down';
             $reason = $device->status ? $device->getOriginal('status_reason') : $device->status_reason;
-            $actor = \config('librenms.node_id', gethostname());
-            Eventlog::log(sprintf('Device status changed to %s from %s check%s.', ucfirst($type), $reason, Config::get('distributed_poller') ? " by $actor" : ''), $device, $type);
+            $polled_by = '';
+            if (Config::get('distributed_poller')) {
+                $polled_by = ' by ' . (\config('librenms.node_id') ?: gethostname());
+            }
+
+            Eventlog::log(sprintf('Device status changed to %s from %s check%s.', ucfirst($type), $reason, $polled_by, $device, $type);
         }
 
         // key attribute changes

--- a/app/Observers/DeviceObserver.php
+++ b/app/Observers/DeviceObserver.php
@@ -42,7 +42,7 @@ class DeviceObserver
         if ($device->isDirty(['status', 'status_reason'])) {
             $type = $device->status ? 'up' : 'down';
             $reason = $device->status ? $device->getOriginal('status_reason') : $device->status_reason;
-            $actor = gethostname();
+            $actor = Config::get('distributed_poller_name', gethostname());
             Eventlog::log(sprintf('Device status changed to %s from %s check%s.', ucfirst($type), $reason, Config::get('distributed_poller') ? " by $actor" : ''), $device, $type);
         }
 

--- a/app/Observers/DeviceObserver.php
+++ b/app/Observers/DeviceObserver.php
@@ -44,7 +44,7 @@ class DeviceObserver
             $reason = $device->status ? $device->getOriginal('status_reason') : $device->status_reason;
             $polled_by = Config::get('distributed_poller') ? (' by ' . \config('librenms.node_id')) : '';
 
-            Eventlog::log(sprintf('Device status changed to %s from %s check%s.', ucfirst($type), $reason, $polled_by, $device, $type));
+            Eventlog::log(sprintf('Device status changed to %s from %s check%s.', ucfirst($type), $reason, $polled_by), $device, $type);
         }
 
         // key attribute changes

--- a/app/Observers/DeviceObserver.php
+++ b/app/Observers/DeviceObserver.php
@@ -42,12 +42,9 @@ class DeviceObserver
         if ($device->isDirty(['status', 'status_reason'])) {
             $type = $device->status ? 'up' : 'down';
             $reason = $device->status ? $device->getOriginal('status_reason') : $device->status_reason;
-            $polled_by = '';
-            if (Config::get('distributed_poller')) {
-                $polled_by = ' by ' . (\config('librenms.node_id') ?: gethostname());
-            }
+            $polled_by = Config::get('distributed_poller') ? (' by ' . \config('librenms.node_id')) : '';
 
-            Eventlog::log(sprintf('Device status changed to %s from %s check%s.', ucfirst($type), $reason, $polled_by, $device, $type);
+            Eventlog::log(sprintf('Device status changed to %s from %s check%s.', ucfirst($type), $reason, $polled_by, $device, $type));
         }
 
         // key attribute changes


### PR DESCRIPTION
One of my pollers can't reach a device, it'd be nice to know which one is causing the issue.

<img width="828" alt="Screenshot 2023-08-09 at 03 31 21" src="https://github.com/librenms/librenms/assets/590630/4f31a984-ec59-44f7-9d4d-ef8053b63d97">

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
