### PR TITLE
Add ui description for reporting dump_errors

### DIFF
--- a/html/mix-manifest.json
+++ b/html/mix-manifest.json
@@ -5,7 +5,7 @@
     "/css/app.css": "/css/app.css?id=ddaa1664b2b7b9dc3293",
     "/js/vendor.js": "/js/vendor.js?id=9a257386f44b3d7f29bc",
     "/js/lang/de.js": "/js/lang/de.js?id=d74df23e729c5dabfee8",
-    "/js/lang/en.js": "/js/lang/en.js?id=4ea5e56f2ff6fbab1244",
+    "/js/lang/en.js": "/js/lang/en.js?id=98442c0577fed73bc90c",
     "/js/lang/fr.js": "/js/lang/fr.js?id=22902d30358443ef2877",
     "/js/lang/it.js": "/js/lang/it.js?id=6220e138068a7e58387f",
     "/js/lang/ru.js": "/js/lang/ru.js?id=f6b7c078755312a0907c",

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -1277,7 +1277,7 @@ return [
             ],
             'dump_errors' => [
                 'description' => 'Dump debug errors (Will break your install)',
-                'help' => 'Dump out errors that are normally hidden so you as a developer can find and fix the possible issues.'
+                'help' => 'Dump out errors that are normally hidden so you as a developer can find and fix the possible issues.',
             ],
         ],
         'route_purge' => [

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -1275,6 +1275,10 @@ return [
                 'description' => 'Send Usage Reports',
                 'help' => 'Reports usage and versions to LibreNMS. To delete anonymous stats, visit the about page. You can view stats at https://stats.librenms.org',
             ],
+            'dump_errors' => [
+                'description' => 'Dump debug errors (Will break your install)',
+                'help' => 'Dump out errors that are normally hidden so you as a developer can find and fix the possible issues.'
+            ],
         ],
         'route_purge' => [
             'description' => 'Route entries older than',


### PR DESCRIPTION
People were enabling this setting and breaking their installs for some reason.
Hopefully, this makes them think a little before enabling this setting.
It is intended for debugging purposes only.

https://community.librenms.org/t/website-no-longer-loads-validate-command-shows-exception-errors/20627
https://community.librenms.org/t/php-exceptions-and-broken-graphs/20946

fixes #15263


#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
