### PR TITLE
Remove some lightly used or unused dbFacile functions

### DIFF
--- a/LibreNMS/Billing.php
+++ b/LibreNMS/Billing.php
@@ -419,7 +419,7 @@ class Billing
         $data = [];
         $average = 0;
         if ($imgtype == 'day') {
-            foreach (dbFetchRows1('SELECT DISTINCT UNIX_TIMESTAMP(timestamp) as timestamp, SUM(delta) as traf_total, SUM(in_delta) as traf_in, SUM(out_delta) as traf_out FROM bill_data WHERE `bill_id` = ? AND `timestamp` >= FROM_UNIXTIME(?) AND `timestamp` <= FROM_UNIXTIME(?) GROUP BY DATE(timestamp) ORDER BY timestamp ASC', [$bill_id, $from, $to]) as $data) {
+            foreach (dbFetchRows('SELECT DISTINCT UNIX_TIMESTAMP(timestamp) as timestamp, SUM(delta) as traf_total, SUM(in_delta) as traf_in, SUM(out_delta) as traf_out FROM bill_data WHERE `bill_id` = ? AND `timestamp` >= FROM_UNIXTIME(?) AND `timestamp` <= FROM_UNIXTIME(?) GROUP BY DATE(timestamp) ORDER BY timestamp ASC', [$bill_id, $from, $to]) as $data) {
                 array_push($ticklabels, date('Y-m-d', $data['timestamp']));
                 array_push($in_data, isset($data['traf_in']) ? $data['traf_in'] : 0);
                 array_push($out_data, isset($data['traf_out']) ? $data['traf_out'] : 0);

--- a/LibreNMS/Billing.php
+++ b/LibreNMS/Billing.php
@@ -267,7 +267,7 @@ class Billing
 
         $bill_data = dbFetchRow('SELECT * from `bills` WHERE `bill_id`= ? LIMIT 1', [$bill_id]);
 
-        foreach (dbFetchRows2('SELECT *, UNIX_TIMESTAMP(timestamp) AS formatted_date FROM bill_data WHERE bill_id = ? AND `timestamp` >= FROM_UNIXTIME( ? ) AND `timestamp` <= FROM_UNIXTIME( ? ) ORDER BY timestamp ASC', [$bill_id, $from, $to]) as $row) {
+        foreach (dbFetchRows('SELECT *, UNIX_TIMESTAMP(timestamp) AS formatted_date FROM bill_data WHERE bill_id = ? AND `timestamp` >= FROM_UNIXTIME( ? ) AND `timestamp` <= FROM_UNIXTIME( ? ) ORDER BY timestamp ASC', [$bill_id, $from, $to]) as $row) {
             $timestamp = $row['formatted_date'];
             if (! $first) {
                 $first = $timestamp;

--- a/LibreNMS/Billing.php
+++ b/LibreNMS/Billing.php
@@ -267,7 +267,7 @@ class Billing
 
         $bill_data = dbFetchRow('SELECT * from `bills` WHERE `bill_id`= ? LIMIT 1', [$bill_id]);
 
-        foreach (dbFetch('SELECT *, UNIX_TIMESTAMP(timestamp) AS formatted_date FROM bill_data WHERE bill_id = ? AND `timestamp` >= FROM_UNIXTIME( ? ) AND `timestamp` <= FROM_UNIXTIME( ? ) ORDER BY timestamp ASC', [$bill_id, $from, $to]) as $row) {
+        foreach (dbFetchRows2('SELECT *, UNIX_TIMESTAMP(timestamp) AS formatted_date FROM bill_data WHERE bill_id = ? AND `timestamp` >= FROM_UNIXTIME( ? ) AND `timestamp` <= FROM_UNIXTIME( ? ) ORDER BY timestamp ASC', [$bill_id, $from, $to]) as $row) {
             $timestamp = $row['formatted_date'];
             if (! $first) {
                 $first = $timestamp;
@@ -419,7 +419,7 @@ class Billing
         $data = [];
         $average = 0;
         if ($imgtype == 'day') {
-            foreach (dbFetch('SELECT DISTINCT UNIX_TIMESTAMP(timestamp) as timestamp, SUM(delta) as traf_total, SUM(in_delta) as traf_in, SUM(out_delta) as traf_out FROM bill_data WHERE `bill_id` = ? AND `timestamp` >= FROM_UNIXTIME(?) AND `timestamp` <= FROM_UNIXTIME(?) GROUP BY DATE(timestamp) ORDER BY timestamp ASC', [$bill_id, $from, $to]) as $data) {
+            foreach (dbFetchRows1('SELECT DISTINCT UNIX_TIMESTAMP(timestamp) as timestamp, SUM(delta) as traf_total, SUM(in_delta) as traf_in, SUM(out_delta) as traf_out FROM bill_data WHERE `bill_id` = ? AND `timestamp` >= FROM_UNIXTIME(?) AND `timestamp` <= FROM_UNIXTIME(?) GROUP BY DATE(timestamp) ORDER BY timestamp ASC', [$bill_id, $from, $to]) as $data) {
                 array_push($ticklabels, date('Y-m-d', $data['timestamp']));
                 array_push($in_data, isset($data['traf_in']) ? $data['traf_in'] : 0);
                 array_push($out_data, isset($data['traf_out']) ? $data['traf_out'] : 0);
@@ -438,7 +438,7 @@ class Billing
                 array_push($tot_data, 0);
             }
         } elseif ($imgtype == 'hour') {
-            foreach (dbFetch('SELECT DISTINCT HOUR(timestamp) as hour, SUM(delta) as traf_total, SUM(in_delta) as traf_in, SUM(out_delta) as traf_out FROM bill_data WHERE `bill_id` = ? AND `timestamp` >= FROM_UNIXTIME(?) AND `timestamp` <= FROM_UNIXTIME(?) GROUP BY HOUR(timestamp) ORDER BY HOUR(timestamp) ASC', [$bill_id, $from, $to]) as $data) {
+            foreach (dbFetchRows('SELECT DISTINCT HOUR(timestamp) as hour, SUM(delta) as traf_total, SUM(in_delta) as traf_in, SUM(out_delta) as traf_out FROM bill_data WHERE `bill_id` = ? AND `timestamp` >= FROM_UNIXTIME(?) AND `timestamp` <= FROM_UNIXTIME(?) GROUP BY HOUR(timestamp) ORDER BY HOUR(timestamp) ASC', [$bill_id, $from, $to]) as $data) {
                 array_push($ticklabels, sprintf('%02d', $data['hour']) . ':00');
                 array_push($in_data, isset($data['traf_in']) ? $data['traf_in'] : 0);
                 array_push($out_data, isset($data['traf_out']) ? $data['traf_out'] : 0);

--- a/LibreNMS/Device/Sensor.php
+++ b/LibreNMS/Device/Sensor.php
@@ -161,11 +161,11 @@ class Sensor implements DiscoveryModule, PollerModule
             if (empty($update)) {
                 echo '.';
             } else {
-                dbUpdate($this->escapeNull($update), $this->getTable(), '`sensor_id`=?', [$this->sensor_id]);
+                dbUpdate($value, $this->getTable(), '`sensor_id`=?', [$this->sensor_id]);
                 echo 'U';
             }
         } else {
-            $this->sensor_id = dbInsert($this->escapeNull($new_sensor), $this->getTable());
+            $this->sensor_id = dbInsert($value, $this->getTable());
             if ($this->sensor_id !== null) {
                 $name = static::$name;
                 $message = "$name Discovered: {$this->type} {$this->subtype} {$this->index} {$this->description}";
@@ -240,20 +240,6 @@ class Sensor implements DiscoveryModule, PollerModule
             'entPhysicalIndex_measured' => $this->entPhysicalMeasured,
             'rrd_type' => $this->rrd_type,
         ];
-    }
-
-    /**
-     * Escape null values so dbFacile doesn't mess them up
-     * honestly, this should be the default, but could break shit
-     *
-     * @param  array  $array
-     * @return array
-     */
-    private function escapeNull($array)
-    {
-        return array_map(function ($value) {
-            return is_null($value) ? ['NULL'] : $value;
-        }, $array);
     }
 
     /**

--- a/LibreNMS/Device/Sensor.php
+++ b/LibreNMS/Device/Sensor.php
@@ -161,11 +161,11 @@ class Sensor implements DiscoveryModule, PollerModule
             if (empty($update)) {
                 echo '.';
             } else {
-                dbUpdate($value, $this->getTable(), '`sensor_id`=?', [$this->sensor_id]);
+                dbUpdate($update, $this->getTable(), '`sensor_id`=?', [$this->sensor_id]);
                 echo 'U';
             }
         } else {
-            $this->sensor_id = dbInsert($value, $this->getTable());
+            $this->sensor_id = dbInsert($new_sensor, $this->getTable());
             if ($this->sensor_id !== null) {
                 $name = static::$name;
                 $message = "$name Discovered: {$this->type} {$this->subtype} {$this->index} {$this->description}";

--- a/billing-calculate.php
+++ b/billing-calculate.php
@@ -19,7 +19,7 @@ $options = getopt('r');
 
 if (isset($options['r'])) {
     echo "Clearing history table.\n";
-    dbQuery('TRUNCATE TABLE `bill_history`');
+    DB::table('bill_history')->truncate();
 }
 
 foreach (dbFetchRows('SELECT * FROM `bills` ORDER BY `bill_id`') as $bill) {

--- a/discovery.php
+++ b/discovery.php
@@ -101,7 +101,7 @@ if (! empty(\LibreNMS\Config::get('distributed_poller_group'))) {
 }
 
 global $device;
-foreach (dbFetch("SELECT * FROM `devices` WHERE disabled = 0 $where ORDER BY device_id DESC", $sqlparams) as $device) {
+foreach (dbFetchRows("SELECT * FROM `devices` WHERE disabled = 0 $where ORDER BY device_id DESC", $sqlparams) as $device) {
     $device_start = microtime(true);
     DeviceCache::setPrimary($device['device_id']);
 

--- a/html/ajax_listports.php
+++ b/html/ajax_listports.php
@@ -22,7 +22,7 @@ Debug::set($_REQUEST['debug']);
 if (is_numeric($_GET['device_id'])) {
     // use php to sort since we need call cleanPort
     $interface_map = [];
-    foreach (dbFetch('SELECT * FROM ports WHERE device_id = ?', [$_GET['device_id']]) as $interface) {
+    foreach (dbFetchRows('SELECT * FROM ports WHERE device_id = ?', [$_GET['device_id']]) as $interface) {
         $interface = cleanPort($interface);
         $interface_map[$interface['label']] = $interface;
     }

--- a/html/network-map.php
+++ b/html/network-map.php
@@ -55,9 +55,9 @@ if (isset($_GET['format']) && preg_match('/^[a-z]*$/', $_GET['format'])) {
     } else {
         $locations = getlocations();
         $loc_count = 1;
-        foreach (dbFetch('SELECT *, locations.location FROM devices LEFT JOIN locations ON devices.location_id = locations.id WHERE 1 ' . $where, $param) as $device) {
+        foreach (dbFetchRows('SELECT *, locations.location FROM devices LEFT JOIN locations ON devices.location_id = locations.id WHERE 1 ' . $where, $param) as $device) {
             if ($device) {
-                $links = dbFetch('SELECT * from ports AS I, links AS L WHERE I.device_id = ? AND L.local_port_id = I.port_id ORDER BY L.remote_hostname', [$device['device_id']]);
+                $links = dbFetchRows('SELECT * from ports AS I, links AS L WHERE I.device_id = ? AND L.local_port_id = I.port_id ORDER BY L.remote_hostname', [$device['device_id']]);
                 if (count($links)) {
                     if ($anon) {
                         $device['hostname'] = md5($device['hostname']);

--- a/includes/dbFacile.php
+++ b/includes/dbFacile.php
@@ -263,28 +263,6 @@ function dbFetchRows($sql, $parameters = [])
 }//end dbFetchRows()
 
 /**
- * This is intended to be the method used for large result sets.
- * It is intended to return an iterator, and act upon buffered data.
- *
- * @deprecated Please use Eloquent instead; https://laravel.com/docs/eloquent
- * @see https://laravel.com/docs/eloquent
- */
-function dbFetch($sql, $parameters = [])
-{
-    return dbFetchRows($sql, $parameters);
-    /*
-        // for now, don't do the iterator thing
-        $result = dbQuery($sql, $parameters);
-        if($result) {
-        // return new iterator
-        return new dbIterator($result);
-        } else {
-        return null; // ??
-        }
-     */
-}//end dbFetch()
-
-/**
  * Like fetch(), accepts any number of arguments
  * The first argument is an sprintf-ready query stringTypes
  *
@@ -366,53 +344,6 @@ function dbFetchColumn($sql, $parameters = [])
 }//end dbFetchColumn()
 
 /**
- * Should be passed a query that fetches two fields
- * The first will become the array key
- * The second the key's value
- *
- * @deprecated Please use Eloquent instead; https://laravel.com/docs/eloquent
- * @see https://laravel.com/docs/eloquent
- */
-function dbFetchKeyValue($sql, $parameters = [])
-{
-    $data = [];
-    foreach (dbFetch($sql, $parameters) as $row) {
-        $key = array_shift($row);
-        if (sizeof($row) == 1) {
-            // if there were only 2 fields in the result
-            // use the second for the value
-            $data[$key] = array_shift($row);
-        } else {
-            // if more than 2 fields were fetched
-            // use the array of the rest as the value
-            $data[$key] = $row;
-        }
-    }
-
-    return $data;
-}//end dbFetchKeyValue()
-
-/**
- * Legacy dbFacile indicates DB::raw() as a value wrapped in an array
- *
- * @param  array  $data
- * @return array
- *
- * @deprecated Please use Eloquent instead; https://laravel.com/docs/eloquent
- * @see https://laravel.com/docs/eloquent
- */
-function dbArrayToRaw($data)
-{
-    array_walk($data, function (&$item) {
-        if (is_array($item)) {
-            $item = Eloquent::DB()->raw(reset($item));
-        }
-    });
-
-    return $data;
-}
-
-/**
  * @deprecated Please use Eloquent instead; https://laravel.com/docs/eloquent
  * @see https://laravel.com/docs/eloquent
  */
@@ -473,33 +404,6 @@ function dbPlaceHolders(&$values)
 }//end dbPlaceHolders()
 
 /**
- * @deprecated Please use Eloquent instead; https://laravel.com/docs/eloquent
- * @see https://laravel.com/docs/eloquent
- */
-function dbBeginTransaction()
-{
-    Eloquent::DB()->beginTransaction();
-}//end dbBeginTransaction()
-
-/**
- * @deprecated Please use Eloquent instead; https://laravel.com/docs/eloquent
- * @see https://laravel.com/docs/eloquent
- */
-function dbCommitTransaction()
-{
-    Eloquent::DB()->commit();
-}//end dbCommitTransaction()
-
-/**
- * @deprecated Please use Eloquent instead; https://laravel.com/docs/eloquent
- * @see https://laravel.com/docs/eloquent
- */
-function dbRollbackTransaction()
-{
-    Eloquent::DB()->rollBack();
-}//end dbRollbackTransaction()
-
-/**
  * Generate a string of placeholders to pass to fill in a list
  * result will look like this: (?, ?, ?, ?)
  *
@@ -548,31 +452,4 @@ function dbSyncRelationship($table, $target_column = null, $target = null, $list
     }
 
     return [$inserted, $deleted];
-}
-
-/**
- * Synchronize a relationship to a list of relations
- *
- * @param  string  $table
- * @param  array  $relationships  array of relationship pairs with columns as keys and ids as values
- * @return array [$inserted, $deleted]
- *
- * @deprecated Please use Eloquent instead; https://laravel.com/docs/eloquent
- * @see https://laravel.com/docs/eloquent
- */
-function dbSyncRelationships($table, $relationships = [])
-{
-    $changed = [[0, 0]];
-    [$target_column, $list_column] = array_keys(reset($relationships));
-
-    $grouped = [];
-    foreach ($relationships as $relationship) {
-        $grouped[$relationship[$target_column]][] = $relationship[$list_column];
-    }
-
-    foreach ($grouped as $target => $list) {
-        $changed[] = dbSyncRelationship($table, $target_column, $target, $list_column, $list);
-    }
-
-    return [array_sum(array_column($changed, 0)), array_sum(array_column($changed, 1))];
 }

--- a/includes/discovery/bgp-peers.inc.php
+++ b/includes/discovery/bgp-peers.inc.php
@@ -48,7 +48,7 @@ foreach (DeviceCache::getPrimary()->getVrfContexts() as $context_name) {
     } else {
         echo 'No BGP on host';
         if ($device['bgpLocalAs']) {
-            dbUpdate(['bgpLocalAs' => ['NULL']], 'devices', 'device_id=?', [$device['device_id']]);
+            dbUpdate(['bgpLocalAs' => null], 'devices', 'device_id=?', [$device['device_id']]);
             echo ' (Removed ASN) ';
         }
     }

--- a/includes/discovery/entity-state.inc.php
+++ b/includes/discovery/entity-state.inc.php
@@ -60,7 +60,7 @@ if (! empty($entPhysical)) {
 
                 if (! empty($update)) {
                     if (array_key_exists('entStateLastChanged', $update) && is_null($update['entStateLastChanged'])) {
-                        $update['entStateLastChanged'] = ['NULL'];
+                        $update['entStateLastChanged'] = null;
                     }
 
                     dbUpdate($update, 'entityState', 'entity_state_id=?', [$db_state['entity_state_id']]);

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -294,7 +294,7 @@ function discover_sensor(&$valid, $class, $device, $oid, $index, $type, $descr, 
         }
 
         if ((string) $high_limit != (string) $sensor_entry['sensor_limit'] && $sensor_entry['sensor_custom'] == 'No') {
-            $update = ['sensor_limit' => ($high_limit == null ? ['NULL'] : $high_limit)];
+            $update = ['sensor_limit' => $high_limit];
             $updated = dbUpdate($update, 'sensors', '`sensor_id` = ?', [$sensor_entry['sensor_id']]);
             d_echo("( $updated updated )\n");
 
@@ -303,7 +303,7 @@ function discover_sensor(&$valid, $class, $device, $oid, $index, $type, $descr, 
         }
 
         if ((string) $sensor_entry['sensor_limit_low'] != (string) $low_limit && $sensor_entry['sensor_custom'] == 'No') {
-            $update = ['sensor_limit_low' => ($low_limit == null ? ['NULL'] : $low_limit)];
+            $update = ['sensor_limit_low' => $low_limit];
             $updated = dbUpdate($update, 'sensors', '`sensor_id` = ?', [$sensor_entry['sensor_id']]);
             d_echo("( $updated updated )\n");
 
@@ -312,7 +312,7 @@ function discover_sensor(&$valid, $class, $device, $oid, $index, $type, $descr, 
         }
 
         if ((string) $warn_limit != (string) $sensor_entry['sensor_limit_warn'] && $sensor_entry['sensor_custom'] == 'No') {
-            $update = ['sensor_limit_warn' => ($warn_limit == null ? ['NULL'] : $warn_limit)];
+            $update = ['sensor_limit_warn' => $warn_limit];
             $updated = dbUpdate($update, 'sensors', '`sensor_id` = ?', [$sensor_entry['sensor_id']]);
             d_echo("( $updated updated )\n");
 
@@ -321,7 +321,7 @@ function discover_sensor(&$valid, $class, $device, $oid, $index, $type, $descr, 
         }
 
         if ((string) $sensor_entry['sensor_limit_low_warn'] != (string) $low_warn_limit && $sensor_entry['sensor_custom'] == 'No') {
-            $update = ['sensor_limit_low_warn' => ($low_warn_limit == null ? ['NULL'] : $low_warn_limit)];
+            $update = ['sensor_limit_low_warn' => $low_warn_limit];
             $updated = dbUpdate($update, 'sensors', '`sensor_id` = ?', [$sensor_entry['sensor_id']]);
             d_echo("( $updated updated )\n");
 

--- a/includes/discovery/vlans/aos6.inc.php
+++ b/includes/discovery/vlans/aos6.inc.php
@@ -25,7 +25,7 @@ foreach ($vlans as $vlan_id => $vlan) {
             'vlan_domain' => $vtpdomain_id,
             'vlan_vlan' => $vlan_id,
             'vlan_name' => $vlan['vlanDescription'],
-            'vlan_type' => ['NULL'],
+            'vlan_type' => null,
         ]);
         echo '+';
     }

--- a/includes/discovery/vlans/aos7.inc.php
+++ b/includes/discovery/vlans/aos7.inc.php
@@ -23,7 +23,7 @@ foreach ($vlans as $vlan_id => $vlan) {
             'vlan_domain' => $vtpdomain_id,
             'vlan_vlan' => $vlan_id,
             'vlan_name' => $vlan['vlanDescription'],
-            'vlan_type' => ['NULL'],
+            'vlan_type' => null,
         ], 'vlans');
         echo '+';
     }

--- a/includes/discovery/vlans/boss.inc.php
+++ b/includes/discovery/vlans/boss.inc.php
@@ -27,7 +27,7 @@ if ($device['os'] == 'boss') {
                 'vlan_domain' => $vtpdomain_id,
                 'vlan_vlan' => $vlan_id,
                 'vlan_name' => $vlan['rcVlanName'],
-                'vlan_type' => ['NULL'],
+                'vlan_type' => null,
             ], 'vlans');
             echo '+';
         }

--- a/includes/discovery/vlans/jetstream.inc.php
+++ b/includes/discovery/vlans/jetstream.inc.php
@@ -86,7 +86,7 @@ if ($vlanversion == 'version1' || $vlanversion == '2') {
                 'vlan_domain' => $vtpdomain_id,
                 'vlan_vlan' => $jet_vlan_id,
                 'vlan_name' => $jet_vlan_data['dot1qVlanDescription'],
-                'vlan_type' => ['NULL'],
+                'vlan_type' => null,
             ], 'vlans');
 
             log_event('VLAN added: ' . $jet_vlan_data['dot1qVlanDescription'] . ", $jet_vlan_id", $device, 'vlan');

--- a/includes/discovery/vlans/junos.inc.php
+++ b/includes/discovery/vlans/junos.inc.php
@@ -79,7 +79,7 @@ if ($vlanversion == 'version1' || $vlanversion == '2') {
                 'vlan_domain' => $vtpdomain_id,
                 'vlan_vlan' => $vlan_id,
                 'vlan_name' => $vlan[$tmp_name],
-                'vlan_type' => ['NULL'],
+                'vlan_type' => null,
             ], 'vlans');
             echo '+';
         }

--- a/includes/discovery/vrf.inc.php
+++ b/includes/discovery/vrf.inc.php
@@ -261,7 +261,7 @@ if (Config::get('enable_vrfs')) {
         if ($row['ifVrf']) {
             if (! $valid_vrf_if[$vrf_id][$if]) {
                 echo '-';
-                dbUpdate(['ifVrf' => 'NULL'], 'ports', 'port_id=?', [$if]);
+                dbUpdate(['ifVrf' => 0], 'ports', 'port_id=?', [$if]);
             } else {
                 echo '.';
             }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -8,7 +8,6 @@
  * @copyright  (C) 2006 - 2012 Adam Armstrong
  */
 
-use App\Models\Device;
 use Illuminate\Support\Str;
 use LibreNMS\Config;
 use LibreNMS\Enum\Severity;
@@ -129,7 +128,7 @@ function device_discovery_trigger($id)
         set_time_limit(0);
     }
 
-    $update = dbUpdate(['last_discovered' => ['NULL']], 'devices', '`device_id` = ?', [$id]);
+    $update = dbUpdate(['last_discovered' => null], 'devices', '`device_id` = ?', [$id]);
     if (! empty($update) || $update == '0') {
         $message = 'Device will be rediscovered';
     } else {

--- a/includes/html/forms/customoid.inc.php
+++ b/includes/html/forms/customoid.inc.php
@@ -18,24 +18,16 @@ $action = $_POST['action'];
 $name = strip_tags($_POST['name']);
 $oid = strip_tags($_POST['oid']);
 $datatype = strip_tags($_POST['datatype']);
-if (! empty($_POST['unit'])) {
-    $unit = $_POST['unit'];
-} else {
-    $unit = ['NULL'];
-}
-$limit = set_numeric($_POST['limit'], ['NULL']);
-$limit_warn = set_numeric($_POST['limit_warn'], ['NULL']);
-$limit_low = set_numeric($_POST['limit_low'], ['NULL']);
-$limit_low_warn = set_numeric($_POST['limit_low_warn'], ['NULL']);
+$unit = $_POST['unit'];
+$limit = $_POST['limit'];
+$limit_warn = $_POST['limit_warn'];
+$limit_low = $_POST['limit_low'];
+$limit_low_warn = $_POST['limit_low_warn'];
 $alerts = ($_POST['alerts'] == 'on' ? 1 : 0);
 $passed = ($_POST['passed'] == 'on' ? 1 : 0);
 $divisor = set_numeric($_POST['divisor'], 1);
 $multiplier = set_numeric($_POST['multiplier'], 1);
-if (! empty($_POST['user_func'])) {
-    $user_func = $_POST['user_func'];
-} else {
-    $user_func = ['NULL'];
-}
+$user_func = $_POST['user_func'];
 
 if ($action == 'test') {
     $query = 'SELECT * FROM `devices` WHERE `device_id` = ? LIMIT 1';

--- a/includes/html/forms/sensor-alert-reset.inc.php
+++ b/includes/html/forms/sensor-alert-reset.inc.php
@@ -36,7 +36,7 @@ $sensor_count = count($sensor_id);
 
 if (is_array($sensor_id)) {
     for ($x = 0; $x < $sensor_count; $x++) {
-        if (dbUpdate(['sensor_limit' => set_null($sensor_limit[$x], ['NULL']), 'sensor_limit_warn' => set_null($sensor_limit_warn[$x], ['NULL']), 'sensor_limit_low_warn' => set_null($sensor_limit_low_warn[$x], ['NULL']), 'sensor_limit_low' => set_null($sensor_limit_low[$x], ['NULL'])], 'sensors', '`sensor_id` = ?', [$sensor_id[$x]]) >= 0) {
+        if (dbUpdate(['sensor_limit' => set_null($sensor_limit[$x]), 'sensor_limit_warn' => set_null($sensor_limit_warn[$x]), 'sensor_limit_low_warn' => set_null($sensor_limit_low_warn[$x]), 'sensor_limit_low' => set_null($sensor_limit_low[$x])], 'sensors', '`sensor_id` = ?', [$sensor_id[$x]]) >= 0) {
             $message = 'Sensor values resetted';
             $status = 'ok';
         } else {

--- a/includes/html/forms/sensor-update.inc.php
+++ b/includes/html/forms/sensor-update.inc.php
@@ -38,7 +38,7 @@ if (! is_numeric($device_id)) {
 } elseif (! isset($data)) {
     $message = 'Missing data';
 } else {
-    if (dbUpdate([$value_type => set_null($data, ['NULL']), 'sensor_custom' => 'Yes'], 'sensors', '`sensor_id` = ? AND `device_id` = ?', [$sensor_id, $device_id]) >= 0) {
+    if (dbUpdate([$value_type => set_null($data), 'sensor_custom' => 'Yes'], 'sensors', '`sensor_id` = ? AND `device_id` = ?', [$sensor_id, $device_id]) >= 0) {
         $message = 'Sensor value updated';
         $status = 'ok';
     } else {

--- a/includes/html/forms/wireless-sensor-alert-reset.inc.php
+++ b/includes/html/forms/wireless-sensor-alert-reset.inc.php
@@ -24,9 +24,9 @@ if (! Auth::user()->hasGlobalAdmin()) {
 for ($x = 0; $x < count($_POST['sensor_id']); $x++) {
     dbUpdate(
         [
-            'sensor_limit' => set_null($_POST['sensor_limit'][$x], ['NULL']),
-            'sensor_limit_low' => set_null($_POST['sensor_limit_low'][$x], ['NULL']),
-            'sensor_alert' => set_null($_POST['sensor_alert'][$x], ['NULL']),
+            'sensor_limit' => set_null($_POST['sensor_limit'][$x]),
+            'sensor_limit_low' => set_null($_POST['sensor_limit_low'][$x]),
+            'sensor_alert' => set_null($_POST['sensor_alert'][$x]),
         ],
         'wireless_sensors',
         '`sensor_id` = ?',

--- a/includes/html/forms/wireless-sensor-update.inc.php
+++ b/includes/html/forms/wireless-sensor-update.inc.php
@@ -31,7 +31,7 @@ if (! is_numeric($_POST['device_id']) || ! is_numeric($_POST['sensor_id']) || ! 
     ]));
 } else {
     $update = dbUpdate(
-        [$_POST['value_type'] => set_null($_POST['data'], ['NULL']), 'sensor_custom' => 'Yes'],
+        [$_POST['value_type'] => set_null($_POST['data'], null), 'sensor_custom' => 'Yes'],
         'wireless_sensors',
         '`sensor_id` = ? AND `device_id` = ?',
         [$_POST['sensor_id'], $_POST['device_id']]

--- a/includes/html/modal/new_bill.inc.php
+++ b/includes/html/modal/new_bill.inc.php
@@ -54,7 +54,7 @@ if (Auth::user()->hasGlobalAdmin()) {
                         <?php
                         if (is_array($port)) {
                             // Need to pre-populate port as we've got a port pre-selected
-                            foreach (dbFetch('SELECT * FROM ports WHERE device_id = ?', [$port_device_id]) as $interface) {
+                            foreach (dbFetchRows('SELECT * FROM ports WHERE device_id = ?', [$port_device_id]) as $interface) {
                                 $interface = cleanPort($interface);
                                 $string = $interface['label'] . ' - ' . \LibreNMS\Util\Clean::html($interface['ifAlias'], []);
                                 $selected = $interface['port_id'] === $port['port_id'] ? ' selected' : '';

--- a/includes/html/pages/syslog.inc.php
+++ b/includes/html/pages/syslog.inc.php
@@ -21,7 +21,7 @@ $param = [];
 $device_id = (int) $vars['device'];
 
 if (isset($vars['action']) && $vars['action'] == 'expunge' && \Auth::user()->hasGlobalAdmin()) {
-    dbQuery('TRUNCATE TABLE `syslog`');
+    \App\Models\Syslog::truncate();
     print_message('syslog truncated');
 }
 

--- a/includes/polling/applications/bird2.inc.php
+++ b/includes/polling/applications/bird2.inc.php
@@ -123,7 +123,7 @@ $deviceObj = DeviceCache::getPrimary();
 
 if (empty($protocolsData)) {
     echo PHP_EOL . $name . ': No BGP Peers found' . PHP_EOL;
-    $deviceObj->bgpLocalAs = 'NULL';
+    $deviceObj->bgpLocalAs = null;
     $deviceObj->save();
 
     return;

--- a/includes/polling/entity-physical/state.inc.php
+++ b/includes/polling/entity-physical/state.inc.php
@@ -1,7 +1,7 @@
 <?php
 
 // Set Entity state
-foreach (dbFetch('SELECT * FROM `entPhysical_state` WHERE `device_id` = ?', [$device['device_id']]) as $entity) {
+foreach (dbFetchRows('SELECT * FROM `entPhysical_state` WHERE `device_id` = ?', [$device['device_id']]) as $entity) {
     if (! isset($entPhysical_state[$entity['entPhysicalIndex']][$entity['subindex']][$entity['group']][$entity['key']])) {
         dbDelete(
             'entPhysical_state',

--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -683,7 +683,7 @@ foreach ($ports as $port) {
             }
 
             if ($port[$oid] != $current_oid && ! isset($current_oid)) {
-                $port['update'][$oid] = ['NULL'];
+                $port['update'][$oid] = null;
                 log_event($oid . ': ' . $port[$oid] . ' -> NULL', $device, 'interface', 4, $port['port_id']);
                 d_echo($oid . ': ' . $port[$oid] . ' -> NULL ', $oid . ' ');
             } elseif ($port[$oid] != $current_oid) {
@@ -749,7 +749,7 @@ foreach ($ports as $port) {
                 $attrib_key = 'port_descr_' . $attrib;
                 if (($port_ifAlias[$attrib] ?? null) != $port[$attrib_key]) {
                     if (! isset($port_ifAlias[$attrib])) {
-                        $port_ifAlias[$attrib] = ['NULL'];
+                        $port_ifAlias[$attrib] = null;
                         $log_port = 'NULL';
                     } else {
                         $log_port = $port_ifAlias[$attrib];

--- a/includes/polling/unix-agent/munin-plugins.inc.php
+++ b/includes/polling/unix-agent/munin-plugins.inc.php
@@ -47,12 +47,12 @@ if (! empty($agent_data['munin'])) {
             $insert = [
                 'device_id'      => $device['device_id'],
                 'mplug_type'     => $plugin_type,
-                'mplug_instance' => ($instance == null ? ['NULL'] : $instance),
+                'mplug_instance' => $instance,
                 'mplug_category' => ($plugin['graph']['category'] == null ? 'general' : strtolower($plugin['graph']['category'])),
-                'mplug_title'    => ($plugin['graph']['title'] == null ? ['NULL'] : $plugin['graph']['title']),
-                'mplug_vlabel'   => ($plugin['graph']['vlabel'] == null ? ['NULL'] : $plugin['graph']['vlabel']),
-                'mplug_args'     => ($plugin['graph']['args'] == null ? ['NULL'] : $plugin['graph']['args']),
-                'mplug_info'     => ($plugin['graph']['info'] == null ? ['NULL'] : $plugin['graph']['info']),
+                'mplug_title'    => $plugin['graph']['title'],
+                'mplug_vlabel'   => $plugin['graph']['vlabel'],
+                'mplug_args'     => $plugin['graph']['args'],
+                'mplug_info'     => $plugin['graph']['info'],
             ];
             $mplug_id = dbInsert($insert, 'munin_plugins');
         } else {

--- a/phpstan-baseline-deprecated.neon
+++ b/phpstan-baseline-deprecated.neon
@@ -314,7 +314,7 @@ parameters:
 
 		-
 			message: """
-				#^Call to deprecated function dbFetch\\(\\)\\:
+				#^Call to deprecated function dbFetchRows\\(\\)\\:
 				Please use Eloquent instead; https\\://laravel\\.com/docs/eloquent$#
 			"""
 			count: 1
@@ -322,7 +322,7 @@ parameters:
 
 		-
 			message: """
-				#^Call to deprecated function dbFetch\\(\\)\\:
+				#^Call to deprecated function dbFetchRows\\(\\)\\:
 				Please use Eloquent instead; https\\://laravel\\.com/docs/eloquent$#
 			"""
 			count: 2
@@ -346,7 +346,7 @@ parameters:
 
 		-
 			message: """
-				#^Call to deprecated function dbFetch\\(\\)\\:
+				#^Call to deprecated function dbFetchRows\\(\\)\\:
 				Please use Eloquent instead; https\\://laravel\\.com/docs/eloquent$#
 			"""
 			count: 3
@@ -2994,7 +2994,7 @@ parameters:
 
 		-
 			message: """
-				#^Call to deprecated function dbFetch\\(\\)\\:
+				#^Call to deprecated function dbFetchRows\\(\\)\\:
 				Please use Eloquent instead; https\\://laravel\\.com/docs/eloquent$#
 			"""
 			count: 1
@@ -4858,7 +4858,7 @@ parameters:
 
 		-
 			message: """
-				#^Call to deprecated function dbFetch\\(\\)\\:
+				#^Call to deprecated function dbFetchRows\\(\\)\\:
 				Please use Eloquent instead; https\\://laravel\\.com/docs/eloquent$#
 			"""
 			count: 1


### PR DESCRIPTION
Cleanup dbFacile a bit
['NULL'] legacy behavior seems unsupported, replace with actual nulls


#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
