### PR TITLE
Change spelling disc -> disk

### DIFF
--- a/includes/html/pages/device/apps/mdadm.inc.php
+++ b/includes/html/pages/device/apps/mdadm.inc.php
@@ -30,8 +30,8 @@ print_optionbar_end();
 $graphs = [
     'mdadm_level'          => 'RAID level',
     'mdadm_size'           => 'RAID Size',
-    'mdadm_disc_count'     => 'RAID Disc count',
-    'mdadm_hotspare_count' => 'RAID Hotspare Disc count',
+    'mdadm_disc_count'     => 'RAID Disk count',
+    'mdadm_hotspare_count' => 'RAID Hotspare Disk count',
     'mdadm_degraded'       => 'RAID degraded',
     'mdadm_sync_speed'     => 'RAID Sync speed',
     'mdadm_sync_completed' => 'RAID Sync completed',


### PR DESCRIPTION
Disc is typically used for optical media, not hard disks (so unlikely to encounter discs in mdraid related circumstances). mdadm and friends use the disk spelling, the host script also shows shows this `"disc_count": $(maybe_get "${mdadmSysDev}/md/raid_disks"),`

Fixing the variable names as well would be nice, but that change would be a lot bigger and probably break things as it would need host script adjustment synchronising and all that, but I think we can at least change the cosmetic spelling.

https://en.wikipedia.org/wiki/Spelling_of_disc

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
