### PR TITLE
Availability module fixes

### DIFF
--- a/LibreNMS/Data/Store/Datastore.php
+++ b/LibreNMS/Data/Store/Datastore.php
@@ -27,9 +27,10 @@ namespace LibreNMS\Data\Store;
 
 use Illuminate\Support\Collection;
 use LibreNMS\Config;
+use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Data\Datastore as DatastoreContract;
 
-class Datastore
+class Datastore implements DataStorageInterface
 {
     protected $stores;
 

--- a/LibreNMS/Device/Availability.php
+++ b/LibreNMS/Device/Availability.php
@@ -25,7 +25,9 @@
 
 namespace LibreNMS\Device;
 
+use App\Models\Device;
 use App\Models\DeviceOutage;
+use Illuminate\Support\Collection;
 use LibreNMS\Util\Number;
 
 class Availability
@@ -37,28 +39,28 @@ class Availability
      * 1 year  365 * 24 * 60 * 60 = 31536000
      */
 
-    public static function day($device, $precision = 3)
+    public static function day(Device $device, int $precision = 3): float
     {
         $duration = 86400;
 
         return self::availability($device, $duration, $precision);
     }
 
-    public static function week($device, $precision = 3)
+    public static function week(Device $device, int $precision = 3): float
     {
         $duration = 604800;
 
         return self::availability($device, $duration, $precision);
     }
 
-    public static function month($device, $precision = 3)
+    public static function month(Device $device, int $precision = 3): float
     {
         $duration = 2592000;
 
         return self::availability($device, $duration, $precision);
     }
 
-    public static function year($device, $precision = 3)
+    public static function year(Device $device, int $precision = 3): float
     {
         $duration = 31536000;
 
@@ -68,17 +70,13 @@ class Availability
     /**
      * addition of all recorded outages in seconds
      *
-     * @param  object  $found_outages  filtered database object with all recorded outages
+     * @param  Collection<DeviceOutage>  $found_outages  filtered database object with all recorded outages
      * @param  int  $duration  time period to calculate for
      * @param  int  $now  timestamp for 'now'
      * @return int sum of all matching outages in seconds
      */
-    protected static function outageSummary($found_outages, $duration, $now = null)
+    protected static function outageSummary(Collection $found_outages, int $duration, int $now): int
     {
-        if (! is_numeric($now)) {
-            $now = time();
-        }
-
         // sum up time period of all outages
         $outage_sum = 0;
         foreach ($found_outages as $outage) {
@@ -103,26 +101,26 @@ class Availability
      * means, starting with 100% as default
      * substracts recorded outages
      *
-     * @param  array  $device  device to be looked at
+     * @param  Device  $device  device to be looked at
      * @param  int  $duration  time period to calculate for
      * @param  int  $precision  float precision for calculated availability
      * @return float calculated availability
      */
-    public static function availability($device, $duration, $precision = 3, $now = null)
+    public static function availability(Device $device, int $duration, int $precision = 3): float
     {
-        if (! is_numeric($now)) {
-            $now = time();
+        $now = time();
+
+        $found_outages = $device->outages()->where('up_again', '>=', $now - $duration)
+            ->orderBy('going_down')->get();
+
+        // no recorded outages found, so use current status
+        if ($found_outages->isEmpty()) {
+            return 100 * $device->status;
         }
 
-        $query = DeviceOutage::where('device_id', '=', $device['device_id'])
-            ->where('up_again', '>=', $now - $duration)
-            ->orderBy('going_down');
-
-        $found_outages = $query->get();
-
-        // no recorded outages found, so use current uptime
-        if (! count($found_outages)) {
-            return 100 * 1;
+        // don't calculate for time when the device didn't exist
+        if ($device->inserted) {
+            $duration = min($duration, $device->inserted->diffInSeconds());
         }
 
         $outage_summary = self::outageSummary($found_outages, $duration, $now);

--- a/LibreNMS/Interfaces/Data/DataStorageInterface.php
+++ b/LibreNMS/Interfaces/Data/DataStorageInterface.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * DataStorageInterface.php
+ *
+ * -Description-
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * @link       https://www.librenms.org
+ *
+ * @copyright  2023 Tony Murray
+ * @author     Tony Murray <murraytony@gmail.com>
+ */
+
+namespace LibreNMS\Interfaces\Data;
+
+interface DataStorageInterface
+{
+    /**
+     * Datastore-independent function which should be used for all polled metrics.
+     *
+     * RRD Tags:
+     *   rrd_def     RrdDefinition
+     *   rrd_name    array|string: the rrd filename, will be processed with rrd_name()
+     *   rrd_oldname array|string: old rrd filename to rename, will be processed with rrd_name()
+     *   rrd_step             int: rrd step, defaults to 300
+     *
+     * @param  array  $device
+     * @param  string  $measurement  Name of this measurement
+     * @param  array  $tags  tags for the data (or to control rrdtool)
+     * @param  array|mixed  $fields  The data to update in an associative array, the order must be consistent with rrd_def,
+     *                               single values are allowed and will be paired with $measurement
+     */
+    public function put($device, $measurement, $tags, $fields);
+}

--- a/LibreNMS/Interfaces/Data/Datastore.php
+++ b/LibreNMS/Interfaces/Data/Datastore.php
@@ -25,7 +25,7 @@
 
 namespace LibreNMS\Interfaces\Data;
 
-interface Datastore
+interface Datastore extends DataStorageInterface
 {
     /**
      * Check if this is enabled by the configuration
@@ -54,21 +54,4 @@ interface Datastore
      * @return array
      */
     public function getStats();
-
-    /**
-     * Datastore-independent function which should be used for all polled metrics.
-     *
-     * RRD Tags:
-     *   rrd_def     RrdDefinition
-     *   rrd_name    array|string: the rrd filename, will be processed with rrd_name()
-     *   rrd_oldname array|string: old rrd filename to rename, will be processed with rrd_name()
-     *   rrd_step             int: rrd step, defaults to 300
-     *
-     * @param  array  $device
-     * @param  string  $measurement  Name of this measurement
-     * @param  array  $tags  tags for the data (or to control rrdtool)
-     * @param  array|mixed  $fields  The data to update in an associative array, the order must be consistent with rrd_def,
-     *                               single values are allowed and will be paired with $measurement
-     */
-    public function put($device, $measurement, $tags, $fields);
 }

--- a/LibreNMS/Interfaces/Module.php
+++ b/LibreNMS/Interfaces/Module.php
@@ -26,7 +26,7 @@
 namespace LibreNMS\Interfaces;
 
 use App\Models\Device;
-use LibreNMS\Interfaces\Data\Datastore;
+use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\OS;
 use LibreNMS\Polling\ModuleStatus;
 
@@ -61,9 +61,9 @@ interface Module
      * Run frequently (default every 5 minutes)
      *
      * @param  \LibreNMS\OS  $os
-     * @param  \LibreNMS\Interfaces\Datastore  $datastore
+     * @param  \LibreNMS\Interfaces\DataStorageInterface  $datastore
      */
-    public function poll(OS $os, Datastore $datastore): void;
+    public function poll(OS $os, DataStorageInterface $datastore): void;
 
     /**
      * Remove all DB data for this module.

--- a/LibreNMS/Interfaces/Module.php
+++ b/LibreNMS/Interfaces/Module.php
@@ -61,7 +61,7 @@ interface Module
      * Run frequently (default every 5 minutes)
      *
      * @param  \LibreNMS\OS  $os
-     * @param  \LibreNMS\Interfaces\DataStorageInterface  $datastore
+     * @param  \LibreNMS\Interfaces\Data\DataStorageInterface  $datastore
      */
     public function poll(OS $os, DataStorageInterface $datastore): void;
 

--- a/LibreNMS/Interfaces/Module.php
+++ b/LibreNMS/Interfaces/Module.php
@@ -26,7 +26,9 @@
 namespace LibreNMS\Interfaces;
 
 use App\Models\Device;
+use LibreNMS\Interfaces\Data\Datastore;
 use LibreNMS\OS;
+use LibreNMS\Polling\ModuleStatus;
 
 interface Module
 {
@@ -34,6 +36,16 @@ interface Module
      * An array of all modules this module depends on
      */
     public function dependencies(): array;
+
+    /**
+     * Should this module be run?
+     */
+    public function shouldDiscover(OS $os, ModuleStatus $status): bool;
+
+    /**
+     * Should polling run for this device?
+     */
+    public function shouldPoll(OS $os, ModuleStatus $status): bool;
 
     /**
      * Discover this module. Heavier processes can be run here
@@ -49,8 +61,9 @@ interface Module
      * Run frequently (default every 5 minutes)
      *
      * @param  \LibreNMS\OS  $os
+     * @param  \LibreNMS\Interfaces\Datastore  $datastore
      */
-    public function poll(OS $os): void;
+    public function poll(OS $os, Datastore $datastore): void;
 
     /**
      * Remove all DB data for this module.

--- a/LibreNMS/Interfaces/Polling/OSPolling.php
+++ b/LibreNMS/Interfaces/Polling/OSPolling.php
@@ -25,11 +25,13 @@
 
 namespace LibreNMS\Interfaces\Polling;
 
+use LibreNMS\Interfaces\Data\DataStorageInterface;
+
 interface OSPolling
 {
     /**
      * Poll additional OS data.
      * Data must be manually saved within this method.
      */
-    public function pollOS(): void;
+    public function pollOS(DataStorageInterface $datastore): void;
 }

--- a/LibreNMS/Modules/Availability.php
+++ b/LibreNMS/Modules/Availability.php
@@ -105,7 +105,7 @@ class Availability implements Module
      */
     public function cleanup(Device $device): void
     {
-        $os->getDevice()->availability()->delete();
+        $device->availability()->delete();
     }
 
     /**

--- a/LibreNMS/Modules/Availability.php
+++ b/LibreNMS/Modules/Availability.php
@@ -27,7 +27,7 @@ namespace LibreNMS\Modules;
 
 use App\Models\Device;
 use LibreNMS\Config;
-use LibreNMS\Interfaces\Data\Datastore;
+use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Module;
 use LibreNMS\OS;
 use LibreNMS\Polling\ModuleStatus;
@@ -68,7 +68,7 @@ class Availability implements Module
     /**
      * @inheritDoc
      */
-    public function poll(OS $os, Datastore $datastore): void
+    public function poll(OS $os, DataStorageInterface $datastore): void
     {
         $os->enableGraph('availability');
 

--- a/LibreNMS/Modules/Availability.php
+++ b/LibreNMS/Modules/Availability.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * Availability.php
+ *
+ * -Description-
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * @link       https://www.librenms.org
+ *
+ * @copyright  2023 Tony Murray
+ * @author     Tony Murray <murraytony@gmail.com>
+ */
+
+namespace LibreNMS\Modules;
+
+use App\Models\Device;
+use LibreNMS\Config;
+use LibreNMS\Interfaces\Data\Datastore;
+use LibreNMS\Interfaces\Module;
+use LibreNMS\OS;
+use LibreNMS\Polling\ModuleStatus;
+use LibreNMS\RRD\RrdDefinition;
+use LibreNMS\Util\Time;
+
+class Availability implements Module
+{
+
+    /**
+     * @inheritDoc
+     */
+    public function dependencies(): array
+    {
+        return [];
+    }
+
+    public function shouldDiscover(OS $os, ModuleStatus $status): bool
+    {
+        return false;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function discover(OS $os): void
+    {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function shouldPoll(OS $os, ModuleStatus $status): bool
+    {
+        return $status->isEnabled();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function poll(OS $os, Datastore $datastore): void
+    {
+        $os->enableGraph('availability');
+
+        $valid_ids = [];
+        foreach (Config::get('graphing.availability') as $duration) {
+            // update database with current calculation
+            $avail = \App\Models\Availability::updateOrCreate([
+                'device_id' => $os->getDeviceId(),
+                'duration' => $duration,
+            ], [
+                'availability_perc' => \LibreNMS\Device\Availability::availability($os->getDevice(), $duration),
+            ]);
+            $valid_ids[] = $avail->availability_id;
+
+            // update rrd
+            $datastore->put($os->getDeviceArray(), 'availability', [
+                'name' => $duration,
+                'rrd_def' => RrdDefinition::make()->addDataset('availability', 'GAUGE', 0, 100),
+                'rrd_name' => ['availability', $duration]
+            ], [
+                'availability' => $avail,
+            ]);
+
+            // output info
+            $human_duration = Time::formatInterval($duration, parts: 1);
+            echo str_pad($human_duration, 7) . ' : ' . $avail->availability_perc . '%' . PHP_EOL;
+        }
+
+        // cleanup
+        $os->getDevice()->availability()->whereNotIn('availability_id', $valid_ids)->delete();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function cleanup(Device $device): void
+    {
+        $os->getDevice()->availability()->delete();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function dump(Device $device)
+    {
+        return [
+            'availability' => $device->availability()->orderBy('duration')
+                ->get()->map->makeHidden(['availability_id', 'device_id']),
+        ];
+    }
+}

--- a/LibreNMS/Modules/Availability.php
+++ b/LibreNMS/Modules/Availability.php
@@ -93,7 +93,7 @@ class Availability implements Module
 
             // output info
             $human_duration = Time::formatInterval($duration, parts: 1);
-            echo str_pad($human_duration, 7) . ' : ' . $avail->availability_perc . '%' . PHP_EOL;
+            \Log::info(str_pad($human_duration, 7) . ' : ' . $avail->availability_perc . '%');
         }
 
         // cleanup

--- a/LibreNMS/Modules/Availability.php
+++ b/LibreNMS/Modules/Availability.php
@@ -36,7 +36,6 @@ use LibreNMS\Util\Time;
 
 class Availability implements Module
 {
-
     /**
      * @inheritDoc
      */
@@ -87,7 +86,7 @@ class Availability implements Module
             $datastore->put($os->getDeviceArray(), 'availability', [
                 'name' => $duration,
                 'rrd_def' => RrdDefinition::make()->addDataset('availability', 'GAUGE', 0, 100),
-                'rrd_name' => ['availability', $duration]
+                'rrd_name' => ['availability', $duration],
             ], [
                 'availability' => $avail,
             ]);

--- a/LibreNMS/Modules/Core.php
+++ b/LibreNMS/Modules/Core.php
@@ -30,7 +30,7 @@ use App\Models\Eventlog;
 use Illuminate\Support\Str;
 use LibreNMS\Config;
 use LibreNMS\Enum\Severity;
-use LibreNMS\Interfaces\Data\Datastore;
+use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Module;
 use LibreNMS\OS;
 use LibreNMS\Polling\ModuleStatus;
@@ -100,7 +100,7 @@ class Core implements Module
         return ! $os->getDevice()->snmp_disable && $os->getDevice()->status;
     }
 
-    public function poll(OS $os, Datastore $datastore): void
+    public function poll(OS $os, DataStorageInterface $datastore): void
     {
         $device = $os->getDevice();
         $oids = [];
@@ -259,7 +259,7 @@ class Core implements Module
         return true;
     }
 
-    private function calculateUptime(OS $os, ?string $sysUpTime, Datastore $datastore): void
+    private function calculateUptime(OS $os, ?string $sysUpTime, DataStorageInterface $datastore): void
     {
         global $agent_data;
         $device = $os->getDevice();

--- a/LibreNMS/Modules/Core.php
+++ b/LibreNMS/Modules/Core.php
@@ -30,8 +30,10 @@ use App\Models\Eventlog;
 use Illuminate\Support\Str;
 use LibreNMS\Config;
 use LibreNMS\Enum\Severity;
+use LibreNMS\Interfaces\Data\Datastore;
 use LibreNMS\Interfaces\Module;
 use LibreNMS\OS;
+use LibreNMS\Polling\ModuleStatus;
 use LibreNMS\RRD\RrdDefinition;
 use LibreNMS\Util\Compare;
 use LibreNMS\Util\Number;
@@ -47,6 +49,11 @@ class Core implements Module
     public function dependencies(): array
     {
         return [];
+    }
+
+    public function shouldDiscover(OS $os, ModuleStatus $status): bool
+    {
+        return ! $os->getDevice()->snmp_disable && $os->getDevice()->status;
     }
 
     public function discover(OS $os): void
@@ -88,7 +95,12 @@ class Core implements Module
         echo 'OS: ' . Config::getOsSetting($device->os, 'text') . " ($device->os)\n\n";
     }
 
-    public function poll(OS $os): void
+    public function shouldPoll(OS $os, ModuleStatus $status): bool
+    {
+        return ! $os->getDevice()->snmp_disable && $os->getDevice()->status;
+    }
+
+    public function poll(OS $os, Datastore $datastore): void
     {
         $device = $os->getDevice();
         $oids = [];
@@ -109,7 +121,7 @@ class Core implements Module
             'sysObjectID' => $snmpdata['.1.3.6.1.2.1.1.2.0'] ?? $device->sysObjectID,
         ]);
 
-        $this->calculateUptime($os, $snmpdata['.1.3.6.1.2.1.1.3.0'] ?? null);
+        $this->calculateUptime($os, $snmpdata['.1.3.6.1.2.1.1.3.0'] ?? null, $datastore);
         $device->save();
     }
 
@@ -247,7 +259,7 @@ class Core implements Module
         return true;
     }
 
-    private function calculateUptime(OS $os, ?string $sysUpTime): void
+    private function calculateUptime(OS $os, ?string $sysUpTime, Datastore $datastore): void
     {
         global $agent_data;
         $device = $os->getDevice();
@@ -280,7 +292,7 @@ class Core implements Module
                 }
             }
 
-            app('Datastore')->put($os->getDeviceArray(), 'uptime', [
+            $datastore->put($os->getDeviceArray(), 'uptime', [
                 'rrd_def' => RrdDefinition::make()->addDataset('uptime', 'GAUGE', 0),
             ], $uptime);
 

--- a/LibreNMS/Modules/Core.php
+++ b/LibreNMS/Modules/Core.php
@@ -298,7 +298,7 @@ class Core implements Module
 
             $os->enableGraph('uptime');
 
-            echo 'Uptime: ' . Time::formatInterval($uptime) . PHP_EOL;
+            Log::info('Uptime: ' . Time::formatInterval($uptime));
             $device->uptime = $uptime;
         }
     }

--- a/LibreNMS/Modules/Isis.php
+++ b/LibreNMS/Modules/Isis.php
@@ -31,10 +31,12 @@ use App\Observers\ModuleModelObserver;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use LibreNMS\DB\SyncsModels;
+use LibreNMS\Interfaces\Data\Datastore;
 use LibreNMS\Interfaces\Discovery\IsIsDiscovery;
 use LibreNMS\Interfaces\Module;
 use LibreNMS\Interfaces\Polling\IsIsPolling;
 use LibreNMS\OS;
+use LibreNMS\Polling\ModuleStatus;
 use LibreNMS\Util\IP;
 
 class Isis implements Module
@@ -56,6 +58,11 @@ class Isis implements Module
         return ['ports'];
     }
 
+    public function shouldDiscover(OS $os, ModuleStatus $status): bool
+    {
+        return $status->isEnabled() && ! $os->getDevice()->snmp_disable && $os->getDevice()->status;
+    }
+
     /**
      * Discover this module. Heavier processes can be run here
      * Run infrequently (default 4 times a day)
@@ -72,6 +79,11 @@ class Isis implements Module
         $this->syncModels($os->getDevice(), 'isisAdjacencies', $adjacencies);
     }
 
+    public function shouldPoll(OS $os, ModuleStatus $status): bool
+    {
+        return $status->isEnabled() && ! $os->getDevice()->snmp_disable && $os->getDevice()->status;
+    }
+
     /**
      * Poll data for this module and update the DB / RRD.
      * Try to keep this efficient and only run if discovery has indicated there is a reason to run.
@@ -79,7 +91,7 @@ class Isis implements Module
      *
      * @param  \LibreNMS\OS  $os
      */
-    public function poll(OS $os): void
+    public function poll(OS $os, Datastore $datastore): void
     {
         $adjacencies = $os->getDevice()->isisAdjacencies;
 

--- a/LibreNMS/Modules/Isis.php
+++ b/LibreNMS/Modules/Isis.php
@@ -31,7 +31,7 @@ use App\Observers\ModuleModelObserver;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use LibreNMS\DB\SyncsModels;
-use LibreNMS\Interfaces\Data\Datastore;
+use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Discovery\IsIsDiscovery;
 use LibreNMS\Interfaces\Module;
 use LibreNMS\Interfaces\Polling\IsIsPolling;
@@ -91,7 +91,7 @@ class Isis implements Module
      *
      * @param  \LibreNMS\OS  $os
      */
-    public function poll(OS $os, Datastore $datastore): void
+    public function poll(OS $os, DataStorageInterface $datastore): void
     {
         $adjacencies = $os->getDevice()->isisAdjacencies;
 

--- a/LibreNMS/Modules/LegacyModule.php
+++ b/LibreNMS/Modules/LegacyModule.php
@@ -29,8 +29,10 @@ use App\Models\Device;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\DB;
 use LibreNMS\Component;
+use LibreNMS\Interfaces\Data\Datastore;
 use LibreNMS\Interfaces\Module;
 use LibreNMS\OS;
+use LibreNMS\Polling\ModuleStatus;
 use LibreNMS\Util\Debug;
 use Symfony\Component\Yaml\Yaml;
 
@@ -64,12 +66,45 @@ class LegacyModule implements Module
         $this->name = $name;
     }
 
-    public function discover(OS $os): void
+    public function shouldDiscover(OS $os, ModuleStatus $status): bool
     {
-        // TODO: Implement discover() method.
+        return $this->shouldPoll($os, $status);
     }
 
-    public function poll(OS $os): void
+    public function discover(OS $os): void
+    {
+        if (! is_file(base_path("includes/discovery/$this->name.inc.php"))) {
+            echo "Module $this->name does not exist, please remove it from your configuration";
+
+            return;
+        }
+
+        $device = &$os->getDeviceArray();
+        $device['attribs'] = $os->getDevice()->attribs->toArray();
+        Debug::disableErrorReporting(); // ignore errors in legacy code
+
+        include_once base_path('includes/datastore.inc.php');
+        include_once base_path('includes/dbFacile.php');
+        include base_path("includes/discovery/$this->name.inc.php");
+
+        Debug::enableErrorReporting(); // and back to normal
+    }
+
+    public function shouldPoll(OS $os, ModuleStatus $status): bool
+    {
+        if (! $status->isEnabled()) {
+            return false;
+        }
+
+        if (! $os->getDevice()->status) {
+            return false;
+        }
+
+        // all legacy modules require snmp except ipmi and unix-agent
+        return ! $os->getDevice()->snmp_disable || in_array($this->name, ['ipmi', 'unix-agent']);
+    }
+
+    public function poll(OS $os, Datastore $datastore): void
     {
         if (! is_file(base_path("includes/polling/$this->name.inc.php"))) {
             echo "Module $this->name does not exist, please remove it from your configuration";
@@ -81,6 +116,7 @@ class LegacyModule implements Module
         $device['attribs'] = $os->getDevice()->attribs->toArray();
         Debug::disableErrorReporting(); // ignore errors in legacy code
 
+        include_once base_path('includes/datastore.inc.php');
         include_once base_path('includes/dbFacile.php');
         include base_path("includes/polling/$this->name.inc.php");
 

--- a/LibreNMS/Modules/LegacyModule.php
+++ b/LibreNMS/Modules/LegacyModule.php
@@ -29,7 +29,7 @@ use App\Models\Device;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\DB;
 use LibreNMS\Component;
-use LibreNMS\Interfaces\Data\Datastore;
+use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Module;
 use LibreNMS\OS;
 use LibreNMS\Polling\ModuleStatus;
@@ -104,7 +104,7 @@ class LegacyModule implements Module
         return ! $os->getDevice()->snmp_disable || in_array($this->name, ['ipmi', 'unix-agent']);
     }
 
-    public function poll(OS $os, Datastore $datastore): void
+    public function poll(OS $os, DataStorageInterface $datastore): void
     {
         if (! is_file(base_path("includes/polling/$this->name.inc.php"))) {
             echo "Module $this->name does not exist, please remove it from your configuration";

--- a/LibreNMS/Modules/Mempools.php
+++ b/LibreNMS/Modules/Mempools.php
@@ -30,7 +30,7 @@ use App\Models\Mempool;
 use App\Observers\MempoolObserver;
 use Illuminate\Support\Collection;
 use LibreNMS\DB\SyncsModels;
-use LibreNMS\Interfaces\Data\Datastore;
+use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Module;
 use LibreNMS\Interfaces\Polling\MempoolsPolling;
 use LibreNMS\OS;
@@ -82,7 +82,7 @@ class Mempools implements Module
         return $status->isEnabled() && ! $os->getDevice()->snmp_disable && $os->getDevice()->status;
     }
 
-    public function poll(OS $os, Datastore $datastore): void
+    public function poll(OS $os, DataStorageInterface $datastore): void
     {
         $mempools = $os->getDevice()->mempools;
 
@@ -94,7 +94,7 @@ class Mempools implements Module
             ? $os->pollMempools($mempools)
             : $this->defaultPolling($os, $mempools);
 
-        $this->calculateAvailable($mempools)->each(function (Mempool $mempool) use ($os) {
+        $this->calculateAvailable($mempools)->each(function (Mempool $mempool) use ($os, $datastore) {
             $this->printMempool($mempool);
 
             if (empty($mempool->mempool_class)) {

--- a/LibreNMS/Modules/Mpls.php
+++ b/LibreNMS/Modules/Mpls.php
@@ -30,10 +30,12 @@ namespace LibreNMS\Modules;
 use App\Models\Device;
 use App\Observers\ModuleModelObserver;
 use LibreNMS\DB\SyncsModels;
+use LibreNMS\Interfaces\Data\Datastore;
 use LibreNMS\Interfaces\Discovery\MplsDiscovery;
 use LibreNMS\Interfaces\Module;
 use LibreNMS\Interfaces\Polling\MplsPolling;
 use LibreNMS\OS;
+use LibreNMS\Polling\ModuleStatus;
 
 class Mpls implements Module
 {
@@ -45,6 +47,11 @@ class Mpls implements Module
     public function dependencies(): array
     {
         return ['ports', 'vrf'];
+    }
+
+    public function shouldDiscover(OS $os, ModuleStatus $status): bool
+    {
+        return $status->isEnabled() && ! $os->getDevice()->snmp_disable && $os->getDevice()->status && $os instanceof MplsDiscovery;
     }
 
     /**
@@ -92,6 +99,11 @@ class Mpls implements Module
         }
     }
 
+    public function shouldPoll(OS $os, ModuleStatus $status): bool
+    {
+        return $status->isEnabled() && ! $os->getDevice()->snmp_disable && $os->getDevice()->status && $os instanceof MplsPolling;
+    }
+
     /**
      * Poll data for this module and update the DB / RRD.
      * Try to keep this efficient and only run if discovery has indicated there is a reason to run.
@@ -99,7 +111,7 @@ class Mpls implements Module
      *
      * @param  \LibreNMS\OS  $os
      */
-    public function poll(OS $os): void
+    public function poll(OS $os, Datastore $datastore): void
     {
         if ($os instanceof MplsPolling) {
             $device = $os->getDevice();

--- a/LibreNMS/Modules/Mpls.php
+++ b/LibreNMS/Modules/Mpls.php
@@ -30,7 +30,7 @@ namespace LibreNMS\Modules;
 use App\Models\Device;
 use App\Observers\ModuleModelObserver;
 use LibreNMS\DB\SyncsModels;
-use LibreNMS\Interfaces\Data\Datastore;
+use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Discovery\MplsDiscovery;
 use LibreNMS\Interfaces\Module;
 use LibreNMS\Interfaces\Polling\MplsPolling;
@@ -111,7 +111,7 @@ class Mpls implements Module
      *
      * @param  \LibreNMS\OS  $os
      */
-    public function poll(OS $os, Datastore $datastore): void
+    public function poll(OS $os, DataStorageInterface $datastore): void
     {
         if ($os instanceof MplsPolling) {
             $device = $os->getDevice();

--- a/LibreNMS/Modules/Nac.php
+++ b/LibreNMS/Modules/Nac.php
@@ -28,7 +28,7 @@ namespace LibreNMS\Modules;
 use App\Models\Device;
 use App\Models\PortsNac;
 use App\Observers\ModuleModelObserver;
-use LibreNMS\Interfaces\Data\Datastore;
+use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Module;
 use LibreNMS\Interfaces\Polling\NacPolling;
 use LibreNMS\OS;
@@ -72,7 +72,7 @@ class Nac implements Module
      *
      * @param  \LibreNMS\OS  $os
      */
-    public function poll(OS $os, Datastore $datastore): void
+    public function poll(OS $os, DataStorageInterface $datastore): void
     {
         if ($os instanceof NacPolling) {
             // discovery output (but don't install it twice (testing can can do this)

--- a/LibreNMS/Modules/Nac.php
+++ b/LibreNMS/Modules/Nac.php
@@ -28,9 +28,11 @@ namespace LibreNMS\Modules;
 use App\Models\Device;
 use App\Models\PortsNac;
 use App\Observers\ModuleModelObserver;
+use LibreNMS\Interfaces\Data\Datastore;
 use LibreNMS\Interfaces\Module;
 use LibreNMS\Interfaces\Polling\NacPolling;
 use LibreNMS\OS;
+use LibreNMS\Polling\ModuleStatus;
 
 class Nac implements Module
 {
@@ -40,6 +42,11 @@ class Nac implements Module
     public function dependencies(): array
     {
         return ['ports'];
+    }
+
+    public function shouldDiscover(OS $os, ModuleStatus $status): bool
+    {
+        return false;
     }
 
     /**
@@ -53,6 +60,11 @@ class Nac implements Module
         // not implemented
     }
 
+    public function shouldPoll(OS $os, ModuleStatus $status): bool
+    {
+        return $status->isEnabled() && ! $os->getDevice()->snmp_disable && $os->getDevice()->status && $os instanceof NacPolling;
+    }
+
     /**
      * Poll data for this module and update the DB / RRD.
      * Try to keep this efficient and only run if discovery has indicated there is a reason to run.
@@ -60,7 +72,7 @@ class Nac implements Module
      *
      * @param  \LibreNMS\OS  $os
      */
-    public function poll(OS $os): void
+    public function poll(OS $os, Datastore $datastore): void
     {
         if ($os instanceof NacPolling) {
             // discovery output (but don't install it twice (testing can can do this)

--- a/LibreNMS/Modules/Netstats.php
+++ b/LibreNMS/Modules/Netstats.php
@@ -26,7 +26,7 @@
 namespace LibreNMS\Modules;
 
 use App\Models\Device;
-use LibreNMS\Interfaces\Data\Datastore;
+use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Module;
 use LibreNMS\Interfaces\Polling\Netstats\IcmpNetstatsPolling;
 use LibreNMS\Interfaces\Polling\Netstats\IpForwardNetstatsPolling;
@@ -197,7 +197,7 @@ class Netstats implements Module
     /**
      * @inheritDoc
      */
-    public function poll(OS $os, Datastore $datastore): void
+    public function poll(OS $os, DataStorageInterface $datastore): void
     {
         foreach ($this->types as $type => $interface) {
             if ($os instanceof $interface) {

--- a/LibreNMS/Modules/Netstats.php
+++ b/LibreNMS/Modules/Netstats.php
@@ -26,6 +26,7 @@
 namespace LibreNMS\Modules;
 
 use App\Models\Device;
+use LibreNMS\Interfaces\Data\Datastore;
 use LibreNMS\Interfaces\Module;
 use LibreNMS\Interfaces\Polling\Netstats\IcmpNetstatsPolling;
 use LibreNMS\Interfaces\Polling\Netstats\IpForwardNetstatsPolling;
@@ -34,6 +35,7 @@ use LibreNMS\Interfaces\Polling\Netstats\SnmpNetstatsPolling;
 use LibreNMS\Interfaces\Polling\Netstats\TcpNetstatsPolling;
 use LibreNMS\Interfaces\Polling\Netstats\UdpNetstatsPolling;
 use LibreNMS\OS;
+use LibreNMS\Polling\ModuleStatus;
 use LibreNMS\RRD\RrdDefinition;
 
 class Netstats implements Module
@@ -174,6 +176,11 @@ class Netstats implements Module
         'tcp' => TcpNetstatsPolling::class,
     ];
 
+    public function shouldDiscover(OS $os, ModuleStatus $status): bool
+    {
+        return false;
+    }
+
     /**
      * @inheritDoc
      */
@@ -182,10 +189,15 @@ class Netstats implements Module
         // no discovery
     }
 
+    public function shouldPoll(OS $os, ModuleStatus $status): bool
+    {
+        return $status->isEnabled() && ! $os->getDevice()->snmp_disable && $os->getDevice()->status;
+    }
+
     /**
      * @inheritDoc
      */
-    public function poll(OS $os): void
+    public function poll(OS $os, Datastore $datastore): void
     {
         foreach ($this->types as $type => $interface) {
             if ($os instanceof $interface) {
@@ -203,7 +215,7 @@ class Netstats implements Module
                         $fields[$stat] = $data[$oid] ?? null;
                     }
 
-                    app('Datastore')->put($os->getDeviceArray(), "netstats-$type", ['rrd_def' => $rrd_def], $fields);
+                    $datastore->put($os->getDeviceArray(), "netstats-$type", ['rrd_def' => $rrd_def], $fields);
 
                     // enable graphs
                     foreach ($this->graphs[$type] as $graph) {

--- a/LibreNMS/Modules/Os.php
+++ b/LibreNMS/Modules/Os.php
@@ -75,7 +75,7 @@ class Os implements Module
     {
         $deviceModel = $os->getDevice(); /** @var \App\Models\Device $deviceModel */
         if ($os instanceof OSPolling) {
-            $os->pollOS();
+            $os->pollOS($datastore);
         } else {
             // legacy poller files
             global $graphs, $device;

--- a/LibreNMS/Modules/Os.php
+++ b/LibreNMS/Modules/Os.php
@@ -27,7 +27,7 @@ namespace LibreNMS\Modules;
 
 use App\Models\Device;
 use App\Models\Location;
-use LibreNMS\Interfaces\Data\Datastore;
+use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Module;
 use LibreNMS\Interfaces\Polling\OSPolling;
 use LibreNMS\Polling\ModuleStatus;
@@ -71,7 +71,7 @@ class Os implements Module
         return $status->isEnabled() && ! $os->getDevice()->snmp_disable && $os->getDevice()->status;
     }
 
-    public function poll(\LibreNMS\OS $os, Datastore $datastore): void
+    public function poll(\LibreNMS\OS $os, DataStorageInterface $datastore): void
     {
         $deviceModel = $os->getDevice(); /** @var \App\Models\Device $deviceModel */
         if ($os instanceof OSPolling) {

--- a/LibreNMS/Modules/Os.php
+++ b/LibreNMS/Modules/Os.php
@@ -27,8 +27,10 @@ namespace LibreNMS\Modules;
 
 use App\Models\Device;
 use App\Models\Location;
+use LibreNMS\Interfaces\Data\Datastore;
 use LibreNMS\Interfaces\Module;
 use LibreNMS\Interfaces\Polling\OSPolling;
+use LibreNMS\Polling\ModuleStatus;
 use LibreNMS\Util\Url;
 
 class Os implements Module
@@ -39,6 +41,11 @@ class Os implements Module
     public function dependencies(): array
     {
         return [];
+    }
+
+    public function shouldDiscover(\LibreNMS\OS $os, ModuleStatus $status): bool
+    {
+        return $status->isEnabled() && ! $os->getDevice()->snmp_disable && $os->getDevice()->status;
     }
 
     public function discover(\LibreNMS\OS $os): void
@@ -59,7 +66,12 @@ class Os implements Module
         $this->handleChanges($os);
     }
 
-    public function poll(\LibreNMS\OS $os): void
+    public function shouldPoll(\LibreNMS\OS $os, ModuleStatus $status): bool
+    {
+        return $status->isEnabled() && ! $os->getDevice()->snmp_disable && $os->getDevice()->status;
+    }
+
+    public function poll(\LibreNMS\OS $os, Datastore $datastore): void
     {
         $deviceModel = $os->getDevice(); /** @var \App\Models\Device $deviceModel */
         if ($os instanceof OSPolling) {

--- a/LibreNMS/Modules/Ospf.php
+++ b/LibreNMS/Modules/Ospf.php
@@ -33,8 +33,10 @@ use App\Models\OspfNbr;
 use App\Models\OspfPort;
 use App\Observers\ModuleModelObserver;
 use Illuminate\Support\Collection;
+use LibreNMS\Interfaces\Data\Datastore;
 use LibreNMS\Interfaces\Module;
 use LibreNMS\OS;
+use LibreNMS\Polling\ModuleStatus;
 use LibreNMS\RRD\RrdDefinition;
 use SnmpQuery;
 
@@ -48,6 +50,11 @@ class Ospf implements Module
         return ['ports'];
     }
 
+    public function shouldDiscover(OS $os, ModuleStatus $status): bool
+    {
+        return false;
+    }
+
     /**
      * @inheritDoc
      */
@@ -56,10 +63,15 @@ class Ospf implements Module
         // no discovery
     }
 
+    public function shouldPoll(OS $os, ModuleStatus $status): bool
+    {
+        return $status->isEnabled() && ! $os->getDevice()->snmp_disable && $os->getDevice()->status;
+    }
+
     /**
      * @inheritDoc
      */
-    public function poll(OS $os): void
+    public function poll(OS $os, Datastore $datastore): void
     {
         foreach ($os->getDevice()->getVrfContexts() as $context_name) {
             echo ' Processes: ';
@@ -216,7 +228,7 @@ class Ospf implements Module
                 ];
 
                 $tags = compact('rrd_def');
-                app('Datastore')->put($os->getDeviceArray(), 'ospf-statistics', $tags, $fields);
+                $datastore->put($os->getDeviceArray(), 'ospf-statistics', $tags, $fields);
             }
         }
     }

--- a/LibreNMS/Modules/Ospf.php
+++ b/LibreNMS/Modules/Ospf.php
@@ -33,7 +33,7 @@ use App\Models\OspfNbr;
 use App\Models\OspfPort;
 use App\Observers\ModuleModelObserver;
 use Illuminate\Support\Collection;
-use LibreNMS\Interfaces\Data\Datastore;
+use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Module;
 use LibreNMS\OS;
 use LibreNMS\Polling\ModuleStatus;
@@ -71,7 +71,7 @@ class Ospf implements Module
     /**
      * @inheritDoc
      */
-    public function poll(OS $os, Datastore $datastore): void
+    public function poll(OS $os, DataStorageInterface $datastore): void
     {
         foreach ($os->getDevice()->getVrfContexts() as $context_name) {
             echo ' Processes: ';

--- a/LibreNMS/Modules/PrinterSupplies.php
+++ b/LibreNMS/Modules/PrinterSupplies.php
@@ -28,8 +28,10 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use LibreNMS\DB\SyncsModels;
 use LibreNMS\Enum\Severity;
+use LibreNMS\Interfaces\Data\Datastore;
 use LibreNMS\Interfaces\Module;
 use LibreNMS\OS;
+use LibreNMS\Polling\ModuleStatus;
 use LibreNMS\RRD\RrdDefinition;
 use LibreNMS\Util\Number;
 
@@ -43,6 +45,11 @@ class PrinterSupplies implements Module
     public function dependencies(): array
     {
         return [];
+    }
+
+    public function shouldDiscover(OS $os, ModuleStatus $status): bool
+    {
+        return $status->isEnabled() && ! $os->getDevice()->snmp_disable && $os->getDevice()->status;
     }
 
     /**
@@ -63,6 +70,11 @@ class PrinterSupplies implements Module
         $this->syncModels($os->getDevice(), 'printerSupplies', $data);
     }
 
+    public function shouldPoll(OS $os, ModuleStatus $status): bool
+    {
+        return $status->isEnabled() && ! $os->getDevice()->snmp_disable && $os->getDevice()->status;
+    }
+
     /**
      * Poll data for this module and update the DB / RRD.
      * Try to keep this efficient and only run if discovery has indicated there is a reason to run.
@@ -70,10 +82,14 @@ class PrinterSupplies implements Module
      *
      * @param  \LibreNMS\OS  $os
      */
-    public function poll(OS $os): void
+    public function poll(OS $os, Datastore $datastore): void
     {
         $device = $os->getDeviceArray();
         $toner_data = $os->getDevice()->printerSupplies;
+
+        if (empty($toner_data)) {
+            return; // no data to poll
+        }
 
         $toner_snmp = snmp_get_multi_oid($device, $toner_data->pluck('supply_oid')->toArray());
 
@@ -90,7 +106,7 @@ class PrinterSupplies implements Module
                 'rrd_oldname' => ['toner', $toner['supply_descr']],
                 'index'       => $toner['supply_index'],
             ];
-            data_update($device, 'toner', $tags, $tonerperc);
+            $datastore->put($device, 'toner', $tags, $tonerperc);
 
             // Log empty supplies (but only once)
             if ($tonerperc == 0 && $toner['supply_current'] > 0) {

--- a/LibreNMS/Modules/PrinterSupplies.php
+++ b/LibreNMS/Modules/PrinterSupplies.php
@@ -28,7 +28,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use LibreNMS\DB\SyncsModels;
 use LibreNMS\Enum\Severity;
-use LibreNMS\Interfaces\Data\Datastore;
+use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Module;
 use LibreNMS\OS;
 use LibreNMS\Polling\ModuleStatus;
@@ -82,7 +82,7 @@ class PrinterSupplies implements Module
      *
      * @param  \LibreNMS\OS  $os
      */
-    public function poll(OS $os, Datastore $datastore): void
+    public function poll(OS $os, DataStorageInterface $datastore): void
     {
         $device = $os->getDeviceArray();
         $toner_data = $os->getDevice()->printerSupplies;

--- a/LibreNMS/Modules/Slas.php
+++ b/LibreNMS/Modules/Slas.php
@@ -90,7 +90,7 @@ class Slas implements Module
 
                 // The base RRD
                 foreach ($slas as $sla) {
-                    $datastore->put($device, 'sla', [
+                    $datastore->put($os->getDeviceArray(), 'sla', [
                         'sla_nr' => $sla->sla_nr,
                         'rrd_name' => ['sla', $sla->sla_nr],
                         'rrd_def' => RrdDefinition::make()->addDataset('rtt', 'GAUGE', 0, 300000),

--- a/LibreNMS/Modules/Slas.php
+++ b/LibreNMS/Modules/Slas.php
@@ -24,7 +24,7 @@ use App\Models\Device;
 use App\Models\Sla;
 use App\Observers\ModuleModelObserver;
 use LibreNMS\DB\SyncsModels;
-use LibreNMS\Interfaces\Data\Datastore;
+use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Discovery\SlaDiscovery;
 use LibreNMS\Interfaces\Module;
 use LibreNMS\Interfaces\Polling\SlaPolling;
@@ -75,7 +75,7 @@ class Slas implements Module
      *
      * @param  \LibreNMS\OS  $os
      */
-    public function poll(OS $os, Datastore $datastore): void
+    public function poll(OS $os, DataStorageInterface $datastore): void
     {
         if ($os instanceof SlaPolling) {
             // Gather our SLA's from the DB.

--- a/LibreNMS/Modules/Stp.php
+++ b/LibreNMS/Modules/Stp.php
@@ -29,7 +29,7 @@ use App\Models\Device;
 use App\Models\PortStp;
 use App\Observers\ModuleModelObserver;
 use LibreNMS\DB\SyncsModels;
-use LibreNMS\Interfaces\Data\Datastore;
+use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Module;
 use LibreNMS\OS;
 use LibreNMS\Polling\ModuleStatus;
@@ -73,7 +73,7 @@ class Stp implements Module
         return $status->isEnabled() && ! $os->getDevice()->snmp_disable && $os->getDevice()->status;
     }
 
-    public function poll(OS $os, Datastore $datastore): void
+    public function poll(OS $os, DataStorageInterface $datastore): void
     {
         $device = $os->getDevice();
 

--- a/LibreNMS/Modules/Stp.php
+++ b/LibreNMS/Modules/Stp.php
@@ -29,8 +29,10 @@ use App\Models\Device;
 use App\Models\PortStp;
 use App\Observers\ModuleModelObserver;
 use LibreNMS\DB\SyncsModels;
+use LibreNMS\Interfaces\Data\Datastore;
 use LibreNMS\Interfaces\Module;
 use LibreNMS\OS;
+use LibreNMS\Polling\ModuleStatus;
 
 class Stp implements Module
 {
@@ -42,6 +44,11 @@ class Stp implements Module
     public function dependencies(): array
     {
         return ['ports', 'vlans'];
+    }
+
+    public function shouldDiscover(OS $os, ModuleStatus $status): bool
+    {
+        return $status->isEnabled() && ! $os->getDevice()->snmp_disable && $os->getDevice()->status;
     }
 
     public function discover(OS $os): void
@@ -61,7 +68,12 @@ class Stp implements Module
         echo PHP_EOL;
     }
 
-    public function poll(OS $os): void
+    public function shouldPoll(OS $os, ModuleStatus $status): bool
+    {
+        return $status->isEnabled() && ! $os->getDevice()->snmp_disable && $os->getDevice()->status;
+    }
+
+    public function poll(OS $os, Datastore $datastore): void
     {
         $device = $os->getDevice();
 

--- a/LibreNMS/Modules/Xdsl.php
+++ b/LibreNMS/Modules/Xdsl.php
@@ -32,7 +32,7 @@ use App\Models\PortVdsl;
 use App\Observers\ModuleModelObserver;
 use Illuminate\Support\Collection;
 use LibreNMS\DB\SyncsModels;
-use LibreNMS\Interfaces\Data\Datastore;
+use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Module;
 use LibreNMS\OS;
 use LibreNMS\Polling\ModuleStatus;
@@ -87,7 +87,7 @@ class Xdsl implements Module
      *
      * @param  \LibreNMS\OS  $os
      */
-    public function poll(OS $os, Datastore $datastore): void
+    public function poll(OS $os, DataStorageInterface $datastore): void
     {
         //only do polling if at least one portAdsl was discovered
         if ($os->getDevice()->portsAdsl()->exists()) {
@@ -128,7 +128,7 @@ class Xdsl implements Module
      * Try to keep this efficient and only run if discovery has indicated there is a reason to run.
      * Run frequently (default every 5 minutes)
      */
-    private function pollAdsl(OS $os, ?Datastore $datastore = null): Collection
+    private function pollAdsl(OS $os, ?DataStorageInterface $datastore = null): Collection
     {
         $adsl = \SnmpQuery::hideMib()->walk('ADSL-LINE-MIB::adslMibObjects')->table(1);
         $adslPorts = new Collection;
@@ -168,7 +168,7 @@ class Xdsl implements Module
      * Try to keep this efficient and only run if discovery has indicated there is a reason to run.
      * Run frequently (default every 5 minutes)
      */
-    private function pollVdsl(OS $os, ?Datastore $datastore = null): Collection
+    private function pollVdsl(OS $os, ?DataStorageInterface $datastore = null): Collection
     {
         $vdsl = \SnmpQuery::hideMib()->walk(['VDSL2-LINE-MIB::xdsl2ChannelStatusTable', 'VDSL2-LINE-MIB::xdsl2LineTable'])->table(1);
         $vdslPorts = new Collection;
@@ -201,7 +201,7 @@ class Xdsl implements Module
         return $this->syncModels($os->getDevice(), 'portsVdsl', $vdslPorts);
     }
 
-    private function storeAdsl(PortAdsl $port, array $data, int $ifIndex, OS $os, Datastore $datastore): void
+    private function storeAdsl(PortAdsl $port, array $data, int $ifIndex, OS $os, DataStorageInterface $datastore): void
     {
         $rrd_def = RrdDefinition::make()
             ->addDataset('AtucCurrSnrMgn', 'GAUGE', 0, 635)
@@ -261,7 +261,7 @@ class Xdsl implements Module
         ], $fields);
     }
 
-    private function storeVdsl(PortVdsl $port, array $data, int $ifIndex, OS $os, Datastore $datastore): void
+    private function storeVdsl(PortVdsl $port, array $data, int $ifIndex, OS $os, DataStorageInterface $datastore): void
     {
         // Attainable
         $datastore->put($os->getDeviceArray(), 'xdsl2LineStatusAttainableRate', [

--- a/LibreNMS/Modules/Xdsl.php
+++ b/LibreNMS/Modules/Xdsl.php
@@ -70,9 +70,9 @@ class Xdsl implements Module
      */
     public function discover(OS $os): void
     {
-        //discover if any port has dsl data. We use the pollXdsl functions, with the store parameter set to false
-        $this->pollAdsl($os, false);
-        $this->pollVdsl($os, false);
+        //discover if any port has dsl data. We use the pollXdsl functions, with the datastore parameter ommitted
+        $this->pollAdsl($os);
+        $this->pollVdsl($os);
     }
 
     public function shouldPoll(OS $os, ModuleStatus $status): bool

--- a/LibreNMS/Modules/Xdsl.php
+++ b/LibreNMS/Modules/Xdsl.php
@@ -32,8 +32,10 @@ use App\Models\PortVdsl;
 use App\Observers\ModuleModelObserver;
 use Illuminate\Support\Collection;
 use LibreNMS\DB\SyncsModels;
+use LibreNMS\Interfaces\Data\Datastore;
 use LibreNMS\Interfaces\Module;
 use LibreNMS\OS;
+use LibreNMS\Polling\ModuleStatus;
 use LibreNMS\RRD\RrdDefinition;
 use LibreNMS\Util\Number;
 
@@ -58,6 +60,11 @@ class Xdsl implements Module
         return ['ports'];
     }
 
+    public function shouldDiscover(OS $os, ModuleStatus $status): bool
+    {
+        return $status->isEnabled() && ! $os->getDevice()->snmp_disable && $os->getDevice()->status;
+    }
+
     /**
      * @inheritDoc
      */
@@ -68,6 +75,11 @@ class Xdsl implements Module
         $this->pollVdsl($os, false);
     }
 
+    public function shouldPoll(OS $os, ModuleStatus $status): bool
+    {
+        return $status->isEnabled() && ! $os->getDevice()->snmp_disable && $os->getDevice()->status;
+    }
+
     /**
      * Poll data for this module and update the DB / RRD.
      * Try to keep this efficient and only run if discovery has indicated there is a reason to run.
@@ -75,15 +87,15 @@ class Xdsl implements Module
      *
      * @param  \LibreNMS\OS  $os
      */
-    public function poll(OS $os): void
+    public function poll(OS $os, Datastore $datastore): void
     {
         //only do polling if at least one portAdsl was discovered
         if ($os->getDevice()->portsAdsl()->exists()) {
-            $this->pollAdsl($os);
+            $this->pollAdsl($os, $datastore);
         }
 
         if ($os->getDevice()->portsVdsl()->exists()) {
-            $this->pollVdsl($os);
+            $this->pollVdsl($os, $datastore);
         }
     }
 
@@ -115,11 +127,8 @@ class Xdsl implements Module
      * Poll data for this module and update the DB / RRD.
      * Try to keep this efficient and only run if discovery has indicated there is a reason to run.
      * Run frequently (default every 5 minutes)
-     *
-     * @param  \LibreNMS\OS  $os
-     * @param  bool  $store
      */
-    private function pollAdsl(OS $os, $store = true): Collection
+    private function pollAdsl(OS $os, ?Datastore $datastore = null): Collection
     {
         $adsl = \SnmpQuery::hideMib()->walk('ADSL-LINE-MIB::adslMibObjects')->table(1);
         $adslPorts = new Collection;
@@ -141,8 +150,8 @@ class Xdsl implements Module
 
             $portAdsl->port_id = $os->ifIndexToId($ifIndex);
 
-            if ($store) {
-                $this->storeAdsl($portAdsl, $data, (int) $ifIndex, $os);
+            if ($datastore) {
+                $this->storeAdsl($portAdsl, $data, (int) $ifIndex, $os, $datastore);
                 echo ' ADSL(' . $portAdsl->adslLineCoding . '/' . Number::formatSi($portAdsl->adslAtucChanCurrTxRate, 2, 3, 'bps') . '/' . Number::formatSi($portAdsl->adslAturChanCurrTxRate, 2, 3, 'bps') . ') ';
             }
 
@@ -158,11 +167,8 @@ class Xdsl implements Module
      * Poll data for this module and update the DB / RRD.
      * Try to keep this efficient and only run if discovery has indicated there is a reason to run.
      * Run frequently (default every 5 minutes)
-     *
-     * @param  \LibreNMS\OS  $os
-     * @param  bool  $store
      */
-    private function pollVdsl(OS $os, $store = true): Collection
+    private function pollVdsl(OS $os, ?Datastore $datastore = null): Collection
     {
         $vdsl = \SnmpQuery::hideMib()->walk(['VDSL2-LINE-MIB::xdsl2ChannelStatusTable', 'VDSL2-LINE-MIB::xdsl2LineTable'])->table(1);
         $vdslPorts = new Collection;
@@ -182,8 +188,8 @@ class Xdsl implements Module
 
             $portVdsl->fill($data); // fill oids that are one to one
 
-            if ($store) {
-                $this->storeVdsl($portVdsl, $data, (int) $ifIndex, $os);
+            if ($datastore) {
+                $this->storeVdsl($portVdsl, $data, (int) $ifIndex, $os, $datastore);
                 echo ' VDSL(' . $os->ifIndexToName($ifIndex) . '/' . Number::formatSi($portVdsl->xdsl2LineStatusAttainableRateDs, 2, 3, 'bps') . '/' . Number::formatSi($portVdsl->xdsl2LineStatusAttainableRateUs, 2, 3, 'bps') . ') ';
             }
 
@@ -195,7 +201,7 @@ class Xdsl implements Module
         return $this->syncModels($os->getDevice(), 'portsVdsl', $vdslPorts);
     }
 
-    private function storeAdsl(PortAdsl $port, array $data, int $ifIndex, OS $os): void
+    private function storeAdsl(PortAdsl $port, array $data, int $ifIndex, OS $os, Datastore $datastore): void
     {
         $rrd_def = RrdDefinition::make()
             ->addDataset('AtucCurrSnrMgn', 'GAUGE', 0, 635)
@@ -248,17 +254,17 @@ class Xdsl implements Module
             'AturChanUncorrectBlks' => $data['adslAturChanUncorrectBlks'] ?? null,
         ];
 
-        data_update($os->getDeviceArray(), 'adsl', [
+        $datastore->put($os->getDeviceArray(), 'adsl', [
             'ifName' => $os->ifIndexToName($ifIndex),
             'rrd_name' => Rrd::portName($port->port_id, 'adsl'),
             'rrd_def' => $rrd_def,
         ], $fields);
     }
 
-    private function storeVdsl(PortVdsl $port, array $data, int $ifIndex, OS $os): void
+    private function storeVdsl(PortVdsl $port, array $data, int $ifIndex, OS $os, Datastore $datastore): void
     {
         // Attainable
-        data_update($os->getDeviceArray(), 'xdsl2LineStatusAttainableRate', [
+        $datastore->put($os->getDeviceArray(), 'xdsl2LineStatusAttainableRate', [
             'ifName' => $os->ifIndexToName($ifIndex),
             'rrd_name' => Rrd::portName($port->port_id, 'xdsl2LineStatusAttainableRate'),
             'rrd_def' => RrdDefinition::make()
@@ -270,7 +276,7 @@ class Xdsl implements Module
         ]);
 
         // actual data rates
-        data_update($os->getDeviceArray(), 'xdsl2ChStatusActDataRate', [
+        $datastore->put($os->getDeviceArray(), 'xdsl2ChStatusActDataRate', [
             'ifName' => $os->ifIndexToName($ifIndex),
             'rrd_name' => Rrd::portName($port->port_id, 'xdsl2ChStatusActDataRate'),
             'rrd_def' => RrdDefinition::make()
@@ -282,7 +288,7 @@ class Xdsl implements Module
         ]);
 
         // power levels
-        data_update($os->getDeviceArray(), 'xdsl2LineStatusActAtp', [
+        $datastore->put($os->getDeviceArray(), 'xdsl2LineStatusActAtp', [
             'ifName' => $os->ifIndexToName($ifIndex),
             'rrd_name' => Rrd::portName($port->port_id, 'xdsl2LineStatusActAtp'),
             'rrd_def' => RrdDefinition::make()

--- a/LibreNMS/OS/Arbos.php
+++ b/LibreNMS/OS/Arbos.php
@@ -25,6 +25,7 @@
 
 namespace LibreNMS\OS;
 
+use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Polling\OSPolling;
 use LibreNMS\OS;
 use LibreNMS\RRD\RrdDefinition;
@@ -32,12 +33,12 @@ use SnmpQuery;
 
 class Arbos extends OS implements OSPolling
 {
-    public function pollOS(): void
+    public function pollOS(DataStorageInterface $datastore): void
     {
         $flows = SnmpQuery::get('PEAKFLOW-SP-MIB::deviceTotalFlows.0')->value();
 
         if (is_numeric($flows)) {
-            app('Datastore')->put($this->getDeviceArray(), 'arbos_flows', [
+            $datastore->put($this->getDeviceArray(), 'arbos_flows', [
                 'rrd_def' => RrdDefinition::make()->addDataset('flows', 'GAUGE', 0, 3000000),
             ], [
                 'flows' => $flows,

--- a/LibreNMS/OS/Asyncos.php
+++ b/LibreNMS/OS/Asyncos.php
@@ -25,20 +25,21 @@
 
 namespace LibreNMS\OS;
 
+use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Polling\OSPolling;
 use LibreNMS\OS;
 use LibreNMS\RRD\RrdDefinition;
 
 class Asyncos extends OS implements OSPolling
 {
-    public function pollOS(): void
+    public function pollOS(DataStorageInterface $datastore): void
     {
         // Get stats only if device is web proxy
         if ($this->getDevice()->sysObjectID == '.1.3.6.1.4.1.15497.1.2') {
             $connections = \SnmpQuery::get('TCP-MIB::tcpCurrEstab.0')->value();
 
             if (is_numeric($connections)) {
-                data_update($this->getDeviceArray(), 'asyncos_conns', [
+                $datastore->put($this->getDeviceArray(), 'asyncos_conns', [
                     'rrd_def' => RrdDefinition::make()->addDataset('connections', 'GAUGE', 0, 50000),
                 ], [
                     'connections' => $connections,

--- a/LibreNMS/OS/Barracudangfirewall.php
+++ b/LibreNMS/OS/Barracudangfirewall.php
@@ -26,6 +26,7 @@
 namespace LibreNMS\OS;
 
 use App\Models\Device;
+use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Discovery\OSDiscovery;
 use LibreNMS\Interfaces\Polling\OSPolling;
 use LibreNMS\OS;
@@ -40,7 +41,7 @@ class Barracudangfirewall extends OS implements OSDiscovery, OSPolling
         }
     }
 
-    public function pollOS(): void
+    public function pollOS(DataStorageInterface $datastore): void
     {
         // TODO move to count sensor
         $sessions = snmp_get($this->getDeviceArray(), 'firewallSessions64.8.102.119.83.116.97.116.115.0', '-OQv', 'PHION-MIB');
@@ -50,7 +51,7 @@ class Barracudangfirewall extends OS implements OSDiscovery, OSPolling
             $fields = ['fw_sessions' => $sessions];
 
             $tags = compact('rrd_def');
-            app('Datastore')->put($this->getDeviceArray(), 'barracuda_firewall_sessions', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'barracuda_firewall_sessions', $tags, $fields);
             $this->enableGraph('barracuda_firewall_sessions');
         }
     }

--- a/LibreNMS/OS/Coriant.php
+++ b/LibreNMS/OS/Coriant.php
@@ -29,11 +29,12 @@ use App\Models\Eventlog;
 use App\Models\TnmsneInfo;
 use App\Observers\ModuleModelObserver;
 use LibreNMS\Enum\Severity;
+use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Polling\OSPolling;
 
 class Coriant extends \LibreNMS\OS implements OSPolling
 {
-    public function pollOS(): void
+    public function pollOS(DataStorageInterface $datastore): void
     {
         echo 'TNMS-NBI-MIB: enmsNETable';
 

--- a/LibreNMS/OS/Epmp.php
+++ b/LibreNMS/OS/Epmp.php
@@ -27,6 +27,7 @@ namespace LibreNMS\OS;
 
 use App\Models\Device;
 use LibreNMS\Device\WirelessSensor;
+use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Discovery\Sensors\WirelessClientsDiscovery;
 use LibreNMS\Interfaces\Discovery\Sensors\WirelessFrequencyDiscovery;
 use LibreNMS\Interfaces\Discovery\Sensors\WirelessRssiDiscovery;
@@ -62,7 +63,7 @@ class Epmp extends OS implements
         }
     }
 
-    public function pollOS(): void
+    public function pollOS(DataStorageInterface $datastore): void
     {
         $device = $this->getDeviceArray();
 
@@ -77,7 +78,7 @@ class Epmp extends OS implements
                 'numVisible' => $cambiumGPSNumVisibleSat,
             ];
             $tags = compact('rrd_def');
-            data_update($device, 'cambium-epmp-gps', $tags, $fields);
+            $datastore->put($device, 'cambium-epmp-gps', $tags, $fields);
             $this->enableGraph('cambium_epmp_gps');
         }
 
@@ -92,7 +93,7 @@ class Epmp extends OS implements
                 'downlinkMCSMode' => $cambiumSTADownlinkMCSMode,
             ];
             $tags = compact('rrd_def');
-            data_update($device, 'cambium-epmp-modulation', $tags, $fields);
+            $datastore->put($device, 'cambium-epmp-modulation', $tags, $fields);
             $this->enableGraph('cambium_epmp_modulation');
         }
 
@@ -110,7 +111,7 @@ class Epmp extends OS implements
                 'authFailure' => $sysNetworkEntryAuthenticationFailure,
             ];
             $tags = compact('rrd_def');
-            data_update($device, 'cambium-epmp-access', $tags, $fields);
+            $datastore->put($device, 'cambium-epmp-access', $tags, $fields);
             $this->enableGraph('cambium_epmp_access');
         }
 
@@ -134,7 +135,7 @@ class Epmp extends OS implements
                 'dlwlanframeutilization' => $dlWlanFrameUtilization,
             ];
             $tags = compact('rrd_def');
-            data_update($device, 'cambium-epmp-frameUtilization', $tags, $fields);
+            $datastore->put($device, 'cambium-epmp-frameUtilization', $tags, $fields);
             $this->enableGraph('cambium-epmp-frameUtilization');
         }
     }

--- a/LibreNMS/OS/F5.php
+++ b/LibreNMS/OS/F5.php
@@ -25,13 +25,14 @@
 
 namespace LibreNMS\OS;
 
+use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Polling\OSPolling;
 use LibreNMS\OS;
 use LibreNMS\RRD\RrdDefinition;
 
 class F5 extends OS implements OSPolling
 {
-    public function pollOS(): void
+    public function pollOS(DataStorageInterface $datastore): void
     {
         $metadata = [
             'F5-BIGIP-APM-MIB::apmAccessStatCurrentActiveSessions.0' => [
@@ -75,7 +76,7 @@ class F5 extends OS implements OSPolling
                     $info['dataset'] => $data[$key],
                 ];
                 $tags = compact('rrd_def');
-                data_update($this->getDeviceArray(), $info['name'], $tags, $fields);
+                $datastore->put($this->getDeviceArray(), $info['name'], $tags, $fields);
                 $this->enableGraph($info['name']);
             }
         }
@@ -90,7 +91,7 @@ class F5 extends OS implements OSPolling
                 'TotCompatConns' => $data['F5-BIGIP-SYSTEM-MIB::sysClientsslStatTotCompatConns.0'],
             ];
             $tags = compact('rrd_def');
-            data_update($this->getDeviceArray(), 'bigip_system_tps', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'bigip_system_tps', $tags, $fields);
             $this->enableGraph('bigip_system_tps');
         }
     }

--- a/LibreNMS/OS/Fortiadc.php
+++ b/LibreNMS/OS/Fortiadc.php
@@ -3,20 +3,15 @@
 namespace LibreNMS\OS;
 
 use App\Models\Device;
-use LibreNMS\Interfaces\Polling\OSPolling;
+use LibreNMS\Interfaces\Discovery\OSDiscovery;
 use LibreNMS\OS\Shared\Fortinet;
 
-class Fortiadc extends Fortinet implements OSPolling
+class Fortiadc extends Fortinet implements OSDiscovery
 {
     public function discoverOS(Device $device): void
     {
         parent::discoverOS($device); // yaml
 
         $device->hardware = $device->hardware ?: $this->getHardwareName();
-    }
-
-    public function pollOS(): void
-    {
-        //
     }
 }

--- a/LibreNMS/OS/Fortigate.php
+++ b/LibreNMS/OS/Fortigate.php
@@ -27,6 +27,7 @@ namespace LibreNMS\OS;
 
 use App\Models\Device;
 use LibreNMS\Device\WirelessSensor;
+use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Discovery\Sensors\WirelessApCountDiscovery;
 use LibreNMS\Interfaces\Discovery\Sensors\WirelessClientsDiscovery;
 use LibreNMS\Interfaces\Polling\OSPolling;

--- a/LibreNMS/OS/Fortigate.php
+++ b/LibreNMS/OS/Fortigate.php
@@ -45,7 +45,7 @@ class Fortigate extends Fortinet implements
         $device->hardware = $device->hardware ?: $this->getHardwareName();
     }
 
-    public function pollOS(): void
+    public function pollOS(DataStorageInterface $datastore): void
     {
         $sessions = snmp_get($this->getDeviceArray(), 'FORTINET-FORTIGATE-MIB::fgSysSesCount.0', '-Ovq');
         if (is_numeric($sessions)) {
@@ -57,7 +57,7 @@ class Fortigate extends Fortinet implements
             ];
 
             $tags = compact('rrd_def');
-            app()->make('Datastore')->put($this->getDeviceArray(), 'fortigate_sessions', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'fortigate_sessions', $tags, $fields);
             $this->enableGraph('fortigate_sessions');
         }
 
@@ -71,7 +71,7 @@ class Fortigate extends Fortinet implements
             ];
 
             $tags = compact('rrd_def');
-            app()->make('Datastore')->put($this->getDeviceArray(), 'fortigate_cpu', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'fortigate_cpu', $tags, $fields);
             $this->enableGraph('fortigate_cpu');
         }
     }

--- a/LibreNMS/OS/Fortios.php
+++ b/LibreNMS/OS/Fortios.php
@@ -26,6 +26,7 @@
 namespace LibreNMS\OS;
 
 use App\Models\Device;
+use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Polling\OSPolling;
 use LibreNMS\OS\Shared\Fortinet;
 use LibreNMS\RRD\RrdDefinition;
@@ -40,7 +41,7 @@ class Fortios extends Fortinet implements OSPolling
         $device->features = snmp_get($this->getDeviceArray(), 'fmDeviceEntMode.1', '-OQv', 'FORTINET-FORTIMANAGER-FORTIANALYZER-MIB') == 'fmg-faz' ? 'with Analyzer features' : null;
     }
 
-    public function pollOS(): void
+    public function pollOS(DataStorageInterface $datastore): void
     {
         // Log rate only for FortiAnalyzer features enabled FortiManagers
         if ($this->getDevice()->features == 'with Analyzer features') {
@@ -49,7 +50,7 @@ class Fortios extends Fortinet implements OSPolling
             $rrd_def = RrdDefinition::make()->addDataset('lograte', 'GAUGE', 0, 100000000);
             $fields = ['lograte' => $log_rate];
             $tags = compact('rrd_def');
-            app()->make('Datastore')->put($this->getDeviceArray(), 'fortios_lograte', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'fortios_lograte', $tags, $fields);
             $this->enableGraph('fortios_lograte');
         }
     }

--- a/LibreNMS/OS/Gaia.php
+++ b/LibreNMS/OS/Gaia.php
@@ -2,12 +2,13 @@
 
 namespace LibreNMS\OS;
 
+use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Polling\OSPolling;
 use LibreNMS\RRD\RrdDefinition;
 
 class Gaia extends \LibreNMS\OS implements OSPolling
 {
-    public function pollOS(): void
+    public function pollOS(DataStorageInterface $datastore): void
     {
         $oids = ['fwLoggingHandlingRate.0', 'mgLSLogReceiveRate.0', 'fwNumConn.0', 'fwAccepted.0', 'fwRejected.0', 'fwDropped.0', 'fwLogged.0'];
 
@@ -24,7 +25,7 @@ class Gaia extends \LibreNMS\OS implements OSPolling
             ];
 
             $tags = compact('rrd_def');
-            data_update($this->getDeviceArray(), 'gaia_firewall_lograte', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'gaia_firewall_lograte', $tags, $fields);
             $this->enableGraph('gaia_firewall_lograte');
         }
 
@@ -39,7 +40,7 @@ class Gaia extends \LibreNMS\OS implements OSPolling
             ];
 
             $tags = compact('rrd_def');
-            data_update($this->getDeviceArray(), 'gaia_logserver_lograte', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'gaia_logserver_lograte', $tags, $fields);
             $this->enableGraph('gaia_logserver_lograte');
         }
 
@@ -54,7 +55,7 @@ class Gaia extends \LibreNMS\OS implements OSPolling
             ];
 
             $tags = compact('rrd_def');
-            data_update($this->getDeviceArray(), 'gaia_connections', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'gaia_connections', $tags, $fields);
             $this->enableGraph('gaia_connections');
         }
 
@@ -76,7 +77,7 @@ class Gaia extends \LibreNMS\OS implements OSPolling
             ];
 
             $tags = compact('rrd_def');
-            data_update($this->getDeviceArray(), 'gaia_firewall_packets', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'gaia_firewall_packets', $tags, $fields);
             $this->enableGraph('gaia_firewall_packets');
         }
     }

--- a/LibreNMS/OS/Iosxe.php
+++ b/LibreNMS/OS/Iosxe.php
@@ -30,6 +30,7 @@ use App\Models\IsisAdjacency;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use LibreNMS\DB\SyncsModels;
+use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Discovery\IsIsDiscovery;
 use LibreNMS\Interfaces\Discovery\Sensors\WirelessCellDiscovery;
 use LibreNMS\Interfaces\Discovery\Sensors\WirelessChannelDiscovery;
@@ -57,7 +58,7 @@ class Iosxe extends Ciscowlc implements
     use SyncsModels;
     use CiscoCellular;
 
-    public function pollOS(): void
+    public function pollOS(DataStorageInterface $datastore): void
     {
         // Don't poll Ciscowlc FIXME remove when wireless-controller module exists
     }

--- a/LibreNMS/OS/Netscaler.php
+++ b/LibreNMS/OS/Netscaler.php
@@ -25,12 +25,13 @@
 
 namespace LibreNMS\OS;
 
+use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Polling\OSPolling;
 use LibreNMS\RRD\RrdDefinition;
 
 class Netscaler extends \LibreNMS\OS implements OSPolling
 {
-    public function pollOS(): void
+    public function pollOS(DataStorageInterface $datastore): void
     {
         echo ' IP';
 
@@ -157,7 +158,7 @@ class Netscaler extends \LibreNMS\OS implements OSPolling
         }
 
         $tags = compact('rrd_def');
-        data_update($this->getDeviceArray(), 'netscaler-stats-tcp', $tags, $fields);
+        $datastore->put($this->getDeviceArray(), 'netscaler-stats-tcp', $tags, $fields);
 
         $this->enableGraph('netscaler_tcp_conn');
         $this->enableGraph('netscaler_tcp_bits');

--- a/LibreNMS/OS/Nios.php
+++ b/LibreNMS/OS/Nios.php
@@ -25,12 +25,13 @@
 
 namespace LibreNMS\OS;
 
+use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Polling\OSPolling;
 use LibreNMS\RRD\RrdDefinition;
 
 class Nios extends \LibreNMS\OS implements OSPolling
 {
-    public function pollOS(): void
+    public function pollOS(DataStorageInterface $datastore): void
     {
         //#############
         // Create ddns update rrd
@@ -59,7 +60,7 @@ class Nios extends \LibreNMS\OS implements OSPolling
         ];
 
         $tags = compact('rrd_def');
-        data_update($this->getDeviceArray(), 'ib_dns_dyn_updates', $tags, $fields);
+        $datastore->put($this->getDeviceArray(), 'ib_dns_dyn_updates', $tags, $fields);
         $this->enableGraph('ib_dns_dyn_updates');
 
         //#################
@@ -83,7 +84,7 @@ class Nios extends \LibreNMS\OS implements OSPolling
         ];
 
         $tags = compact('rrd_def');
-        data_update($this->getDeviceArray(), 'ib_dns_performance', $tags, $fields);
+        $datastore->put($this->getDeviceArray(), 'ib_dns_performance', $tags, $fields);
         $this->enableGraph('ib_dns_performance');
 
         //#################
@@ -113,7 +114,7 @@ class Nios extends \LibreNMS\OS implements OSPolling
         ];
 
         $tags = compact('rrd_def');
-        data_update($this->getDeviceArray(), 'ib_dns_request_return_codes', $tags, $fields);
+        $datastore->put($this->getDeviceArray(), 'ib_dns_request_return_codes', $tags, $fields);
         $this->enableGraph('ib_dns_request_return_codes');
 
         //#################
@@ -158,7 +159,7 @@ class Nios extends \LibreNMS\OS implements OSPolling
         ];
 
         $tags = compact('rrd_def');
-        data_update($this->getDeviceArray(), 'ib_dhcp_messages', $tags, $fields);
+        $datastore->put($this->getDeviceArray(), 'ib_dhcp_messages', $tags, $fields);
         $this->enableGraph('ib_dhcp_messages');
     }
 }

--- a/LibreNMS/OS/Panos.php
+++ b/LibreNMS/OS/Panos.php
@@ -26,6 +26,7 @@
 namespace LibreNMS\OS;
 
 use Illuminate\Support\Str;
+use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Polling\OSPolling;
 use LibreNMS\RRD\RrdDefinition;
 
@@ -36,7 +37,7 @@ class Panos extends \LibreNMS\OS implements OSPolling
         'Packet Buffers',
     ];
 
-    public function pollOS(): void
+    public function pollOS(DataStorageInterface $datastore): void
     {
         $data = snmp_get_multi($this->getDeviceArray(), [
             'panSessionActive.0',
@@ -76,7 +77,7 @@ class Panos extends \LibreNMS\OS implements OSPolling
             ];
 
             $tags = compact('rrd_def');
-            data_update($this->getDeviceArray(), 'panos-sessions', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'panos-sessions', $tags, $fields);
 
             $this->enableGraph('panos_sessions');
         }
@@ -89,7 +90,7 @@ class Panos extends \LibreNMS\OS implements OSPolling
             ];
 
             $tags = compact('rrd_def');
-            data_update($this->getDeviceArray(), 'panos-sessions-tcp', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'panos-sessions-tcp', $tags, $fields);
 
             $this->enableGraph('panos_sessions_tcp');
         }
@@ -102,7 +103,7 @@ class Panos extends \LibreNMS\OS implements OSPolling
             ];
 
             $tags = compact('rrd_def');
-            data_update($this->getDeviceArray(), 'panos-sessions-udp', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'panos-sessions-udp', $tags, $fields);
 
             $this->enableGraph('panos_sessions_udp');
         }
@@ -115,7 +116,7 @@ class Panos extends \LibreNMS\OS implements OSPolling
             ];
 
             $tags = compact('rrd_def');
-            data_update($this->getDeviceArray(), 'panos-sessions-icmp', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'panos-sessions-icmp', $tags, $fields);
 
             $this->enableGraph('panos_sessions_icmp');
         }
@@ -128,7 +129,7 @@ class Panos extends \LibreNMS\OS implements OSPolling
             ];
 
             $tags = compact('rrd_def');
-            data_update($this->getDeviceArray(), 'panos-sessions-ssl', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'panos-sessions-ssl', $tags, $fields);
 
             $this->enableGraph('panos_sessions_ssl');
         }
@@ -141,7 +142,7 @@ class Panos extends \LibreNMS\OS implements OSPolling
             ];
 
             $tags = compact('rrd_def');
-            data_update($this->getDeviceArray(), 'panos-sessions-sslutil', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'panos-sessions-sslutil', $tags, $fields);
 
             $this->enableGraph('panos_sessions_sslutil');
         }
@@ -154,7 +155,7 @@ class Panos extends \LibreNMS\OS implements OSPolling
             ];
 
             $tags = compact('rrd_def');
-            data_update($this->getDeviceArray(), 'panos-activetunnels', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'panos-activetunnels', $tags, $fields);
 
             $this->enableGraph('panos_activetunnels');
         }
@@ -166,7 +167,7 @@ class Panos extends \LibreNMS\OS implements OSPolling
             ];
 
             $tags = compact('rrd_def');
-            data_update($this->getDeviceArray(), 'panos-panFlowDosBlkNumEntries', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'panos-panFlowDosBlkNumEntries', $tags, $fields);
 
             $this->enableGraph('panos_panFlowDosBlkNumEntries');
         }
@@ -178,7 +179,7 @@ class Panos extends \LibreNMS\OS implements OSPolling
             ];
 
             $tags = compact('rrd_def');
-            data_update($this->getDeviceArray(), 'panos-panFlowMeterVsysThrottle', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'panos-panFlowMeterVsysThrottle', $tags, $fields);
 
             $this->enableGraph('panos_panFlowMeterVsysThrottle');
         }
@@ -190,7 +191,7 @@ class Panos extends \LibreNMS\OS implements OSPolling
             ];
 
             $tags = compact('rrd_def');
-            data_update($this->getDeviceArray(), 'panos-panFlowPolicyDeny', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'panos-panFlowPolicyDeny', $tags, $fields);
 
             $this->enableGraph('panos_panFlowPolicyDeny');
         }
@@ -202,7 +203,7 @@ class Panos extends \LibreNMS\OS implements OSPolling
             ];
 
             $tags = compact('rrd_def');
-            data_update($this->getDeviceArray(), 'panos-panFlowPolicyNat', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'panos-panFlowPolicyNat', $tags, $fields);
 
             $this->enableGraph('panos_panFlowPolicyNat');
         }
@@ -214,7 +215,7 @@ class Panos extends \LibreNMS\OS implements OSPolling
             ];
 
             $tags = compact('rrd_def');
-            data_update($this->getDeviceArray(), 'panos-panFlowScanDrop', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'panos-panFlowScanDrop', $tags, $fields);
 
             $this->enableGraph('panos_panFlowScanDrop');
         }
@@ -226,7 +227,7 @@ class Panos extends \LibreNMS\OS implements OSPolling
             ];
 
             $tags = compact('rrd_def');
-            data_update($this->getDeviceArray(), 'panos-panFlowDosDropIpBlocked', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'panos-panFlowDosDropIpBlocked', $tags, $fields);
 
             $this->enableGraph('panos_panFlowDosDropIpBlocked');
         }
@@ -238,7 +239,7 @@ class Panos extends \LibreNMS\OS implements OSPolling
             ];
 
             $tags = compact('rrd_def');
-            data_update($this->getDeviceArray(), 'panos-panFlowDosRedIcmp', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'panos-panFlowDosRedIcmp', $tags, $fields);
 
             $this->enableGraph('panos_panFlowDosRedIcmp');
         }
@@ -250,7 +251,7 @@ class Panos extends \LibreNMS\OS implements OSPolling
             ];
 
             $tags = compact('rrd_def');
-            data_update($this->getDeviceArray(), 'panos-panFlowDosRedIcmp6', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'panos-panFlowDosRedIcmp6', $tags, $fields);
 
             $this->enableGraph('panos_panFlowDosRedIcmp6');
         }
@@ -262,7 +263,7 @@ class Panos extends \LibreNMS\OS implements OSPolling
             ];
 
             $tags = compact('rrd_def');
-            data_update($this->getDeviceArray(), 'panos-panFlowDosRedIp', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'panos-panFlowDosRedIp', $tags, $fields);
 
             $this->enableGraph('panos_panFlowDosRedIp');
         }
@@ -274,7 +275,7 @@ class Panos extends \LibreNMS\OS implements OSPolling
             ];
 
             $tags = compact('rrd_def');
-            data_update($this->getDeviceArray(), 'panos-panFlowDosRedTcp', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'panos-panFlowDosRedTcp', $tags, $fields);
 
             $this->enableGraph('panos_panFlowDosRedTcp');
         }
@@ -286,7 +287,7 @@ class Panos extends \LibreNMS\OS implements OSPolling
             ];
 
             $tags = compact('rrd_def');
-            data_update($this->getDeviceArray(), 'panos-panFlowDosRedUdp', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'panos-panFlowDosRedUdp', $tags, $fields);
 
             $this->enableGraph('panos_panFlowDosRedUdp');
         }
@@ -298,7 +299,7 @@ class Panos extends \LibreNMS\OS implements OSPolling
             ];
 
             $tags = compact('rrd_def');
-            data_update($this->getDeviceArray(), 'panos-panFlowDosPbpDrop', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'panos-panFlowDosPbpDrop', $tags, $fields);
 
             $this->enableGraph('panos_panFlowDosPbpDrop');
         }
@@ -310,7 +311,7 @@ class Panos extends \LibreNMS\OS implements OSPolling
             ];
 
             $tags = compact('rrd_def');
-            data_update($this->getDeviceArray(), 'panos-panFlowDosRuleDeny', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'panos-panFlowDosRuleDeny', $tags, $fields);
 
             $this->enableGraph('panos_panFlowDosRuleDeny');
         }
@@ -322,7 +323,7 @@ class Panos extends \LibreNMS\OS implements OSPolling
             ];
 
             $tags = compact('rrd_def');
-            data_update($this->getDeviceArray(), 'panos-panFlowDosRuleDrop', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'panos-panFlowDosRuleDrop', $tags, $fields);
 
             $this->enableGraph('panos_panFlowDosRuleDrop');
         }
@@ -334,7 +335,7 @@ class Panos extends \LibreNMS\OS implements OSPolling
             ];
 
             $tags = compact('rrd_def');
-            data_update($this->getDeviceArray(), 'panos-panFlowDosZoneRedAct', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'panos-panFlowDosZoneRedAct', $tags, $fields);
 
             $this->enableGraph('panos_panFlowDosZoneRedAct');
         }
@@ -346,7 +347,7 @@ class Panos extends \LibreNMS\OS implements OSPolling
             ];
 
             $tags = compact('rrd_def');
-            data_update($this->getDeviceArray(), 'panos-panFlowDosZoneRedMax', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'panos-panFlowDosZoneRedMax', $tags, $fields);
 
             $this->enableGraph('panos_panFlowDosZoneRedMax');
         }
