### PR TITLE
show never polled Information on Widget and in Device itself

### DIFF
--- a/app/Http/Controllers/Widgets/AvailabilityMapController.php
+++ b/app/Http/Controllers/Widgets/AvailabilityMapController.php
@@ -221,7 +221,12 @@ class AvailabilityMapController extends WidgetController
     private function getDeviceTooltip(Device $device, string $state_name): string
     {
         $tooltip = $device->displayName();
-        $time = $device->formatDownUptime(true);
+
+        if (! $device->status && ! $device->last_polled) {
+            $time = __('Never polled');
+        } else {
+            $time = $device->formatDownUptime(true);
+        }
 
         if ($time) {
             $tooltip .= ' - ' . ($state_name == 'down' ? 'downtime ' : '') . $time;

--- a/includes/html/dev-overview-data.inc.php
+++ b/includes/html/dev-overview-data.inc.php
@@ -113,8 +113,14 @@ if (! empty($device['last_discovered'])) {
     echo "<div class='row'><div class='col-sm-4'>$last_discovered_text</div><div class='col-sm-8' title='$last_discovered_text at " . $device['last_discovered'] . "'>$last_discovered</div></div>";
 }
 
-$uptime = (\LibreNMS\Util\Time::formatInterval($device['status'] ? $device['uptime'] : time() - strtotime($device['last_polled'])));
-$uptime_text = ($device['status'] ? 'Uptime' : 'Downtime');
+
+if (! $device['status'] && ! $device['last_polled']) {
+    $uptime = __('Never polled');
+    $uptime_text = 'Uptime';
+} else {
+    $uptime = (\LibreNMS\Util\Time::formatInterval($device['status'] ? $device['uptime'] : time() - strtotime($device['last_polled'])));
+    $uptime_text = ($device['status'] ? 'Uptime' : 'Downtime');
+}
 
 if ($uptime) {
     echo "<div class='row'><div class='col-sm-4'>$uptime_text</div><div class='col-sm-8'>$uptime</div></div>";


### PR DESCRIPTION
show "never polled" Information also on Availability Widget Tooltip
and in Device "Overview"- Field

not only on Device List

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
