### PR TITLE
Send event log when alert rule fails

### DIFF
--- a/LibreNMS/Alert/AlertRules.php
+++ b/LibreNMS/Alert/AlertRules.php
@@ -31,8 +31,11 @@
 
 namespace LibreNMS\Alert;
 
+use App\Models\Eventlog;
 use Carbon\Carbon;
+use Illuminate\Database\QueryException;
 use LibreNMS\Enum\AlertState;
+use LibreNMS\Enum\Severity;
 use Log;
 
 class AlertRules
@@ -69,7 +72,19 @@ class AlertRules
                 $rule['query'] = AlertDB::genSQL($rule['rule'], $rule['builder']);
             }
             $sql = $rule['query'];
-            $qry = dbFetchRows($sql, [$device_id]);
+
+            // set fetch assoc
+            global $PDO_FETCH_ASSOC;
+            $PDO_FETCH_ASSOC = true;
+            try {
+                $qry = \DB::select($sql, [$device_id]);
+            } catch (QueryException $e) {
+                c_echo('%RError: %n' . $e->getMessage() . PHP_EOL);
+                Eventlog::log("Error in alert rule {$rule['name']} ({$rule['id']}): " . $e->getMessage(), $device_id, 'alert', Severity::Error);
+                continue; // skip this rule
+            }
+            $PDO_FETCH_ASSOC = false;
+
             $cnt = count($qry);
             for ($i = 0; $i < $cnt; $i++) {
                 if (isset($qry[$i]['ip'])) {


### PR DESCRIPTION
Instead of breaking all following alerts when one has an error, just skip that one alert rule and send and eventlog detailing the error.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