@@ -358,7 +359,7 @@ class Panos extends \LibreNMS\OS implements OSPolling
             ];
 
             $tags = compact('rrd_def');
-            data_update($this->getDeviceArray(), 'panos-panFlowDosSyncookieNotTcpSyn', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'panos-panFlowDosSyncookieNotTcpSyn', $tags, $fields);
 
             $this->enableGraph('panos_panFlowDosSyncookieNotTcpSyn');
         }
@@ -370,7 +371,7 @@ class Panos extends \LibreNMS\OS implements OSPolling
             ];
 
             $tags = compact('rrd_def');
-            data_update($this->getDeviceArray(), 'panos-panFlowDosSyncookieNotTcpSynAck', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'panos-panFlowDosSyncookieNotTcpSynAck', $tags, $fields);
 
             $this->enableGraph('panos_panFlowDosSyncookieNotTcpSynAck');
         }
@@ -382,7 +383,7 @@ class Panos extends \LibreNMS\OS implements OSPolling
             ];
 
             $tags = compact('rrd_def');
-            data_update($this->getDeviceArray(), 'panos-panFlowDosBlkSwEntries', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'panos-panFlowDosBlkSwEntries', $tags, $fields);
 
             $this->enableGraph('panos_panFlowDosBlkSwEntries');
         }
