### PR TITLE
Only set user roles if they are defined

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -185,7 +185,10 @@ class UserController extends Controller
         }
 
         $user->fill($request->validated());
-        $user->setRoles($request->get('roles', []));
+
+        if ($request->has('roles')) {
+            $user->setRoles($request->get('roles', []));
+        }
 
         if ($request->has('dashboard') && $this->updateDashboard($user, $request->get('dashboard'))) {
             $flasher->addSuccess(__('Updated dashboard for :username', ['username' => $user->username]));


### PR DESCRIPTION
Fixes a bug where setting your password would unset all roles.

fixes
https://community.librenms.org/t/admin-permission-removed-when-changing-password-via-my-settings/22796

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
