### PR TITLE
Set array before use to stop discovery erroring

### DIFF
--- a/includes/discovery/sensors/temperature/axiscam.inc.php
+++ b/includes/discovery/sensors/temperature/axiscam.inc.php
@@ -6,6 +6,7 @@ echo 'AXIS Temperatures ';
 $oids_tmp = snmpwalk_cache_multi_oid($device, 'tempSensorTable', [], 'AXIS-VIDEO-MIB');
 $cur_oid = '.1.3.6.1.4.1.368.4.1.3.1.4.1.';
 
+$oids = [];
 // Exclude from $oids content .common string
 foreach ($oids_tmp as $key_oids_tmp => $val_oids_tmp) {
     $oids[str_replace('common.', '', $key_oids_tmp)] = $val_oids_tmp;


### PR DESCRIPTION
https://community.librenms.org/t/error-on-discovery-sensors-on-axis-camera/22944/2

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
