### PR TITLE
Fix .env quoting issue

### DIFF
--- a/LibreNMS/Util/EnvHelper.php
+++ b/LibreNMS/Util/EnvHelper.php
@@ -163,7 +163,7 @@ class EnvHelper
             $parts = explode('=', $line, 2);
             if (isset($parts[1])
                 && preg_match('/(?<!\s)#/', $parts[1]) // number symbol without a space before it
-                && ! preg_match('/^(".*"|\'.*\')$/', $parts[1]) // not already quoted
+                && ! preg_match('/^(".*"|\'.*\')$/', trim($parts[1])) // not already quoted
             ) {
                 return trim($parts[0]) . '="' . trim($parts[1]) . '"';
             }


### PR DESCRIPTION
Triggered when password contains # and .env file uses windows line returns.

Friends don't let friends use windows line returns


#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
