### PR TITLE
bug - FDB Table - allow empty searchby as well

### DIFF
--- a/app/Http/Controllers/Table/FdbTablesController.php
+++ b/app/Http/Controllers/Table/FdbTablesController.php
@@ -46,7 +46,7 @@ class FdbTablesController extends TableController
         return [
             'port_id' => 'nullable|integer',
             'device_id' => 'nullable|integer',
-            'searchby' => 'in:mac,vlan,dnsname,ip,description,first_seen,last_seen,vendor',
+            'searchby' => 'in:mac,vlan,dnsname,ip,description,first_seen,last_seen,vendor,',
             'dns' => 'nullable|in:true,false',
         ];
     }


### PR DESCRIPTION
This is a follow up of https://github.com/librenms/librenms/pull/15619

Allowing empty searchby is necessary to allow the page to load the complete list ... 

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
