### PR TITLE
Another OR statement in GL-api

### DIFF
--- a/app/ApiClients/GraylogApi.php
+++ b/app/ApiClients/GraylogApi.php
@@ -59,7 +59,7 @@ class GraylogApi
 
         $uri = $this->api_prefix . '/streams';
 
-        $response = $this->client->get($uri);
+        $response = $this->client->get($uri, $data)->throw();
 
         return $response->json() ?: [];
     }
@@ -87,7 +87,7 @@ class GraylogApi
             'filter' => $filter,
         ];
 
-        $response = $this->client->get($uri, $data)->throw();
+        $response = $this->client->get($uri, $data);
 
         return $response->json() ?: [];
     }
@@ -119,7 +119,8 @@ class GraylogApi
             gethostbyname($device->hostname),
             $device->hostname,
             $device->displayName(),
-            $device->ip,
+	    $device->ip,
+	    $device->sysName,
         ]);
 
         if (Config::get('graylog.match-any-address')) {


### PR DESCRIPTION
In some bizarre cases the `src` in Graylog will refer to the server or device hostname, rather than IP. Rather than changing the display name to match `sysName`, this change attempts to match the `sysName` in LibreNMS to the src of the message in Graylog, and then display the correct logs in the Graylog tab in the web UI.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
