### PR TITLE
Minor fix and tweak for graylog integration

### DIFF
--- a/LibreNMS/Alert/RunAlerts.php
+++ b/LibreNMS/Alert/RunAlerts.php
@@ -254,8 +254,9 @@ class RunAlerts
         $obj = $this->describeAlert($alert);
         if (is_array($obj)) {
             echo 'Issuing Alert-UID #' . $alert['id'] . '/' . $alert['state'] . ':' . PHP_EOL;
-            $this->extTransports($obj);
-
+            if ($alert['state'] != AlertState::ACKNOWLEDGED || Config::get('alert.acknowledged') === true) {
+                $this->extTransports($obj);
+            }
             echo "\r\n";
         }
 

--- a/app/ApiClients/GraylogApi.php
+++ b/app/ApiClients/GraylogApi.php
@@ -103,7 +103,7 @@ class GraylogApi
         }
 
         if ($device) {
-            $query[] = 'source: ("' . $this->getAddresses($device)->implode('" OR "') . '")';
+            $query[] = 'gl2_remote_ip: ("' . $this->getAddresses($device)->implode('" OR "') . '")';
         }
 
         if (empty($query)) {

--- a/app/ApiClients/GraylogApi.php
+++ b/app/ApiClients/GraylogApi.php
@@ -97,13 +97,14 @@ class GraylogApi
      */
     public function buildSimpleQuery(?string $search = null, ?Device $device = null): string
     {
+        $field = Config::get('graylog.query.field');
         $query = [];
         if ($search) {
             $query[] = 'message:"' . $search . '"';
         }
 
         if ($device) {
-            $query[] = 'gl2_remote_ip: ("' . $this->getAddresses($device)->implode('" OR "') . '")';
+            $query[] = $field . ': ("' . $this->getAddresses($device)->implode('" OR "') . '")';
         }
 
         if (empty($query)) {

--- a/app/Http/Controllers/Table/GraylogController.php
+++ b/app/Http/Controllers/Table/GraylogController.php
@@ -111,14 +111,16 @@ class GraylogController extends SimpleTableController
             $displayTime = $message['message']['timestamp'];
         }
 
-        $device = $this->deviceFromSource($message['message']['source']);
+        $device = $this->deviceFromSource($message['message']['gl2_remote_ip']);
+        $source = $this->deviceFromSource($message['message']['source']);
         $level = $message['message']['level'] ?? '';
         $facility = $message['message']['facility'] ?? '';
 
         return [
+            'device'    => $device ? Url::deviceLink($device) : htmlspecialchars($message['message']['gl2_remote_ip']),
             'severity'  => $this->severityLabel($level),
             'timestamp' => $displayTime,
-            'source'    => $device ? Url::deviceLink($device) : htmlspecialchars($message['message']['source']),
+            'source'    => htmlspecialchars($message['message']['source']),
             'message'   => htmlspecialchars($message['message']['message'] ?? ''),
             'facility'  => is_numeric($facility) ? "($facility) " . __("syslog.facility.$facility") : $facility,
             'level'     => (is_numeric($level) && $level >= 0) ? "($level) " . __("syslog.severity.$level") : $level,

--- a/app/Http/Controllers/Table/GraylogController.php
+++ b/app/Http/Controllers/Table/GraylogController.php
@@ -111,16 +111,16 @@ class GraylogController extends SimpleTableController
             $displayTime = $message['message']['timestamp'];
         }
 
-        $device = $this->deviceFromSource($message['message']['gl2_remote_ip']);
+        $origin = $this->deviceFromSource($message['message']['gl2_remote_ip']);
         $source = $this->deviceFromSource($message['message']['source']);
         $level = $message['message']['level'] ?? '';
         $facility = $message['message']['facility'] ?? '';
 
         return [
-            'device'    => $device ? Url::deviceLink($device) : htmlspecialchars($message['message']['gl2_remote_ip']),
+            'origin'    => $origin ? Url::deviceLink($origin) : htmlspecialchars($message['message']['gl2_remote_ip']),
             'severity'  => $this->severityLabel($level),
             'timestamp' => $displayTime,
-            'source'    => htmlspecialchars($message['message']['source']),
+            'source'    => $source ? Url::deviceLink($source) : htmlspecialchars($message['message']['source']),
             'message'   => htmlspecialchars($message['message']['message'] ?? ''),
             'facility'  => is_numeric($facility) ? "($facility) " . __("syslog.facility.$facility") : $facility,
             'level'     => (is_numeric($level) && $level >= 0) ? "($level) " . __("syslog.severity.$level") : $level,

--- a/html/mix-manifest.json
+++ b/html/mix-manifest.json
@@ -5,7 +5,7 @@
     "/css/app.css": "/css/app.css?id=ddaa1664b2b7b9dc3293",
     "/js/vendor.js": "/js/vendor.js?id=9a257386f44b3d7f29bc",
     "/js/lang/de.js": "/js/lang/de.js?id=d74df23e729c5dabfee8",
-    "/js/lang/en.js": "/js/lang/en.js?id=78876958dd68997f3ec6",
+    "/js/lang/en.js": "/js/lang/en.js?id=32bfdbbe12d86a9395a4",
     "/js/lang/fr.js": "/js/lang/fr.js?id=0ce8fdb91332174459d4",
     "/js/lang/it.js": "/js/lang/it.js?id=f024ff80dfe2c976c4e5",
     "/js/lang/ru.js": "/js/lang/ru.js?id=f6b7c078755312a0907c",

--- a/html/mix-manifest.json
+++ b/html/mix-manifest.json
@@ -5,12 +5,12 @@
     "/css/app.css": "/css/app.css?id=ddaa1664b2b7b9dc3293",
     "/js/vendor.js": "/js/vendor.js?id=9a257386f44b3d7f29bc",
     "/js/lang/de.js": "/js/lang/de.js?id=d74df23e729c5dabfee8",
-    "/js/lang/en.js": "/js/lang/en.js?id=98442c0577fed73bc90c",
-    "/js/lang/fr.js": "/js/lang/fr.js?id=22902d30358443ef2877",
-    "/js/lang/it.js": "/js/lang/it.js?id=6220e138068a7e58387f",
+    "/js/lang/en.js": "/js/lang/en.js?id=78876958dd68997f3ec6",
+    "/js/lang/fr.js": "/js/lang/fr.js?id=0ce8fdb91332174459d4",
+    "/js/lang/it.js": "/js/lang/it.js?id=f024ff80dfe2c976c4e5",
     "/js/lang/ru.js": "/js/lang/ru.js?id=f6b7c078755312a0907c",
     "/js/lang/sr.js": "/js/lang/sr.js?id=388e38b41f63e3517506",
-    "/js/lang/uk.js": "/js/lang/uk.js?id=fdfb4cfa77a3340e50f8",
+    "/js/lang/uk.js": "/js/lang/uk.js?id=8309e7619e030ac1e7bc",
     "/js/lang/zh-CN.js": "/js/lang/zh-CN.js?id=cc4309e63a32a671f107",
     "/js/lang/zh-TW.js": "/js/lang/zh-TW.js?id=2248687ad44f27299377"
 }

--- a/includes/html/common/graylog.inc.php
+++ b/includes/html/common/graylog.inc.php
@@ -29,6 +29,7 @@ $tmp_output = '
         <thead>
             <tr>
             <th data-column-id="severity" data-sortable="false"></th>
+            <th data-column-id="device">Device</th>
             <th data-column-id="timestamp" data-formatter="browserTime">Timestamp</th>
             <th data-column-id="level">Level</th>
             <th data-column-id="source">Source</th>

--- a/includes/html/common/graylog.inc.php
+++ b/includes/html/common/graylog.inc.php
@@ -29,7 +29,7 @@ $tmp_output = '
         <thead>
             <tr>
             <th data-column-id="severity" data-sortable="false"></th>
-            <th data-column-id="device">Device</th>
+            <th data-column-id="origin">Origin</th>
             <th data-column-id="timestamp" data-formatter="browserTime">Timestamp</th>
             <th data-column-id="level">Level</th>
             <th data-column-id="source">Source</th>

--- a/includes/html/pages/device/logs.inc.php
+++ b/includes/html/pages/device/logs.inc.php
@@ -57,7 +57,7 @@ if (\LibreNMS\Config::get('enable_syslog') == 1) {
     }
 }
 
-if (\LibreNMS\Config::get('graylog.port')) {
+if (\LibreNMS\Config::get('graylog.server')) {
     echo ' | ';
     if ($vars['section'] == 'graylog') {
         echo '<span class="pagemenu-selected">';

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -160,6 +160,10 @@ return [
                 'description' => 'Disable alerting',
                 'help' => 'Stop alerts being generated',
             ],
+            'acknowledged' => [
+                'description' => 'Send Acknowledged Alerts',
+                'help' => 'Notify if Alert has been acknowledged',
+            ],
             'fixed-contacts' => [
                 'description' => 'Updates to contact email addresses not honored',
                 'help' => 'If TRUE any changes to sysContact or users emails will not be honoured whilst alert is active',

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -815,6 +815,12 @@ return [
                 'description' => 'Version',
                 'help' => 'This is used to automatically create the base_uri for the Graylog API. If you have modified the API uri from the default, set this to other and specify your base_uri.',
             ],
+            'query' => [
+                'field' => [
+                    'description' => 'Query api field',
+                    'help' => 'Changes the default field to query graylog API.',
+                ],
+            ],
         ],
         'html' => [
             'device' => [

--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -90,6 +90,13 @@
             "order": 1,
             "type": "boolean"
         },
+        "alert.acknowledged": {
+            "default": true,
+            "group": "alerting",
+            "section": "general",
+            "order": 1,
+            "type": "boolean"
+        },
         "alert.fixed-contacts": {
             "default": true,
             "group": "alerting",
@@ -198,26 +205,33 @@
             "section": "rules",
             "order": 4
         },
+        "alert_rule.acknowledged_alerts": {
+            "default": true,
+            "type": "boolean",
+            "group": "alerting",
+            "section": "rules",
+            "order": 5
+        },
         "alert_rule.invert_rule_match": {
             "default": false,
             "type": "boolean",
             "group": "alerting",
             "section": "rules",
-            "order": 5
+            "order": 6
         },
         "alert_rule.recovery_alerts": {
             "default": true,
             "type": "boolean",
             "group": "alerting",
             "section": "rules",
-            "order": 6
+            "order": 7
         },
         "alert_rule.invert_map": {
             "default": false,
             "type": "boolean",
             "group": "alerting",
             "section": "rules",
-            "order": 7
+            "order": 8
         },
         "discovery_on_reboot": {
             "default": false,

--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -3735,6 +3735,13 @@
                 "other": "Other"
             }
         },
+        "graylog.query.field": {
+            "default": "source",
+            "type": "text",
+            "group": "external",
+            "section": "graylog",
+            "order": 10
+        },
         "group": {
             "type": "text",
             "default": "librenms"

--- a/resources/views/widgets/graylog.blade.php
+++ b/resources/views/widgets/graylog.blade.php
@@ -3,6 +3,7 @@
         <thead>
         <tr>
             <th data-column-id="severity" data-sortable="false"></th>
+            <th data-column-id="device">{{ __('Device') }}</th>
             <th data-column-id="timestamp" data-formatter="browserTime">{{ __('Timestamp') }}</th>
             <th data-column-id="level" data-sortable="false">{{ __('Level') }}</th>
             <th data-column-id="source">{{ __('Source') }}</th>

--- a/resources/views/widgets/graylog.blade.php
+++ b/resources/views/widgets/graylog.blade.php
@@ -3,7 +3,7 @@
         <thead>
         <tr>
             <th data-column-id="severity" data-sortable="false"></th>
-            <th data-column-id="device">{{ __('Device') }}</th>
+            <th data-column-id="origin">{{ __('Origin') }}</th>
             <th data-column-id="timestamp" data-formatter="browserTime">{{ __('Timestamp') }}</th>
             <th data-column-id="level" data-sortable="false">{{ __('Level') }}</th>
             <th data-column-id="source">{{ __('Source') }}</th>


### PR DESCRIPTION
Using graylog integration while having RFC5424 syslog messages `source` field is used to store process names, this causes a mismatch in most cases. So librenms will never display syslog messages.

Changing librenms to query graylog for `gl2_remote_ip` results in all messages recieved from this source ip.



DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
