### PR TITLE
Documentation - Smokeping Integration in Centos - Update Smokeping.md

### DIFF
--- a/doc/Extensions/Smokeping.md
+++ b/doc/Extensions/Smokeping.md
@@ -178,6 +178,129 @@ After creating the symlink, restart Apache with `sudo systemctl apache2 restart`
 
 You should be able to load the Smokeping web interface at `http://yourhost/cgi-bin/smokeping.cgi`
 
+### Nginx Configuration - RHEL, CentOS and alike
+This section assumes you have configured LibreNMS with Nginx as
+specified in [Configure Nginx](../Installation/Installation-CentOS-7-Nginx).
+
+Note, you need to install fcgiwrap for CGI wrapper interact with Nginx
+```
+yum install fcgiwrap
+```
+Then create a new configuration file for fcgiwrap in /etc/nginx/fcgiwrap.conf
+```
+# Include this file on your nginx.conf to support debian cgi-bin scripts using
+# fcgiwrap
+location /cgi-bin/ {
+  # Disable gzip (it makes scripts feel slower since they have to complete
+  # before getting gzipped)
+  gzip off;
+
+  # Set the root to /usr/lib (inside this location this means that we are
+  # giving access to the files under /usr/lib/cgi-bin)
+  #root /usr/lib;
+  root /usr/share/nginx;
+
+  # Fastcgi socket
+  fastcgi_pass  unix:/var/run/fcgiwrap.socket;
+
+  # Fastcgi parameters, include the standard ones
+  include /etc/nginx/fastcgi_params;
+
+  # Adjust non standard parameters (SCRIPT_FILENAME)
+  fastcgi_param SCRIPT_FILENAME  /usr/lib$fastcgi_script_name;
+} 
+```
+Be sure to create the folder cgi-bin folder with required permissions (755)
+```
+mkdir /usr/share/nginx/cgi-bin
+```
+Create fcgiwrap systemd service in /usr/lib/systemd/system/fcgiwrap.service
+```
+# create new
+[Unit]
+Description=Simple CGI Server
+After=nss-user-lookup.target
+Requires=fcgiwrap.socket
+
+[Service]
+EnvironmentFile=/etc/sysconfig/fcgiwrap
+ExecStart=/usr/sbin/fcgiwrap ${DAEMON_OPTS} -c ${DAEMON_PROCS}
+User=librenms
+Group=librenms
+
+[Install]
+Also=fcgiwrap.socket
+```
+The socket file in /usr/lib/systemd/system/fcgiwrap.socket
+```
+# create new
+[Unit]
+Description=fcgiwrap Socket
+
+[Socket]
+ListenStream=/var/run/fcgiwrap.socket
+
+[Install]
+WantedBy=sockets.target
+```
+Enable fcgiwrap
+```
+systemctl enable --now fcgiwrap
+```
+
+Add the following configuration to your `/etc/nginx/conf.d/librenms.conf` file within `server` section.
+
+The following will configure Nginx to respond to `http://yourlibrenms/smokeping`:
+```
+location = /smokeping/ {
+        fastcgi_intercept_errors on;
+        fastcgi_param   SCRIPT_FILENAME         /usr/share/smokeping/cgi/smokeping.fcgi;
+        fastcgi_param   QUERY_STRING            $query_string;
+        fastcgi_param   REQUEST_METHOD          $request_method;
+        fastcgi_param   CONTENT_TYPE            $content_type;
+        fastcgi_param   CONTENT_LENGTH          $content_length;
+        fastcgi_param   REQUEST_URI             $request_uri;
+        fastcgi_param   DOCUMENT_URI            $document_uri;
+        fastcgi_param   DOCUMENT_ROOT           $document_root;
+        fastcgi_param   SERVER_PROTOCOL         $server_protocol;
+        fastcgi_param   GATEWAY_INTERFACE       CGI/1.1;
+        fastcgi_param   SERVER_SOFTWARE         nginx/$nginx_version;
+        fastcgi_param   REMOTE_ADDR             $remote_addr;
+        fastcgi_param   REMOTE_PORT             $remote_port;
+        fastcgi_param   SERVER_ADDR             $server_addr;
+        fastcgi_param   SERVER_PORT             $server_port;
+        fastcgi_param   SERVER_NAME             $server_name;
+        fastcgi_param   HTTPS                   $https if_not_empty;
+        fastcgi_pass unix:/var/run/fcgiwrap.socket;
+}
+
+location ^~ /smokeping/ {
+        alias /usr/share/smokeping/cgi/;
+        index smokeping.fcgi;
+        gzip off;
+}
+```
+If images/js/css don't load, you might have to add
+```
+location ^~ /smokeping/css {
+        alias /usr/share/smokeping/htdocs/css/;
+        gzip off;
+}
+location ^~ /smokeping/js {
+        alias /usr/share/smokeping/htdocs/js/;
+        gzip off;
+}
+location ^~ /smokeping/images {
+        alias /opt/librenms/rrd/smokeping/images;
+        gzip off;
+}
+```
+After saving the configuration file, verify your Nginx configuration file syntax
+is OK with `sudo nginx -t`, then restart Nginx with `sudo systemctl restart nginx`
+
+You should be able to load the Smokeping web interface at `http://yourlibrenms/smokeping`
+
+
 ### Nginx Configuration - Ubuntu, Debian and alike
 
 This section assumes you have configured LibreNMS with Nginx as


### PR DESCRIPTION
fcgiwrap install for CentOS + specific nginx config for CSS/JS/Images

Updates documentation in order to integrate Smokeping GUI in LibreNMS

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
