### PR TITLE
Fix incorrect pages offset on app ntp page

### DIFF
--- a/includes/html/table/app_ntp.inc.php
+++ b/includes/html/table/app_ntp.inc.php
@@ -6,8 +6,9 @@ $options['filter']['ignore'] = ['=', 0];
 $options['type'] = 'ntp';
 $components = $component->getComponents(null, $options);
 
-$first = $vars['current'] - 1;           // Which record do we start on.
+$first = ($vars['current'] * 10) - 1;           // Which record do we start on.
 $last = $first + $vars['rowCount'];    // Which record do we end on.
+$showAll = ($vars['rowCount'] == -1) ? true : false;
 $count = 0;
 // Loop through each device in the component array
 foreach ($components as $devid => $comp) {
@@ -48,7 +49,7 @@ foreach ($components as $devid => $comp) {
             $count++;
 
             // If this record is in the range we want.
-            if (($count > $first) && ($count <= $last)) {
+            if ((($count > $first) && ($count <= $last)) or ($showAll === true)) {
                 $device_link = generate_device_link($device, null, ['tab' => 'apps', 'app' => 'ntp']);
 
                 $graph_array = [];

--- a/includes/html/table/app_ntp.inc.php
+++ b/includes/html/table/app_ntp.inc.php
@@ -6,9 +6,9 @@ $options['filter']['ignore'] = ['=', 0];
 $options['type'] = 'ntp';
 $components = $component->getComponents(null, $options);
 
-$first = ($vars['current'] * 10) - 1;           // Which record do we start on.
-$last = $first + $vars['rowCount'];    // Which record do we end on.
-$showAll = ($vars['rowCount'] == -1) ? true : false;
+$first = ($vars['current'] * $vars['rowCount']) - 1;      // Which record do we start on.
+$last = $first + $vars['rowCount'];                       // Which record do we end on.
+$showAll = ($vars['rowCount'] == -1) ? true : false;      // Show all devices y/n
 $count = 0;
 // Loop through each device in the component array
 foreach ($components as $devid => $comp) {

--- a/includes/html/table/app_ntp.inc.php
+++ b/includes/html/table/app_ntp.inc.php
@@ -6,9 +6,9 @@ $options['filter']['ignore'] = ['=', 0];
 $options['type'] = 'ntp';
 $components = $component->getComponents(null, $options);
 
-$first = ($vars['current'] * $vars['rowCount']) - 1;      // Which record do we start on.
-$last = $first + $vars['rowCount'];                       // Which record do we end on.
-$showAll = ($vars['rowCount'] == -1) ? true : false;      // Show all devices y/n
+$first = ($vars['current'] - 1) * $vars['rowCount']; // Which record do we start on.
+$last = $first + $vars['rowCount']; // Which record do we end on.
+$showAll = $vars['rowCount'] == -1; // Show all devices y/n
 $count = 0;
 // Loop through each device in the component array
 foreach ($components as $devid => $comp) {
@@ -49,7 +49,7 @@ foreach ($components as $devid => $comp) {
             $count++;
 
             // If this record is in the range we want.
-            if ((($count > $first) && ($count <= $last)) or ($showAll === true)) {
+            if ($showAll || (($count > $first) && ($count <= $last))) {
                 $device_link = generate_device_link($device, null, ['tab' => 'apps', 'app' => 'ntp']);
 
                 $graph_array = [];


### PR DESCRIPTION
Fixes #15344
- Corrects start point in table when showing NTP APP
- Corrects blank page when showing ALL NTP entries

I included screen shots of "page2" and "All".
 
(https://docs.librenms.org
![librenms_apps_ntp_page2](https://github.com/librenms/librenms/assets/4017755/868d8a0e-73b5-42a9-bfc7-85fc82193234)

![librenms_apps_ntp_all](https://github.com/librenms/librenms/assets/4017755/ce03e03b-ffae-47cd-a17e-980d994d0cac)

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data]
/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
