### PR TITLE
Fixed the wrong field being used for join

### DIFF
--- a/app/Models/Bill.php
+++ b/app/Models/Bill.php
@@ -52,6 +52,6 @@ class Bill extends Model
 
     public function ports(): BelongsToMany
     {
-        return $this->belongsToMany(\App\Models\Port::class, 'bill_ports', 'bill_id', 'bill_id');
+        return $this->belongsToMany(\App\Models\Port::class, 'bill_ports', 'bill_id', 'port_id');
     }
 }


### PR DESCRIPTION
Wrong field was being used for the join so within the `$bill->port` results, the port_id was the bill_id field.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
