### PR TITLE
ports - auto-deleting ports with doubled ifIndex

### DIFF
--- a/includes/discovery/ports.inc.php
+++ b/includes/discovery/ports.inc.php
@@ -125,6 +125,8 @@ foreach ($port_stats as $ifIndex => $snmp_data) {
 
         // Port newly discovered?
         if (! isset($ports_db[$port_id]) || ! is_array($ports_db[$port_id])) {
+            dbDelete('ports', '`device_id` = ? AND `ifIndex` = ?', [$device['device_id'], $ifIndex]);
+            
             $snmp_data['device_id'] = $device['device_id'];
             $port_id = dbInsert($snmp_data, 'ports');
 


### PR DESCRIPTION
Hi,
After reinstalling OS on VM, replacing router we sometimes see that some ports are missing from Ports tab.
We are using `Port Association Mode = ifName`, because after reboot sometimes ifIndex are changes.

Discover after reinstall OS:
```
SQL[INSERT IGNORE INTO `ports` (`ifDescr`,`ifName`,`ifAlias`,`ifType`,`ifOperStatus`,`ifIndex`,`device_id`)  VALUES (:ifDescr,:ifName,:ifAlias,:ifType,:ifOperStatus,:ifIndex,:device_id) {"ifDescr":"eth0","ifName":"eth0","ifAlias":"eth0","ifType":"ethernetCsmacd","ifOperStatus":"up","ifIndex":2,"device_id":196} 2.45ms] 
  

SQL[SELECT * FROM `ports` WHERE `device_id` = ? AND `port_id` = ? [196,"0"] 0.3ms] 
  

Adding: eth0(2)(0)

UPDATE `ports` set `ifDuplex`=null WHERE `port_id` = 850947


SQL[UPDATE `ports` set `ifDescr`=?,`ifName`=?,`ifAlias`=?,`ifType`=?,`ifOperStatus`=?,`ifIndex`=?,`deleted`=? WHERE `port_id` = ? ["eth0","eth0","eth0","ethernetCsmacd","up",2,0,850947] 3.65ms] 
```

```
MariaDB [librenms]> SELECT `ifDescr`, `ifName`, `ifAlias`, `ifOperStatus`, `ifIndex` FROM `ports` WHERE `device_id` = 196;
+---------------------------+--------+---------+--------------+---------+
| ifDescr                   | ifName | ifAlias | ifOperStatus | ifIndex |
+---------------------------+--------+---------+--------------+---------+
| lo                        | lo     | lo      | up           |       1 |
| Red Hat, Inc. Device 0001 | enp1s0 | repoll  | up           |       2 |
| tun0                      | tun0   | tun0    | up           |      11 |
+---------------------------+--------+---------+--------------+---------+
3 rows in set (0.000 sec)
```

Temporarily change `Port Association Mode = ifIndex`, run Discovery:
```
MariaDB [librenms]> SELECT `ifDescr`, `ifName`, `ifAlias`, `ifOperStatus`, `ifIndex` FROM `ports` WHERE `device_id` = 196;
+---------+--------+---------+--------------+---------+
| ifDescr | ifName | ifAlias | ifOperStatus | ifIndex |
+---------+--------+---------+--------------+---------+
| lo      | lo     | lo      | up           |       1 |
| eth0    | eth0   | eth0    | up           |       2 |
| tun0    | tun0   | tun0    | up           |      11 |
+---------+--------+---------+--------------+---------+
3 rows in set (0.000 sec)

MariaDB [librenms]>
```
And then next pooling with `Port Association Mode = ifName` works fine.


In discovery there is line `Adding: eth0(2)(0)` - probably LibreNMS is treating this as new port and trying to make INSERT into SQL... but INSERT will not work when there is unique index at `ifIndex` field.

We should remove existing ports with same ifIndex when this port have set `deleted=1`.

I added automatic deletion of this ports when ifIndex is used.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
