### PR TITLE
Discovery: Allow filtering by device groups

### DIFF
--- a/LibreNMS/wrapper.py
+++ b/LibreNMS/wrapper.py
@@ -287,9 +287,7 @@ def poll_worker(
                 )
                 if exit_code not in [0, 6]:
                     thread_name = threading.current_thread().name
-                    logger.error(
-                        f"Thread {thread_name} exited with code {exit_code}"
-                    )
+                    logger.error(f"Thread {thread_name} exited with code {exit_code}")
                     ERRORS += 1
                     logger.error(output)
                 elif exit_code == 5:

--- a/LibreNMS/wrapper.py
+++ b/LibreNMS/wrapper.py
@@ -242,8 +242,7 @@ def poll_worker(
         #  <<<EOC
         if (
             not DISTRIBUTED_POLLING
-            or MEMC.get(f"{wrapper_type}.device.{device_id}{TIME_TAG}")
-            is None
+            or MEMC.get(f"{wrapper_type}.device.{device_id}{TIME_TAG}") is None
         ):
             if DISTRIBUTED_POLLING:
                 result = MEMC.add(
@@ -410,26 +409,26 @@ def wrapper(
     devices_list = []
 
     query_args = []
-    dg_where_expansion = ''
+    dg_where_expansion = ""
     # if device groups were passed, build an additional where condition here
-    d_groups = kwargs.get('groups')
+    d_groups = kwargs.get("groups")
 
-    if kwargs.get('groups'):
+    if kwargs.get("groups"):
         # remove trailing comma whitespace combinations
-        cleaned_groups = re.sub('(^,|,$)', '', str(d_groups).strip())
-        device_groups = re.split(',', cleaned_groups)
+        cleaned_groups = re.sub("(^,|,$)", "", str(d_groups).strip())
+        device_groups = re.split(",", cleaned_groups)
         group_where_items = []
         for group in device_groups:
             group = group.strip()
             if group.isnumeric():
                 query_args.append(int(group))
-                group_where_items.append('device_groups.id = %s')
+                group_where_items.append("device_groups.id = %s")
             else:
-                query_args.append(group.replace('*', '%'))
-                group_where_items.append('device_groups.name LIKE %s')
+                query_args.append(group.replace("*", "%"))
+                group_where_items.append("device_groups.name LIKE %s")
         if group_where_items:
-            group_where = ' OR '.join(group_where_items)
-            dg_where_expansion = f'AND ({group_where})'
+            group_where = " OR ".join(group_where_items)
+            dg_where_expansion = f"AND ({group_where})"
 
     if wrapper_type == "service":
         #  <<<EOC

--- a/discovery-wrapper.py
+++ b/discovery-wrapper.py
@@ -40,6 +40,12 @@ parser.add_argument(
     default="",
     help="Enable passing of a module string, modules are separated by comma",
 )
+parser.add_argument(
+    "--device-groups",
+    dest="groups",
+    default="",
+    help="Enable passing one or more device groups (id, name, namepart), multiple groups are separated by comma",
+)
 args = parser.parse_args()
 
 config = LibreNMS.get_config_data(os.path.dirname(os.path.realpath(__file__)))
@@ -67,5 +73,6 @@ wrapper.wrapper(
     config=config,
     log_dir=log_dir,
     modules=args.modules or "",
+    groups=args.groups or "",
     _debug=args.debug,
 )

--- a/discovery.php
+++ b/discovery.php
@@ -17,7 +17,7 @@ require __DIR__ . '/includes/init.php';
 $start = microtime(true);
 Log::setDefaultDriver('console');
 $sqlparams = [];
-$options = getopt('h:m:i:n:d::v::a::q', ['os:', 'type:']);
+$options = getopt('h:m:i:n:d::v::a::q', ['os:', 'type:', 'device-groups:']);
 
 if (! isset($options['q'])) {
     echo \LibreNMS\Config::get('project_name') . " Discovery\n";
@@ -35,14 +35,14 @@ if (isset($options['h'])) {
         $doing = 'all';
     } elseif ($options['h'] == 'new') {
         $new_discovery_lock = Cache::lock('new-discovery', 300);
-        $where = 'AND `last_discovered` IS NULL';
+        $where = 'AND devices.last_discovered IS NULL';
         $doing = 'new';
     } elseif ($options['h']) {
         if (is_numeric($options['h'])) {
-            $where = "AND `device_id` = '" . $options['h'] . "'";
+            $where = "AND devices.device_id = '" . $options['h'] . "'";
             $doing = $options['h'];
         } else {
-            $where = "AND `hostname` LIKE '" . str_replace('*', '%', $options['h']) . "'";
+            $where = "AND devices.hostname LIKE '" . str_replace('*', '%', $options['h']) . "'";
             $doing = $options['h'];
         }
     }//end if
@@ -58,8 +58,28 @@ if (isset($options['type'])) {
     $sqlparams[] = $options['type'];
 }
 
+if (isset($options['device-groups'])) {
+    $cleaned_groups = preg_replace('/^([ ]*,[ ]*|[ ]*,[ ]*)$/', '', trim($options['device-groups']));
+    $device_groups = preg_split('/[ ]*,[ ]*/', $cleaned_groups);
+    $group_where_items = [];
+    foreach ($device_groups as $group) {
+        $group = trim($group);
+        if (is_numeric($group)) {
+            $sqlparams[] = $group;
+            $group_where_items[] = 'device_groups.id = ?';
+        } else {
+            // even add empty values, they will not yield any result
+            $sqlparams[] = str_replace('*', '%', $group);
+            $group_where_items[] = 'device_groups.name LIKE ?';
+        }
+    }
+    if ($group_where_items) {
+        $where .= ' AND (' . implode(' OR ', $group_where_items) . ')';
+    }
+}
+
 if (isset($options['i']) && $options['i'] && isset($options['n'])) {
-    $where .= ' AND MOD(device_id,' . $options['i'] . ") = '" . $options['n'] . "'";
+    $where .= ' AND MOD(devices.device_id, ' . $options['i'] . ") = '" . $options['n'] . "'";
     $doing = $options['n'] . '/' . $options['i'];
 }
 
@@ -72,20 +92,25 @@ if (Debug::set(isset($options['d']), false) || isset($options['v'])) {
 }
 
 if (! $where) {
-    echo "-h <device id> | <device hostname wildcard>  Poll single device\n";
-    echo "-h odd             Poll odd numbered devices  (same as -i 2 -n 0)\n";
-    echo "-h even            Poll even numbered devices (same as -i 2 -n 1)\n";
-    echo "-h all             Poll all devices\n";
-    echo "-h new             Poll all devices that have not had a discovery run before\n";
-    echo "--os <os_name>     Poll devices only with specified operating system\n";
-    echo "--type <type>      Poll devices only with specified type\n";
-    echo "-i <instances> -n <number>                   Poll as instance <number> of <instances>\n";
+    echo "-h <device id> | <device hostname wildcard>\n";
+    echo "                   Discover single device\n";
+    echo "-h odd             Discover odd numbered devices  (same as -i 2 -n 0)\n";
+    echo "-h even            Discover even numbered devices (same as -i 2 -n 1)\n";
+    echo "-h all             Discover all devices\n";
+    echo "-h new             Discover all devices that have not had a discovery run before\n";
+    echo "--os <os_name>     Discover devices only with specified operating system\n";
+    echo "--type <type>      Discover devices only with specified type\n";
+    echo "-m                 Specify single module to be run. Comma separate modules, submodules may be added with /\n";
+    echo "--device-groups <group id/s or name/s or name part/s)>";
+    echo "                   Discover only devices having at least one of the given device groups\n";
+    echo "                   Multiple groups may be separated by comma\n";
+    echo "-i <instances> -n <number>\n";
+    echo "                   Discover as instance <number> of <instances>\n";
     echo "                   Instances start at 0. 0-3 for -n 4\n";
     echo "\n";
     echo "Debugging and testing options:\n";
     echo "-d                 Enable debugging output\n";
     echo "-v                 Enable verbose debugging output\n";
-    echo "-m                 Specify single module to be run. Comma separate modules, submodules may be added with /\n";
     echo "\n";
     echo "Invalid arguments!\n";
     exit;
@@ -97,11 +122,16 @@ $module_override = parse_modules('discovery', $options);
 $discovered_devices = 0;
 
 if (! empty(\LibreNMS\Config::get('distributed_poller_group'))) {
-    $where .= ' AND poller_group IN(' . \LibreNMS\Config::get('distributed_poller_group') . ')';
+    $where .= ' AND devices.poller_group IN(' . \LibreNMS\Config::get('distributed_poller_group') . ')';
 }
 
+$sql = "SELECT DISTINCT devices.* FROM `devices` ".
+       "LEFT JOIN device_group_device ON devices.device_id = device_group_device.device_id ".
+       "LEFT JOIN device_groups ON device_group_device.device_group_id = device_groups.id ".
+       "WHERE devices.disabled = 0 $where ORDER BY devices.device_id DESC";
+
 global $device;
-foreach (dbFetch("SELECT * FROM `devices` WHERE disabled = 0 $where ORDER BY device_id DESC", $sqlparams) as $device) {
+foreach (dbFetch($sql, $sqlparams) as $device) {
     $device_start = microtime(true);
     DeviceCache::setPrimary($device['device_id']);
 

--- a/discovery.php
+++ b/discovery.php
@@ -101,7 +101,7 @@ if (! $where) {
     echo "--os <os_name>     Discover devices only with specified operating system\n";
     echo "--type <type>      Discover devices only with specified type\n";
     echo "-m                 Specify single module to be run. Comma separate modules, submodules may be added with /\n";
-    echo "--device-groups <group id/s or name/s or name part/s)>";
+    echo "--device-groups <group id/s or name/s or name part/s)>\n";
     echo "                   Discover only devices having at least one of the given device groups\n";
     echo "                   Multiple groups may be separated by comma\n";
     echo "-i <instances> -n <number>\n";
@@ -125,9 +125,9 @@ if (! empty(\LibreNMS\Config::get('distributed_poller_group'))) {
     $where .= ' AND devices.poller_group IN(' . \LibreNMS\Config::get('distributed_poller_group') . ')';
 }
 
-$sql = "SELECT DISTINCT devices.* FROM `devices` ".
-       "LEFT JOIN device_group_device ON devices.device_id = device_group_device.device_id ".
-       "LEFT JOIN device_groups ON device_group_device.device_group_id = device_groups.id ".
+$sql = 'SELECT DISTINCT devices.* FROM `devices` '.
+       'LEFT JOIN device_group_device ON devices.device_id = device_group_device.device_id '.
+       'LEFT JOIN device_groups ON device_group_device.device_group_id = device_groups.id '.
        "WHERE devices.disabled = 0 $where ORDER BY devices.device_id DESC";
 
 global $device;

--- a/discovery.php
+++ b/discovery.php
@@ -125,9 +125,9 @@ if (! empty(\LibreNMS\Config::get('distributed_poller_group'))) {
     $where .= ' AND devices.poller_group IN(' . \LibreNMS\Config::get('distributed_poller_group') . ')';
 }
 
-$sql = 'SELECT DISTINCT devices.* FROM `devices` '.
-       'LEFT JOIN device_group_device ON devices.device_id = device_group_device.device_id '.
-       'LEFT JOIN device_groups ON device_group_device.device_group_id = device_groups.id '.
+$sql = 'SELECT DISTINCT devices.* FROM `devices` ' .
+       'LEFT JOIN device_group_device ON devices.device_id = device_group_device.device_id ' .
+       'LEFT JOIN device_groups ON device_group_device.device_group_id = device_groups.id ' .
        "WHERE devices.disabled = 0 $where ORDER BY devices.device_id DESC";
 
 global $device;

--- a/doc/Support/Discovery Support.md
+++ b/doc/Support/Discovery Support.md
@@ -13,6 +13,8 @@ manually running to process data.
 -h new                                       Poll all devices that have not had a discovery run before
 --os <os_name>                               Poll devices only with specified operating system
 --type <type>                                Poll devices only with specified type
+--device-groups <group name/s>               Poll only devices having at least one of given device groups
+                                             Separate multiple groups by comma
 -i <instances> -n <number>                   Poll as instance <number> of <instances>
                                              Instances start at 0. 0-3 for -n 4
 
@@ -26,6 +28,18 @@ Debugging and testing options:
 wildcard using *). You can also specify odd and even. all will run
 discovery against all devices whilst new will poll only those devices
 that have recently been added or have been selected for rediscovery.
+
+`--os` Limit the amount of devices to ones having the given operating system.
+Please note: You must use the value that is stored in the database!
+Example: 'ios' for Cisco IOS
+
+`--type` Limit the amount of devices to ones having the given device type.
+
+`--device-groups` Limit the amount of devices to ones that are at least part of any
+of the given device groups. Separate multiple groups by comma, the whole
+list may (and should) be enclosed by quotation marks in case a group name
+contains whitespaces or similar. Please note that group names containing
+a comma cannot be used here.
 
 `-i` This can be used to stagger the discovery process.
 
@@ -51,6 +65,15 @@ in cron.
 You also may use `-m` to pass a list of comma-separated modules.
 Please refer to [Command options](#command-options) of discovery.php.
 Example: `/opt/librenms/discovery-wrapper.py 1 -m bgp-peers`
+
+If you need to filter by device groups, you may also pass one or more device
+group names separated by comma as option `--device-groups`
+Example: `/opt/librenms/discovery-wrapper.py 1 --device-groups 'Access Switches,Core Nodes'`
+
+It is also possible to use the ID of the group:
+`/opt/librenms/discovery-wrapper.py 1 --device-groups '26,4,Core Nodes'`
+
+Please note that group names containing a comma cannot be used here.
 
 If you want to switch back to discovery.php then you can replace:
 


### PR DESCRIPTION
The discovery supports filtering by stuff like module, os and type, but not by device group. This pull request enables filtering either by name or by ID.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [-] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [-] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
