### PR TITLE
add auth_ldap_cacertfile and auth_ldap_ignorecert options

### DIFF
--- a/LibreNMS/Authentication/LdapAuthorizer.php
+++ b/LibreNMS/Authentication/LdapAuthorizer.php
@@ -350,13 +350,13 @@ class LdapAuthorizer extends AuthorizerBase
             ldap_set_option(null, LDAP_OPT_DEBUG_LEVEL, 7);
         }
         /*
-         * Due to https://bugs.php.net/bug.php?id=78029 these set options are done at this stage otherwise they 
+         * Due to https://bugs.php.net/bug.php?id=78029 these set options are done at this stage otherwise they
          * will not take effect after the first bind is performed.
          */
-        if(Config::get('auth_ldap_cacertfile')) {
-            ldap_set_option($this->ldap_connection, LDAP_OPT_X_TLS_CACERTFILE , Config::get('auth_ldap_cacertfile'));
+        if (Config::get('auth_ldap_cacertfile')) {
+            ldap_set_option($this->ldap_connection, LDAP_OPT_X_TLS_CACERTFILE, Config::get('auth_ldap_cacertfile'));
         }
-        if(Config::get('auth_ldap_ignorecert')) {
+        if (Config::get('auth_ldap_ignorecert')) {
             ldap_set_option($this->ldap_connection, LDAP_OPT_X_TLS_REQUIRE_CERT, 0);
         }
 

--- a/LibreNMS/Authentication/LdapAuthorizer.php
+++ b/LibreNMS/Authentication/LdapAuthorizer.php
@@ -349,6 +349,16 @@ class LdapAuthorizer extends AuthorizerBase
         if (Config::get('auth_ldap_debug')) {
             ldap_set_option(null, LDAP_OPT_DEBUG_LEVEL, 7);
         }
+        /*
+         * Due to https://bugs.php.net/bug.php?id=78029 these set options are done at this stage otherwise they 
+         * will not take effect after the first bind is performed.
+         */
+        if(Config::get('auth_ldap_cacertfile')) {
+            ldap_set_option($this->ldap_connection, LDAP_OPT_X_TLS_CACERTFILE , Config::get('auth_ldap_cacertfile'));
+        }
+        if(Config::get('auth_ldap_ignorecert')) {
+            ldap_set_option($this->ldap_connection, LDAP_OPT_X_TLS_REQUIRE_CERT, 0);
+        }
 
         $this->connect();
 

--- a/doc/Extensions/Authentication.md
+++ b/doc/Extensions/Authentication.md
@@ -227,6 +227,8 @@ same version as PHP.
     lnms config:set auth_ldap_userdn true
     lnms config:set auth_ldap_userlist_filter service=informatique
     lnms config:set auth_ldap_wildcard_ou false
+    lnms config:set auth_ldap_cacertfile /opt/librenms/ldap-ca-cert
+    lnms config:set auth_ldap_ignorecert false
     ```
 
 ### LDAP bind user (optional)

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -362,6 +362,14 @@ return [
             'description' => 'Show debug',
             'help' => 'Shows debug information.  May expose private information, do not leave enabled.',
         ],
+        'auth_ldap_cacertfile' => [
+            'description' => 'Override system TLS CA Cert',
+            'help' => 'Use supplied CA Cert for LDAPS.'
+        ],
+        'auth_ldap_ignorecert' => [
+            'description' => 'Do not require valid Cert',
+            'help' => 'Do not require a valid TLS Cert for LDAPS.'
+        ],
         'auth_ldap_emailattr' => [
             'description' => 'Mail attribute',
         ],

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -364,11 +364,11 @@ return [
         ],
         'auth_ldap_cacertfile' => [
             'description' => 'Override system TLS CA Cert',
-            'help' => 'Use supplied CA Cert for LDAPS.'
+            'help' => 'Use supplied CA Cert for LDAPS.',
         ],
         'auth_ldap_ignorecert' => [
             'description' => 'Do not require valid Cert',
-            'help' => 'Do not require a valid TLS Cert for LDAPS.'
+            'help' => 'Do not require a valid TLS Cert for LDAPS.',
         ],
         'auth_ldap_emailattr' => [
             'description' => 'Mail attribute',

--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -562,6 +562,20 @@
             "order": 21,
             "type": "boolean"
         },
+        "auth_ldap_cacertfile": {
+            "group": "auth",
+            "section": "ldap",
+            "order": 22,
+            "type": "text"
+        },
+        "auth_ldap_ignorecert": {
+            "default": false,
+            "group": "auth",
+            "section": "ldap",
+            "order": 23,
+            "type": "boolean"
+        },
+
         "auth_ldap_emailattr": {
             "default": "mail",
             "group": "auth",


### PR DESCRIPTION
Please give a short description what your pull request is for

Add some options to
-  use a different CA cert for LDAPS than the system cert, and 
-  not require a valid cert when doing LDAPS

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
