### PR TITLE
Huawei Controllers - Exception removed and changed OID for AP Type

### DIFF
--- a/LibreNMS/OS/Vrp.php
+++ b/LibreNMS/OS/Vrp.php
@@ -133,7 +133,7 @@ class Vrp extends OS implements
                 'hwWlanRadioChUtilizationRate',
                 'hwWlanRadioChInterferenceRate',
                 'hwWlanRadioActualEIRP',
-                'hwWlanRadioFreqType',
+                'hwWlanRadioType',
                 'hwWlanRadioWorkingChannel',
             ];
 
@@ -182,16 +182,32 @@ class Vrp extends OS implements
                     $interference = $radio['hwWlanRadioChInterferenceRate'] ?? 0;
                     $radioutil = $radio['hwWlanRadioChUtilizationRate'] ?? 0;
                     $numasoclients = $clientPerRadio[$ap_id][$r_id] ?? 0;
+                    $radio['hwWlanRadioType'] = $radio['hwWlanRadioType'] ?? 0;
 
-                    switch ($radio['hwWlanRadioFreqType'] ?? null) {
-                        case 1:
-                            $type = '2.4Ghz';
-                            break;
-                        case 2:
-                            $type = '5Ghz';
-                            break;
-                        default:
-                            $type = 'unknown (huawei ' . ($radio['hwWlanRadioFreqType'] ?? null) . ')';
+                    $type = 'dot11';
+
+                    if ($radio['hwWlanRadioType'] & 2) {
+                        $type .= 'a';
+                    }
+
+                    if ($radio['hwWlanRadioType'] & 1) {
+                        $type .= 'b';
+                    }
+
+                    if ($radio['hwWlanRadioType'] & 4) {
+                        $type .= 'g';
+                    }
+
+                    if ($radio['hwWlanRadioType'] & 8) {
+                        $type .= 'n';
+                    }
+
+                    if ($radio['hwWlanRadioType'] & 16) {
+                        $type .= '_ac';
+                    }
+
+                    if ($radio['hwWlanRadioType'] & 32) {
+                        $type .= '_ax';
                     }
 
                     // TODO


### PR DESCRIPTION
- Remove the too long state  'unknown (huawei)'.
```
SQLSTATE[22001]: String data, right truncated: 1406 Data too long for column 'type' at row 1 (Connection: mysql, SQL: update `access_points` set `type` = unknown (huawei ) where `accesspoint_id` = 530) {"exception":"[object] (Illuminate\\Database\\QueryException(code: 22001): SQLSTATE[22001]: String data, right truncated: 1406 Data too long for column 'type' at row 1 (Connection: mysql, SQL: update `access_points` set `type` = unknown (huawei ) where `accesspoint_id` = 530) at /opt/librenms/vendor/laravel/framework/src/Illuminate/Database/Connection.php:795)
[previous exception] [object] (PDOException(code: 22001): SQLSTATE[22001]: String data, right truncated: 1406 Data too long for column 'type' at row 1 at /opt/librenms/vendor/laravel/framework/src/Illuminate/Database/Connection.php:605)"} 
Error polling os module for 172.18.250.3. PDOException: SQLSTATE[22001]: String data, right truncated: 1406 Data too long for column 'type' at row 1 in /opt/librenms/vendor/laravel/framework/src/Illuminate/Database/Connection.php:605
Stack trace:
#0 /opt/librenms/vendor/laravel/framework/src/Illuminate/Database/Connection.php(605): PDOStatement->execute()
#1 /opt/librenms/vendor/laravel/framework/src/Illuminate/Database/Connection.php(788): Illuminate\Database\Connection->Illuminate\Database\{closure}('update `access_...', Array)
#2 /opt/librenms/vendor/laravel/framework/src/Illuminate/Database/Connection.php(755): Illuminate\Database\Connection->runQueryCallback('update `access_...', Array, Object(Closure))
#3 /opt/librenms/vendor/laravel/framework/src/Illuminate/Database/Connection.php(612): Illuminate\Database\Connection->run('update `access_...', Array, Object(Closure))
#4 /opt/librenms/vendor/laravel/framework/src/Illuminate/Database/Connection.php(545): Illuminate\Database\Connection->affectingStatement('update `access_...', Array)
#5 /opt/librenms/vendor/laravel/framework/src/Illuminate/Database/Query/Builder.php(3418): Illuminate\Database\Connection->update('update `access_...', Array)
#6 /opt/librenms/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Builder.php(1042): Illuminate\Database\Query\Builder->update(Array)
#7 /opt/librenms/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Model.php(1213): Illuminate\Database\Eloquent\Builder->update(Array)
#8 /opt/librenms/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Model.php(1130): Illuminate\Database\Eloquent\Model->performUpdate(Object(Illuminate\Database\Eloquent\Builder))
#9 /opt/librenms/LibreNMS/DB/SyncsModels.php(52): Illuminate\Database\Eloquent\Model->save()
#10 /opt/librenms/LibreNMS/OS/Vrp.php(253): LibreNMS\OS\Vrp->syncModels(Object(App\Models\Device), 'accessPoints', Object(Illuminate\Support\Collection))
#11 /opt/librenms/LibreNMS/Modules/Os.php(80): LibreNMS\OS\Vrp->pollOS(Object(LibreNMS\Data\Store\Datastore))
#12 /opt/librenms/LibreNMS/Poller.php(178): LibreNMS\Modules\Os->poll(Object(LibreNMS\OS\Vrp), Object(LibreNMS\Data\Store\Datastore))
#13 /opt/librenms/LibreNMS/Poller.php(105): LibreNMS\Poller->pollModules()
#14 /opt/librenms/app/Console/Commands/DevicePoll.php(44): LibreNMS\Poller->poll()
#15 /opt/librenms/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(36): App\Console\Commands\DevicePoll->handle(Object(App\Polling\Measure\MeasurementManager))
#16 /opt/librenms/vendor/laravel/framework/src/Illuminate/Container/Util.php(41): Illuminate\Container\BoundMethod::Illuminate\Container\{closure}()
#17 /opt/librenms/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(93): Illuminate\Container\Util::unwrapIfClosure(Object(Closure))
#18 /opt/librenms/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(37): Illuminate\Container\BoundMethod::callBoundMethod(Object(Illuminate\Foundation\Application), Array, Object(Closure))
#19 /opt/librenms/vendor/laravel/framework/src/Illuminate/Container/Container.php(662): Illuminate\Container\BoundMethod::call(Object(Illuminate\Foundation\Application), Array, Array, NULL)
#20 /opt/librenms/vendor/laravel/framework/src/Illuminate/Console/Command.php(208): Illuminate\Container\Container->call(Array)
#21 /opt/librenms/vendor/symfony/console/Command/Command.php(326): Illuminate\Console\Command->execute(Object(Symfony\Component\Console\Input\ArgvInput), Object(Illuminate\Console\OutputStyle))
#22 /opt/librenms/vendor/laravel/framework/src/Illuminate/Console/Command.php(178): Symfony\Component\Console\Command\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Illuminate\Console\OutputStyle))
#23 /opt/librenms/vendor/symfony/console/Application.php(1081): Illuminate\Console\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#24 /opt/librenms/vendor/symfony/console/Application.php(320): Symfony\Component\Console\Application->doRunCommand(Object(App\Console\Commands\DevicePoll), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#25 /opt/librenms/vendor/symfony/console/Application.php(174): Symfony\Component\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#26 /opt/librenms/vendor/laravel/framework/src/Illuminate/Foundation/Console/Kernel.php(201): Symfony\Component\Console\Application->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#27 /opt/librenms/app/Console/Kernel.php(66): Illuminate\Foundation\Console\Kernel->handle(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#28 /opt/librenms/lnms(40): App\Console\Kernel->handle(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#29 {main}
```
- Avoid NULL in type
- Change from hwWlanRadioFreqType to hwWlanRadioType with bitwise mask

![image](https://github.com/librenms/librenms/assets/38363551/2cbad35f-ba5a-4e10-a1da-921efafd22a1)

Follows #15450

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
