### PR TITLE
New utility Number::constrainInteger()

### DIFF
--- a/LibreNMS/Enum/IntegerType.php
+++ b/LibreNMS/Enum/IntegerType.php
@@ -47,7 +47,6 @@ enum IntegerType
             self::uint16 => 65535,
             self::uint32 => 4294967295,
             self::uint64 => 9223372036854775807,
-            default => throw new \InvalidArgumentException('Invalid integer type'),
         };
     }
 
@@ -56,7 +55,6 @@ enum IntegerType
         return match ($this) {
             self::int8,self::int16,self::int32,self::int64 => true,
             self::uint8,self::uint16,self::uint32,self::uint64 => false,
-            default => throw new \InvalidArgumentException('Invalid integer type'),
         };
     }
 }

--- a/LibreNMS/Enum/IntegerType.php
+++ b/LibreNMS/Enum/IntegerType.php
@@ -38,7 +38,7 @@ enum IntegerType
 
     public function maxValue(): int
     {
-        return match($this) {
+        return match ($this) {
             self::int8 => 127,
             self::int16 => 32767,
             self::int32 => 2147483647,
@@ -53,7 +53,7 @@ enum IntegerType
 
     public function isSigned(): bool
     {
-        return match($this) {
+        return match ($this) {
             self::int8,self::int16,self::int32,self::int64 => true,
             self::uint8,self::uint16,self::uint32,self::uint64 => false,
             default => throw new \InvalidArgumentException('Invalid integer type'),

--- a/LibreNMS/Enum/IntegerType.php
+++ b/LibreNMS/Enum/IntegerType.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * IntegerType.php
+ *
+ * -Description-
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * @link       https://www.librenms.org
+ *
+ * @copyright  2023 Tony Murray
+ * @author     Tony Murray <murraytony@gmail.com>
+ */
+
+namespace LibreNMS\Enum;
+
+enum IntegerType
+{
+    case int8;
+    case int16;
+    case int32;
+    case int64;
+    case uint8;
+    case uint16;
+    case uint32;
+    case uint64;
+
+    public function maxValue(): int
+    {
+        return match($this) {
+            self::int8 => 127,
+            self::int16 => 32767,
+            self::int32 => 2147483647,
+            self::int64 => 4611686018427387903,
+            self::uint8 => 255,
+            self::uint16 => 65535,
+            self::uint32 => 4294967295,
+            self::uint64 => 9223372036854775807,
+            default => throw new \InvalidArgumentException('Invalid integer type'),
+        };
+    }
+
+    public function isSigned(): bool
+    {
+        return match($this) {
+            self::int8,self::int16,self::int32,self::int64 => true,
+            self::uint8,self::uint16,self::uint32,self::uint64 => false,
+            default => throw new \InvalidArgumentException('Invalid integer type'),
+        };
+    }
+}

--- a/LibreNMS/Modules/Xdsl.php
+++ b/LibreNMS/Modules/Xdsl.php
@@ -32,6 +32,7 @@ use App\Models\PortVdsl;
 use App\Observers\ModuleModelObserver;
 use Illuminate\Support\Collection;
 use LibreNMS\DB\SyncsModels;
+use LibreNMS\Enum\IntegerType;
 use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Module;
 use LibreNMS\OS;
@@ -139,7 +140,7 @@ class Xdsl implements Module
                 if (isset($data[$oid])) {
                     if ($oid == 'adslAtucCurrOutputPwr') {
                         // workaround Cisco Bug CSCvj53634
-                        $data[$oid] = Number::unsignedAsSigned($data[$oid]);
+                        $data[$oid] = Number::constrainInteger($data[$oid], IntegerType::int32);
                     }
                     $data[$oid] = $data[$oid] / 10;
                 }

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -26,6 +26,7 @@
 namespace LibreNMS\Tests;
 
 use LibreNMS\Device\YamlDiscovery;
+use LibreNMS\Enum\IntegerType;
 use LibreNMS\Util\Number;
 use LibreNMS\Util\Time;
 
@@ -129,18 +130,27 @@ class FunctionsTest extends TestCase
 
     public function testNumberAsUnsigned()
     {
-        $this->assertSame(42, Number::unsignedAsSigned('42'));  /** @phpstan-ignore-line */
-        $this->assertSame(2147483647, Number::unsignedAsSigned(2147483647));
-        $this->assertSame(-2147483648, Number::unsignedAsSigned(2147483648));
-        $this->assertSame(-2147483647, Number::unsignedAsSigned(2147483649));
-        $this->assertSame(-1, Number::unsignedAsSigned(4294967295));
+        $this->assertSame(42, Number::constrainInteger('42', IntegerType::int32));  /** @phpstan-ignore-line */
+        $this->assertSame(2147483647, Number::constrainInteger(2147483647, IntegerType::int32));
+        $this->assertSame(-2147483648, Number::constrainInteger(2147483648, IntegerType::int32));
+        $this->assertSame(-2147483647, Number::constrainInteger(2147483649, IntegerType::int32));
+        $this->assertSame(-1, Number::constrainInteger(4294967295, IntegerType::int32));
+        $this->assertSame(-3757, Number::constrainInteger(61779, IntegerType::int16));
+        $this->assertSame(0, Number::constrainInteger(0, IntegerType::uint32));
+        $this->assertSame(42, Number::constrainInteger(42, IntegerType::uint32));
+        $this->assertSame(4294967252, Number::constrainInteger(-42, IntegerType::uint32));
+        $this->assertSame(2147483648, Number::constrainInteger(-2147483646, IntegerType::uint32));
+        $this->assertSame(2147483647, Number::constrainInteger(-2147483647, IntegerType::uint32));
+        $this->assertSame(2147483646, Number::constrainInteger(-2147483648, IntegerType::uint32));
+        $this->assertSame(2147483645, Number::constrainInteger(-2147483649, IntegerType::uint32));
     }
 
     public function testNumberAsUnsignedValueExceedsMaxUnsignedValue()
     {
         $this->expectException(\InvalidArgumentException::class);
 
-        // Exceeds the maximum representable value for a 32-bit unsigned integer
-        Number::unsignedAsSigned(4294967296, 32);
+
+        // Exceeds the maximum representable value for a 16-bit unsigned integer
+        $value = Number::constrainInteger(4294967296, IntegerType::int16);
     }
 }

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -149,8 +149,7 @@ class FunctionsTest extends TestCase
     {
         $this->expectException(\InvalidArgumentException::class);
 
-
         // Exceeds the maximum representable value for a 16-bit unsigned integer
-        $value = Number::constrainInteger(4294967296, IntegerType::int16);
+        Number::constrainInteger(4294967296, IntegerType::int16);
     }
 }


### PR DESCRIPTION
Fixes a bug with Number::unsignedAsSigned() and implements signed support as well.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
