### PR TITLE
Throttle error reporting

### DIFF
--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -1291,6 +1291,10 @@ return [
                 'description' => 'Dump debug errors (Will break your install)',
                 'help' => 'Dump out errors that are normally hidden so you as a developer can find and fix the possible issues.',
             ],
+            'throttle' => [
+                'description' => 'Throttle Error Reports',
+                'help' => 'Reports will only be sent every specified amount of seconds. Without this if you have an error in common code reporting can get out of hand. Set to 0 to disable throttling.',
+            ],
         ],
         'route_purge' => [
             'description' => 'Route entries older than',

--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -5167,15 +5167,26 @@
             }
         },
         "reporting.error": {
+            "group": "system",
+            "section": "reporting",
+            "order": 1,
             "default": false,
             "type": "boolean"
         },
         "reporting.dump_errors": {
             "group": "system",
             "section": "reporting",
-            "order": 1,
+            "order": 2,
             "default": false,
             "type": "boolean"
+        },
+        "reporting.throttle": {
+            "default": 300,
+            "type": "integer",
+            "units": "seconds",
+            "group": "system",
+            "section": "reporting",
+            "order": 3
         },
         "reporting.usage": {
             "group": "system",


### PR DESCRIPTION
Sets how frequently errors can be reported (across all pollers) Also has the side effect of at most 1 error reported per run To disable, set reporting.throttle to 0 (for development and testing purposes)

With this setting, it should be safe for users to have error reporting enabled without destroying their performance if they had common or frequent errors.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
