### PR TITLE
Fix manual port speed storage

### DIFF
--- a/includes/html/forms/update-ifspeed.inc.php
+++ b/includes/html/forms/update-ifspeed.inc.php
@@ -30,7 +30,7 @@ if ($port) {
             $port->device->forgetAttrib('ifSpeed:' . $port->ifName);
             \App\Models\Eventlog::log("{$port->ifName} Port speed cleared manually", $port->device, 'interface', Severity::Notice, $port_id);
         } else {
-            $port->device->setAttrib('ifSpeed:' . $port->ifName, 1);
+            $port->device->setAttrib('ifSpeed:' . $port->ifName, $speed);
             \App\Models\Eventlog::log("{$port->ifName} Port speed set manually: $speed", $port->device, 'interface', Severity::Notice, $port_id);
             $port_tune = $port->device->getAttrib('ifName_tune:' . $port->ifName);
             $device_tune = $port->device->getAttrib('override_rrdtool_tune');

--- a/misc/notifications.rss
+++ b/misc/notifications.rss
@@ -96,7 +96,7 @@
   <item>
     <title>Manually set port speeds reset</title>
     <description>Due to a bug, all manually set port speeds will need to be reconfigured. Likely they are set to 1 instead of the expected value.</description>
-    <pubDate>Mon, 21 Oct 2023 15:00:00 +0000</pubDate>
+    <pubDate>Mon, 21 Aug 2023 15:00:00 +0000</pubDate>
   </item>
 </channel>
 </rss>

--- a/misc/notifications.rss
+++ b/misc/notifications.rss
@@ -93,5 +93,10 @@
     <description>Due to a security vulnerability, you must upgrade your memcached application scripts to the latest version. (1.1)</description>
     <pubDate>Fri, 10 Oct 2022 18:00:00 +0000</pubDate>
   </item>
+  <item>
+    <title>Manually set port speeds reset</title>
+    <description>Due to a bug, all manually set port speeds will need to be reconfigured. Likely they are set to 1 instead of the expected value.</description>
+    <pubDate>Mon, 21 Oct 2023 15:00:00 +0000</pubDate>
+  </item>
 </channel>
 </rss>

--- a/misc/notifications.rss
+++ b/misc/notifications.rss
@@ -95,7 +95,7 @@
   </item>
   <item>
     <title>Manually set port speeds reset</title>
-    <description>Due to a bug, all manually set port speeds will need to be reconfigured. Likely they are set to 1 instead of the expected value. See https://github.com/librenms/librenms/pull/15238 for more informtaion.</description>
+    <description>Due to a bug, all manually set port speeds will need to be reconfigured. Likely they are set to 1 instead of the expected value. See https://github.com/librenms/librenms/pull/15238 for more information.</description>
     <pubDate>Mon, 21 Aug 2023 15:00:00 +0000</pubDate>
   </item>
 </channel>

--- a/misc/notifications.rss
+++ b/misc/notifications.rss
@@ -95,7 +95,7 @@
   </item>
   <item>
     <title>Manually set port speeds reset</title>
-    <description>Due to a bug, all manually set port speeds will need to be reconfigured. Likely they are set to 1 instead of the expected value.</description>
+    <description>Due to a bug, all manually set port speeds will need to be reconfigured. Likely they are set to 1 instead of the expected value. See https://github.com/librenms/librenms/pull/15238 for more informtaion.</description>
     <pubDate>Mon, 21 Aug 2023 15:00:00 +0000</pubDate>
   </item>
 </channel>


### PR DESCRIPTION
Due to a bug all manually configured port speeds were lost and will need to be reconfigured. This allows them to work in a way that will prevent that issue in the future by storing the speed with the override. Includes notification.

To find ports set incorrectly, you can run this command:
`lnms tinker --execute="dump(DeviceAttrib::where('attrib_type', 'like', 'ifSpeed:%')->where('attrib_value', '1')->select(['device_id', 'attrib_type', 'attrib_value'])->get()->toArray() ?: 'None found')"`

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
