### PR TITLE
OSPF tables fix integer types

### DIFF
--- a/database/migrations/2023_10_31_074547_ospf_areas_unsigned.php
+++ b/database/migrations/2023_10_31_074547_ospf_areas_unsigned.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('ospf_areas', function (Blueprint $table) {
+            $table->unsignedInteger('ospfSpfRuns')->change();
+            $table->unsignedInteger('ospfAreaBdrRtrCount')->change();
+            $table->unsignedInteger('ospfAsBdrRtrCount')->change();
+            $table->unsignedInteger('ospfAreaLsaCount')->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('ospf_areas', function (Blueprint $table) {
+            $table->integer('ospfSpfRuns')->change();
+            $table->integer('ospfAreaBdrRtrCount')->change();
+            $table->integer('ospfAsBdrRtrCount')->change();
+            $table->integer('ospfAreaLsaCount')->change();
+        });
+    }
+};

--- a/database/migrations/2023_10_31_074901_ospf_instances_unsigned.php
+++ b/database/migrations/2023_10_31_074901_ospf_instances_unsigned.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('ospf_instances', function (Blueprint $table) {
+            $table->unsignedInteger('ospfExternLsaCount')->change();
+            $table->unsignedInteger('ospfOriginateNewLsas')->change();
+            $table->unsignedInteger('ospfRxNewLsas')->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('ospf_instances', function (Blueprint $table) {
+            $table->integer('ospfExternLsaCount')->change();
+            $table->integer('ospfOriginateNewLsas')->change();
+            $table->integer('ospfRxNewLsas')->change();
+        });
+    }
+};

--- a/database/migrations/2023_10_31_075239_ospf_nbrs_unsigned.php
+++ b/database/migrations/2023_10_31_075239_ospf_nbrs_unsigned.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('ospf_nbrs', function (Blueprint $table) {
+            $table->unsignedInteger('ospfNbrEvents')->change();
+            $table->unsignedInteger('ospfNbrLsRetransQLen')->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('ospf_nbrs', function (Blueprint $table) {
+            $table->integer('ospfNbrEvents')->change();
+            $table->integer('ospfNbrLsRetransQLen')->change();
+        });
+    }
+};

--- a/database/migrations/2023_10_31_080052_ospf_ports_unsigned.php
+++ b/database/migrations/2023_10_31_080052_ospf_ports_unsigned.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('ospf_ports', function (Blueprint $table) {
+            $table->unsignedInteger('ospfIfEvents')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('ospf_ports', function (Blueprint $table) {
+            $table->integer('ospfIfEvents')->nullable()->change();
+        });
+    }
+};

--- a/misc/db_schema.yaml
+++ b/misc/db_schema.yaml
@@ -1251,10 +1251,10 @@ ospf_areas:
     - { Field: ospfAreaId, Type: varchar(32), 'Null': false, Extra: '' }
     - { Field: ospfAuthType, Type: varchar(64), 'Null': true, Extra: '' }
     - { Field: ospfImportAsExtern, Type: varchar(128), 'Null': false, Extra: '' }
-    - { Field: ospfSpfRuns, Type: int, 'Null': false, Extra: '' }
-    - { Field: ospfAreaBdrRtrCount, Type: int, 'Null': false, Extra: '' }
-    - { Field: ospfAsBdrRtrCount, Type: int, 'Null': false, Extra: '' }
-    - { Field: ospfAreaLsaCount, Type: int, 'Null': false, Extra: '' }
+    - { Field: ospfSpfRuns, Type: 'int unsigned', 'Null': false, Extra: '' }
+    - { Field: ospfAreaBdrRtrCount, Type: 'int unsigned', 'Null': false, Extra: '' }
+    - { Field: ospfAsBdrRtrCount, Type: 'int unsigned', 'Null': false, Extra: '' }
+    - { Field: ospfAreaLsaCount, Type: 'int unsigned', 'Null': false, Extra: '' }
     - { Field: ospfAreaLsaCksumSum, Type: int, 'Null': false, Extra: '' }
     - { Field: ospfAreaSummary, Type: varchar(64), 'Null': false, Extra: '' }
     - { Field: ospfAreaStatus, Type: varchar(64), 'Null': false, Extra: '' }
