### PR TITLE
Show error if "Check Type" field is empty when creating new service template

### DIFF
--- a/app/Http/Controllers/ServiceTemplateController.php
+++ b/app/Http/Controllers/ServiceTemplateController.php
@@ -69,7 +69,7 @@ class ServiceTemplateController extends Controller
                 'groups.*' => 'integer',
                 'devices' => 'array',
                 'devices.*' => 'integer',
-                'check' => 'string',
+                'check' => 'required|string',
                 'type' => 'required|in:dynamic,static',
                 'rules' => 'json|required_if:type,dynamic',
                 'param' => 'nullable|string',


### PR DESCRIPTION
service_templates.check database field is not nullable and hence mandatory. Web UI fails with "Whoops, ..." error if user tries to create new service template without empty "check" field. 

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
