### PR TITLE
Add 'to' parameter where missing to fix a graph visualization issue

### DIFF
--- a/LibreNMS/Util/Html.php
+++ b/LibreNMS/Util/Html.php
@@ -116,6 +116,7 @@ class Html
         $graph_data = [];
         foreach ($periods as $period => $period_text) {
             $graph_array['from'] = Config::get("time.$period");
+            $graph_array['to'] = Config::get("time.now"); 
             $graph_array_zoom = $graph_array;
             $graph_array_zoom['height'] = '150';
             $graph_array_zoom['width'] = '400';

--- a/app/Http/Controllers/Table/MempoolsController.php
+++ b/app/Http/Controllers/Table/MempoolsController.php
@@ -119,6 +119,7 @@ class MempoolsController extends TableController
             'type' => 'mempool_usage',
             'id' => $mempool->mempool_id,
             'from' => Config::get('time.day'),
+            'to' => Config::get('time.now') ,
             'height' => 150,
             'width' => 400,
         ];
@@ -129,7 +130,7 @@ class MempoolsController extends TableController
         $total = $is_percent ? $mempool->mempool_total : Number::formatBi($mempool->mempool_total);
 
         $percent = Html::percentageBar(400, 20, $mempool->mempool_perc, "$used / $total", $free, $mempool->mempool_perc_warn);
-        $link = Url::generate(['page' => 'graphs'], Arr::only($graph, ['id', 'type', 'from']));
+        $link = Url::generate(['page' => 'graphs'], Arr::only($graph, ['id', 'type', 'from','to']));
 
         return Url::overlibLink($link, $percent, Url::graphTag($graph));
     }

--- a/includes/html/functions.inc.php
+++ b/includes/html/functions.inc.php
@@ -403,7 +403,7 @@ function generate_sensor_link($args, $text = null, $type = null)
 
     $content .= '</div>';
 
-    $url = \LibreNMS\Util\Url::generate(['page' => 'graphs', 'id' => $args['sensor_id'], 'type' => $args['graph_type'], 'from' => \LibreNMS\Config::get('time.day')], []);
+    $url = \LibreNMS\Util\Url::generate(['page' => 'graphs', 'id' => $args['sensor_id'], 'type' => $args['graph_type'], 'from' => \LibreNMS\Config::get('time.day'), 'to' => \LibreNMS\Config::get('time.now')], []);
 
     return \LibreNMS\Util\Url::overlibLink($url, $text, $content);
 }//end generate_sensor_link()

--- a/includes/html/pages/device/overview/mempools.inc.php
+++ b/includes/html/pages/device/overview/mempools.inc.php
@@ -69,7 +69,7 @@ if ($mempools->isNotEmpty()) {
             'legend' => 'no',
         ];
 
-        $link = Url::generate(['page' => 'graphs'], Arr::only($graph_array, ['id', 'type', 'from']));
+        $link = Url::generate(['page' => 'graphs'], Arr::only($graph_array, ['id', 'type', 'from','to'])); 
         $overlib_content = generate_overlib_content($graph_array, DeviceCache::getPrimary()->hostname . ' - ' . $mempool->mempool_descr);
 
         $graph_array['width'] = 80;


### PR DESCRIPTION
When analyzing a graph and selecting a custom 'to' date, it consistently defaults to the current date and time.

After encountering this issue, I found a workaround on the LibreNMS forum, which involves manually adding the 'to' parameter in the URL. Upon inspecting the source code, I discovered that the 'to' parameter is missing several times when generating the URL.

This pull request highlights the locations where I have added the 'to' parameter.

I have tested these changes, and now the custom 'to' parameter is being considered. 

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
