### PR TITLE
Additional contact options for email transports

### DIFF
--- a/LibreNMS/Alert/AlertData.php
+++ b/LibreNMS/Alert/AlertData.php
@@ -80,7 +80,7 @@ class AlertData extends \Illuminate\Support\Collection
             'name' => 'Test-Rule',
             'string' => '#1: test => string;',
             'timestamp' => date('Y-m-d H:i:s'),
-            'contacts' => AlertUtil::getContacts($device->toArray()),
+            'contacts' => AlertUtil::getContacts([$device->toArray()]),
             'state' => AlertState::ACTIVE,
             'msg' => 'This is a test alert',
             'builder' => '{}',

--- a/LibreNMS/Alert/AlertUtil.php
+++ b/LibreNMS/Alert/AlertUtil.php
@@ -151,7 +151,7 @@ class AlertUtil
         return User::whereIs(...$roles)->whereNot('email', '')->dumpRawSql()->pluck('realname', 'email')->toArray();
     }
 
-    public static function findContactsSysContact(array $results): arraay
+    public static function findContactsSysContact(array $results): array
     {
         $contacts = [];
 

--- a/LibreNMS/Alert/AlertUtil.php
+++ b/LibreNMS/Alert/AlertUtil.php
@@ -28,6 +28,8 @@ namespace LibreNMS\Alert;
 use App\Models\Device;
 use App\Models\User;
 use DeviceCache;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\DB;
 use LibreNMS\Config;
 use PHPMailer\PHPMailer\PHPMailer;
 
@@ -83,59 +85,28 @@ class AlertUtil
         if (empty($results)) {
             return [];
         }
+
         if (Config::get('alert.default_only') === true || Config::get('alerts.email.default_only') === true) {
             $email = Config::get('alert.default_mail', Config::get('alerts.email.default'));
 
             return $email ? [$email => ''] : [];
         }
-        $users = User::query()->thisAuth()->get();
+
         $contacts = [];
-        $uids = [];
-        foreach ($results as $result) {
-            $tmp = null;
-            if (isset($result['bill_id']) && is_numeric($result['bill_id'])) {
-                $tmpa = dbFetchRows('SELECT user_id FROM bill_perms WHERE bill_id = ?', [$result['bill_id']]);
-                foreach ($tmpa as $tmp) {
-                    $uids[$tmp['user_id']] = $tmp['user_id'];
-                }
-            }
-            if (isset($result['port_id']) && is_numeric($result['port_id'])) {
-                $tmpa = dbFetchRows('SELECT user_id FROM ports_perms WHERE port_id = ?', [$result['port_id']]);
-                foreach ($tmpa as $tmp) {
-                    $uids[$tmp['user_id']] = $tmp['user_id'];
-                }
-            }
-            if (isset($result['device_id']) && is_numeric($result['device_id'])) {
-                if (Config::get('alert.syscontact') == true) {
-                    if (dbFetchCell("SELECT attrib_value FROM devices_attribs WHERE attrib_type = 'override_sysContact_bool' AND device_id = ?", [$result['device_id']])) {
-                        $tmpa = dbFetchCell("SELECT attrib_value FROM devices_attribs WHERE attrib_type = 'override_sysContact_string' AND device_id = ?", [$result['device_id']]);
-                    } else {
-                        $tmpa = dbFetchCell('SELECT sysContact FROM devices WHERE device_id = ?', [$result['device_id']]);
-                    }
-                    if (! empty($tmpa)) {
-                        $contacts[$tmpa] = '';
-                    }
-                }
-                $tmpa = dbFetchRows('SELECT user_id FROM devices_perms WHERE device_id = ?', [$result['device_id']]);
-                foreach ($tmpa as $tmp) {
-                    $uids[$tmp['user_id']] = $tmp['user_id'];
-                }
-            }
+
+        if (Config::get('alert.syscontact')) {
+            $contacts = array_merge($contacts, self::findContactsSysContact($results));
         }
-        foreach ($users as $user) {
-            if (empty($user->email)) {
-                continue; // no email, skip this user
-            }
 
-            $name = $user->realname ?: $user->username;
+        if (Config::get('alert.users')) {
+            $contacts = array_merge($contacts, self::findContactsOwners($results));
+        }
 
-            if (Config::get('alert.globals') && $user->hasGlobalRead()) {
-                $contacts[$user->email] = $name;
-            } elseif (Config::get('alert.admins') && $user->isAdmin()) {
-                $contacts[$user->email] = $name;
-            } elseif (Config::get('alert.users') && in_array($user['user_id'], $uids)) {
-                $contacts[$user->email] = $name;
-            }
+        $roles = Config::get('alert.globals')
+            ? ['admin', 'global-read']
+            : (Config::get('alert.admins') ? ['admin'] : []);
+        if ($roles) {
+            $contacts = array_merge($contacts, self::findContactsRoles($roles));
         }
 
         $tmp_contacts = [];
@@ -173,6 +144,53 @@ class AlertUtil
         }
 
         return $tmp_contacts;
+    }
+
+    public static function findContactsRoles(array $roles): array
+    {
+        return User::whereIs(...$roles)->whereNot('email', '')->dumpRawSql()->pluck('realname', 'email')->toArray();
+    }
+
+    public static function findContactsSysContact(array $results): arraay
+    {
+        $contacts = [];
+
+        foreach ($results as $result) {
+            $device = DeviceCache::get($result);
+            $email = $device->getAttrib('override_sysContact_bool')
+                ? $device->getAttrib('override_sysContact_string')
+                : $device->sysContact;
+            $contacts[$email] = '';
+        }
+
+        return $contacts;
+    }
+
+    public static function findContactsOwners(array $results): array
+    {
+        return User::whereNot('email', '')->whereIn('user_id', function (\Illuminate\Database\Query\Builder $query) use ($results) {
+            $tables = [
+                'bill_id' => 'bill_perms',
+                'port_id' => 'ports_perms',
+                'device_id' => 'devices_perms',
+            ];
+
+            $first = true;
+            foreach ($tables as $column => $table) {
+                $ids = array_filter(Arr::pluck($results, $column)); // find IDs for this type
+
+                if (! empty($ids)) {
+                    if ($first) {
+                        $query->select('user_id')->from($table)->whereIn($column, $ids);
+                        $first = false;
+                    } else {
+                        $query->union(DB::table($table)->select('user_id')->whereIn($column, $ids));
+                    }
+                }
+            }
+
+            return $query;
+        })->pluck('realname', 'email')->all();
     }
 
     public static function getRules($device_id)

--- a/LibreNMS/Alert/Transport/Mail.php
+++ b/LibreNMS/Alert/Transport/Mail.php
@@ -31,7 +31,7 @@ class Mail extends Transport
 {
     public function deliverAlert(array $alert_data): bool
     {
-        $emails = match($this->config['mail-contact']) {
+        $emails = match ($this->config['mail-contact']) {
             'sysContact' => AlertUtil::findContactsSysContact($alert_data['faults']),
             'owners' => AlertUtil::findContactsOwners($alert_data['faults']),
             'role' => AlertUtil::findContactsRoles([$this->config['role']]),
@@ -66,7 +66,7 @@ class Mail extends Transport
                         'Specified Email' => 'email',
                         'Device sysContact' => 'sysContact',
                         'Owner(s)' => 'owners',
-                        'Role' => 'role'
+                        'Role' => 'role',
                     ],
                     'default' => 'email',
                 ],

--- a/LibreNMS/Alert/Transport/Mail.php
+++ b/LibreNMS/Alert/Transport/Mail.php
@@ -23,6 +23,7 @@
 
 namespace LibreNMS\Alert\Transport;
 
+use LibreNMS\Alert\AlertUtil;
 use LibreNMS\Alert\Transport;
 use LibreNMS\Config;
 
@@ -30,7 +31,13 @@ class Mail extends Transport
 {
     public function deliverAlert(array $alert_data): bool
     {
-        $email = $this->config['email'] ?? $alert_data['contacts'];
+        $emails = match($this->config['mail-contact']) {
+            'sysContact' => AlertUtil::findContactsSysContact($alert_data['faults']),
+            'owners' => AlertUtil::findContactsOwners($alert_data['faults']),
+            'role' => AlertUtil::findContactsRoles([$this->config['role']]),
+            default => $this->config['email'],
+        };
+
         $html = Config::get('email_html');
 
         if ($html && ! $this->isHtmlContent($alert_data['msg'])) {
@@ -41,18 +48,40 @@ class Mail extends Transport
             $msg = preg_replace("/(?<!\r)\n/", "\r\n", $alert_data['msg']);
         }
 
-        return \LibreNMS\Util\Mail::send($email, $alert_data['title'], $msg, $html, $this->config['attach-graph'] ?? null);
+        return \LibreNMS\Util\Mail::send($emails, $alert_data['title'], $msg, $html, $this->config['attach-graph'] ?? null);
     }
 
     public static function configTemplate(): array
     {
+        $roles = array_merge(['None' => ''], \Bouncer::role()->pluck('name', 'title')->all());
+
         return [
             'config' => [
+                [
+                    'title' => 'Contact Type',
+                    'name' => 'mail-contact',
+                    'descr' => 'Method for selecting contacts',
+                    'type'  => 'select',
+                    'options' => [
+                        'Specified Email' => 'email',
+                        'Device sysContact' => 'sysContact',
+                        'Owner(s)' => 'owners',
+                        'Role' => 'role'
+                    ],
+                    'default' => 'email',
+                ],
                 [
                     'title' => 'Email',
                     'name' => 'email',
                     'descr' => 'Email address of contact',
                     'type'  => 'text',
+                ],
+                [
+                    'title' => 'Role',
+                    'name' => 'role',
+                    'descr' => 'Role of users to mail',
+                    'type'  => 'select',
+                    'options' => $roles,
                 ],
                 [
                     'title' => 'Include Graphs',
@@ -63,7 +92,9 @@ class Mail extends Transport
                 ],
             ],
             'validation' => [
-                'email' => 'required|email',
+                'mail-contact' => 'required|in:email,sysContact,owners,role',
+                'email' => 'required_if:mail-contact,email|prohibited_unless:mail-contact,email|email',
+                'role' => 'required_if:mail-contact,role|prohibited_unless:mail-contact,role|exists:roles,name',
             ],
         ];
     }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,6 +1,11 @@
 parameters:
 	ignoreErrors:
 		-
+			message: "#^Static method Silber\\\\Bouncer\\\\BouncerFacade\\:\\:role\\(\\) invoked with 0 parameters, 1 required\\.$#"
+			count: 1
+			path: LibreNMS/Alert/Transport/Mail.php
+
+		-
 			message: "#^Property LibreNMS\\\\Data\\\\Store\\\\Rrd\\:\\:\\$async_process \\(LibreNMS\\\\Proc\\) in isset\\(\\) is not nullable\\.$#"
 			count: 1
 			path: LibreNMS/Data/Store/Rrd.php


### PR DESCRIPTION
- email: same as always
- sysContact: the sysContact field from the device's snmp response (or overriden one)
- owners: users that have been assigned explicit permission to the device, port, or bill
- role: all members of a role

Note: users must have valid email fields to be included.

Similar system email options will be deprecated:
alert.default_only
alert.syscontact
alert.users
alert.globals
alert.admins

It is suggested to set them to false and migrate to the new transport options.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
