### PR TITLE
Fixes check_dns against localhost when a search-domain is configured

### DIFF
--- a/includes/services/check_dns.inc.php
+++ b/includes/services/check_dns.inc.php
@@ -4,7 +4,7 @@
 if ($service['service_param']) {
     $nsquery = $service['service_param'];
 } else {
-    $nsquery = 'localhost';
+    $nsquery = 'localhost.';
 }
 if ($service['service_ip']) {
     $resolver = $service['service_ip'];


### PR DESCRIPTION
Fixes check_dns against localhost when a search-domain is configured

Otherwise `check_dns` uses `nslookup` and tries to resolve `localhost.searchdomain.tld` instead of just `localhost`.

Adding a `.` to `localhost.` prevents this behaviour.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
