### PR TITLE
OSPF instances and missing mandatory fields fix attempt

### DIFF
--- a/LibreNMS/Modules/Ospf.php
+++ b/LibreNMS/Modules/Ospf.php
@@ -87,9 +87,9 @@ class Ospf implements Module
                 if (empty($ospf_entry['ospfRouterId'])) {
                     continue; // skip invalid data
                 }
-                foreach (['ospfRxNewLsas', 'ospfOriginateNewLsas', 'ospfAreaBdrRtrStatus', 'ospfExternLsaCount'] as $column) {
-                    if (! array_key_exists($column, $ospf_entry)) {
-                        continue; // This column must exist
+                foreach (['ospfRxNewLsas', 'ospfOriginateNewLsas', 'ospfAreaBdrRtrStatus', 'ospfExternLsaCount', 'ospfTOSSupport', 'ospfExternLsaCksumSum', 'ospfExternLsaCount', 'ospfASBdrRtrStatus', 'ospfVersionNumber', 'ospfAdminStat'] as $column) {
+                    if (! array_key_exists($column, $ospf_entry) || is_null($ospf_entry[$column])) {
+                        continue; // This column must exist and not be null
                     }
                 }
 

--- a/LibreNMS/Modules/Ospf.php
+++ b/LibreNMS/Modules/Ospf.php
@@ -84,8 +84,13 @@ class Ospf implements Module
 
             $ospf_instances = new Collection();
             foreach ($ospf_instances_poll as $ospf_instance_id => $ospf_entry) {
-                if (empty($ospf_entry['ospfRouterId']) || empty($ospf_entry['ospfAreaBdrRtrStatus']) || empty($ospf_entry['ospfExternLsaCount'])) {
-                    continue; // skip invalid or incomplete data
+                if (empty($ospf_entry['ospfRouterId'])) {
+                    continue; // skip invalid data
+                }
+                foreach (['ospfRxNewLsas', 'ospfOriginateNewLsas', 'ospfAreaBdrRtrStatus', 'ospfExternLsaCount'] as $column) {
+                    if (! array_key_exists($column, $ospf_entry)) {
+                        continue; // This column must exist
+                    }
                 }
 
                 $instance = OspfInstance::updateOrCreate([

--- a/LibreNMS/Modules/Ospf.php
+++ b/LibreNMS/Modules/Ospf.php
@@ -84,8 +84,8 @@ class Ospf implements Module
 
             $ospf_instances = new Collection();
             foreach ($ospf_instances_poll as $ospf_instance_id => $ospf_entry) {
-                if (empty($ospf_entry['ospfRouterId'])) {
-                    continue; // skip invalid data
+                if (empty($ospf_entry['ospfRouterId']) || empty($ospf_entry['ospfAreaBdrRtrStatus']) || empty($ospf_entry['ospfExternLsaCount'])) {
+                    continue; // skip invalid or incomplete data
                 }
 
                 $instance = OspfInstance::updateOrCreate([

--- a/LibreNMS/Modules/Ospf.php
+++ b/LibreNMS/Modules/Ospf.php
@@ -87,7 +87,7 @@ class Ospf implements Module
                 if (empty($ospf_entry['ospfRouterId'])) {
                     continue; // skip invalid data
                 }
-                foreach (['ospfRxNewLsas', 'ospfOriginateNewLsas', 'ospfAreaBdrRtrStatus', 'ospfExternLsaCount', 'ospfTOSSupport', 'ospfExternLsaCksumSum', 'ospfExternLsaCount', 'ospfASBdrRtrStatus', 'ospfVersionNumber', 'ospfAdminStat'] as $column) {
+                foreach (['ospfRxNewLsas', 'ospfOriginateNewLsas', 'ospfAreaBdrRtrStatus', 'ospfTOSSupport', 'ospfExternLsaCksumSum', 'ospfExternLsaCount', 'ospfASBdrRtrStatus', 'ospfVersionNumber', 'ospfAdminStat'] as $column) {
                     if (! array_key_exists($column, $ospf_entry) || is_null($ospf_entry[$column])) {
                         continue; // This column must exist and not be null
                     }

--- a/LibreNMS/Modules/Ospf.php
+++ b/LibreNMS/Modules/Ospf.php
@@ -89,7 +89,7 @@ class Ospf implements Module
                 }
                 foreach (['ospfRxNewLsas', 'ospfOriginateNewLsas', 'ospfAreaBdrRtrStatus', 'ospfTOSSupport', 'ospfExternLsaCksumSum', 'ospfExternLsaCount', 'ospfASBdrRtrStatus', 'ospfVersionNumber', 'ospfAdminStat'] as $column) {
                     if (! array_key_exists($column, $ospf_entry) || is_null($ospf_entry[$column])) {
-                        continue; // This column must exist and not be null
+                        continue 2; // This column must exist and not be null
                     }
                 }
 


### PR DESCRIPTION
We have a lot of columns that cannot be NULL, so we need to check that before trying to createOrUpdate

|           id          | int(10) unsigned | NO | PRI | NULL | auto_increment |
|:---------------------:|:----------------:|:--:|:---:|:----:|:--------------:|
| ospfRouterId          | varchar(32)      | NO |     | NULL |                |
| ospfAdminStat         | varchar(32)      | NO |     | NULL |                |
| ospfVersionNumber     | varchar(32)      | NO |     | NULL |                |
| ospfAreaBdrRtrStatus  | varchar(32)      | NO |     | NULL |                |
| ospfASBdrRtrStatus    | varchar(32)      | NO |     | NULL |                |
| ospfExternLsaCount    | int(10) unsigned | NO |     | NULL |                |
| ospfExternLsaCksumSum | int(11)          | NO |     | NULL |                |
| ospfTOSSupport        | varchar(32)      | NO |     | NULL |                |
| ospfOriginateNewLsas  | int(10) unsigned | NO |     | NULL |                |
| ospfRxNewLsas         | int(10) unsigned | NO |     | NULL |                |

fixes #15701 

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
