### PR TITLE
Fixed typo in misc/alert_rules.json with regards to "Space on ..." alerts

### DIFF
--- a/misc/alert_rules.json
+++ b/misc/alert_rules.json
@@ -699,12 +699,12 @@
     "severity": "critical"
   },
   {
-    "rule": "storage.storage_deleted = 0 && storage.storage_descr = / && storage.storage_perc >= 90 && storage.storage_perc < 95",
+    "rule": "storage.storage_deleted = 0 && storage.storage_descr = \"/\" && storage.storage_perc >= 90 && storage.storage_perc < 95",
     "name": "Space on / is >= 90% and < 95% in use",
     "severity":"warning"
   },
   {
-    "rule": "storage.storage_deleted = 0 && storage.storage_descr = / && storage.storage_perc >= 95",
+    "rule": "storage.storage_deleted = 0 && storage.storage_descr = \"/\" && storage.storage_perc >= 95",
     "name": "Space on / is >= 95% in use",
     "severity":"critical"
   },

--- a/misc/alert_rules.json
+++ b/misc/alert_rules.json
@@ -699,12 +699,12 @@
     "severity": "critical"
   },
   {
-    "rule": "storage.storage_deleted = 0 AND storage.storage_descr = \"/\" AND storage.storage_perc >= 90 AND storage.storage_perc < 95",
+    "rule": "storage.storage_deleted = 0 && storage.storage_descr = / && storage.storage_perc >= 90 && storage.storage_perc < 95",
     "name": "Space on / is >= 90% and < 95% in use",
     "severity":"warning"
   },
   {
-    "rule": "storage.storage_deleted = 0 AND storage.storage_descr = \"/\" AND storage.storage_perc >= 95",
+    "rule": "storage.storage_deleted = 0 && storage.storage_descr = / && storage.storage_perc >= 95",
     "name": "Space on / is >= 95% in use",
     "severity":"critical"
   },


### PR DESCRIPTION
I fixed the alerts from the alert_rules.json collection for `Space on .....` 

Before:
![before](https://github.com/librenms/librenms/assets/459167/e2668b44-41a9-4efa-94ed-8334e256c852)
After:
![after](https://github.com/librenms/librenms/assets/459167/7ef3121a-0bde-4c8d-86d7-417c62413bdb)


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
