### PR TITLE
New command: lnms report:devices

### DIFF
--- a/LibreNMS/Poller.php
+++ b/LibreNMS/Poller.php
@@ -32,10 +32,8 @@ use App\Models\Eventlog;
 use App\Polling\Measure\Measurement;
 use App\Polling\Measure\MeasurementManager;
 use Carbon\Carbon;
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Str;
 use LibreNMS\Enum\Severity;
-use LibreNMS\Exceptions\PollerException;
 use LibreNMS\Polling\ConnectivityHelper;
 use LibreNMS\Polling\Result;
 use LibreNMS\RRD\RrdDefinition;
@@ -89,7 +87,7 @@ class Poller
 
         $this->logger->info("Starting polling run:\n");
 
-        foreach ($this->buildDeviceQuery()->pluck('device_id') as $device_id) {
+        foreach ($this->whereDeviceSpec($this->device_spec)->pluck('device_id') as $device_id) {
             $results->markAttempted();
             $this->initDevice($device_id);
             PollingDevice::dispatch($this->device);
@@ -224,27 +222,6 @@ class Poller
         }
 
         return false;
-    }
-
-    private function buildDeviceQuery(): Builder
-    {
-        $query = Device::query();
-
-        if (empty($this->device_spec)) {
-            throw new PollerException('Invalid device spec');
-        } elseif ($this->device_spec == 'all') {
-            return $query;
-        } elseif ($this->device_spec == 'even') {
-            return $query->whereRaw('device_id % 2 = 0');
-        } elseif ($this->device_spec == 'odd') {
-            return $query->whereRaw('device_id % 2 = 1');
-        } elseif (is_numeric($this->device_spec)) {
-            return $query->where('device_id', $this->device_spec);
-        } elseif (Str::contains($this->device_spec, '*')) {
-            return $query->where('hostname', 'like', str_replace('*', '%', $this->device_spec));
-        }
-
-        return $query->where('hostname', $this->device_spec);
     }
 
     private function initDevice(int $device_id): void

--- a/LibreNMS/Poller.php
+++ b/LibreNMS/Poller.php
@@ -87,7 +87,7 @@ class Poller
 
         $this->logger->info("Starting polling run:\n");
 
