### PR TITLE
Update alertlog query to be more efficient

### DIFF
--- a/includes/html/table/alertlog.inc.php
+++ b/includes/html/table/alertlog.inc.php
@@ -59,7 +59,7 @@ if (isset($searchPhrase) && ! empty($searchPhrase)) {
     $param[] = "%$searchPhrase%";
 }
 
-$sql = " FROM `alert_log` AS E LEFT JOIN devices AS D ON E.device_id=D.device_id RIGHT JOIN alert_rules AS R ON E.rule_id=R.id WHERE $where";
+$sql = " FROM `alert_log` AS E LEFT JOIN devices AS D ON E.device_id=D.device_id LEFT JOIN alert_rules AS R ON E.rule_id=R.id WHERE $where";
 
 $count_sql = "SELECT COUNT(`E`.`id`) $sql";
 $total = dbFetchCell($count_sql, $param);
@@ -92,7 +92,6 @@ if (session('preferences.timezone')) {
 $rulei = 0;
 foreach (dbFetchRows($sql, $param) as $alertlog) {
     $dev = device_by_id_cache($alertlog['device_id']);
-    logfile($alertlog['rule_id']);
     $log = dbFetchCell('SELECT details FROM alert_log WHERE rule_id = ? AND device_id = ? AND `state` = 1 ORDER BY id DESC LIMIT 1', [$alertlog['rule_id'], $alertlog['device_id']]);
     $alert_log_id = dbFetchCell('SELECT id FROM alert_log WHERE rule_id = ? AND device_id = ? ORDER BY id DESC LIMIT 1', [$alertlog['rule_id'], $alertlog['device_id']]);
     [$fault_detail, $max_row_length] = alert_details($log);


### PR DESCRIPTION
Reduces query time for high-usage installs. With 1.3m records in the alert_log table this could take 50+ seconds to run, changing to LEFT JOIN and its sub 1 second.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
