### PR TITLE
MikroTik: Add Fan no. 3 and no. 4 to the discovery/routeros.yaml

### DIFF
--- a/doc/Extensions/Applications.md
+++ b/doc/Extensions/Applications.md
@@ -409,8 +409,18 @@ Debian-snmp ALL=(ALL) NOPASSWD: /usr/sbin/birdc
 _If your snmp daemon is running on a user that isnt `Debian-snmp` make sure that user has the correct permission to execute `birdc`_
 3. Restart snmpd on your host
 
-The application should be auto-discovered as described at the top of the page. If it is not, please follow the steps set out under `SNMP Extend` heading top of page.
+4. Verify the time format for bird2 is defined. Otherwise `timeformat protocols iso short ms;` is the default value that will be used. Which is not compatible with the datetime parsing logic used to parse the output from the bird show command. `timeformat protocol` is the one important to be defined for the parsing to work.
 
+Starting point can be:
+
+```
+timeformat base iso long;
+timeformat log iso long;
+timeformat protocol iso long;
+timeformat route iso long;
+```
+
+The application should be auto-discovered as described at the top of the page. If it is not, please follow the steps set out under `SNMP Extend` heading top of page.
 
 ## Certificate
 

--- a/includes/definitions/discovery/routeros.yaml
+++ b/includes/definitions/discovery/routeros.yaml
@@ -234,3 +234,13 @@ modules:
                     num_oid: '.1.3.6.1.4.1.14988.1.1.3.18.{{ $index }}'
                     descr: 'Fan #2'
                     index: '1'
+                -
+                    oid: mtxrHlFanSpeed3
+                    num_oid: '.1.3.6.1.4.1.14988.1.1.3.100.1.3.7003'
+                    descr: 'Fan #3'
+                    index: '7003'
+                -
+                    oid: mtxrHlFanSpeed4
+                    num_oid: '.1.3.6.1.4.1.14988.1.1.3.100.1.3.7004'
+                    descr: 'Fan #4'
+                    index: '7004'

--- a/mibs/mikrotik/MIKROTIK-MIB
+++ b/mibs/mikrotik/MIKROTIK-MIB
@@ -1467,6 +1467,20 @@ mtxrGaugeValue OBJECT-TYPE
     DESCRIPTION ""
     ::= { mtxrGaugeTableEntry 3 }
 
+mtxrHlFanSpeed3 OBJECT-TYPE
+    SYNTAX Gauge32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION "rpm"
+    ::= { mtxrGaugeValue 7003 }
+
+mtxrHlFanSpeed4 OBJECT-TYPE
+    SYNTAX Gauge32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION "rpm"
+    ::= { mtxrGaugeValue 7004 }
+
 mtxrGaugeUnit OBJECT-TYPE
     SYNTAX INTEGER {
         celsius(1),
@@ -1490,6 +1504,7 @@ mtxrHealthGroup OBJECT-GROUP OBJECTS {
         mtxrHlProcessorFrequency,
         mtxrHlPowerSupplyState, mtxrHlBackupPowerSupplyState,
         mtxrHlFanSpeed1, mtxrHlFanSpeed2,
+        mtxrHlFanSpeed3, mtxrHlFanSpeed4,
         mtxrGaugeName, mtxrGaugeValue, mtxrGaugeUnit
     }
     STATUS current


### PR DESCRIPTION
Some MikroTik models has more than 2 fans installed. This PR is an attempt to solicit feedback on how best to expand the current discovery model to be able to fetch data concerning Fan no. 3 and no. 4.

#### Changes

Add

1. mtxrHlFanSpeed3, mtxrHlFanSpeed4 in `discovery/routeros.yaml`, and
2. custom objects for the same names in the `mikrotik/MIKROTIK-MIB` file.

#### Models

- [CCR2116-12G-4S+](https://mikrotik.com/product/ccr2116_12g_4splus)
- [CCR2216-1G-12XS-2XQ](https://mikrotik.com/product/ccr2216_1g_12xs_2xq)
- [CRS518-16XS-2XQ-RM](https://mikrotik.com/product/crs518_16xs_2xq)
- [CRS326-24S+2Q+RM](https://mikrotik.com/product/crs326_24s_2q_rm)

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] ~~If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.~~
- [ ] ~~If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).~~

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
