### PR TITLE
Rename index_string to str_index_as_numeric

### DIFF
--- a/LibreNMS/Device/YamlDiscovery.php
+++ b/LibreNMS/Device/YamlDiscovery.php
@@ -190,7 +190,7 @@ class YamlDiscovery
                 'count' => $count,
                 // we compute a numOid compatible version of index
                 // string length followed by ASCII of each char.
-                'index:str2num' => implode('.', array_map(function ($index) {
+                'str_index_as_numeric' => implode('.', array_map(function ($index) {
                     return strlen($index) . '.' . implode('.', unpack('c*', $index));
                 }, explode('.', $index))),
             ];

--- a/LibreNMS/Device/YamlDiscovery.php
+++ b/LibreNMS/Device/YamlDiscovery.php
@@ -190,7 +190,7 @@ class YamlDiscovery
                 'count' => $count,
                 // we compute a numOid compatible version of index
                 // string length followed by ASCII of each char.
-                'index_string' => implode('.', array_map(function ($index) {
+                'index:str2num' => implode('.', array_map(function ($index) {
                     return strlen($index) . '.' . implode('.', unpack('c*', $index));
                 }, explode('.', $index))),
             ];

--- a/doc/Developing/os/Health-Information.md
+++ b/doc/Developing/os/Health-Information.md
@@ -90,7 +90,7 @@ are as follows:
   automatically by discovery process. This parameter is still required to
   submit a pull request. This is the numerical OID that contains
   `value`. This should usually include `{{ $index }}`.
-  In case the index is a string, `{{ $index:str2num }}` can be used instead and will convert
+  In case the index is a string, `{{ $str_index_as_numeric }}` can be used instead and will convert
 the string to the equivalent OID representation.
 - `divisor` (optional): This is the divisor to use against the returned `value`.
 - `multiplier` (optional): This is the multiplier to use against the returned `value`.

--- a/doc/Developing/os/Health-Information.md
+++ b/doc/Developing/os/Health-Information.md
@@ -90,7 +90,8 @@ are as follows:
   automatically by discovery process. This parameter is still required to
   submit a pull request. This is the numerical OID that contains
   `value`. This should usually include `{{ $index }}`.
-  In case the index is a string, `{{ $index_string }}` can be used instead.
+  In case the index is a string, `{{ $index:str2num }}` can be used instead and will convert
+the string to the equivalent OID representation.
 - `divisor` (optional): This is the divisor to use against the returned `value`.
 - `multiplier` (optional): This is the multiplier to use against the returned `value`.
 - `low_limit` (optional): This is the critical low threshold that

--- a/includes/definitions/discovery/ciena-rls.yaml
+++ b/includes/definitions/discovery/ciena-rls.yaml
@@ -14,16 +14,16 @@ modules:
             data:
                 -
                     oid: rlsCircuitPackCurrTemprature
-                    num_oid: '.1.3.6.1.4.1.1271.4.1.1.1.1.1.1.29.{{ $index:str2num }}'
-                    index: 'rlsCircuitPackCurrTemprature.{{ $index:str2num }}'
+                    num_oid: '.1.3.6.1.4.1.1271.4.1.1.1.1.1.1.29.{{ $str_index_as_numeric }}'
+                    index: 'rlsCircuitPackCurrTemprature.{{ $str_index_as_numeric }}'
                     descr: '{{ $rlsCircuitPackCtype }} Slot {{ $index }}'
         state:
             data:
                 -
                     oid: rlsInventoryAmpsTable
                     value: rlsInventoryAmpsAmpMode
-                    num_oid: '.1.3.6.1.4.1.1271.4.1.1.1.2.1.1.1.3.{{ $index:str2num }}'
-                    index: 'rlsInventoryAmpsAmpMode.{{ $index:str2num }}'
+                    num_oid: '.1.3.6.1.4.1.1271.4.1.1.1.2.1.1.1.3.{{ $str_index_as_numeric }}'
+                    index: 'rlsInventoryAmpsAmpMode.{{ $str_index_as_numeric }}'
                     descr: 'Slot {{ $subindex0 }} {{ $subindex1 }}'
                     group: 'Amplifier Mode'
                     state_name: rlsInventoryAmpsAmpMode
@@ -34,8 +34,8 @@ modules:
                 -
                     oid: rlsInventoryAmpsTable
                     value: rlsInventoryAmpsState
-                    num_oid: '.1.3.6.1.4.1.1271.4.1.1.1.2.1.1.1.4.{{ $index:str2num }}'
-                    index: 'rlsInventoryAmpsState.{{ $index:str2num }}'
+                    num_oid: '.1.3.6.1.4.1.1271.4.1.1.1.2.1.1.1.4.{{ $str_index_as_numeric }}'
+                    index: 'rlsInventoryAmpsState.{{ $str_index_as_numeric }}'
                     descr: 'Slot {{ $subindex0 }} {{ $subindex1 }}'
                     group: 'Amplifier State'
                     state_name: rlsInventoryAmpsState
@@ -48,8 +48,8 @@ modules:
                 -
                     oid: rlsInventoryAmpsTable
                     value: rlsInventoryAmpsGainMode
-                    num_oid: '.1.3.6.1.4.1.1271.4.1.1.1.2.1.1.1.5.{{ $index:str2num }}'
-                    index: 'rlsInventoryAmpsGainMode.{{ $index:str2num }}'
+                    num_oid: '.1.3.6.1.4.1.1271.4.1.1.1.2.1.1.1.5.{{ $str_index_as_numeric }}'
+                    index: 'rlsInventoryAmpsGainMode.{{ $str_index_as_numeric }}'
                     descr: 'Slot {{ $subindex0 }} {{ $subindex1 }}'
                     group: 'Amplifier Gain Mode'
                     state_name: rlsInventoryAmpsGainMode
@@ -59,8 +59,8 @@ modules:
                 -
                     oid: rlsInventoryAmpsTable
                     value: rlsInventoryAmpsForcedShutdown
-                    num_oid: '.1.3.6.1.4.1.1271.4.1.1.1.2.1.1.1.6.{{ $index:str2num }}'
-                    index: 'rlsInventoryAmpsForcedShutdown.{{ $index:str2num }}'
+                    num_oid: '.1.3.6.1.4.1.1271.4.1.1.1.2.1.1.1.6.{{ $str_index_as_numeric }}'
+                    index: 'rlsInventoryAmpsForcedShutdown.{{ $str_index_as_numeric }}'
                     descr: 'Slot {{ $subindex0 }} {{ $subindex1 }}'
                     group: 'Amplifier Forced Shutdown State'
                     state_name: rlsInventoryAmpsForcedShutdown
@@ -72,51 +72,51 @@ modules:
                 -
                     oid: rlsInventoryAmpsTable
                     value: rlsInventoryAmpsInCurrPower
-                    num_oid: '.1.3.6.1.4.1.1271.4.1.1.1.2.1.1.1.48.{{ $index:str2num }}'
-                    index: 'rlsInventoryAmpsInCurrPower.{{ $index:str2num }}'
+                    num_oid: '.1.3.6.1.4.1.1271.4.1.1.1.2.1.1.1.48.{{ $str_index_as_numeric }}'
+                    index: 'rlsInventoryAmpsInCurrPower.{{ $str_index_as_numeric }}'
                     descr: 'Slot {{ $subindex0 }} {{ $subindex1 }}'
                     group: 'Amplifier Input - Current'
                     low_limit: rlsInventoryAmpsInputLosThreshold
                 -
                     oid: rlsInventoryAmpsTable
                     value: rlsInventoryAmpsInMinPower
-                    num_oid: '.1.3.6.1.4.1.1271.4.1.1.1.2.1.1.1.49.{{ $index:str2num }}'
-                    index: 'rlsInventoryAmpsInMinPower.{{ $index:str2num }}'
+                    num_oid: '.1.3.6.1.4.1.1271.4.1.1.1.2.1.1.1.49.{{ $str_index_as_numeric }}'
+                    index: 'rlsInventoryAmpsInMinPower.{{ $str_index_as_numeric }}'
                     descr: 'Slot {{ $subindex0 }} {{ $subindex1 }}'
                     group: 'Amplifier Input - Minimum'
                 -
                     oid: rlsInventoryAmpsTable
                     value: rlsInventoryAmpsInMaxPower
-                    num_oid: '.1.3.6.1.4.1.1271.4.1.1.1.2.1.1.1.50.{{ $index:str2num }}'
-                    index: 'rlsInventoryAmpsInMaxPower.{{ $index:str2num }}'
+                    num_oid: '.1.3.6.1.4.1.1271.4.1.1.1.2.1.1.1.50.{{ $str_index_as_numeric }}'
+                    index: 'rlsInventoryAmpsInMaxPower.{{ $str_index_as_numeric }}'
                     descr: 'Slot {{ $subindex0 }} {{ $subindex1 }}'
                     group: 'Amplifier Input - Maximum'
                 -
                     oid: rlsInventoryAmpsTable
                     value: rlsInventoryAmpsOutCurrPower
-                    num_oid: '.1.3.6.1.4.1.1271.4.1.1.1.2.1.1.1.51.{{ $index:str2num }}'
-                    index: 'rlsInventoryAmpsOutCurrPower.{{ $index:str2num }}'
+                    num_oid: '.1.3.6.1.4.1.1271.4.1.1.1.2.1.1.1.51.{{ $str_index_as_numeric }}'
+                    index: 'rlsInventoryAmpsOutCurrPower.{{ $str_index_as_numeric }}'
                     descr: 'Slot {{ $subindex0 }} {{ $subindex1 }}'
                     group: 'Amplifier Output - Current'
                 -
                     oid: rlsInventoryAmpsTable
                     value: rlsInventoryAmpsOutMinPower
-                    num_oid: '.1.3.6.1.4.1.1271.4.1.1.1.2.1.1.1.52.{{ $index:str2num }}'
-                    index: 'rlsInventoryAmpsOutMinPower.{{ $index:str2num }}'
+                    num_oid: '.1.3.6.1.4.1.1271.4.1.1.1.2.1.1.1.52.{{ $str_index_as_numeric }}'
+                    index: 'rlsInventoryAmpsOutMinPower.{{ $str_index_as_numeric }}'
                     descr: 'Slot {{ $subindex0 }} {{ $subindex1 }}'
                     group: 'Amplifier Output - Minimum'
                 -
                     oid: rlsInventoryAmpsTable
                     value: rlsInventoryAmpsOutMaxPower
-                    num_oid: '.1.3.6.1.4.1.1271.4.1.1.1.2.1.1.1.53.{{ $index:str2num }}'
-                    index: 'rlsInventoryAmpsOutMaxPower.{{ $index:str2num }}'
+                    num_oid: '.1.3.6.1.4.1.1271.4.1.1.1.2.1.1.1.53.{{ $str_index_as_numeric }}'
+                    index: 'rlsInventoryAmpsOutMaxPower.{{ $str_index_as_numeric }}'
                     descr: 'Slot {{ $subindex0 }} {{ $subindex1 }}'
                     group: 'Amplifier Output - Maximum'
                 -
                     oid: rlsInventoryAmpsTable
                     value: rlsInventoryAmpsOpticalReturnLoss
-                    num_oid: '.1.3.6.1.4.1.1271.4.1.1.1.2.1.1.1.54.{{ $index:str2num }}'
-                    index: 'rlsInventoryAmpsOpticalReturnLoss.{{ $index:str2num }}'
+                    num_oid: '.1.3.6.1.4.1.1271.4.1.1.1.2.1.1.1.54.{{ $str_index_as_numeric }}'
+                    index: 'rlsInventoryAmpsOpticalReturnLoss.{{ $str_index_as_numeric }}'
                     descr: 'Slot {{ $subindex0 }} {{ $subindex1 }}'
                     group: 'Amplifier Optical Return Loss'
                     low_warn_limit: rlsInventoryAmpsOrlThreshold

--- a/includes/definitions/discovery/ciena-rls.yaml
+++ b/includes/definitions/discovery/ciena-rls.yaml
@@ -14,16 +14,16 @@ modules:
             data:
                 -
                     oid: rlsCircuitPackCurrTemprature
-                    num_oid: '.1.3.6.1.4.1.1271.4.1.1.1.1.1.1.29.{{ $index_string }}'
-                    index: 'rlsCircuitPackCurrTemprature.{{ $index_string }}'
+                    num_oid: '.1.3.6.1.4.1.1271.4.1.1.1.1.1.1.29.{{ $index:str2num }}'
+                    index: 'rlsCircuitPackCurrTemprature.{{ $index:str2num }}'
                     descr: '{{ $rlsCircuitPackCtype }} Slot {{ $index }}'
         state:
             data:
                 -
                     oid: rlsInventoryAmpsTable
                     value: rlsInventoryAmpsAmpMode
-                    num_oid: '.1.3.6.1.4.1.1271.4.1.1.1.2.1.1.1.3.{{ $index_string }}'
-                    index: 'rlsInventoryAmpsAmpMode.{{ $index_string }}'
+                    num_oid: '.1.3.6.1.4.1.1271.4.1.1.1.2.1.1.1.3.{{ $index:str2num }}'
+                    index: 'rlsInventoryAmpsAmpMode.{{ $index:str2num }}'
                     descr: 'Slot {{ $subindex0 }} {{ $subindex1 }}'
                     group: 'Amplifier Mode'
                     state_name: rlsInventoryAmpsAmpMode
@@ -34,8 +34,8 @@ modules:
                 -
                     oid: rlsInventoryAmpsTable
                     value: rlsInventoryAmpsState
-                    num_oid: '.1.3.6.1.4.1.1271.4.1.1.1.2.1.1.1.4.{{ $index_string }}'
-                    index: 'rlsInventoryAmpsState.{{ $index_string }}'
+                    num_oid: '.1.3.6.1.4.1.1271.4.1.1.1.2.1.1.1.4.{{ $index:str2num }}'
+                    index: 'rlsInventoryAmpsState.{{ $index:str2num }}'
                     descr: 'Slot {{ $subindex0 }} {{ $subindex1 }}'
                     group: 'Amplifier State'
                     state_name: rlsInventoryAmpsState
@@ -48,8 +48,8 @@ modules:
                 -
                     oid: rlsInventoryAmpsTable
                     value: rlsInventoryAmpsGainMode
-                    num_oid: '.1.3.6.1.4.1.1271.4.1.1.1.2.1.1.1.5.{{ $index_string }}'
-                    index: 'rlsInventoryAmpsGainMode.{{ $index_string }}'
+                    num_oid: '.1.3.6.1.4.1.1271.4.1.1.1.2.1.1.1.5.{{ $index:str2num }}'
+                    index: 'rlsInventoryAmpsGainMode.{{ $index:str2num }}'
                     descr: 'Slot {{ $subindex0 }} {{ $subindex1 }}'
                     group: 'Amplifier Gain Mode'
                     state_name: rlsInventoryAmpsGainMode
@@ -59,8 +59,8 @@ modules:
                 -
                     oid: rlsInventoryAmpsTable
                     value: rlsInventoryAmpsForcedShutdown
-                    num_oid: '.1.3.6.1.4.1.1271.4.1.1.1.2.1.1.1.6.{{ $index_string }}'
-                    index: 'rlsInventoryAmpsForcedShutdown.{{ $index_string }}'
+                    num_oid: '.1.3.6.1.4.1.1271.4.1.1.1.2.1.1.1.6.{{ $index:str2num }}'
+                    index: 'rlsInventoryAmpsForcedShutdown.{{ $index:str2num }}'
                     descr: 'Slot {{ $subindex0 }} {{ $subindex1 }}'
                     group: 'Amplifier Forced Shutdown State'
                     state_name: rlsInventoryAmpsForcedShutdown
@@ -72,51 +72,51 @@ modules:
                 -
                     oid: rlsInventoryAmpsTable
                     value: rlsInventoryAmpsInCurrPower
-                    num_oid: '.1.3.6.1.4.1.1271.4.1.1.1.2.1.1.1.48.{{ $index_string }}'
-                    index: 'rlsInventoryAmpsInCurrPower.{{ $index_string }}'
+                    num_oid: '.1.3.6.1.4.1.1271.4.1.1.1.2.1.1.1.48.{{ $index:str2num }}'
+                    index: 'rlsInventoryAmpsInCurrPower.{{ $index:str2num }}'
                     descr: 'Slot {{ $subindex0 }} {{ $subindex1 }}'
                     group: 'Amplifier Input - Current'
                     low_limit: rlsInventoryAmpsInputLosThreshold
                 -
                     oid: rlsInventoryAmpsTable
                     value: rlsInventoryAmpsInMinPower
-                    num_oid: '.1.3.6.1.4.1.1271.4.1.1.1.2.1.1.1.49.{{ $index_string }}'
-                    index: 'rlsInventoryAmpsInMinPower.{{ $index_string }}'
+                    num_oid: '.1.3.6.1.4.1.1271.4.1.1.1.2.1.1.1.49.{{ $index:str2num }}'
+                    index: 'rlsInventoryAmpsInMinPower.{{ $index:str2num }}'
                     descr: 'Slot {{ $subindex0 }} {{ $subindex1 }}'
                     group: 'Amplifier Input - Minimum'
                 -
                     oid: rlsInventoryAmpsTable
                     value: rlsInventoryAmpsInMaxPower
-                    num_oid: '.1.3.6.1.4.1.1271.4.1.1.1.2.1.1.1.50.{{ $index_string }}'
-                    index: 'rlsInventoryAmpsInMaxPower.{{ $index_string }}'
+                    num_oid: '.1.3.6.1.4.1.1271.4.1.1.1.2.1.1.1.50.{{ $index:str2num }}'
+                    index: 'rlsInventoryAmpsInMaxPower.{{ $index:str2num }}'
                     descr: 'Slot {{ $subindex0 }} {{ $subindex1 }}'
                     group: 'Amplifier Input - Maximum'
                 -
                     oid: rlsInventoryAmpsTable
                     value: rlsInventoryAmpsOutCurrPower
-                    num_oid: '.1.3.6.1.4.1.1271.4.1.1.1.2.1.1.1.51.{{ $index_string }}'
-                    index: 'rlsInventoryAmpsOutCurrPower.{{ $index_string }}'
+                    num_oid: '.1.3.6.1.4.1.1271.4.1.1.1.2.1.1.1.51.{{ $index:str2num }}'
+                    index: 'rlsInventoryAmpsOutCurrPower.{{ $index:str2num }}'
                     descr: 'Slot {{ $subindex0 }} {{ $subindex1 }}'
                     group: 'Amplifier Output - Current'
                 -
                     oid: rlsInventoryAmpsTable
                     value: rlsInventoryAmpsOutMinPower
-                    num_oid: '.1.3.6.1.4.1.1271.4.1.1.1.2.1.1.1.52.{{ $index_string }}'
-                    index: 'rlsInventoryAmpsOutMinPower.{{ $index_string }}'
+                    num_oid: '.1.3.6.1.4.1.1271.4.1.1.1.2.1.1.1.52.{{ $index:str2num }}'
+                    index: 'rlsInventoryAmpsOutMinPower.{{ $index:str2num }}'
                     descr: 'Slot {{ $subindex0 }} {{ $subindex1 }}'
                     group: 'Amplifier Output - Minimum'
                 -
                     oid: rlsInventoryAmpsTable
                     value: rlsInventoryAmpsOutMaxPower
-                    num_oid: '.1.3.6.1.4.1.1271.4.1.1.1.2.1.1.1.53.{{ $index_string }}'
-                    index: 'rlsInventoryAmpsOutMaxPower.{{ $index_string }}'
+                    num_oid: '.1.3.6.1.4.1.1271.4.1.1.1.2.1.1.1.53.{{ $index:str2num }}'
+                    index: 'rlsInventoryAmpsOutMaxPower.{{ $index:str2num }}'
                     descr: 'Slot {{ $subindex0 }} {{ $subindex1 }}'
                     group: 'Amplifier Output - Maximum'
                 -
                     oid: rlsInventoryAmpsTable
                     value: rlsInventoryAmpsOpticalReturnLoss
-                    num_oid: '.1.3.6.1.4.1.1271.4.1.1.1.2.1.1.1.54.{{ $index_string }}'
-                    index: 'rlsInventoryAmpsOpticalReturnLoss.{{ $index_string }}'
+                    num_oid: '.1.3.6.1.4.1.1271.4.1.1.1.2.1.1.1.54.{{ $index:str2num }}'
+                    index: 'rlsInventoryAmpsOpticalReturnLoss.{{ $index:str2num }}'
                     descr: 'Slot {{ $subindex0 }} {{ $subindex1 }}'
                     group: 'Amplifier Optical Return Loss'
                     low_warn_limit: rlsInventoryAmpsOrlThreshold

--- a/includes/definitions/discovery/junos.yaml
+++ b/includes/definitions/discovery/junos.yaml
@@ -256,7 +256,7 @@ modules:
                 -
                     oid: jnxRpmResultsSummaryTable
                     value: jnxRpmResSumPercentLost
-                    num_oid: '.1.3.6.1.4.1.2636.3.50.1.2.1.{{ $index:str2num }}'
+                    num_oid: '.1.3.6.1.4.1.2636.3.50.1.2.1.{{ $str_index_as_numeric }}'
                     group: RPM Probes
                     descr: '{{ $index }} Probe Loss'
                     index: 'jnxRpmResSumPercentLost.{{ $index }}'

--- a/includes/definitions/discovery/junos.yaml
+++ b/includes/definitions/discovery/junos.yaml
@@ -256,7 +256,7 @@ modules:
                 -
                     oid: jnxRpmResultsSummaryTable
                     value: jnxRpmResSumPercentLost
-                    num_oid: '.1.3.6.1.4.1.2636.3.50.1.2.1.{{ $index_string }}'
+                    num_oid: '.1.3.6.1.4.1.2636.3.50.1.2.1.{{ $index:str2num }}'
                     group: RPM Probes
                     descr: '{{ $index }} Probe Loss'
                     index: 'jnxRpmResSumPercentLost.{{ $index }}'

--- a/includes/definitions/discovery/solidserver.yaml
+++ b/includes/definitions/discovery/solidserver.yaml
@@ -44,7 +44,7 @@ modules:
                 -
                     oid: eipDnsStatTable
                     value: eipDnsStatValue
-                    num_oid: '.1.3.6.1.4.1.2440.1.4.2.3.1.3.{{ $index:str2num }}'
+                    num_oid: '.1.3.6.1.4.1.2440.1.4.2.3.1.3.{{ $str_index_as_numeric }}'
                     descr: '{{ $eipDnsStatName }}'
                     index: 'counter__{{ $index }}'
                     rrd_type: 'COUNTER'
@@ -73,7 +73,7 @@ modules:
                 -
                     oid: eipDhcpStatTable
                     value: eipDhcpStatValue
-                    num_oid: '.1.3.6.1.4.1.2440.1.3.2.22.1.3.{{ $index:str2num }}'
+                    num_oid: '.1.3.6.1.4.1.2440.1.3.2.22.1.3.{{ $str_index_as_numeric }}'
                     descr: '{{ $eipDhcpStatName }}'
                     rrd_type: 'COUNTER'
                     index: 'counter__{{ $index }}'

--- a/includes/definitions/discovery/solidserver.yaml
+++ b/includes/definitions/discovery/solidserver.yaml
@@ -44,7 +44,7 @@ modules:
                 -
                     oid: eipDnsStatTable
                     value: eipDnsStatValue
-                    num_oid: '.1.3.6.1.4.1.2440.1.4.2.3.1.3.{{ $index_string }}'
+                    num_oid: '.1.3.6.1.4.1.2440.1.4.2.3.1.3.{{ $index:str2num }}'
                     descr: '{{ $eipDnsStatName }}'
                     index: 'counter__{{ $index }}'
                     rrd_type: 'COUNTER'
@@ -73,7 +73,7 @@ modules:
                 -
                     oid: eipDhcpStatTable
                     value: eipDhcpStatValue
-                    num_oid: '.1.3.6.1.4.1.2440.1.3.2.22.1.3.{{ $index_string }}'
+                    num_oid: '.1.3.6.1.4.1.2440.1.3.2.22.1.3.{{ $index:str2num }}'
                     descr: '{{ $eipDhcpStatName }}'
                     rrd_type: 'COUNTER'
                     index: 'counter__{{ $index }}'

--- a/misc/discovery_schema.json
+++ b/misc/discovery_schema.json
@@ -229,7 +229,7 @@
                                             },
                                             "num_oid": {
                                                 "type": "string",
-                                                "pattern": "^(\\.\\d+)+(\\.?\\{\\{ \\$index(:str2num)? \\}\\})?(\\.\\d+)*$"
+                                                "pattern": "^(\\.\\d+)+(\\.?\\{\\{ \\$(index|str_index_as_numeric) \\}\\})?(\\.\\d+)*$"
                                             },
                                             "descr": {
                                                 "type": "string"
@@ -414,7 +414,7 @@
                             },
                             "num_oid": {
                                 "type": "string",
-                                "pattern": "^(\\.\\d+)+(\\.?\\{\\{ \\$index(:str2num)? \\}\\})?(\\.\\d+)*$"
+                                "pattern": "^(\\.\\d+)+(\\.?\\{\\{ \\$(index|str_index_as_numeric) \\}\\})?(\\.\\d+)*$"
                             },
                             "index": {
                                 "type": ["integer", "string"]

--- a/misc/discovery_schema.json
+++ b/misc/discovery_schema.json
@@ -229,7 +229,7 @@
                                             },
                                             "num_oid": {
                                                 "type": "string",
-                                                "pattern": "^(\\.\\d+)+(\\.?\\{\\{ \\$index(.string)? \\}\\})?(\\.\\d+)*$"
+                                                "pattern": "^(\\.\\d+)+(\\.?\\{\\{ \\$index(:str2num)? \\}\\})?(\\.\\d+)*$"
                                             },
                                             "descr": {
                                                 "type": "string"
@@ -414,7 +414,7 @@
                             },
                             "num_oid": {
                                 "type": "string",
-                                "pattern": "^(\\.\\d+)+(\\.?\\{\\{ \\$index(.string)? \\}\\})?(\\.\\d+)*$"
+                                "pattern": "^(\\.\\d+)+(\\.?\\{\\{ \\$index(:str2num)? \\}\\})?(\\.\\d+)*$"
                             },
                             "index": {
                                 "type": ["integer", "string"]


### PR DESCRIPTION
Renaming index_string to a more self explanatory index:str2num. Documentation also updated.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
