### PR TITLE
Scale disk spezific SMART Graph from 0

### DIFF
--- a/includes/html/pages/device/apps/smart.inc.php
+++ b/includes/html/pages/device/apps/smart.inc.php
@@ -169,6 +169,7 @@ foreach ($graphs as $key => $text) {
     $graph_array['to'] = \LibreNMS\Config::get('time.now');
     $graph_array['id'] = $app['app_id'];
     $graph_array['type'] = 'application_' . $key;
+    $graph_array['scale_min'] = '0';
 
     if (isset($vars['disk'])) {
         $graph_array['disk'] = $vars['disk'];


### PR DESCRIPTION
Disks specific Graphs should start on 0, not on minimum value, so value change in relationship is easier to see.

before:
![image](https://github.com/librenms/librenms/assets/7978916/328e1170-ba1a-401e-b471-e06f5dcdc993)

after:
![image](https://github.com/librenms/librenms/assets/7978916/add3ea72-f2c2-4b27-a0e6-a0deca4949c0)





#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
