### PR TITLE
Prefetch devices in group to avoid cost of subquery

### DIFF
--- a/app/Models/DeviceRelatedModel.php
+++ b/app/Models/DeviceRelatedModel.php
@@ -39,13 +39,14 @@ class DeviceRelatedModel extends BaseModel
 
     public function scopeInDeviceGroup($query, $deviceGroup)
     {
-        // Build the comma-separated list of device IDs in SQL
+        // Build the list of device IDs in SQL
         $deviceIdsSubquery = \DB::table('device_group_device')
         ->where('device_group_id', $deviceGroup)
         ->pluck('device_id');
 
-        // Use the result in the whereIn clause
-        return $query->whereIn($query->qualifyColumn('device_id'), $deviceIdsSubquery);
+        // Use the result in the whereIn clause to avoid unoptimized subqueries
+        // use whereIntegerInRaw to avoid a the defautl limit of 1000 for whereIn
+        return $query->whereIntegerInRaw($query->qualifyColumn('device_id'), $deviceIdsSubquery);
     }
 
     // ---- Define Relationships ----

--- a/app/Models/DeviceRelatedModel.php
+++ b/app/Models/DeviceRelatedModel.php
@@ -39,11 +39,14 @@ class DeviceRelatedModel extends BaseModel
 
     public function scopeInDeviceGroup($query, $deviceGroup)
     {
-        return $query->whereIn($query->qualifyColumn('device_id'), function ($query) use ($deviceGroup) {
-            $query->select('device_id')
-                ->from('device_group_device')
-                ->where('device_group_id', $deviceGroup);
-        });
+        // Build the comma-separated list of device IDs in SQL
+        $deviceIdsSubquery = \DB::table('device_group_device')
+        ->where('device_group_id', $deviceGroup)
+        ->pluck('device_id')
+        ->implode(',');
+
+        // Use the result in the whereIn clause
+        return $query->whereIn($query->qualifyColumn('device_id'), explode(',', $deviceIdsSubquery));
     }
 
     // ---- Define Relationships ----

--- a/app/Models/DeviceRelatedModel.php
+++ b/app/Models/DeviceRelatedModel.php
@@ -42,11 +42,10 @@ class DeviceRelatedModel extends BaseModel
         // Build the comma-separated list of device IDs in SQL
         $deviceIdsSubquery = \DB::table('device_group_device')
         ->where('device_group_id', $deviceGroup)
-        ->pluck('device_id')
-        ->implode(',');
+        ->pluck('device_id');
 
         // Use the result in the whereIn clause
-        return $query->whereIn($query->qualifyColumn('device_id'), explode(',', $deviceIdsSubquery));
+        return $query->whereIn($query->qualifyColumn('device_id'), $deviceIdsSubquery);
     }
 
     // ---- Define Relationships ----


### PR DESCRIPTION
For widgets that filter by group the subquery is very costly and can lead to a timeout.
As proposed in https://community.librenms.org/t/librenms-getting-slow-and-eventlog-widget-gets-canceled-or-504/22270/4?u=slalomsk8er this prefetches the list of devices in the group to avoid the subquery and is orders of magnitude faster.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
