### PR TITLE
New Transport for Xmatters and hiding secrets in other Transports

### DIFF
--- a/LibreNMS/Alert/Transport/Alerta.php
+++ b/LibreNMS/Alert/Transport/Alerta.php
@@ -83,7 +83,7 @@ class Alerta extends Transport
                     'title' => 'Api Key',
                     'name' => 'apikey',
                     'descr' => 'Your alerta api key with minimally write:alert permissions.',
-                    'type' => 'text',
+                    'type' => 'password',
                 ],
                 [
                     'title' => 'Alert State',

--- a/LibreNMS/Alert/Transport/Canopsis.php
+++ b/LibreNMS/Alert/Transport/Canopsis.php
@@ -97,7 +97,7 @@ class Canopsis extends Transport
                     'title' => 'Password',
                     'name' => 'canopsis-pass',
                     'descr' => 'Canopsis Password',
-                    'type' => 'text',
+                    'type' => 'password',
                 ],
                 [
                     'title' => 'Vhost',

--- a/LibreNMS/Alert/Transport/Gitlab.php
+++ b/LibreNMS/Alert/Transport/Gitlab.php
@@ -78,7 +78,7 @@ class Gitlab extends Transport
                     'title' => 'Personal Access Token',
                     'name' => 'gitlab-key',
                     'descr' => 'Personal Access Token',
-                    'type' => 'text',
+                    'type' => 'password',
                 ],
             ],
             'validation' => [

--- a/LibreNMS/Alert/Transport/Jira.php
+++ b/LibreNMS/Alert/Transport/Jira.php
@@ -99,7 +99,7 @@ class Jira extends Transport
                     'title' => 'Jira Password',
                     'name' => 'jira-password',
                     'descr' => 'Jira Password',
-                    'type' => 'text',
+                    'type' => 'password',
                 ],
             ],
             'validation' => [

--- a/LibreNMS/Alert/Transport/Jira.php
+++ b/LibreNMS/Alert/Transport/Jira.php
@@ -41,6 +41,7 @@ class Jira extends Transport
         $details = empty($alert_data['title']) ? 'Librenms alert for: ' . $alert_data['hostname'] : $alert_data['title'];
         $description = $alert_data['msg'];
         $url = $this->config['jira-url'] . '/rest/api/latest/issue';
+        $custom = json_decode('{' . $this->config['jira-custom'] . '}', true);   
 
         $data = [
             'fields' => [
@@ -54,6 +55,10 @@ class Jira extends Transport
                 ],
             ],
         ];
+
+        if (!empty($custom)) {
+            $data['fields'] = array_merge($data['fields'], $custom);
+        }
 
         $res = Http::client()
             ->withBasicAuth($this->config['jira-username'], $this->config['jira-password'])
@@ -100,6 +105,12 @@ class Jira extends Transport
                     'name' => 'jira-password',
                     'descr' => 'Jira Password',
                     'type' => 'password',
