### PR TITLE
Added empty string check

### DIFF
--- a/app/Models/Device.php
+++ b/app/Models/Device.php
@@ -188,10 +188,10 @@ class Device extends BaseModel
         ]);
 
         // in case the displayName is a string without any content
-        if($return_value == '' or is_null($return_value)) {
+        if ($return_value == '' or is_null($return_value)) {
             $return_value = $this->hostname;
         }
-		
+
         return $return_value;
     }
 

--- a/app/Models/Device.php
+++ b/app/Models/Device.php
@@ -187,12 +187,8 @@ class Device extends BaseModel
             'ip' => $this->overwrite_ip ?: ($hostname_is_ip ? $this->hostname : $this->ip),
         ]);
 
-        // in case the displayName is a string without any content
-        if ($return_value == '') {
-            $return_value = $this->hostname;
-        }
-
-        return $return_value;
+        // in case the displayName is a string without any content, return hostname
+        return $return_value ?: $this->hostname;
     }
 
     /**

--- a/app/Models/Device.php
+++ b/app/Models/Device.php
@@ -180,12 +180,17 @@ class Device extends BaseModel
     {
         $hostname_is_ip = IP::isValid($this->hostname);
 
-        return SimpleTemplate::parse($this->display ?: \LibreNMS\Config::get('device_display_default', '{{ $hostname }}'), [
-            'hostname' => $this->hostname,
-            'sysName' => $this->sysName ?: $this->hostname,
+	$return_value = SimpleTemplate::parse($this->display ?: \LibreNMS\Config::get('device_display_default', '{{ $hostname }}'), [
+            'hostname' => (($this->hostname)),
+            'sysName' => (($this->sysName)) ?: $this->hostname,
             'sysName_fallback' => $hostname_is_ip ? $this->sysName : $this->hostname,
             'ip' => $this->overwrite_ip ?: ($hostname_is_ip ? $this->hostname : $this->ip),
         ]);
+
+	// in case the displayName is a string without any content
+	if($return_value == '' or is_null($return_value)) $return_value = $this->hostname;
+
+        return $return_value;
     }
 
     /**

--- a/app/Models/Device.php
+++ b/app/Models/Device.php
@@ -181,15 +181,17 @@ class Device extends BaseModel
         $hostname_is_ip = IP::isValid($this->hostname);
 
         $return_value = SimpleTemplate::parse($this->display ?: \LibreNMS\Config::get('device_display_default', '{{ $hostname }}'), [
-            'hostname' => (($this->hostname)),
-            'sysName' => (($this->sysName)) ?: $this->hostname,
+            'hostname' => $this->hostname,
+            'sysName' => $this->sysName ?: $this->hostname,
             'sysName_fallback' => $hostname_is_ip ? $this->sysName : $this->hostname,
             'ip' => $this->overwrite_ip ?: ($hostname_is_ip ? $this->hostname : $this->ip),
         ]);
 
         // in case the displayName is a string without any content
-        if($return_value == '' or is_null($return_value)) $return_value = $this->hostname;
-
+        if($return_value == '' or is_null($return_value)) {
+            $return_value = $this->hostname;
+        }
+		
         return $return_value;
     }
 

--- a/app/Models/Device.php
+++ b/app/Models/Device.php
@@ -188,7 +188,7 @@ class Device extends BaseModel
         ]);
 
         // in case the displayName is a string without any content
-        if ($return_value == '' or is_null($return_value)) {
+        if ($return_value == '') {
             $return_value = $this->hostname;
         }
 

--- a/app/Models/Device.php
+++ b/app/Models/Device.php
@@ -180,15 +180,15 @@ class Device extends BaseModel
     {
         $hostname_is_ip = IP::isValid($this->hostname);
 
-	$return_value = SimpleTemplate::parse($this->display ?: \LibreNMS\Config::get('device_display_default', '{{ $hostname }}'), [
+        $return_value = SimpleTemplate::parse($this->display ?: \LibreNMS\Config::get('device_display_default', '{{ $hostname }}'), [
             'hostname' => (($this->hostname)),
             'sysName' => (($this->sysName)) ?: $this->hostname,
             'sysName_fallback' => $hostname_is_ip ? $this->sysName : $this->hostname,
             'ip' => $this->overwrite_ip ?: ($hostname_is_ip ? $this->hostname : $this->ip),
         ]);
 
-	// in case the displayName is a string without any content
-	if($return_value == '' or is_null($return_value)) $return_value = $this->hostname;
+        // in case the displayName is a string without any content
+        if($return_value == '' or is_null($return_value)) $return_value = $this->hostname;
 
         return $return_value;
     }

--- a/app/Models/Device.php
+++ b/app/Models/Device.php
@@ -188,7 +188,7 @@ class Device extends BaseModel
         ]);
 
         // in case the displayName is a string without any content, return hostname
-        return $return_value ?: $this->hostname;
+        return trim($return_value) ?: $this->hostname;
     }
 
     /**


### PR DESCRIPTION
I've added a check to make sure that in the device list in every case a name is shown:

before:
![image](https://github.com/librenms/librenms/assets/53938045/b19b0ceb-ef4e-4d11-856b-7e1393002923)
after:
![image](https://github.com/librenms/librenms/assets/53938045/793e334b-8717-40ce-85f7-620d51d6cd67)

I think the underlaying reason is that the printer reports an empty name back via SNMP. In this case the hostname is shown (as this field should never be empty).
With this improvement the entry is clickable by its IP again. 

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [X] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
