### PR TITLE
[webui] sort ports in VLANs blade

### DIFF
--- a/app/Http/Controllers/Device/Tabs/VlansController.php
+++ b/app/Http/Controllers/Device/Tabs/VlansController.php
@@ -86,7 +86,7 @@ class VlansController implements DeviceTab
             ->select('ports_vlans.*', 'vlans.vlan_name')->orderBy('vlan_vlan')->orderBy('ports.ifName')->orderBy('ports.ifDescr')
             ->get();
 
-        $data = $portVlan->groupBy('vlan');
+        $data = $portVlan->sortBy('port')->groupBy('vlan');
 
         return $data;
     }

--- a/app/Http/Controllers/Device/Tabs/VlansController.php
+++ b/app/Http/Controllers/Device/Tabs/VlansController.php
@@ -84,9 +84,9 @@ class VlansController implements DeviceTab
             })
             ->with(['port.device'])
             ->select('ports_vlans.*', 'vlans.vlan_name')->orderBy('vlan_vlan')->orderBy('ports.ifName')->orderBy('ports.ifDescr')
-            ->get();
+            ->get()->sortBy(['vlan', 'port']);
 
-        $data = $portVlan->sortBy('port')->groupBy('vlan');
+        $data = $portVlan->groupBy('vlan');
 
         return $data;
     }

--- a/resources/views/device/tabs/vlans.blade.php
+++ b/resources/views/device/tabs/vlans.blade.php
@@ -16,7 +16,7 @@
                 <td>{{ $vlan_number }}</td>
                 <td>{{ $vlans->first()->vlan_name }}</td>
                 <td>
-                @foreach($vlans->sortBy('port') as $port)
+                @foreach($vlans as $port)
                     @if(!$port->port)
                         @continue;
                     @endif

--- a/resources/views/device/tabs/vlans.blade.php
+++ b/resources/views/device/tabs/vlans.blade.php
@@ -16,7 +16,7 @@
                 <td>{{ $vlan_number }}</td>
                 <td>{{ $vlans->first()->vlan_name }}</td>
                 <td>
-                @foreach($vlans as $port)
+                @foreach($vlans->sortBy('port') as $port)
                     @if(!$port->port)
                         @continue;
                     @endif


### PR DESCRIPTION
sort ports in VLANs blade

before:
gi1/0/1,gi1/0/10,gi1/0/2,gi1/0/23,gi1/0/24,gi1/0/3,gi1/0/4,gi1/0/5,gi1/0/6,gi1/0/7,gi1/0/8,gi1/0/9,Po1,te1/0/2,te1/0/3,te1/0/4

after:
gi1/0/1,gi1/0/2,gi1/0/3,gi1/0/4,gi1/0/5,gi1/0/6,gi1/0/7,gi1/0/8,gi1/0/9,gi1/0/10,gi1/0/23,gi1/0/24,te1/0/2,te1/0/3,te1/0/4,Po1

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