+                ],
+                [
+                    'title' => 'Custom Fileds',
+                    'name' => 'jira-custom',
+                    'type' => 'textarea',
+                    'descr' => '&quot;components&quot;: [{&quot;id&quot;: &quot;00001&quot;}],&#xA;&quot;customfield_10001&quot;: [{&quot;id&quot;: &quot;00002&quot;}]',
                 ],
             ],
             'validation' => [

--- a/LibreNMS/Alert/Transport/Kayako.php
+++ b/LibreNMS/Alert/Transport/Kayako.php
@@ -79,7 +79,7 @@ class Kayako extends Transport
                     'title' => 'Kayako API Secret',
                     'name' => 'kayako-secret',
                     'descr' => 'ServiceDesk API Secret Key',
-                    'type' => 'text',
+                    'type' => 'password',
                 ],
                 [
                     'title' => 'Kayako Department',

--- a/LibreNMS/Alert/Transport/Linemessagingapi.php
+++ b/LibreNMS/Alert/Transport/Linemessagingapi.php
@@ -62,7 +62,7 @@ class LineMessagingAPI extends Transport
                     'title' => 'Access token',
                     'name' => 'line-messaging-token',
                     'descr' => 'LINE Channel access token',
-                    'type' => 'text',
+                    'type' => 'password',
                 ],
                 [
                     'title' => 'Recipient (groupID, userID or roomID)',

--- a/LibreNMS/Alert/Transport/Linenotify.php
+++ b/LibreNMS/Alert/Transport/Linenotify.php
@@ -39,7 +39,7 @@ class Linenotify extends Transport
                     'title' => 'Token',
                     'name' => 'line-notify-access-token',
                     'descr' => 'LINE Notify Token',
-                    'type' => 'text',
+                    'type' => 'password',
                 ],
             ],
             'validation' => [

--- a/LibreNMS/Alert/Transport/Matrix.php
+++ b/LibreNMS/Alert/Transport/Matrix.php
@@ -78,7 +78,7 @@ class Matrix extends Transport
                     'title' => 'Auth_token',
                     'name' => 'matrix-authtoken',
                     'descr' => 'Enter the auth_token',
-                    'type' => 'text',
+                    'type' => 'password',
                 ],
                 [
                     'title' => 'Message',

--- a/LibreNMS/Alert/Transport/Messagebird.php
+++ b/LibreNMS/Alert/Transport/Messagebird.php
@@ -69,7 +69,7 @@ class Messagebird extends Transport
                     'title' => 'Messagebird API key',
                     'name' => 'messagebird-key',
                     'descr' => 'Messagebird API REST key',
-                    'type' => 'text',
+                    'type' => 'password',
                 ],
                 [
                     'title' => 'Messagebird originator',

--- a/LibreNMS/Alert/Transport/Messagebirdvoice.php
+++ b/LibreNMS/Alert/Transport/Messagebirdvoice.php
@@ -72,7 +72,7 @@ class Messagebirdvoice extends Transport
                     'title' => 'Messagebird API key',
                     'name' => 'messagebird-key',
                     'descr' => 'Messagebird API REST key',
-                    'type' => 'text',
+                    'type' => 'password',
                 ],
                 [
                     'title' => 'Messagebird originator',

--- a/LibreNMS/Alert/Transport/Osticket.php
+++ b/LibreNMS/Alert/Transport/Osticket.php
@@ -66,7 +66,7 @@ class Osticket extends Transport
                     'title' => 'API Token',
                     'name' => 'os-token',
                     'descr' => 'osTicket API Token',
-                    'type' => 'text',
+                    'type' => 'password',
                 ],
             ],
             'validation' => [

--- a/LibreNMS/Alert/Transport/Playsms.php
+++ b/LibreNMS/Alert/Transport/Playsms.php
@@ -77,7 +77,7 @@ class Playsms extends Transport
                     'title' => 'Token',
                     'name' => 'playsms-token',
                     'descr' => 'PlaySMS Token',
-                    'type' => 'text',
+                    'type' => 'password',
                 ],
                 [
                     'title' => 'From',

--- a/LibreNMS/Alert/Transport/Pushbullet.php
+++ b/LibreNMS/Alert/Transport/Pushbullet.php
@@ -54,7 +54,7 @@ class Pushbullet extends Transport
                     'title' => 'Access Token',
                     'name' => 'pushbullet-token',
                     'descr' => 'Pushbullet Access Token',
-                    'type' => 'text',
+                    'type' => 'password',
                 ],
             ],
             'validation' => [

--- a/LibreNMS/Alert/Transport/Pushover.php
+++ b/LibreNMS/Alert/Transport/Pushover.php
@@ -97,13 +97,13 @@ class Pushover extends Transport
                     'title' => 'Api Key',
                     'name'  => 'appkey',
                     'descr' => 'Api Key',
-                    'type'  => 'text',
+                    'type'  => 'password',
                 ],
                 [
                     'title' => 'User Key',
                     'name'  => 'userkey',
                     'descr' => 'User Key',
-                    'type'  => 'text',
+                    'type'  => 'password',
                 ],
                 [
                     'title' => 'Pushover Options',

--- a/LibreNMS/Alert/Transport/Signalwire.php
+++ b/LibreNMS/Alert/Transport/Signalwire.php
@@ -66,7 +66,7 @@ class Signalwire extends Transport
                     'title' => 'Token',
                     'name' => 'signalwire-token',
                     'descr' => 'SignalWire Account Token ',
-                    'type' => 'text',
+                    'type' => 'password',
                 ],
                 [
                     'title' => 'Mobile Number',

--- a/LibreNMS/Alert/Transport/Smseagle.php
+++ b/LibreNMS/Alert/Transport/Smseagle.php
@@ -74,7 +74,7 @@ class Smseagle extends Transport
                     'title' => 'Access Token',
                     'name' => 'smseagle-token',
                     'descr' => 'SMSEagle Access Token',
-                    'type' => 'text',
+                    'type' => 'password',
                 ],
                 [
                     'title' => 'User',
@@ -86,7 +86,7 @@ class Smseagle extends Transport
                     'title' => 'Password',
                     'name' => 'smseagle-pass',
                     'descr' => 'SMSEagle Password',
-                    'type' => 'text',
+                    'type' => 'password',
                 ],
                 [
                     'title' => 'Mobiles',

--- a/LibreNMS/Alert/Transport/Smsfeedback.php
+++ b/LibreNMS/Alert/Transport/Smsfeedback.php
@@ -65,7 +65,7 @@ class Smsfeedback extends Transport
                     'title' => 'Password',
                     'name' => 'smsfeedback-pass',
                     'descr' => 'smsfeedback Password',
-                    'type' => 'text',
+                    'type' => 'password',
                 ],
                 [
                     'title' => 'Mobiles',

--- a/LibreNMS/Alert/Transport/Telegram.php
+++ b/LibreNMS/Alert/Transport/Telegram.php
@@ -81,7 +81,7 @@ class Telegram extends Transport
                     'title' => 'Token',
                     'name' => 'telegram-token',
                     'descr' => 'Telegram Token',
-                    'type' => 'text',
+                    'type' => 'password',
                 ],
                 [
                     'title' => 'Format',

--- a/LibreNMS/Alert/Transport/Twilio.php
+++ b/LibreNMS/Alert/Transport/Twilio.php
@@ -56,7 +56,7 @@ class Twilio extends Transport
                     'title' => 'Token',
                     'name' => 'twilio-token',
                     'descr' => 'Twilio Account Token',
-                    'type' => 'text',
+                    'type' => 'password',
                 ],
                 [
                     'title' => 'Mobile Number',

--- a/LibreNMS/Alert/Transport/Ukfastpss.php
+++ b/LibreNMS/Alert/Transport/Ukfastpss.php
@@ -71,7 +71,7 @@ class Ukfastpss extends Transport
                     'title' => 'API Key',
                     'name' => 'api-key',
                     'descr' => 'API key to use for authentication',
-                    'type' => 'text',
+                    'type' => 'password',
                 ],
                 [
                     'title' => 'Author',

--- a/LibreNMS/Alert/Transport/Xmatters.php
+++ b/LibreNMS/Alert/Transport/Xmatters.php
@@ -118,4 +118,5 @@ class Xmatters extends Transport
             ],
         ];
     }
