### PR TITLE
bug - string VS array 

### DIFF
--- a/LibreNMS/Data/Source/NetSnmpQuery.php
+++ b/LibreNMS/Data/Source/NetSnmpQuery.php
@@ -394,7 +394,7 @@ class NetSnmpQuery implements SnmpQueryInterface
 
             // if abort on failure is set, return after first failure
             if ($this->abort && ! $response->isValid()) {
-                $oid_list = implode(',', array_map(fn ($group) => implode(',', $group), $oids));
+                $oid_list = implode(',', array_map(fn ($group) => is_array($group) ? implode(',', $group) : $group, $oids));
                 Log::debug("SNMP failed walking $oid of $oid_list aborting.");
 
                 return $response;


### PR DESCRIPTION
```
#### Load disco module ipv6-addresses ####
Error discovering ipv6-addresses module for 10.199.255.3. TypeError: implode(): Argument #2 ($array) must be of type ?array, string given in /opt/librenms/LibreNMS/Data/Source/NetSnmpQuery.php:397
Stack trace:
#0 /opt/librenms/LibreNMS/Data/Source/NetSnmpQuery.php(397): implode()
#1 [internal function]: LibreNMS\Data\Source\NetSnmpQuery->LibreNMS\Data\Source\{closure}()
#2 /opt/librenms/LibreNMS/Data/Source/NetSnmpQuery.php(397): array_map()
#3 /opt/librenms/LibreNMS/Data/Source/NetSnmpQuery.php(288): LibreNMS\Data\Source\NetSnmpQuery->execMultiple()
#4 /opt/librenms/includes/discovery/ipv6-addresses.inc.php(14): LibreNMS\Data\Source\NetSnmpQuery->walk()
#5 /opt/librenms/includes/discovery/functions.inc.php(164): include('...')
#6 /opt/librenms/discovery.php(108): discover_device()
#7 {main}  
implode(): Argument #2 ($array) must be of type ?array, string given {"exception":"[object] (TypeError(code: 0): implode(): Argument #2 ($array) must be of type ?array, string given at /opt/librenms/LibreNMS/Data/Source/NetSnmpQuery.php:397)"} 
```

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
