### PR TITLE
show ignored device up when up

### DIFF
--- a/app/Http/Controllers/Widgets/AvailabilityMapController.php
+++ b/app/Http/Controllers/Widgets/AvailabilityMapController.php
@@ -249,10 +249,10 @@ class AvailabilityMapController extends WidgetController
 
         if ($device->ignore) {
             if (($device->status == 1) && ($device->uptime != 0)) {
-                return ['up', 'label-success'];
+                return ['ignored-up', 'label-success'];
             }
 
-            return ['ignored', 'label-default'];
+            return ['ignored-down', 'label-default'];
         }
 
         if ($device->status == 1) {

--- a/app/Http/Controllers/Widgets/AvailabilityMapController.php
+++ b/app/Http/Controllers/Widgets/AvailabilityMapController.php
@@ -248,6 +248,10 @@ class AvailabilityMapController extends WidgetController
         }
 
         if ($device->ignore) {
+            if (($device->status == 1) && ($device->uptime != 0)) {
+                return ['up', 'label-success'];
+            }
+
             return ['ignored', 'label-default'];
         }
 


### PR DESCRIPTION
When Device Setting "Ignore alert tag" is enabled,
show "up" when device is up, and "ignored" if down

Device UP:
![image](https://github.com/librenms/librenms/assets/7978916/bbc7d144-280c-4caa-9ed9-7c2926a88a22)


Device Down:
![image](https://github.com/librenms/librenms/assets/7978916/7360f6bf-a561-47b9-a652-f93692763138)





#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
