### PR TITLE
Added BGP Remote peer link and graph in Routing Overview

### DIFF
--- a/includes/html/pages/routing/bgp.inc.php
+++ b/includes/html/pages/routing/bgp.inc.php
@@ -313,11 +313,12 @@ if (! Auth::user()->hasGlobalRead()) {
         }
 
         unset($sep);
+        $peer_device = \App\Models\Device::whereHas('bgppeers', fn ($q) => $q->where('bgpLocalAddr', $peer['bgpPeerIdentifier']))->first();
 
         echo '  <td></td>
             <td width=150>' . $localaddresslink . '<br />' . generate_device_link($peer, null, ['tab' => 'routing', 'proto' => 'bgp']) . '</td>
             <td width=30><b>&#187;</b></td>
-            <td width=150>' . $peeraddresslink . "</td>
+            <td width=150>' . $peeraddresslink . '<br />' . \LibreNMS\Util\Url::deviceLink($peer_device, vars: ['tab' => 'routing', 'proto' => 'bgp']) . "</td>
             <td width=50><b>$peer_type</b></td>
             <td width=50>" . $peer['afi'] . '</td>
             <td><strong>AS' . $peer['bgpPeerRemoteAs'] . '</strong><br />' . $peer['astext'] . '</td>


### PR DESCRIPTION
Added BGP Remote peer link and graph in Routing Overview;

<img width="723" alt="Screenshot 2023-10-30 at 09 04 35" src="https://github.com/librenms/librenms/assets/4570297/c6683c99-fb4e-4af5-bd2e-c1dc3bd34cef">
<img width="564" alt="Screenshot 2023-10-30 at 09 08 19" src="https://github.com/librenms/librenms/assets/4570297/11b9974f-653d-42b2-a726-98a8b3738976">


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
