### PR TITLE
fix auth_ldap_prefix and auth_ldap_suffix handling to make it all behave predicably

### DIFF
--- a/LibreNMS/Authentication/LdapAuthorizer.php
+++ b/LibreNMS/Authentication/LdapAuthorizer.php
@@ -79,7 +79,7 @@ class LdapAuthorizer extends AuthorizerBase
         try {
             $connection = $this->getLdapConnection();
 
-            $filter = '(' . Config::get('auth_ldap_prefix') . $username . ')';
+            $filter = '(' . trim(Config::get('auth_ldap_prefix'), '=') . '=' . $username . ')';
             $search = ldap_search($connection, trim(Config::get('auth_ldap_suffix'), ','), $filter);
             $entries = ldap_get_entries($connection, $search);
             if ($entries['count']) {
@@ -155,7 +155,7 @@ class LdapAuthorizer extends AuthorizerBase
         try {
             $connection = $this->getLdapConnection();
 
-            $filter = '(' . Config::get('auth_ldap_prefix') . $username . ')';
+            $filter = '(' . trim(Config::get('auth_ldap_prefix'), '=') . '=' . $username . ')';
             $search = ldap_search($connection, trim(Config::get('auth_ldap_suffix'), ','), $filter);
             $entries = ldap_get_entries($connection, $search);
 
@@ -175,7 +175,7 @@ class LdapAuthorizer extends AuthorizerBase
     {
         $connection = $this->getLdapConnection();
 
-        $filter = '(' . Config::get('auth_ldap_prefix') . $this->userloginname . ')';
+        $filter = '(' . trim(Config::get('auth_ldap_prefix'), '=') . '=' . $this->userloginname . ')';
         if (Config::get('auth_ldap_userlist_filter') != null) {
             $filter = '(' . Config::get('auth_ldap_userlist_filter') . ')';
         }
@@ -243,7 +243,7 @@ class LdapAuthorizer extends AuthorizerBase
      */
     protected function getFullDn($username)
     {
-        return Config::get('auth_ldap_prefix', '') . $username . Config::get('auth_ldap_suffix', '');
+        return trim(Config::get('auth_ldap_prefix', ''), '=') . $username . ',' . trim(Config::get('auth_ldap_suffix', ''), ',');
     }
 
     /**

--- a/LibreNMS/Authentication/LdapAuthorizer.php
+++ b/LibreNMS/Authentication/LdapAuthorizer.php
@@ -243,7 +243,7 @@ class LdapAuthorizer extends AuthorizerBase
      */
     protected function getFullDn($username)
     {
-        return trim(Config::get('auth_ldap_prefix', ''), '=') . $username . ',' . trim(Config::get('auth_ldap_suffix', ''), ',');
+        return trim(Config::get('auth_ldap_prefix', ''), '=') . '=' . $username . ',' . trim(Config::get('auth_ldap_suffix', ''), ',');
     }
 
     /**


### PR DESCRIPTION
No longer requires the admin to wonder WTF is going on when it comes to `auth_ldap_prefix` and `auth_ldap_suffix` as requiring `=` and ',' is very non-standard and confusing.

Use trim where applicable.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
