### PR TITLE
Always mark device last_discovered

### DIFF
--- a/LibreNMS/service.py
+++ b/LibreNMS/service.py
@@ -589,7 +589,7 @@ class Service:
                 """SELECT `device_id`,
                   `poller_group`,
                   COALESCE(`last_polled` <= DATE_ADD(DATE_ADD(NOW(), INTERVAL -%s SECOND), INTERVAL COALESCE(`last_polled_timetaken`, 0) SECOND), 1) AS `poll`,
-                  IF(snmp_disable=1 OR status=0, 0, IF (%s < `last_discovered_timetaken` * 1.25, 0, COALESCE(`last_discovered` <= DATE_ADD(DATE_ADD(NOW(), INTERVAL -%s SECOND), INTERVAL COALESCE(`last_discovered_timetaken`, 0) SECOND), 1))) AS `discover`
+                  IF(status=0, 0, IF (%s < `last_discovered_timetaken` * 1.25, 0, COALESCE(`last_discovered` <= DATE_ADD(DATE_ADD(NOW(), INTERVAL -%s SECOND), INTERVAL COALESCE(`last_discovered_timetaken`, 0) SECOND), 1))) AS `discover`
                 FROM `devices`
                 WHERE `disabled` = 0 AND (
                     `last_polled` IS NULL OR

--- a/discovery.php
+++ b/discovery.php
@@ -102,8 +102,20 @@ if (! empty(\LibreNMS\Config::get('distributed_poller_group'))) {
 
 global $device;
 foreach (dbFetch("SELECT * FROM `devices` WHERE disabled = 0 $where ORDER BY device_id DESC", $sqlparams) as $device) {
+    $device_start = microtime(true);
     DeviceCache::setPrimary($device['device_id']);
-    $discovered_devices += (int) discover_device($device, $module_override);
+
+    if (discover_device($device, $module_override)) {
+        $discovered_devices++;
+
+        $device_time = round(microtime(true) - $device_start, 3);
+        DB::table('devices')->where('device_id', $device['device_id'])->update([
+            'last_discovered_timetaken' => $device_time,
+            'last_discovered' => DB::raw('NOW()'),
+        ]);
+
+        echo "Discovered in $device_time seconds\n\n";
+    }
 }
 
 $end = microtime(true);

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -119,7 +119,6 @@ function discover_device(&$device, $force_module = false)
     // Reset $valid array
     $device['attribs'] = DeviceCache::getPrimary()->getAttribs();
 
-    $device_start = microtime(true);
     // Start counting device poll time
     echo $device['hostname'] . ' ' . $device['device_id'] . ' ' . $device['os'] . ' ';
 
@@ -178,14 +177,6 @@ function discover_device(&$device, $force_module = false)
             echo "Module [ $module ] disabled globally.\n\n";
         }
     }
-
-    $device_time = round(microtime(true) - $device_start, 3);
-
-    dbUpdate(['last_discovered' => ['NOW()'], 'last_discovered_timetaken' => $device_time], 'devices', '`device_id` = ?', [$device['device_id']]);
-
-    echo "Discovered in $device_time seconds\n";
-
-    echo PHP_EOL;
 
     return true;
 }


### PR DESCRIPTION
Previously, if the device was ping only, it wasn't marked as discovered. Now we always run discovery, but basically all it does is update last_discovered.

This prevents the device from being perceived as never being discovered.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
