### PR TITLE
Update SQL override section after switch to SQL strict mode

### DIFF
--- a/doc/Alerting/Rules.md
+++ b/doc/Alerting/Rules.md
@@ -72,10 +72,14 @@ On the Advanced tab, you can specify some additional options for the alert rule:
 - An example of this would be an average rule for all CPUs over 10%
 
 ```sql
-SELECT *,AVG(processors.processor_usage) as cpu_avg FROM
-devices,processors WHERE (devices.device_id = ? AND devices.device_id
-= processors.device_id) AND (devices.status = 1 && (devices.disabled =
-0 && devices.ignore = 0)) = 1 HAVING AVG(processors.processor_usage)
+SELECT devices.device_id, devices.status, devices.disabled, devices.ignore, 
+AVG(processors.processor_usage) AS cpu_avg  FROM 
+devices INNER JOIN processors ON devices.device_id 
+= processors.device_id WHERE devices.device_id 
+= ? AND devices.status = 1 AND devices.disabled = 
+0 AND devices.ignore = 0 GROUP BY devices.device_id, 
+devices.status, devices.disabled, devices.ignore 
+HAVING AVG(processors.processor_usage) 
 > 10
 ```
 


### PR DESCRIPTION
Since 23.10.0 the currently documented SQL override rule does not work. This one I got from ChatGPT does work so far. 

For reference and fixes #15700

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
