### PR TITLE
Replace pivotTable() by ->table(2) in powerconnect NAC polling

### DIFF
--- a/LibreNMS/OS/Powerconnect.php
+++ b/LibreNMS/OS/Powerconnect.php
@@ -137,18 +137,6 @@ class Powerconnect extends OS implements ProcessorDiscovery, ProcessorPolling, N
         return $res;
     }
 
-    private static function pivotTable(array $table): array
-    {
-        $res = [];
-        foreach ($table as $column => $data) {
-            foreach ($data as $index => $value) {
-                $res[$index][$column] = $value;
-            }
-        }
-
-        return $res;
-    }
-
     public function pollNac()
     {
         $nac = new Collection();
@@ -160,14 +148,12 @@ class Powerconnect extends OS implements ProcessorDiscovery, ProcessorPolling, N
             return $nac;
         }
 
-        $table = SnmpQuery::mibs(['DNOS-AUTHENTICATION-MANAGER-MIB'])->mibDir('dell')->hideMib()->enumStrings()->walk('agentAuthMgrClientStatusTable')->table();
+        $table = SnmpQuery::mibs(['DNOS-AUTHENTICATION-MANAGER-MIB'])->mibDir('dell')->hideMib()->enumStrings()->walk('agentAuthMgrClientStatusTable')->table(2);
         if (count($table) === 0) {
             d_echo('Client status table is empty, not processing NAC entries.');
 
             return $nac;
         }
-
-        $table = self::pivotTable($table);
 
         $hostmode = SnmpQuery::mibs(['DNOS-AUTHENTICATION-MANAGER-MIB'])->mibDir('dell')->hideMib()->enumStrings()->walk('agentAuthMgrPortHostMode')->valuesByIndex();
         foreach ($table as &$row) {


### PR DESCRIPTION
Requested by @PipoCanaja in #15778 comments: This is to remove `pivotTable` function and use `->table(2)` instead.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