-        foreach ($this->whereDeviceSpec($this->device_spec)->pluck('device_id') as $device_id) {
+        foreach (Device::whereDeviceSpec($this->device_spec)->pluck('device_id') as $device_id) {
             $results->markAttempted();
             $this->initDevice($device_id);
             PollingDevice::dispatch($this->device);

--- a/app/Console/Commands/DevicePing.php
+++ b/app/Console/Commands/DevicePing.php
@@ -4,7 +4,6 @@ namespace App\Console\Commands;
 
 use App\Console\LnmsCommand;
 use App\Models\Device;
-use Illuminate\Database\Eloquent\Builder;
 use LibreNMS\Config;
 use LibreNMS\Polling\ConnectivityHelper;
 use Symfony\Component\Console\Input\InputArgument;
@@ -32,12 +31,7 @@ class DevicePing extends LnmsCommand
     public function handle(): int
     {
         $spec = $this->argument('device spec');
-        $devices = Device::query()->when($spec !== 'all', function (Builder $query) use ($spec) {
-            /** @phpstan-var Builder<Device> $query */
-            return $query->where('device_id', $spec)
-                ->orWhere('hostname', $spec)
-                ->limit(1);
-        })->get();
+        $devices = Device::whereDeviceSpec($spec)->get();
 
         if ($devices->isEmpty()) {
             $devices = [new Device(['hostname' => $spec])];

--- a/app/Console/Commands/ReportDevices.php
+++ b/app/Console/Commands/ReportDevices.php
@@ -126,7 +126,7 @@ class ReportDevices extends LnmsCommand
 
         if ($output == 'none') {
             foreach ($rows as $row) {
-                $this->line(implode("\t", $row));
+                $this->line(implode(' ', $row));
             }
 
             return;

--- a/app/Console/Commands/ReportDevices.php
+++ b/app/Console/Commands/ReportDevices.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Console\SyntheticDeviceField;
+use App\Models\Device;
+use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Schema;
+
+class ReportDevices extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'report:devices {-f|--fields=hostname,ip,sysName} {-o|--output=table}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Print out data from all devices';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        try {
+            $fields = collect(explode(',', $this->option('fields')))->map(fn($field) => $this->getField($field));
+        } catch (\Exception $e) {
+            $this->error($e->getMessage());
+
+            return 1;
+        }
+        $output = $this->option('output');
+
+        $headers = $fields->map->headerName()->all();
+        $devices = $this->fetchDeviceData($fields);
+
+        $out = fopen('php://output', 'w');
+        if ($output == 'csv') {
+            fputcsv($out, $headers);
+            foreach ($devices as $device) {
+                fputcsv($out, $device);
+            }
+            fclose($out);
+
+            return 0;
+        }
+
+        // print table
+        $this->table($headers, $devices);
+
+        return 0;
+    }
+
+    protected function fetchDeviceData($fields): Collection
+    {
+        $columns = $fields->pluck('columns')->flatten()->all();
+        $query = Device::select($columns);
+
+        // apply any field query modifications
+        foreach ($fields as $field) {
+            $field->modifyQuery($query);
+        }
+
+        // fetch data and call the toString method for each field.
+        return $query->get()->map(function (Device $device) use ($fields) {
+            $data = [];
+            foreach ($fields as $field) {
+                $data[$field->name] = $field->toString($device);
+            }
+
+            return $data;
+        });
+    }
+
+
+    protected function getField(string $field): SyntheticDeviceField
+    {
+        // relationship counts
+        if (str_ends_with($field, '_count')) {
+            [$relationship] = explode('_', $field, -1);
+            if (! (new Device)->isRelation($relationship)) {
+                throw new \Exception("Invalid field: $field");
+            }
+
+            return new SyntheticDeviceField(
+                $field,
+                modifyQuery: fn(Builder $query) => $query->withCount($relationship),
+                headerName: "$relationship count");
+        }
+
+        // misc synthetic fields
+        $custom = match($field) {
+            'displayName' => new SyntheticDeviceField($field, ['hostname', 'sysName', 'ip', 'display'], fn(Device $device) => $device->displayName(), headerName: 'display name'),
+            default => null,
+        };
+
+        if ($custom) {
+            return $custom;
+        }
+
+        // just a regular column, check that it exists
+        if (! Schema::hasColumn('devices', $field)) {
+            throw new \Exception("Invalid field: $field");
+        }
+
+       return new SyntheticDeviceField($field, [$field]);
+    }
+}

--- a/app/Console/Commands/ReportDevices.php
+++ b/app/Console/Commands/ReportDevices.php
@@ -22,7 +22,7 @@ class ReportDevices extends LnmsCommand
         $this->addOption('fields', 'f', InputOption::VALUE_REQUIRED, default: 'hostname,ip');
         $this->addOption('output', 'o', InputOption::VALUE_REQUIRED, __('commands.report:devices.options.output', ['types' => '[table, csv, none]']), 'table');
         $this->addOption('list-fields');
-   }
+    }
 
     /**
      * Execute the console command.
@@ -36,7 +36,7 @@ class ReportDevices extends LnmsCommand
         }
 
         try {
-            $fields = collect(explode(',', $this->option('fields')))->map(fn($field) => $this->getField($field));
+            $fields = collect(explode(',', $this->option('fields')))->map(fn ($field) => $this->getField($field));
         } catch (\Exception $e) {
             $this->error($e->getMessage());
 
@@ -72,7 +72,6 @@ class ReportDevices extends LnmsCommand
         });
     }
 
-
     protected function getField(string $field): SyntheticDeviceField
     {
         // relationship counts
@@ -84,7 +83,7 @@ class ReportDevices extends LnmsCommand
 
             return new SyntheticDeviceField(
                 $field,
-                modifyQuery: fn(Builder $query) => $query->withCount($relationship),
+                modifyQuery: fn (Builder $query) => $query->withCount($relationship),
                 headerName: "$relationship count");
         }
 
@@ -99,14 +98,14 @@ class ReportDevices extends LnmsCommand
             throw new \Exception("Invalid field: $field");
         }
 
-       return new SyntheticDeviceField($field, [$field]);
+        return new SyntheticDeviceField($field, [$field]);
     }
 
     protected function getSyntheticFields(): array
     {
         return [
-            'displayName' => new SyntheticDeviceField('displayName', ['hostname', 'sysName', 'ip', 'display'], fn(Device $device) => $device->displayName(), headerName: 'display name'),
-            'location' => new SyntheticDeviceField('location', ['location_id'], fn(Device $device) => $device->location->location, fn(Builder $q) => $q->with('location')),
+            'displayName' => new SyntheticDeviceField('displayName', ['hostname', 'sysName', 'ip', 'display'], fn (Device $device) => $device->displayName(), headerName: 'display name'),
+            'location' => new SyntheticDeviceField('location', ['location_id'], fn (Device $device) => $device->location->location, fn (Builder $q) => $q->with('location')),
         ];
     }
 
@@ -132,7 +131,6 @@ class ReportDevices extends LnmsCommand
 
             return;
         }
-
 
         // print table
         $this->table($headers, $rows);

--- a/app/Console/Commands/ReportDevices.php
+++ b/app/Console/Commands/ReportDevices.php
@@ -14,6 +14,7 @@ use Symfony\Component\Console\Input\InputOption;
 class ReportDevices extends LnmsCommand
 {
     protected $name = 'report:devices';
+    const NONE_SEPERATOR = "\t";
 
     public function __construct()
     {
@@ -126,7 +127,7 @@ class ReportDevices extends LnmsCommand
 
         if ($output == 'none') {
             foreach ($rows as $row) {
-                $this->line(implode(' ', $row));
+                $this->line(implode(self::NONE_SEPERATOR, $row));
             }
 
             return;

--- a/app/Console/Commands/SnmpFetch.php
+++ b/app/Console/Commands/SnmpFetch.php
@@ -5,7 +5,6 @@ namespace App\Console\Commands;
 use App\Console\LnmsCommand;
 use App\Models\Device;
 use DeviceCache;
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Arr;
 use Illuminate\Validation\Rule;
 use LibreNMS\Data\Source\SnmpResponse;
@@ -149,12 +148,8 @@ abstract class SnmpFetch extends LnmsCommand
 
     protected function getDevices(): \Illuminate\Support\Collection
     {
-        return Device::query()->when($this->deviceSpec !== 'all', function (Builder $query) {
-            return $query->where('device_id', $this->deviceSpec)
-                ->orWhere('hostname', 'regexp', "^$this->deviceSpec$");
-        })->pluck('device_id')->map(function ($device_id) {
-            return DeviceCache::get($device_id);
-        });
+        return Device::whereDeviceSpec($this->deviceSpec)->pluck('device_id')
+            ->map(fn($device_id) => DeviceCache::get($device_id));
     }
 
     protected function fetchData(): SnmpResponse

--- a/app/Console/Commands/SnmpFetch.php
+++ b/app/Console/Commands/SnmpFetch.php
@@ -149,7 +149,7 @@ abstract class SnmpFetch extends LnmsCommand
     protected function getDevices(): \Illuminate\Support\Collection
     {
         return Device::whereDeviceSpec($this->deviceSpec)->pluck('device_id')
-            ->map(fn($device_id) => DeviceCache::get($device_id));
+            ->map(fn ($device_id) => DeviceCache::get($device_id));
     }
 
     protected function fetchData(): SnmpResponse

--- a/app/Console/SyntheticDeviceField.php
+++ b/app/Console/SyntheticDeviceField.php
@@ -1,0 +1,64 @@
+<?php
+/*
+ * SyntheticDeviceField.php
+ *
+ * -Description-
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @package    LibreNMS
+ * @link       http://librenms.org
+ * @copyright  2023 Tony Murray
+ * @author     Tony Murray <murraytony@gmail.com>
+ */
+
+namespace App\Console;
+
+use App\Models\Device;
+use Closure;
+use Illuminate\Database\Eloquent\Builder;
+
+class SyntheticDeviceField
+{
+public function __construct(
+    public readonly string $name,
+    public readonly array $columns = [],
+    public readonly ?Closure $displayFunction = null,
+    public readonly ?Closure $modifyQuery = null,
+    public readonly ?string $headerName = null,
+){}
+
+    public function headerName(): string
+    {
+        return $this->headerName ?? $this->name;
+    }
+
+    public function modifyQuery(Builder $query): Builder
+    {
+        if ($this->modifyQuery) {
+            return call_user_func($this->modifyQuery, $query);
+        }
+
+        return $query;
+    }
+
+    public function toString(Device $device): string
+    {
+        if ($this->displayFunction) {
+            return (string) call_user_func($this->displayFunction, $device);
+        }
+
+        return (string) $device->getAttributeValue($this->name);
+    }
+}

--- a/app/Console/SyntheticDeviceField.php
+++ b/app/Console/SyntheticDeviceField.php
@@ -31,13 +31,14 @@ use Illuminate\Database\Eloquent\Builder;
 
 class SyntheticDeviceField
 {
-public function __construct(
+    public function __construct(
     public readonly string $name,
     public readonly array $columns = [],
     public readonly ?Closure $displayFunction = null,
     public readonly ?Closure $modifyQuery = null,
     public readonly ?string $headerName = null,
-){}
+) {
+    }
 
     public function headerName(): string
     {

--- a/app/Models/BaseModel.php
+++ b/app/Models/BaseModel.php
@@ -103,7 +103,7 @@ abstract class BaseModel extends Model
 
         return collect($reflector->getMethods())
             ->filter(
-                fn($method) => !empty($method->getReturnType()) &&
+                fn ($method) => ! empty($method->getReturnType()) &&
                     str_contains(
                         $method->getReturnType(),
                         'Illuminate\Database\Eloquent\Relations'

--- a/app/Models/BaseModel.php
+++ b/app/Models/BaseModel.php
@@ -96,4 +96,20 @@ abstract class BaseModel extends Model
                 ->orWhereIntegerInRaw("$table.device_id", \Permissions::devicesForUser($user));
         });
     }
+
+    public static function definedRelations(): array
+    {
+        $reflector = new \ReflectionClass(get_called_class());
+
+        return collect($reflector->getMethods())
+            ->filter(
+                fn($method) => !empty($method->getReturnType()) &&
+                    str_contains(
+                        $method->getReturnType(),
+                        'Illuminate\Database\Eloquent\Relations'
+                    )
+            )
+            ->pluck('name')
+            ->all();
+    }
 }

--- a/app/Models/Device.php
+++ b/app/Models/Device.php
@@ -628,6 +628,25 @@ class Device extends BaseModel
         );
     }
 
