### PR TITLE
SnmpQuery runtime cache

### DIFF
--- a/LibreNMS/Data/Source/NetSnmpQuery.php
+++ b/LibreNMS/Data/Source/NetSnmpQuery.php
@@ -394,7 +394,7 @@ class NetSnmpQuery implements SnmpQueryInterface
 
             // if abort on failure is set, return after first failure
             if ($this->abort && ! $response->isValid()) {
-                $oid_list = implode(',', array_map(fn($group) => implode(',', $group), $oids));
+                $oid_list = implode(',', array_map(fn ($group) => implode(',', $group), $oids));
                 Log::debug("SNMP failed walking $oid of $oid_list aborting.");
 
                 return $response;

--- a/LibreNMS/Data/Source/NetSnmpQuery.php
+++ b/LibreNMS/Data/Source/NetSnmpQuery.php
@@ -387,8 +387,11 @@ class NetSnmpQuery implements SnmpQueryInterface
 
     private function execMultiple(string $command, array $oids): SnmpResponse
     {
-        // use runtime(array) cache if requested. The 'null' driver will simple return the value without caching
-        return Cache::driver($this->cache ? 'array' : 'null')->rememberForever($this->getCacheKey($oids), function () use ($command, $oids) {
+        // use runtime(array) cache if requested. The 'null' driver will simply return the value without caching
+        $driver = $this->cache ? 'array' : 'null';
+        $key = $this->cache ? $this->getCacheKey($command, $oids) : '';
+
+        return Cache::driver($driver)->rememberForever($key, function () use ($command, $oids) {
             $response = new SnmpResponse('');
 
             foreach ($oids as $oid) {
@@ -538,11 +541,11 @@ class NetSnmpQuery implements SnmpQueryInterface
         return is_string($oid) ? explode(' ', $oid) : $oid;
     }
 
-    private function getCacheKey(array $oids): string
+    private function getCacheKey(string $type, array $oids): string
     {
         $oids = implode(',', array_map(fn ($group) => implode(',', $group), $oids));
         $options = implode(',', $this->options);
 
-        return "{$this->device->hostname}|$this->context|$oids|$options";
+        return "$type|{$this->device->hostname}|$this->context|$oids|$options";
     }
 }

--- a/LibreNMS/Data/Source/NetSnmpQuery.php
+++ b/LibreNMS/Data/Source/NetSnmpQuery.php
@@ -540,7 +540,7 @@ class NetSnmpQuery implements SnmpQueryInterface
 
     private function getCacheKey(array $oids): string
     {
-        $oids = implode(',', array_map(fn($group) => implode(',', $group), $oids));
+        $oids = implode(',', array_map(fn ($group) => implode(',', $group), $oids));
         $options = implode(',', $this->options);
 
         return "{$this->device->hostname}|$this->context|$oids|$options";

--- a/LibreNMS/Data/Source/SnmpQueryInterface.php
+++ b/LibreNMS/Data/Source/SnmpQueryInterface.php
@@ -47,6 +47,11 @@ interface SnmpQueryInterface
     public function deviceArray(array $device): SnmpQueryInterface;
 
     /**
+     * Cache the data for the rest of the runtime (or retrieve from cache if available)
+     */
+    public function cache(): SnmpQueryInterface;
+
+    /**
      * Set a context for the snmp query
      * This is most commonly used to fetch alternate sets of data, such as different VRFs
      */
@@ -80,6 +85,11 @@ interface SnmpQueryInterface
      * Output all OIDs numerically
      */
     public function numeric(bool $numeric = true): SnmpQueryInterface;
+
+    /**
+     * Output indexes only as numeric
+     */
+    public function numericIndex(bool $numericIndex = true): SnmpQueryInterface;
 
     /**
      * Hide MIB in output

--- a/LibreNMS/Data/Source/SnmpResponse.php
+++ b/LibreNMS/Data/Source/SnmpResponse.php
@@ -286,4 +286,9 @@ class SnmpResponse
         // regular oid
         return explode('.', $key);
     }
+
+    public function __sleep()
+    {
+        return ['raw', 'exitCode', 'stderr'];
+    }
 }

--- a/tests/Mocks/SnmpQueryMock.php
+++ b/tests/Mocks/SnmpQueryMock.php
@@ -73,6 +73,11 @@ class SnmpQueryMock implements SnmpQueryInterface
         return $this;
     }
 
+    public function cache(): SnmpQueryInterface
+    {
+        return $this; // ignore, always cached
+    }
+
     public function context(string $context): SnmpQueryInterface
     {
         $this->context = $context;
@@ -113,6 +118,14 @@ class SnmpQueryMock implements SnmpQueryInterface
     public function numeric(bool $numeric = true): SnmpQueryInterface
     {
         $this->numeric = $numeric;
+
+        return $this;
+    }
+
+    public function numericIndex(bool $numericIndex = true): SnmpQueryInterface
+    {
+        // TODO: Implement numericIndex() method
+        Log::error('numericIndex not implemented in SnmpQueryMock');
 
         return $this;
     }


### PR DESCRIPTION
Optionally cache the SnmpResponse from queries for the rest of the runtime.
It would be nice to have cache hits for these to help prevent wasting memory caching data that is only used once.
Key data must match: command, device, context, options, oids

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
