### PR TITLE
bug - XDSL adslAtucCurrOutputPwr exception (Cisco CSCvj53634)

### DIFF
--- a/LibreNMS/Modules/Xdsl.php
+++ b/LibreNMS/Modules/Xdsl.php
@@ -137,6 +137,10 @@ class Xdsl implements Module
             // Values are 1/10
             foreach ($this->adslTenthValues as $oid) {
                 if (isset($data[$oid])) {
+                    if ($oid == 'adslAtucCurrOutputPwr' && $data[$oid] > 0x7FFFFFFF) {
+                        // workaround Cisco Bug CSCvj53634
+                        $data[$oid] -= 0x100000000;
+                    }
                     $data[$oid] = $data[$oid] / 10;
                 }
             }
@@ -206,12 +210,12 @@ class Xdsl implements Module
         $rrd_def = RrdDefinition::make()
             ->addDataset('AtucCurrSnrMgn', 'GAUGE', 0, 635)
             ->addDataset('AtucCurrAtn', 'GAUGE', 0, 635)
-            ->addDataset('AtucCurrOutputPwr', 'GAUGE', 0, 635)
+            ->addDataset('AtucCurrOutputPwr', 'GAUGE', -100, 635)
             ->addDataset('AtucCurrAttainableR', 'GAUGE', 0)
             ->addDataset('AtucChanCurrTxRate', 'GAUGE', 0)
             ->addDataset('AturCurrSnrMgn', 'GAUGE', 0, 635)
             ->addDataset('AturCurrAtn', 'GAUGE', 0, 635)
-            ->addDataset('AturCurrOutputPwr', 'GAUGE', 0, 635)
+            ->addDataset('AturCurrOutputPwr', 'GAUGE', -100, 635)
             ->addDataset('AturCurrAttainableR', 'GAUGE', 0)
             ->addDataset('AturChanCurrTxRate', 'GAUGE', 0)
             ->addDataset('AtucPerfLofs', 'COUNTER', null, 100000000000)

--- a/LibreNMS/Modules/Xdsl.php
+++ b/LibreNMS/Modules/Xdsl.php
@@ -137,9 +137,9 @@ class Xdsl implements Module
             // Values are 1/10
             foreach ($this->adslTenthValues as $oid) {
                 if (isset($data[$oid])) {
-                    if ($oid == 'adslAtucCurrOutputPwr' && $data[$oid] > 0x7FFFFFFF) {
+                    if ($oid == 'adslAtucCurrOutputPwr') {
                         // workaround Cisco Bug CSCvj53634
-                        $data[$oid] -= 0x100000000;
+                        $data[$oid] = Number::unsignedAsSigned($data[$oid]);
                     }
                     $data[$oid] = $data[$oid] / 10;
                 }

--- a/LibreNMS/Modules/Xdsl.php
+++ b/LibreNMS/Modules/Xdsl.php
@@ -296,8 +296,8 @@ class Xdsl implements Module
             'ifName' => $os->ifIndexToName($ifIndex),
             'rrd_name' => Rrd::portName($port->port_id, 'xdsl2LineStatusActAtp'),
             'rrd_def' => RrdDefinition::make()
-                ->addDataset('ds', 'GAUGE', 0)
-                ->addDataset('us', 'GAUGE', 0),
+                ->addDataset('ds', 'GAUGE', -100)
+                ->addDataset('us', 'GAUGE', -100),
         ], [
             'ds' => $data['xdsl2LineStatusActAtpDs'] ?? null,
             'us' => $data['xdsl2LineStatusActAtpUs'] ?? null,

--- a/LibreNMS/Util/Number.php
+++ b/LibreNMS/Util/Number.php
@@ -30,8 +30,8 @@ class Number
     public static function unsignedAsSigned($value, $numberBytes = 4)
     {
         // defaults to 4 bytes, or 32 bits
-        if ($value > ((0x100**($numberBytes)) / 2) - 1) {
-            return ($value - (0x100**($numberBytes)));
+        if ($value > ((0x100 ** $numberBytes) / 2) - 1) {
+            return $value - (0x100 ** $numberBytes);
         }
         return $value;
     }

--- a/LibreNMS/Util/Number.php
+++ b/LibreNMS/Util/Number.php
@@ -27,16 +27,6 @@ namespace LibreNMS\Util;
 
 class Number
 {
-    public static function unsignedAsSigned($value, $numberBytes = 4)
-    {
-        // defaults to 4 bytes, or 32 bits
-        if ($value > ((0x100 ** $numberBytes) / 2) - 1) {
-            return $value - (0x100 ** $numberBytes);
-        }
-
-        return $value;
-    }
-
     public static function formatBase($value, $base = 1000, $round = 2, $sf = 3, $suffix = 'B')
     {
         return $base == 1000
@@ -184,5 +174,15 @@ class Number
         }
 
         return (int) ($number * (1024 ** $exponent));
+    }
+
+    public static function unsignedAsSigned(int $value, $numberBytes = 4): int
+    {
+        // defaults to 4 bytes, or 32 bits
+        if ($value > ((0x100 ** $numberBytes) / 2) - 1) {
+            return $value - (0x100 ** $numberBytes);
+        }
+
+        return $value;
     }
 }

--- a/LibreNMS/Util/Number.php
+++ b/LibreNMS/Util/Number.php
@@ -176,13 +176,21 @@ class Number
         return (int) ($number * (1024 ** $exponent));
     }
 
-    public static function unsignedAsSigned(int $value, $numberBytes = 4): int
+    public static function unsignedAsSigned(int $unsignedValue, int $bitLength = 32): int
     {
-        // defaults to 4 bytes, or 32 bits
-        if ($value > ((0x100 ** $numberBytes) / 2) - 1) {
-            return $value - (0x100 ** $numberBytes);
+        // Maximum representable value for signed integer
+        $maxSignedValue = pow(2, $bitLength - 1) - 1;
+
+        // Check if the unsigned value is greater than the maximum representable unsigned value
+        // If so, convert it to its two's complement representation
+        if ($unsignedValue > $maxSignedValue) {
+            if ($unsignedValue > 2 ** $bitLength - 1) {
+                throw new \InvalidArgumentException('Unsigned value exceeds the maximum representable value of the give bit length: ' . $bitLength);
+            }
+
+            return $unsignedValue - ($maxSignedValue + 1) * 2;
         }
 
-        return $value;
+        return $unsignedValue;
     }
 }

--- a/LibreNMS/Util/Number.php
+++ b/LibreNMS/Util/Number.php
@@ -33,6 +33,7 @@ class Number
         if ($value > ((0x100 ** $numberBytes) / 2) - 1) {
             return $value - (0x100 ** $numberBytes);
         }
+
         return $value;
     }
 

