### PR TITLE
Remove config_bgp config check in bird2 app

### DIFF
--- a/includes/polling/applications/bird2.inc.php
+++ b/includes/polling/applications/bird2.inc.php
@@ -5,12 +5,6 @@ use Carbon\Carbon;
 
 $name = 'bird2';
 
-if (! \LibreNMS\Config::get('enable_bgp')) {
-    echo PHP_EOL . $name . ': BGP is not enabled in config' . PHP_EOL;
-
-    return;
-}
-
 $birdOutput = snmp_get($device, 'nsExtendOutputFull.' . \LibreNMS\Util\Oid::ofString($name), '-Oqv', 'NET-SNMP-EXTEND-MIB');
 
 // make sure we actually get something back


### PR DESCRIPTION
For issue #15876
PR #14931 removed `config_bgp` from the config but it's still in use by the bird2 app. Sadly I don't know the inner workings of LibreNMS very well, so I looked at the changes in the previous PR and it seems all checks for config_bgp were simply removed.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
