### PR TITLE
Add alert transport for Grafana Oncall

### DIFF
--- a/LibreNMS/Alert/Transport/Grafana.php
+++ b/LibreNMS/Alert/Transport/Grafana.php
@@ -28,7 +28,6 @@ class Grafana extends Transport
 
     public function deliverAlert(array $alert_data): bool
     {
-        #$message_lines = explode("\n", $alert_data['msg'] ?? '');
         $device = DeviceCache::get($alert_data['device_id']);
 
         $graph_args = [
@@ -59,7 +58,7 @@ class Grafana extends Transport
             return true;
         }
 
-        throw new AlertTransportDeliveryException($alert_data, $res->status(), $res->body(), $message_lines[0], $data);
+        throw new AlertTransportDeliveryException($alert_data, $res->status(), $res->body(), $alert_data['msg'], $data);
     }
 
     public static function configTemplate(): array

--- a/LibreNMS/Alert/Transport/Grafana.php
+++ b/LibreNMS/Alert/Transport/Grafana.php
@@ -1,0 +1,81 @@
+<?php
+/* LibreNMS
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>. */
+
+namespace LibreNMS\Alert\Transport;
+
+use App\Facades\DeviceCache;
+use LibreNMS\Alert\Transport;
+use LibreNMS\Enum\AlertState;
+use LibreNMS\Exceptions\AlertTransportDeliveryException;
+use LibreNMS\Util\Http;
+use LibreNMS\Util\Url;
+
+class Grafana extends Transport
+{
+    protected string $name = 'Grafana Oncall';
+
+    public function deliverAlert(array $alert_data): bool
+    {
+        #$message_lines = explode("\n", $alert_data['msg'] ?? '');
+        $device = DeviceCache::get($alert_data['device_id']);
+
+        $graph_args = [
+            'type' => 'device_bits', #FIXME use graph url related to alert
+            'device' => $device['device_id'],
+            'height' => 150,
+            'width' => 300,
+            'legend' => 'no',
+            'title' => 'yes',
+        ];
+
+        #$graph_url = url('graph.php') . '?' . http_build_query($graph_args);
+        # FIXME - workaround for https://github.com/grafana/oncall/issues/3031
+        $graph_url = url('graph.php') . '/' . str_replace('&', '/', http_build_query($graph_args));
+
+        $data = [
+            'alert_uid' => $alert_data['id'] ?: $alert_data['uid'],
+            'title' => $alert_data['title'] ?? null,
+            'message' => $alert_data['msg'],
+            'image_url' => $graph_url,
+            'link_to_upstream_details' => Url::deviceUrl($device),
+            'state' => ($alert_data['state'] == AlertState::ACTIVE) ? 'alerting' : 'ok',
+        ];
+
+        $res = Http::client()->post($this->config['url'] ?? '', $data);
+
+        if ($res->successful()) {
+            return true;
+        }
+
+        throw new AlertTransportDeliveryException($alert_data, $res->status(), $res->body(), $message_lines[0], $data);
+    }
+
+    public static function configTemplate(): array
+    {
+        return [
+            'config' => [
+                [
+                    'title' => 'Webhook URL',
+                    'name' => 'url',
+                    'descr' => 'Grafana Oncall Webhook URL',
+                    'type' => 'text',
+                ],
+            ],
+            'validation' => [
+                'url' => 'required|url',
+            ],
+        ];
+    }
+}

--- a/LibreNMS/Alert/Transport/Grafana.php
+++ b/LibreNMS/Alert/Transport/Grafana.php
@@ -31,7 +31,7 @@ class Grafana extends Transport
         $device = DeviceCache::get($alert_data['device_id']);
 
         $graph_args = [
-            'type' => 'device_bits', #FIXME use graph url related to alert
+            'type' => 'device_bits', // FIXME use graph url related to alert
             'device' => $device['device_id'],
             'height' => 150,
             'width' => 300,
@@ -39,8 +39,8 @@ class Grafana extends Transport
             'title' => 'yes',
         ];
 
-        #$graph_url = url('graph.php') . '?' . http_build_query($graph_args);
-        # FIXME - workaround for https://github.com/grafana/oncall/issues/3031
+        //$graph_url = url('graph.php') . '?' . http_build_query($graph_args);
+        // FIXME - workaround for https://github.com/grafana/oncall/issues/3031
         $graph_url = url('graph.php') . '/' . str_replace('&', '/', http_build_query($graph_args));
 
         $data = [

--- a/doc/Alerting/Transports.md
+++ b/doc/Alerting/Transports.md
@@ -294,6 +294,17 @@ tokens to authenticate with GitLab and will store the token in cleartext.
 | Project ID | 1 |
 | Personal Access Token | AbCdEf12345 |
 
+
+## Grafana Oncall
+
+Send alerts to Grafana Oncall using a [Formatted Webhook](https://grafana.com/docs/oncall/latest/integrations/webhook/)
+
+**Example:**
+
+| Config | Example |
+| ------ | ------- |
+| Webhook URL | https://a-prod-us-central-0.grafana.net/integrations/v1/formatted_webhook/m12xmIjOcgwH74UF8CN4dk0Dh/ |
+
 ## HipChat
 
 See the HipChat API Documentation for [rooms/message](https://www.hipchat.com/docs/api/method/rooms/message)


### PR DESCRIPTION
Adds an alert transport for [Grafana Oncall](https://github.com/grafana/oncall) which uses a [Formatted Webhook](https://grafana.com/docs/oncall/latest/integrations/webhook/) payload.

Grafana Oncall only has the ability to list a single image url so it includes a graph for the device itself instead of a list of graphs for each interface that would be alerting.

Also there is a bug in the [rendering of the graph urls inside Grafana Oncall](https://github.com/grafana/oncall/issues/3031) but I have implemented a workaround that works for us.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
