### PR TITLE
add apps.no_app_id config item and add support for it to Logsize

### DIFF
--- a/doc/Extensions/Applications.md
+++ b/doc/Extensions/Applications.md
@@ -155,6 +155,25 @@ LibreNMS during discovery and polling.
 
 ![Enable-applications](/img/Enable_applications.png)
 
+## Disabling using app ID with RRDs
+
+When a application is discovered it is assigned a ID. Then if
+discovery runs again and it has issues polling that app, that app
+will be removed from database table and it will loose association
+with that app ID, meaning next redicovery in which it is found
+it have a new app ID and have lost the previous RRDs.
+
+Using app ID in the naming of the app RRDs can be disabled as below.
+
+```
+lnms config:set apps.no_app_id true
+```
+
+This requires application specific support and ones that support this
+are listed below.
+
+- Logsize
+
 ## Agent
 
 The unix-agent does not have a discovery module, only a poller

--- a/includes/html/graphs/application/logsize-common.inc.php
+++ b/includes/html/graphs/application/logsize-common.inc.php
@@ -1,11 +1,27 @@
 <?php
 
+use LibreNMS\Config;
+
+$no_app_id = Config::get('apps.no_app_id');
+
 $name = 'logsize';
 
 if (isset($vars['log_set']) && isset($vars['log_file'])) {
-    $filename = Rrd::name($device['hostname'], ['app', $name, $app->app_id, $vars['log_set'] . '_____-_____' . $vars['log_file']]);
+    if ($no_app_id) {
+        $filename = Rrd::name($device['hostname'], ['app', $name, $vars['log_set'] . '_____-_____' . $vars['log_file']]);
+    } else {
+        $filename = Rrd::name($device['hostname'], ['app', $name, $app->app_id, $vars['log_set'] . '_____-_____' . $vars['log_file']]);
+    }
 } elseif (isset($vars['log_set'])) {
-    $filename = Rrd::name($device['hostname'], ['app', $name, $app->app_id, $vars['log_set']]);
+    if ($no_app_id) {
+        $filename = Rrd::name($device['hostname'], ['app', $name, $vars['log_set']]);
+    } else {
+        $filename = Rrd::name($device['hostname'], ['app', $name, $app->app_id, $vars['log_set']]);
+    }
 } else {
-    $filename = Rrd::name($device['hostname'], ['app', $name, $app->app_id]);
+    if ($no_app_id) {
+        $filename = Rrd::name($device['hostname'], ['app', $name]);
+    } else {
+        $filename = Rrd::name($device['hostname'], ['app', $name, $app->app_id]);
+    }
 }

--- a/includes/html/graphs/application/logsize_log_sizes.inc.php
+++ b/includes/html/graphs/application/logsize_log_sizes.inc.php
@@ -1,5 +1,9 @@
 <?php
 
+use LibreNMS\Config;
+
+$no_app_id = Config::get('apps.no_app_id');
+
 $name = 'logsize';
 $app_id = $app['app_id'];
 $unit_text = 'Bytes';
@@ -16,7 +20,11 @@ $log_files = array_slice(array_keys($log_files_sizes), 0, 12);
 
 $rrd_list = [];
 foreach ($log_files as $index => $log_file) {
-    $rrd_filename = Rrd::name($device['hostname'], ['app', $name, $app['app_id'], $vars['log_set'] . '_____-_____' . $log_file]);
+    if ($no_app_id) {
+        $rrd_filename = Rrd::name($device['hostname'], ['app', $name, $vars['log_set'] . '_____-_____' . $log_file]);
+    } else {
+        $rrd_filename = Rrd::name($device['hostname'], ['app', $name, $app['app_id'], $vars['log_set'] . '_____-_____' . $log_file]);
+    }
     $rrd_list[] = [
         'filename' => $rrd_filename,
         'descr'    => $log_file,

--- a/includes/html/graphs/application/logsize_set_sizes.inc.php
+++ b/includes/html/graphs/application/logsize_set_sizes.inc.php
@@ -15,7 +15,11 @@ $log_sets = Rrd::getRrdApplicationArrays($device, $app['app_id'], 'logsize');
 $rrd_list = [];
 foreach ($log_sets as $index => $log_set) {
     if (! preg_match('/\_\_\_\_\_\-\_\_\_\_\_/', $log_set)) {
-        $rrd_filename = Rrd::name($device['hostname'], ['app', $name, $app['app_id'], $log_set]);
+        if ($no_app_id) {
+            $rrd_filename = Rrd::name($device['hostname'], ['app', $name, $log_set]);
+        } else {
+            $rrd_filename = Rrd::name($device['hostname'], ['app', $name, $app['app_id'], $log_set]);
+        }
         $rrd_list[] = [
             'filename' => $rrd_filename,
             'descr'    => $log_set,

--- a/includes/polling/applications/logsize.inc.php
+++ b/includes/polling/applications/logsize.inc.php
@@ -88,9 +88,9 @@ foreach ($data['sets'] as $set_name => $set_data) {
 
     foreach ($set_data['files'] as $log_name => $log_size) {
         if ($no_app_id) {
-            $rrd_name = ['app', $name, $app->app_id, $set_name . '_____-_____' . $log_name];
-        } else {
             $rrd_name = ['app', $name, $set_name . '_____-_____' . $log_name];
+        } else {
+            $rrd_name = ['app', $name, $app->app_id, $set_name . '_____-_____' . $log_name];
         }
         $fields = [
             'size' => $log_size,
@@ -105,9 +105,9 @@ foreach ($data['sets'] as $set_name => $set_data) {
 
     foreach ($set_data['unseen'] as $log_name) {
         if ($no_app_id) {
-            $rrd_name = ['app', $name, $set_name . '_____-_____' . $log_name];
-        } else {
             $rrd_name = ['app', $name, $app->app_id, $set_name . '_____-_____' . $log_name];
+        } else {
+            $rrd_name = ['app', $name, $set_name . '_____-_____' . $log_name];
         }
         $fields = [
             'size' => 0,

--- a/includes/polling/applications/logsize.inc.php
+++ b/includes/polling/applications/logsize.inc.php
@@ -1,8 +1,8 @@
 <?php
 
+use LibreNMS\Config;
 use LibreNMS\Exceptions\JsonAppException;
 use LibreNMS\RRD\RrdDefinition;
-use LibreNMS\Config;
 
 $name = 'logsize';
 

--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -370,6 +370,10 @@
             "default": false,
             "type": "boolean"
         },
+        "apps.no_app_id": {
+            "default": false,
+            "type": "boolean"
+        },
         "astext": {
             "default": {
                 "65332": "Cymru FullBogon Feed",


### PR DESCRIPTION
Created this due to network issues with remote sensors occasionally leads to apps being removed and re-added, resulting in loss of old monitoring data.

This adds a optional work around for that via adding in a new config item to control if the app ID is used in the RRD file name.

Initial support has been added to Logsize.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
