### PR TITLE
[bugfix] Fix json-app-tool.php to work with Oid class.

### DIFF
--- a/scripts/json-app-tool.php
+++ b/scripts/json-app-tool.php
@@ -1,6 +1,8 @@
 #!/usr/bin/env php
 <?php
 
+require realpath(__DIR__ . '/..') . '/includes/init.php';
+
 // Pulled from includes/polling/functions.inc.php
 function data_flatten($array, $prefix = '', $joiner = '_')
 {


### PR DESCRIPTION
After commit https://github.com/librenms/librenms/commit/be24993cbb9c303d2b7d511acd955ab9b4ce60be , the json-app-tool.php script fails with the following error:

```
# ./scripts/json-app-tool.php -a systemd -s -j /tmp/systemd.json
PHP Fatal error:  Uncaught Error: Class "LibreNMS\Util\Oid" not found in /opt/librenms/scripts/json-app-tool.php:153
Stack trace:
#0 {main}
  thrown in /opt/librenms/scripts/json-app-tool.php on line 153
```

Adding the proposed "require" statement fixes the issue, though I'm not positive this is exactly what should be pulled into the script.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [X] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
