### PR TITLE
Switch bill_notes input to textarea

### DIFF
--- a/includes/html/pages/bill/addoreditbill.inc.php
+++ b/includes/html/pages/bill/addoreditbill.inc.php
@@ -103,7 +103,7 @@
     <div class="form-group">
       <label class="col-sm-4 control-label" for="bill_notes">Notes</label>
       <div class="col-sm-8">
-        <input class="form-control input-sm" type="textarea" name="bill_notes" value="<?php echo htmlentities($bill_data['bill_notes']); ?>">
+        <textarea class="form-control input-sm" name="bill_notes"><?php echo htmlentities($bill_data['bill_notes']); ?></textarea>
       </div>
     </div>
 </fieldset>


### PR DESCRIPTION
Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

Looking at https://github.com/librenms/librenms/blob/19e206289399a0851feef3f1006d39829cf71148/database/migrations/2018_07_03_091314_create_bills_table.php#L33C1-L35 -- the "bill_notes" allows upto 256 characters, although it was setup as type="textarea" already it still appeared as a normal input box, I've switched it to a <textarea></textarea> instead so URLs to customer profiles are visible easily.

#### Before

![chrome_z2CXhfoMPA](https://github.com/librenms/librenms/assets/363587/56f04ffc-8b87-4b13-8593-83b738feecef)

#### After

![chrome_1bhVKAWEmn](https://github.com/librenms/librenms/assets/363587/93f7bd76-d6b1-435a-8984-16ed4059eb83)



#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
