### PR TITLE
Documentation - opcache issue on Debian 12

### DIFF
--- a/doc/Support/Performance.md
+++ b/doc/Support/Performance.md
@@ -213,5 +213,6 @@ opcache.memory_consumption=256
 ```
 
 If you are having caching issues, you can clear the file based opcache with `rm -rf /tmp/cache`.
+
 Debian 12 users, be aware php 8.2 current stable version (8.2.7) creates segmentation faults when opcache uses file cache. Issue should be this one https://github.com/php/php-src/issues/10914 
 Using sury packages of disabling file cache solves the issue

--- a/doc/Support/Performance.md
+++ b/doc/Support/Performance.md
@@ -213,5 +213,5 @@ opcache.memory_consumption=256
 ```
 
 If you are having caching issues, you can clear the file based opcache with `rm -rf /tmp/cache`.
-
-
+Debian 12 users, be aware php 8.2 current stable version (8.2.7) creates segmentation faults when opcache uses file cache. Issue should be this one https://github.com/php/php-src/issues/10914 
+Using sury packages of disabling file cache solves the issue

--- a/doc/Support/Performance.md
+++ b/doc/Support/Performance.md
@@ -215,4 +215,4 @@ opcache.memory_consumption=256
 If you are having caching issues, you can clear the file based opcache with `rm -rf /tmp/cache`.
 
 Debian 12 users, be aware php 8.2 current stable version (8.2.7) creates segmentation faults when opcache uses file cache. Issue should be this one https://github.com/php/php-src/issues/10914 
-Using sury packages of disabling file cache solves the issue
+Using sury packages or disabling file cache solves the issue


### PR DESCRIPTION
Please give a short description what your pull request is for : hints to use opcache with Debian 12 (php 8.2.7, current stable version has an opcache bug solved in 8.2.9 https://github.com/php/php-src/issues/10914)

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
