### PR TITLE
Fix typo

### DIFF
--- a/includes/html/pages/device/apps/linux_softnet_stat.inc.php
+++ b/includes/html/pages/device/apps/linux_softnet_stat.inc.php
@@ -10,7 +10,7 @@ print_optionbar_end();
 $graphs = [
     'linux_softnet_stat_packets' => 'Packets Per Second',
     'linux_softnet_stat_time_squeeze' => 'Time Squeezes Per Second',
-    'linux_softnet_stat_backlog_length' => 'Backlog Lenght',
+    'linux_softnet_stat_backlog_length' => 'Backlog Length',
     'linux_softnet_stat_packet_dropped' => 'Packets Dropped Per Second',
     'linux_softnet_stat_cpu_collision' => 'CPU Collisions Per Second',
     'linux_softnet_stat_flow_limit' => 'Flow Limit Hit Per Second',


### PR DESCRIPTION
Fixed a typo `Backlog Lenght` -> `Backlog Length`

I noticed this typo underneath `Devices` -> `[Device]` -> `Apps` -> `Linux SoftNet Stats` and wanted to fix it.
I also noticed there is a similar typo in a mib file here: https://github.com/librenms/librenms/blob/d29201fce134347f891102699fbde7070debee33/mibs/radware/RADWARE-MIB#L9916

But I'll be honest, I am not good with SNMP/MIBs, maybe it has to be a typo in that MIB file, to be able to parse the description.
If it's fine to fix, lmk and I'll push another commit addressing this.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
