### PR TITLE
fix catos discovery

### DIFF
--- a/includes/definitions/discovery/catos.yaml
+++ b/includes/definitions/discovery/catos.yaml
@@ -1,3 +1,4 @@
 modules:
   os:
-    sysDescr_regex: '/(?<hardware>WS-[\w-]+).*Version (?<version>[\w.()]+)/'
+    sysDescr_regex: '/(?<hardware>WS-[\w-]+).*Version (?<version>[\w.()]+)/s'
+    serial: ENTITY-MIB::entPhysicalSerialNum.1


### PR DESCRIPTION
Please give a short description what your pull request is for

fixes #15914 

fixes regex detection for Hardware and Version for Catos. Also adds serial OID for serial number detection. 

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
