### PR TITLE
bug - Fix API bug causing note updates to fail

### DIFF
--- a/includes/common.php
+++ b/includes/common.php
@@ -291,7 +291,7 @@ function zeropad($num, $length = 2)
 
 function set_dev_attrib($device, $attrib_type, $attrib_value)
 {
-    return DeviceCache::get((int) $device['device_id'])->setAttrib($attrib_type, $attrib_value);
+    return DeviceCache::get((int) $device)->setAttrib($attrib_type, $attrib_value);
 }
 
 function get_dev_attribs($device_id)


### PR DESCRIPTION
Fix API bug causing note updates to fail.
$device in this piece of code is a string containing the device ID or hostname, not an array

https://community.librenms.org/t/can-someone-post-a-working-curl-for-update-device-port-notes/23412

https://github.com/librenms/librenms/issues/15762


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
