### PR TITLE
Make vminfo.vmwVmGuestOS wider

### DIFF
--- a/database/migrations/2023_11_21_172239_increase_vminfo.vmwvmguestos_column_length.php
+++ b/database/migrations/2023_11_21_172239_increase_vminfo.vmwvmguestos_column_length.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('vminfo', function (Blueprint $table) {
+            $table->string('vmwVmGuestOS', 256)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('vminfo', function (Blueprint $table) {
+            $table->string('vmwVmGuestOS', 128)->change();
+        });
+    }
+};

--- a/misc/db_schema.yaml
+++ b/misc/db_schema.yaml
@@ -2171,7 +2171,7 @@ vminfo:
     - { Field: vm_type, Type: varchar(16), 'Null': false, Extra: '', Default: vmware }
     - { Field: vmwVmVMID, Type: int, 'Null': false, Extra: '' }
     - { Field: vmwVmDisplayName, Type: varchar(128), 'Null': false, Extra: '' }
-    - { Field: vmwVmGuestOS, Type: varchar(128), 'Null': true, Extra: '' }
+    - { Field: vmwVmGuestOS, Type: varchar(256), 'Null': true, Extra: '' }
     - { Field: vmwVmMemSize, Type: int, 'Null': false, Extra: '' }
     - { Field: vmwVmCpus, Type: int, 'Null': false, Extra: '' }
     - { Field: vmwVmState, Type: 'smallint unsigned', 'Null': false, Extra: '' }


### PR DESCRIPTION
With tools installed, the string provided by ESXi contains a lot more information. In 8.9, Red Hat have further extended the string to include a machine readable string, parsable by tools that are compatible with OVAL:

Linux 4.18.0-513.5.1.el8_9.x86_64 Red Hat Enterprise Linux 8.9 (Ootpa) 8.9 Red Hat Enterprise Linux 8.9 (Ootpa) cpe:/o:redhat:enterprise_linux:8::baseos

I looked at extracting a substring, but if anyone is actually looking to use LibreNMS as a source of data to feed into other tools, having that OVAL string is probably quite useful.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
