### PR TITLE
docs: more precise OAuth group/role claim information

### DIFF
--- a/doc/Extensions/OAuth-SAML.md
+++ b/doc/Extensions/OAuth-SAML.md
@@ -298,7 +298,10 @@ Socialite can specifiy scopes that should be included with in the authentication
 For example, if Okta is configured to expose group information it is possible to use these group
 names to configure User Roles.
 
-First enable sending the 'groups' claim (along with the normal openid, profile, and email claims )
+First enable sending the 'groups' claim (along with the normal openid, profile, and email claims).
+Be aware that the scope name must match the claim name. For identity providers where the scope does
+not match (e.g. Keycloak: roles -> groups) you need to configure a custom scope.
+
 !!! setting "settings/auth/socialite"
     ```bash
     lnms config:set auth.socialite.scopes.+ groups


### PR DESCRIPTION
While configuring SSO with Keycloak we were trying to send the scope 'roles' and were expecting libreNMS to use the returned 'groups' claim, but when reading the code we discovered that the scope name is used to access the claims.

I made the documentation a bit clearer to indicate that the scope needs to match the claim name in order for the roles to work.
The relevant code is here: https://github.com/librenms/librenms/blob/5769d7356efc62991209a27fa4bb527118c360c9/app/Http/Controllers/Auth/SocialiteController.php#L165

![image](https://github.com/librenms/librenms/assets/613138/1324aa69-ac64-4e0e-ad29-12a7f5069f6e)


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
