### PR TITLE
Smokeping menu and title use device displayname

### DIFF
--- a/app/Console/Commands/SmokepingGenerateCommand.php
+++ b/app/Console/Commands/SmokepingGenerateCommand.php
@@ -128,7 +128,7 @@ class SmokepingGenerateCommand extends LnmsCommand
         $smokelist = [];
         foreach ($devices as $device) {
             $smokelist[$device->type][$device->hostname] = ['transport' => $device->transport];
-            $smokelist[$device->type][$device->hostname]['displayname'] = $device->displayName() ?? $device->hostname;
+            $smokelist[$device->type][$device->hostname]['displayname'] = $device->displayName() ?: $device->hostname;
         }
 
         $targets = $this->buildTargets($smokelist, Config::get('smokeping.probes'), $this->option('single-process'));

--- a/app/Console/Commands/SmokepingGenerateCommand.php
+++ b/app/Console/Commands/SmokepingGenerateCommand.php
@@ -127,8 +127,10 @@ class SmokepingGenerateCommand extends LnmsCommand
         // Take the devices array and build it into a hierarchical list
         $smokelist = [];
         foreach ($devices as $device) {
-            $smokelist[$device->type][$device->hostname] = ['transport' => $device->transport];
-            $smokelist[$device->type][$device->hostname]['displayname'] = $device->displayName() ?: $device->hostname;
+            $smokelist[$device->type][$device->hostname] = [
+                'transport' => $device->transport,
+                'displayname' => $device->displayName(),
+            ];
         }
 
         $targets = $this->buildTargets($smokelist, Config::get('smokeping.probes'), $this->option('single-process'));

--- a/app/Console/Commands/SmokepingGenerateCommand.php
+++ b/app/Console/Commands/SmokepingGenerateCommand.php
@@ -77,7 +77,7 @@ class SmokepingGenerateCommand extends LnmsCommand
             return 1;
         }
 