+
 }

--- a/LibreNMS/Alert/Transport/Xmatters.php
+++ b/LibreNMS/Alert/Transport/Xmatters.php
@@ -17,7 +17,6 @@ class Xmatters extends Transport
 {
     public function deliverAlert(array $alert_data): bool
     {
-
         $url = $this->config['xmatters_url'] . '/api/integration/1/functions/' . $this->config['xmatters_function'] . '/triggers';
 
         $device_url = \Config::get('base_url');
@@ -27,13 +26,13 @@ class Xmatters extends Transport
         $data = [
             'properties' => $alert_data,
             'recipients' => $alert_data['contacts'],
-            'priority' => $this->mapSeverityToPriority($alert_data['severity'])
+            'priority' => $this->mapSeverityToPriority($alert_data['severity']),
         ];
 
         $data['properties']['event_state'] = $this->mapStateToEventState($alert_data['state']);
         $data['properties']['instance_url'] = $device_url;
         $data['properties']['device_url'] = ($device_url . '/device/' . $alert_data['device_id']);
-        $data['properties']['alert_url'] = ($device_url . '/device/' . $alert_data['device_id'] . '/alerts/'  .$alert_data['alert_id']);
+        $data['properties']['alert_url'] = ($device_url . '/device/' . $alert_data['device_id'] . '/alerts/' . $alert_data['alert_id']);
         $data['properties']['hostname'] = $alert_data['sysName'];
         $data['properties']['ip'] = $alert_data['hostname'];
         $data['properties']['device_groups'] = $device_groups;
@@ -47,36 +46,37 @@ class Xmatters extends Transport
             return true;
         }
 
-        throw new AlertTransportDeliveryException($alert_data, $res->status(), $res->body(), $data['message'] ?? '', $data);
+        throw new AlertTransportDeliveryException($alert_data, $res->status(), $res->body(), $alert_data['msg'], $data);
     }
 
