### PR TITLE
Stop libvirt ssh attempts when disabled

### DIFF
--- a/LibreNMS/OS/Traits/VminfoLibvirt.php
+++ b/LibreNMS/OS/Traits/VminfoLibvirt.php
@@ -39,6 +39,8 @@ trait VminfoLibvirt
 
         if (! Config::get('enable_libvirt')) {
             echo 'not configured';
+
+            return new Collection;
         }
 
         $vms = new Collection;


### PR DESCRIPTION
If enable_libvirt is not enabled, do not attempt to ssh to the target device.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
