### PR TITLE
Add circular loop detection to MaxDepth

### DIFF
--- a/app/Jobs/PingCheck.php
+++ b/app/Jobs/PingCheck.php
@@ -167,6 +167,7 @@ class PingCheck implements ShouldQueue
 
         if ($device === null) {
             Log::error("Ping host from response not found $response->host");
+
             return;
         }
 

--- a/app/Jobs/PingCheck.php
+++ b/app/Jobs/PingCheck.php
@@ -135,7 +135,7 @@ class PingCheck implements ShouldQueue
 
         $waiting_on = [];
         foreach ($device->parents as $parent) {
-            if (!$this->processed->has($parent->device_id)) {
+            if (! $this->processed->has($parent->device_id)) {
                 $waiting_on[] = $parent->device_id;
             }
         }
@@ -198,7 +198,8 @@ class PingCheck implements ShouldQueue
     /**
      * Run any deferred alerts
      */
-    private function runDeferredAlerts(int $device_id) {
+    private function runDeferredAlerts(int $device_id)
+    {
         // check for any devices waiting on this device
         if ($this->waiting_on->has($device_id)) {
             $children = $this->waiting_on->get($device_id)->keys();
@@ -211,7 +212,7 @@ class PingCheck implements ShouldQueue
                     $parents = $this->deferred->get($child_id);
 
                     foreach ($parents as $parent) {
-                        if (!$this->processed->has($parent->device_id)) {
+                        if (! $this->processed->has($parent->device_id)) {
                             if (Debug::isVerbose()) {
                                 echo "Deferring device $child_id triggered by $device_id still waiting for $parent->device_id\n";
                             }
@@ -238,7 +239,8 @@ class PingCheck implements ShouldQueue
     /**
      * run alerts for a device
      */
-    private function runAlerts(int $device_id) {
+    private function runAlerts(int $device_id)
+    {
         $rules = new AlertRules;
         $rules->runRules($device_id);
     }

--- a/app/Jobs/PingCheck.php
+++ b/app/Jobs/PingCheck.php
@@ -78,7 +78,7 @@ class PingCheck implements ShouldQueue
         $ordered_hostname_list = $this->fetchOrderedHostnames();
 
         if (Debug::isVerbose()) {
-            echo "Processing hosts in this order : " . implode(', ', $ordered_hostname_list) . PHP_EOL;
+            echo 'Processing hosts in this order : ' . implode(', ', $ordered_hostname_list) . PHP_EOL;
         }
 
         // bulk ping and send FpingResponse's to recordData as they come in
@@ -101,7 +101,7 @@ class PingCheck implements ShouldQueue
     /**
      * Get an ordered list of hostnames that we need to ping starting from devices with no parents
      */
-    private function fetchOrderedHostnames() : array
+    private function fetchOrderedHostnames(): array
     {
         $ret = [];
         $current_hostnames = [];
@@ -119,7 +119,7 @@ class PingCheck implements ShouldQueue
 
         while (count($current_hostnames) > 0) {
             if (Debug::isVerbose()) {
-                echo "Adding hosts to ordered list : " . implode(', ', $current_hostnames) . PHP_EOL;
+                echo 'Adding hosts to ordered list : ' . implode(', ', $current_hostnames) . PHP_EOL;
             }
 
             $ret = array_merge($ret, $current_hostnames);
@@ -129,7 +129,7 @@ class PingCheck implements ShouldQueue
 
         if (count($deferred_device_ids) > 0) {
             if (Debug::isVerbose()) {
-                echo "Adding unprocessed deferred hosts to ordered list : " . $deferred_device_ids->values()->implode(', ') . PHP_EOL;
+                echo 'Adding unprocessed deferred hosts to ordered list : ' . $deferred_device_ids->values()->implode(', ') . PHP_EOL;
             }
 
             $ret = array_merge($ret, $deferred_device_ids->values()->toArray());
@@ -141,7 +141,7 @@ class PingCheck implements ShouldQueue
     /**
      * For each hostname given, get the device and return any unprocessed child hostnames, removing from the unprocessed list
      */
-    private function getUnprocessedChildren(array $hostnames, Collection &$unprocessed) : array
+    private function getUnprocessedChildren(array $hostnames, Collection &$unprocessed): array
     {
         $ret = [];
 

--- a/app/Jobs/PingCheck.php
+++ b/app/Jobs/PingCheck.php
@@ -105,7 +105,7 @@ class PingCheck implements ShouldQueue
         $ordered_device_list = new Collection;
 
         // start with root nodes (no parents)
-        [$current_tier_devices, $pending_children] = $devices->keyBy('device_id')->partition(fn(Device $d) => $d->parents_count === 0);
+        [$current_tier_devices, $pending_children] = $devices->keyBy('device_id')->partition(fn (Device $d) => $d->parents_count === 0);
 
         // recurse down until no children are found
         while ($current_tier_devices->isNotEmpty()) {
@@ -114,14 +114,14 @@ class PingCheck implements ShouldQueue
             // fetch the next tier of devices
             $current_tier_devices = $current_tier_devices
                 ->pluck('children.*.device_id')->flatten() // get all direct child ids
-                ->map(fn($child_id) => $pending_children->pull($child_id)) // fetch and remove the device from pending if it exists
+                ->map(fn ($child_id) => $pending_children->pull($child_id)) // fetch and remove the device from pending if it exists
                 ->filter(); // filter out children that are already in the list
         }
 
         // just add any left over
         $ordered_device_list = $ordered_device_list->merge($pending_children);
 
-        return $ordered_device_list->map(fn(Device $device) => $device->overwrite_ip ?: $device->hostname)->all();
+        return $ordered_device_list->map(fn (Device $device) => $device->overwrite_ip ?: $device->hostname)->all();
     }
 
     /**
@@ -198,7 +198,7 @@ class PingCheck implements ShouldQueue
             if (count($waiting_on) === 0) {
                 $this->runAlerts($device->device_id);
             } else {
-                Log::debug("Alerts Deferred");
+                Log::debug('Alerts Deferred');
 
                 $this->deferred->put($device->device_id, $device->parents);
                 foreach ($waiting_on as $parent_id) {

--- a/app/Jobs/PingCheck.php
+++ b/app/Jobs/PingCheck.php
@@ -49,7 +49,7 @@ class PingCheck implements ShouldQueue
     // working data for loop
     /** @var Collection */
     private Collection $deferred;
-    /** @var Collection<int, Collection<Device>> device id, parent devices */
+    /** @var Collection<int, Collection<int, bool>> device id, parent devices */
     private Collection $waiting_on;
     /** @var Collection<int, bool> */
     private Collection $processed;

--- a/app/Jobs/PingCheck.php
+++ b/app/Jobs/PingCheck.php
@@ -36,7 +36,6 @@ use Illuminate\Support\Facades\Log;
 use LibreNMS\Alert\AlertRules;
 use LibreNMS\Data\Source\Fping;
 use LibreNMS\Data\Source\FpingResponse;
-use LibreNMS\Util\Debug;
 
 class PingCheck implements ShouldQueue
 {
@@ -79,9 +78,7 @@ class PingCheck implements ShouldQueue
 
         $ordered_hostname_list = $this->orderHostnames($this->fetchDevices());
 
-        if (Debug::isVerbose()) {
-            Log::info('Processing hosts in this order : ' . implode(', ', $ordered_hostname_list));
-        }
+        Log::info('Processing hosts in this order : ' . implode(', ', $ordered_hostname_list));
 
         // bulk ping and send FpingResponse's to recordData as they come in
         app()->make(Fping::class)->bulkPing($ordered_hostname_list, [$this, 'handleResponse']);
@@ -105,7 +102,6 @@ class PingCheck implements ShouldQueue
      */
     private function orderHostnames(Collection $devices): array
     {
-
         $ordered_device_list = new Collection;
 
         // start with root nodes (no parents)

--- a/app/Jobs/PingCheck.php
+++ b/app/Jobs/PingCheck.php
@@ -166,7 +166,7 @@ class PingCheck implements ShouldQueue
 
         $waiting_on = [];
         foreach ($device->parents as $parent) {
-            if (!$this->processed->has($parent->device_id)) {
+            if (! $this->processed->has($parent->device_id)) {
                 $waiting_on[] = $parent->device_id;
             }
         }
@@ -231,7 +231,8 @@ class PingCheck implements ShouldQueue
     /**
      * Run any deferred alerts
      */
-    private function runDeferredAlerts(int $device_id) {
+    private function runDeferredAlerts(int $device_id)
+    {
         // check for any devices waiting on this device
         if ($this->waiting_on->has($device_id)) {
             $children = $this->waiting_on->get($device_id)->keys();
@@ -244,7 +245,7 @@ class PingCheck implements ShouldQueue
                     $parents = $this->deferred->get($child_id);
 
                     foreach ($parents as $parent) {
-                        if (!$this->processed->has($parent->device_id)) {
+                        if (! $this->processed->has($parent->device_id)) {
                             if (Debug::isVerbose()) {
                                 echo "Deferring device $child_id triggered by $device_id still waiting for $parent->device_id\n";
                             }
@@ -271,7 +272,8 @@ class PingCheck implements ShouldQueue
     /**
      * Record the data and run alerts if all parents have been processed
      */
-    private function runAlerts(int $device_id) {
+    private function runAlerts(int $device_id)
+    {
         $rules = new AlertRules;
         $rules->runRules($device_id);
     }

--- a/app/Jobs/PingCheck.php
+++ b/app/Jobs/PingCheck.php
@@ -104,7 +104,7 @@ class PingCheck implements ShouldQueue
 
         $query = Device::canPing()
             ->select(['devices.device_id', 'hostname', 'overwrite_ip', 'status', 'status_reason', 'last_ping', 'last_ping_timetaken'])
-            ->with(['parents' => function($q) {
+            ->with(['parents' => function ($q) {
                 $q->canPing()->select('devices.device_id');
             }]);
 

--- a/app/Jobs/PingCheck.php
+++ b/app/Jobs/PingCheck.php
@@ -104,7 +104,9 @@ class PingCheck implements ShouldQueue
 
         $query = Device::canPing()
             ->select(['devices.device_id', 'hostname', 'overwrite_ip', 'status', 'status_reason', 'last_ping', 'last_ping_timetaken'])
-            ->with('parents:device_id');
+            ->with(['parents' => function($q) {
+                $q->canPing()->select('devices.device_id');
+            }]);
 
         if ($this->groups) {
             $query->whereIntegerInRaw('poller_group', $this->groups);

--- a/app/Jobs/PingCheck.php
+++ b/app/Jobs/PingCheck.php
@@ -151,11 +151,6 @@ class PingCheck implements ShouldQueue
         // save last_ping_timetaken and rrd data
         $response->saveStats($device);
 
-        $device->save(); // save every time because of last_ping
-
-        // add data to rrd
-        app('Datastore')->put($device->toArray(), 'ping-perf', $this->rrd_tags, ['ping' => $device->last_ping_timetaken]);
-
         // mark as processed
         $this->processed->put($device->device_id, true);
         d_echo("Recorded data for $device->hostname\n");

--- a/app/Jobs/PingCheck.php
+++ b/app/Jobs/PingCheck.php
@@ -77,7 +77,7 @@ class PingCheck implements ShouldQueue
 
         $device_collection = $this->fetchDevices();
 
-        $device_list = $device_collection->keys();
+        $device_list = $device_collection->keys()->all();
 
         // bulk ping and send FpingResponse's to recordData as they come in
         app()->make(Fping::class)->bulkPing($device_list, [$this, 'handleResponse']);
@@ -128,7 +128,7 @@ class PingCheck implements ShouldQueue
     public function handleResponse(FpingResponse $response): void
     {
         if (Debug::isVerbose()) {
-            echo "Attempting to record data for $response->host... ";
+            echo "Attempting to record data for $response->host... \n";
         }
 
         $device = $this->devices->get($response->host);

--- a/app/Models/Device.php
+++ b/app/Models/Device.php
@@ -351,34 +351,9 @@ class Device extends BaseModel
             } else {
                 $this->max_depth = 1; // has children
             }
-        } elseif ($count === 1 && $this->parents[0]->parents()->getQuery()->where('device_id', '=', $this->device_id)->count() == 0) {
-            // Shortcut for devices with a single parent and no circular dependency
+        } else {
             $parents_max_depth = $query->max('max_depth');
             $this->max_depth = $parents_max_depth + 1;
-        } else {
-            // Work out the longest path to any root node, avoiding loops
-            $found_parents = [];
-            $max_depth = 1;
-            $this_parents = $this->parents;
-            $next_parents = [];
-            while (count($this_parents) > 0) {
-                $max_depth++;
-                foreach ($this_parents as $parent) {
-                    if (array_key_exists($parent->device_id, $found_parents)) {
-                        continue;
-                    }
-                    $found_parents[$parent->device_id] = true;
-
-                    foreach ($parent->parents as $next_parent) {
-                        if (! array_key_exists($next_parent->device_id, $found_parents)) {
-                            $next_parents[] = $next_parent;
-                        }
-                    }
-                }
-                $this_parents = $next_parents;
-                $next_parents = [];
-            }
-            $this->max_depth = $max_depth;
         }
 
         $this->save();

--- a/app/Models/Device.php
+++ b/app/Models/Device.php
@@ -370,7 +370,7 @@ class Device extends BaseModel
                     $found_parents[$parent->device_id] = true;
 
                     foreach ($parent->parents as $next_parent) {
-                        if (!array_key_exists($next_parent->device_id, $found_parents)) {
+                        if (! array_key_exists($next_parent->device_id, $found_parents)) {
                             $next_parents[] = $next_parent;
                         }
                     }

--- a/app/Models/Device.php
+++ b/app/Models/Device.php
@@ -351,9 +351,34 @@ class Device extends BaseModel
             } else {
                 $this->max_depth = 1; // has children
             }
-        } else {
+        } elseif ($count === 1 && $this->parents[0]->parents()->getQuery()->where('device_id', '=', $this->device_id)->count() == 0) {
+            // Shortcut for devices with a single parent and no circular dependency
             $parents_max_depth = $query->max('max_depth');
             $this->max_depth = $parents_max_depth + 1;
+        } else {
+            // Work out the longest path to any root node, avoiding loops
+            $found_parents = [];
+            $max_depth = 1;
+            $this_parents = $this->parents;
+            $next_parents = [];
+            while (count($this_parents) > 0) {
+                $max_depth++;
+                foreach ($this_parents as $parent) {
+                    if (array_key_exists($parent->device_id, $found_parents)) {
+                        continue;
+                    }
+                    $found_parents[$parent->device_id] = true;
+
+                    foreach ($parent->parents as $next_parent) {
+                        if (!array_key_exists($next_parent->device_id, $found_parents)) {
+                            $next_parents[] = $next_parent;
+                        }
+                    }
+                }
+                $this_parents = $next_parents;
+                $next_parents = [];
+            }
+            $this->max_depth = $max_depth;
         }
 
         $this->save();

--- a/app/Observers/DeviceObserver.php
+++ b/app/Observers/DeviceObserver.php
@@ -33,11 +33,6 @@ class DeviceObserver
      */
     public function updated(Device $device): void
     {
-        // handle device dependency updates
-        if ($device->isDirty('max_depth')) {
-            $device->children->each->updateMaxDepth();
-        }
-
         // log up/down status changes
         if ($device->isDirty(['status', 'status_reason'])) {
             $type = $device->status ? 'up' : 'down';

--- a/daily.php
+++ b/daily.php
@@ -371,7 +371,13 @@ if ($options['f'] === 'recalculate_device_dependencies') {
         // update all root nodes and recurse, chunk so we don't blow up
         Device::doesntHave('parents')->with('children')->chunkById(100, function (Collection $devices) {
             // anonymous recursive function
-            $recurse = function (Device $device) use (&$recurse) {
+            $processed = [];
+            $recurse = function (Device $device) use (&$recurse, &$processed) {
+                // Do not process the same device 2 times
+                if (array_key_exists($device->device_id, $processed)) {
+                    return;
+                }
+                $processed[$device->device_id] = true;
                 $device->updateMaxDepth();
 
                 $device->children->each($recurse);

--- a/routes/console.php
+++ b/routes/console.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Jobs\PingCheck;
 use Illuminate\Support\Facades\Artisan;
 use Symfony\Component\Process\Process;
 
@@ -43,19 +44,7 @@ Artisan::command('update', function () {
 Artisan::command('poller:ping
     {groups?* : ' . __('Optional List of distributed poller groups to poll') . '}
 ', function () {
-//    PingCheck::dispatch(new PingCheck($this->argument('groups')));
-    $command = [base_path('ping.php')];
-    if ($this->argument('groups')) {
-        $command[] = '-g';
-        $command[] = implode(',', $this->argument('groups'));
-    }
-    if (($verbosity = $this->getOutput()->getVerbosity()) >= 128) {
-        $command[] = '-d';
-        if ($verbosity >= 256) {
-            $command[] = '-v';
-        }
-    }
-    (new Process($command))->setTimeout(null)->setIdleTimeout(null)->setTty(true)->run();
+    PingCheck::dispatch($this->argument('groups', []));
 })->purpose(__('Check if devices are up or down via icmp'));
 
 Artisan::command('poller:discovery


### PR DESCRIPTION
If device dependencies are created with circular dependencies, the code currently runs in a tight loop due to the MaxDepth code.  There is also a daily task to update the max_depth column, which runs forever until the server runs out of RAM.

This code adds checks in both of the loops above to make sure we don't try to process the same device twice.

Circular dependencies could be A->B->C->A, which is always an error.  The code in this request will avoid these loops, but could produce undefined results.

The other type of circular dependency, which is what we have, is where there are redundant links.  e.g. A<-B<->C<->D<->B->A.  As long as B->A is a one-way dependency the code will produce consistent results.  We have these configured in our network, which is why we were having this issue.

It does add more database requests when calculating the depth on devices, and the number of extra requests are based on the number of parents a device needs to traverse.  I couldn't see another way of doing this given that updating one device triggers all its children to re-evaluate their depth through the Device Observer code.
 
DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
