### PR TITLE
Added RFC1628 Compatibility to Alpha CXC Definitions

### DIFF
--- a/includes/definitions/cxc.yaml
+++ b/includes/definitions/cxc.yaml
@@ -2,6 +2,7 @@ os: cxc
 text: 'Alpha CXC HP Controller'
 type: power
 icon: alpha
+rfc1628_compat: true
 over:
     - { graph: device_current, text: Current }
     - { graph: device_voltage, text: Voltage }


### PR DESCRIPTION
Please give a short description what your pull request is for

Added RFC1628 compatability for the cxc.yaml discovery file to properly discover base ups metrics that the proprietary oid structure was not covering on Alpha CXC HP Controllers.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
