### PR TITLE
for the applications table set the defaults for app_instance and app_instance to ''

### DIFF
--- a/database/migrations/2023_09_01_084057_application_new_defaults.php
+++ b/database/migrations/2023_09_01_084057_application_new_defaults.php
@@ -15,7 +15,7 @@ class ApplicationNewDefaults extends Migration
     {
         Schema::table('applications', function (Blueprint $table) {
             $table->string('app_instance')->default('')->change();
-            $table->string('app_status')->default('')->change();
+            $table->string('app_status', 1024)->default('')->change();
         });
     }
 
@@ -28,7 +28,7 @@ class ApplicationNewDefaults extends Migration
     {
         Schema::table('applications', function (Blueprint $table) {
             $table->string('app_instance')->default(null)->change();
-            $table->string('app_status')->default(null)->change();
+            $table->string('app_status', 1024)->default(null)->change();
         });
     }
 }

--- a/database/migrations/2023_09_01_084057_application_new_defaults.php
+++ b/database/migrations/2023_09_01_084057_application_new_defaults.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class ApplicationNewDefaults extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('applications', function (Blueprint $table) {
+            $table->string('app_instance')->default('')->change();
+            $table->string('app_status')->default('')->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('applications', function (Blueprint $table) {
+            $table->string('app_instance')->default(null)->change();
+            $table->string('app_status')->default(null)->change();
+        });
+    }
+}

--- a/misc/db_schema.yaml
+++ b/misc/db_schema.yaml
@@ -183,9 +183,9 @@ applications:
     - { Field: app_state, Type: varchar(32), 'Null': false, Extra: '', Default: UNKNOWN }
     - { Field: discovered, Type: tinyint, 'Null': false, Extra: '', Default: '0' }
     - { Field: app_state_prev, Type: varchar(32), 'Null': true, Extra: '' }
-    - { Field: app_status, Type: varchar(1024), 'Null': false, Extra: '' }
+    - { Field: app_status, Type: varchar(1024), 'Null': false, Extra: '', Default: '' }
     - { Field: timestamp, Type: timestamp, 'Null': false, Extra: 'on update CURRENT_TIMESTAMP', Default: CURRENT_TIMESTAMP }
-    - { Field: app_instance, Type: varchar(255), 'Null': false, Extra: '' }
+    - { Field: app_instance, Type: varchar(255), 'Null': false, Extra: '', Default: '' }
     - { Field: data, Type: longtext, 'Null': true, Extra: '' }
   Indexes:
     PRIMARY: { Name: PRIMARY, Columns: [app_id], Unique: true, Type: BTREE }


### PR DESCRIPTION
Previously `app_status` and `app_instance` had a default value of null. Simplify that to '' as that is what both discovery and enabling via web does so those don't need manually set each time.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