--- a/LibreNMS/Util/Number.php
+++ b/LibreNMS/Util/Number.php
@@ -27,6 +27,15 @@ namespace LibreNMS\Util;
 
 class Number
 {
+    public static function unsignedAsSigned($value, $numberBytes = 4)
+    {
+        // defaults to 4 bytes, or 32 bits
+        if ($value > ((0x100**($numberBytes)) / 2) - 1) {
+            return ($value - (0x100**($numberBytes)));
+        }
+        return $value;
+    }
+
     public static function formatBase($value, $base = 1000, $round = 2, $sf = 3, $suffix = 'B')
     {
         return $base == 1000

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -129,7 +129,7 @@ class FunctionsTest extends TestCase
 
     public function testNumberAsUnsigned()
     {
-        $this->assertSame(42, Number::unsignedAsSigned('42'));
+        $this->assertSame(42, Number::unsignedAsSigned('42'));  /** @phpstan-ignore-line */
         $this->assertSame(2147483647, Number::unsignedAsSigned(2147483647));
         $this->assertSame(-2147483648, Number::unsignedAsSigned(2147483648));
         $this->assertSame(-2147483647, Number::unsignedAsSigned(2147483649));

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -126,4 +126,21 @@ class FunctionsTest extends TestCase
         $this->assertSame(1, Number::cast(1.0));
         $this->assertSame(2, Number::cast('2.000'));
     }
+    
+    public function testNumberAsUnsigned()
+    {
+        $this->assertSame(42, Number::unsignedAsSigned("42"));
+        $this->assertSame(2147483647, Number::unsignedAsSigned(2147483647));
+        $this->assertSame(-2147483648, Number::unsignedAsSigned(2147483648));
+        $this->assertSame(-2147483647, Number::unsignedAsSigned(2147483649));
+        $this->assertSame(-1, Number::unsignedAsSigned(4294967295));
+    }
+
+    public function testNumberAsUnsignedValueExceedsMaxUnsignedValue()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        // Exceeds the maximum representable value for a 32-bit unsigned integer
+        Number::unsignedAsSigned(4294967296, 32);
+    }
 }

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -126,10 +126,10 @@ class FunctionsTest extends TestCase
         $this->assertSame(1, Number::cast(1.0));
         $this->assertSame(2, Number::cast('2.000'));
     }
-    
+
     public function testNumberAsUnsigned()
     {
-        $this->assertSame(42, Number::unsignedAsSigned("42"));
+        $this->assertSame(42, Number::unsignedAsSigned('42'));
         $this->assertSame(2147483647, Number::unsignedAsSigned(2147483647));
         $this->assertSame(-2147483648, Number::unsignedAsSigned(2147483648));
         $this->assertSame(-2147483647, Number::unsignedAsSigned(2147483649));


### PR DESCRIPTION
Workaround for Cisco CSCvj53634 (basically, signed int handled as unsigned, so negative values (-9.6 dbm for instance) ends up with this error in librenms.log : 

```
SQLSTATE[22003]: Numeric value out of range: 1264 Out of range value for column 'adslAtucCurrOutputPwr' at row 1 (Connection: mysql, SQL: update `ports_adsl` set `adslAtucCurrSnrMgn` = 15.7, `adslAtucCurrAtn` = 0, `adslAtucCurrOutputPwr` = 429496720, `adslAtucCurrAttainableRate` = 48103000, `adslAturCurrAtn` = 0 where `port_id` = 289396) {"exception":"[object] (Illuminate\\Database\\QueryException(code: 22003): SQLSTATE[22003]: Numeric value out of range: 1264 Out of range value for column 'adslAtucCurrOutputPwr' at row 1 (Connection: mysql, SQL: update `ports_adsl` set `adslAtucCurrSnrMgn` = 15.7, `adslAtucCurrAtn` = 0, `adslAtucCurrOutputPwr` = 429496720, `adslAtucCurrAttainableRate` = 48103000, `adslAturCurrAtn` = 0 where `port_id` = 289396) at /opt/librenms/vendor/laravel/framework/src/Illuminate/Database/Connection.php:795)
```

No tests so far for Xdsl module so no tests to upgrade.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
