### PR TITLE
bug - Fix API Content-Type Header handling

### DIFF
--- a/LibreNMS/Alert/Transport/Api.php
+++ b/LibreNMS/Alert/Transport/Api.php
@@ -49,8 +49,11 @@ class Api extends Transport
         ->withHeaders($request_headers); //get each line of key-values and process the variables for Headers
 
         if ($method !== 'get') {
+            // Set default value for Content-Type but use whatever is already in request_headers
+            $request_headers = array_merge(['Content-Type' => 'text/plain'], $request_headers);
             $request_body = SimpleTemplate::parse($this->config['api-body'], $alert_data);
-            $client->withBody($request_body, 'text/plain'); // Content-Type can be overriden by user headers
+            $client->withBody($request_body); // always overrides Content-Type
+            $client->replaceHeaders($request_headers); // replace with our computed headers
         }
 
         if ($username) {

--- a/LibreNMS/Alert/Transport/Api.php
+++ b/LibreNMS/Alert/Transport/Api.php
@@ -52,7 +52,7 @@ class Api extends Transport
             $request_body = SimpleTemplate::parse($this->config['api-body'], $alert_data);
             // withBody always overrides Content-Type so we compute a proper set (with 'Content-Type' => 'text/plain'
             // as default value, and replace all headers with our computed headers
-            $client->withBody($request_body)->replaceHeaders(array_merge(['Content-Type' => 'text/plain'], $request_headers)); 
+            $client->withBody($request_body)->replaceHeaders(array_merge(['Content-Type' => 'text/plain'], $request_headers));
         }
 
         if ($username) {

--- a/LibreNMS/Alert/Transport/Api.php
+++ b/LibreNMS/Alert/Transport/Api.php
@@ -49,11 +49,10 @@ class Api extends Transport
         ->withHeaders($request_headers); //get each line of key-values and process the variables for Headers
 
         if ($method !== 'get') {
-            // Set default value for Content-Type but use whatever is already in request_headers
-            $request_headers = array_merge(['Content-Type' => 'text/plain'], $request_headers);
             $request_body = SimpleTemplate::parse($this->config['api-body'], $alert_data);
-            $client->withBody($request_body); // always overrides Content-Type
-            $client->replaceHeaders($request_headers); // replace with our computed headers
+            // withBody always overrides Content-Type so we compute a proper set (with 'Content-Type' => 'text/plain'
+            // as default value, and replace all headers with our computed headers
+            $client->withBody($request_body)->replaceHeaders(array_merge(['Content-Type' => 'text/plain'], $request_headers)); 
         }
 
         if ($username) {


### PR DESCRIPTION
fixes #15082

Laravel HTTP client does not handle Content-Type as we supposed. (https://laravel.com/docs/10.x/http-client). withBody() will always override the Content-Type. And even setting the Content-Type after withBody fails (we end up with 2 Content-Type). 
array_merge, in the correct order, seems to solve the case in all the tests I ran. 

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