@@ -394,7 +395,7 @@ class Panos extends \LibreNMS\OS implements OSPolling
             ];
 
             $tags = compact('rrd_def');
-            data_update($this->getDeviceArray(), 'panos-panFlowDosBlkHwEntries', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'panos-panFlowDosBlkHwEntries', $tags, $fields);
 
             $this->enableGraph('panos_panFlowDosBlkHwEntries');
         }

--- a/LibreNMS/OS/Pfsense.php
+++ b/LibreNMS/OS/Pfsense.php
@@ -25,13 +25,14 @@
 
 namespace LibreNMS\OS;
 
+use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Polling\OSPolling;
 use LibreNMS\OS\Shared\Unix;
 use LibreNMS\RRD\RrdDefinition;
 
 class Pfsense extends Unix implements OSPolling
 {
-    public function pollOS(): void
+    public function pollOS(DataStorageInterface $datastore): void
     {
         $oids = snmp_get_multi($this->getDeviceArray(), [
             'pfStateTableCount.0',
@@ -54,7 +55,7 @@ class Pfsense extends Unix implements OSPolling
             ];
 
             $tags = compact('rrd_def');
-            data_update($this->getDeviceArray(), 'pf_states', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'pf_states', $tags, $fields);
 
             $this->enableGraph('pf_states');
         }
@@ -67,7 +68,7 @@ class Pfsense extends Unix implements OSPolling
             ];
 
             $tags = compact('rrd_def');
-            data_update($this->getDeviceArray(), 'pf_searches', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'pf_searches', $tags, $fields);
 
             $this->enableGraph('pf_searches');
         }
