### PR TITLE
[bugfix] Passing $device into data_update_helper functions instead of declaring it as global.

### DIFF
--- a/includes/polling/applications/ss.inc.php
+++ b/includes/polling/applications/ss.inc.php
@@ -17,20 +17,18 @@ if (! function_exists('ss_data_update_helper')) {
     /**
      * Performs a data update and returns the updated metrics.
      *
-     * @param  string  $app_id
-     * @param  class  $device
-     * @param  array  $fields
-     * @param  array  $metrics
-     * @param  string  $name
-     * @param  string  $polling_type
-     * @param  class  $rrd_def
-     * @param  string  $gen_type
+     * @param  class    $device
+     * @param  string   $app_id
+     * @param  array    $fields
+     * @param  array    $metrics
+     * @param  string   $name
+     * @param  string   $polling_type
+     * @param  class    $rrd_def
+     * @param  string   $gen_type
      * @return $metrics
      */
-    function ss_data_update_helper($app_id, $fields, $metrics, $name, $polling_type, $rrd_def, $gen_type)
+    function ss_data_update_helper($device, $app_id, $fields, $metrics, $name, $polling_type, $rrd_def, $gen_type)
     {
-        global $device;
-
         $rrd_name = [$polling_type, $name, $app_id, $gen_type];
         $metrics[$gen_type] = $fields;
         $tags = [
@@ -120,7 +118,7 @@ foreach ($ss_section_list as $gen_type) {
             }
             $rrd_def->addDataset($field_name, 'GAUGE', 0);
         }
-        $metrics = ss_data_update_helper($app->app_id, $fields, $metrics, $name, $polling_type, $rrd_def, $gen_type);
+        $metrics = ss_data_update_helper($device, $app->app_id, $fields, $metrics, $name, $polling_type, $rrd_def, $gen_type);
     } else {
         // Process sockets that have netids.  These are all address families.
 
@@ -171,7 +169,7 @@ foreach ($ss_section_list as $gen_type) {
                 $rrd_def->addDataset($field_name, 'GAUGE', 0);
             }
             $flat_type = $gen_type . '_' . $netid;
-            $metrics = ss_data_update_helper($app->app_id, $fields, $metrics, $name, $polling_type, $rrd_def, $flat_type);
+            $metrics = ss_data_update_helper($device, $app->app_id, $fields, $metrics, $name, $polling_type, $rrd_def, $flat_type);
         }
     }
 }

--- a/includes/polling/applications/ss.inc.php
+++ b/includes/polling/applications/ss.inc.php
@@ -17,14 +17,14 @@ if (! function_exists('ss_data_update_helper')) {
     /**
      * Performs a data update and returns the updated metrics.
      *
-     * @param  class    $device
-     * @param  string   $app_id
-     * @param  array    $fields
-     * @param  array    $metrics
-     * @param  string   $name
-     * @param  string   $polling_type
-     * @param  class    $rrd_def
-     * @param  string   $gen_type
+     * @param  class  $device
+     * @param  string  $app_id
+     * @param  array  $fields
+     * @param  array  $metrics
+     * @param  string  $name
+     * @param  string  $polling_type
+     * @param  class  $rrd_def
+     * @param  string  $gen_type
      * @return $metrics
      */
     function ss_data_update_helper($device, $app_id, $fields, $metrics, $name, $polling_type, $rrd_def, $gen_type)

--- a/includes/polling/applications/systemd.inc.php
+++ b/includes/polling/applications/systemd.inc.php
@@ -17,14 +17,14 @@ if (! function_exists('systemd_data_update_helper')) {
     /**
      * Performs a data update and returns the updated metrics.
      *
-     * @param  class    $device
-     * @param  string   $app_id
-     * @param  array    $fields
-     * @param  array    $metrics
-     * @param  string   $name
-     * @param  string   $polling_type
-     * @param  class    $rrd_def
-     * @param  string   $state_type
+     * @param  class  $device
+     * @param  string  $app_id
+     * @param  array  $fields
+     * @param  array  $metrics
+     * @param  string  $name
+     * @param  string  $polling_type
+     * @param  class  $rrd_def
+     * @param  string  $state_type
      * @return $metrics
      */
     function systemd_data_update_helper($device, $app_id, $fields, $metrics, $name, $polling_type, $rrd_def, $state_type)

--- a/includes/polling/applications/systemd.inc.php
+++ b/includes/polling/applications/systemd.inc.php
@@ -17,20 +17,18 @@ if (! function_exists('systemd_data_update_helper')) {
     /**
      * Performs a data update and returns the updated metrics.
      *
-     * @param  string  $app_id
-     * @param  class  $device
-     * @param  array  $fields
-     * @param  array  $metrics
-     * @param  string  $name
-     * @param  string  $polling_type
-     * @param  class  $rrd_def
-     * @param  string  $state_type
+     * @param  class    $device
+     * @param  string   $app_id
+     * @param  array    $fields
+     * @param  array    $metrics
+     * @param  string   $name
+     * @param  string   $polling_type
+     * @param  class    $rrd_def
+     * @param  string   $state_type
      * @return $metrics
      */
-    function systemd_data_update_helper($app_id, $fields, $metrics, $name, $polling_type, $rrd_def, $state_type)
+    function systemd_data_update_helper($device, $app_id, $fields, $metrics, $name, $polling_type, $rrd_def, $state_type)
     {
-        global $device;
-
         $rrd_name = [$polling_type, $name, $app_id, $state_type];
         $metrics[$state_type] = $fields;
         $tags = [
@@ -85,7 +83,7 @@ foreach ($systemd_mapper as $state_type => $state_statuses) {
             }
             $rrd_def->addDataset($field_name, 'GAUGE', 0);
         }
-        $metrics = systemd_data_update_helper($app->app_id, $fields, $metrics, $name, $polling_type, $rrd_def, $state_type);
+        $metrics = systemd_data_update_helper($device, $app->app_id, $fields, $metrics, $name, $polling_type, $rrd_def, $state_type);
     } else {
         // Process systemd states that have three
         // levels of depth (sub)
@@ -114,7 +112,7 @@ foreach ($systemd_mapper as $state_type => $state_statuses) {
                 $rrd_def->addDataset($field_name, 'GAUGE', 0);
             }
             $flat_type = $state_type . '_' . $sub_state_type;
-            $metrics = systemd_data_update_helper($app->app_id, $fields, $metrics, $name, $polling_type, $rrd_def, $flat_type);
+            $metrics = systemd_data_update_helper($device, $app->app_id, $fields, $metrics, $name, $polling_type, $rrd_def, $flat_type);
         }
     }
 }


### PR DESCRIPTION
Somewhere around 10/13/2023 polling for the SS/Systemd applications stopped working.  RRDs for the applications were being populated in the global `includes/rrd/` folder instead of the `includes/rrd/<device-id>` folder.  I think it's related to the changes in this PR: https://github.com/librenms/librenms/pull/15460

Removing the global declaration for the `@device` in favor of passing it as an argument to the `systemd_data_update_helper`/`ss_data_update_helper` functions fixes the issue.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
