### PR TITLE
Fixed BGP Remote peer link and graph in Routing Overview, or just static text when not a device in LibreNMS

### DIFF
--- a/LibreNMS/Util/Url.php
+++ b/LibreNMS/Util/Url.php
@@ -48,10 +48,10 @@ class Url
      * @param  int  $overlib
      * @return string
      */
-    public static function deviceLink($device, $text = null, $vars = [], $start = 0, $end = 0, $escape_text = 1, $overlib = 1)
+    public static function deviceLink($device, $text = '', $vars = [], $start = 0, $end = 0, $escape_text = 1, $overlib = 1)
     {
         if (! $device instanceof Device || ! $device->hostname) {
-            return '';
+            return $text;
         }
 
         if (! $device->canAccess(Auth::user())) {

--- a/LibreNMS/Util/Url.php
+++ b/LibreNMS/Util/Url.php
@@ -39,8 +39,8 @@ use Symfony\Component\HttpFoundation\ParameterBag;
 class Url
 {
     /**
-     * @param  Device  $device
-     * @param  string  $text
+     * @param  Device|null  $device
+     * @param  string|null  $text
      * @param  array  $vars
      * @param  int  $start
      * @param  int  $end
@@ -51,7 +51,7 @@ class Url
     public static function deviceLink($device, $text = '', $vars = [], $start = 0, $end = 0, $escape_text = 1, $overlib = 1)
     {
         if (! $device instanceof Device || ! $device->hostname) {
-            return $text;
+            return (string) $text;
         }
 
         if (! $device->canAccess(Auth::user())) {

--- a/includes/html/pages/routing/bgp.inc.php
+++ b/includes/html/pages/routing/bgp.inc.php
@@ -1,7 +1,11 @@
 <?php
 
+use App\Models\Device;
 use LibreNMS\Exceptions\InvalidIpException;
 use LibreNMS\Util\IPv6;
+use LibreNMS\Util\Number;
+use LibreNMS\Util\Time;
+use LibreNMS\Util\Url;
 
 if (! Auth::user()->hasGlobalRead()) {
     include 'includes/html/error-no-perm.inc.php';
@@ -278,12 +282,8 @@ if (! Auth::user()->hasGlobalRead()) {
         $graph_array['width'] = $width;
 
         // Peer Address
-        $peer_device = \App\Models\Device::whereHas('bgppeers', fn ($q) => $q->where('bgpLocalAddr', $peer['bgpPeerIdentifier']))->first();
-        if (! empty($peer_device)) {
-            $peeraddresslink = '<span class=list-large>' . \LibreNMS\Util\Url::deviceLink($peer_device, $peer_addr, vars: ['tab' => 'routing', 'proto' => 'bgp']) . '</span>';
-        } else {
-            $peeraddresslink = '<span class=list-large>' . $peer_addr . '</span>';
-        }
+        $peer_device = Device::whereHas('bgppeers', fn ($q) => $q->where('bgpLocalAddr', $peer['bgpPeerIdentifier']))->first();
+        $peeraddresslink = '<span class=list-large>' . Url::deviceLink($peer_device, $peer_addr, ['tab' => 'routing', 'proto' => 'bgp']) . '</span>';
 
         // Local Address
         $graph_array['id'] = $peer['bgpPeer_id'];
@@ -295,7 +295,7 @@ if (! Auth::user()->hasGlobalRead()) {
         $graph_array_zoom['afi'] = 'ipv4';
         $graph_array_zoom['safi'] = 'unicast';
         $overlib_link = 'device/device=' . $peer['device_id'] . '/tab=routing/proto=bgp/';
-        $localaddresslink = '<span class=list-large>' . \LibreNMS\Util\Url::overlibLink($overlib_link, $local_addr, \LibreNMS\Util\Url::graphTag($graph_array_zoom)) . '</span>';
+        $localaddresslink = '<span class=list-large>' . Url::overlibLink($overlib_link, $local_addr, Url::graphTag($graph_array_zoom)) . '</span>';
 
         if ($peer['bgpPeerLastErrorCode'] == 0 && $peer['bgpPeerLastErrorSubCode'] == 0) {
             $last_error = $peer['bgpPeerLastErrorText'];
@@ -321,16 +321,16 @@ if (! Auth::user()->hasGlobalRead()) {
         echo '  <td></td>
             <td width=150>' . $localaddresslink . '<br />' . generate_device_link($peer, null, ['tab' => 'routing', 'proto' => 'bgp']) . '</td>
             <td width=30><b>&#187;</b></td>
-            <td width=150>' . $peeraddresslink . '<br />' . \LibreNMS\Util\Url::deviceLink($peer_device, vars: ['tab' => 'routing', 'proto' => 'bgp']) . "</td>
+            <td width=150>' . $peeraddresslink . '<br />' . Url::deviceLink($peer_device, vars: ['tab' => 'routing', 'proto' => 'bgp']) . "</td>
             <td width=50><b>$peer_type</b></td>
             <td width=50>" . $peer['afi'] . '</td>
             <td><strong>AS' . $peer['bgpPeerRemoteAs'] . '</strong><br />' . $peer['astext'] . '</td>
             <td>' . $peer['bgpPeerDescr'] . "</td>
             <td><strong><span style='color: $admin_col;'>" . $peer['bgpPeerAdminStatus'] . "</span><br /><span style='color: $col;'>" . $peer['bgpPeerState'] . '</span></strong></td>
             <td>' . $last_error . '</td>
-            <td>' . \LibreNMS\Util\Time::formatInterval($peer['bgpPeerFsmEstablishedTime']) . "<br />
-            Updates <i class='fa fa-arrow-down icon-theme' aria-hidden='true'></i> " . \LibreNMS\Util\Number::formatSi($peer['bgpPeerInUpdates'], 2, 3, '') . "
-            <i class='fa fa-arrow-up icon-theme' aria-hidden='true'></i> " . \LibreNMS\Util\Number::formatSi($peer['bgpPeerOutUpdates'], 2, 3, '') . '</td></tr>';
+            <td>' . Time::formatInterval($peer['bgpPeerFsmEstablishedTime']) . "<br />
+            Updates <i class='fa fa-arrow-down icon-theme' aria-hidden='true'></i> " . Number::formatSi($peer['bgpPeerInUpdates'], 2, 3, '') . "
+            <i class='fa fa-arrow-up icon-theme' aria-hidden='true'></i> " . Number::formatSi($peer['bgpPeerOutUpdates'], 2, 3, '') . '</td></tr>';
 
         unset($invalid);
         switch ($vars['graph']) {

--- a/includes/html/pages/routing/bgp.inc.php
+++ b/includes/html/pages/routing/bgp.inc.php
@@ -279,17 +279,28 @@ if (! Auth::user()->hasGlobalRead()) {
         $graph_array['width'] = $width;
 
         // Peer Address
+        $graph_array_zoom = $graph_array;
+        $graph_array_zoom['height'] = '150';
+        $graph_array_zoom['width'] = '500';
         $peer_device = \App\Models\Device::whereHas('bgppeers', fn ($q) => $q->where('bgpLocalAddr', $peer['bgpPeerIdentifier']))->first();
-        $peerdevicelink = \LibreNMS\Util\Url::deviceLink($peer_device, $peer_addr, vars: ['tab' => 'routing', 'proto' => 'bgp']);
-        if (! empty($peerdevicelink)) {
-            $peeraddresslink = '<span class=list-large>' . $peerdevicelink . '</span>';
+        $graph_array['afi'] = 'ipv4';
+        $graph_array['safi'] = 'unicast';
+        $graph_array_zoom['afi'] = 'ipv4';
+        $graph_array_zoom['safi'] = 'unicast';
+        $overlib_link = 'device/device=' . $peer_device['device_id'] . '/tab=routing/proto=bgp/';
+        if (! empty($peer_device)) {
+            $peeraddresslink = '<span class=list-large>' . \LibreNMS\Util\Url::overlibLink($overlib_link, $peer_addr, \LibreNMS\Util\Url::graphTag($graph_array_zoom)). '</span>';
         } else {
             $peeraddresslink = '<span class=list-large>' . $peer_addr . '</span>';
         }
 
         // Local Address
-        $local_device = \App\Models\Device::where('device_id', $peer['device_id'])->first();
-        $localaddresslink = '<span class=list-large>' . \LibreNMS\Util\Url::deviceLink($local_device, $local_addr, vars: ['tab' => 'routing', 'proto' => 'bgp']) . '</span>';
+        $graph_array['afi'] = 'ipv4';
+        $graph_array['safi'] = 'unicast';
+        $graph_array_zoom['afi'] = 'ipv4';
+        $graph_array_zoom['safi'] = 'unicast';
+        $overlib_link = 'device/device=' . $peer['device_id'] . '/tab=routing/proto=bgp/';
+        $localaddresslink = '<span class=list-large>' . \LibreNMS\Util\Url::overlibLink($overlib_link, $local_addr, \LibreNMS\Util\Url::graphTag($graph_array_zoom)) . '</span>';
 
         if ($peer['bgpPeerLastErrorCode'] == 0 && $peer['bgpPeerLastErrorSubCode'] == 0) {
             $last_error = $peer['bgpPeerLastErrorText'];

--- a/includes/html/pages/routing/bgp.inc.php
+++ b/includes/html/pages/routing/bgp.inc.php
@@ -279,19 +279,17 @@ if (! Auth::user()->hasGlobalRead()) {
         $graph_array['width'] = $width;
 
         // Peer Address
-        $graph_array_zoom = $graph_array;
-        $graph_array_zoom['height'] = '150';
-        $graph_array_zoom['width'] = '500';
-        $overlib_link = 'device/device=' . $peer['device_id'] . '/tab=routing/proto=bgp/';
-        $peeraddresslink = '<span class=list-large>' . \LibreNMS\Util\Url::overlibLink($overlib_link, $peer_addr, \LibreNMS\Util\Url::graphTag($graph_array_zoom)) . '</span>';
+        $peer_device = \App\Models\Device::whereHas('bgppeers', fn ($q) => $q->where('bgpLocalAddr', $peer['bgpPeerIdentifier']))->first();
+        $peerdevicelink = \LibreNMS\Util\Url::deviceLink($peer_device, $peer_addr, vars: ['tab' => 'routing', 'proto' => 'bgp']);
+        if (!empty($peerdevicelink)) {
+            $peeraddresslink = '<span class=list-large>' . $peerdevicelink . '</span>';
+        } else {
+            $peeraddresslink = '<span class=list-large>' . $peer_addr . '</span>';
+        }
 
         // Local Address
-        $graph_array['afi'] = 'ipv4';
-        $graph_array['safi'] = 'unicast';
-        $graph_array_zoom['afi'] = 'ipv4';
-        $graph_array_zoom['safi'] = 'unicast';
-        $overlib_link = 'device/device=' . $peer['device_id'] . '/tab=routing/proto=bgp/';
-        $localaddresslink = '<span class=list-large>' . \LibreNMS\Util\Url::overlibLink($overlib_link, $local_addr, \LibreNMS\Util\Url::graphTag($graph_array_zoom)) . '</span>';
+        $local_device = \App\Models\Device::where('device_id', $peer['device_id'])->first();
+        $localaddresslink = '<span class=list-large>' . \LibreNMS\Util\Url::deviceLink($local_device, $local_addr, vars: ['tab' => 'routing', 'proto' => 'bgp']) . '</span>';
 
         if ($peer['bgpPeerLastErrorCode'] == 0 && $peer['bgpPeerLastErrorSubCode'] == 0) {
             $last_error = $peer['bgpPeerLastErrorText'];
@@ -313,7 +311,6 @@ if (! Auth::user()->hasGlobalRead()) {
         }
 
         unset($sep);
-        $peer_device = \App\Models\Device::whereHas('bgppeers', fn ($q) => $q->where('bgpLocalAddr', $peer['bgpPeerIdentifier']))->first();
 
         echo '  <td></td>
             <td width=150>' . $localaddresslink . '<br />' . generate_device_link($peer, null, ['tab' => 'routing', 'proto' => 'bgp']) . '</td>

--- a/includes/html/pages/routing/bgp.inc.php
+++ b/includes/html/pages/routing/bgp.inc.php
@@ -281,7 +281,7 @@ if (! Auth::user()->hasGlobalRead()) {
         // Peer Address
         $peer_device = \App\Models\Device::whereHas('bgppeers', fn ($q) => $q->where('bgpLocalAddr', $peer['bgpPeerIdentifier']))->first();
         $peerdevicelink = \LibreNMS\Util\Url::deviceLink($peer_device, $peer_addr, vars: ['tab' => 'routing', 'proto' => 'bgp']);
-        if (!empty($peerdevicelink)) {
+        if (! empty($peerdevicelink)) {
             $peeraddresslink = '<span class=list-large>' . $peerdevicelink . '</span>';
         } else {
             $peeraddresslink = '<span class=list-large>' . $peer_addr . '</span>';

--- a/includes/html/pages/routing/bgp.inc.php
+++ b/includes/html/pages/routing/bgp.inc.php
@@ -279,20 +279,6 @@ if (! Auth::user()->hasGlobalRead()) {
 
         // Peer Address
         $peer_device = \App\Models\Device::whereHas('bgppeers', fn ($q) => $q->where('bgpLocalAddr', $peer['bgpPeerIdentifier']))->first();
-        // $graph_array['id'] = $peer['bgpPeer_id'];
-        // $graph_array['afi'] = 'ipv4';
-        // $graph_array['safi'] = 'unicast';
-        // $graph_array_zoom = $graph_array;
-        // $graph_array_zoom['height'] = '150';
-        // $graph_array_zoom['width'] = '500';
-        // $graph_array_zoom['afi'] = 'ipv4';
-        // $graph_array_zoom['safi'] = 'unicast';
-        // $overlib_link = 'device/device=' . $peer_device['device_id'] . '/tab=routing/proto=bgp/';
-        // if (! empty($peer_device)) {
-        //     $peeraddresslink = '<span class=list-large>' . \LibreNMS\Util\Url::deviceLink($peer_device, $peer_addr, vars: ['tab' => 'routing', 'proto' => 'bgp']) . '</span>';
-        // } else {
-        //     $peeraddresslink = '<span class=list-large>' . $peer_addr . '</span>';
-        // }
         $peeraddresslink = '<span class=list-large>' . $peer_addr . '</span>';
 
         // Local Address

--- a/includes/html/pages/routing/bgp.inc.php
+++ b/includes/html/pages/routing/bgp.inc.php
@@ -272,31 +272,36 @@ if (! Auth::user()->hasGlobalRead()) {
         // display overlib graphs
         $graph_array = [];
         $graph_array['type'] = 'bgp_updates';
-        $graph_array['id'] = $peer['bgpPeer_id'];
         $graph_array['to'] = \LibreNMS\Config::get('time.now');
         $graph_array['from'] = \LibreNMS\Config::get('time.day');
         $graph_array['height'] = '110';
         $graph_array['width'] = $width;
 
         // Peer Address
+        $peer_device = \App\Models\Device::whereHas('bgppeers', fn ($q) => $q->where('bgpLocalAddr', $peer['bgpPeerIdentifier']))->first();
+        // $graph_array['id'] = $peer['bgpPeer_id'];
+        // $graph_array['afi'] = 'ipv4';
+        // $graph_array['safi'] = 'unicast';
+        // $graph_array_zoom = $graph_array;
+        // $graph_array_zoom['height'] = '150';
+        // $graph_array_zoom['width'] = '500';
+        // $graph_array_zoom['afi'] = 'ipv4';
+        // $graph_array_zoom['safi'] = 'unicast';
+        // $overlib_link = 'device/device=' . $peer_device['device_id'] . '/tab=routing/proto=bgp/';
+        // if (! empty($peer_device)) {
+        //     $peeraddresslink = '<span class=list-large>' . \LibreNMS\Util\Url::deviceLink($peer_device, $peer_addr, vars: ['tab' => 'routing', 'proto' => 'bgp']) . '</span>';
+        // } else {
+        //     $peeraddresslink = '<span class=list-large>' . $peer_addr . '</span>';
+        // }
+        $peeraddresslink = '<span class=list-large>' . $peer_addr . '</span>';
+
+        // Local Address
+        $graph_array['id'] = $peer['bgpPeer_id'];
+        $graph_array['afi'] = 'ipv4';
+        $graph_array['safi'] = 'unicast';
         $graph_array_zoom = $graph_array;
         $graph_array_zoom['height'] = '150';
         $graph_array_zoom['width'] = '500';
-        $peer_device = \App\Models\Device::whereHas('bgppeers', fn ($q) => $q->where('bgpLocalAddr', $peer['bgpPeerIdentifier']))->first();
-        $graph_array['afi'] = 'ipv4';
-        $graph_array['safi'] = 'unicast';
-        $graph_array_zoom['afi'] = 'ipv4';
-        $graph_array_zoom['safi'] = 'unicast';
-        $overlib_link = 'device/device=' . $peer_device['device_id'] . '/tab=routing/proto=bgp/';
-        if (! empty($peer_device)) {
-            $peeraddresslink = '<span class=list-large>' . \LibreNMS\Util\Url::overlibLink($overlib_link, $peer_addr, \LibreNMS\Util\Url::graphTag($graph_array_zoom)) . '</span>';
-        } else {
-            $peeraddresslink = '<span class=list-large>' . $peer_addr . '</span>';
-        }
-
-        // Local Address
-        $graph_array['afi'] = 'ipv4';
-        $graph_array['safi'] = 'unicast';
         $graph_array_zoom['afi'] = 'ipv4';
         $graph_array_zoom['safi'] = 'unicast';
         $overlib_link = 'device/device=' . $peer['device_id'] . '/tab=routing/proto=bgp/';

--- a/includes/html/pages/routing/bgp.inc.php
+++ b/includes/html/pages/routing/bgp.inc.php
@@ -279,7 +279,11 @@ if (! Auth::user()->hasGlobalRead()) {
 
         // Peer Address
         $peer_device = \App\Models\Device::whereHas('bgppeers', fn ($q) => $q->where('bgpLocalAddr', $peer['bgpPeerIdentifier']))->first();
-        $peeraddresslink = '<span class=list-large>' . $peer_addr . '</span>';
+        if (! empty($peer_device)) {
+            $peeraddresslink = '<span class=list-large>' . \LibreNMS\Util\Url::deviceLink($peer_device, $peer_addr, vars: ['tab' => 'routing', 'proto' => 'bgp']) . '</span>';
+        } else {
+            $peeraddresslink = '<span class=list-large>' . $peer_addr . '</span>';
+        }
 
         // Local Address
         $graph_array['id'] = $peer['bgpPeer_id'];

--- a/includes/html/pages/routing/bgp.inc.php
+++ b/includes/html/pages/routing/bgp.inc.php
@@ -289,7 +289,7 @@ if (! Auth::user()->hasGlobalRead()) {
         $graph_array_zoom['safi'] = 'unicast';
         $overlib_link = 'device/device=' . $peer_device['device_id'] . '/tab=routing/proto=bgp/';
         if (! empty($peer_device)) {
-            $peeraddresslink = '<span class=list-large>' . \LibreNMS\Util\Url::overlibLink($overlib_link, $peer_addr, \LibreNMS\Util\Url::graphTag($graph_array_zoom)). '</span>';
+            $peeraddresslink = '<span class=list-large>' . \LibreNMS\Util\Url::overlibLink($overlib_link, $peer_addr, \LibreNMS\Util\Url::graphTag($graph_array_zoom)) . '</span>';
         } else {
             $peeraddresslink = '<span class=list-large>' . $peer_addr . '</span>';
         }


### PR DESCRIPTION
Replaced "overlibLink" with "deviceLink" and using the RemotePeer-device, instead of LocalPeer-device.

When the device isn't monitored by LibreNMS, then just a static text with the address is shown.

<img width="698" alt="Screenshot 2023-10-31 at 21 14 15" src="https://github.com/librenms/librenms/assets/4570297/966ae133-5833-4b0b-8b30-e07ae5bf25e4">


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
