### PR TITLE
Discover AEN with sysobjectid instead of sysdescr

### DIFF
--- a/includes/definitions/aen.yaml
+++ b/includes/definitions/aen.yaml
@@ -9,5 +9,7 @@ over:
 mib_dir: accedian
 discovery:
     -
-        sysObjectID:
-            - .1.3.6.1.4.1.22420.1.1
+        sysDescr_regex:
+            - '^AMN-'
+            - '^AEN-'
+            - '^AMO-'

--- a/includes/definitions/aen.yaml
+++ b/includes/definitions/aen.yaml
@@ -10,6 +10,7 @@ mib_dir: accedian
 discovery:
     -
         sysDescr_regex:
-            - '^AMN-'
-            - '^AEN-'
-            - '^AMO-'
+            - '/^AMN-/'
+            - '/^AEN-/'
+            - '/^AMO-/'
+            

--- a/includes/definitions/aen.yaml
+++ b/includes/definitions/aen.yaml
@@ -9,7 +9,5 @@ over:
 mib_dir: accedian
 discovery:
     -
-        sysDescr:
-            - AMN-
-            - AEN-
-            - AMO-
+        sysObjectID:
+            - .1.3.6.1.4.1.22420.1.1


### PR DESCRIPTION
--- This part is obsolete ---
According to:
- https://docs.vmware.com/en/VMware-Smart-Assurance/10.1.11/ncm-dsr-support-matrix-33HF1/GUID-C98227E4-830C-4044-894C-157D3CE71058.html
- https://oid-rep.orange-labs.fr/get/1.3.6.1.4.1.22420.1.1
- the fact that the AEN yaml file use ACD-DESC-MIB which is under this same OID (https://www.circitor.fr/Mibs/Html/A/ACD-DESC-MIB.php)

I'm changing the discovery mode, so it won't prevent devices with AEN in their sysname to be properly discovered.
--- End of obsolete ---



Solve https://github.com/librenms/librenms/issues/15476
**Edit:** change to sysdescr_regex
 
Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
