### PR TITLE
Prevent non-unicode characters in ifAlias

### DIFF
--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -678,6 +678,7 @@ foreach ($ports as $port) {
                 } else {
                     $current_oid = \LibreNMS\Util\StringHelpers::inferEncoding($this_port['ifAlias']);
                 }
+                $current_oid = utf8_encode($current_oid); // prevent invalid non-utf8 characters
             }
             if ($oid == 'ifSpeed') {
                 $ifSpeed_override = DeviceCache::getPrimary()->getAttrib('ifSpeed:' . $port['ifName']);


### PR DESCRIPTION
non-unicode characters will show up oddly, but at least they won't cause an error.

https://community.librenms.org/t/interface-description-parsing-regex-port-descr-type-port-descr-descr-not-populated-in-database/22820
https://community.librenms.org/t/loss-of-some-graphics-after-update-23-10-0/22669/12

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
