### PR TITLE
Fix grabled characters when oid already UTF-8

### DIFF
--- a/includes/discovery/sensors/rittal-cmc-iii-sensors.inc.php
+++ b/includes/discovery/sensors/rittal-cmc-iii-sensors.inc.php
@@ -22,6 +22,9 @@
  * @copyright 2020 Denny Friebe
  * @author    Denny Friebe <denny.friebe@icera-network.de>
  */
+
+use LibreNMS\Util\StringHelpers;
+
 $cmc_iii_var_table = snmpwalk_cache_oid($device, 'cmcIIIVarTable', [], 'RITTAL-CMC-III-MIB', null);
 $cmc_iii_sensors = [];
 
@@ -77,7 +80,7 @@ foreach ($cmc_iii_var_table as $index => $entry) {
             }
 
             // encode string to ensure that degree sign may be used properly for unit comparison
-            $unit = utf8_encode($entry['cmcIIIVarUnit']);
+            $unit = StringHelpers::inferEncoding($entry['cmcIIIVarUnit']);
             $type = 'state';
             $temperature_units = ['degree C', 'degree F', '°C', '°F'];
             if ($unit == 'mA') {

--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -6,6 +6,7 @@ use LibreNMS\RRD\RrdDefinition;
 use LibreNMS\Util\Debug;
 use LibreNMS\Util\Mac;
 use LibreNMS\Util\Number;
+use LibreNMS\Util\StringHelpers;
 
 // Build SNMP Cache Array
 $data_oids = [
@@ -676,9 +677,9 @@ foreach ($ports as $port) {
                     // handle legacy '1' setting, otherwise use value set by override
                     $current_oid = $ifAlias_override === '1' ? $port['ifAlias'] : $ifAlias_override;
                 } else {
-                    $current_oid = \LibreNMS\Util\StringHelpers::inferEncoding($this_port['ifAlias']);
+                    $current_oid = $this_port['ifAlias'];
                 }
-                $current_oid = utf8_encode($current_oid); // prevent invalid non-utf8 characters
+                $current_oid = StringHelpers::inferEncoding($current_oid); // prevent invalid non-utf8 characters
             }
             if ($oid == 'ifSpeed') {
                 $ifSpeed_override = DeviceCache::getPrimary()->getAttrib('ifSpeed:' . $port['ifName']);


### PR DESCRIPTION
Please give a short description what your pull request is for

This will fix a oid characters issue that when oid returns a already UTF-8 string, utf8_encode will make grabled, and also the `utf8_encode` is deprecated since PHP8.2.0

For a test run is here:

<img width="450" alt="image" src="https://github.com/librenms/librenms/assets/10653144/ff03281a-83b8-4d31-b5bc-caad5a9248c2">


#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
