### PR TITLE
doc - entPhysicalIndex and entPhysicalIndex_measured usage

### DIFF
--- a/doc/Developing/os/Health-Information.md
+++ b/doc/Developing/os/Health-Information.md
@@ -117,10 +117,11 @@ are as follows:
   over (see note below).
 - `skip_value_lt` (optional): If sensor value is less than this, skip the discovery.
 - `skip_value_gt` (optional): If sensor value is greater than this, skip the discovery.
-- `entPhysicalIndex` (optional): If the sensor belongs to a physical
-  entity then you can specify the index here.
-- `entPhysicalIndex_measured` (optional): If the sensor belongs to a
-  physical entity then you can specify the entity type here.
+- `entPhysicalIndex` and `entPhysicalIndex_measured` (optional) : If the
+  sensor belongs to a physical entity then you can link them here. The currently
+  supported variants are :
+    - `entPhysicalIndex` contains the entPhysicalIndex from entPhysical table, and `entPhysicalIndex_measured` is NULL
+    - `entPhysicalIndex` contains "ifIndex" value of the linked port and `entPhysicalIndex_measured` contains "ports"
 - `user_func` (optional): You can provide a function name for the
   sensors value to be processed through (i.e. Convert fahrenheit to
   celsius use `fahrenheit_to_celsius`)


### PR DESCRIPTION
A few details on how the entPhysicalIndex column should be currently used.


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
