### PR TITLE
muteable acknowledged alert notifications

### DIFF
--- a/LibreNMS/Alert/RunAlerts.php
+++ b/LibreNMS/Alert/RunAlerts.php
@@ -254,8 +254,9 @@ class RunAlerts
         $obj = $this->describeAlert($alert);
         if (is_array($obj)) {
             echo 'Issuing Alert-UID #' . $alert['id'] . '/' . $alert['state'] . ':' . PHP_EOL;
-            $this->extTransports($obj);
-
+            if ($alert['state'] != AlertState::ACKNOWLEDGED || Config::get('alert.acknowledged') === true) {
+                $this->extTransports($obj);
+            }
             echo "\r\n";
         }
 

--- a/html/mix-manifest.json
+++ b/html/mix-manifest.json
@@ -5,12 +5,12 @@
     "/css/app.css": "/css/app.css?id=ddaa1664b2b7b9dc3293",
     "/js/vendor.js": "/js/vendor.js?id=9a257386f44b3d7f29bc",
     "/js/lang/de.js": "/js/lang/de.js?id=d74df23e729c5dabfee8",
-    "/js/lang/en.js": "/js/lang/en.js?id=98442c0577fed73bc90c",
-    "/js/lang/fr.js": "/js/lang/fr.js?id=22902d30358443ef2877",
-    "/js/lang/it.js": "/js/lang/it.js?id=6220e138068a7e58387f",
+    "/js/lang/en.js": "/js/lang/en.js?id=32bfdbbe12d86a9395a4",
+    "/js/lang/fr.js": "/js/lang/fr.js?id=0ce8fdb91332174459d4",
+    "/js/lang/it.js": "/js/lang/it.js?id=f024ff80dfe2c976c4e5",
     "/js/lang/ru.js": "/js/lang/ru.js?id=f6b7c078755312a0907c",
     "/js/lang/sr.js": "/js/lang/sr.js?id=388e38b41f63e3517506",
-    "/js/lang/uk.js": "/js/lang/uk.js?id=fdfb4cfa77a3340e50f8",
+    "/js/lang/uk.js": "/js/lang/uk.js?id=8309e7619e030ac1e7bc",
     "/js/lang/zh-CN.js": "/js/lang/zh-CN.js?id=cc4309e63a32a671f107",
     "/js/lang/zh-TW.js": "/js/lang/zh-TW.js?id=2248687ad44f27299377"
 }

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -160,6 +160,10 @@ return [
                 'description' => 'Disable alerting',
                 'help' => 'Stop alerts being generated',
             ],
+            'acknowledged' => [
+                'description' => 'Send Acknowledged Alerts',
+                'help' => 'Notify if Alert has been acknowledged',
+            ],
             'fixed-contacts' => [
                 'description' => 'Updates to contact email addresses not honored',
                 'help' => 'If TRUE any changes to sysContact or users emails will not be honoured whilst alert is active',

--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -90,6 +90,13 @@
             "order": 1,
             "type": "boolean"
         },
+        "alert.acknowledged": {
+            "default": true,
+            "group": "alerting",
+            "section": "general",
+            "order": 1,
+            "type": "boolean"
+        },
         "alert.fixed-contacts": {
             "default": true,
             "group": "alerting",
@@ -198,26 +205,33 @@
             "section": "rules",
             "order": 4
         },
+        "alert_rule.acknowledged_alerts": {
+            "default": true,
+            "type": "boolean",
+            "group": "alerting",
+            "section": "rules",
+            "order": 5
+        },
         "alert_rule.invert_rule_match": {
             "default": false,
             "type": "boolean",
             "group": "alerting",
             "section": "rules",
-            "order": 5
+            "order": 6
         },
         "alert_rule.recovery_alerts": {
             "default": true,
             "type": "boolean",
             "group": "alerting",
             "section": "rules",
-            "order": 6
+            "order": 7
         },
         "alert_rule.invert_map": {
             "default": false,
             "type": "boolean",
             "group": "alerting",
             "section": "rules",
-            "order": 7
+            "order": 8
         },
         "discovery_on_reboot": {
             "default": false,


### PR DESCRIPTION

Ability to disable Alert Transport Notification about Alert Acknowledgement


![image](https://github.com/librenms/librenms/assets/7978916/354cb4c6-5b13-4606-bbe5-35ad25862e13)



#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
