### PR TITLE
Update the type of nummonbssid column in the access_points table

### DIFF
--- a/database/migrations/2023_12_15_105529_access_points_nummonbssid_integer.php
+++ b/database/migrations/2023_12_15_105529_access_points_nummonbssid_integer.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration 
+return new class extends Migration
 {
     /**
      * Run the migrations.

--- a/database/migrations/2023_12_15_105529_access_points_nummonbssid_integer.php
+++ b/database/migrations/2023_12_15_105529_access_points_nummonbssid_integer.php
@@ -4,7 +4,8 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration {
+return new class extends Migration 
+{
     /**
      * Run the migrations.
      */

--- a/database/migrations/2023_12_15_105529_access_points_nummonbssid_integer.php
+++ b/database/migrations/2023_12_15_105529_access_points_nummonbssid_integer.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('access_points', function (Blueprint $table) {
+            $table->integer('nummonbssid')->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('access_points', function (Blueprint $table) {
+            $table->tinyInteger('nummonbssid')->change();
+        });
+    }
+};

--- a/misc/db_schema.yaml
+++ b/misc/db_schema.yaml
@@ -28,7 +28,7 @@ access_points:
     - { Field: numasoclients, Type: smallint, 'Null': false, Extra: '', Default: '0' }
     - { Field: nummonclients, Type: smallint, 'Null': false, Extra: '', Default: '0' }
     - { Field: numactbssid, Type: tinyint, 'Null': false, Extra: '', Default: '0' }
-    - { Field: nummonbssid, Type: tinyint, 'Null': false, Extra: '', Default: '0' }
+    - { Field: nummonbssid, Type: int, 'Null': false, Extra: '', Default: '0' }
     - { Field: interference, Type: 'tinyint unsigned', 'Null': false, Extra: '' }
   Indexes:
     PRIMARY: { Name: PRIMARY, Columns: [accesspoint_id], Unique: true, Type: BTREE }


### PR DESCRIPTION
When I perform polling on the Aruba-Controller device, the following error occurs

```
SQLSTATE[22003]: Numeric value out of range: 1264 Out of range value for column 'nummonbssid' at row 1 (Connection: mysql, SQL: UPDATE `access_points` set `channel`=11,`deleted`=0,`interference`=43,`mac_addr`=d8:c7:c8:c7:14:cf,`name`=D-129,`numactbssid`=8,`numasoclients`=0,`nummonbssid`=139,`nummonclients`=10,`radio_number`=2,`radioutil`=76,`txpow`=15,`type`=dot11g WHERE `accesspoint_id` = 562) (Connection: dbFacile, SQL: UPDATE `access_points` set `channel`=11,`deleted`=0,`interference`=43,`mac_addr`=d8:c7:c8:c7:14:cf,`name`=D-129,`numactbssid`=8,`numasoclients`=0,`nummonbssid`=139,`nummonclients`=10,`radio_number`=2,`radioutil`=76,`txpow`=15,`type`=dot11g WHERE `accesspoint_id` = 562)#0 /opt/librenms/includes/polling/aruba-controller.inc.php(184): dbUpdate()
#1 /opt/librenms/LibreNMS/Modules/LegacyModule.php(114): include('...')
#2 /opt/librenms/LibreNMS/Poller.php(176): LibreNMS\Modules\LegacyModule->poll()
#3 /opt/librenms/LibreNMS/Poller.php(103): LibreNMS\Poller->pollModules()
#4 /opt/librenms/app/Console/Commands/DevicePoll.php(44): LibreNMS\Poller->poll()
#5 /opt/librenms/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(36): App\Console\Commands\DevicePoll->handle()
#6 /opt/librenms/vendor/laravel/framework/src/Illuminate/Container/Util.php(41): Illuminate\Container\BoundMethod::Illuminate\Container\{closure}()
#7 /opt/librenms/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(93): Illuminate\Container\Util::unwrapIfClosure()
#8 /opt/librenms/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(37): Illuminate\Container\BoundMethod::callBoundMethod()
#9 /opt/librenms/vendor/laravel/framework/src/Illuminate/Container/Container.php(662): Illuminate\Container\BoundMethod::call()
#10 /opt/librenms/vendor/laravel/framework/src/Illuminate/Console/Command.php(208): Illuminate\Container\Container->call()
#11 /opt/librenms/vendor/symfony/console/Command/Command.php(326): Illuminate\Console\Command->execute()
#12 /opt/librenms/vendor/laravel/framework/src/Illuminate/Console/Command.php(178): Symfony\Component\Console\Command\Command->run()
#13 /opt/librenms/vendor/symfony/console/Application.php(1081): Illuminate\Console\Command->run()
#14 /opt/librenms/vendor/symfony/console/Application.php(320): Symfony\Component\Console\Application->doRunCommand()
#15 /opt/librenms/vendor/symfony/console/Application.php(174): Symfony\Component\Console\Application->doRun()
#16 /opt/librenms/vendor/laravel/framework/src/Illuminate/Foundation/Console/Kernel.php(201): Symfony\Component\Console\Application->run()
#17 /opt/librenms/app/Console/Kernel.php(66): Illuminate\Foundation\Console\Kernel->handle()
#18 /opt/librenms/lnms(40): App\Console\Kernel->handle()
#19 {main}  
```
Because the number of visible BSSIDs is too large and exceeds the acceptable range of tinyint, changing the nummonbssid type from tinyint to int solves this problem.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
