### PR TITLE
bug - timos MPLS - more poller fixes

### DIFF
--- a/LibreNMS/Modules/Mpls.php
+++ b/LibreNMS/Modules/Mpls.php
@@ -146,7 +146,7 @@ class Mpls implements Module
                 $this->syncModels($device, 'mplsSaps', $os->pollMplsSaps($svcs));
             }
 
-            if ($device->mplsSdpBinds()->exists()) {
+            if ($device->mplsSdpBinds()->exists() && isset($sdps, $svcs)) {
                 echo "\nMPLS SDP Bindings: ";
                 ModuleModelObserver::observe(\App\Models\MplsSdpBind::class);
                 $this->syncModels($device, 'mplsSdpBinds', $os->pollMplsSdpBinds($sdps, $svcs));

--- a/LibreNMS/Modules/Mpls.php
+++ b/LibreNMS/Modules/Mpls.php
@@ -140,7 +140,7 @@ class Mpls implements Module
                 $svcs = $this->syncModels($device, 'mplsServices', $os->pollMplsServices());
             }
 
-            if ($device->mplsSaps()->exists()) {
+            if ($device->mplsSaps()->exists() && isset($svcs)) {
                 echo "\nMPLS SAPs: ";
                 ModuleModelObserver::observe(\App\Models\MplsSap::class);
                 $this->syncModels($device, 'mplsSaps', $os->pollMplsSaps($svcs));

--- a/LibreNMS/OS/Timos.php
+++ b/LibreNMS/OS/Timos.php
@@ -581,7 +581,10 @@ class Timos extends OS implements MplsDiscovery, MplsPolling, WirelessPowerDisco
                 $ip = long2ip(hexdec(str_replace(' ', '', $value['sdpFarEndInetAddress'])));
             } else {
                 //Fixme implement ipv6 conversion
-                $ip = $value['sdpFarEndInetAddress'] ?? 'unknown';
+                //$value['sdpFarEndInetAddress'] might still be any of these:
+                //  -> unknown(0), ipv4(1), ipv6(2), ipv4z(3), ipv6z(4), dns(16)
+
+                $ip = $value['sdpFarEndInetAddress'] ?? null;
             }
             $sdps->push(new MplsSdp([
                 'sdp_oid' => $value['sdpId'],

--- a/LibreNMS/OS/Timos.php
+++ b/LibreNMS/OS/Timos.php
@@ -787,7 +787,11 @@ class Timos extends OS implements MplsDiscovery, MplsPolling, WirelessPowerDisco
         $arhops = new Collection();
         foreach ($mplsTunnelArHopCache as $key => $value) {
             [$mplsTunnelARHopListIndex, $mplsTunnelARHopIndex] = explode('.', $key);
-            $lsp_path_id = $paths->firstWhere('mplsLspPathTunnelARHopListIndex', $mplsTunnelARHopListIndex)->lsp_path_id;
+            $firstPath = $paths->firstWhere('mplsLspPathTunnelARHopListIndex', $mplsTunnelARHopListIndex);
+            if (!isset($firstPath)) {
+                continue;
+            }
+            $lsp_path_id = $firstPath->lsp_path_id;
             $protection = intval($value['vRtrMplsTunnelARHopProtection'] ?? 0, 16);
 
             $localLinkProtection = ($protection & $localAvailable) ? 'true' : 'false';

--- a/LibreNMS/OS/Timos.php
+++ b/LibreNMS/OS/Timos.php
@@ -788,7 +788,7 @@ class Timos extends OS implements MplsDiscovery, MplsPolling, WirelessPowerDisco
         foreach ($mplsTunnelArHopCache as $key => $value) {
             [$mplsTunnelARHopListIndex, $mplsTunnelARHopIndex] = explode('.', $key);
             $firstPath = $paths->firstWhere('mplsLspPathTunnelARHopListIndex', $mplsTunnelARHopListIndex);
-            if (!isset($firstPath)) {
+            if (! isset($firstPath)) {
                 continue;
             }
             $lsp_path_id = $firstPath->lsp_path_id;

--- a/LibreNMS/OS/Timos.php
+++ b/LibreNMS/OS/Timos.php
@@ -581,7 +581,7 @@ class Timos extends OS implements MplsDiscovery, MplsPolling, WirelessPowerDisco
                 $ip = long2ip(hexdec(str_replace(' ', '', $value['sdpFarEndInetAddress'])));
             } else {
                 //Fixme implement ipv6 conversion
-                $ip = $value['sdpFarEndInetAddress'];
+                $ip = $value['sdpFarEndInetAddress'] ?? 'unknown';
             }
             $sdps->push(new MplsSdp([
                 'sdp_oid' => $value['sdpId'],

--- a/database/migrations/2023_12_08_184652_mpls_addrtype_fix.php
+++ b/database/migrations/2023_12_08_184652_mpls_addrtype_fix.php
@@ -1,8 +1,6 @@
 <?php
 
 use Illuminate\Database\Migrations\Migration;
-use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {

--- a/database/migrations/2023_12_08_184652_mpls_addrtype_fix.php
+++ b/database/migrations/2023_12_08_184652_mpls_addrtype_fix.php
@@ -9,12 +9,12 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::table('mpls_sdps', function($table) {
+        Schema::table('mpls_sdps', function ($table) {
             // drop and recreate because of SQLite not accepting any changes.
             // data is collected again next poll anyway.
             $table->dropColumn(['sdpFarEndInetAddressType']);
         });
-        Schema::table('mpls_sdps', function($table) {
+        Schema::table('mpls_sdps', function ($table) {
             $table->enum('sdpFarEndInetAddressType', ['unknown', 'ipv4', 'ipv6', 'ipv4z', 'ipv6z', 'dns'])->nullable();
         });
     }
@@ -24,10 +24,10 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::table('mpls_sdps', function($table) {
+        Schema::table('mpls_sdps', function ($table) {
             $table->dropColumn(['sdpFarEndInetAddressType']);
         });
-        Schema::table('mpls_sdps', function($table) {
+        Schema::table('mpls_sdps', function ($table) {
             $table->enum('sdpFarEndInetAddressType', ['ipv4', 'ipv6'])->nullable();
         });
     }

--- a/database/migrations/2023_12_08_184652_mpls_addrtype_fix.php
+++ b/database/migrations/2023_12_08_184652_mpls_addrtype_fix.php
@@ -13,6 +13,8 @@ return new class extends Migration
             // drop and recreate because of SQLite not accepting any changes.
             // data is collected again next poll anyway.
             $table->dropColumn(['sdpFarEndInetAddressType']);
+        });
+        Schema::table('mpls_sdps', function($table) {
             $table->enum('sdpFarEndInetAddressType', ['unknown', 'ipv4', 'ipv6', 'ipv4z', 'ipv6z', 'dns'])->nullable();
         });
     }
@@ -24,6 +26,8 @@ return new class extends Migration
     {
         Schema::table('mpls_sdps', function($table) {
             $table->dropColumn(['sdpFarEndInetAddressType']);
+        });
+        Schema::table('mpls_sdps', function($table) {
             $table->enum('sdpFarEndInetAddressType', ['ipv4', 'ipv6'])->nullable();
         });
     }

--- a/database/migrations/2023_12_08_184652_mpls_addrtype_fix.php
+++ b/database/migrations/2023_12_08_184652_mpls_addrtype_fix.php
@@ -9,7 +9,12 @@ return new class extends Migration
      */
     public function up(): void
     {
-        DB::statement("ALTER TABLE mpls_sdps MODIFY COLUMN sdpFarEndInetAddressType ENUM('unknown', 'ipv4', 'ipv6', 'ipv4z', 'ipv6z', 'dns')");
+        Schema::table('mpls_sdps', function($table) {
+            // drop and recreate because of SQLite not accepting any changes.
+            // data is collected again next poll anyway.
+            $table->dropColumn(['sdpFarEndInetAddressType']);
+            $table->enum('sdpFarEndInetAddressType', ['unknown', 'ipv4', 'ipv6', 'ipv4z', 'ipv6z', 'dns'])->nullable();
+        });
     }
 
     /**
@@ -17,6 +22,9 @@ return new class extends Migration
      */
     public function down(): void
     {
-        DB::statement("ALTER TABLE mpls_sdps MODIFY COLUMN sdpFarEndInetAddressType ENUM('ipv4', 'ipv6')");
+        Schema::table('mpls_sdps', function($table) {
+            $table->dropColumn(['sdpFarEndInetAddressType']);
+            $table->enum('sdpFarEndInetAddressType', ['ipv4', 'ipv6'])->nullable();
+        });
     }
 };

--- a/database/migrations/2023_12_08_184652_mpls_addrtype_fix.php
+++ b/database/migrations/2023_12_08_184652_mpls_addrtype_fix.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        DB::statement("ALTER TABLE mpls_sdps MODIFY COLUMN sdpFarEndInetAddressType ENUM('unknown', 'ipv4', 'ipv6', 'ipv4z', 'ipv6z', 'dns')");
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        DB::statement("ALTER TABLE mpls_sdps MODIFY COLUMN sdpFarEndInetAddressType ENUM('ipv4', 'ipv6')");
+    }
+};

--- a/misc/db_schema.yaml
+++ b/misc/db_schema.yaml
@@ -1078,8 +1078,8 @@ mpls_sdps:
     - { Field: sdpLastMgmtChange, Type: bigint, 'Null': true, Extra: '' }
     - { Field: sdpLastStatusChange, Type: bigint, 'Null': true, Extra: '' }
     - { Field: sdpActiveLspType, Type: "enum('not-applicable','rsvp','ldp','bgp','none','mplsTp','srIsis','srOspf','srTeLsp','fpe')", 'Null': true, Extra: '' }
-    - { Field: sdpFarEndInetAddressType, Type: "enum('unknown','ipv4','ipv6','ipv4z','ipv6z','dns')", 'Null': true, Extra: '' }
     - { Field: sdpFarEndInetAddress, Type: varchar(46), 'Null': true, Extra: '' }
+    - { Field: sdpFarEndInetAddressType, Type: "enum('unknown','ipv4','ipv6','ipv4z','ipv6z','dns')", 'Null': true, Extra: '' }
   Indexes:
     PRIMARY: { Name: PRIMARY, Columns: [sdp_id], Unique: true, Type: BTREE }
     mpls_sdps_device_id_index: { Name: mpls_sdps_device_id_index, Columns: [device_id], Unique: false, Type: BTREE }

--- a/misc/db_schema.yaml
+++ b/misc/db_schema.yaml
@@ -1078,7 +1078,7 @@ mpls_sdps:
     - { Field: sdpLastMgmtChange, Type: bigint, 'Null': true, Extra: '' }
     - { Field: sdpLastStatusChange, Type: bigint, 'Null': true, Extra: '' }
     - { Field: sdpActiveLspType, Type: "enum('not-applicable','rsvp','ldp','bgp','none','mplsTp','srIsis','srOspf','srTeLsp','fpe')", 'Null': true, Extra: '' }
-    - { Field: sdpFarEndInetAddressType, Type: "enum('ipv4','ipv6')", 'Null': true, Extra: '' }
+    - { Field: sdpFarEndInetAddressType, Type: "enum('unknown','ipv4','ipv6','ipv4z','ipv6z','dns')", 'Null': true, Extra: '' }
     - { Field: sdpFarEndInetAddress, Type: varchar(46), 'Null': true, Extra: '' }
   Indexes:
     PRIMARY: { Name: PRIMARY, Columns: [sdp_id], Unique: true, Type: BTREE }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -51,16 +51,6 @@ parameters:
 			path: LibreNMS/Modules/Mpls.php
 
 		-
-			message: "#^Variable \\$sdps might not be defined\\.$#"
-			count: 1
-			path: LibreNMS/Modules/Mpls.php
-
-		-
-			message: "#^Variable \\$svcs might not be defined\\.$#"
-			count: 2
-			path: LibreNMS/Modules/Mpls.php
-
-		-
 			message: "#^Variable \\$features on left side of \\?\\? is never defined\\.$#"
 			count: 1
 			path: LibreNMS/Modules/Os.php


### PR DESCRIPTION
A few more fixes for Nokia (TImos) and mostly MPLS code. 
Includes a migration for AddrType column which can take other values than ipv4 and ipv6, currently causing a crash

```
SQLSTATE[01000]: Warning: 1265 Data truncated for column 'sdpFarEndInetAddressType' at row 1 (Connection: mysql, SQL: update mpls_sdps set sdpFarEndInetAddressType = unknown where sdp_id = 286) {"exception":"[object] (Illuminate\Database\QueryException(code: 01000): SQLSTATE[01000]: Warning: 1265 Data truncated for column 'sdpFarEndInetAddressType' at row 1 (Connection: mysql, SQL: update mpls_sdps set sdpFarEndInetAddressType = unknown where sdp_id = 286) at /opt/librenms/vendor/laravel/framework/src/Illuminate/Database/Connection.php:795)
```

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
