### PR TITLE
Specify radius attributes for auth roles

### DIFF
--- a/doc/Extensions/Authentication.md
+++ b/doc/Extensions/Authentication.md
@@ -304,13 +304,14 @@ The attribute `Filter-ID` is a standard Radius-Reply-Attribute (string) that
 can be assigned a specially formatted string to assign a single role to the user. 
 
 The string to send in `Filter-ID` reply attribute must start with `librenms_role_` followed by the role name.
-For example to set the admin role send `librenms_role_admin`
+For example to set the admin role send `librenms_role_admin`.
+
+The following strings correspond to the built-in roles, but any defined role can be used:
 - `librenms_role_normal` - Sets the normal user level.
 - `librenms_role_admin` - Sets the administrator level.
 - `librenms_role_global-read` - Sets the global read level
 
-LibreNMS will ignore any other strings sent in `Filter-ID` and revert to default
-role that is set in your config.
+LibreNMS will ignore any other strings sent in `Filter-ID` and revert to default role that is set in your config.
 
 ```php
 $config['radius']['hostname']      = 'localhost';

--- a/doc/Extensions/Authentication.md
+++ b/doc/Extensions/Authentication.md
@@ -305,6 +305,9 @@ can be assigned a specially formatted string to assign a single role to the user
 
 The string to send in `Filter-ID` reply attribute must start with `librenms_role_` followed by the role name.
 For example to set the admin role send `librenms_role_admin`
+- `librenms_role_normal` - Sets the normal user level.
+- `librenms_role_admin` - Sets the administrator level.
+- `librenms_role_global-read` - Sets the global read level
 
 LibreNMS will ignore any other strings sent in `Filter-ID` and revert to default
 role that is set in your config.


### PR DESCRIPTION
Add back to documentation the accepted radius attribute vales for each role.

I implemented this yesterday and could only find the appropriate values by reading back through the commit logs to their removal.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