@@ -1272,11 +1272,11 @@ ospf_instances:
     - { Field: ospfVersionNumber, Type: varchar(32), 'Null': false, Extra: '' }
     - { Field: ospfAreaBdrRtrStatus, Type: varchar(32), 'Null': false, Extra: '' }
     - { Field: ospfASBdrRtrStatus, Type: varchar(32), 'Null': false, Extra: '' }
-    - { Field: ospfExternLsaCount, Type: int, 'Null': false, Extra: '' }
+    - { Field: ospfExternLsaCount, Type: 'int unsigned', 'Null': false, Extra: '' }
     - { Field: ospfExternLsaCksumSum, Type: int, 'Null': false, Extra: '' }
     - { Field: ospfTOSSupport, Type: varchar(32), 'Null': false, Extra: '' }
-    - { Field: ospfOriginateNewLsas, Type: int, 'Null': false, Extra: '' }
-    - { Field: ospfRxNewLsas, Type: int, 'Null': false, Extra: '' }
+    - { Field: ospfOriginateNewLsas, Type: 'int unsigned', 'Null': false, Extra: '' }
+    - { Field: ospfRxNewLsas, Type: 'int unsigned', 'Null': false, Extra: '' }
     - { Field: ospfExtLsdbLimit, Type: int, 'Null': true, Extra: '' }
     - { Field: ospfMulticastExtensions, Type: int, 'Null': true, Extra: '' }
     - { Field: ospfExitOverflowInterval, Type: int, 'Null': true, Extra: '' }
@@ -1297,8 +1297,8 @@ ospf_nbrs:
     - { Field: ospfNbrOptions, Type: int, 'Null': false, Extra: '' }
     - { Field: ospfNbrPriority, Type: int, 'Null': false, Extra: '' }
     - { Field: ospfNbrState, Type: varchar(32), 'Null': false, Extra: '' }
-    - { Field: ospfNbrEvents, Type: int, 'Null': false, Extra: '' }
-    - { Field: ospfNbrLsRetransQLen, Type: int, 'Null': false, Extra: '' }
+    - { Field: ospfNbrEvents, Type: 'int unsigned', 'Null': false, Extra: '' }
+    - { Field: ospfNbrLsRetransQLen, Type: 'int unsigned', 'Null': false, Extra: '' }
     - { Field: ospfNbmaNbrStatus, Type: varchar(32), 'Null': false, Extra: '' }
     - { Field: ospfNbmaNbrPermanence, Type: varchar(32), 'Null': false, Extra: '' }
     - { Field: ospfNbrHelloSuppressed, Type: varchar(32), 'Null': false, Extra: '' }
@@ -1326,7 +1326,7 @@ ospf_ports:
     - { Field: ospfIfState, Type: varchar(32), 'Null': true, Extra: '' }
     - { Field: ospfIfDesignatedRouter, Type: varchar(32), 'Null': true, Extra: '' }
     - { Field: ospfIfBackupDesignatedRouter, Type: varchar(32), 'Null': true, Extra: '' }
-    - { Field: ospfIfEvents, Type: int, 'Null': true, Extra: '' }
+    - { Field: ospfIfEvents, Type: 'int unsigned', 'Null': true, Extra: '' }
     - { Field: ospfIfAuthKey, Type: varchar(128), 'Null': true, Extra: '' }
     - { Field: ospfIfStatus, Type: varchar(32), 'Null': true, Extra: '' }
     - { Field: ospfIfMulticastForwarding, Type: varchar(32), 'Null': true, Extra: '' }


### PR DESCRIPTION
All Counter32 and Gauge32 types should be unsigned integers to match the range that can be returned via snmp

fixes #15520

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
