### PR TITLE
bug - vrp - fix signed-tinyint overloaded with disabled radios

### DIFF
--- a/LibreNMS/OS/Vrp.php
+++ b/LibreNMS/OS/Vrp.php
@@ -184,6 +184,11 @@ class Vrp extends OS implements
                     $numasoclients = $clientPerRadio[$ap_id][$r_id] ?? 0;
                     $radio['hwWlanRadioType'] = $radio['hwWlanRadioType'] ?? 0;
 
+                    if ($txpow > 127) {
+                        // means the radio is disabled for some reason.
+                        $txpow = 0;
+                    }
+
                     $type = 'dot11';
 
                     if ($radio['hwWlanRadioType'] & 2) {


### PR DESCRIPTION
fix disabled radio returning 255, overloading tinyint signed (-128 +127)

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
