### PR TITLE
Use Number::constrainInteger instead of unsignedToSigned in Cisco NTP poller

### DIFF
--- a/includes/polling/ntp/cisco.inc.php
+++ b/includes/polling/ntp/cisco.inc.php
@@ -11,8 +11,8 @@
  * the source code distribution for details.
  */
 
-use LibreNMS\RRD\RrdDefinition;
 use LibreNMS\Enum\IntegerType;
+use LibreNMS\RRD\RrdDefinition;
 use LibreNMS\Util\Number;
 
 $tmp_module = 'ntp';

--- a/includes/polling/ntp/cisco.inc.php
+++ b/includes/polling/ntp/cisco.inc.php
@@ -12,6 +12,7 @@
  */
 
 use LibreNMS\RRD\RrdDefinition;
+use LibreNMS\Enum\IntegerType;
 use LibreNMS\Util\Number;
 
 $tmp_module = 'ntp';
@@ -63,10 +64,10 @@ if (is_array($components) && count($components) > 0) {
         // the last 16 bits.
 
         $hexoffset = $cntpPeersVarEntry['1.3.6.1.4.1.9.9.168.1.2.1.1'][23][$array['UID']];
-        $rrd['offset'] = Number::unsignedAsSigned(hexdec(substr($hexoffset, 0, 5)), 16) + hexdec(substr($hexoffset, -5)) / 65536;
+        $rrd['offset'] = Number::constrainInteger(hexdec(substr($hexoffset, 0, 5)), IntegerType::int16) + hexdec(substr($hexoffset, -5)) / 65536;
 
         $hexdelay = $cntpPeersVarEntry['1.3.6.1.4.1.9.9.168.1.2.1.1'][24][$array['UID']];
-        $rrd['delay'] = Number::unsignedAsSigned(hexdec(substr($hexdelay, 0, 5)), 16) + hexdec(substr($hexdelay, -5)) / 65536;
+        $rrd['delay'] = Number::constrainInteger(hexdec(substr($hexdelay, 0, 5)), IntegerType::int16) + hexdec(substr($hexdelay, -5)) / 65536;
 
         // Cisco NTPUnsignedTimeValue - 16 bits of unsignedint, and 16 bits of unsignedint for fractional
         $hexdisp = $cntpPeersVarEntry['1.3.6.1.4.1.9.9.168.1.2.1.1'][25][$array['UID']];


### PR DESCRIPTION
in #15663 `unsignedAsSigned` was renamed to `constrainInteger`. The use of `unsignedAsSigned` in old cisco ntp polling module was not updated. This MR fixes this.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
