### PR TITLE
fix malformed snmp data parsing

### DIFF
--- a/includes/discovery/storage/hpe-ilo.inc.php
+++ b/includes/discovery/storage/hpe-ilo.inc.php
@@ -6,6 +6,8 @@ if (in_array($device['os'], ['windows', 'hpe-ilo']) || $device['os_group'] == 'u
     if (is_array($ilo_storage)) {
         echo 'HPE ILO4 ';
         foreach ($ilo_storage as $index => $storage) {
+            if( !is_array($storage) ) continue;
+            
             $type = $storage['cpqHoFileSysDesc'];
             preg_match_all('/\[.*?:(.*?)\]/', $type, $matches);
 


### PR DESCRIPTION
one of our windows server seams to provide broken snmp data. At least in this plugin "ilo_storage" is

```
(
    [End of MIB] => 
)
```

which results in a exception like

`TypeError: Cannot access offset of type string on string in /opt/librenms/includes/discovery/storage/hpe-ilo.inc.php:11
Stack trace:
#0 /opt/librenms/includes/include-dir.inc.php(6): include()
#1 /opt/librenms/includes/discovery/storage.inc.php(7): require('...')
#2 /opt/librenms/includes/discovery/functions.inc.php(167): include('...')
#3 /opt/librenms/discovery.php(108): discover_device()
#4 {main}  
Cannot access offset of type string on string {"exception":"[object] (TypeError(code: 0): Cannot access offset of type string on string at /opt/librenms/includes/discovery/storage/hpe-ilo.inc.php:11)"}`

and at the end nothing is detected. With the attached fix, we ignore this malformed data and are able to continue.

The result is that the harddisks of this machine are detected properly now.
