### PR TITLE
WIP - Hide navbar when dashboard is full screen

### DIFF
--- a/resources/views/overview/default.blade.php
+++ b/resources/views/overview/default.blade.php
@@ -648,5 +648,19 @@
         $('#dashboard_name').val('Default');
         dashboard_add($('#add_form'));
     @endif
+
+     function checkFullScreen() {
+         if (window.innerHeight > (screen.height - 10)) {
+            $(".navbar-fixed-top").hide();
+            $("#dashboard-editor").hide();
+            $("body").css("padding-top", 0).css("padding-bottom", 0);
+         } else {
+            $(".navbar-fixed-top").show();
+            $("#dashboard-editor").show();
+            $("body").css("padding-top", "50px").css("padding-bottom", "50px");
+         };
+     }
+     window.addEventListener('resize', checkFullScreen(), false);
+     checkFullScreen();
 </script>
 @endpush

--- a/resources/views/overview/default.blade.php
+++ b/resources/views/overview/default.blade.php
@@ -649,7 +649,7 @@
         dashboard_add($('#add_form'));
     @endif
 
-     function checkFullScreen() {
+     function checkFullScreen(event) {
          if (window.innerHeight > (screen.height - 10)) {
             $(".navbar-fixed-top").hide();
             $("#dashboard-editor").hide();
@@ -660,7 +660,7 @@
             $("body").css("padding-top", "50px").css("padding-bottom", "50px");
          };
      }
-     window.addEventListener('resize', checkFullScreen(), false);
+     addEvent(window, 'resize', checkFullScreen);
      checkFullScreen();
 </script>
 @endpush

--- a/resources/views/overview/default.blade.php
+++ b/resources/views/overview/default.blade.php
@@ -650,7 +650,7 @@
     @endif
 
      function checkFullScreen(event) {
-         if (window.innerHeight > (screen.height - 10)) {
+         if (window.matchMedia('(display-mode: fullscreen)').matches) {
             $(".navbar-fixed-top").hide();
             $("#dashboard-editor").hide();
             $("body").css("padding-top", 0).css("padding-bottom", 0);
@@ -660,7 +660,7 @@
             $("body").css("padding-top", "50px").css("padding-bottom", "50px");
          };
      }
-     addEvent(window, 'resize', checkFullScreen);
+     window.matchMedia('(display-mode: fullscreen)').addEventListener('change', checkFullScreen);
      checkFullScreen();
 </script>
 @endpush

--- a/resources/views/overview/default.blade.php
+++ b/resources/views/overview/default.blade.php
@@ -650,7 +650,7 @@
     @endif
 
      function checkFullScreen(event) {
-         if (window.matchMedia('(display-mode: fullscreen)').matches) {
+         if (window.innerHeight > (screen.height - 10) || window.matchMedia('(display-mode: fullscreen)').matches) {
             $(".navbar-fixed-top").hide();
             $("#dashboard-editor").hide();
             $("body").css("padding-top", 0).css("padding-bottom", 0);

--- a/resources/views/overview/default.blade.php
+++ b/resources/views/overview/default.blade.php
@@ -650,7 +650,12 @@
     @endif
 
      function checkFullScreen(event) {
-         if (window.innerHeight > (screen.height - 10) || window.matchMedia('(display-mode: fullscreen)').matches) {
+         var isFullscreen = window.matchMedia('(display-mode: fullscreen)').matches;
+         if (isFullscreen != null && isFullscreen) {
+            $(".navbar-fixed-top").hide();
+            $("#dashboard-editor").hide();
+            $("body").css("padding-top", 0).css("padding-bottom", 0);
+         } else if (isFullscreen == null && window.innerHeight > (screen.height - 10)) {
             $(".navbar-fixed-top").hide();
             $("#dashboard-editor").hide();
             $("body").css("padding-top", 0).css("padding-bottom", 0);

--- a/resources/views/overview/default.blade.php
+++ b/resources/views/overview/default.blade.php
@@ -649,13 +649,8 @@
         dashboard_add($('#add_form'));
     @endif
 
-     function checkFullScreen(event) {
-         var isFullscreen = window.matchMedia('(display-mode: fullscreen)').matches;
-         if (isFullscreen != null && isFullscreen) {
-            $(".navbar-fixed-top").hide();
-            $("#dashboard-editor").hide();
-            $("body").css("padding-top", 0).css("padding-bottom", 0);
-         } else if (isFullscreen == null && window.innerHeight > (screen.height - 10)) {
+     function checkFullScreen() {
+         if (window.innerHeight > (screen.height - 10)) {
             $(".navbar-fixed-top").hide();
             $("#dashboard-editor").hide();
             $("body").css("padding-top", 0).css("padding-bottom", 0);
@@ -665,7 +660,7 @@
             $("body").css("padding-top", "50px").css("padding-bottom", "50px");
          };
      }
-     window.matchMedia('(display-mode: fullscreen)').addEventListener('change', checkFullScreen);
+     window.addEventListener('resize', checkFullScreen(), false);
      checkFullScreen();
 </script>
 @endpush

--- a/resources/views/overview/default.blade.php
+++ b/resources/views/overview/default.blade.php
@@ -660,7 +660,7 @@
             $("body").css("padding-top", "50px").css("padding-bottom", "50px");
          };
      }
-     window.addEventListener('resize', checkFullScreen(), false);
+     window.addEventListener('resize', checkFullScreen, false);
      checkFullScreen();
 </script>
 @endpush


### PR DESCRIPTION
Hide the navbar and edit options when the dashboard page is set to full screen, giving more space for data.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