-
-    protected function mapSeverityToPriority(string $severity): string {
+    protected function mapSeverityToPriority(string $severity): string
+    {
         switch ($severity) {
             case 'critical':
                 return 'High';
-            case 'warning':  
+            case 'warning':
                 return 'Medium';
             case 'ok':
                 return 'Low';
             default:
-                return 'invalid severity'; 
+                return 'invalid severity';
         }
     }
 
-    protected function mapStateToEventState(int $state): string {
+    protected function mapStateToEventState(int $state): string
+    {
         switch ($state) {
-            case 0: 
+            case 0:
                 return 'ok';
             case 1:
                 return 'alert';
             case 2:
                 return 'ack';
-            case 3: 
+            case 3:
                 return 'better';
             case 4:
                 return 'worse';
-            default:  
+            default:
                 return 'invalid state';
         }
     }
@@ -89,33 +89,33 @@ class Xmatters extends Transport
                     'title' => 'xMatters URL',
                     'name' => 'xmatters_url',
                     'descr' => 'The hostname of the xMatters instance.',
-                    'type' => 'text'
+                    'type' => 'text',
                 ],
                 [
                     'title' => 'xMatters Function',
                     'name' => 'xmatters_function',
                     'descr' => 'The ID of the xmatters flow http trigger or legacy inbound integration.',
-                    'type' => 'text'
+                    'type' => 'text',
                 ],
                 [
                     'title' => 'xMatters API Key',
                     'name' => 'xmatters_api_key',
                     'descr' => 'The API Key key for authenticating the flow http trigger or legacy inbound integration.',
-                    'type' => 'text'
+                    'type' => 'text',
                 ],
                 [
                     'title' => 'xMatters API Secret',
                     'name' => 'xmatters_api_secret',
                     'descr' => 'The Secret matching the API Key for authenticating the flow http trigger or legacy inbound integration.',
-                    'type' => 'password'
+                    'type' => 'password',
                 ]
             ],
             'validation' => [
                 'xmatters_url' => 'required|url',
                 'xmatters_function' => 'required|string',
                 'xmatters_api_key' => 'required|string',
-                'xmatters_api_secret' => 'required|string'
-            ]
+                'xmatters_api_secret' => 'required|string',
+            ],
         ];
     }
 }

--- a/LibreNMS/Alert/Transport/Xmatters.php
+++ b/LibreNMS/Alert/Transport/Xmatters.php
@@ -108,7 +108,7 @@ class Xmatters extends Transport
                     'name' => 'xmatters_api_secret',
                     'descr' => 'The Secret matching the API Key for authenticating the flow http trigger or legacy inbound integration.',
                     'type' => 'password',
-                ]
+                ],
             ],
             'validation' => [
                 'xmatters_url' => 'required|url',

--- a/LibreNMS/Alert/Transport/Xmatters.php
+++ b/LibreNMS/Alert/Transport/Xmatters.php
@@ -118,5 +118,4 @@ class Xmatters extends Transport
             ],
         ];
     }
-
 }

--- a/LibreNMS/Alert/Transport/Xmatters.php
+++ b/LibreNMS/Alert/Transport/Xmatters.php
@@ -118,4 +118,5 @@ class Xmatters extends Transport
             ],
         ];
     }
+x
 }

