### PR TITLE
Make all image URLs absolute and fix path for viewer

### DIFF
--- a/app/Http/Controllers/Maps/CustomMapController.php
+++ b/app/Http/Controllers/Maps/CustomMapController.php
@@ -88,6 +88,7 @@ class CustomMapController extends Controller
             'bgversion' => $map->background_version,
             'page_refresh' => Config::get('page_refresh', 300),
             'map_conf' => $map_conf,
+            'base_url' => Config::get('base_url'),
             'newedge_conf' => $map->newedgeconfig,
             'newnode_conf' => $map->newnodeconfig,
             'vmargin' => 20,
@@ -111,6 +112,7 @@ class CustomMapController extends Controller
             'edit' => true,
             'vmargin' => 20,
             'hmargin' => 20,
+            'base_url' => Config::get('base_url'),
             'images' => $this->listNodeImages(),
             'maps' => CustomMap::orderBy('name')->where('custom_map_id', '<>', $map->custom_map_id)->get(['custom_map_id', 'name']),
         ];

--- a/resources/views/map/custom-edit.blade.php
+++ b/resources/views/map/custom-edit.blade.php
@@ -63,7 +63,7 @@
     var network_nodes = new vis.DataSet({queue: {delay: 100}});
     var network_edges = new vis.DataSet({queue: {delay: 100}});
     var node_device_map = {};
-    var custom_image_base = "images/custommap/icons/";
+    var custom_image_base = "{{ $base_url }}images/custommap/icons/";
 
     function CreateNetwork() {
         // Flush the nodes and edges so they are rendered immediately

--- a/resources/views/map/custom-view.blade.php
+++ b/resources/views/map/custom-view.blade.php
@@ -33,7 +33,7 @@
     var edge_port_map = {};
     var node_device_map = {};
     var node_link_map = {};
-    var custom_image_base = "images/custommap/";
+    var custom_image_base = "{{ $base_url }}images/custommap/icons/";
 
     function CreateNetwork() {
         // Flush the nodes and edges so they are rendered immediately


### PR DESCRIPTION
This make all image icon URLs absolute following feedback that images were not working at all.
It also adds the /icons/ part of the URLs in the viewer

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
