### PR TITLE
Add support for Webex max message length.

### DIFF
--- a/LibreNMS/Alert/Transport/Ciscospark.php
+++ b/LibreNMS/Alert/Transport/Ciscospark.php
@@ -31,18 +31,20 @@ class Ciscospark extends Transport
             'roomId' => $room_id,
         ];
 
-        if (strlen($alert_data['msg']) > Ciscospark::$MAX_MSG_SIZE) {
-            $msg = substr($alert_data['msg'], 0, Ciscospark::$MAX_MSG_SIZE) . '...';
-        } else {
-            $msg = $alert_data['msg'];
-        }
-
         if ($this->config['use-markdown'] === 'on') {
             // Remove blank lines as they create weird markdown behaviors.
-            $data['markdown'] = preg_replace('/^\s+/m', '', $msg);
+            $msg = preg_replace('/^\s+/m', '', $alert_data['msg']);
+            $mtype = 'markdown';
         } else {
-            $data['text'] = strip_tags($msg);
+            $msg = strip_tags($alert_data['msg']);
+            $mtype = 'text';
         }
+
+        if (strlen($msg) > Ciscospark::$MAX_MSG_SIZE) {
+            $msg = substr($msg, 0, Ciscospark::$MAX_MSG_SIZE) . '...';
+        }
+
+        $data[$mtype] = $msg;
 
         $res = Http::client()
             ->withToken($token)

--- a/LibreNMS/Alert/Transport/Ciscospark.php
+++ b/LibreNMS/Alert/Transport/Ciscospark.php
@@ -31,11 +31,11 @@ class Ciscospark extends Transport
             'roomId' => $room_id,
         ];
 
-	if (strlen($alert_data['msg']) > Ciscospark::$MAX_MSG_SIZE) {
-	    $msg = substr($alert_data['msg'], 0, Ciscospark::$MAX_MSG_SIZE) . '...';
-	} else {
-	    $msg = $alert_data['msg'];
-	}
+        if (strlen($alert_data['msg']) > Ciscospark::$MAX_MSG_SIZE) {
+            $msg = substr($alert_data['msg'], 0, Ciscospark::$MAX_MSG_SIZE) . '...';
+        } else {
+            $msg = $alert_data['msg'];
+        }
 
         if ($this->config['use-markdown'] === 'on') {
             // Remove blank lines as they create weird markdown behaviors.


### PR DESCRIPTION
Webex limits messages to just over 7 KB.  Some alerts might be longer than this.  So truncate the message with ellipses.

While here switch to using the new API URL.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
