### PR TITLE
Bump Github Actions to Node.JS 20.

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         name: Build mkdocs Docker image
         run: |

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -37,13 +37,13 @@ jobs:
           sudo chown -R $(id -u):$(id -g) ./out
       -
         name: Check GitHub Pages status
-        uses: crazy-max/ghaction-github-status@v2
+        uses: crazy-max/ghaction-github-status@v4
         with:
           pages_threshold: major_outage
       -
         name: Deploy
         if: github.event_name != 'pull_request' && endsWith(github.ref, github.event.repository.default_branch)
-        uses: crazy-max/ghaction-github-pages@v2
+        uses: crazy-max/ghaction-github-pages@v4
         with:
           repo: librenms/docs.librenms.org
           target_branch: main

--- a/.github/workflows/label-actions.yml
+++ b/.github/workflows/label-actions.yml
@@ -18,4 +18,4 @@ jobs:
   action:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/label-actions@v2
+      - uses: dessant/label-actions@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       -
         name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -46,7 +46,7 @@ jobs:
     steps:
       -
         name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       -
         name: Set up PHP
@@ -63,7 +63,7 @@ jobs:
 
       -
         name: Cache composer
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ matrix.php }}-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/composer.lock') }}
@@ -71,7 +71,7 @@ jobs:
 
       -
         name: Cache pip
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/requirements.txt') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       -
@@ -86,7 +86,7 @@ jobs:
           echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       -
         name: Cache composer
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/composer.lock') }}
@@ -94,7 +94,7 @@ jobs:
             ${{ runner.os }}-composer-${{ secrets.CACHE_VERSION }}-
       -
         name: Cache pip
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/requirements.txt') }}


### PR DESCRIPTION
Please give a short description what your pull request is for

Currently, some Github Actions still use Node.js 16. These Actions are deprecated (see image below). This PR bumps them to Node.js 20 Actions, which are not deprecated.

![image](https://github.com/librenms/librenms/assets/14372332/cec96d75-0686-4cdb-9b79-c98192c440b1)

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [X] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
