### PR TITLE
Don't escape leaflet tile url in location edit map

### DIFF
--- a/app/Http/Controllers/LocationController.php
+++ b/app/Http/Controllers/LocationController.php
@@ -12,7 +12,7 @@ class LocationController extends Controller
     public function index()
     {
         $maps_api = Config::get('geoloc.api_key');
-        $maps_config = array('tile_url' => Config::get('leaflet.tile_url', '{s}.tile.openstreetmap.org'));
+        $maps_config = ['tile_url' => Config::get('leaflet.tile_url', '{s}.tile.openstreetmap.org')];
         $data = [
             'maps_api' => $maps_api,
             'maps_engine' => $maps_api ? Config::get('geoloc.engine') : '',

--- a/app/Http/Controllers/LocationController.php
+++ b/app/Http/Controllers/LocationController.php
@@ -12,9 +12,11 @@ class LocationController extends Controller
     public function index()
     {
         $maps_api = Config::get('geoloc.api_key');
+        $maps_config = array('tile_url' => Config::get('leaflet.tile_url', '{s}.tile.openstreetmap.org'));
         $data = [
             'maps_api' => $maps_api,
             'maps_engine' => $maps_api ? Config::get('geoloc.engine') : '',
+            'maps_config' => $maps_config,
         ];
 
         $data['graph_template'] = '';

--- a/resources/views/locations.blade.php
+++ b/resources/views/locations.blade.php
@@ -148,7 +148,7 @@
                 locationId = $btn.data('id');
 
                 if (locationMap === null) {
-                    config = {"tile_url": "{!! \LibreNMS\Config::get('leaflet.tile_url', '{s}.tile.openstreetmap.org') !!}"};
+                    config = {{ Js::from($maps_config) }}
                     locationMap = init_map('location-edit-map', '{{ $maps_engine }}', '{{ $maps_api }}', config);
                     locationMarker = init_map_marker(locationMap, location);
                 }

--- a/resources/views/locations.blade.php
+++ b/resources/views/locations.blade.php
@@ -148,7 +148,7 @@
                 locationId = $btn.data('id');
 
                 if (locationMap === null) {
-                    config = {"tile_url": "{{ \LibreNMS\Config::get('leaflet.tile_url', '{s}.tile.openstreetmap.org') }}"};
+                    config = {"tile_url": "{!! \LibreNMS\Config::get('leaflet.tile_url', '{s}.tile.openstreetmap.org') !!}"};
                     locationMap = init_map('location-edit-map', '{{ $maps_engine }}', '{{ $maps_api }}', config);
                     locationMarker = init_map_marker(locationMap, location);
                 }


### PR DESCRIPTION
Hello,

with this PR the leaflet tile url for the location edit map won't get escaped.
As I'm using a custom url with get parameters which does not work, when the ampersands get escaped.
The fullscreen map doesn't have this problem.


#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