@@ -80,7 +81,7 @@ class Pfsense extends Unix implements OSPolling
             ];
 
             $tags = compact('rrd_def');
-            data_update($this->getDeviceArray(), 'pf_inserts', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'pf_inserts', $tags, $fields);
 
             $this->enableGraph('pf_inserts');
         }
@@ -93,7 +94,7 @@ class Pfsense extends Unix implements OSPolling
             ];
 
             $tags = compact('rrd_def');
-            data_update($this->getDeviceArray(), 'pf_removals', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'pf_removals', $tags, $fields);
 
             $this->enableGraph('pf_removals');
         }
@@ -106,7 +107,7 @@ class Pfsense extends Unix implements OSPolling
             ];
 
             $tags = compact('rrd_def');
-            data_update($this->getDeviceArray(), 'pf_matches', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'pf_matches', $tags, $fields);
 
             $this->enableGraph('pf_matches');
         }
@@ -119,7 +120,7 @@ class Pfsense extends Unix implements OSPolling
             ];
 
             $tags = compact('rrd_def');
-            data_update($this->getDeviceArray(), 'pf_badoffset', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'pf_badoffset', $tags, $fields);
 
             $this->enableGraph('pf_badoffset');
         }
@@ -132,7 +133,7 @@ class Pfsense extends Unix implements OSPolling
             ];
 
             $tags = compact('rrd_def');
