### PR TITLE
Socket Statistic Application cleanup and application page graph fixes.

### DIFF
--- a/doc/Extensions/Applications.md
+++ b/doc/Extensions/Applications.md
@@ -3011,34 +3011,34 @@ sagan_stat_check](https://metacpan.org/dist/Sagan-Monitoring/view/bin/sagan_stat
 
 ## Socket Statistics (ss)
 
-The Socket Statistics application polls ss and scrapes socket statuses.  Individual sockets and address families may be filtered out within the script's optional configuration JSON file.
+The Socket Statistics application polls ss and scrapes socket statuses.  Individual sockets and address-families may be filtered out within the script's optional configuration JSON file.
 
-a. The following socket types are polled directly.  Filtering a socket will disable direct polling as-well-as indirect polling via any address families that list the socket as their child:
+* The following socket types are polled directly.  Filtering a socket type will disable direct polling as-well-as indirect polling within any address-families that list the socket type as their child:
 ```
-dccp (also exists within AF inet,inet6)
-mptcp (also exists within AF inet,inet6)
-raw (also exists within AF inet,inet6)
-sctp (also exists within AF inet,inet6)
-tcp (also exists within AF inet,inet6)
-udp (also exists within AF inet,inet6)
+dccp (also exists within address-families "inet" and "inet6")
+mptcp (also exists within address-families "inet" and "inet6")
+raw (also exists within address-families "inet" and "inet6")
+sctp (also exists within address-families "inet" and "inet6")
+tcp (also exists within address-families "inet" and "inet6")
+udp (also exists within address-families "inet" and "inet6")
 xdp
 ```
 
-b. The following socket types are polled within an address family only:
+* The following socket types are polled within an address-family only:
 ```
-inet6 (within AF inet6)
-p_dgr (within AF link)
-p_raw (within AF link)
-ti_dg (within AF tipc)
-ti_rd (within AF tipc)
-ti_sq (within AF tipc)
-ti_st (within AF tipc)
-v_dgr (within AF vsock)
-v_str (within AF vsock)
-unknown (within AF inet,inet6,link,tipc,vsock)
+inet6 (within address-family "inet6")
+p_dgr (within address-family "link")
+p_raw (within address-family "link")
+ti_dg (within address-family "tipc")
+ti_rd (within address-family "tipc")
+ti_sq (within address-family "tipc")
+ti_st (within address-family "tipc")
+v_dgr (within address-family "vsock")
+v_str (within address-family "vsock")
+unknown (within address-families "inet", "inet6", "link", "tipc", and "vsock")
 ```
 
-c. The following address families are polled directly, however, they also have socket types within their address family "umbrella".  Filtering a socket will filter it from the address family.  Filtering an address family will filter out all of its child sockets UNLESS those child sockets are polled directly; see (a) above:
+* The following address-families are polled directly and have their child socket types tab-indented below them.  Filtering a socket type (see "a" above) will filter it from the address-family.  Filtering an address-family will filter out all of its child socket types.  However, if those socket types are not DIRECTLY filtered out (see "a" above), then they will continue to be monitored either directly or within other address-families in which they exist:
 ```
 inet
     dccp
@@ -3096,9 +3096,9 @@ extend ss /etc/snmp/ss.py
 ```
 
 4. (Optional) Create a /etc/snmp/ss.json file and specify:
-    a.) "ss_cmd" - String path to the ss binary: ["/sbin/ss"]
-    b.) "socket_types"  - A comma-delimited list of socket types to include.  The following socket types are valid: dccp, icmp6, mptcp, p_dgr, p_raw, raw, sctp, tcp, ti_dg, ti_rd, ti_sq, ti_st, u_dgr, u_seq, u_str, udp, unknown, v_dgr, v_dgr, xdp.  Please note that the "unknown" socket type is represented in ss output with the netid "???".  Please also note that the p_dgr and p_raw socket types are specific to the "link" address family; the ti_dg, ti_rd, ti_sq, and ti_st socket types are specific to the "tipc" address family; the u_dgr, u_seq, and u_str socket types are specific to the "unix" address family; and the v_dgr and v_str socket types are specific to the "vsock" address family.  Filtering out the parent address families for the aforementioned will also filter out their specific socket types.  Specifying "all" includes all of the socket types.  For example: to include only tcp, udp, icmp6 sockets, you would specify "tcp,udp,icmp6": ["all"]
-    c.) "addr_families" - A comma-delimited list of address families to include.  The following families are valid: inet, inet6, link, netlink, tipc, unix, vsock.  As mentioned above under (b), filtering out the link, tipc, unix, or vsock address families will also filter out their respective socket types.  Specifying "all" includes all of the families.  For example: to include only inet and inet6 families, you would specify "inet,inet6": ["all"]
+a. "ss_cmd" - String path to the ss binary: ["/sbin/ss"]
+b. "socket_types"  - A comma-delimited list of socket types to include.  The following socket types are valid: dccp, icmp6, mptcp, p_dgr, p_raw, raw, sctp, tcp, ti_dg, ti_rd, ti_sq, ti_st, u_dgr, u_seq, u_str, udp, unknown, v_dgr, v_dgr, xdp.  Please note that the "unknown" socket type is represented in /sbin/ss output with the netid "???".  Please also note that the p_dgr and p_raw socket types are specific to the "link" address family; the ti_dg, ti_rd, ti_sq, and ti_st socket types are specific to the "tipc" address family; the u_dgr, u_seq, and u_str socket types are specific to the "unix" address family; and the v_dgr and v_str socket types are specific to the "vsock" address family.  Filtering out the parent address families for the aforementioned will also filter out their specific socket types.  Specifying "all" includes all of the socket types.  For example: to include only tcp, udp, icmp6 sockets, you would specify "tcp,udp,icmp6": ["all"]
+c. "addr_families" - A comma-delimited list of address families to include.  The following families are valid: inet, inet6, link, netlink, tipc, unix, vsock.  As mentioned above under (b), filtering out the link, tipc, unix, or vsock address families will also filter out their respective socket types.  Specifying "all" includes all of the families.  For example: to include only inet and inet6 families, you would specify "inet,inet6": ["all"]
 ```
 {
     "ss_cmd": "/sbin/ss",
@@ -3106,7 +3106,7 @@ extend ss /etc/snmp/ss.py
     "addr_families": "all"
 }
 ```
