### PR TITLE
Add port description API endpoints and documentation

### DIFF
--- a/doc/API/Ports.md
+++ b/doc/API/Ports.md
@@ -410,6 +410,7 @@ Route: `/api/v0/ports/:portid/description`
 Input (JSON):
 
 - description: The string data to use as the new port description.
+Sending an empty string will reset the description to default.
 
 Example:
 

--- a/doc/API/Ports.md
+++ b/doc/API/Ports.md
@@ -379,3 +379,48 @@ Output:
   ]
 }
 ```
+
+### `get_port_description`
+
+Get the description (`ifAlias`) for a given port id.
+
+Route: `/api/v0/ports/:portid/description`
+
+Example:
+
+```curl
+curl -H 'X-Auth-Token: YOURAPITOKENHERE' https://librenms.org/api/v0/ports/323/description
+```
+
+Output:
+
+```json
+{
+    "status": "ok",
+    "port_description": "GigabitEthernet14"
+}
+```
+
+### `update_port_description`
+
+Change the description (`ifAlias`) for a given port id.
+
+Route: `/api/v0/ports/:portid/description`
+
+Input (JSON):
+
+- description: The string data to use as the new port description.
+
+Example:
+
+```curl
+curl -X PATCH -d '{"description": "Out-of-Band Management Link"}' -H 'X-Auth-Token: YOURAPITOKENHERE' https://librenms.org/api/v0/ports/323/description
+```
+
+Output:
+```json
+{
+    "status": "ok",
+    "message": "Port description updated."
+}
+```

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -1084,6 +1084,45 @@ function get_port_info(Illuminate\Http\Request $request)
     });
 }
 
+function update_port_description(Illuminate\Http\Request $request)
+{
+    $port_id = $request->route('portid');
+    $port = Port::hasAccess(Auth::user())
+        ->where([
+            'port_id' => $port_id,
+        ])->first();
+    if (empty($port)) {
+        return api_error(400, 'Invalid port ID.');
+    }
+
+    $data = json_decode($request->getContent(), true);
+    $field = 'description';
+    $content = $data[$field];
+
+    if (empty($content)) {
+        return api_error(400, 'New port description has not been supplied.');
+    }
+
+    $port->ifAlias = $content;
+    $port->save();
+
+    return api_success_noresult(200, 'Port description updated.');
+}
+
+function get_port_description(Illuminate\Http\Request $request)
+{
+    $port_id = $request->route('portid');
+    $port = Port::hasAccess(Auth::user())
+        ->where([
+            'port_id' => $port_id,
+        ])->first();
+    if (empty($port)) {
+        return api_error(400, 'Invalid port ID.');
+    } else {
+        return api_success($port->ifAlias, 'port_description');
+    }
+}
+
 /**
  * @throws \LibreNMS\Exceptions\ApiException
  */

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -1121,7 +1121,7 @@ function update_port_description(Illuminate\Http\Request $request)
         // Prevent poller from overwriting new description
         set_dev_attrib($port, 'ifName:' . $ifName, 1); // see above
         log_event("$ifName Port ifAlias set via API: $description", $device, 'interface', 3, $port_id);
-        
+
         return api_success_noresult(200, 'Port description updated.');
     }
 }

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -1115,11 +1115,13 @@ function update_port_description(Illuminate\Http\Request $request)
         // No description provided, clear description
         del_dev_attrib($port, 'ifName:' . $ifName); // "port" object has required device_id
         log_event("$ifName Port ifAlias cleared via API", $device, 'interface', 3, $port_id);
+
         return api_success_noresult(200, 'Port description cleared.');
     } else {
         // Prevent poller from overwriting new description
         set_dev_attrib($port, 'ifName:' . $ifName, 1); // see above
         log_event("$ifName Port ifAlias set via API: $description", $device, 'interface', 3, $port_id);
+        
         return api_success_noresult(200, 'Port description updated.');
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -134,6 +134,8 @@ Route::prefix('v0')->namespace('\App\Api\Controllers')->group(function () {
         Route::get('search/{field}/{search?}', 'LegacyApiController@search_ports')->name('search_ports')->where('search', '.*');
         Route::get('mac/{search}', 'LegacyApiController@search_by_mac')->name('search_mac');
         Route::get('', 'LegacyApiController@get_all_ports')->name('get_all_ports');
+        Route::get('{portid}/description', 'LegacyApiController@get_port_description')->name('get_port_description');
+        Route::patch('{portid}/description', 'LegacyApiController@update_port_description')->name('update_port_description');
     });
 
     Route::prefix('bills')->group(function () {


### PR DESCRIPTION
Please give a short description what your pull request is for

This pull request adds a new API endpoint - `/api/v0/ports/:portid/description` - and associated functions - `update_port_description` and `get_port_description` - which allow a developer to both read and write the description (`ifAlias`) for a port. Previously, the description could be read as part of the data returned by `/api/v0/ports/:portid`, but there was no way to update the description/`ifAlias` via the API. This PR adds an endpoint to enable such functionality.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
    - (not relevant)
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).
    - (not relevant)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.

I have tested these endpoints on my own install and they appear to work as intended. However, I would appreciate a double-check from a security perspective - I believe that these endpoints are authenticated through `Port::hasAccess`, but if this is not the correct way to verify that a user is authorised to update a port in such a manner, please let me know.