### PR TITLE
WebUI Services, generate more compact table

### DIFF
--- a/includes/html/pages/services.inc.php
+++ b/includes/html/pages/services.inc.php
@@ -144,7 +144,6 @@ require_once 'includes/html/modal/delete_service.inc.php';
                     }
 
                     $header = true;
-                    $footer = false;
 
                     $service_iteration = 0;
                     $services = dbFetchRows("SELECT * FROM `services` WHERE `device_id` = ? $where ORDER BY service_type", $sql_param);
@@ -169,7 +168,6 @@ require_once 'includes/html/modal/delete_service.inc.php';
                         if ($service_iteration < 2 && $header) {
                             echo '<div class="panel panel-default">';
                             echo '<div class="panel-heading"><h3 class="panel-title">' . $devlink . '</h3>' . $device_sysName . '</div>';
-                            echo '<div class="panel-body">';
                             echo '<table class="table table-hover table-condensed">';
                             echo '<thead>';
                             echo '<th style="width:1%;max-width:1%;"></th>';
@@ -181,7 +179,7 @@ require_once 'includes/html/modal/delete_service.inc.php';
                             echo '<th style="width:15%;max-width: 15%;">Last Changed</th>';
                             echo '<th style="width:2%;max-width: 2%;">Alert</th>';
                             echo '<th style="width:4%;max-width: 4%;">Status</th>';
-                            echo '<th style="width:80px;max-width: 80px;"></th>';
+                            echo '<th style="width:100px;max-width: 100px;"></th>';
                             echo '</thead>';
                         }
 
@@ -236,12 +234,7 @@ require_once 'includes/html/modal/delete_service.inc.php';
                         echo '</tr>';
 
                         if ($service_iteration >= $services_count) {
-                            $footer = true;
-                        }
-
-                        if ($footer) {
                             echo '</table>';
-                            echo '</div>';
                             echo '</div>';
                         }
                     }


### PR DESCRIPTION
Generate a more compact table removing big empty space after last service of each device.
Fix edit, delete button on top of each other,

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.

Screenshot
Before:
![image](https://github.com/librenms/librenms/assets/3173115/90251725-b12a-484d-923f-5ae87f3bb54c)

After:
![image](https://github.com/librenms/librenms/assets/3173115/20562423-dc93-4989-b479-f0e1ea715520)
