### PR TITLE
Hide token, keys and passwords in Transports

### DIFF
--- a/LibreNMS/Alert/Transport/Alerta.php
+++ b/LibreNMS/Alert/Transport/Alerta.php
@@ -83,7 +83,7 @@ class Alerta extends Transport
                     'title' => 'Api Key',
                     'name' => 'apikey',
                     'descr' => 'Your alerta api key with minimally write:alert permissions.',
-                    'type' => 'text',
+                    'type' => 'password',
                 ],
                 [
                     'title' => 'Alert State',

--- a/LibreNMS/Alert/Transport/Canopsis.php
+++ b/LibreNMS/Alert/Transport/Canopsis.php
@@ -97,7 +97,7 @@ class Canopsis extends Transport
                     'title' => 'Password',
                     'name' => 'canopsis-pass',
                     'descr' => 'Canopsis Password',
-                    'type' => 'text',
+                    'type' => 'password',
                 ],
                 [
                     'title' => 'Vhost',

--- a/LibreNMS/Alert/Transport/Ciscospark.php
+++ b/LibreNMS/Alert/Transport/Ciscospark.php
@@ -55,7 +55,7 @@ class Ciscospark extends Transport
                     'title' => 'API Token',
                     'name' => 'api-token',
                     'descr' => 'CiscoSpark API Token',
-                    'type' => 'text',
+                    'type' => 'password',
                 ],
                 [
                     'title' => 'RoomID',

--- a/LibreNMS/Alert/Transport/Clickatell.php
+++ b/LibreNMS/Alert/Transport/Clickatell.php
@@ -55,7 +55,7 @@ class Clickatell extends Transport
                     'title' => 'Token',
                     'name'  => 'clickatell-token',
                     'descr' => 'Clickatell Token',
-                    'type'  => 'text',
+                    'type'  => 'password',
                 ],
                 [
                     'title' => 'Mobile Numbers',

--- a/LibreNMS/Alert/Transport/Gitlab.php
+++ b/LibreNMS/Alert/Transport/Gitlab.php
@@ -78,7 +78,7 @@ class Gitlab extends Transport
                     'title' => 'Personal Access Token',
                     'name' => 'gitlab-key',
                     'descr' => 'Personal Access Token',
-                    'type' => 'text',
+                    'type' => 'password',
                 ],
             ],
             'validation' => [

--- a/LibreNMS/Alert/Transport/Jira.php
+++ b/LibreNMS/Alert/Transport/Jira.php
@@ -99,7 +99,7 @@ class Jira extends Transport
                     'title' => 'Jira Password',
                     'name' => 'jira-password',
                     'descr' => 'Jira Password',
-                    'type' => 'text',
+                    'type' => 'password',
                 ],
             ],
             'validation' => [

--- a/LibreNMS/Alert/Transport/Kayako.php
+++ b/LibreNMS/Alert/Transport/Kayako.php
@@ -79,7 +79,7 @@ class Kayako extends Transport
                     'title' => 'Kayako API Secret',
                     'name' => 'kayako-secret',
                     'descr' => 'ServiceDesk API Secret Key',
-                    'type' => 'text',
+                    'type' => 'password',
                 ],
                 [
                     'title' => 'Kayako Department',

--- a/LibreNMS/Alert/Transport/Linemessagingapi.php
+++ b/LibreNMS/Alert/Transport/Linemessagingapi.php
@@ -62,7 +62,7 @@ class LineMessagingAPI extends Transport
                     'title' => 'Access token',
                     'name' => 'line-messaging-token',
                     'descr' => 'LINE Channel access token',
-                    'type' => 'text',
+                    'type' => 'password',
                 ],
                 [
                     'title' => 'Recipient (groupID, userID or roomID)',

--- a/LibreNMS/Alert/Transport/Linenotify.php
+++ b/LibreNMS/Alert/Transport/Linenotify.php
@@ -39,7 +39,7 @@ class Linenotify extends Transport
                     'title' => 'Token',
                     'name' => 'line-notify-access-token',
                     'descr' => 'LINE Notify Token',
-                    'type' => 'text',
+                    'type' => 'password',
                 ],
             ],
             'validation' => [

--- a/LibreNMS/Alert/Transport/Matrix.php
+++ b/LibreNMS/Alert/Transport/Matrix.php
@@ -78,7 +78,7 @@ class Matrix extends Transport
                     'title' => 'Auth_token',
                     'name' => 'matrix-authtoken',
                     'descr' => 'Enter the auth_token',
-                    'type' => 'text',
+                    'type' => 'password',
                 ],
                 [
                     'title' => 'Message',

--- a/LibreNMS/Alert/Transport/Messagebird.php
+++ b/LibreNMS/Alert/Transport/Messagebird.php
@@ -69,7 +69,7 @@ class Messagebird extends Transport
                     'title' => 'Messagebird API key',
                     'name' => 'messagebird-key',
                     'descr' => 'Messagebird API REST key',
-                    'type' => 'text',
+                    'type' => 'password',
                 ],
                 [
                     'title' => 'Messagebird originator',

--- a/LibreNMS/Alert/Transport/Messagebirdvoice.php
+++ b/LibreNMS/Alert/Transport/Messagebirdvoice.php
@@ -72,7 +72,7 @@ class Messagebirdvoice extends Transport
                     'title' => 'Messagebird API key',
                     'name' => 'messagebird-key',
                     'descr' => 'Messagebird API REST key',
-                    'type' => 'text',
+                    'type' => 'password',
                 ],
                 [
                     'title' => 'Messagebird originator',

--- a/LibreNMS/Alert/Transport/Osticket.php
+++ b/LibreNMS/Alert/Transport/Osticket.php
@@ -66,7 +66,7 @@ class Osticket extends Transport
                     'title' => 'API Token',
                     'name' => 'os-token',
                     'descr' => 'osTicket API Token',
-                    'type' => 'text',
+                    'type' => 'password',
                 ],
             ],
             'validation' => [

--- a/LibreNMS/Alert/Transport/Playsms.php
+++ b/LibreNMS/Alert/Transport/Playsms.php
@@ -77,7 +77,7 @@ class Playsms extends Transport
                     'title' => 'Token',
                     'name' => 'playsms-token',
                     'descr' => 'PlaySMS Token',
-                    'type' => 'text',
+                    'type' => 'password',
                 ],
                 [
                     'title' => 'From',

--- a/LibreNMS/Alert/Transport/Pushbullet.php
+++ b/LibreNMS/Alert/Transport/Pushbullet.php
@@ -54,7 +54,7 @@ class Pushbullet extends Transport
                     'title' => 'Access Token',
                     'name' => 'pushbullet-token',
                     'descr' => 'Pushbullet Access Token',
-                    'type' => 'text',
+                    'type' => 'password',
                 ],
             ],
             'validation' => [

--- a/LibreNMS/Alert/Transport/Pushover.php
+++ b/LibreNMS/Alert/Transport/Pushover.php
@@ -97,13 +97,13 @@ class Pushover extends Transport
                     'title' => 'Api Key',
                     'name'  => 'appkey',
                     'descr' => 'Api Key',
-                    'type'  => 'text',
+                    'type'  => 'password',
                 ],
                 [
                     'title' => 'User Key',
                     'name'  => 'userkey',
                     'descr' => 'User Key',
-                    'type'  => 'text',
+                    'type'  => 'password',
                 ],
                 [
                     'title' => 'Pushover Options',

--- a/LibreNMS/Alert/Transport/Signalwire.php
+++ b/LibreNMS/Alert/Transport/Signalwire.php
@@ -66,7 +66,7 @@ class Signalwire extends Transport
                     'title' => 'Token',
                     'name' => 'signalwire-token',
                     'descr' => 'SignalWire Account Token ',
-                    'type' => 'text',
+                    'type' => 'password',
                 ],
                 [
                     'title' => 'Mobile Number',

--- a/LibreNMS/Alert/Transport/Smseagle.php
+++ b/LibreNMS/Alert/Transport/Smseagle.php
@@ -74,7 +74,7 @@ class Smseagle extends Transport
                     'title' => 'Access Token',
                     'name' => 'smseagle-token',
                     'descr' => 'SMSEagle Access Token',
-                    'type' => 'text',
+                    'type' => 'password',
                 ],
                 [
                     'title' => 'User',
@@ -86,7 +86,7 @@ class Smseagle extends Transport
                     'title' => 'Password',
                     'name' => 'smseagle-pass',
                     'descr' => 'SMSEagle Password',
-                    'type' => 'text',
+                    'type' => 'password',
                 ],
                 [
                     'title' => 'Mobiles',

--- a/LibreNMS/Alert/Transport/Smsfeedback.php
+++ b/LibreNMS/Alert/Transport/Smsfeedback.php
@@ -65,7 +65,7 @@ class Smsfeedback extends Transport
                     'title' => 'Password',
                     'name' => 'smsfeedback-pass',
                     'descr' => 'smsfeedback Password',
-                    'type' => 'text',
+                    'type' => 'password',
                 ],
                 [
                     'title' => 'Mobiles',

--- a/LibreNMS/Alert/Transport/Telegram.php
+++ b/LibreNMS/Alert/Transport/Telegram.php
@@ -81,7 +81,7 @@ class Telegram extends Transport
                     'title' => 'Token',
                     'name' => 'telegram-token',
                     'descr' => 'Telegram Token',
-                    'type' => 'text',
+                    'type' => 'password',
                 ],
                 [
                     'title' => 'Format',

--- a/LibreNMS/Alert/Transport/Twilio.php
+++ b/LibreNMS/Alert/Transport/Twilio.php
@@ -56,7 +56,7 @@ class Twilio extends Transport
                     'title' => 'Token',
                     'name' => 'twilio-token',
                     'descr' => 'Twilio Account Token',
-                    'type' => 'text',
+                    'type' => 'password',
                 ],
                 [
                     'title' => 'Mobile Number',

--- a/LibreNMS/Alert/Transport/Ukfastpss.php
+++ b/LibreNMS/Alert/Transport/Ukfastpss.php
@@ -71,7 +71,7 @@ class Ukfastpss extends Transport
                     'title' => 'API Key',
                     'name' => 'api-key',
                     'descr' => 'API key to use for authentication',
-                    'type' => 'text',
+                    'type' => 'password',
                 ],
                 [
                     'title' => 'Author',


### PR DESCRIPTION
I've gone over all the Transporters adn changed all 'text' fields for token, keys and passwords to 'password' so the no longer show up as clear text in the GUI

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
