### PR TITLE
Added additional lines for selinux config to work with RHEL8

### DIFF
--- a/doc/Extensions/RRDCached.md
+++ b/doc/Extensions/RRDCached.md
@@ -245,17 +245,20 @@ require {
         type rrdcached_t;
         type httpd_sys_rw_content_t;
         class dir { add_name getattr open read remove_name rmdir search write };
-        class file { create getattr open read rename setattr unlink write };
+        class file { create getattr open read rename setattr unlink write map lock };
         class sock_file { create setattr unlink write };
         class capability { fsetid sys_resource };
+        class unix_stream_socket connectto;
 }
  
 #============= rrdcached_t ==============
  
 allow rrdcached_t httpd_sys_rw_content_t:dir { add_name getattr remove_name search write };
-allow rrdcached_t httpd_sys_rw_content_t:file { create getattr open read rename setattr unlink write };
+allow rrdcached_t httpd_sys_rw_content_t:file { create getattr open read rename setattr unlink write map lock };
 allow rrdcached_t self:capability fsetid;
 allow rrdcached_t var_run_t:sock_file { create setattr unlink };
+allow httpd_t var_run_t:sock_file write;
+allow httpd_t rrdcached_t:unix_stream_socket connectto;
 EOF
 
 checkmodule -M -m -o rrdcached_librenms.mod rrdcached_librenms.te


### PR DESCRIPTION
Added additional lines for selinux config to work with RHEL8
Added map and lock attribute to file class, and allowed httpd access to the rrdcached socket.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
