### PR TITLE
Fixed CSS error causing generic image widgets not to do height correctly

### DIFF
--- a/resources/views/widgets/image.blade.php
+++ b/resources/views/widgets/image.blade.php
@@ -1,3 +1,3 @@
 <a target="_blank" rel="noopener" href="{{ $target_url }}">
-    <img class="dashboard-image" style="max-width: {{ $dimensions['x'] }}px; max-height: {{ $dimensions['y'] }}" src="{{ $image_url }}"/>
+    <img class="dashboard-image" style="max-width: {{ $dimensions['x'] }}px; max-height: {{ $dimensions['y'] }}px" src="{{ $image_url }}"/>
 </a>


### PR DESCRIPTION
The `px` is missing for `max-height` in the Generic Image widget, causing vertical overflow in some setups. This PR resolves this in line with `max-width`.

Screenshots as per requirements are below.

**Before**:
<img width="454" alt="Screenshot 2023-08-12 at 10 55 23 am" src="https://github.com/librenms/librenms/assets/287821/8c1e2e90-7fcf-46ad-94ff-932447731f13">
<img width="357" alt="Screenshot 2023-08-12 at 10 55 26 am" src="https://github.com/librenms/librenms/assets/287821/fa0900fe-5f0a-4a82-8726-cdd9d7a45148">


**After**:
<img width="447" alt="Screenshot 2023-08-12 at 10 55 32 am" src="https://github.com/librenms/librenms/assets/287821/e8e10974-1786-4ae3-8b20-e2a4cb796876">
<img width="349" alt="Screenshot 2023-08-12 at 10 55 35 am" src="https://github.com/librenms/librenms/assets/287821/f813deca-2f9c-41e3-8ceb-15c15fd5c6ba">

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
