### PR TITLE
Custommap label fixes

### DIFF
--- a/resources/views/map/custom-edit.blade.php
+++ b/resources/views/map/custom-edit.blade.php
@@ -854,6 +854,7 @@
         $("#edgePortReverseRow").hide();
         $("#edgePortSearchRow").hide();
         $("#edgeRecenterRow").hide();
+        $("#edgelabel").hide();
 
         $("#edgestyle").val(newedgeconf.smooth.type);
         $("#edgetextface").val(newedgeconf.font.face);
@@ -923,10 +924,12 @@
         $("#edgetextcolour").val(edgedata.edge1.font.color);
         $("#edgetextshow").bootstrapSwitch('state', (edgedata.edge1.label != null && edgedata.edge1.label.includes('xx%')));
         $("#edgebpsshow").bootstrapSwitch('state', (edgedata.edge1.label != null && edgedata.edge1.label.includes('bps')));
+        $("#edgelabel").val('label' in edgedata.mid ? edgedata.mid.label : '');
 
         $("#edgeRecenterRow").show();
         $("#divEdgeFrom").show();
         $("#divEdgeTo").show();
+        $("#edgelabel").show();
         $("#edge-saveButton").show();
         $("#edge-saveDefaultsButton").hide();
         $("#edge-saveButton").on("click", {data: edgedata}, callback);

--- a/resources/views/map/custom-edit.blade.php
+++ b/resources/views/map/custom-edit.blade.php
@@ -253,7 +253,7 @@
                 var mid_x = mid_pos.x;
                 var mid_y = mid_pos.y;
 
-                var mid = {id: edgeid + "_mid", shape: "dot", size: 3, x: mid_x, y: mid_y};
+                var mid = {id: edgeid + "_mid", shape: "dot", size: 3, x: mid_x, y: mid_y, label: ''};
 
                 var edge1 = structuredClone(newedgeconf);
                 edge1.id = edgeid + "_from";
@@ -952,7 +952,11 @@
         edgedata.edge1.font.color = edgedata.edge2.font.color = $("#edgetextcolour").val();
         edgedata.edge1.label = edgedata.edge2.label = edgeLabel($("#edgetextshow").prop('checked'), $("#edgebpsshow").prop('checked'), null);
         edgedata.edge1.title = edgedata.edge2.title = $("#port_id").val();
-        edgedata.mid.label = ($("#edgelabel").val() || '');
+	let newlabel = $("#edgelabel").val() || '';
+	if (newlabel == '' && edgedata.mid.label != '') {
+            $("#map-renderButton").show();
+	}
+        edgedata.mid.label = newlabel;
 
         if(edgedata.id) {
             if($("#port_id").val()) {


### PR DESCRIPTION
Fix a few bugs in the labels on the custom maps:
 - Copy the correct value into the editor when editing an edge
 - Hide the label when editing the edge defaults
 - Show the re-render map button if a label is cleared (the vis.js editor doesn't clear the label if it is removed)

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
