### PR TITLE
Fix auth_ad_url validation

### DIFF
--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -500,7 +500,7 @@
             "order": 1,
             "type": "text",
             "validate": {
-                "value": "regex:#(ldaps?://[\\w.]+\\s+)+#"
+                "value": ["regex:#^ldaps?://([-0-9a-zA-Z_.]+|\\[[a-fA-F0-9:]{3,39}\\])(\\s+ldaps?://([-0-9a-zA-Z_.]+|\\[[a-fA-F0-9:]{3,39}\\]))*$#"]
             }
         },
         "auth_ad_require_groupmembership": {


### PR DESCRIPTION
It didn't allow a single server, only multiple
Improve the validation, but try not to be too strict.
Allow IPv6 addresses too

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
