### PR TITLE
bug - ADSL ifIndex to port error not handled

### DIFF
--- a/LibreNMS/Modules/Xdsl.php
+++ b/LibreNMS/Modules/Xdsl.php
@@ -150,6 +150,11 @@ class Xdsl implements Module
 
             $portAdsl->port_id = $os->ifIndexToId($ifIndex);
 
+            if ($portAdsl->port_id == 0) {
+                // failure of ifIndexToId(), port_id is invalid, and syncModels will crash
+                continue;
+            }
+
             if ($datastore) {
                 $this->storeAdsl($portAdsl, $data, (int) $ifIndex, $os, $datastore);
                 echo ' ADSL(' . $portAdsl->adslLineCoding . '/' . Number::formatSi($portAdsl->adslAtucChanCurrTxRate, 2, 3, 'bps') . '/' . Number::formatSi($portAdsl->adslAturChanCurrTxRate, 2, 3, 'bps') . ') ';

--- a/LibreNMS/Modules/Xdsl.php
+++ b/LibreNMS/Modules/Xdsl.php
@@ -152,6 +152,7 @@ class Xdsl implements Module
 
             if ($portAdsl->port_id == 0) {
                 // failure of ifIndexToId(), port_id is invalid, and syncModels will crash
+                echo ' ADSL( Failed to discover this port, ifIndex invalid : ' . $portAdsl->adslLineCoding . '/' . Number::formatSi($portAdsl->adslAtucChanCurrTxRate, 2, 3, 'bps') . '/' . Number::formatSi($portAdsl->adslAturChanCurrTxRate, 2, 3, 'bps') . ') ';
                 continue;
             }
 


### PR DESCRIPTION
Function ifIndexToId (in `$portAdsl->port_id = $os->ifIndexToId($ifIndex);`) can fail and return 0 instead of a valid port_id. A crash of XDSL module will occur when syncing data if we don't catch it properly here. 

```
 PDOException: SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry '0' for key 'ports_adsl_port_id_unique' in /opt/librenms/vendor/laravel/framework/src/Illuminate/Database/Connection.php:580
Stack trace:
#0 /opt/librenms/vendor/laravel/framework/src/Illuminate/Database/Connection.php(580): PDOStatement->execute()
#1 /opt/librenms/vendor/laravel/framework/src/Illuminate/Database/Connection.php(788): Illuminate\Database\Connection->Illuminate\Database\{closure}()
#2 /opt/librenms/vendor/laravel/framework/src/Illuminate/Database/Connection.php(755): Illuminate\Database\Connection->runQueryCallback()
#3 /opt/librenms/vendor/laravel/framework/src/Illuminate/Database/Connection.php(581): Illuminate\Database\Connection->run()
#4 /opt/librenms/vendor/laravel/framework/src/Illuminate/Database/Connection.php(533): Illuminate\Database\Connection->statement()
#5 /opt/librenms/vendor/laravel/framework/src/Illuminate/Database/Query/Processors/Processor.php(32): Illuminate\Database\Connection->insert()
#6 /opt/librenms/vendor/laravel/framework/src/Illuminate/Database/Query/Builder.php(3383): Illuminate\Database\Query\Processors\Processor->processInsertGetId()
#7 /opt/librenms/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Builder.php(1925): Illuminate\Database\Query\Builder->insertGetId()
#8 /opt/librenms/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Model.php(1333): Illuminate\Database\Eloquent\Builder->__call()
#9 /opt/librenms/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Model.php(1298): Illuminate\Database\Eloquent\Model->insertAndSetId()
#10 /opt/librenms/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Model.php(1137): Illuminate\Database\Eloquent\Model->performInsert()
#11 /opt/librenms/vendor/laravel/framework/src/Illuminate/Collections/HigherOrderCollectionProxy.php(60): Illuminate\Database\Eloquent\Model->save()
#12 /opt/librenms/vendor/laravel/framework/src/Illuminate/Collections/Traits/EnumeratesValues.php(236): Illuminate\Support\HigherOrderCollectionProxy->Illuminate\Support\{closure}()
#13 /opt/librenms/vendor/laravel/framework/src/Illuminate/Collections/HigherOrderCollectionProxy.php(61): Illuminate\Support\Collection->each()
#14 /opt/librenms/LibreNMS/DB/SyncsModels.php(70): Illuminate\Support\HigherOrderCollectionProxy->__call()
#15 /opt/librenms/LibreNMS/Modules/Xdsl.php(163): LibreNMS\Modules\Xdsl->syncModels()
#16 /opt/librenms/LibreNMS/Modules/Xdsl.php(74): LibreNMS\Modules\Xdsl->pollAdsl()
#17 /opt/librenms/includes/discovery/xdsl.inc.php(8): LibreNMS\Modules\Xdsl->discover()
#18 /opt/librenms/includes/discovery/functions.inc.php(164): include('...')
#19 /opt/librenms/discovery.php(108): discover_device()
#20 {main}
```

After fix: 

```
#### Load disco module xdsl ####
 ADSL( Failed to discover this port, ifIndex invalid : 2/33.17 Mbps/10.23 Mbps) ..
>> Runtime for discovery module 'xdsl': 0.1390 seconds with 443096 bytes
>> SNMP: [3/0.13s] MySQL: [3/0.02s] RRD: [0/0.00s]  
#### Unload disco module xdsl ####

```

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
