### PR TITLE
Ensure ospfExternLsaCount is numeric before inserting into ospf_instances

### DIFF
--- a/LibreNMS/Modules/Ospf.php
+++ b/LibreNMS/Modules/Ospf.php
@@ -88,6 +88,10 @@ class Ospf implements Module
                     continue; // skip invalid data
                 }
 
+                if (!is_numeric($ospf_entry['ospfExternLsaCount'] ?? '')) {
+                    continue;
+                }
+
                 $instance = OspfInstance::updateOrCreate([
                     'device_id' => $os->getDeviceId(),
                     'ospf_instance_id' => $ospf_instance_id,

--- a/LibreNMS/Modules/Ospf.php
+++ b/LibreNMS/Modules/Ospf.php
@@ -88,7 +88,7 @@ class Ospf implements Module
                     continue; // skip invalid data
                 }
 
-                if (!is_numeric($ospf_entry['ospfExternLsaCount'] ?? '')) {
+                if (! is_numeric($ospf_entry['ospfExternLsaCount'] ?? '')) {
                     continue;
                 }
 


### PR DESCRIPTION
ospfExternLsaCount must be numeric or the insert will fail. Database column is also not nullable so this value must be present. 

Fixes the issue #15701.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
