### PR TITLE
Fix pagination in alert rules page

### DIFF
--- a/includes/html/print-alert-rules.php
+++ b/includes/html/print-alert-rules.php
@@ -430,7 +430,7 @@ foreach ($rule_list as $rule) {
 <?php
 // Pagination
 
-if (($count % $results) > 0) {
+if ($count > $results) {
     echo '<div class="table-responsive">';
     echo '<div class="col pull-left">';
     echo generate_pagination($count, $results, $page_number);


### PR DESCRIPTION
The pagination in alert rules page is not displayed if the number of rules is a multiple of the number of results per page.

For example, create 20 rules and select 10 results per page.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