-        $devices = Device::isNotDisabled()->orderBy('type')->orderBy('hostname')->get();
+        $devices = Device::isNotDisabled()->orderBy('type')->orderBy('hostname')->groupBy(['type', 'hostname'])->get();
 
         if (count($devices) < 1) {
             $this->error(__('commands.smokeping:generate.no-devices'));
@@ -124,15 +124,6 @@ class SmokepingGenerateCommand extends LnmsCommand
      */
     public function buildTargetsConfiguration($devices)
     {
-        // Take the devices array and build it into a hierarchical list
-        $smokelist = [];
-        foreach ($devices as $device) {
-            $smokelist[$device->type][$device->hostname] = [
-                'transport' => $device->transport,
-                'displayname' => $device->displayName(),
-            ];
-        }
-
         $targets = $this->buildTargets($smokelist, Config::get('smokeping.probes'), $this->option('single-process'));
         $header = $this->buildHeader($this->option('no-header'), $this->option('compat'));
 

--- a/app/Console/Commands/SmokepingGenerateCommand.php
+++ b/app/Console/Commands/SmokepingGenerateCommand.php
@@ -128,6 +128,7 @@ class SmokepingGenerateCommand extends LnmsCommand
         $smokelist = [];
         foreach ($devices as $device) {
             $smokelist[$device->type][$device->hostname] = ['transport' => $device->transport];
+            $smokelist[$device->type][$device->hostname]['displayname'] = $device->displayName() ?? $device->hostname;
         }
 
         $targets = $this->buildTargets($smokelist, Config::get('smokeping.probes'), $this->option('single-process'));
@@ -315,8 +316,8 @@ class SmokepingGenerateCommand extends LnmsCommand
         foreach ($devices as $hostname => $config) {
             if (! $this->dnsLookup || $this->deviceIsResolvable($hostname)) {
                 $lines[] = sprintf('++ %s', $this->buildMenuEntry($hostname));
-                $lines[] = sprintf('   menu = %s', $hostname);
-                $lines[] = sprintf('   title = %s', $hostname);
+                $lines[] = sprintf('   menu = %s', $config['displayname']);
+                $lines[] = sprintf('   title = %s', $config['displayname']);
 
                 if (! $singleProcess) {
                     $lines[] = sprintf('   probe = %s', $this->balanceProbes($config['transport'], $probeCount));

--- a/app/Console/Commands/SmokepingGenerateCommand.php
+++ b/app/Console/Commands/SmokepingGenerateCommand.php
@@ -124,7 +124,7 @@ class SmokepingGenerateCommand extends LnmsCommand
      */
     public function buildTargetsConfiguration($devices)
     {
-        $targets = $this->buildTargets($smokelist, Config::get('smokeping.probes'), $this->option('single-process'));
+        $targets = $this->buildTargets($devices, Config::get('smokeping.probes'), $this->option('single-process'));
         $header = $this->buildHeader($this->option('no-header'), $this->option('compat'));
 
         return $this->render($header, $targets);

--- a/tests/SmokepingCliTest.php
+++ b/tests/SmokepingCliTest.php
@@ -39,43 +39,55 @@ class SmokepingCliTest extends DBTestCase
         'Le23HKVMvN' => [
             'Cl09bZU4sn' => [
                 'transport' => 'udp',
+                'displayname' => 'Cl09bZU4sn',
             ],
             'c559TvthzY' => [
                 'transport' => 'udp6',
+                'displayname' => 'c559TvthzY',
             ],
             'sNtzSdxdw8' => [
                 'transport' => 'udp6',
+                'displayname' => 'sNtzSdxdw8',
             ],
             '10.0.0.3' => [
                 'transport' => 'udp',
+                'displayname' => '10.0.0.3',
             ],
             '2600::' => [
                 'transport' => 'udp',
+                'displayname' => '2600::',
             ],
         ],
         'Psv9oZcxdC' => [
             'oHiPfLzrmU' => [
                 'transport' => 'udp',
+                'displayname' => 'Psv9oZcxdC',
             ],
             'kEn7hZ7N37' => [
                 'transport' => 'udp6',
+                'displayname' => 'kEn7hZ7N37',
             ],
             'PcbZ5FKtS3' => [
                 'transport' => 'udp6',
+                'displayname' => 'PcbZ5FKtS3',
             ],
             '192.168.1.1' => [
                 'transport' => 'udp',
+                'displayname' => '192.168.1.1',
             ],
             'fe80::' => [
                 'transport' => 'udp',
+                'displayname' => 'fe80::',
             ],
         ],
         '4diY0pWFik' => [
             'example.org' => [
                 'transport' => 'udp',
+                'displayname' => '4diY0pWFik',
             ],
             'host_with_under_score.example.org' => [
                 'transport' => 'udp6',
+                'displayname' => 'host_with_under_score.example.org',
             ],
         ],
     ];

--- a/tests/SmokepingCliTest.php
+++ b/tests/SmokepingCliTest.php
@@ -61,7 +61,7 @@ class SmokepingCliTest extends DBTestCase
         'Psv9oZcxdC' => [
             'oHiPfLzrmU' => [
                 'transport' => 'udp',
-                'displayname' => 'Psv9oZcxdC',
+                'displayname' => 'oHiPfLzrmU',
             ],
             'kEn7hZ7N37' => [
                 'transport' => 'udp6',
@@ -83,7 +83,7 @@ class SmokepingCliTest extends DBTestCase
         '4diY0pWFik' => [
             'example.org' => [
                 'transport' => 'udp',
-                'displayname' => '4diY0pWFik',
+                'displayname' => 'example.org',
             ],
             'host_with_under_score.example.org' => [
                 'transport' => 'udp6',


### PR DESCRIPTION
When devices are added with IP address but a displayname exists, use it in smokeping: 
![image](https://github.com/librenms/librenms/assets/8980985/45d42232-d8a0-4bc1-a59f-b83561894f53)

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
