### PR TITLE
Fix for explicit timezone selection

### DIFF
--- a/app/Http/Middleware/LoadUserPreferences.php
+++ b/app/Http/Middleware/LoadUserPreferences.php
@@ -29,6 +29,7 @@ class LoadUserPreferences
         });
 
         $this->setPreference($request, 'timezone', function ($timezone) use ($request) {
+            $request->session()->put('preferences.timezone', $timezone);
             $request->session()->put('preferences.timezone_static', true);
         });
 


### PR DESCRIPTION
The explicit timezone has been broken for a few months.  I added some logging and found that this was because the timezone was not being set correctly in the session data.  This PR fixes the issue for me.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
