### PR TITLE
Fix graph_type variable (svg / png)

### DIFF
--- a/LibreNMS/Data/Store/Rrd.php
+++ b/LibreNMS/Data/Store/Rrd.php
@@ -27,6 +27,7 @@ namespace LibreNMS\Data\Store;
 
 use App\Polling\Measure\Measurement;
 use LibreNMS\Config;
+use LibreNMS\Enum\ImageFormat;
 use LibreNMS\Exceptions\FileExistsException;
 use LibreNMS\Exceptions\RrdGraphException;
 use LibreNMS\Proc;
@@ -596,8 +597,11 @@ class Rrd extends BaseDatastore
         }
 
         // if valid image is returned with error, extract image and feedback
-        $image_type = Config::get('webui.graph_type', 'svg');
-        $search = $this->getImageEnd($image_type);
+        // rrdtool defaults to png if imgformat not specified
+        $graph_type = preg_match('/--imgformat=([^\s]+)/', $options, $matches) ? strtolower($matches[1]) : 'png';
+        $imageFormat = ImageFormat::forGraph($graph_type);
+
+        $search = $imageFormat->getImageEnd();
         if (($position = strrpos($process->getOutput(), $search)) !== false) {
             $position += strlen($search);
             throw new RrdGraphException(
@@ -613,16 +617,6 @@ class Rrd extends BaseDatastore
         // only error text was returned
         $error = trim($process->getOutput() . PHP_EOL . $process->getErrorOutput());
         throw new RrdGraphException($error, null, null, null, $process->getExitCode());
-    }
-
-    private function getImageEnd(string $type): string
-    {
-        $image_suffixes = [
-            'png' => hex2bin('0000000049454e44ae426082'),
-            'svg' => '</svg>',
-        ];
-
-        return $image_suffixes[$type] ?? '';
     }
 
     public function __destruct()

--- a/LibreNMS/Enum/ImageFormat.php
+++ b/LibreNMS/Enum/ImageFormat.php
@@ -41,4 +41,14 @@ enum ImageFormat: string
     {
         return $this->value == 'svg' ? 'image/svg+xml' : 'image/png';
     }
+
+    public function getImageEnd(): string
+    {
+        $image_suffixes = [
+            'png' => hex2bin('0000000049454e44ae426082'),
+            'svg' => '</svg>',
+        ];
+
+        return $image_suffixes[$this->value] ?? '';
+    }
 }

--- a/LibreNMS/Util/Graph.php
+++ b/LibreNMS/Util/Graph.php
@@ -87,7 +87,7 @@ class Graph
                 throw $e;
             }
 
-            return new GraphImage(ImageFormat::forGraph(), 'Error', $e->generateErrorImage());
+            return new GraphImage(ImageFormat::forGraph($vars['graph_type'] ?? null), 'Error', $e->generateErrorImage());
         }
     }
 

--- a/app/Http/Controllers/GraphController.php
+++ b/app/Http/Controllers/GraphController.php
@@ -45,7 +45,7 @@ class GraphController extends Controller
                 throw $e;
             }
 
-            return response($e->generateErrorImage(), 500, ['Content-type' => ImageFormat::forGraph()->contentType()]);
+            return response($e->generateErrorImage(), 500, ['Content-type' => ImageFormat::forGraph($vars['graph_type'] ?? null)->contentType()]);
         }
     }
 }

--- a/includes/html/graphs/graph.inc.php
+++ b/includes/html/graphs/graph.inc.php
@@ -96,9 +96,9 @@ try {
 
     // output the graph
     if (\LibreNMS\Util\Debug::isEnabled()) {
-        echo '<img src="data:' . ImageFormat::forGraph()->contentType() . ';base64,' . base64_encode($image_data) . '" alt="graph" />';
+        echo '<img src="data:' . ImageFormat::forGraph($vars['graph_type'] ?? null)->contentType() . ';base64,' . base64_encode($image_data) . '" alt="graph" />';
     } else {
-        header('Content-type: ' . ImageFormat::forGraph()->contentType());
+        header('Content-type: ' . ImageFormat::forGraph($vars['graph_type'] ?? null)->contentType());
         echo (isset($vars['output']) && $vars['output'] === 'base64') ? base64_encode($image_data) : $image_data;
     }
 } catch (\LibreNMS\Exceptions\RrdGraphException $e) {


### PR DESCRIPTION
Fix graph_type variable (svg / png), otherwise system configured graph type is always used.

To have a graph rendered in a different image format than that of the system default (svg), passing `graph_type=png` into graph.php is expected to work; however other functions involved in graph creation always assume the system configured image format has been used (e.g. content type header).

These changes ensure the requested graph_type is always considered where it needs to be, falling back to the system default where one isn't specified.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [X] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