-            data_update($this->getDeviceArray(), 'pf_fragmented', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'pf_fragmented', $tags, $fields);
 
             $this->enableGraph('pf_fragmented');
         }
@@ -145,7 +146,7 @@ class Pfsense extends Unix implements OSPolling
             ];
 
             $tags = compact('rrd_def');
-            data_update($this->getDeviceArray(), 'pf_short', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'pf_short', $tags, $fields);
 
             $this->enableGraph('pf_short');
         }
@@ -158,7 +159,7 @@ class Pfsense extends Unix implements OSPolling
             ];
 
             $tags = compact('rrd_def');
-            data_update($this->getDeviceArray(), 'pf_normalized', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'pf_normalized', $tags, $fields);
 
             $this->enableGraph('pf_normalized');
         }
@@ -171,7 +172,7 @@ class Pfsense extends Unix implements OSPolling
             ];
 
             $tags = compact('rrd_def');
-            data_update($this->getDeviceArray(), 'pf_memdropped', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'pf_memdropped', $tags, $fields);
 
             $this->enableGraph('pf_memdropped');
         }

--- a/LibreNMS/OS/Pmp.php
+++ b/LibreNMS/OS/Pmp.php
@@ -28,6 +28,7 @@ namespace LibreNMS\OS;
 use App\Models\Device;
 use Illuminate\Support\Str;
 use LibreNMS\Device\WirelessSensor;