--- a/LibreNMS/Alert/Transport/Xmatters.php
+++ b/LibreNMS/Alert/Transport/Xmatters.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Xmatters API Transport
+ *
+ * @author Sigurdur Stefan <https://github.com/LoveSkylark>
+ * @copyright 2023 Sigurdur Stefan
+ * @license GPL
+ */
+
+namespace LibreNMS\Alert\Transport;
+
+use LibreNMS\Alert\Transport;
+use LibreNMS\Exceptions\AlertTransportDeliveryException;
+use LibreNMS\Util\Http;
+
+class Xmatters extends Transport
+{
+    public function deliverAlert(array $alert_data): bool
+    {
+
+        $url = $this->config['xmatters_url'] . '/api/integration/1/functions/' . $this->config['xmatters_function'] . '/triggers';
+
+        $device_url = \Config::get('base_url');
+        $device_groups = \DeviceCache::get($alert_data['device_id'])->groups->pluck('name');
+
+        // Build request data
+        $data = [
+            'properties' => $alert_data,
+            'recipients' => $alert_data['contacts'],
+            'priority' => $this->mapSeverityToPriority($alert_data['severity'])
+        ];
+
+        $data['properties']['event_state'] = $this->mapStateToEventState($alert_data['state']);
+        $data['properties']['instance_url'] = $device_url;
+        $data['properties']['device_url'] = ($device_url . '/device/' . $alert_data['device_id']);
+        $data['properties']['alert_url'] = ($device_url . '/device/' . $alert_data['device_id'] . '/alerts/'  .$alert_data['alert_id']);
+        $data['properties']['hostname'] = $alert_data['sysName'];
+        $data['properties']['ip'] = $alert_data['hostname'];
+        $data['properties']['device_groups'] = $device_groups;
+
+        $res = Http::client()
+            ->withBasicAuth($this->config['xmatters_api_key'], $this->config['xmatters_api_secret'])
+            ->acceptJson()
+            ->post($url, $data);
+
+        if ($res->successful()) {
+            return true;
+        }
+
+        throw new AlertTransportDeliveryException($alert_data, $res->status(), $res->body(), $data['message'] ?? '', $data);
+    }
+
+
+    protected function mapSeverityToPriority(string $severity): string {
+        switch ($severity) {
+            case 'critical':
+                return 'High';
+            case 'warning':  
+                return 'Medium';
+            case 'ok':
+                return 'Low';
+            default:
+                return 'invalid severity'; 
+        }
+    }
+
+    protected function mapStateToEventState(int $state): string {
+        switch ($state) {
+            case 0: 
+                return 'ok';
+            case 1:
+                return 'alert';
+            case 2:
+                return 'ack';
+            case 3: 
+                return 'better';
+            case 4:
+                return 'worse';
+            default:  
+                return 'invalid state';
+        }
+    }
+
+    public static function configTemplate(): array
+    {
+        return [
+            'config' => [
+                [
+                    'title' => 'xMatters URL',
+                    'name' => 'xmatters_url',
+                    'descr' => 'The hostname of the xMatters instance.',
+                    'type' => 'text'
+                ],
+                [
+                    'title' => 'xMatters Function',
+                    'name' => 'xmatters_function',
+                    'descr' => 'The ID of the xmatters flow http trigger or legacy inbound integration.',
+                    'type' => 'text'
+                ],
+                [
+                    'title' => 'xMatters API Key',
+                    'name' => 'xmatters_api_key',
+                    'descr' => 'The API Key key for authenticating the flow http trigger or legacy inbound integration.',
+                    'type' => 'text'
+                ],
+                [
+                    'title' => 'xMatters API Secret',
+                    'name' => 'xmatters_api_secret',
+                    'descr' => 'The Secret matching the API Key for authenticating the flow http trigger or legacy inbound integration.',
+                    'type' => 'password'
+                ]
+            ],
+            'validation' => [
+                'xmatters_url' => 'required|url',
+                'xmatters_function' => 'required|string',
+                'xmatters_api_key' => 'required|string',
+                'xmatters_api_secret' => 'required|string'
+            ]
+        ];
+    }
+}

--- a/LibreNMS/Alert/Transport/Xmatters.php
+++ b/LibreNMS/Alert/Transport/Xmatters.php
@@ -118,5 +118,4 @@ class Xmatters extends Transport
             ],
         ];
     }
-x
 }


### PR DESCRIPTION
Please give a short description what your pull request is for

1. Add new transport for Xmatters
2. Hide tokens, keys, secrets and passwords in all Transports

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
