### PR TITLE
Fix twofactor default value

### DIFF
--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -5837,7 +5837,7 @@
             "order": 1
         },
         "twofactor": {
-            "default": "false",
+            "default": false,
             "type": "boolean",
             "group": "auth",
             "section": "general",


### PR DESCRIPTION
Showed enabled in the webui, when it was actually disabled.


#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
