### PR TITLE
bug - Fix Cisco NTP values

### DIFF
--- a/includes/polling/ntp/cisco.inc.php
+++ b/includes/polling/ntp/cisco.inc.php
@@ -54,9 +54,27 @@ if (is_array($components) && count($components) > 0) {
 
         // Extract the statistics and update rrd
         $rrd['stratum'] = $array['stratum'];
-        $rrd['offset'] = hexdec($cntpPeersVarEntry['1.3.6.1.4.1.9.9.168.1.2.1.1'][23][$array['UID']]);
-        $rrd['delay'] = hexdec($cntpPeersVarEntry['1.3.6.1.4.1.9.9.168.1.2.1.1'][24][$array['UID']]);
-        $rrd['dispersion'] = hexdec($cntpPeersVarEntry['1.3.6.1.4.1.9.9.168.1.2.1.1'][25][$array['UID']]);
+
+        // Cisco NTPSignedTimeValue - 16 bits of signedint, and 16 bits of unsignedint for fractional
+        // The time in seconds that could represent signed quantities like time delay with respect to some
+        // source. This textual-convention is specific to Cisco implementation of NTP where 32-bit integers are
+        // used for such quantities. The signed integer part is in the first 16 bits and the fraction part is in
+        // the last 16 bits.
+
+        $hexoffset = $cntpPeersVarEntry['1.3.6.1.4.1.9.9.168.1.2.1.1'][23][$array['UID']];
+        $rrd['offset'] = hexdec(substr($hexoffset, 0, 5));
+        $rrd['offset'] = ($rrd['offset'] > ((0x100 ** 2) / 2) - 1) ? $rrd['offset'] - (0x100 ** 2) : $rrd['offset'];
+        $rrd['offset'] += hexdec(substr($hexoffset, -5)) / 65536;
+
+        $hexdelay = $cntpPeersVarEntry['1.3.6.1.4.1.9.9.168.1.2.1.1'][24][$array['UID']];
+        $rrd['delay'] = hexdec(substr($hexdelay, 0, 5));
+        $rrd['delay'] = ($rrd['delay'] > ((0x100 ** 2) / 2) - 1) ? $rrd['delay'] - (0x100 ** 2) : $rrd['delay'];
+        $rrd['delay'] += hexdec(substr($hexdelay, -5)) / 65536;
+
+        // Cisco NTPUnsignedTimeValue - 16 bits of unsignedint, and 16 bits of unsignedint for fractional
+        $hexdisp = $cntpPeersVarEntry['1.3.6.1.4.1.9.9.168.1.2.1.1'][25][$array['UID']];
+        $rrd['dispersion'] = hexdec(substr($hexdisp, 0, 5)) + hexdec(substr($hexdisp, -5)) / 65536;
+
         $tags = compact('ntp', 'rrd_name', 'rrd_def', 'peer');
         data_update($device, 'ntp', $tags, $rrd);
 

--- a/includes/polling/ntp/cisco.inc.php
+++ b/includes/polling/ntp/cisco.inc.php
@@ -62,14 +62,10 @@ if (is_array($components) && count($components) > 0) {
         // the last 16 bits.
 
         $hexoffset = $cntpPeersVarEntry['1.3.6.1.4.1.9.9.168.1.2.1.1'][23][$array['UID']];
-        $rrd['offset'] = hexdec(substr($hexoffset, 0, 5));
-        $rrd['offset'] = ($rrd['offset'] > ((0x100 ** 2) / 2) - 1) ? $rrd['offset'] - (0x100 ** 2) : $rrd['offset'];
-        $rrd['offset'] += hexdec(substr($hexoffset, -5)) / 65536;
+        $rrd['offset'] = Number::unsignedAsSigned(hexdec(substr($hexoffset, 0, 5)), 16) + hexdec(substr($hexoffset, -5)) / 65536;
 
         $hexdelay = $cntpPeersVarEntry['1.3.6.1.4.1.9.9.168.1.2.1.1'][24][$array['UID']];
-        $rrd['delay'] = hexdec(substr($hexdelay, 0, 5));
-        $rrd['delay'] = ($rrd['delay'] > ((0x100 ** 2) / 2) - 1) ? $rrd['delay'] - (0x100 ** 2) : $rrd['delay'];
-        $rrd['delay'] += hexdec(substr($hexdelay, -5)) / 65536;
+        $rrd['delay'] = Number::unsignedAsSigned(hexdec(substr($hexdelay, 0, 5)), 16) + hexdec(substr($hexdelay, -5)) / 65536;
 
         // Cisco NTPUnsignedTimeValue - 16 bits of unsignedint, and 16 bits of unsignedint for fractional
         $hexdisp = $cntpPeersVarEntry['1.3.6.1.4.1.9.9.168.1.2.1.1'][25][$array['UID']];


### PR DESCRIPTION
Cisco devices reply a pair of 16 bit hex values for 3 of the NTP metrics ( delay, offset and dispersion). 1st member of the pair is either signed or unsigned, and second is the fractional part and is always unsigned. Conversion must be done separately for both 2 Bytes Words, and the fractional part must be divided by 2^16 and added to the 1st part. 

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