+    public function scopeWhereDeviceSpec(Builder $query, ?string $deviceSpec): Builder
+    {
+        if (empty($deviceSpec)) {
+            return $query;
+        } elseif ($deviceSpec == 'all') {
+            return $query;
+        } elseif ($deviceSpec == 'even') {
+            return $query->whereRaw('device_id % 2 = 0');
+        } elseif ($deviceSpec == 'odd') {
+            return $query->whereRaw('device_id % 2 = 1');
+        } elseif (is_numeric($deviceSpec)) {
+            return $query->where('device_id', $deviceSpec);
+        } elseif (str_contains($deviceSpec, '*')) {
+            return $query->where('hostname', 'like', str_replace('*', '%', $deviceSpec));
+        }
+
+        return $query->where('hostname', $deviceSpec);
+    }
+
     // ---- Define Relationships ----
 
     public function accessPoints(): HasMany

--- a/lang/en/commands.php
+++ b/lang/en/commands.php
@@ -194,6 +194,20 @@ return [
         'enabled' => ':count plugin enabled|:count plugins enabled',
         'failed' => 'Failed to enable plugin(s)',
     ],
+    'report:devices' => [
+        'description' => 'Print out data from devices',
+        'columns' => 'Database columns:',
+        'synthetic' => 'Additional fields:',
+        'counts' => 'Relationship counts:',
+        'arguments' => [
+            'device spec' => 'Device spec to poll: device_id, hostname, wildcard (*), odd, even, all',
+        ],
+        'options' => [
+            'list-fields' => 'Print out a list of valid fields',
+            'fields' => 'A comma seperated list of fields to display. Valid options: device column names from the database, relationship counts (ports_count), and/or displayName',
+            'output' => 'Output format to display the data :types',
+        ]
+    ],
     'smokeping:generate' => [
         'args-nonsense' => 'Use one of --probes and --targets',
         'config-insufficient' => 'In order to generate a smokeping configuration, you must have set "smokeping.probes", "fping", and "fping6" set in your configuration',

--- a/lang/en/commands.php
+++ b/lang/en/commands.php
@@ -230,7 +230,7 @@ return [
     'snmp:fetch' => [
         'description' => 'Run snmp query against a device',
         'arguments' => [
-            'device spec' => 'Device to query: device_id, hostname/ip, hostname regex, or all',
+            'device spec' => 'Device spec to poll: device_id, hostname, wildcard (*), odd, even, all',
             'oid(s)' => 'One or more SNMP OID to fetch.  Should be either MIB::oid or a numeric oid',
         ],
         'failed' => 'SNMP command failed!',

--- a/lang/en/commands.php
+++ b/lang/en/commands.php
@@ -206,7 +206,7 @@ return [
             'list-fields' => 'Print out a list of valid fields',
             'fields' => 'A comma seperated list of fields to display. Valid options: device column names from the database, relationship counts (ports_count), and/or displayName',
             'output' => 'Output format to display the data :types',
-        ]
+        ],
     ],
     'smokeping:generate' => [
         'args-nonsense' => 'Use one of --probes and --targets',


### PR DESCRIPTION
Print out a list of devices with user specified fields in one of three formats table, csv, and none (tab separated suitable for shell scripting)

```
$ lnms report:devices --help
Description:
  Print out data from devices

Usage:
  report:devices [options] [--] [<device spec>]

Arguments:
  device spec           Device spec to poll: device_id, hostname, wildcard (*), odd, even, all

Options:
  -f, --fields=FIELDS   A comma seperated list of fields to display. Valid options: device column names from the database, relationship counts (ports_count), and/or displayName [default: "hostname,ip"]
  -o, --output=OUTPUT   Output format to display the data [table, csv, none] [default: "table"]
      --list-fields     Print out a list of valid fields
```

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
