### PR TITLE
option to ignore device status

### DIFF
--- a/app/Http/Controllers/Widgets/AvailabilityMapController.php
+++ b/app/Http/Controllers/Widgets/AvailabilityMapController.php
@@ -90,7 +90,7 @@ class AvailabilityMapController extends WidgetController
         if (! $settings['show_disabled_and_ignored']) {
             $device_query->isNotDisabled();
         }
-        $devices = $device_query->select(['devices.device_id', 'hostname', 'sysName', 'display', 'status', 'uptime', 'last_polled', 'disabled', 'ignore'])->get();
+        $devices = $device_query->select(['devices.device_id', 'hostname', 'sysName', 'display', 'status', 'uptime', 'last_polled', 'disabled', 'ignore', 'ignore_status'])->get();
 
         // process status
         $uptime_warn = (int) Config::get('uptime_warning', 86400);
@@ -251,6 +251,10 @@ class AvailabilityMapController extends WidgetController
     {
         if ($device->disabled) {
             return ['disabled', 'blackbg'];
+        }
+
+        if ($device->ignore_status) {
+            return ['ignored-up', 'label-success'];
         }
 
         if ($device->ignore) {

--- a/app/Models/Device.php
+++ b/app/Models/Device.php
@@ -55,6 +55,7 @@ class Device extends BaseModel
         'display',
         'icon',
         'ignore',
+        'ignore_status',
         'ip',
         'location_id',
         'notes',

--- a/app/Models/Device.php
+++ b/app/Models/Device.php
@@ -467,6 +467,7 @@ class Device extends BaseModel
         if (empty($ip)) {
             return null;
         }
+
         // @ suppresses warning, inet_ntop() returns false if it fails
         return @inet_ntop($ip) ?: null;
     }

--- a/database/migrations/2024_01_04_195618_add_ignore_status_to_devices_tables.php
+++ b/database/migrations/2024_01_04_195618_add_ignore_status_to_devices_tables.php
@@ -30,4 +30,3 @@ return new class extends Migration
         });
     }
 };
-

--- a/database/migrations/2024_01_04_195618_add_ignore_status_to_devices_tables.php
+++ b/database/migrations/2024_01_04_195618_add_ignore_status_to_devices_tables.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up(): void
+    {
+        Schema::table('devices', function (Blueprint $table) {
+            $table->boolean('ignore_status')->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down(): void
+    {
+        Schema::table('devices', function (Blueprint $table) {
+            $table->dropColumn('ignore_status');
+        });
+    }
+};
+

--- a/includes/html/pages/device/edit/device.inc.php
+++ b/includes/html/pages/device/edit/device.inc.php
@@ -32,6 +32,7 @@ if (! empty($_POST['editing'])) {
         $device_model->purpose = $_POST['descr'];
         $device_model->poller_group = $_POST['poller_group'];
         $device_model->ignore = (int) isset($_POST['ignore']);
+        $device_model->ignore_status = (int) isset($_POST['ignore_status']);
         $device_model->disabled = (int) isset($_POST['disabled']);
         $device_model->disable_notify = (int) isset($_POST['disable_notify']);
         $device_model->type = $_POST['type'];
@@ -309,6 +310,17 @@ If `devices.ignore = 0` or `macros.device = 1` condition is is set and ignore al
            <input name="ignore" type="checkbox" id="ignore" value="1" data-size="small"
                 <?php
                 if ($device_model->ignore) {
+                    echo 'checked=checked';
+                }
+                ?> />
+        </div>
+    </div>
+    <div class="form-group">
+        <label for="ignore_status" class="col-sm-2 control-label" title="Tag device to ignore Status. It will always be shown as online.">Ignore Device Status</label>
+        <div class="col-sm-6">
+           <input name="ignore_status" type="checkbox" id="ignore_status" value="1" data-size="small"
+                <?php
+                if ($device_model->ignore_status) {
                     echo 'checked=checked';
                 }
                 ?> />

--- a/misc/db_schema.yaml
+++ b/misc/db_schema.yaml
@@ -574,6 +574,7 @@ devices:
     - { Field: port_association_mode, Type: int, 'Null': false, Extra: '', Default: '1' }
     - { Field: max_depth, Type: int, 'Null': false, Extra: '', Default: '0' }
     - { Field: disable_notify, Type: tinyint, 'Null': false, Extra: '', Default: '0' }
+    - { Field: ignore_status, Type: tinyint, 'Null': false, Extra: '', Default: '0' }
   Indexes:
     PRIMARY: { Name: PRIMARY, Columns: [device_id], Unique: true, Type: BTREE }
     devices_hostname_sysname_display_index: { Name: devices_hostname_sysname_display_index, Columns: [hostname, sysName, display], Unique: false, Type: BTREE }


### PR DESCRIPTION
Add Option to show device always as up.
Useful for Devices which are not up all the time, and prevent Question ("Is it ok this Device is down")

Also Alerts are still running, including Transports. So Device will be completely monitored if available.

![image](https://github.com/librenms/librenms/assets/7978916/1f153980-ab00-424a-8483-cb9d6c56ec20)

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
