### PR TITLE
Fix some issues with admin self settings

### DIFF
--- a/app/Http/Requests/UpdateUserRequest.php
+++ b/app/Http/Requests/UpdateUserRequest.php
@@ -81,8 +81,8 @@ class UpdateUserRequest extends FormRequest
             // if not an admin and new_password is set, check old password matches
             $user = $this->route('user');
             if ($user && $this->user()->can('update', $user) && $this->user()->is($user)) {
-                if ($this->has('new_password')) {
-                    if ($this->has('old_password')) {
+                if ($this->get('new_password')) {
+                    if ($this->get('old_password')) {
                         $user = $this->route('user');
                         if ($user && ! Hash::check($this->old_password, $user->password)) {
                             $validator->errors()->add('old_password', __('Existing password did not match'));

--- a/resources/views/user/form.blade.php
+++ b/resources/views/user/form.blade.php
@@ -60,9 +60,9 @@
     <div class="form-group @if($errors->hasAny(['old_password', 'new_password', 'new_password_confirmation'])) has-error @endif">
         <label for="password" class="control-label col-sm-3">{{ __('Password') }}</label>
         <div class="col-sm-9">
-            @cannot('admin')
+            @if(auth()->user()->cannot('admin') || auth()->user()->is($user))
                 <input type="password" class="form-control" id="old_password" name="old_password" placeholder="{{ __('Current Password') }}">
-            @endcannot
+            @endif
             <input type="password" autocomplete="off" class="form-control" id="new_password" name="new_password" placeholder="{{ __('New Password') }}">
             <input type="password" autocomplete="off" class="form-control" id="new_password_confirmation" name="new_password_confirmation" placeholder="{{ __('Confirm Password') }}">
             <span class="help-block">


### PR DESCRIPTION
Don't require old password when not settings password Show old password field for user's own user

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
