### PR TITLE
Update Pushover.php

### DIFF
--- a/LibreNMS/Alert/Transport/Pushover.php
+++ b/LibreNMS/Alert/Transport/Pushover.php
@@ -53,7 +53,7 @@ class Pushover extends Transport
         $data['token'] = $this->config['appkey'];
         $data['user'] = $this->config['userkey'];
         // Entities are html encoded so this will cause them to be displayed correctly in pushover alerts
-        $data['html'] = "1";
+        $data['html'] = '1';
         switch ($alert_data['severity']) {
             case 'critical':
                 $data['priority'] = 1;

--- a/LibreNMS/Alert/Transport/Pushover.php
+++ b/LibreNMS/Alert/Transport/Pushover.php
@@ -52,7 +52,8 @@ class Pushover extends Transport
         $data = [];
         $data['token'] = $this->config['appkey'];
         $data['user'] = $this->config['userkey'];
-        $data['html'] = "1"; // Entities are html encoded so this will cause them to be displayed correctly in pushover alerts
+        // Entities are html encoded so this will cause them to be displayed correctly in pushover alerts
+        $data['html'] = "1";
         switch ($alert_data['severity']) {
             case 'critical':
                 $data['priority'] = 1;

--- a/LibreNMS/Alert/Transport/Pushover.php
+++ b/LibreNMS/Alert/Transport/Pushover.php
@@ -52,6 +52,7 @@ class Pushover extends Transport
         $data = [];
         $data['token'] = $this->config['appkey'];
         $data['user'] = $this->config['userkey'];
+        $data['html'] = "1"; // Entities are html encoded so this will cause them to be displayed correctly in pushover alerts
         switch ($alert_data['severity']) {
             case 'critical':
                 $data['priority'] = 1;


### PR DESCRIPTION
Entities are html encoded so this will cause them to be displayed correctly in pushover alerts

after fix:
![image](https://github.com/librenms/librenms/assets/175930/154e345d-9492-43bf-8fbc-0d255147d8a2)

before fix:
![image](https://github.com/librenms/librenms/assets/175930/cf11add0-91eb-4e57-b76a-67a95906eb53)

Notice the = `&gt;` entities

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
