### PR TITLE
Use full name for vendor_oui

### DIFF
--- a/app/Console/Commands/MaintenanceFetchOuis.php
+++ b/app/Console/Commands/MaintenanceFetchOuis.php
@@ -104,7 +104,7 @@ class MaintenanceFetchOuis extends LnmsCommand
                 continue;
             }
 
-            [$oui, $vendor] = str_getcsv($csv_line, "\t");
+            [$oui, $short_vendor, $vendor] = str_getcsv($csv_line, "\t");
 
             $oui = strtolower(str_replace(':', '', $oui)); // normalize oui
             $prefix_index = strpos($oui, '/');


### PR DESCRIPTION
Current code uses the "short" name created by Wireshark. Might be an issue while searching when the short name does not include the entire name of the vendor ... 

Is there another reason to use this short name ? 

I suggest to use the full registered IEEE name which is in the 3rd column of the file. 

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
