### PR TITLE
app: bird2 set timeformat protocols

### DIFF
--- a/doc/Extensions/Applications.md
+++ b/doc/Extensions/Applications.md
@@ -396,7 +396,9 @@ Due to the lack of SNMP support in the BIRD daemon, this application extracts al
 This application supports both IPv4 and IPv6 Peer processing.
 
 ### SNMP Extend
+
 1. Edit your snmpd.conf file (usually /etc/snmp/snmpd.conf) and add:
+
 ```
 extend bird2 '/usr/bin/sudo /usr/sbin/birdc -r show protocols all'
 ```
@@ -406,11 +408,31 @@ extend bird2 '/usr/bin/sudo /usr/sbin/birdc -r show protocols all'
 ```
 Debian-snmp ALL=(ALL) NOPASSWD: /usr/sbin/birdc
 ```
+
 _If your snmp daemon is running on a user that isnt `Debian-snmp` make sure that user has the correct permission to execute `birdc`_
-3. Restart snmpd on your host
+
+3. Verify the time format for bird2 is defined. Otherwise `iso short
+   ms` (hh:mm:ss) is the default value that will be used. Which is not
+   compatible with the datetime parsing logic used to parse the output
+   from the bird show command. `timeformat protocol` is the one
+   important to be defibned for the bird2 app parsing logic to work.
+
+Example starting point using Bird2 shorthand `iso long` (YYYY-MM-DD hh:mm:ss):
+
+```
+timeformat base iso long;
+timeformat log iso long;
+timeformat protocol iso long;
+timeformat route iso long;
+```
+
+*Timezone can be manually specified, example "%F %T %z" (YYYY-MM-DD
+hh:mm:ss +11:45). See the [Bird
+2 docs](https://bird.network.cz/?get_doc&v=20&f=bird-3.html) for more information*
+
+4. Restart snmpd on your host
 
 The application should be auto-discovered as described at the top of the page. If it is not, please follow the steps set out under `SNMP Extend` heading top of page.
-
 
 ## Certificate
 


### PR DESCRIPTION
By default "iso show ms" is used. Which is not compatible with the timeformat parsing used. Add a note to the doc specifying it is important to set the timeformat used in the timeformat protocol output.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
