### PR TITLE
Custom ssh,telnet port with oxidized

### DIFF
--- a/app/Http/Controllers/DeviceController.php
+++ b/app/Http/Controllers/DeviceController.php
@@ -192,9 +192,10 @@ class DeviceController extends Controller
         }
 
         // Web
+        $http_port = $device->attribs->firstWhere('attrib_type', 'override_device_http_port') ? ":" . $device->attribs->firstWhere('attrib_type', 'override_device_http_port')->attrib_value : "";
         $device_links['web'] = [
             'icon' => 'fa-globe',
-            'url' => 'https://' . $device->hostname,
+            'url' => 'https://' . $device->hostname . $http_port,
             'title' => __('Web'),
             'external' => true,
             'onclick' => 'http_fallback(this); return false;',
@@ -212,9 +213,10 @@ class DeviceController extends Controller
         }
 
         // SSH
+        $ssh_port = $device->attribs->firstWhere('attrib_type', 'override_device_ssh_port') ? ":" . $device->attribs->firstWhere('attrib_type', 'override_device_ssh_port')->attrib_value : "";
         $ssh_url = Config::has('gateone.server')
             ? Config::get('gateone.server') . '?ssh=ssh://' . (Config::get('gateone.use_librenms_user') ? Auth::user()->username . '@' : '') . $device['hostname'] . '&location=' . $device['hostname']
-            : 'ssh://' . $device->hostname;
+            : 'ssh://' . $device->hostname . $ssh_port;
         $device_links['ssh'] = [
             'icon' => 'fa-lock',
             'url' => $ssh_url,
@@ -223,9 +225,10 @@ class DeviceController extends Controller
         ];
 
         // Telnet
+        $telnet_port = $device->attribs->firstWhere('attrib_type', 'override_device_telnet_port') ? ":" . $device->attribs->firstWhere('attrib_type', 'override_device_telnet_port')->attrib_value : "";
         $device_links['telnet'] = [
             'icon' => 'fa-terminal',
-            'url' => 'telnet://' . $device->hostname,
+            'url' => 'telnet://' . $device->hostname . $telnet_port,
             'title' => __('Telnet'),
             'external' => true,
         ];

--- a/app/Http/Controllers/DeviceController.php
+++ b/app/Http/Controllers/DeviceController.php
@@ -192,7 +192,7 @@ class DeviceController extends Controller
         }
 
         // Web
-        $http_port = $device->attribs->firstWhere('attrib_type', 'override_device_http_port') ? ":" . $device->attribs->firstWhere('attrib_type', 'override_device_http_port')->attrib_value : "";
+        $http_port = $device->attribs->firstWhere('attrib_type', 'override_device_http_port') ? ':' . $device->attribs->firstWhere('attrib_type', 'override_device_http_port')->attrib_value : '';
         $device_links['web'] = [
             'icon' => 'fa-globe',
             'url' => 'https://' . $device->hostname . $http_port,
@@ -213,7 +213,7 @@ class DeviceController extends Controller
         }
 
         // SSH
-        $ssh_port = $device->attribs->firstWhere('attrib_type', 'override_device_ssh_port') ? ":" . $device->attribs->firstWhere('attrib_type', 'override_device_ssh_port')->attrib_value : "";
+        $ssh_port = $device->attribs->firstWhere('attrib_type', 'override_device_ssh_port') ? ':' . $device->attribs->firstWhere('attrib_type', 'override_device_ssh_port')->attrib_value : '';
         $ssh_url = Config::has('gateone.server')
             ? Config::get('gateone.server') . '?ssh=ssh://' . (Config::get('gateone.use_librenms_user') ? Auth::user()->username . '@' : '') . $device['hostname'] . '&location=' . $device['hostname']
             : 'ssh://' . $device->hostname . $ssh_port;
@@ -225,7 +225,7 @@ class DeviceController extends Controller
         ];
 
         // Telnet
