### PR TITLE
Fix websensor temp user_func

### DIFF
--- a/includes/discovery/sensors/temperature/websensor.inc.php
+++ b/includes/discovery/sensors/temperature/websensor.inc.php
@@ -51,7 +51,7 @@ if ($oids) {
 }
 
 $temp_unit = snmp_get($device, 'tempUnit.0', '-OevTQUs', 'T3610-MIB');
-$user_func = '';
+$user_func = null;
 
 if (Str::contains($temp_unit, 'F')) {
     $user_func = 'fahrenheit_to_celsius';


### PR DESCRIPTION
default should be null, not ''

https://community.librenms.org/t/thermometer-device-no-graph-and-error/22610

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
