### PR TITLE
Long and short vendor name stored in OUIs

### DIFF
--- a/app/Console/Commands/MaintenanceFetchOuis.php
+++ b/app/Console/Commands/MaintenanceFetchOuis.php
@@ -104,7 +104,7 @@ class MaintenanceFetchOuis extends LnmsCommand
                 continue;
             }
 
-            [$oui, $vendor] = str_getcsv($csv_line, "\t");
+            [$oui, $vendor_short, $vendor] = str_getcsv($csv_line, "\t");
 
             $oui = strtolower(str_replace(':', '', $oui)); // normalize oui
             $prefix_index = strpos($oui, '/');
@@ -122,12 +122,13 @@ class MaintenanceFetchOuis extends LnmsCommand
 
             // Add to the list of vendor ids
             $ouis[] = [
-                'vendor' => $vendor,
+                'vendor' => trim($vendor),
+                'vendor_short' => trim($vendor_short),
                 'oui' => $oui,
             ];
 
             if ($this->verbosity == OutputInterface::VERBOSITY_DEBUG) {
-                $this->line(trans('commands.maintenance:fetch-ouis.vendor_update', ['vendor' => $vendor, 'oui' => $oui]));
+                $this->line(trans('commands.maintenance:fetch-ouis.vendor_update', ['vendor' => $vendor, 'vendor_short' => $vendor_short, 'oui' => $oui]));
             }
         }
 

--- a/database/migrations/2023_08_20_230406_extend_vendor.php
+++ b/database/migrations/2023_08_20_230406_extend_vendor.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up(): void
+    {
+        Schema::table('vendor_ouis', function (Blueprint $table) {
+            $table->string('vendor_short');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down(): void
+    {
+        Schema::table('vendor_ouis', function (Blueprint $table) {
+            $table->dropColumn(['vendor_short']);
+        });
+    }
+};

--- a/misc/db_schema.yaml
+++ b/misc/db_schema.yaml
@@ -576,9 +576,9 @@ devices_perms:
     devices_perms_user_id_index: { Name: devices_perms_user_id_index, Columns: [user_id], Unique: false, Type: BTREE }
 device_graphs:
   Columns:
-    - { Field: id, Type: 'bigint unsigned', 'Null': false, Extra: auto_increment }
     - { Field: device_id, Type: 'int unsigned', 'Null': false, Extra: '' }
     - { Field: graph, Type: varchar(255), 'Null': true, Extra: '' }
+    - { Field: id, Type: 'bigint unsigned', 'Null': false, Extra: auto_increment }
   Indexes:
     PRIMARY: { Name: PRIMARY, Columns: [id], Unique: true, Type: BTREE }
     device_graphs_device_id_index: { Name: device_graphs_device_id_index, Columns: [device_id], Unique: false, Type: BTREE }
@@ -2089,6 +2089,7 @@ vendor_ouis:
     - { Field: id, Type: 'bigint unsigned', 'Null': false, Extra: auto_increment }
     - { Field: vendor, Type: varchar(255), 'Null': false, Extra: '' }
     - { Field: oui, Type: varchar(12), 'Null': false, Extra: '' }
+    - { Field: vendor_short, Type: varchar(255), 'Null': false, Extra: '' }
   Indexes:
     PRIMARY: { Name: PRIMARY, Columns: [id], Unique: true, Type: BTREE }
     vendor_ouis_oui_unique: { Name: vendor_ouis_oui_unique, Columns: [oui], Unique: true, Type: BTREE }

--- a/misc/db_schema.yaml
+++ b/misc/db_schema.yaml
@@ -576,9 +576,9 @@ devices_perms:
     devices_perms_user_id_index: { Name: devices_perms_user_id_index, Columns: [user_id], Unique: false, Type: BTREE }
 device_graphs:
   Columns:
+    - { Field: id, Type: 'bigint unsigned', 'Null': false, Extra: auto_increment }
     - { Field: device_id, Type: 'int unsigned', 'Null': false, Extra: '' }
     - { Field: graph, Type: varchar(255), 'Null': true, Extra: '' }
-    - { Field: id, Type: 'bigint unsigned', 'Null': false, Extra: auto_increment }
   Indexes:
     PRIMARY: { Name: PRIMARY, Columns: [id], Unique: true, Type: BTREE }
     device_graphs_device_id_index: { Name: device_graphs_device_id_index, Columns: [device_id], Unique: false, Type: BTREE }


### PR DESCRIPTION
- Store both short and long vendor name.
- default to long one
- short one is accessible with column "vendor_short" in TABLE vendor_ouis.
- trimed the variables before storage to avoid the whitespaces in vendor_short.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
