### PR TITLE
Ignore nameless health sensors for Fortigate

### DIFF
--- a/includes/definitions/discovery/fortigate.yaml
+++ b/includes/definitions/discovery/fortigate.yaml
@@ -37,6 +37,11 @@ modules:
                     index: 'fgHwSensorEntIndex.{{ $index }}'
                     descr: fgHwSensorEntName
                     value: fgHwSensorEntAlarmStatus
+                    skip_values:
+                        -
+                            oid: fgHwSensorEntName
+                            op: '='
+                            value: ''
                     states:
                         - { value: 0, descr: OK, graph: 1, generic: 0 }
                         - { value: 1, descr: ERROR, graph: 1, generic: 2 }


### PR DESCRIPTION
Our Fortigates give a lot (about 190) of empty state sensors in LibreNMS, which do not have a name and alarms and value are always zero.  
This PR ignores the state sensors which do not return a name. Tested with FortiOS 7.2.5.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.