### PR TITLE
new feature: fdb-tables and vlans for fortiswitches

### DIFF
--- a/includes/discovery/fdb-table/fortiswitch.inc.php
+++ b/includes/discovery/fdb-table/fortiswitch.inc.php
@@ -54,7 +54,7 @@ preg_match_all('/^Set-Cookie:\s*([^;]*)/mi', $response, $matches);
 if ($response === false) {
     echo 'Error cURL: ' . curl_error($ch) . "\n";
     echo 'Código de error: ' . curl_errno($ch) . "\n";
-  
+
     return; // No hay conectividad, salimos
 }
 

--- a/includes/discovery/fdb-table/fortiswitch.inc.php
+++ b/includes/discovery/fdb-table/fortiswitch.inc.php
@@ -54,6 +54,7 @@ preg_match_all('/^Set-Cookie:\s*([^;]*)/mi', $response, $matches);
 if ($response === false) {
     echo 'Error cURL: ' . curl_error($ch) . "\n";
     echo 'Código de error: ' . curl_errno($ch) . "\n";
+  
     return; // No hay conectividad, salimos
 }
 

--- a/includes/discovery/fdb-table/fortiswitch.inc.php
+++ b/includes/discovery/fdb-table/fortiswitch.inc.php
@@ -59,8 +59,8 @@ if ($response === false) {
 
 $url_get = 'https://' . $device_ip . '/api/v2/monitor/switch/mac-address';
 $curl_connection = curl_init($url_get);
-curl_setopt($curl_connection, CURLOPT_SSL_VERIFYPEER, FALSE);
-curl_setopt($curl_connection, CURLOPT_SSL_VERIFYHOST, FALSE);
+curl_setopt($curl_connection, CURLOPT_SSL_VERIFYPEER, false);
+curl_setopt($curl_connection, CURLOPT_SSL_VERIFYHOST, false);
 curl_setopt($curl_connection, CURLOPT_COOKIE, $matches[1][0]);
 curl_setopt($curl_connection, CURLOPT_RETURNTRANSFER, true);
 $response = curl_exec($curl_connection);

--- a/includes/discovery/fdb-table/fortiswitch.inc.php
+++ b/includes/discovery/fdb-table/fortiswitch.inc.php
@@ -121,4 +121,4 @@ for ($i = 0; $i < count($vlan_sw); $i++) {
 if (empty($insert)) { //if there aren't any mac on any port I insert a 0, cause if $insert is null, then  bridge.inc.php is called
     $insert[0][0][0] = '0';
 }
-?>
+echo PHP_EOL;

--- a/includes/discovery/fdb-table/fortiswitch.inc.php
+++ b/includes/discovery/fdb-table/fortiswitch.inc.php
@@ -36,7 +36,7 @@ $timeout_seconds = 10;
 
 echo 'Connecting: ' . $device_ip . '\n';
 $url_login = 'https://' . $device_ip . '/logincheck';
-$data = array('username'=>$user,'secretkey'=>$pass);
+$data = ['username' => $user, 'secretkey' => $pass];
 $post_data = http_build_query($data);
 
 $curl_connection = curl_init($url_login);

--- a/includes/discovery/fdb-table/fortiswitch.inc.php
+++ b/includes/discovery/fdb-table/fortiswitch.inc.php
@@ -1,0 +1,119 @@
+<?php
+
+/**
+ * fortiswicht.inc.php
+ *
+ * FDP Table discovery file for fortiswitch
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * @link       https://www.librenms.org
+ *
+ * @author     Oriol Lorenzo <oriol.lorenzo@urv.cat>
+ */
+
+require Config::get('install_dir') . "config.php";
+use App\Models\Device;
+use App\Models\Vlan;
+use DeviceCache;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Arr;
+use LibreNMS\Config;
+
+
+$device_id = $device['device_id'];
+$device_ip = $device['hostname'];
+$community = $device['community'];
+$user = $config['fortiswitch']['usuari'];
+$pass = $config['fortiswitch']['password'];
+$timeout_seconds = 10;
+
+echo "Connecting: " . $device_ip . "\n";
+$url_login = "https://" . $device_ip . "/logincheck";
+$data = array('username'=>$user,'secretkey'=>$pass);
+$post_data = http_build_query($data);
+
+$curl_connection = curl_init($url_login);
+
+
+curl_setopt($curl_connection, CURLOPT_SSL_VERIFYPEER, FALSE);
+curl_setopt($curl_connection, CURLOPT_SSL_VERIFYHOST, false);
+curl_setopt($curl_connection, CURLOPT_POST, TRUE);
+curl_setopt($curl_connection, CURLOPT_POSTFIELDS, $post_data);
+curl_setopt($curl_connection, CURLOPT_RETURNTRANSFER, TRUE);
+curl_setopt($curl_connection, CURLOPT_HEADER, TRUE);
+$response = curl_exec($curl_connection);
+
+
+$response_data = json_decode($response, true);
+if ($response_data === null) {
+    echo "Error al decodificar la respuesta JSON";
+    exit;
+}
+
+$vlan_sw = [];
+$interface = [];
+$mac = [];
+$port_id = [];
+
+foreach ($response_data['results'] as $result) {
+   if (strpos($result['interface'], 'port') === 0) { // only get data from ports, not static trunks nor fortilink trunks
+      $mac[] = $result['mac'];
+      $vlan_sw[] = $result['vlan'];
+      $interface[] = $result['interface'];
+   }
+}
+
+curl_close($curl_connection);
+
+
+foreach ($interface as $int) {
+
+        $ports_data = get_ports_mapped($device_id, $with_statistics = false);
+
+        $ifName = $int;
+        if (isset($ports_data['maps']['ifName'][$ifName])) {
+           $port_id[] = $ports_data['maps']['ifName'][$ifName];
+        } else {
+          echo "No se encontró el port_id para la interfaz $ifName";
+        }
+}
+
+for ($i = 0; $i < count($vlan_sw); $i++) {
+    $vlan_name = "vlan".$vlan_sw[$i];
+    //$vlan_id = dbFetchRow('SELECT vlan_id FROM `vlans` WHERE `device_id` = ? AND `vlan_name` = ?', [$device_id, $vlan_name]);
+    $vlan = Vlan::where('device_id', $device_id)
+            ->where('vlan_name', $vlan_name)
+            ->first();
+
+    if ($vlan) {
+       $vlan_id = $vlan->vlan_id;
+    } else {
+       $vlan_id = null;
+    }
+    $vlan_id_final = $vlan['vlan_id'];
+    $mac_address = implode(array_map('zeropad', explode(':', $mac[$i])));
+            if (strlen($mac_address) != 12) {
+                d_echo("MAC address padding failed for $mac\n");
+                continue;
+            }
+
+    $insert[$vlan_id_final][$mac_address]['port_id'] = $port_id[$i];
+}
+
+if (empty($insert)) { //if there aren't any mac on any port I insert a 0, cause if $insert is null, then  bridge.inc.php is called
+   $insert[0][0][0]='0';
+}
+
+?>

--- a/includes/discovery/fdb-table/fortiswitch.inc.php
+++ b/includes/discovery/fdb-table/fortiswitch.inc.php
@@ -34,7 +34,7 @@ $user = $config['fortiswitch']['usuari'];
 $pass = $config['fortiswitch']['password'];
 $timeout_seconds = 10;
 
-echo 'Connecting: ' . $device_ip . '\n';
+echo 'Connecting: ' . $device_ip;
 $url_login = 'https://' . $device_ip . '/logincheck';
 $data = ['username' => $user, 'secretkey' => $pass];
 $post_data = http_build_query($data);
@@ -47,6 +47,22 @@ curl_setopt($curl_connection, CURLOPT_POST, true);
 curl_setopt($curl_connection, CURLOPT_POSTFIELDS, $post_data);
 curl_setopt($curl_connection, CURLOPT_RETURNTRANSFER, true);
 curl_setopt($curl_connection, CURLOPT_HEADER, true);
+$response = curl_exec($curl_connection);
+
+preg_match_all('/^Set-Cookie:\s*([^;]*)/mi', $response, $matches);
+
+if ($response === false) {
+    echo 'Error cURL: ' . curl_error($ch) . "\n";
+    echo 'Código de error: ' . curl_errno($ch) . "\n";
+    return; // No hay conectividad, salimos
+}
+
+$url_get = 'https://' . $device_ip . '/api/v2/monitor/switch/mac-address';
+$curl_connection = curl_init($url_get);
+curl_setopt($curl_connection, CURLOPT_SSL_VERIFYPEER, FALSE);
+curl_setopt($curl_connection, CURLOPT_SSL_VERIFYHOST, FALSE);
+curl_setopt($curl_connection, CURLOPT_COOKIE, $matches[1][0]);
+curl_setopt($curl_connection, CURLOPT_RETURNTRANSFER, true);
 $response = curl_exec($curl_connection);
 
 $response_data = json_decode($response, true);

--- a/includes/discovery/fdb-table/fortiswitch.inc.php
+++ b/includes/discovery/fdb-table/fortiswitch.inc.php
@@ -24,10 +24,8 @@
  */
 
 require Config::get('install_dir') . 'config.php';
-use App\Models\Device;
 use App\Models\Vlan;
 use LibreNMS\Config;
-
 
 $device_id = $device['device_id'];
 $device_ip = $device['hostname'];
@@ -36,13 +34,12 @@ $user = $config['fortiswitch']['usuari'];
 $pass = $config['fortiswitch']['password'];
 $timeout_seconds = 10;
 
-echo "Connecting: " . $device_ip . "\n";
-$url_login = "https://" . $device_ip . "/logincheck";
+echo 'Connecting: ' . $device_ip . '\n';
+$url_login = 'https://' . $device_ip . '/logincheck';
 $data = array('username'=>$user,'secretkey'=>$pass);
 $post_data = http_build_query($data);
 
 $curl_connection = curl_init($url_login);
-
 
 curl_setopt($curl_connection, CURLOPT_SSL_VERIFYPEER, false);
 curl_setopt($curl_connection, CURLOPT_SSL_VERIFYHOST, false);
@@ -51,7 +48,6 @@ curl_setopt($curl_connection, CURLOPT_POSTFIELDS, $post_data);
 curl_setopt($curl_connection, CURLOPT_RETURNTRANSFER, true);
 curl_setopt($curl_connection, CURLOPT_HEADER, true);
 $response = curl_exec($curl_connection);
-
 
 $response_data = json_decode($response, true);
 if ($response_data === null) {
@@ -66,28 +62,27 @@ $port_id = [];
 
 foreach ($response_data['results'] as $result) {
     if (strpos($result['interface'], 'port') === 0) { // only get data from ports, not static trunks nor fortilink trunks
-       $mac[] = $result['mac'];
-       $vlan_sw[] = $result['vlan'];
-       $interface[] = $result['interface'];
+        $mac[] = $result['mac'];
+        $vlan_sw[] = $result['vlan'];
+        $interface[] = $result['interface'];
     }
 }
 
 curl_close($curl_connection);
 
 foreach ($interface as $int) {
-
     $ports_data = get_ports_mapped($device_id, $with_statistics = false);
 
     $ifName = $int;
     if (isset($ports_data['maps']['ifName'][$ifName])) {
-       $port_id[] = $ports_data['maps']['ifName'][$ifName];
+        $port_id[] = $ports_data['maps']['ifName'][$ifName];
     } else {
-      echo "No se encontró el port_id para la interfaz $ifName";
+        echo "No se encontró el port_id para la interfaz $ifName";
     }
 }
 
 for ($i = 0; $i < count($vlan_sw); $i++) {
-    $vlan_name = "vlan" . $vlan_sw[$i];
+    $vlan_name = 'vlan' . $vlan_sw[$i];
     $vlan = Vlan::where('device_id', $device_id)
             ->where('vlan_name', $vlan_name)
             ->first();
@@ -108,7 +103,6 @@ for ($i = 0; $i < count($vlan_sw); $i++) {
 }
 
 if (empty($insert)) { //if there aren't any mac on any port I insert a 0, cause if $insert is null, then  bridge.inc.php is called
-    $insert[0][0][0]='0';
+    $insert[0][0][0] = '0';
 }
-
 ?>

--- a/includes/discovery/vlans/fortiswitch.inc.php
+++ b/includes/discovery/vlans/fortiswitch.inc.php
@@ -1,0 +1,98 @@
+<?php
+
+
+/**
+ * fortiswitch.inc.php
+ *
+ * FDP Table discovery file for fortiswitch
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * @link       https://www.librenms.org
+ *
+ * @author     Oriol Lorenzo <oriol.lorenzo@urv.cat>
+ */
+
+
+
+
+
+use App\Models\Vlan;
+use LibreNMS\Enum\Severity;
+
+echo 'IEEE8021-Q-BRIDGE-MIB VLANs: ';
+
+//$vlanversion = snmp_get($device, 'dot1qVlanVersionNumber.0', '-Oqv', 'IEEE8021-Q-BRIDGE-MIB'); // On fortiswitches there's not a vlan version
+$vlanversion = 2;
+echo "ver $vlanversion ";
+if ($vlanversion == 'version1' || $vlanversion == '2') {
+    echo "ver $vlanversion ";
+
+    $vtpdomain_id = '1';
+
+    // fetch vlan data
+    $vlans = SnmpQuery::walk('Q-BRIDGE-MIB::dot1qVlanCurrentUntaggedPorts')->table(2);
+    $vlans = SnmpQuery::walk('Q-BRIDGE-MIB::dot1qVlanCurrentEgressPorts')->table(2, $vlans);
+    $vlans = SnmpQuery::walk('Q-BRIDGE-MIB::dot1qVlanStaticName')->table(1, $vlans);
+
+    //print_r($vlans);
+
+    foreach ($vlans as $vlan_id => $vlan) {
+        echo ("Processing $vlan_id \n");
+        d_echo('Processing vlan ID: ' . $vlan_id);
+        $vlan_name = empty($vlan['Q-BRIDGE-MIB::dot1qVlanStaticName']) ? "VLAN $vlan_id" : $vlan['Q-BRIDGE-MIB::dot1qVlanStaticName'];
+        preg_match_all('!\d+!', $vlan_name, $matches);
+        $vlan_id = implode('', $matches[0]);
+
+        echo ("Processing $vlan_name \n");
+        //try to get existing data from DB
+        
+        $vlanDB = Vlan::firstOrNew([
+            'device_id' => $device['device_id'],
+            'vlan_vlan' => $vlan_id,
+        ], [
+            'vlan_domain' => $vtpdomain_id,
+            'vlan_name' => $vlan_name,
+        ]);
+        echo ("vlanDB-> $vlanDB\n");
+
+        //vlan does not exist
+        if (! $vlanDB->exists) {
+            \App\Models\Eventlog::log("Vlan added: $vlan_id with name $vlan_name ", $device['device_id'], 'vlan', Severity::Warning);
+        }
+        echo ("vlan_name-> $vlan_name , $vlanDB->vlan_name\n");
+
+        if ($vlanDB->vlan_name != $vlan_name) {
+            $vlanDB->vlan_name = $vlan_name;
+            \App\Models\Eventlog::log("Vlan changed: $vlan_id new name $vlan_name", $device['device_id'], 'vlan', Severity::Warning);
+        }
+
+        $vlanDB->save();
+
+        $device['vlans'][$vtpdomain_id][$vlan_id] = $vlan_id; //populate device['vlans'] with ID's
+
+        //portmap for untagged ports
+        $untagged_ids = q_bridge_bits2indices($vlan['Q-BRIDGE-MIB::dot1qVlanCurrentUntaggedPorts'] ?? $vlan['Q-BRIDGE-MIB::dot1qVlanStaticUntaggedPorts'] ?? '');
+        //print_r($untagged_ids);
+        //portmap for members ports (might be tagged)
+        $egress_ids = q_bridge_bits2indices($vlan['Q-BRIDGE-MIB::dot1qVlanCurrentEgressPorts'] ?? $vlan['Q-BRIDGE-MIB::dot1qVlanStaticEgressPorts'] ?? '');
+        foreach ($egress_ids as $port_id) {
+            if (isset($base_to_index[$port_id])) {
+                $ifIndex = $base_to_index[$port_id];
+                $per_vlan_data[$vlan_id][$ifIndex]['untagged'] = (in_array($port_id, $untagged_ids) ? 1 : 0);
+            }
+        }
+    }
+}
+echo PHP_EOL;

--- a/includes/discovery/vlans/fortiswitch.inc.php
+++ b/includes/discovery/vlans/fortiswitch.inc.php
@@ -1,6 +1,5 @@
 <?php
 
-
 /**
  * fortiswitch.inc.php
  *
@@ -24,10 +23,6 @@
  * @author     Oriol Lorenzo <oriol.lorenzo@urv.cat>
  */
 
-
-
-
-
 use App\Models\Vlan;
 use LibreNMS\Enum\Severity;
 
@@ -49,15 +44,14 @@ if ($vlanversion == 'version1' || $vlanversion == '2') {
     //print_r($vlans);
 
     foreach ($vlans as $vlan_id => $vlan) {
-        echo ("Processing $vlan_id \n");
+        echo "Processing $vlan_id \n";
         d_echo('Processing vlan ID: ' . $vlan_id);
         $vlan_name = empty($vlan['Q-BRIDGE-MIB::dot1qVlanStaticName']) ? "VLAN $vlan_id" : $vlan['Q-BRIDGE-MIB::dot1qVlanStaticName'];
         preg_match_all('!\d+!', $vlan_name, $matches);
         $vlan_id = implode('', $matches[0]);
 
-        echo ("Processing $vlan_name \n");
-        //try to get existing data from DB
-        
+        echo "Processing $vlan_name \n";
+        //try to get existing data from DB 
         $vlanDB = Vlan::firstOrNew([
             'device_id' => $device['device_id'],
             'vlan_vlan' => $vlan_id,
@@ -65,13 +59,13 @@ if ($vlanversion == 'version1' || $vlanversion == '2') {
             'vlan_domain' => $vtpdomain_id,
             'vlan_name' => $vlan_name,
         ]);
-        echo ("vlanDB-> $vlanDB\n");
+        echo "vlanDB-> $vlanDB\n";
 
         //vlan does not exist
         if (! $vlanDB->exists) {
             \App\Models\Eventlog::log("Vlan added: $vlan_id with name $vlan_name ", $device['device_id'], 'vlan', Severity::Warning);
         }
-        echo ("vlan_name-> $vlan_name , $vlanDB->vlan_name\n");
+        echo "vlan_name-> $vlan_name , $vlanDB->vlan_name\n";
 
         if ($vlanDB->vlan_name != $vlan_name) {
             $vlanDB->vlan_name = $vlan_name;

--- a/includes/discovery/vlans/fortiswitch.inc.php
+++ b/includes/discovery/vlans/fortiswitch.inc.php
@@ -51,7 +51,7 @@ if ($vlanversion == 'version1' || $vlanversion == '2') {
         $vlan_id = implode('', $matches[0]);
 
         echo "Processing $vlan_name \n";
-        //try to get existing data from DB 
+        //try to get existing data from DB
         $vlanDB = Vlan::firstOrNew([
             'device_id' => $device['device_id'],
             'vlan_vlan' => $vlan_id,


### PR DESCRIPTION
Please give a short description what your pull request is for

Fortiswitches from Fortinet has a poor SNMP MIB implementation. I've made a script the retrieves fdb-table via API. I've made changes on q-bridge-mib.inc.php adapting it to fortiswitches, for that I've created fortiswitch.inc.php in discovery/vlans

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
