### PR TITLE
Device links formatting changes

### DIFF
--- a/LibreNMS/Util/Url.php
+++ b/LibreNMS/Util/Url.php
@@ -80,27 +80,32 @@ class Url
 
         // beginning of overlib box contains large hostname followed by hardware & OS details
         $contents = '<div><span class="list-large">' . $device->displayName() . '</span>';
+        $devinfo = '';
         if ($device->hardware) {
-            $contents .= ' - ' . htmlentities($device->hardware);
+            $devinfo .= htmlentities($device->hardware);
         }
 
         if ($device->os) {
-            $contents .= ' - ' . htmlentities(Config::getOsSetting($device->os, 'text'));
+            $devinfo .= ($devinfo ? ' - ' : '') . htmlentities(Config::getOsSetting($device->os, 'text'));
         }
 
         if ($device->version) {
-            $contents .= ' ' . htmlentities($device->version);
+            $devinfo .= ($devinfo ? ' - ' : '') . htmlentities($device->version);
         }
 
         if ($device->features) {
-            $contents .= ' (' . htmlentities($device->features) . ')';
+            $devinfo .= ' (' . htmlentities($device->features) . ')';
+        }
+
+        if ($devinfo) {
+            $contents .= '<br />' . $devinfo;
         }
 
         if ($device->location_id) {
-            $contents .= ' - ' . htmlentities($device->location ?? '');
+            $contents .= '<br />' . htmlentities($device->location ?? '');
         }
 
-        $contents .= '</div>';
+        $contents .= '</div><br />';
 
         foreach ((array) $graphs as $entry) {
             $graph = isset($entry['graph']) ? $entry['graph'] : 'unknown';

--- a/html/css/styles.css
+++ b/html/css/styles.css
@@ -1567,6 +1567,7 @@ tr.search:nth-child(odd) {
 }
 
 .minigraph-image {
+  display: inline;
   margin: 2px;
 }
 


### PR DESCRIPTION
This affects the device links pop-up that shows when you hover over a device on various pages.  The 2 changes are:
- Make the images inline so they appear side by side 
- Put newlines between the major device information sections (name, model/OS, location)

These changes make the pop-up narrower because the device name, info and location is a lot of one line, and also shorter because we get 2 graphs side by side.

Before the change the pop-up looks like this:
![image](https://github.com/librenms/librenms/assets/16013255/e1d0bcd2-2b51-40ed-9cfe-57acd13b141f)

After the change, the pop-up looks like this:
![image](https://github.com/librenms/librenms/assets/16013255/36a85a4d-1bef-438b-8a20-e03aedccb9c8)



DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
