### PR TITLE
Radius enforce roles

### DIFF
--- a/LibreNMS/Authentication/RadiusAuthorizer.php
+++ b/LibreNMS/Authentication/RadiusAuthorizer.php
@@ -42,6 +42,7 @@ class RadiusAuthorizer extends MysqlAuthorizer
                 'auth_type' => LegacyAuth::getType(),
                 'can_modify_passwd' => 0,
             ]);
+            $new_user = ! $user->exists;
             $user->save();
 
             // cache a single role from the Filter-ID attribute now because attributes are cleared every accessRequest
@@ -50,7 +51,9 @@ class RadiusAuthorizer extends MysqlAuthorizer
                 $this->roles[$credentials['username']] = [substr($filter_id_attribute, 14)];
             }
 
-            $user->setRoles($this->roles[$credentials['username']] ?? $this->getDefaultRoles(), true);
+            if (Config::get('radius.enforce_roles') || $new_user) {
+                $user->setRoles($this->roles[$credentials['username']] ?? $this->getDefaultRoles(), true);
+            }
 
             return true;
         }

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -1265,6 +1265,10 @@ return [
                 'description' => 'Default user roles',
                 'help' => 'Sets the roles that will be assigned to the user unless Radius sends attributes that specify role(s)',
             ],
+            'enforce_roles' => [
+                'description' => 'Enforce roles at login',
+                'help' => 'If enabled, roles will be set to the ones specified by the Filter-ID attribute or radius.default_roles at login.  Otherwise, they will be set when the user is created and never changed after that.',
+            ],
         ],
         'reporting' => [
             'error' => [

--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -33,7 +33,7 @@
                  "value": "array",
                  "value.*": "string"
              }
-        },	
+        },
         "alert_colour.ok": {
             "default": "#00ff00",
             "type": "color"
@@ -5110,6 +5110,13 @@
             "section": "radius",
             "order": 3,
             "type": "array"
+        },
+        "radius.enforce_roles": {
+            "default": true,
+            "group": "auth",
+            "section": "radius",
+            "order": 4,
+            "type": "boolean"
         },
         "rancid_configs": {
             "default": [],


### PR DESCRIPTION
Add new setting (radius.enforce_roles) to specify if user roles will be set at login or not.

Without this setting enabled, roles are only set when the user is first created and never after that. If roles set via Filter-ID attribute or radius.default_roles change, they will never be reflected on existing users.

For that reason, the default is set to enabled.  Historically, radius did not enforce roles.

You can change the setting with `lnms config:set radius.enforce_roles false`

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
