### PR TITLE
Fix alerting find owner contacts on old SQL server versions

### DIFF
--- a/LibreNMS/Alert/AlertUtil.php
+++ b/LibreNMS/Alert/AlertUtil.php
@@ -28,8 +28,8 @@ namespace LibreNMS\Alert;
 use App\Models\Device;
 use App\Models\User;
 use DeviceCache;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Facades\DB;
 use LibreNMS\Config;
 use PHPMailer\PHPMailer\PHPMailer;
 
@@ -168,28 +168,16 @@ class AlertUtil
 
     public static function findContactsOwners(array $results): array
     {
-        return User::whereNot('email', '')->whereIn('user_id', function (\Illuminate\Database\Query\Builder $query) use ($results) {
-            $tables = [
-                'bill_id' => 'bill_perms',
-                'port_id' => 'ports_perms',
-                'device_id' => 'devices_perms',
-            ];
-
-            $first = true;
-            foreach ($tables as $column => $table) {
-                $ids = array_filter(Arr::pluck($results, $column)); // find IDs for this type
-
-                if (! empty($ids)) {
-                    if ($first) {
-                        $query->select('user_id')->from($table)->whereIn($column, $ids);
-                        $first = false;
-                    } else {
-                        $query->union(DB::table($table)->select('user_id')->whereIn($column, $ids));
-                    }
-                }
+        return User::whereNot('email', '')->where(function (Builder $query) use ($results) {
+            if ($device_ids = array_filter(Arr::pluck($results, 'device_id'))) {
+                $query->orWhereHas('devicesOwned', fn($q) => $q->whereIn('devices_perms.device_id', $device_ids));
             }
-
-            return $query;
+            if ($port_ids = array_filter(Arr::pluck($results, 'port_id'))) {
+                $query->orWhereHas('portsOwned', fn($q) => $q->whereIn('ports_perms.port_id', $port_ids));
+            }
+            if ($bill_ids = array_filter(Arr::pluck($results, 'bill_id'))) {
+                $query->orWhereHas('bills', fn($q) => $q->whereIn('bill_perms.bill_id', $bill_ids));
+            }
         })->pluck('realname', 'email')->all();
     }
 

--- a/LibreNMS/Alert/AlertUtil.php
+++ b/LibreNMS/Alert/AlertUtil.php
@@ -170,13 +170,13 @@ class AlertUtil
     {
         return User::whereNot('email', '')->where(function (Builder $query) use ($results) {
             if ($device_ids = array_filter(Arr::pluck($results, 'device_id'))) {
-                $query->orWhereHas('devicesOwned', fn($q) => $q->whereIn('devices_perms.device_id', $device_ids));
+                $query->orWhereHas('devicesOwned', fn ($q) => $q->whereIn('devices_perms.device_id', $device_ids));
             }
             if ($port_ids = array_filter(Arr::pluck($results, 'port_id'))) {
-                $query->orWhereHas('portsOwned', fn($q) => $q->whereIn('ports_perms.port_id', $port_ids));
+                $query->orWhereHas('portsOwned', fn ($q) => $q->whereIn('ports_perms.port_id', $port_ids));
             }
             if ($bill_ids = array_filter(Arr::pluck($results, 'bill_id'))) {
-                $query->orWhereHas('bills', fn($q) => $q->whereIn('bill_perms.bill_id', $bill_ids));
+                $query->orWhereHas('bills', fn ($q) => $q->whereIn('bill_perms.bill_id', $bill_ids));
             }
         })->pluck('realname', 'email')->all();
     }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -228,12 +228,22 @@ class User extends Authenticatable
         return $this->hasMany(\App\Models\ApiToken::class, 'user_id', 'user_id');
     }
 
+    public function bills(): BelongsToMany
+    {
+        return $this->belongsToMany(\App\Models\Bill::class, 'bill_perms', 'user_id', 'bill_id');
+    }
+
     public function devices()
     {
         // pseudo relation
         return Device::query()->when(! $this->hasGlobalRead(), function ($query) {
             return $query->whereIntegerInRaw('device_id', Permissions::devicesForUser($this));
         });
+    }
+
+    public function devicesOwned(): BelongsToMany
+    {
+        return $this->belongsToMany(\App\Models\Device::class, 'devices_perms', 'user_id', 'device_id');
     }
 
     public function deviceGroups(): BelongsToMany
@@ -247,8 +257,13 @@ class User extends Authenticatable
             return Port::query();
         } else {
             //FIXME we should return all ports for a device if the user has been given access to the whole device.
-            return $this->belongsToMany(\App\Models\Port::class, 'ports_perms', 'user_id', 'port_id');
+            return $this->portsOwned();
         }
+    }
+
+    public function portsOwned(): BelongsToMany
+    {
+        return $this->belongsToMany(\App\Models\Port::class, 'ports_perms', 'user_id', 'port_id');
     }
 
     public function dashboards(): HasMany


### PR DESCRIPTION
Older SQL server versions had a bug where they didn't accept parenthesis around the first query of a union statement. It was difficult to remove these parenthesis, so use whereHas instead.

fixes #15346

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
