### PR TITLE
Update edgeswitch.yaml - Remove sysDescr regex ^US[ -]/

### DIFF
--- a/includes/definitions/edgeswitch.yaml
+++ b/includes/definitions/edgeswitch.yaml
@@ -21,6 +21,7 @@ discovery:
             - '/^EdgePoint/'
             - '/^USW[ -]/'
             - '/^UBNT US/'
+            - '/^US[W]{0,1}-[\d]{1,2}/'
     -
         sysObjectID:
             - .1.3.6.1.4.1.8072.3.2.10

--- a/includes/definitions/edgeswitch.yaml
+++ b/includes/definitions/edgeswitch.yaml
@@ -21,7 +21,6 @@ discovery:
             - '/^EdgePoint/'
             - '/^USW[ -]/'
             - '/^UBNT US/'
-            - '/^US[ -]/'
     -
         sysObjectID:
             - .1.3.6.1.4.1.8072.3.2.10


### PR DESCRIPTION
We had systems misidentified as EdgeSwitches because the SNMP system description we use is based on country-city-device, eg:

US-BOSTON-FW01
DE-KOLN-SW01
etc

For the EdgeSwitch device detection there was a regex based on the sysDescr that included ^US[ -]/

I feel it's better to have this removed, as it could cause lots of devices to be misidentified as EdgeSwitches since 'US-' is such a common part of a description.

If someone feels this is incorrect, feel free to reject this PR

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
