### PR TITLE
VRP - avoid emptying bgpPeers description at discovery when manually set

### DIFF
--- a/includes/discovery/bgp-peers/vrp.inc.php
+++ b/includes/discovery/bgp-peers/vrp.inc.php
@@ -99,7 +99,7 @@ if (count($bgpPeersCache) > 0 || count($bgpPeersCache_ietf) == 0) {
                     'bgpPeerOutTotalMessages' => 0,
                     'bgpPeerFsmEstablishedTime' => $value['hwBgpPeerFsmEstablishedTime'],
                     'bgpPeerInUpdateElapsedTime' => 0,
-                    'bgpPeerDescr' => $value['bgpPeerDescr'] ?? '',
+                    'bgpPeerDescr' => $value['bgpPeerDescr'],
                     'astext' => $astext,
                 ];
                 if (empty($vrfId)) {
@@ -117,7 +117,7 @@ if (count($bgpPeersCache) > 0 || count($bgpPeersCache_ietf) == 0) {
                 $peers = [
                     'bgpPeerRemoteAs' => $value['hwBgpPeerRemoteAs'],
                     'astext' => $astext,
-                    'bgpPeerDescr' => $value['bgpPeerDescr'] ?? '',
+                    'bgpPeerDescr' => $value['bgpPeerDescr'],
                 ];
                 $affected = DeviceCache::getPrimary()->bgppeers()->where('bgpPeerIdentifier', $address)->where('vrf_id', $vrfId)->update($peers);
                 $seenPeerID[] = DeviceCache::getPrimary()->bgppeers()->where('bgpPeerIdentifier', $address)->where('vrf_id', $vrfId)->select('bgpPeer_id')->orderBy('bgpPeer_id', 'ASC')->first()->bgpPeer_id;

--- a/includes/discovery/bgp-peers/vrp.inc.php
+++ b/includes/discovery/bgp-peers/vrp.inc.php
@@ -72,7 +72,6 @@ if (count($bgpPeersCache) > 0 || count($bgpPeersCache_ietf) == 0) {
         $bgpPeers[$vrfInstance][$address]['afi'] = $oid[1];
         $bgpPeers[$vrfInstance][$address]['safi'] = $oid[2];
         $bgpPeers[$vrfInstance][$address]['typePeer'] = $oid[3];
-        $bgpPeers[$vrfInstance][$address]['bgpPeerDescr'] = '';
         if (array_key_exists('0.' . $oid[3] . '.' . $oid_address, $bgpPeersDesc)) {
             // We may have a description
             $bgpPeers[$vrfInstance][$address]['bgpPeerDescr'] = $bgpPeersDesc['0.' . $oid[3] . '.' . $oid_address]['hwBgpPeerSessionExtDescription'];

--- a/includes/discovery/bgp-peers/vrp.inc.php
+++ b/includes/discovery/bgp-peers/vrp.inc.php
@@ -99,9 +99,11 @@ if (count($bgpPeersCache) > 0 || count($bgpPeersCache_ietf) == 0) {
                     'bgpPeerOutTotalMessages' => 0,
                     'bgpPeerFsmEstablishedTime' => $value['hwBgpPeerFsmEstablishedTime'],
                     'bgpPeerInUpdateElapsedTime' => 0,
-                    'bgpPeerDescr' => $value['bgpPeerDescr'],
                     'astext' => $astext,
                 ];
+                if (array_key_exists('bgpPeerDescr', $value)) {
+                    $peers['bgpPeerDescr'] = $value['bgpPeerDescr'];
+                }
                 if (empty($vrfId)) {
                     unset($peers['vrf_id']);
                 }
@@ -117,8 +119,10 @@ if (count($bgpPeersCache) > 0 || count($bgpPeersCache_ietf) == 0) {
                 $peers = [
                     'bgpPeerRemoteAs' => $value['hwBgpPeerRemoteAs'],
                     'astext' => $astext,
-                    'bgpPeerDescr' => $value['bgpPeerDescr'],
                 ];
+                if (array_key_exists('bgpPeerDescr', $value)) {
+                    $peers['bgpPeerDescr'] = $value['bgpPeerDescr'];
+                }
                 $affected = DeviceCache::getPrimary()->bgppeers()->where('bgpPeerIdentifier', $address)->where('vrf_id', $vrfId)->update($peers);
                 $seenPeerID[] = DeviceCache::getPrimary()->bgppeers()->where('bgpPeerIdentifier', $address)->where('vrf_id', $vrfId)->select('bgpPeer_id')->orderBy('bgpPeer_id', 'ASC')->first()->bgpPeer_id;
 


### PR DESCRIPTION
This is an attempt to fix #15677 

As the BGP Description field in DB defaults to empty string, it should be safe to only update the db whenever a value is retrieved. Before this PR, value was always initiated to an empty string which caused the issue. 

| Field                      | Type             | Null | Key | Default | Extra          |
|----------|:-------------:|------:|----------|:-------------:|------:|
| bgpPeerDescr               | varchar(255)     | NO   |     |         |                |

fixes #15677

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
