### PR TITLE
WebUI - Filter FDB and ARP tabs in port page if empty

### DIFF
--- a/includes/html/pages/device/port.inc.php
+++ b/includes/html/pages/device/port.inc.php
@@ -1,8 +1,10 @@
 <?php
 
+use App\Models\Ipv4Mac;
 use App\Models\Port;
 use App\Models\PortAdsl;
 use App\Models\PortVdsl;
+use App\Models\PortsFdb;
 use App\Plugins\Hooks\PortTabHook;
 use LibreNMS\Util\Rewrite;
 use LibreNMS\Util\Url;
@@ -74,9 +76,14 @@ $link_array = [
 
 $menu_options['graphs'] = 'Graphs';
 $menu_options['realtime'] = 'Real time';
-// FIXME CONDITIONAL
-$menu_options['arp'] = 'ARP Table';
-$menu_options['fdb'] = 'FDB Table';
+
+if (ipv4Mac::where('port_id', $port->port_id)->exists()) {
+    $menu_options['arp'] = 'ARP Table';
+}
+
+if (PortsFdb::where('port_id', $port->port_id)->exists()) {
+    $menu_options['fdb'] = 'FDB Table';
+}
 $menu_options['events'] = 'Eventlog';
 $menu_options['notes'] = (get_dev_attrib($device, 'port_id_notes:' . $port->port_id) ?? '') == '' ? 'Notes' : 'Notes*';
 

--- a/includes/html/pages/device/port.inc.php
+++ b/includes/html/pages/device/port.inc.php
@@ -3,8 +3,8 @@
 use App\Models\Ipv4Mac;
 use App\Models\Port;
 use App\Models\PortAdsl;
-use App\Models\PortVdsl;
 use App\Models\PortsFdb;
+use App\Models\PortVdsl;
 use App\Plugins\Hooks\PortTabHook;
 use LibreNMS\Util\Rewrite;
 use LibreNMS\Util\Url;

--- a/includes/html/pages/device/port.inc.php
+++ b/includes/html/pages/device/port.inc.php
@@ -1,9 +1,7 @@
 <?php
 
-use App\Models\Ipv4Mac;
 use App\Models\Port;
 use App\Models\PortAdsl;
-use App\Models\PortsFdb;
 use App\Models\PortVdsl;
 use App\Plugins\Hooks\PortTabHook;
 use LibreNMS\Util\Rewrite;
@@ -77,11 +75,11 @@ $link_array = [
 $menu_options['graphs'] = 'Graphs';
 $menu_options['realtime'] = 'Real time';
 
-if (ipv4Mac::where('port_id', $port->port_id)->exists()) {
+if ($port->macs()->exists()) {
     $menu_options['arp'] = 'ARP Table';
 }
 
-if (PortsFdb::where('port_id', $port->port_id)->exists()) {
+if ($port->fdbEntries()->exists()) {
     $menu_options['fdb'] = 'FDB Table';
 }
 $menu_options['events'] = 'Eventlog';


### PR DESCRIPTION
Do not display FDB or ARP tabs if there is nothing in the corresponding DB tables

Before:
<img width="452" alt="Capture d’écran 2023-12-17 à 21 55 28" src="https://github.com/librenms/librenms/assets/38363551/89996f3f-9b6b-4268-ad9b-2cc26b4bbeb8">


After:
<img width="454" alt="Capture d’écran 2023-12-17 à 21 55 07" src="https://github.com/librenms/librenms/assets/38363551/f4bac501-af76-45d8-bf1b-f305b5c80c12">


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
