### PR TITLE
Make the installer use the schema dump

### DIFF
--- a/app/Http/Controllers/Install/DatabaseController.php
+++ b/app/Http/Controllers/Install/DatabaseController.php
@@ -103,7 +103,7 @@ class DatabaseController extends InstallationController implements InstallerStep
                 $this->configureDatabase();
                 $output = new StreamedOutput(fopen('php://stdout', 'w'));
                 echo "Starting Update...\n";
-                $ret = \Artisan::call('migrate', ['--seed' => true, '--force' => true], $output);
+                $ret = \Artisan::call('migrate', ['--seed' => true, '--force' => true, '--no-ansi' => true, '--no-interaction' => true, '--schema-path' => database_path('schema/mysql-schema.dump')], $output);
                 if ($ret !== 0) {
                     throw new \RuntimeException('Migration failed');
                 }


### PR DESCRIPTION
It current doesn't find it since the connection for the installer is called "setup", so it ends up looking for the wrong file.
This is rather hackish but didn't see a better way to do it currently.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
