### PR TITLE
bug - typo for request rate + sanity on numerical not_null values

### DIFF
--- a/includes/polling/netscaler-vsvr.inc.php
+++ b/includes/polling/netscaler-vsvr.inc.php
@@ -105,9 +105,9 @@ if ($device['os'] == 'netscaler') {
                 'vsvr_port' => $vsvr['vsvrPort'],
                 'vsvr_state' => $vsvr['vsvrState'],
                 'vsvr_type' => $vsvr['vsvrType'],
-                'vsvr_req_rate' => $vsvr['RequestRate'],
-                'vsvr_bps_in' => $vsvr['vsvrRxBytesRate'],
-                'vsvr_bps_out' => $vsvr['vsvrTxBytesRate'],
+                'vsvr_req_rate' => $vsvr['vsvrRequestRate'] ?? 0,
+                'vsvr_bps_in' => $vsvr['vsvrRxBytesRate'] ?? 0,
+                'vsvr_bps_out' => $vsvr['vsvrTxBytesRate'] ?? 0,
             ];
 
             if (! is_array($vsvrs[$vsvr['vsvrFullName']])) {


### PR DESCRIPTION
typo for request rate + sanity on numerical not_null values

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
