### PR TITLE
Correct swapped SET and WHERE parameters in bgp-peers/dell-os10.inc.php

### DIFF
--- a/includes/discovery/bgp-peers/dell-os10.inc.php
+++ b/includes/discovery/bgp-peers/dell-os10.inc.php
@@ -78,7 +78,7 @@ if ($device['os'] == 'dell-os10') {
                 }
                 echo '+';
             } else {
-                BgpPeer::where('bgpPeerRemoteAs', $value['os10bgp4V2PeerRemoteAs'])->where('astext', $astext)->update(['bgpPeerIdentifier' => $address, 'device_id' => $device['device_id'], 'vrf_id' => $vrfId]);
+                BgpPeer::where('device_id', $device['device_id'])->where('bgpPeerIdentifier', $address)->where('vrf_id', $vrfId)->update(['bgpPeerRemoteAs' => $value['os10bgp4V2PeerRemoteAs'], 'astext' => $astext]);
                 echo '.';
             }
         }


### PR DESCRIPTION
When the code was refactored in daa8c757f6, the selectors and updated columns were reversed in the `BgpPeer::where()->update()` expression.

https://github.com/librenms/librenms/pull/14278/files#diff-2155dfbc44df62336d9f87cd162455720709b638a30b6577da003c3fdc8f5c04L81-R82

This swap causes duplicate records to be added to the `bgpPeers` table every discovery cycle.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
