### PR TITLE
Update renamehost to include more logging if a folder already exists#

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -160,8 +160,15 @@ function getImageName($device, $use_database = true, $dir = 'images/os/')
 function renamehost($id, $new, $source = 'console')
 {
     $host = gethostbyid($id);
+    $new_rrd_dir = Rrd::dirFromHost($new);
 
-    if (! is_dir(Rrd::dirFromHost($new)) && rename(Rrd::dirFromHost($host), Rrd::dirFromHost($new)) === true) {
+    if (is_dir($new_rrd_dir)) {
+        log_event("Renaming of $host failed due to existing RRD folder for $new", $id, 'system', 5);
+
+        return "Renaming of $host failed due to existing RRD folder for $new\n";
+    }
+
+    if (! is_dir($new_rrd_dir) && rename(Rrd::dirFromHost($host), $new_rrd_dir) === true) {
         dbUpdate(['hostname' => $new, 'ip' => null], 'devices', 'device_id=?', [$id]);
         log_event("Hostname changed -> $new ($source)", $id, 'system', 3);
 


### PR DESCRIPTION
Added logging output to renamehost() if an RRD Folder already exists for the new hostname. 
Before:
```NOT renamed: Renaming of 10.4.0.146 failed```
 Now:
```NOT renamed: Renaming of 10.4.0.146 failed due to existing RRD folder for DEVICE```



DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
~~- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.~~
~~- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).~~

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
