### PR TITLE
Changed log item, source(s_sys) to source(s_src)

### DIFF
--- a/doc/Extensions/Syslog.md
+++ b/doc/Extensions/Syslog.md
@@ -37,7 +37,7 @@ destination d_librenms {
 
 log {
         source(s_net);
-        source(s_sys);
+        source(s_src);
         destination(d_librenms);
 };
 ```


### PR DESCRIPTION
This is based on the existing bug report: https://community.librenms.org/t/syslog-not-working-with-librenms-conf/20727

Proposed fix is tested and works

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
