### PR TITLE
for gzip+base64 compressed json, don't call stripslashes

### DIFF
--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -470,10 +470,15 @@ function json_app_get($device, $extend, $min_version = 1)
         if (Debug::isVerbose()) {
             echo 'Decoded Base64+GZip Output: ' . $output . "\n\n";
         }
+    } else {
+        $output = stripslashes($output);
+        if (Debug::isVerbose()) {
+            echo 'Output post stripslashes: ' . $output . "\n\n";
+        }
     }
 
     //  turn the JSON into a array
-    $parsed_json = json_decode(stripslashes($output), true);
+    $parsed_json = json_decode($output, true);
 
     // improper JSON or something else was returned. Populate the variable with an error.
     if (json_last_error() !== JSON_ERROR_NONE) {


### PR DESCRIPTION
The gzip+base64 is already protected against munging by snmpd, so no reason to call stripslahes. Not doing so can occasionally create invalid JSON as valid JSON is being passed to it and then being borked by stripslashes.

Found this when looking into why Sneck was not functioning for a system here and found that was the cause. 

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
