### PR TITLE
Option for read-only user access Oxidized configs

### DIFF
--- a/includes/html/pages/device/showconfig.inc.php
+++ b/includes/html/pages/device/showconfig.inc.php
@@ -4,7 +4,7 @@
 use LibreNMS\Config;
 use Symfony\Component\Process\Process;
 
-if (Auth::user()->hasGlobalAdmin() || ((Auth::user()->hasGlobalRead() && Config::get('oxidized.read_only_configs') == true))) {
+if (Auth::user()->hasGlobalAdmin() || (Auth::user()->hasGlobalRead() && Config::get('oxidized.read_only_configs') == true)) {
     if (! empty($rancid_file)) {
         echo '<div style="clear: both;">';
 

--- a/includes/html/pages/device/showconfig.inc.php
+++ b/includes/html/pages/device/showconfig.inc.php
@@ -4,7 +4,7 @@
 use LibreNMS\Config;
 use Symfony\Component\Process\Process;
 
-if (Auth::user()->hasGlobalAdmin()) {
+if (Auth::user()->hasGlobalAdmin() || ((Auth::user()->hasGlobalRead() && Config::get('oxidized.read_only_configs') == true))) {
     if (! empty($rancid_file)) {
         echo '<div style="clear: both;">';
 

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -1075,6 +1075,10 @@ return [
             'default_group' => [
                 'description' => 'Set the default group returned',
             ],
+            'read_only_configs' => [
+                'description' => 'Allow read only user config access',
+                'help' => 'When true all read only users are able to access Oxidized backups',
+            ],
             'ignore_groups' => [
                 'description' => 'Do not backup these Oxidized groups',
                 'help' => 'Groups (set via Variable Mapping) excluded from being sent to Oxidized',

--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -4679,6 +4679,13 @@
             "order": 0,
             "type": "boolean"
         },
+        "oxidized.read_only_configs": {
+            "default": false,
+            "group": "external",
+            "section": "oxidized",
+            "order": 3,
+            "type": "boolean"
+        },
         "oxidized.features.versioning": {
             "default": false,
             "group": "external",


### PR DESCRIPTION
Created option in oxidized settings to allow read only users to access Oxidized configs.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
