### PR TITLE
Allow for more than one instance of device_id to be replaced in the a…

### DIFF
--- a/LibreNMS/Alert/AlertRules.php
+++ b/LibreNMS/Alert/AlertRules.php
@@ -77,8 +77,8 @@ class AlertRules
             global $PDO_FETCH_ASSOC;
             $PDO_FETCH_ASSOC = true;
             try {
-                $ce = substr_count($sql,'?');
-                $device_id_array = array_fill(0,$ce,$device_id);
+                $ce = substr_count($sql, '?');
+                $device_id_array = array_fill(0, $ce, $device_id);
                 $qry = \DB::select($sql, $device_id_array);
             } catch (QueryException $e) {
                 c_echo('%RError: %n' . $e->getMessage() . PHP_EOL);

--- a/LibreNMS/Alert/AlertRules.php
+++ b/LibreNMS/Alert/AlertRules.php
@@ -77,7 +77,9 @@ class AlertRules
             global $PDO_FETCH_ASSOC;
             $PDO_FETCH_ASSOC = true;
             try {
-                $qry = \DB::select($sql, [$device_id]);
+                $ce = substr_count($sql,'?');
+                $device_id_array = array_fill(0,$ce,$device_id);
+                $qry = \DB::select($sql, $device_id_array);
             } catch (QueryException $e) {
                 c_echo('%RError: %n' . $e->getMessage() . PHP_EOL);
                 Eventlog::log("Error in alert rule {$rule['name']} ({$rule['id']}): " . $e->getMessage(), $device_id, 'alert', Severity::Error);

--- a/LibreNMS/Alert/RunAlerts.php
+++ b/LibreNMS/Alert/RunAlerts.php
@@ -306,7 +306,9 @@ class RunAlerts
                 if (empty($alert['query'])) {
                     $alert['query'] = AlertDB::genSQL($alert['rule'], $alert['builder']);
                 }
-                $chk = dbFetchRows($alert['query'], [$alert['device_id']]);
+                $ce = substr_count($alert['query'],'?');
+                $device_id_array = array_fill(0,$ce,$alert['device_id']);
+                $chk = dbFetchRows($alert['query'], $device_id_array);
                 //make sure we can json_encode all the datas later
                 $cnt = count($chk);
                 for ($i = 0; $i < $cnt; $i++) {

--- a/LibreNMS/Alert/RunAlerts.php
+++ b/LibreNMS/Alert/RunAlerts.php
@@ -306,8 +306,8 @@ class RunAlerts
                 if (empty($alert['query'])) {
                     $alert['query'] = AlertDB::genSQL($alert['rule'], $alert['builder']);
                 }
-                $ce = substr_count($alert['query'],'?');
-                $device_id_array = array_fill(0,$ce,$alert['device_id']);
+                $ce = substr_count($alert['query'], '?');
+                $device_id_array = array_fill(0, $ce, $alert['device_id']);
                 $chk = dbFetchRows($alert['query'], $device_id_array);
                 //make sure we can json_encode all the datas later
                 $cnt = count($chk);


### PR DESCRIPTION
This will allow for more than one instance of ? to be replaced by device_id in a custom alertrule.


Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