-In order to filter out usually unused socket types, it is recommended to go with the following JSON:
+In order to filter out uncommon/unused socket types, the following JSON configuration is recommended:
 ```
 {
     "ss_cmd": "/sbin/ss",
@@ -3116,7 +3116,7 @@ In order to filter out usually unused socket types, it is recommended to go with
 ```
 
 
-5. (Optional) If you have SELinux in Enforcing mode, you must add a module so the script can access socket state:
+5. (Optional) If SELinux is in Enforcing mode, you must add a module so the script can poll sockets:
 ```
 cat << EOF > snmpd_ss.te
 module snmp_ss 1.0;

--- a/includes/html/graphs/application/ss-af-common.inc.php
+++ b/includes/html/graphs/application/ss-af-common.inc.php
@@ -1,0 +1,59 @@
+<?php
+
+require 'includes/ss-shared.inc.php';
+
+$allowed_afs = $app->data['allowed_afs'] ?? [];
+$rrdArray = [];
+
+// This section draws the individual graphs in the device application page
+// displaying the SPECIFIED address-family's socket type's states.
+if (isset($vars['netid'])) {
+    $netid = $vars['netid'];
+    $af_netid = $addr_family . '_' . $netid;
+
+    // Map the socket type to its available statuses.
+    if (array_key_exists($netid, $ss_socket_states_mapper)) {
+        $local_ss_socket_states_mapper = $ss_socket_states_mapper[$netid];
+    } else {
+        $local_ss_socket_states_mapper = $ss_socket_states_mapper['default'];
+    }
+
+    // Create the rrdArray and map the address family's socket type
+    // to its "clean" socket state name and description.
+    foreach ($local_ss_socket_states_mapper as $socket_state => $socket_state_clean_name) {
+        $rrdArray[$af_netid][$socket_state_clean_name] = [
+            'descr' => $socket_state_clean_name,
+        ];
+    }
+}
+
+// This section draws the graph for the application-specific pages
+// displaying ALL of the address-family's sockets types' states.
+if (! isset($vars['netid']) && in_array($addr_family, $allowed_afs)) {
+    $allowed_sockets = $app->data['allowed_sockets'] ?? [];
+
+    foreach ($ss_netid_mapper[$addr_family] as $netid) {
+        // Don't display data for filtered sockets.
+        if (! in_array($netid, $allowed_sockets)) {
+            continue;
+        }
+        $af_netid = $addr_family . '_' . $netid;
+
+        // Map the socket type to its available statuses.
+        if (array_key_exists($netid, $ss_socket_states_mapper)) {
+            $local_ss_socket_states_mapper = $ss_socket_states_mapper[$netid];
+        } else {
+            $local_ss_socket_states_mapper = $ss_socket_states_mapper['default'];
+        }
+
+        // Create the rrdArray and map the address family's socket type
+        // to its "clean" socket state name and description.
+        foreach ($local_ss_socket_states_mapper as $socket_state => $socket_state_clean_name) {
+            $rrdArray[$af_netid][$socket_state_clean_name] = [
+                'descr' => $af_netid . '_' . $socket_state_clean_name,
+            ];
+        }
+    }
+}
+
+require 'ss-common.inc.php';

--- a/includes/html/graphs/application/ss-common.inc.php
+++ b/includes/html/graphs/application/ss-common.inc.php
@@ -11,6 +11,11 @@ $smalldescrlen = 20;
 
 $rrd_list = [];
 
+if (! $rrdArray) {
+    graph_error('No Data to Display', 'No Data');
+}
+
+$i = 0;
 foreach (array_keys($rrdArray) as $socket_type) {
     $rrd_filename = Rrd::name($device['hostname'], [
         $polling_type,
@@ -20,7 +25,6 @@ foreach (array_keys($rrdArray) as $socket_type) {
     ]);
 
     if (Rrd::checkRrdExists($rrd_filename)) {
-        $i = 0;
         foreach ($rrdArray[$socket_type] as $socket_status => $socket_status_desc) {
             $rrd_list[$i]['filename'] = $rrd_filename;
             $rrd_list[$i]['descr'] = $socket_status_desc['descr'];
@@ -28,7 +32,7 @@ foreach (array_keys($rrdArray) as $socket_type) {
             $i++;
         }
     } else {
-        d_echo('RRD ' . $rrd_filename . ' not found');
+        graph_error('No Data file ' . basename($rrd_filename), 'No Data');
     }
 }
 

--- a/includes/html/graphs/application/ss-netid-common.inc.php
+++ b/includes/html/graphs/application/ss-netid-common.inc.php
@@ -1,0 +1,20 @@
+<?php
+
+require 'includes/ss-shared.inc.php';
+
+$rrdArray = [];
+
+// Map the socket type to its available statuses.
+if (array_key_exists($netid, $ss_socket_states_mapper)) {
+    $local_ss_socket_states_mapper = $ss_socket_states_mapper[$netid];
+} else {
+    $local_ss_socket_states_mapper = $ss_socket_states_mapper['default'];
+}
+
+// Create the rrdArray and map the address family's socket type
+// to its "clean" socket state name and description.
+foreach ($local_ss_socket_states_mapper as $socket_state => $socket_state_clean_name) {
+    $rrdArray[$netid][$socket_state_clean_name] = ['descr' => $socket_state_clean_name];
+}
+
+require 'ss-common.inc.php';

--- a/includes/html/graphs/application/ss_dccp.inc.php
+++ b/includes/html/graphs/application/ss_dccp.inc.php
@@ -1,18 +1,5 @@
 <?php
 
-require_once 'includes/ss-shared.inc.php';
+$netid = 'dccp';
 
-$socket_type = 'dccp';
-$rrdArray = [];
-
-if (array_key_exists($socket_type, $ss_socket_states_mapper)) {
-    $local_ss_socket_states_mapper = $ss_socket_states_mapper[$socket_type];
-} else {
-    $local_ss_socket_states_mapper = $ss_socket_states_mapper['default'];
-}
-
-foreach ($local_ss_socket_states_mapper as $socket_state => $socket_state_clean_name) {
-    $rrdArray[$socket_type][$socket_state_clean_name] = ['descr' => $socket_state_clean_name];
-}
-
-require 'ss-common.inc.php';
+require 'ss-netid-common.inc.php';

--- a/includes/html/graphs/application/ss_inet.inc.php
+++ b/includes/html/graphs/application/ss_inet.inc.php
@@ -1,24 +1,5 @@
 <?php
 
-require_once 'includes/ss-shared.inc.php';
-
 $addr_family = 'inet';
-$rrdArray = [];
 
-$netid = $vars['netid'];
-
-$socket_type = $addr_family . '_' . $netid;
-
-if (array_key_exists($netid, $ss_socket_states_mapper)) {
-    $local_ss_socket_states_mapper = $ss_socket_states_mapper[$netid];
-} else {
-    $local_ss_socket_states_mapper = $ss_socket_states_mapper['default'];
-}
-
-foreach ($local_ss_socket_states_mapper as $socket_state => $socket_state_clean_name) {
-    $rrdArray[$socket_type][$socket_state_clean_name] = [
-        'descr' => $socket_state_clean_name,
-    ];
-}
-
-require 'ss-common.inc.php';
+require 'ss-af-common.inc.php';

--- a/includes/html/graphs/application/ss_inet6.inc.php
+++ b/includes/html/graphs/application/ss_inet6.inc.php
@@ -1,24 +1,5 @@
 <?php
 
-require_once 'includes/ss-shared.inc.php';
-
 $addr_family = 'inet6';
-$rrdArray = [];
 
-$netid = $vars['netid'];
-
-$socket_type = $addr_family . '_' . $netid;
-
-if (array_key_exists($netid, $ss_socket_states_mapper)) {
-    $local_ss_socket_states_mapper = $ss_socket_states_mapper[$netid];
-} else {
-    $local_ss_socket_states_mapper = $ss_socket_states_mapper['default'];
-}
-
-foreach ($local_ss_socket_states_mapper as $socket_state => $socket_state_clean_name) {
-    $rrdArray[$socket_type][$socket_state_clean_name] = [
-        'descr' => $socket_state_clean_name,
-    ];
-}
-
-require 'ss-common.inc.php';
+require 'ss-af-common.inc.php';

--- a/includes/html/graphs/application/ss_link.inc.php
+++ b/includes/html/graphs/application/ss_link.inc.php
@@ -1,24 +1,5 @@
 <?php
 
-require_once 'includes/ss-shared.inc.php';
-
 $addr_family = 'link';
-$rrdArray = [];
 
-$netid = $vars['netid'];
-
-$socket_type = $addr_family . '_' . $netid;
-
-if (array_key_exists($netid, $ss_socket_states_mapper)) {
-    $local_ss_socket_states_mapper = $ss_socket_states_mapper[$netid];
-} else {
-    $local_ss_socket_states_mapper = $ss_socket_states_mapper['default'];
-}
-
-foreach ($local_ss_socket_states_mapper as $socket_state => $socket_state_clean_name) {
-    $rrdArray[$socket_type][$socket_state_clean_name] = [
-        'descr' => $socket_state_clean_name,
-    ];
-}
-
-require 'ss-common.inc.php';
+require 'ss-af-common.inc.php';

--- a/includes/html/graphs/application/ss_mptcp.inc.php
+++ b/includes/html/graphs/application/ss_mptcp.inc.php
@@ -1,18 +1,5 @@
 <?php
 
-require_once 'includes/ss-shared.inc.php';
+$netid = 'mptcp';
 
-$socket_type = 'mptcp';
-$rrdArray = [];
-
-if (array_key_exists($socket_type, $ss_socket_states_mapper)) {
-    $local_ss_socket_states_mapper = $ss_socket_states_mapper[$socket_type];
-} else {
-    $local_ss_socket_states_mapper = $ss_socket_states_mapper['default'];
-}
-
-foreach ($local_ss_socket_states_mapper as $socket_state => $socket_state_clean_name) {
-    $rrdArray[$socket_type][$socket_state_clean_name] = ['descr' => $socket_state_clean_name];
-}
-
-require 'ss-common.inc.php';
+require 'ss-netid-common.inc.php';

--- a/includes/html/graphs/application/ss_netlink.inc.php
+++ b/includes/html/graphs/application/ss_netlink.inc.php
@@ -1,18 +1,5 @@
 <?php
 
-require_once 'includes/ss-shared.inc.php';
+$netid = 'netlink';
 
-$addr_family = 'netlink';
-$rrdArray = [];
-
-if (array_key_exists($addr_family, $ss_socket_states_mapper)) {
-    $local_ss_socket_states_mapper = $ss_socket_states_mapper[$addr_family];
-} else {
-    $local_ss_socket_states_mapper = $ss_socket_states_mapper['default'];
-}
-
-foreach ($local_ss_socket_states_mapper as $socket_state => $socket_state_clean_name) {
-    $rrdArray[$addr_family][$socket_state_clean_name] = ['descr' => $socket_state_clean_name];
-}
-
-require 'ss-common.inc.php';
+require 'ss-netid-common.inc.php';

--- a/includes/html/graphs/application/ss_raw.inc.php
+++ b/includes/html/graphs/application/ss_raw.inc.php
@@ -1,18 +1,5 @@
 <?php
 
-require_once 'includes/ss-shared.inc.php';
+$netid = 'raw';
 
-$socket_type = 'raw';
-$rrdArray = [];
-
-if (array_key_exists($socket_type, $ss_socket_states_mapper)) {
-    $local_ss_socket_states_mapper = $ss_socket_states_mapper[$socket_type];
-} else {
-    $local_ss_socket_states_mapper = $ss_socket_states_mapper['default'];
-}
-
-foreach ($local_ss_socket_states_mapper as $socket_state => $socket_state_clean_name) {
-    $rrdArray[$socket_type][$socket_state_clean_name] = ['descr' => $socket_state_clean_name];
-}
-
-require 'ss-common.inc.php';
+require 'ss-netid-common.inc.php';

--- a/includes/html/graphs/application/ss_sctp.inc.php
+++ b/includes/html/graphs/application/ss_sctp.inc.php
@@ -1,18 +1,5 @@
 <?php
 
-require_once 'includes/ss-shared.inc.php';
+$netid = 'sctp';
 
-$socket_type = 'sctp';
-$rrdArray = [];
-
-if (array_key_exists($socket_type, $ss_socket_states_mapper)) {
-    $local_ss_socket_states_mapper = $ss_socket_states_mapper[$socket_type];
-} else {
-    $local_ss_socket_states_mapper = $ss_socket_states_mapper['default'];
-}
-
-foreach ($local_ss_socket_states_mapper as $socket_state => $socket_state_clean_name) {
-    $rrdArray[$socket_type][$socket_state_clean_name] = ['descr' => $socket_state_clean_name];
-}
-
-require 'ss-common.inc.php';
+require 'ss-netid-common.inc.php';

--- a/includes/html/graphs/application/ss_tcp.inc.php
+++ b/includes/html/graphs/application/ss_tcp.inc.php
@@ -1,18 +1,5 @@
 <?php
 
-require_once 'includes/ss-shared.inc.php';
+$netid = 'tcp';
 
-$socket_type = 'tcp';
-$rrdArray = [];
-
-if (array_key_exists($socket_type, $ss_socket_states_mapper)) {
-    $local_ss_socket_states_mapper = $ss_socket_states_mapper[$socket_type];
-} else {
-    $local_ss_socket_states_mapper = $ss_socket_states_mapper['default'];
-}
-
-foreach ($local_ss_socket_states_mapper as $socket_state => $socket_state_clean_name) {
-    $rrdArray[$socket_type][$socket_state_clean_name] = ['descr' => $socket_state_clean_name];
-}
-
-require 'ss-common.inc.php';
+require 'ss-netid-common.inc.php';

--- a/includes/html/graphs/application/ss_tipc.inc.php
+++ b/includes/html/graphs/application/ss_tipc.inc.php
@@ -1,24 +1,5 @@
 <?php
 
-require_once 'includes/ss-shared.inc.php';
-
 $addr_family = 'tipc';
-$rrdArray = [];
 
-$netid = $vars['netid'];
-
-$socket_type = $addr_family . '_' . $netid;
-
-if (array_key_exists($netid, $ss_socket_states_mapper)) {
-    $local_ss_socket_states_mapper = $ss_socket_states_mapper[$netid];
-} else {
-    $local_ss_socket_states_mapper = $ss_socket_states_mapper['default'];
-}
-
-foreach ($local_ss_socket_states_mapper as $socket_state => $socket_state_clean_name) {
-    $rrdArray[$socket_type][$socket_state_clean_name] = [
-        'descr' => $socket_state_clean_name,
-    ];
-}
-
-require 'ss-common.inc.php';
+require 'ss-af-common.inc.php';

--- a/includes/html/graphs/application/ss_udp.inc.php
+++ b/includes/html/graphs/application/ss_udp.inc.php
@@ -1,18 +1,5 @@
 <?php
 
-require_once 'includes/ss-shared.inc.php';
+$netid = 'udp';
 
-$socket_type = 'udp';
-$rrdArray = [];
-
-if (array_key_exists($socket_type, $ss_socket_states_mapper)) {
-    $local_ss_socket_states_mapper = $ss_socket_states_mapper[$socket_type];
-} else {
-    $local_ss_socket_states_mapper = $ss_socket_states_mapper['default'];
-}
-
-foreach ($local_ss_socket_states_mapper as $socket_state => $socket_state_clean_name) {
-    $rrdArray[$socket_type][$socket_state_clean_name] = ['descr' => $socket_state_clean_name];
-}
-
-require 'ss-common.inc.php';
+require 'ss-netid-common.inc.php';

--- a/includes/html/graphs/application/ss_unix.inc.php
+++ b/includes/html/graphs/application/ss_unix.inc.php
@@ -1,24 +1,5 @@
 <?php
 
-require_once 'includes/ss-shared.inc.php';
-
 $addr_family = 'unix';
-$rrdArray = [];
 
-$netid = $vars['netid'];
-
-$socket_type = $addr_family . '_' . $netid;
-
-if (array_key_exists($netid, $ss_socket_states_mapper)) {
-    $local_ss_socket_states_mapper = $ss_socket_states_mapper[$netid];
-} else {
-    $local_ss_socket_states_mapper = $ss_socket_states_mapper['default'];
-}
-
-foreach ($local_ss_socket_states_mapper as $socket_state => $socket_state_clean_name) {
-    $rrdArray[$socket_type][$socket_state_clean_name] = [
-        'descr' => $socket_state_clean_name,
-    ];
-}
-
-require 'ss-common.inc.php';
+require 'ss-af-common.inc.php';

--- a/includes/html/graphs/application/ss_vsock.inc.php
+++ b/includes/html/graphs/application/ss_vsock.inc.php
@@ -1,24 +1,5 @@
 <?php
 
-require_once 'includes/ss-shared.inc.php';
-
 $addr_family = 'vsock';
-$rrdArray = [];
 
-$netid = $vars['netid'];
-
-$socket_type = $addr_family . '_' . $netid;
-
-if (array_key_exists($netid, $ss_socket_states_mapper)) {
-    $local_ss_socket_states_mapper = $ss_socket_states_mapper[$netid];
-} else {
-    $local_ss_socket_states_mapper = $ss_socket_states_mapper['default'];
-}
-
-foreach ($local_ss_socket_states_mapper as $socket_state => $socket_state_clean_name) {
-    $rrdArray[$socket_type][$socket_state_clean_name] = [
-        'descr' => $socket_state_clean_name,
-    ];
-}
-
-require 'ss-common.inc.php';
+require 'ss-af-common.inc.php';

--- a/includes/html/graphs/application/ss_xdp.inc.php
+++ b/includes/html/graphs/application/ss_xdp.inc.php
@@ -1,18 +1,5 @@
 <?php
 
-require_once 'includes/ss-shared.inc.php';
+$netid = 'xdp';
 
-$socket_type = 'xdp';
-$rrdArray = [];
-
-if (array_key_exists($socket_type, $ss_socket_states_mapper)) {
-    $local_ss_socket_states_mapper = $ss_socket_states_mapper[$socket_type];
-} else {
-    $local_ss_socket_states_mapper = $ss_socket_states_mapper['default'];
-}
-
-foreach ($local_ss_socket_states_mapper as $socket_state => $socket_state_clean_name) {
-    $rrdArray[$socket_type][$socket_state_clean_name] = ['descr' => $socket_state_clean_name];
-}
-
-require 'ss-common.inc.php';
+require 'ss-netid-common.inc.php';

--- a/includes/html/pages/apps.inc.php
+++ b/includes/html/pages/apps.inc.php
@@ -523,6 +523,20 @@ $graphs['privoxy'] = [
 ];
 $graphs['ss'] = [
     'sockets',
+    'dccp',
+    'inet',
+    'inet6',
+    'link',
+    'mptcp',
+    'netlink',
+    'raw',
+    'sctp',
+    'tcp',
+    'tipc',
+    'udp',
+    'unix',
+    'vsock',
+    'xdp',
 ];
 $graphs['borgbackup'] = [
     'unique_csize',


### PR DESCRIPTION
This PR fixes four main issues in the Socket Statistics application graphing:
1. Code re-use: Two new helper php files, [ss-af-common.inc.php](https://github.com/librenms/librenms/compare/master...bnerickson:librenms:sockets_statistics_cleanup?expand=1#diff-d63c63ebe3cabd0fe3f25ff7f199c2c8fb724d8e27af86d971fb573725f9077e) and [ss-netid-common.inc.php](https://github.com/librenms/librenms/compare/master...bnerickson:librenms:sockets_statistics_cleanup?expand=1#diff-6875a5c4eb3161f097f42107086fd9b8e801244778a39d4f29954d86397f8060), have been added to the includes/html/graphs/application folder.  The former is called by all socket types that utilize address-families (inet, inet6, link, tipc, vsock, and unix) and the latter is called by all socket types polled directly (dccp, mptcp, raw, sctp, tcp, udp, xdp, and netlink).
2. Documentation clean-up: [Applications.md](https://github.com/librenms/librenms/compare/master...bnerickson:librenms:sockets_statistics_cleanup?expand=1#diff-130a75806df530067f1023b43fbec546c6f3b13bc70ba8adfa4ae06bf57a2299) has been updated to hopefully be a bit more readable on the wiki.
3. Fixing graph call errors: previously d_echo() was called if an RRD was missing or unknown.  Now the graph_error() function is called in [ss-common.inc.php](https://github.com/librenms/librenms/compare/master...bnerickson:librenms:sockets_statistics_cleanup?expand=1#diff-d8f32c45525975c4c597ac776219d53247898ab4b8030cede85cc9b829d1d9df) instead.
4. Add all of the socket types to the Application overview page as as-well-as the Socket Statistic specific Application page.  Before, we were only displaying TCP statistics.

Application Overview Page After Change:
![application_overview_page_after](https://github.com/librenms/librenms/assets/4349917/9702b3ff-0f58-49fb-abba-493c39c05954)

Socket Statistics Application Page After Change:
![socket_statistics_app_page_after](https://github.com/librenms/librenms/assets/4349917/e3c8ed9f-57b4-40d6-b9de-51a15aaadb50)

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [X] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
