### PR TITLE
device - fix Counter64 octets value in 32bit column bgpPeerInTotalMessages

### DIFF
--- a/includes/polling/bgp-peers.inc.php
+++ b/includes/polling/bgp-peers.inc.php
@@ -238,8 +238,8 @@ if (! empty($peers)) {
                     } else {
                         $peer_data['bgpPeerAdminStatus'] = $bgpPeers[$vrfOid][$address]['tBgpPeerNgOperLastEvent'];
                     }
-                    $peer_data['bgpPeerInTotalMessages'] = $bgpPeers[$vrfOid][$address]['tBgpPeerNgOperMsgOctetsRcvd'];  // That are actually only octets available,
-                    $peer_data['bgpPeerOutTotalMessages'] = $bgpPeers[$vrfOid][$address]['tBgpPeerNgOperMsgOctetsSent']; // not messages
+                    $peer_data['bgpPeerInTotalMessages'] = $bgpPeers[$vrfOid][$address]['tBgpPeerNgOperMsgOctetsRcvd'] % (2 ** 32);  // That are actually only octets available,
+                    $peer_data['bgpPeerOutTotalMessages'] = $bgpPeers[$vrfOid][$address]['tBgpPeerNgOperMsgOctetsSent'] % (2 ** 32); // not messages
                     $peer_data['bgpPeerFsmEstablishedTime'] = $establishedTime;
                 } elseif ($device['os'] == 'firebrick') {
                     // ToDo, It seems that bgpPeer(In|Out)Updates and bgpPeerInUpdateElapsedTime are actually not available over SNMP


### PR DESCRIPTION
Nokia is not providing bgpPeerInTotalMessages (and bgpPeerOutTotalMessages) via their own MIB and do not support BGP4-MIB. 

Current support in LibreNMS uses the Octet Received and Sent to feed these 2 column. 

Of course, when this Octet value crosses the 32bits limit, polling crashes: 
```
QLSTATE[22003]: Numeric value out of range: 1264 Out of range value for column 'bgpPeerInTotalMessages' at row 1 (Connection: mysql, SQL: UPDATE bgpPeers set bgpPeerInTotalMessages=18446744072895027644,bgpPeerOutTotalMessages=29900860 WHERE device_id = 64 AND bgpPeerIdentifier = 10.15.0.1 AND vrf_id = 1) (Connection: dbFacile, SQL: UPDATE bgpPeers set bgpPeerInTotalMessages=18446744072895027644,bgpPeerOutTotalMessages=29900860 WHERE device_id = 64 AND bgpPeerIdentifier = 10.15.0.1 AND vrf_id = 1)#0 /opt/librenms/includes/polling/bgp-peers.inc.php(524): dbUpdate()
```

I see only 2 ways to fix this : 
- Avoid feeding `bgpPeerInTotalMessages` with `tBgpPeerNgOperMsgOctetsSent`. That is wrong at the beginning
  - Probably the best solution
- Put a modulo 2 exp 32 to avoid the crash if nokia owners are used to this behaviour in LibreNMS.
  - The solution that I implemented here. At least it fixes the crash

Please advise :) 

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
