### PR TITLE
Add support for -OX snmpflag to snmpwalk_cache_oid()

### DIFF
--- a/includes/snmp.inc.php
+++ b/includes/snmp.inc.php
@@ -399,13 +399,14 @@ function snmp_walk($device, $oid, $options = null, $mib = null, $mibdir = null)
     return $data;
 }//end snmp_walk()
 
-function is_array_index($snmpflags) {
-    if (!is_array($snmpflags)) {
-        $snmpflags=[$snmpflags];
+function is_array_index($snmpflags)
+{
+    if (! is_array($snmpflags)) {
+        $snmpflags = [$snmpflags];
     }
 
     foreach ($snmpflags as $flag) {
-        if (preg_match('/-O[a-zA-Z0-9]*X/',$flag) === 1) {
+        if (preg_match('/-O[a-zA-Z0-9]*X/', $flag) === 1) {
             return true;
         }
     }
@@ -435,12 +436,12 @@ function snmpwalk_cache_oid($device, $oid, $array = [], $mib = null, $mibdir = n
         $value = trim($value, "\" \\\n\r");
 
         if (is_array_index($snmpflags)) {
-            if (preg_match('/(.*)\[(.*)]/',$oid,$m) !== 1) {
+            if (preg_match('/(.*)\[(.*)]/', $oid, $m) !== 1) {
                 continue;
             }
 
-            $oid=$m[1];
-            $index=$m[2];
+            $oid = $m[1];
+            $index = $m[2];
         } else {
             [$oid, $index] = explode('.', $oid, 2);
         }

--- a/includes/snmp.inc.php
+++ b/includes/snmp.inc.php
@@ -399,6 +399,20 @@ function snmp_walk($device, $oid, $options = null, $mib = null, $mibdir = null)
     return $data;
 }//end snmp_walk()
 
+function is_array_index($snmpflags) {
+    if (!is_array($snmpflags)) {
+        $snmpflags=[$snmpflags];
+    }
+
+    foreach ($snmpflags as $flag) {
+        if (preg_match('/-O[a-zA-Z0-9]*X/',$flag) === 1) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 function snmpwalk_cache_oid($device, $oid, $array = [], $mib = null, $mibdir = null, $snmpflags = '-OQUs')
 {
     $data = snmp_walk($device, $oid, $snmpflags, $mib, $mibdir);
@@ -419,7 +433,18 @@ function snmpwalk_cache_oid($device, $oid, $array = [], $mib = null, $mibdir = n
         [$oid,$value] = explode('=', $entry, 2);
         $oid = trim($oid);
         $value = trim($value, "\" \\\n\r");
-        [$oid, $index] = explode('.', $oid, 2);
+
+        if (is_array_index($snmpflags)) {
+            if (preg_match('/(.*)\[(.*)]/',$oid,$m) !== 1) {
+                continue;
+            }
+
+            $oid=$m[1];
+            $index=$m[2];
+        } else {
+            [$oid, $index] = explode('.', $oid, 2);
+        }
+
         if (! strstr($value, 'at this OID') && ! empty($oid)) {
             $array[$index][$oid] = $value;
         }


### PR DESCRIPTION
Add support for -OX  snmpflag to snmpwalk_cache_oid() to  allow support for binary indexes. 

This fixes #15739.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
