### PR TITLE
Detect UniFi U7 APs as UniFi AP type

### DIFF
--- a/includes/definitions/unifi.yaml
+++ b/includes/definitions/unifi.yaml
@@ -15,6 +15,7 @@ discovery:
         sysDescr_regex:
             - '/^UAP/'
             - '/^U6/'
+            - '/^U7/'
     -
         sysObjectID: .1.3.6.1.4.1.10002.1
         sysDescr: Linux


### PR DESCRIPTION
Relatively trivial update to allow discovery of UniFi U7 AP models as UniFi.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/) **(No code change, just a YAML update)**
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it. **(N/A - no functional change, purely data update)**
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