-        $telnet_port = $device->attribs->firstWhere('attrib_type', 'override_device_telnet_port') ? ":" . $device->attribs->firstWhere('attrib_type', 'override_device_telnet_port')->attrib_value : "";
+        $telnet_port = $device->attribs->firstWhere('attrib_type', 'override_device_telnet_port') ? ':' . $device->attribs->firstWhere('attrib_type', 'override_device_telnet_port')->attrib_value : '';
         $device_links['telnet'] = [
             'icon' => 'fa-terminal',
             'url' => 'telnet://' . $device->hostname . $telnet_port,

--- a/doc/Extensions/Customizing-the-Web-UI.md
+++ b/doc/Extensions/Customizing-the-Web-UI.md
@@ -103,3 +103,8 @@ The primary button is edit device by default.
 | custom7 | Custom Link 7 |
 | custom8 | Custom Link 8 |
 
+!!! Custom http, ssh, telnet ports
+
+Custom ports can be set through the device setting misc tab and will be appended to the Uri. Empty value will not append anything and automatically default to the standard.
+	- custom ssh port set to 2222 will result in ssh://10.0.0.0:2222
+	- custom telnet port set to 2323 will result in telnet://10.0.0.0:2323

--- a/doc/Extensions/Oxidized.md
+++ b/doc/Extensions/Oxidized.md
@@ -244,6 +244,20 @@ If you have devices which you do not wish to appear in Oxidized then
 you can edit those devices in Device -> Edit -> Misc and enable
 "Exclude from Oxidized?"
 
+The use of custom ssh and telnet ports can be set through device settings misc tab, and can be passed on to oxidized with the following `vars_map`
+
+```bash
+      source:
+        http:
+          map:
+            name: hostname
+            model: os
+            group: group
+          vars_map:
+            ssh_port: ssh_port
+            telnet_port: telnet_port
+```
+
 It's also possible to exclude certain device types and OS' from being
 output via the API.
 

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -1491,12 +1491,20 @@ function list_oxidized(Illuminate\Http\Request $request)
 
     /** @var Device $device */
     foreach ($devices as $device) {
+        $device['device_id'] = DeviceCache::getByHostname($device->hostname)->device_id;
         $output = [
             'hostname' => $device->hostname,
             'os' => $device->os,
             'ip' => $device->ip,
         ];
-
+        $custom_ssh_port = get_dev_attrib($device, 'override_device_ssh_port');
+        if (!empty($custom_ssh_port)) {
+            $output["ssh_port"] = $custom_ssh_port;
+        }
+        $custom_telnet_port = get_dev_attrib($device, 'override_device_telnet_port');
+        if (!empty($custom_telnet_port)) {
+            $output["telnet_port"] = $custom_telnet_port;
+        }
         // Pre-populate the group with the default
         if (Config::get('oxidized.group_support') === true && ! empty(Config::get('oxidized.default_group'))) {
             $output['group'] = Config::get('oxidized.default_group');

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -1498,12 +1498,12 @@ function list_oxidized(Illuminate\Http\Request $request)
             'ip' => $device->ip,
         ];
         $custom_ssh_port = get_dev_attrib($device, 'override_device_ssh_port');
-        if (!empty($custom_ssh_port)) {
-            $output["ssh_port"] = $custom_ssh_port;
+        if (! empty($custom_ssh_port)) {
+            $output['ssh_port'] = $custom_ssh_port;
         }
         $custom_telnet_port = get_dev_attrib($device, 'override_device_telnet_port');
-        if (!empty($custom_telnet_port)) {
-            $output["telnet_port"] = $custom_telnet_port;
+        if (! empty($custom_telnet_port)) {
+            $output['telnet_port'] = $custom_telnet_port;
         }
         // Pre-populate the group with the default
         if (Config::get('oxidized.group_support') === true && ! empty(Config::get('oxidized.default_group'))) {

--- a/includes/html/pages/device/edit/misc.inc.php
+++ b/includes/html/pages/device/edit/misc.inc.php
@@ -16,19 +16,19 @@ echo '
         </div>
     </div>
     <div class="form-group">
-        <label for="unixagent" class="col-sm-4 control-label">Override default ssh port</label>
+        <label for="override_ssh" class="col-sm-4 control-label">Override default ssh port</label>
         <div class="col-sm-8">
             ' . dynamic_override_config('text', 'override_device_ssh_port', $device) . '
         </div>
     </div>
     <div class="form-group">
-        <label for="unixagent" class="col-sm-4 control-label">Override default telnet port</label>
+        <label for="override_telnet" class="col-sm-4 control-label">Override default telnet port</label>
         <div class="col-sm-8">
             ' . dynamic_override_config('text', 'override_device_telnet_port', $device) . '
         </div>
     </div>
     <div class="form-group">
-        <label for="unixagent" class="col-sm-4 control-label">Override default http port</label>
+        <label for="override_http" class="col-sm-4 control-label">Override default http port</label>
         <div class="col-sm-8">
             ' . dynamic_override_config('text', 'override_device_http_port', $device) . '
         </div>
@@ -40,7 +40,7 @@ echo '
         </div>
     </div>
     <div class="form-group">
-        <label for="unixagent" class="col-sm-4 control-label">Enable RRD Tune for all ports?</label>
+        <label for="rrdtool_tune" class="col-sm-4 control-label">Enable RRD Tune for all ports?</label>
         <div class="col-sm-8">
             ' . dynamic_override_config('checkbox', 'override_rrdtool_tune', $device) . '
         </div>

--- a/includes/html/pages/device/edit/misc.inc.php
+++ b/includes/html/pages/device/edit/misc.inc.php
@@ -16,6 +16,24 @@ echo '
         </div>
     </div>
     <div class="form-group">
+        <label for="unixagent" class="col-sm-4 control-label">Override default ssh port</label>
+        <div class="col-sm-8">
+            ' . dynamic_override_config('text', 'override_device_ssh_port', $device) . '
+        </div>
+    </div>
+    <div class="form-group">
+        <label for="unixagent" class="col-sm-4 control-label">Override default telnet port</label>
+        <div class="col-sm-8">
+            ' . dynamic_override_config('text', 'override_device_telnet_port', $device) . '
+        </div>
+    </div>
+    <div class="form-group">
+        <label for="unixagent" class="col-sm-4 control-label">Override default http port</label>
+        <div class="col-sm-8">
+            ' . dynamic_override_config('text', 'override_device_http_port', $device) . '
+        </div>
+    </div>
+    <div class="form-group">
         <label for="unixagent" class="col-sm-4 control-label">Unix agent port</label>
         <div class="col-sm-8">
             ' . dynamic_override_config('text', 'override_Unixagent_port', $device) . '


### PR DESCRIPTION
New misc device setting to pass on within the oxidized list api.

This addition allows Librenms to let oxidized know on which port it can connect to the device.
Motivation for this is an environment with several remote devices behind NAT with a wide range of ports. Using the grouping feature got messy on both Librenms and oxidized config.

With this PR librenms adds `ssh_port` if misc value is set to the list which in oxidized config can be mapped using `vars_map:`

Additionally if the custom port is set the device action Uri's for ssh:// telnet:// http:// will be appended with the custom ports.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
