### PR TITLE
VRP: Use hwEntityOpticalLaneRxPower if available

### DIFF
--- a/includes/definitions/discovery/vrp.yaml
+++ b/includes/definitions/discovery/vrp.yaml
@@ -253,6 +253,10 @@ modules:
                             op: '<='
                             value: 0
                         -
+                            oid: hwEntityOpticalLaneRxPower
+                            op: 'exists'
+                            value: true
+                        -
                             oid: hwEntityAdminStatus
                             op: '='
                             value: 12
@@ -299,6 +303,10 @@ modules:
                             op: '<='
                             value: 0
                         -
+                            oid: hwEntityOpticalLaneTxPower
+                            op: 'exists'
+                            value: true
+                        -
                             oid: hwEntityAdminStatus
                             op: '='
                             value: 12
@@ -336,16 +344,14 @@ modules:
                     descr: '{{ $entPhysicalName }} Rx'
                     entPhysicalIndex: '{{ $index }}'
                     entPhysicalIndex_measured: ports
-                    index: 'lane-rx-{{ $index }}'
+                    index: 'rx-{{ $index }}'
                     divisor: 100
                     group: '{{ $entPhysicalName }}'
                     high_limit: hwEntityOpticalRxHighThreshold
+                    warn_limit: hwEntityOpticalRxHighWarnThreshold
+                    low_warn_limit: hwEntityOpticalRxLowWarnThreshold
                     low_limit: hwEntityOpticalRxLowThreshold
                     skip_values:
-                        -
-                            oid: hwEntityOpticalRxPower
-                            op: '>'
-                            value: 0
                         -
                             oid: hwEntityAdminStatus
                             op: '='
@@ -357,15 +363,13 @@ modules:
                     descr: '{{ $entPhysicalName }} Tx'
                     entPhysicalIndex: '{{ $index }}'
                     entPhysicalIndex_measured: ports
-                    index: 'lane-tx-{{ $index }}'
+                    index: 'tx-{{ $index }}'
                     group: '{{ $entPhysicalName }}'
                     high_limit: hwEntityOpticalTxHighThreshold
+                    warn_limit: hwEntityOpticalTxHighWarnThreshold
+                    low_warn_limit: hwEntityOpticalTxLowWarnThreshold
                     low_limit: hwEntityOpticalTxLowThreshold
                     skip_values:
-                        -
-                            oid: hwEntityOpticalTxPower
-                            op: '>'
-                            value: 0
                         -
                             oid: hwEntityAdminStatus
                             op: '='


### PR DESCRIPTION
The values in hwEntityOpticalRxPower are measured in µW while the limits are using dBm. Converting all of them with uw_to_dbm creates bogus limits.

Use hwEntityOpticalLaneRxPower (and hwEntityOpticalLaneTxPower) if available.

Also set warning limits.

Tested in Huawei S5720-LI Software V022

Please give a short description what your pull request is for

Fix for #15424 

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
