### PR TITLE
Fixed graphs for icmp service showing PL 4 times

### DIFF
--- a/includes/services/check_icmp.inc.php
+++ b/includes/services/check_icmp.inc.php
@@ -5,25 +5,25 @@ $check_cmd = \LibreNMS\Config::get('nagios_plugins') . '/check_icmp ' . $service
 
 if (isset($rrd_filename)) {
     // Check DS is a json array of the graphs that are available
-    $check_ds = '{"rtt":"s","pl":"%"}';
+    $check_ds = '{"rta":"s","rtmax":"s","rtmin":"s","pl":"%"}';
 
     // Build the graph data
     $check_graph = [];
-    $check_graph['rtt'] = ' DEF:DS0=' . $rrd_filename . ':rta:AVERAGE ';
-    $check_graph['rtt'] .= ' LINE1.25:DS0#' . \LibreNMS\Config::get('graph_colours.mixed.0') . ":'" . str_pad(substr('Round Trip Average', 0, 15), 15) . "' ";
-    $check_graph['rtt'] .= ' GPRINT:DS0:LAST:%5.2lf%s ';
-    $check_graph['rtt'] .= ' GPRINT:DS0:AVERAGE:%5.2lf%s ';
-    $check_graph['rtt'] .= ' GPRINT:DS0:MAX:%5.2lf%s\\l ';
-    $check_graph['rtt'] .= ' DEF:DS1=' . $rrd_filename . ':rtmax:AVERAGE ';
-    $check_graph['rtt'] .= ' LINE1.25:DS1#' . \LibreNMS\Config::get('graph_colours.mixed.1') . ":'" . str_pad(substr('Round Trip Max', 0, 15), 15) . "' ";
-    $check_graph['rtt'] .= ' GPRINT:DS1:LAST:%5.2lf%s ';
-    $check_graph['rtt'] .= ' GPRINT:DS1:AVERAGE:%5.2lf%s ';
-    $check_graph['rtt'] .= ' GPRINT:DS1:MAX:%5.2lf%s\\l ';
-    $check_graph['rtt'] .= ' DEF:DS2=' . $rrd_filename . ':rtmin:AVERAGE ';
-    $check_graph['rtt'] .= ' LINE1.25:DS2#' . \LibreNMS\Config::get('graph_colours.mixed.2') . ":'" . str_pad(substr('Round Trip Min', 0, 15), 15) . "' ";
-    $check_graph['rtt'] .= ' GPRINT:DS2:LAST:%5.2lf%s ';
-    $check_graph['rtt'] .= ' GPRINT:DS2:AVERAGE:%5.2lf%s ';
-    $check_graph['rtt'] .= ' GPRINT:DS2:MAX:%5.2lf%s\\l ';
+    $check_graph['rta'] = ' DEF:DS0=' . $rrd_filename . ':rta:AVERAGE ';
+    $check_graph['rta'] .= ' LINE1.25:DS0#' . \LibreNMS\Config::get('graph_colours.mixed.0') . ":'" . str_pad(substr('Round Trip Average', 0, 15), 15) . "' ";
+    $check_graph['rta'] .= ' GPRINT:DS0:LAST:%5.2lf%s ';
+    $check_graph['rta'] .= ' GPRINT:DS0:AVERAGE:%5.2lf%s ';
+    $check_graph['rta'] .= ' GPRINT:DS0:MAX:%5.2lf%s\\l ';
+    $check_graph['rtmax'] .= ' DEF:DS1=' . $rrd_filename . ':rtmax:AVERAGE ';
+    $check_graph['rtmax'] .= ' LINE1.25:DS1#' . \LibreNMS\Config::get('graph_colours.mixed.1') . ":'" . str_pad(substr('Round Trip Max', 0, 15), 15) . "' ";
+    $check_graph['rtmax'] .= ' GPRINT:DS1:LAST:%5.2lf%s ';
+    $check_graph['rtmax'] .= ' GPRINT:DS1:AVERAGE:%5.2lf%s ';
+    $check_graph['rtmax'] .= ' GPRINT:DS1:MAX:%5.2lf%s\\l ';
+    $check_graph['rtmin'] .= ' DEF:DS2=' . $rrd_filename . ':rtmin:AVERAGE ';
+    $check_graph['rtmin'] .= ' LINE1.25:DS2#' . \LibreNMS\Config::get('graph_colours.mixed.2') . ":'" . str_pad(substr('Round Trip Min', 0, 15), 15) . "' ";
+    $check_graph['rtmin'] .= ' GPRINT:DS2:LAST:%5.2lf%s ';
+    $check_graph['rtmin'] .= ' GPRINT:DS2:AVERAGE:%5.2lf%s ';
+    $check_graph['rtmin'] .= ' GPRINT:DS2:MAX:%5.2lf%s\\l ';
 
     $check_graph['pl'] = ' DEF:DS0=' . $rrd_filename . ':pl:AVERAGE ';
     $check_graph['pl'] .= ' AREA:DS0#' . \LibreNMS\Config::get('graph_colours.mixed.2') . ":'" . str_pad(substr('Packet Loss (%)', 0, 15), 15) . "' ";


### PR DESCRIPTION
Please give a short description what your pull request is for:
Using the icmp Nagios plugin, instead of rta, rtmax, rtmin and pl, we see only the pl graph 4 times.
This PR fixes the problem, see attached screenshots for before and after.
Before:
![image](https://github.com/librenms/librenms/assets/118352982/41d52e3b-102d-49e2-be9f-451adfd0f35b)
After:
![image](https://github.com/librenms/librenms/assets/118352982/46f0e9fa-26e9-4ecc-aa21-940a46e34118)


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
