### PR TITLE
Always create rrd folder on localhost

### DIFF
--- a/LibreNMS/Data/Store/Rrd.php
+++ b/LibreNMS/Data/Store/Rrd.php
@@ -26,7 +26,6 @@
 namespace LibreNMS\Data\Store;
 
 use App\Polling\Measure\Measurement;
-use Illuminate\Support\Str;
 use LibreNMS\Config;
 use LibreNMS\Exceptions\FileExistsException;
 use LibreNMS\Exceptions\RrdGraphException;
@@ -524,10 +523,9 @@ class Rrd extends BaseDatastore
     public function checkRrdExists($filename)
     {
         if ($this->rrdcached && version_compare($this->version, '1.5', '>=')) {
-            $chk = $this->command('last', $filename, '');
-            $filename = str_replace([$this->rrd_dir . '/', $this->rrd_dir], '', $filename);
+            $check_output = implode($this->command('last', $filename, ''));
 
-            return ! Str::contains(implode($chk), "$filename': No such file or directory");
+            return ! (str_contains($check_output, $filename) && str_contains($check_output, 'No such file or directory'));
         } else {
             return is_file($filename);
         }

--- a/LibreNMS/Poller.php
+++ b/LibreNMS/Poller.php
@@ -278,7 +278,7 @@ class Poller
     private function initRrdDirectory(): void
     {
         $host_rrd = \Rrd::name($this->device->hostname, '', '');
-        if (Config::get('rrd.enable', true) && ! Config::get('rrdcached') && ! is_dir($host_rrd)) {
+        if (Config::get('rrd.enable', true) && ! is_dir($host_rrd)) {
             try {
                 mkdir($host_rrd);
                 $this->logger->info("Created directory : $host_rrd");


### PR DESCRIPTION
for some reason rrdcached cannot create folders when it is running on localhost 
Always create directories on the local poller in case rrdcached is running on the same machine 
A few small changes to checkRrdExists() too

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