+use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Discovery\Sensors\WirelessClientsDiscovery;
 use LibreNMS\Interfaces\Discovery\Sensors\WirelessErrorsDiscovery;
 use LibreNMS\Interfaces\Discovery\Sensors\WirelessFrequencyDiscovery;
@@ -95,7 +96,7 @@ class Pmp extends OS implements
         $device->hardware = $hardware;
     }
 
-    public function pollOS(): void
+    public function pollOS(DataStorageInterface $datastore): void
     {
         // Migrated to Wireless Sensor
         $fec = snmp_get_multi_oid($this->getDeviceArray(), ['fecInErrorsCount.0', 'fecOutErrorsCount.0', 'fecCRCError.0'], '-OQUs', 'WHISP-BOX-MIBV2-MIB');
@@ -109,7 +110,7 @@ class Pmp extends OS implements
                 'fecOutErrorsCount' => $fec['fecOutErrorsCount.0'],
             ];
             $tags = compact('rrd_def');
-            data_update($this->getDeviceArray(), 'canopy-generic-errorCount', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'canopy-generic-errorCount', $tags, $fields);
             $this->enableGraph('canopy_generic_errorCount');
         }
 
@@ -120,7 +121,7 @@ class Pmp extends OS implements
                 'crcErrors' => $fec['fecCRCError.0'],
             ];
             $tags = compact('rrd_def');
-            data_update($this->getDeviceArray(), 'canopy-generic-crcErrors', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'canopy-generic-crcErrors', $tags, $fields);
             $this->enableGraph('canopy_generic_crcErrors');
         }
 
@@ -131,7 +132,7 @@ class Pmp extends OS implements
                 'jitter' => $jitter,
             ];
             $tags = compact('rrd_def');
-            data_update($this->getDeviceArray(), 'canopy-generic-jitter', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'canopy-generic-jitter', $tags, $fields);
             $this->enableGraph('canopy_generic_jitter');
             unset($rrd_def, $jitter);
         }
@@ -150,7 +151,7 @@ class Pmp extends OS implements
                 'failed' => $failed,
             ];
             $tags = compact('rrd_def');
-            data_update($this->getDeviceArray(), 'canopy-generic-regCount', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'canopy-generic-regCount', $tags, $fields);
             $this->enableGraph('canopy_generic_regCount');
             unset($rrd_def, $registered, $failed);
         }
@@ -166,7 +167,7 @@ class Pmp extends OS implements
                 'tracked' => floatval($tracked),
             ];
             $tags = compact('rrd_def');
-            data_update($this->getDeviceArray(), 'canopy-generic-gpsStats', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'canopy-generic-gpsStats', $tags, $fields);
             $this->enableGraph('canopy_generic_gpsStats');
         }
 
@@ -185,7 +186,7 @@ class Pmp extends OS implements
                 'avg' => $radio['radioDbmAvg.0'],
             ];
             $tags = compact('rrd_def');
-            data_update($this->getDeviceArray(), 'canopy-generic-radioDbm', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'canopy-generic-radioDbm', $tags, $fields);
             $this->enableGraph('canopy_generic_radioDbm');
         }
 
@@ -199,7 +200,7 @@ class Pmp extends OS implements
                 'vertical' => $dbm['linkRadioDbmVertical.2'],
             ];
             $tags = compact('rrd_def');
-            data_update($this->getDeviceArray(), 'canopy-generic-450-linkRadioDbm', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'canopy-generic-450-linkRadioDbm', $tags, $fields);
             $this->enableGraph('canopy_generic_450_linkRadioDbm');
         }
 
@@ -210,7 +211,7 @@ class Pmp extends OS implements
                 'last' => $lastLevel,
             ];
             $tags = compact('rrd_def');
-            data_update($this->getDeviceArray(), 'canopy-generic-450-powerlevel', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'canopy-generic-450-powerlevel', $tags, $fields);
             $this->enableGraph('canopy_generic_450_powerlevel');
         }
 
@@ -228,7 +229,7 @@ class Pmp extends OS implements
                 'combined' => $combined,
             ];
             $tags = compact('rrd_def');
-            data_update($this->getDeviceArray(), 'canopy-generic-signalHV', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'canopy-generic-signalHV', $tags, $fields);
             $this->enableGraph('canopy_generic_signalHV');
             unset($rrd_def, $vertical, $horizontal, $combined);
         }
@@ -245,7 +246,7 @@ class Pmp extends OS implements
                 'vertical' => $vertical,
             ];
             $tags = compact('rrd_def');
-            data_update($this->getDeviceArray(), 'canopy-generic-450-slaveHV', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'canopy-generic-450-slaveHV', $tags, $fields);
             $this->enableGraph('canopy_generic_450_slaveHV');
         }
     }

--- a/LibreNMS/OS/Poweralert.php
+++ b/LibreNMS/OS/Poweralert.php
@@ -26,6 +26,7 @@
 namespace LibreNMS\OS;
 
 use App\Models\Device;
+use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Polling\OSPolling;
 
 class Poweralert extends \LibreNMS\OS implements OSPolling
@@ -37,7 +38,7 @@ class Poweralert extends \LibreNMS\OS implements OSPolling
         $this->customSysName($device);
     }
 
-    public function pollOs(): void
+    public function pollOS(DataStorageInterface $datastore): void
     {
         $this->customSysName($this->getDevice());
     }

--- a/LibreNMS/OS/Procurve.php
+++ b/LibreNMS/OS/Procurve.php
@@ -25,12 +25,13 @@
 
 namespace LibreNMS\OS;
 
+use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Polling\OSPolling;
 use LibreNMS\RRD\RrdDefinition;
 
 class Procurve extends \LibreNMS\OS implements OSPolling
 {
-    public function pollOS(): void
+    public function pollOS(DataStorageInterface $datastore): void
     {
         $FdbAddressCount = snmp_get($this->getDeviceArray(), 'hpSwitchFdbAddressCount.0', '-Ovqn', 'STATISTICS-MIB');
 
@@ -42,7 +43,7 @@ class Procurve extends \LibreNMS\OS implements OSPolling
             ];
 
             $tags = compact('rrd_def');
-            data_update($this->getDeviceArray(), 'fdb_count', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'fdb_count', $tags, $fields);
 
             $this->enableGraph('fdb_count');
         }

--- a/LibreNMS/OS/Pulse.php
+++ b/LibreNMS/OS/Pulse.php
@@ -25,12 +25,13 @@
 
 namespace LibreNMS\OS;
 
+use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Polling\OSPolling;
 use LibreNMS\RRD\RrdDefinition;
 
 class Pulse extends \LibreNMS\OS implements OSPolling
 {
-    public function pollOS(): void
+    public function pollOS(DataStorageInterface $datastore): void
     {
         $users = snmp_get($this->getDeviceArray(), 'iveConcurrentUsers.0', '-OQv', 'PULSESECURE-PSG-MIB');
 
@@ -42,7 +43,7 @@ class Pulse extends \LibreNMS\OS implements OSPolling
             ];
 
             $tags = compact('rrd_def');
-            data_update($this->getDeviceArray(), 'pulse_users', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'pulse_users', $tags, $fields);
             $this->enableGraph('pulse_users');
         }
     }

--- a/LibreNMS/OS/Riverbed.php
+++ b/LibreNMS/OS/Riverbed.php
@@ -25,13 +25,14 @@
 
 namespace LibreNMS\OS;
 
