### PR TITLE
Ospf metrics fix

### DIFF
--- a/LibreNMS/Modules/Ospf.php
+++ b/LibreNMS/Modules/Ospf.php
@@ -193,20 +193,25 @@ class Ospf implements Module
             echo ' TOS Metrics: ';
 
             // Pull data from device
+            $ospf_ports_by_ip = $ospf_ports->keyBy('ospfIfIpAddress');
             $ospf_tos_metrics = SnmpQuery::context($context_name)
                 ->hideMib()->enumStrings()
                 ->walk('OSPF-MIB::ospfIfMetricTable')
-                ->mapTable(function ($ospf_tos, $ip) use ($context_name, $os) {
-                    $ospf_tos['ospf_port_id'] = OspfPort::query()
-                        ->where('ospfIfIpAddress', $ip)
-                        ->where('context_name', $context_name)
-                        ->value('ospf_port_id');
+                ->mapTable(function ($ospf_tos, $ip) use ($ospf_ports_by_ip) {
+                    $port = $ospf_ports_by_ip->get($ip);
 
-                    return OspfPort::updateOrCreate([
-                        'device_id' => $os->getDeviceId(),
-                        'ospf_port_id' => $ospf_tos['ospf_port_id'],
-                        'context_name' => $context_name,
-                    ], $ospf_tos);
+                    if (! $port) {
+                        // didn't find port by IP, try harder
+                        $port = $ospf_ports_by_ip->where(fn($p) => str_starts_with($p->ospf_port_id, $ip))->first();
+                    }
+
+                    if ($port) {
+                        $port->fill($ospf_tos)->save();
+                    } else {
+                        \Log::error("No port found when fetching metrics for $ip");
+                    }
+
+                    return $port;
                 });
 
             echo $ospf_tos_metrics->count();

--- a/LibreNMS/Modules/Ospf.php
+++ b/LibreNMS/Modules/Ospf.php
@@ -202,7 +202,7 @@ class Ospf implements Module
 
                     if (! $port) {
                         // didn't find port by IP, try harder
-                        $port = $ospf_ports_by_ip->where(fn($p) => str_starts_with($p->ospf_port_id, $ip))->first();
+                        $port = $ospf_ports_by_ip->where(fn ($p) => str_starts_with($p->ospf_port_id, $ip))->first();
                     }
 
                     if ($port) {


### PR DESCRIPTION
If the device gave an invalid IP for metrics, it would fail.
Fix this issue, and optimize the code so less sql queries are needed.



#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
