### PR TITLE
Pretty up Slack formatting.

### DIFF
--- a/doc/Alerting/Transports.md
+++ b/doc/Alerting/Transports.md
@@ -774,16 +774,36 @@ only required value is for url, without this  then no call to Slack will be made
 
 We currently support the following attachment options:
 
-`author_name`
+- `author_name`
+
+We currently support the following global message options:
+
+- `channel_name` : Slack channel name (without the leading '#') to which the alert will go
+- `icon_emoji` : Emoji name in colon format to use as the author icon
 
 [Slack docs](https://api.slack.com/docs/message-attachments)
+
+The alert template can make use of [Slack markdown]
+(https://api.slack.com/reference/surfaces/formatting#basic-formatting).
+In the Slack markdown dialect, custom links are denoted with HTML angled
+brackets, but LibreNMS strips these out. To support embedding custom links in alerts,
+use the bracket/parenthese markdown syntax for links.  For example if you would
+typically use this for a Slack link:
+
+&lt;https://www.example.com|My Link&gt;
+
+Use this in your alert template:
+
+\[My Link](https://www.example.com)
 
 **Example:**
 
 | Config | Example |
 | ------ | ------- |
 | Webhook URL | <https://slack.com/url/somehook> |
-| Slack Options | author_name=Me |
+| Channel | network-alerts |
+| Author Name | LibreNMS Bot |
+| Icon | :scream: |
 
 ## SMSEagle
 

--- a/doc/Alerting/Transports.md
+++ b/doc/Alerting/Transports.md
@@ -787,7 +787,7 @@ The alert template can make use of
 [Slack markdown](https://api.slack.com/reference/surfaces/formatting#basic-formatting).
 In the Slack markdown dialect, custom links are denoted with HTML angled
 brackets, but LibreNMS strips these out. To support embedding custom links in alerts,
-use the bracket/parenthese markdown syntax for links.  For example if you would
+use the bracket/parentheses markdown syntax for links.  For example if you would
 typically use this for a Slack link:
 
 `<https://www.example.com|My Link>`

--- a/doc/Alerting/Transports.md
+++ b/doc/Alerting/Transports.md
@@ -790,11 +790,11 @@ brackets, but LibreNMS strips these out. To support embedding custom links in al
 use the bracket/parenthese markdown syntax for links.  For example if you would
 typically use this for a Slack link:
 
-`&lt;https://www.example.com|My Link&gt;`
+`<https://www.example.com|My Link>`
 
 Use this in your alert template:
 
-`\[My Link](https://www.example.com)`
+`[My Link](https://www.example.com)`
 
 **Example:**
 

--- a/doc/Alerting/Transports.md
+++ b/doc/Alerting/Transports.md
@@ -783,8 +783,8 @@ We currently support the following global message options:
 
 [Slack docs](https://api.slack.com/docs/message-attachments)
 
-The alert template can make use of [Slack markdown]
-(https://api.slack.com/reference/surfaces/formatting#basic-formatting).
+The alert template can make use of
+[Slack markdown](https://api.slack.com/reference/surfaces/formatting#basic-formatting).
 In the Slack markdown dialect, custom links are denoted with HTML angled
 brackets, but LibreNMS strips these out. To support embedding custom links in alerts,
 use the bracket/parenthese markdown syntax for links.  For example if you would

--- a/doc/Alerting/Transports.md
+++ b/doc/Alerting/Transports.md
@@ -790,11 +790,11 @@ brackets, but LibreNMS strips these out. To support embedding custom links in al
 use the bracket/parenthese markdown syntax for links.  For example if you would
 typically use this for a Slack link:
 
-&lt;https://www.example.com|My Link&gt;
+`&lt;https://www.example.com|My Link&gt;`
 
 Use this in your alert template:
 
-\[My Link](https://www.example.com)
+`\[My Link](https://www.example.com)`
 
 **Example:**
 
@@ -803,7 +803,7 @@ Use this in your alert template:
 | Webhook URL | <https://slack.com/url/somehook> |
 | Channel | network-alerts |
 | Author Name | LibreNMS Bot |
-| Icon | :scream: |
+| Icon | `:scream:` |
 
 ## SMSEagle
 


### PR DESCRIPTION
* Normalize spaces by turning every instance of two or more spaces into one space.
* Allow for custom URL links even when strip_tags() is in effect by transforming "standard" markdown syntax into Slack link markdown after strip_tags() is run.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