+use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Polling\OSPolling;
 use LibreNMS\OS;
 use LibreNMS\RRD\RrdDefinition;
 
 class Riverbed extends OS implements OSPolling
 {
-    public function pollOS(): void
+    public function pollOS(DataStorageInterface $datastore): void
     {
         /* optimisation oids
          *
@@ -76,7 +77,7 @@ class Riverbed extends OS implements OSPolling
 
             $tags = compact('rrd_def');
 
-            data_update($this->getDeviceArray(), 'riverbed_connections', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'riverbed_connections', $tags, $fields);
             $this->enableGraph('riverbed_connections');
         }
 
@@ -107,7 +108,7 @@ class Riverbed extends OS implements OSPolling
 
             $tags = compact('rrd_def');
 
-            data_update($this->getDeviceArray(), 'riverbed_datastore', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'riverbed_datastore', $tags, $fields);
             $this->enableGraph('riverbed_datastore');
         }
 
@@ -139,7 +140,7 @@ class Riverbed extends OS implements OSPolling
 
             $tags = compact('rrd_def');
 
-            data_update($this->getDeviceArray(), 'riverbed_optimization', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'riverbed_optimization', $tags, $fields);
             $this->enableGraph('riverbed_optimization');
         }
 
@@ -177,7 +178,7 @@ class Riverbed extends OS implements OSPolling
 
             $tags = compact('rrd_def');
 
-            data_update($this->getDeviceArray(), 'riverbed_passthrough', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'riverbed_passthrough', $tags, $fields);
             $this->enableGraph('riverbed_passthrough');
         }
     }

--- a/LibreNMS/OS/Routeros.php
+++ b/LibreNMS/OS/Routeros.php
@@ -26,6 +26,7 @@
 namespace LibreNMS\OS;
 
 use LibreNMS\Device\WirelessSensor;
+use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Discovery\Sensors\WirelessCcqDiscovery;
 use LibreNMS\Interfaces\Discovery\Sensors\WirelessClientsDiscovery;
 use LibreNMS\Interfaces\Discovery\Sensors\WirelessDistanceDiscovery;
@@ -466,7 +467,7 @@ class Routeros extends OS implements
         return $sensors;
     }
 
-    public function pollOS(): void
+    public function pollOS(DataStorageInterface $datastore): void
     {
         $leases = snmp_get($this->getDeviceArray(), 'mtxrDHCPLeaseCount.0', '-OQv', 'MIKROTIK-MIB');
 
@@ -478,7 +479,7 @@ class Routeros extends OS implements
             ];
 
             $tags = compact('rrd_def');
-            data_update($this->getDeviceArray(), 'routeros_leases', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'routeros_leases', $tags, $fields);
             $this->enableGraph('routeros_leases');
         }
 
@@ -492,7 +493,7 @@ class Routeros extends OS implements
             ];
 
             $tags = compact('rrd_def');
-            data_update($this->getDeviceArray(), 'routeros_pppoe_sessions', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'routeros_pppoe_sessions', $tags, $fields);
             $this->enableGraph('routeros_pppoe_sessions');
         }
     }

--- a/LibreNMS/OS/Rutos2xx.php
+++ b/LibreNMS/OS/Rutos2xx.php
@@ -26,6 +26,7 @@
 namespace LibreNMS\OS;
 
 use LibreNMS\Device\WirelessSensor;
+use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Discovery\Sensors\WirelessRssiDiscovery;
 use LibreNMS\Interfaces\Discovery\Sensors\WirelessSnrDiscovery;
 use LibreNMS\Interfaces\Polling\OSPolling;
@@ -37,7 +38,7 @@ class Rutos2xx extends OS implements
     WirelessSnrDiscovery,
     WirelessRssiDiscovery
 {
-    public function pollOS(): void
+    public function pollOS(DataStorageInterface $datastore): void
     {
         // Mobile Data Usage
         $usage = snmp_get_multi_oid($this->getDeviceArray(), [
@@ -59,7 +60,7 @@ class Rutos2xx extends OS implements
             ];
 
             $tags = compact('rrd_def');
-            data_update($this->getDeviceArray(), 'rutos_2xx_mobileDataUsage', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'rutos_2xx_mobileDataUsage', $tags, $fields);
             $this->enableGraph('rutos_2xx_mobileDataUsage');
         }
     }

--- a/LibreNMS/OS/Screenos.php
+++ b/LibreNMS/OS/Screenos.php
@@ -25,12 +25,13 @@
 
 namespace LibreNMS\OS;
 
+use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Polling\OSPolling;
 use LibreNMS\RRD\RrdDefinition;
 
 class Screenos extends \LibreNMS\OS implements OSPolling
 {
-    public function pollOS(): void
+    public function pollOS(DataStorageInterface $datastore): void
     {
         $sess_data = snmp_get_multi_oid($this->getDeviceArray(), [
             '.1.3.6.1.4.1.3224.16.3.2.0',
@@ -53,7 +54,7 @@ class Screenos extends \LibreNMS\OS implements OSPolling
             ];
 
             $tags = compact('rrd_def');
-            data_update($this->getDeviceArray(), 'screenos_sessions', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'screenos_sessions', $tags, $fields);
 
             $this->enableGraph('screenos_sessions');
         }

--- a/LibreNMS/OS/Secureplatform.php
+++ b/LibreNMS/OS/Secureplatform.php
@@ -25,12 +25,13 @@
 
 namespace LibreNMS\OS;
 
+use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Polling\OSPolling;
 use LibreNMS\RRD\RrdDefinition;
 
 class Secureplatform extends \LibreNMS\OS implements OSPolling
 {
-    public function pollOS(): void
+    public function pollOS(DataStorageInterface $datastore): void
     {
         $connections = snmp_get($this->getDeviceArray(), 'fwNumConn.0', '-OQv', 'CHECKPOINT-MIB');
 
@@ -42,7 +43,7 @@ class Secureplatform extends \LibreNMS\OS implements OSPolling
             ];
 
             $tags = compact('rrd_def');
-            data_update($this->getDeviceArray(), 'secureplatform_sessions', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'secureplatform_sessions', $tags, $fields);
             $this->enableGraph('secureplatform_sessions');
         }
     }

--- a/LibreNMS/OS/Sgos.php
+++ b/LibreNMS/OS/Sgos.php
@@ -26,6 +26,7 @@
 namespace LibreNMS\OS;
 
 use LibreNMS\Device\Processor;
+use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Discovery\ProcessorDiscovery;
 use LibreNMS\Interfaces\Polling\OSPolling;
 use LibreNMS\OS;
@@ -33,7 +34,7 @@ use LibreNMS\RRD\RrdDefinition;
 
 class Sgos extends OS implements ProcessorDiscovery, OSPolling
 {
-    public function pollOS(): void
+    public function pollOS(DataStorageInterface $datastore): void
     {
         $oid_list = [
             'sgProxyHttpClientRequestRate.0',
@@ -55,7 +56,7 @@ class Sgos extends OS implements ProcessorDiscovery, OSPolling
                 'requests' => $sgos[0]['sgProxyHttpClientRequestRate'],
             ];
 
-            data_update($this->getDeviceArray(), 'sgos_average_requests', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'sgos_average_requests', $tags, $fields);
 
             $this->enableGraph('sgos_average_requests');
             echo ' HTTP Req Rate';
@@ -69,7 +70,7 @@ class Sgos extends OS implements ProcessorDiscovery, OSPolling
                 'client_conn' => $sgos[0]['sgProxyHttpClientConnections'],
             ];
 
-            data_update($this->getDeviceArray(), 'sgos_client_connections', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'sgos_client_connections', $tags, $fields);
 
             $this->enableGraph('sgos_client_connections');
             echo ' Client Conn';
@@ -83,7 +84,7 @@ class Sgos extends OS implements ProcessorDiscovery, OSPolling
                 'server_conn' => $sgos[0]['sgProxyHttpServerConnections'],
             ];
 
-            data_update($this->getDeviceArray(), 'sgos_server_connections', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'sgos_server_connections', $tags, $fields);
 
             $this->enableGraph('sgos_server_connections');
             echo ' Server Conn';
@@ -97,7 +98,7 @@ class Sgos extends OS implements ProcessorDiscovery, OSPolling
                 'client_conn_active' => $sgos[0]['sgProxyHttpClientConnectionsActive'],
             ];
 
-            data_update($this->getDeviceArray(), 'sgos_client_connections_active', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'sgos_client_connections_active', $tags, $fields);
 
             $this->enableGraph('sgos_client_connections_active');
             echo ' Client Conn Active';
@@ -111,7 +112,7 @@ class Sgos extends OS implements ProcessorDiscovery, OSPolling
                 'server_conn_active' => $sgos[0]['sgProxyHttpServerConnectionsActive'],
             ];
 
-            data_update($this->getDeviceArray(), 'sgos_server_connections_active', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'sgos_server_connections_active', $tags, $fields);
 
             $this->enableGraph('sgos_server_connections_active');
             echo ' Server Conn Active';
@@ -125,7 +126,7 @@ class Sgos extends OS implements ProcessorDiscovery, OSPolling
                 'client_idle' => $sgos[0]['sgProxyHttpClientConnectionsIdle'],
             ];
 
-            data_update($this->getDeviceArray(), 'sgos_client_connections_idle', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'sgos_client_connections_idle', $tags, $fields);
 
             $this->enableGraph('sgos_client_connections_idle');
             echo ' Client Conne Idle';
@@ -139,7 +140,7 @@ class Sgos extends OS implements ProcessorDiscovery, OSPolling
                 'server_idle' => $sgos[0]['sgProxyHttpServerConnectionsIdle'],
             ];
 
-            data_update($this->getDeviceArray(), 'sgos_server_connections_idle', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'sgos_server_connections_idle', $tags, $fields);
 
             $this->enableGraph('sgos_server_connections_idle');
             echo ' Server Conn Idle';

--- a/LibreNMS/OS/Sonicwall.php
+++ b/LibreNMS/OS/Sonicwall.php
@@ -19,6 +19,7 @@ namespace LibreNMS\OS;
 
 use Illuminate\Support\Str;
 use LibreNMS\Device\Processor;
+use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Discovery\ProcessorDiscovery;
 use LibreNMS\Interfaces\Polling\OSPolling;
 use LibreNMS\OS;
@@ -26,7 +27,7 @@ use LibreNMS\RRD\RrdDefinition;
 
 class Sonicwall extends OS implements OSPolling, ProcessorDiscovery
 {
-    public function pollOS(): void
+    public function pollOS(DataStorageInterface $datastore): void
     {
         $data = snmp_get_multi($this->getDeviceArray(), [
             'sonicCurrentConnCacheEntries.0',
@@ -42,7 +43,7 @@ class Sonicwall extends OS implements OSPolling, ProcessorDiscovery
                 'maxsessions' => $data[0]['sonicMaxConnCacheEntries'],
             ];
             $tags = compact('rrd_def');
-            data_update($this->getDeviceArray(), 'sonicwall_sessions', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'sonicwall_sessions', $tags, $fields);
             $this->enableGraph('sonicwall_sessions');
         }
     }

--- a/LibreNMS/OS/Timos.php
+++ b/LibreNMS/OS/Timos.php
@@ -720,7 +720,7 @@ class Timos extends OS implements MplsDiscovery, MplsPolling, WirelessPowerDisco
                 'rrd_def' => $rrd_def,
             ];
 
-            data_update($this->getDeviceArray(), 'sap', $tags, $fields);
+            app('Datastore')->put($this->getDeviceArray(), 'sap', $tags, $fields);
             $this->enableGraph('sap');
         }
 

--- a/LibreNMS/OS/Topvision.php
+++ b/LibreNMS/OS/Topvision.php
@@ -26,6 +26,7 @@
 namespace LibreNMS\OS;
 
 use App\Models\Device;
+use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Polling\OSPolling;
 use LibreNMS\RRD\RrdDefinition;
 
@@ -40,7 +41,7 @@ class Topvision extends \LibreNMS\OS implements OSPolling
         }
     }
 
-    public function pollOS(): void
+    public function pollOS(DataStorageInterface $datastore): void
     {
         $cmstats = snmp_get_multi_oid($this->getDeviceArray(), ['.1.3.6.1.4.1.32285.11.1.1.2.2.3.1.0', '.1.3.6.1.4.1.32285.11.1.1.2.2.3.6.0', '.1.3.6.1.4.1.32285.11.1.1.2.2.3.5.0']);
         if (is_numeric($cmstats['.1.3.6.1.4.1.32285.11.1.1.2.2.3.1.0'])) {
@@ -49,7 +50,7 @@ class Topvision extends \LibreNMS\OS implements OSPolling
                 'cmtotal' => $cmstats['.1.3.6.1.4.1.32285.11.1.1.2.2.3.1.0'],
             ];
             $tags = compact('rrd_def');
-            data_update($this->getDeviceArray(), 'topvision_cmtotal', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'topvision_cmtotal', $tags, $fields);
             $this->enableGraph('topvision_cmtotal');
         }
 
@@ -59,7 +60,7 @@ class Topvision extends \LibreNMS\OS implements OSPolling
                 'cmreg' => $cmstats['.1.3.6.1.4.1.32285.11.1.1.2.2.3.6.0'],
             ];
             $tags = compact('rrd_def');
-            data_update($this->getDeviceArray(), 'topvision_cmreg', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'topvision_cmreg', $tags, $fields);
             $this->enableGraph('topvision_cmreg');
         }
 
@@ -69,7 +70,7 @@ class Topvision extends \LibreNMS\OS implements OSPolling
                 'cmoffline' => $cmstats['.1.3.6.1.4.1.32285.11.1.1.2.2.3.5.0'],
             ];
             $tags = compact('rrd_def');
-            data_update($this->getDeviceArray(), 'topvision_cmoffline', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'topvision_cmoffline', $tags, $fields);
             $this->enableGraph('topvision_cmoffline');
         }
     }

--- a/LibreNMS/OS/Vrp.php
+++ b/LibreNMS/OS/Vrp.php
@@ -35,6 +35,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use LibreNMS\Device\Processor;
 use LibreNMS\Device\WirelessSensor;
+use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Discovery\MempoolsDiscovery;
 use LibreNMS\Interfaces\Discovery\OSDiscovery;
 use LibreNMS\Interfaces\Discovery\ProcessorDiscovery;
@@ -107,7 +108,7 @@ class Vrp extends OS implements
         }
     }
 
-    public function pollOS(): void
+    public function pollOS(DataStorageInterface $datastore): void
     {
         // Polling the Wireless data TODO port to module
         $apTable = snmpwalk_group($this->getDeviceArray(), 'hwWlanApName', 'HUAWEI-WLAN-AP-MIB', 2);
@@ -162,7 +163,7 @@ class Vrp extends OS implements
             ];
 
             $tags = compact('rrd_def');
-            data_update($this->getDeviceArray(), 'vrp', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'vrp', $tags, $fields);
 
             $ap_db = dbFetchRows('SELECT * FROM `access_points` WHERE `device_id` = ?', [$this->getDeviceArray()['device_id']]);
 
@@ -223,7 +224,7 @@ class Vrp extends OS implements
                     ];
 
                     $tags = compact('name', 'radionum', 'rrd_name', 'rrd_def');
-                    data_update($this->getDeviceArray(), 'arubaap', $tags, $fields);
+                    $datastore->put($this->getDeviceArray(), 'arubaap', $tags, $fields);
 
                     $foundid = 0;
 
@@ -549,7 +550,7 @@ class Vrp extends OS implements
             $rrd_name = ['sla', $sla['sla_nr']];
             $rrd_def = RrdDefinition::make()->addDataset('rtt', 'GAUGE', 0, 300000);
             $tags = compact('sla_nr', 'rrd_name', 'rrd_def');
-            data_update($device, 'sla', $tags, $fields);
+            $datastore->put($device, 'sla', $tags, $fields);
 
             // Let's gather some per-type fields.
             switch ($rtt_type) {
@@ -567,7 +568,7 @@ class Vrp extends OS implements
                         ->addDataset('ProbeResponses', 'GAUGE', 0, 300000)
                         ->addDataset('ProbeLoss', 'GAUGE', 0, 300000);
                     $tags = compact('rrd_name', 'rrd_def', 'sla_nr', 'rtt_type');
-                    data_update($device, 'sla', $tags, $icmp);
+                    $datastore->put($device, 'sla', $tags, $icmp);
                     $fields = array_merge($fields, $icmp);
                     break;
             }

--- a/LibreNMS/OS/Vrp.php
+++ b/LibreNMS/OS/Vrp.php
@@ -542,15 +542,7 @@ class Vrp extends OS implements
             $time = Carbon::parse($data[$owner][$test]['pingResultsLastGoodProbe'] ?? null)->toDateTimeString();
             echo 'SLA : ' . $rtt_type . ' ' . $owner . ' ' . $test . '... ' . $sla->rtt . 'ms at ' . $time . "\n";
 
-            $fields = [
-                'rtt' => $sla->rtt,
-            ];
-
-            // The base RRD
-            $rrd_name = ['sla', $sla['sla_nr']];
-            $rrd_def = RrdDefinition::make()->addDataset('rtt', 'GAUGE', 0, 300000);
-            $tags = compact('sla_nr', 'rrd_name', 'rrd_def');
-            $datastore->put($device, 'sla', $tags, $fields);
+            $collected = ['rtt' => $sla->rtt];
 
             // Let's gather some per-type fields.
             switch ($rtt_type) {
@@ -568,13 +560,13 @@ class Vrp extends OS implements
                         ->addDataset('ProbeResponses', 'GAUGE', 0, 300000)
                         ->addDataset('ProbeLoss', 'GAUGE', 0, 300000);
                     $tags = compact('rrd_name', 'rrd_def', 'sla_nr', 'rtt_type');
-                    $datastore->put($device, 'sla', $tags, $icmp);
-                    $fields = array_merge($fields, $icmp);
+                    app('Datastore')->put($device, 'sla', $tags, $icmp);
+                    $collected = array_merge($collected, $icmp);
                     break;
             }
 
-            d_echo('The following datasources were collected for #' . $sla['sla_nr'] . ":\n");
-            d_echo($fields);
+            d_echo('The following datasources were collected for #' . $sla->sla_nr. ":\n");
+            d_echo($collected);
         }
     }
 }

--- a/LibreNMS/OS/Vrp.php
+++ b/LibreNMS/OS/Vrp.php
@@ -565,7 +565,7 @@ class Vrp extends OS implements
                     break;
             }
 
-            d_echo('The following datasources were collected for #' . $sla->sla_nr. ":\n");
+            d_echo('The following datasources were collected for #' . $sla->sla_nr . ":\n");
             d_echo($collected);
         }
     }

--- a/LibreNMS/OS/XirrusAos.php
+++ b/LibreNMS/OS/XirrusAos.php
@@ -26,6 +26,7 @@
 namespace LibreNMS\OS;
 
 use LibreNMS\Device\WirelessSensor;
+use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Discovery\Sensors\WirelessClientsDiscovery;
 use LibreNMS\Interfaces\Discovery\Sensors\WirelessFrequencyDiscovery;
 use LibreNMS\Interfaces\Discovery\Sensors\WirelessNoiseFloorDiscovery;
@@ -49,7 +50,7 @@ class XirrusAos extends OS implements
     WirelessRssiDiscovery,
     WirelessSnrDiscovery
 {
-    public function pollOS(): void
+    public function pollOS(DataStorageInterface $datastore): void
     {
         $associations = [];
 
@@ -75,7 +76,7 @@ class XirrusAos extends OS implements
                     'stations' => $count,
                 ];
                 $tags = compact('radio', 'rrd_name', 'rrd_def');
-                data_update($this->getDeviceArray(), $measurement, $tags, $fields);
+                $datastore->put($this->getDeviceArray(), $measurement, $tags, $fields);
             }
             $this->enableGraph('xirrus_stations');
         }

--- a/LibreNMS/OS/Zywall.php
+++ b/LibreNMS/OS/Zywall.php
@@ -26,6 +26,7 @@
 namespace LibreNMS\OS;
 
 use App\Models\Device;
+use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Discovery\OSDiscovery;
 use LibreNMS\Interfaces\Polling\OSPolling;
 use LibreNMS\OS\Shared\Zyxel;
@@ -44,7 +45,7 @@ class Zywall extends Zyxel implements OSDiscovery, OSPolling
         }
     }
 
-    public function pollOS(): void
+    public function pollOS(DataStorageInterface $datastore): void
     {
         $sessions = snmp_get($this->getDeviceArray(), '.1.3.6.1.4.1.890.1.6.22.1.6.0', '-Ovq');
         if (is_numeric($sessions)) {
@@ -53,7 +54,7 @@ class Zywall extends Zyxel implements OSDiscovery, OSPolling
                 'sessions' => $sessions,
             ];
             $tags = compact('rrd_def');
-            data_update($this->getDeviceArray(), 'zywall-sessions', $tags, $fields);
+            $datastore->put($this->getDeviceArray(), 'zywall-sessions', $tags, $fields);
             $this->enableGraph('zywall_sessions');
         }
     }

--- a/LibreNMS/Poller.php
+++ b/LibreNMS/Poller.php
@@ -226,7 +226,18 @@ class Poller
 
     private function isModuleManuallyEnabled(string $module): ?bool
     {
-        return empty($this->module_override) ? null : in_array($module, $this->module_override);
+        if (empty($this->module_override)) {
+            return null;
+        }
+
+        foreach ($this->module_override as $override) {
+            [$override_module] = explode('/', $override);
+            if ($module == $override_module) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private function buildDeviceQuery(): Builder

--- a/LibreNMS/Poller.php
+++ b/LibreNMS/Poller.php
@@ -33,7 +33,6 @@ use App\Polling\Measure\Measurement;
 use App\Polling\Measure\MeasurementManager;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use LibreNMS\Enum\Severity;
 use LibreNMS\Exceptions\PollerException;
@@ -249,11 +248,9 @@ class Poller
         } elseif ($this->device_spec == 'all') {
             return $query;
         } elseif ($this->device_spec == 'even') {
-            /** @phpstan-ignore-next-line */
-            return $query->where(DB::raw('device_id % 2'), 0);
+            return $query->whereRaw('device_id % 2 = 0');
         } elseif ($this->device_spec == 'odd') {
-            /** @phpstan-ignore-next-line */
-            return $query->where(DB::raw('device_id % 2'), 1);
+            return $query->whereRaw('device_id % 2 = 1');
         } elseif (is_numeric($this->device_spec)) {
             return $query->where('device_id', $this->device_spec);
         } elseif (Str::contains($this->device_spec, '*')) {

--- a/LibreNMS/Poller.php
+++ b/LibreNMS/Poller.php
@@ -178,15 +178,15 @@ class Poller
         foreach (array_keys(Config::get('poller_modules')) as $module) {
             $module_status = Module::status($module, $this->device, $this->isModuleManuallyEnabled($module));
             $should_poll = false;
+            $start_memory = memory_get_usage();
+            $module_start = microtime(true);
 
             try {
                 $instance = Module::fromName($module);
                 $should_poll = $instance->shouldPoll($this->os, $module_status);
 
                 if ($should_poll) {
-                    $start_memory = memory_get_usage();
-                    $module_start = microtime(true);
-                    $this->logger->info("\n#### Load poller module $module ####");
+                    $this->logger->info("#### Load poller module $module ####\n");
                     $this->logger->debug($module_status);
 
                     $instance->poll($this->os, $datastore);
@@ -199,6 +199,7 @@ class Poller
             }
 
             if ($should_poll) {
+                $this->logger->info('');
                 app(MeasurementManager::class)->printChangedStats();
                 $this->saveModulePerformance($module, $module_start, $start_memory);
                 $this->logger->info("#### Unload poller module $module ####\n");

--- a/LibreNMS/Polling/ModuleStatus.php
+++ b/LibreNMS/Polling/ModuleStatus.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * ModuleStatus.php
+ *
+ * -Description-
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * @link       https://www.librenms.org
+ *
+ * @copyright  2023 Tony Murray
+ * @author     Tony Murray <murraytony@gmail.com>
+ */
+
+namespace LibreNMS\Polling;
+
+class ModuleStatus
+{
+    public function __construct(
+        public bool $global,
+        public ?bool $os = null,
+        public ?bool $device = null,
+        public ?bool $manual = null,
+    ) {}
+
+    public function isEnabled(): bool
+    {
+        if ($this->manual !== null) {
+            return $this->manual;
+        }
+
+        if ($this->device !== null) {
+            return $this->device;
+        }
+
+        if ($this->os !== null) {
+            return $this->os;
+        }
+
+        return $this->global;
+    }
+
+    public function reason(): string
+    {
+        if ($this->manual !== null) {
+            return 'mannually';
+        }
+
+        if ($this->device !== null) {
+            return 'by device';
+        }
+
+        if ($this->os !== null) {
+            return 'by OS';
+        }
+
+        return 'globally';
+    }
+
+    public function __toString(): string
+    {
+        return sprintf('Module %s: Global %s | OS %s | Device %s | Manual %s',
+            $this->isEnabled() ? 'enabled' : 'disabled',
+            $this->global ? '+' : '-',
+            $this->os === null ? ' ' : ($this->os ? '+' : '-'),
+            $this->device === null ? ' ' : ($this->device ? '+' : '-'),
+            $this->manual === null ? ' ' : ($this->manual ? '+' : '-'),
+        );
+    }
+}

--- a/LibreNMS/Polling/ModuleStatus.php
+++ b/LibreNMS/Polling/ModuleStatus.php
@@ -32,7 +32,8 @@ class ModuleStatus
         public ?bool $os = null,
         public ?bool $device = null,
         public ?bool $manual = null,
-    ) {}
+    ) {
+    }
 
     public function isEnabled(): bool
     {

--- a/LibreNMS/Waas.php
+++ b/LibreNMS/Waas.php
@@ -25,17 +25,18 @@
 
 namespace LibreNMS;
 
+use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Polling\OSPolling;
 use LibreNMS\RRD\RrdDefinition;
 
 class Waas extends OS implements OSPolling
 {
-    public function pollOS(): void
+    public function pollOS(DataStorageInterface $datastore): void
     {
         $connections = \SnmpQuery::get('CISCO-WAN-OPTIMIZATION-MIB::cwoTfoStatsActiveOptConn.0')->value();
 
         if (is_numeric($connections)) {
-            data_update($this->getDeviceArray(), 'waas_cwotfostatsactiveoptconn', [
+            $datastore->put($this->getDeviceArray(), 'waas_cwotfostatsactiveoptconn', [
                 'rrd_def' => RrdDefinition::make()->addDataset('connections', 'GAUGE', 0),
             ], [
                 'connections' => $connections,

--- a/app/Models/Availability.php
+++ b/app/Models/Availability.php
@@ -31,4 +31,10 @@ class Availability extends Model
 {
     public $timestamps = false;
     protected $table = 'availability';
+    protected $primaryKey = 'availability_id';
+    protected $fillable = [
+        'device_id',
+        'duration',
+        'availability_perc',
+    ];
 }

--- a/app/Models/Device.php
+++ b/app/Models/Device.php
@@ -81,6 +81,7 @@ class Device extends BaseModel
     ];
 
     protected $casts = [
+        'inserted' => 'datetime',
         'last_polled' => 'datetime',
         'status' => 'boolean',
     ];

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -128,13 +128,13 @@ function discover_device(&$device, $force_module = false)
         return false;
     }
 
-    $discovery_devices = Config::get('discovery_modules', []);
+    $discovery_modules = ['core' => true] + Config::get('discovery_modules', []);
 
     /** @var \App\Polling\Measure\MeasurementManager $measurements */
     $measurements = app(\App\Polling\Measure\MeasurementManager::class);
     $measurements->checkpoint(); // don't count previous stats
 
-    foreach ($discovery_devices as $module => $module_status) {
+    foreach ($discovery_modules as $module => $module_status) {
         $os_module_status = Config::getOsSetting($device['os'], "discovery_modules.$module");
         d_echo('Modules status: Global' . (isset($module_status) ? ($module_status ? '+ ' : '- ') : '  '));
         d_echo('OS' . (isset($os_module_status) ? ($os_module_status ? '+ ' : '- ') : '  '));

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -129,7 +129,6 @@ function discover_device(&$device, $force_module = false)
     }
 
     $discovery_devices = Config::get('discovery_modules', []);
-    $discovery_devices = ['core' => true] + $discovery_devices;
 
     /** @var \App\Polling\Measure\MeasurementManager $measurements */
     $measurements = app(\App\Polling\Measure\MeasurementManager::class);

--- a/includes/html/pages/device/graphs/availability.inc.php
+++ b/includes/html/pages/device/graphs/availability.inc.php
@@ -2,30 +2,26 @@
 
 $graph_type = 'availability';
 
-$row = 1;
-
-$duration_list = dbFetchRows('SELECT * FROM `availability` WHERE `device_id` = ? ORDER BY `duration`', [$device['device_id']]);
-foreach ($duration_list as $duration) {
-    if (is_integer($row / 2)) {
+$deviceModel = DeviceCache::getPrimary();
+foreach ($deviceModel->availability as $index => $duration) {
+    if (is_integer($index / 2)) {
         $row_colour = \LibreNMS\Config::get('list_colour.even');
     } else {
         $row_colour = \LibreNMS\Config::get('list_colour.odd');
     }
 
-    $graph_array['device'] = $duration['device_id'];
+    $graph_array['device'] = $duration->device_id;
     $graph_array['type'] = 'device_' . $graph_type;
-    $graph_array['duration'] = $duration['duration'];
+    $graph_array['duration'] = $duration->duration;
 
-    $human_duration = \LibreNMS\Util\Time::formatInterval($duration['duration'], parts: 1);
-    $graph_title = DeviceCache::get($device['device_id'])->displayName() . ' - ' . $human_duration;
+    $human_duration = \LibreNMS\Util\Time::formatInterval($duration->duration, parts: 1);
+    $graph_title = $deviceModel->displayName() . ' - ' . $human_duration;
 
     echo "<div class='panel panel-default'>
             <div class='panel-heading'>
-                <h3 class='panel-title'>" . $human_duration . "<div class='pull-right'>" . round($duration['availability_perc'], 3) . '%</div></h3>
+                <h3 class='panel-title'>" . $human_duration . "<div class='pull-right'>" . round($duration->availability_perc, 3) . '%</div></h3>
             </div>';
     echo "<div class='panel-body'>";
     include 'includes/html/print-graphrow.inc.php';
     echo '</div></div>';
-
-    $row++;
 }

--- a/includes/polling/availability.inc.php
+++ b/includes/polling/availability.inc.php
@@ -6,4 +6,3 @@ if (! $os instanceof OS) {
     $os = OS::make($device);
 }
 (new \LibreNMS\Modules\Availability())->poll($os);
-

--- a/includes/polling/availability.inc.php
+++ b/includes/polling/availability.inc.php
@@ -5,4 +5,4 @@ use LibreNMS\OS;
 if (! $os instanceof OS) {
     $os = OS::make($device);
 }
-(new \LibreNMS\Modules\Availability())->poll($os);
+(new \LibreNMS\Modules\Availability())->poll($os, app('Datastore'));

--- a/includes/polling/availability.inc.php
+++ b/includes/polling/availability.inc.php
@@ -1,44 +1,9 @@
 <?php
 
-use LibreNMS\Config;
-use LibreNMS\RRD\RrdDefinition;
+use LibreNMS\OS;
 
-$os->enableGraph('availability');
-
-$col = dbFetchColumn('SELECT duration FROM availability WHERE device_id = ?', [$device['device_id']]);
-foreach (Config::get('graphing.availability') as $duration) {
-    if (! in_array($duration, $col)) {
-        $data = ['device_id' => $device['device_id'],
-            'duration' => $duration, ];
-        dbInsert($data, 'availability');
-    }
+if (! $os instanceof OS) {
+    $os = OS::make($device);
 }
+(new \LibreNMS\Modules\Availability())->poll($os);
 
-echo 'Availability: ' . PHP_EOL;
-
-foreach (dbFetchRows('SELECT * FROM availability WHERE device_id = ?', [$device['device_id']]) as $row) {
-    //delete not more interested availabilities
-    if (! in_array($row['duration'], Config::get('graphing.availability'))) {
-        dbDelete('availability', 'availability_id=?', [$row['availability_id']]);
-        continue;
-    }
-
-    $avail = \LibreNMS\Device\Availability::availability($device, $row['duration']);
-    $human_time = \LibreNMS\Util\Time::formatInterval($row['duration'], parts: 1);
-
-    $rrd_name = ['availability', $row['duration']];
-    $rrd_def = RrdDefinition::make()
-        ->addDataset('availability', 'GAUGE', 0);
-
-    $fields = [
-        'availability' => $avail,
-    ];
-
-    $tags = ['name' => $row['duration'], 'rrd_def' => $rrd_def, 'rrd_name' => $rrd_name];
-    data_update($device, 'availability', $tags, $fields);
-
-    dbUpdate(['availability_perc' => $avail], 'availability', '`availability_id` = ?', [$row['availability_id']]);
-
-    echo $human_time . ' : ' . $avail . '%' . PHP_EOL;
-}
-unset($duration);

--- a/includes/polling/core.inc.php
+++ b/includes/polling/core.inc.php
@@ -11,4 +11,4 @@
  * See COPYING for more details.
  */
 
-(new \LibreNMS\Modules\Core())->poll($os);
+(new \LibreNMS\Modules\Core())->poll($os, app('Datastore'));

--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -316,9 +316,6 @@ function poll_device($device, $force_module = false)
                 'ipmi' => true,
                 'unix-agent' => true,
             ]));
-        } else {
-            // we always want the core module to be included, prepend it
-            Config::set('poller_modules', ['core' => true] + Config::get('poller_modules'));
         }
 
         // update $device array status

--- a/includes/polling/isis.inc.php
+++ b/includes/polling/isis.inc.php
@@ -28,4 +28,4 @@ use LibreNMS\OS;
 if (! $os instanceof OS) {
     $os = OS::make($device);
 }
-(new \LibreNMS\Modules\Isis())->poll($os);
+(new \LibreNMS\Modules\Isis())->poll($os, app('Datastore'));

--- a/includes/polling/mempools.inc.php
+++ b/includes/polling/mempools.inc.php
@@ -5,4 +5,4 @@ use LibreNMS\OS;
 if (! $os instanceof OS) {
     $os = OS::make($device);
 }
-(new \LibreNMS\Modules\Mempools())->poll($os);
+(new \LibreNMS\Modules\Mempools())->poll($os, app('Datastore'));

--- a/includes/polling/mpls.inc.php
+++ b/includes/polling/mpls.inc.php
@@ -28,4 +28,4 @@ use LibreNMS\OS;
 if (! $os instanceof OS) {
     $os = OS::make($device);
 }
-(new \LibreNMS\Modules\Mpls())->poll($os);
+(new \LibreNMS\Modules\Mpls())->poll($os, app('Datastore'));

--- a/includes/polling/nac.inc.php
+++ b/includes/polling/nac.inc.php
@@ -29,4 +29,4 @@ use LibreNMS\OS;
 if (! $os instanceof OS) {
     $os = OS::make($device);
 }
-(new \LibreNMS\Modules\Nac())->poll($os);
+(new \LibreNMS\Modules\Nac())->poll($os, app('Datastore'));

--- a/includes/polling/netstats.inc.php
+++ b/includes/polling/netstats.inc.php
@@ -5,4 +5,4 @@ use LibreNMS\OS;
 if (! $os instanceof OS) {
     $os = OS::make($device);
 }
-(new \LibreNMS\Modules\Netstats())->poll($os);
+(new \LibreNMS\Modules\Netstats())->poll($os, app('Datastore'));

--- a/includes/polling/os.inc.php
+++ b/includes/polling/os.inc.php
@@ -5,4 +5,4 @@ use LibreNMS\OS;
 if (! $os instanceof OS) {
     $os = OS::make($device);
 }
-(new \LibreNMS\Modules\Os())->poll($os);
+(new \LibreNMS\Modules\Os())->poll($os, app('Datastore'));

--- a/includes/polling/ospf.inc.php
+++ b/includes/polling/ospf.inc.php
@@ -5,4 +5,4 @@ use LibreNMS\OS;
 if (! $os instanceof OS) {
     $os = OS::make($device);
 }
-(new \LibreNMS\Modules\Ospf())->poll($os);
+(new \LibreNMS\Modules\Ospf())->poll($os, app('Datastore'));

--- a/includes/polling/printer-supplies.inc.php
+++ b/includes/polling/printer-supplies.inc.php
@@ -23,4 +23,4 @@ use LibreNMS\OS;
 if (! $os instanceof OS) {
     $os = OS::make($device);
 }
-(new \LibreNMS\Modules\PrinterSupplies())->poll($os);
+(new \LibreNMS\Modules\PrinterSupplies())->poll($os, app('Datastore'));

--- a/includes/polling/slas.inc.php
+++ b/includes/polling/slas.inc.php
@@ -23,4 +23,4 @@ use LibreNMS\OS;
 if (! $os instanceof OS) {
     $os = OS::make($device);
 }
-(new \LibreNMS\Modules\Slas())->poll($os);
+(new \LibreNMS\Modules\Slas())->poll($os, app('Datastore'));

--- a/includes/polling/stp.inc.php
+++ b/includes/polling/stp.inc.php
@@ -20,4 +20,4 @@ if (! $os instanceof OS) {
     $os = OS::make($device);
 }
 
-(new \LibreNMS\Modules\Stp())->poll($os);
+(new \LibreNMS\Modules\Stp())->poll($os, app('Datastore'));

--- a/includes/polling/xdsl.inc.php
+++ b/includes/polling/xdsl.inc.php
@@ -5,4 +5,4 @@ use LibreNMS\OS;
 if (! $os instanceof OS) {
     $os = OS::make($device);
 }
-(new \LibreNMS\Modules\Xdsl())->poll($os);
+(new \LibreNMS\Modules\Xdsl())->poll($os, app('Datastore'));

--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -1066,6 +1066,13 @@
             "default": false,
             "type": "boolean"
         },
+        "discovery_modules.core": {
+            "default": true,
+            "type": "boolean",
+            "validate": {
+                "value": "boolean|accepted"
+            }
+        },
         "discovery_modules.os": {
             "order": 230,
             "group": "discovery",
@@ -1413,12 +1420,16 @@
             "section": "availability",
             "order": 1,
             "default": [
-                "86400",
-                "604800",
-                "2592000",
-                "31536000"
+                86400,
+                604800,
+                2592000,
+                31536000
             ],
-            "type": "array"
+            "type": "array",
+            "validate": {
+                "value": "array",
+                "value.*": "int"
+            }
         },
         "graphing.availability_consider_maintenance": {
             "group": "poller",
@@ -4679,6 +4690,13 @@
         },
         "plugin_dir": {
             "type": "directory"
+        },
+        "poller_modules.core": {
+            "default": true,
+            "type": "boolean",
+            "validate": {
+                "value": "boolean|accepted"
+            }
         },
         "poller_modules.unix-agent": {
             "order": 420,


### PR DESCRIPTION
Fix a couple corner cases in calculations and allow the availability module to always run (even when the device is down)

Previously, there was no way for the module to run if the device was down.
This only works in the new `lnms device:poll` code path and took some refactoring to enable that

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
