### PR TITLE
Cisco ASA table add alert defaults

### DIFF
--- a/database/migrations/2023_10_20_075853_cisco_asa_add_default_limits.php
+++ b/database/migrations/2023_10_20_075853_cisco_asa_add_default_limits.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('ciscoASA', function (Blueprint $table) {
+            $table->bigInteger('high_alert')->default(-1)->change();
+            $table->bigInteger('low_alert')->default(0)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('ciscoASA', function (Blueprint $table) {
+            $table->bigInteger('high_alert')->change();
+            $table->bigInteger('low_alert')->change();
+        });
+    }
+};

--- a/misc/db_schema.yaml
+++ b/misc/db_schema.yaml
@@ -428,8 +428,8 @@ ciscoASA:
     - { Field: device_id, Type: 'int unsigned', 'Null': false, Extra: '' }
     - { Field: oid, Type: varchar(255), 'Null': false, Extra: '' }
     - { Field: data, Type: bigint, 'Null': false, Extra: '' }
-    - { Field: high_alert, Type: bigint, 'Null': false, Extra: '' }
-    - { Field: low_alert, Type: bigint, 'Null': false, Extra: '' }
+    - { Field: high_alert, Type: bigint, 'Null': false, Extra: '', Default: '-1' }
+    - { Field: low_alert, Type: bigint, 'Null': false, Extra: '', Default: '0' }
     - { Field: disabled, Type: tinyint, 'Null': false, Extra: '', Default: '0' }
   Indexes:
     PRIMARY: { Name: PRIMARY, Columns: [ciscoASA_id], Unique: true, Type: BTREE }


### PR DESCRIPTION
Fixes issue when values weren't set
Can't set an upper limit since models are different
Also, no way to set this in the webui and the default alert rule doesn't use the values, so yeah, probably could have deleted the fields.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
