### PR TITLE
SNMP Traps - Ciena AAA

### DIFF
--- a/LibreNMS/Snmptrap/Handlers/CienaCesAAAUserAuthenticationEvent.php
+++ b/LibreNMS/Snmptrap/Handlers/CienaCesAAAUserAuthenticationEvent.php
@@ -51,6 +51,6 @@ class CienaCesAAAUserAuthenticationEvent implements SnmptrapHandler
         if ($trap->getOidData($trap->findOid('CIENA-CES-AAA-MIB::cienaCesAAAUserAuthenticationStatus')) == 'failure') {
             $severity = Severity::Warning;
         }
-        $trap->log("Authentication attempt by $user. $message", $severity, 'auth');
+        $trap->log("Authentication attempt by $user. $message", $severity);
     }
 }

--- a/LibreNMS/Snmptrap/Handlers/CienaCesAAAUserAuthenticationEvent.php
+++ b/LibreNMS/Snmptrap/Handlers/CienaCesAAAUserAuthenticationEvent.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * CienaCesAAAUserAuthenticationEvent.php
+ *
+ * -Description-
+ *
+ * Handles Ciena authentication traps. States whether or not user
+ * successfully authenticates to the device.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * @link       https://www.librenms.org
+ *
+ * @copyright  2024 KanREN Inc
+ * @author     Heath Barnhart <hbarnhart@kanren.net>
+ */
+
+namespace LibreNMS\Snmptrap\Handlers;
+
+use App\Models\Device;
+use LibreNMS\Enum\Severity;
+use LibreNMS\Interfaces\SnmptrapHandler;
+use LibreNMS\Snmptrap\Trap;
+
+class CienaCesAAAUserAuthenticationEvent implements SnmptrapHandler
+{
+    /**
+     * Handle snmptrap.
+     * Data is pre-parsed and delivered as a Trap.
+     *
+     * @param  Device  $device
+     * @param  Trap  $trap
+     * @return void
+     */
+    public function handle(Device $device, Trap $trap)
+    {
+        $user = $trap->getOidData($trap->findOid('CIENA-CES-AAA-MIB::cienaCesAAAUserName'));
+        //hostIp has an issue, device is currrently returning octet string instead of IP. Waiting for update to see if fixed. If not, omitt.
+        $hostIp = $trap->getOidData($trap->findOid('CIENA-CES-AAA-MIB::cienaCesAAAHostIp'));
+        $message = $trap->getOidData($trap->findOid('CIENA-CES-AAA-MIB::cienaCesAAAUserAuthenticationDescription'));
+        $severity = Severity::Notice;
+        if ($trap->getOidData($trap->findOid('CIENA-CES-AAA-MIB::cienaCesAAAUserAuthenticationStatus')) == 'failure') {
+            $severity = Severity::Warning;
+        }
+        $trap->log("Authentication attempt from $hostIp by $user on " . $device->displayName() . ' ' . $message, $severity, 'auth');
+    }
+}

--- a/LibreNMS/Snmptrap/Handlers/CienaCesAAAUserAuthenticationEvent.php
+++ b/LibreNMS/Snmptrap/Handlers/CienaCesAAAUserAuthenticationEvent.php
@@ -46,13 +46,11 @@ class CienaCesAAAUserAuthenticationEvent implements SnmptrapHandler
     public function handle(Device $device, Trap $trap)
     {
         $user = $trap->getOidData($trap->findOid('CIENA-CES-AAA-MIB::cienaCesAAAUserName'));
-        //hostIp has an issue, device is currrently returning octet string instead of IP. Waiting for update to see if fixed. If not, omitt.
-        $hostIp = $trap->getOidData($trap->findOid('CIENA-CES-AAA-MIB::cienaCesAAAHostIp'));
         $message = $trap->getOidData($trap->findOid('CIENA-CES-AAA-MIB::cienaCesAAAUserAuthenticationDescription'));
         $severity = Severity::Notice;
         if ($trap->getOidData($trap->findOid('CIENA-CES-AAA-MIB::cienaCesAAAUserAuthenticationStatus')) == 'failure') {
             $severity = Severity::Warning;
         }
-        $trap->log("Authentication attempt from $hostIp by $user on " . $device->displayName() . ' ' . $message, $severity, 'auth');
+        $trap->log("Authentication attempt by $user. $message", $severity, 'auth');
     }
 }

--- a/config/snmptraps.php
+++ b/config/snmptraps.php
@@ -10,7 +10,6 @@
 
 return [
     'trap_handlers' => [
-        'CIENA-CES-AAA-MIB::cienaCesAAAUserAuthenticationEvent' => \LibreNMS\Snmptrap\Handlers\CienaCesAAAUserAuthenticationEvent::class,
         'ALCATEL-IND1-VLAN-STP-MIB::stpNewRoot' => \LibreNMS\Snmptrap\Handlers\Aos7stpNewRoot::class,
         'ALCATEL-IND1-VLAN-STP-MIB::stpRootPortChange' => \LibreNMS\Snmptrap\Handlers\Aos7stpRootPortChange::class,
         'ALCATEL-IND1-PORT-MIB::portViolationTrap' => \LibreNMS\Snmptrap\Handlers\Aos7portViolation::class,
@@ -29,6 +28,7 @@ return [
         'BGP4-V2-MIB-JUNIPER::jnxBgpM2Established' => \LibreNMS\Snmptrap\Handlers\JnxBgpM2Established::class,
         'BRIDGE-MIB::newRoot' => \LibreNMS\Snmptrap\Handlers\BridgeNewRoot::class,
         'BRIDGE-MIB::topologyChange' => \LibreNMS\Snmptrap\Handlers\BridgeTopologyChanged::class,
+        'CIENA-CES-AAA-MIB::cienaCesAAAUserAuthenticationEvent' => \LibreNMS\Snmptrap\Handlers\CienaCesAAAUserAuthenticationEvent::class,
         'CISCO-PORT-SECURITY-MIB::cpsSecureMacAddrViolation' => \LibreNMS\Snmptrap\Handlers\CiscoMacViolation::class,
         'CISCO-ERR-DISABLE-MIB::cErrDisableInterfaceEventRev1' => \LibreNMS\Snmptrap\Handlers\CiscoErrDisableInterfaceEvent::class,
         'CISCO-IETF-DHCP-SERVER-MIB::cDhcpv4ServerStartTime' => \LibreNMS\Snmptrap\Handlers\CiscoDHCPServerStart::class,

--- a/config/snmptraps.php
+++ b/config/snmptraps.php
@@ -10,6 +10,7 @@
 
 return [
     'trap_handlers' => [
+        'CIENA-CES-AAA-MIB::cienaCesAAAUserAuthenticationEvent' => \LibreNMS\Snmptrap\Handlers\CienaCesAAAUserAuthenticationEvent::class,
         'ALCATEL-IND1-VLAN-STP-MIB::stpNewRoot' => \LibreNMS\Snmptrap\Handlers\Aos7stpNewRoot::class,
         'ALCATEL-IND1-VLAN-STP-MIB::stpRootPortChange' => \LibreNMS\Snmptrap\Handlers\Aos7stpRootPortChange::class,
         'ALCATEL-IND1-PORT-MIB::portViolationTrap' => \LibreNMS\Snmptrap\Handlers\Aos7portViolation::class,

--- a/mibs/ciena/CIENA-CES-AAA-MIB
+++ b/mibs/ciena/CIENA-CES-AAA-MIB
@@ -1,0 +1,252 @@
+CIENA-CES-AAA-MIB DEFINITIONS ::= BEGIN
+
+	IMPORTS
+		cienaGlobalMacAddress
+			FROM CIENA-GLOBAL-MIB
+		cienaCommon, cienaCesConfig, cienaCesNotifications
+			FROM CIENA-SMI
+		CienaGlobalSeverity
+			FROM CIENA-TC
+		enterprises, IpAddress, Unsigned32,
+		MODULE-IDENTITY, OBJECT-IDENTITY, NOTIFICATION-TYPE
+			FROM SNMPv2-SMI
+		DisplayString, MacAddress, TruthValue,
+		TEXTUAL-CONVENTION
+			FROM SNMPv2-TC;
+
+--
+-- Node definitions
+--
+	-- 1.3.6.1.4.1.1271.2.1.60
+	cienaCesAAAMIB MODULE-IDENTITY
+		LAST-UPDATED "202212060000Z"		-- December 6, 2022 at 00:00 GMT (202212060000Z)
+		ORGANIZATION
+			"Ciena Corp."
+		CONTACT-INFO
+			"   Mib Meister
+			7035 Ridge Road
+			Hanover, Maryland 21076
+			USA
+			Phone:  +1 800 921 1144
+			Email:  support@ciena.com"
+		DESCRIPTION
+			"This MIB module defines objects and notifications used by User Authentication,
+			Authorization and Accounting (AAA) services on system."
+		REVISION "202212060000Z"		-- December 6, 2022 at 00:00 GMT (202212060000Z)
+		DESCRIPTION
+			"Added support for TACACS server events cienaCesAAATacacsServerStatusEvent,
+			cienaCesAAAAllTacacsServersDownEvent and support for LDAP server events
+			cienaCesAAALdapServerStatusEvent, cienaCesAAAAllLdapServersDownEvent."
+		REVISION "202108110000Z"		-- August 11, 2021 at 00:00 GMT (202108110000Z)
+		DESCRIPTION
+			"Initial creation."
+	::= { cienaCesConfig 60 }
+
+	-- 1.3.6.1.4.1.1271.2.1.60.1
+	cienaCesAAAMibObjects OBJECT IDENTIFIER ::= { cienaCesAAAMIB 1 }
+
+	-- 1.3.6.1.4.1.1271.2.1.60.1.1
+	cienaCesAAAUserName OBJECT-TYPE
+		SYNTAX DisplayString (SIZE (0..32))
+		ACCESS accessible-for-notify
+		STATUS current
+		DESCRIPTION
+			"User credentials used by a remote host to connect to the system."
+	::= { cienaCesAAAMibObjects 1 }
+
+	-- 1.3.6.1.4.1.1271.2.1.60.1.2
+	cienaCesAAAHostIp OBJECT-TYPE
+		SYNTAX IpAddress
+		ACCESS accessible-for-notify
+		STATUS current
+		DESCRIPTION
+			"IP address of a remote host trying to connect to the system."
+	::= { cienaCesAAAMibObjects 2 }
+
+	-- 1.3.6.1.4.1.1271.2.1.60.1.3
+	cienaCesAAAUserPort OBJECT-TYPE
+		SYNTAX Unsigned32
+		ACCESS accessible-for-notify
+		STATUS current
+		DESCRIPTION
+			"Port number used by a remote host to connect for an ssh or telnet session."
+	::= { cienaCesAAAMibObjects 3 }
+
+	-- 1.3.6.1.4.1.1271.2.1.60.1.4
+	cienaCesAAAUserAuthenticationServiceType OBJECT-TYPE
+		SYNTAX INTEGER
+		{
+			local(1),
+			tacacs(2),
+			radius(3),
+			radsec(4)
+		}
+		ACCESS accessible-for-notify
+		STATUS current
+		DESCRIPTION
+			"User authentication service being used, local or remote."
+	::= { cienaCesAAAMibObjects 4 }
+
+	-- 1.3.6.1.4.1.1271.2.1.60.1.5
+	cienaCesAAAUserAuthenticationStatus OBJECT-TYPE
+		SYNTAX INTEGER
+		{
+			success(1),
+			failure(2)
+		}
+		ACCESS accessible-for-notify
+		STATUS current
+		DESCRIPTION
+			"User authentication status as success or failure."
+	::= { cienaCesAAAMibObjects 5 }
+
+	-- 1.3.6.1.4.1.1271.2.1.60.1.6
+	cienaCesAAAUserAuthenticationDescription OBJECT-TYPE
+		SYNTAX DisplayString
+		ACCESS accessible-for-notify
+		STATUS current
+		DESCRIPTION
+			"Detailed description of the user authentication event."
+	::= { cienaCesAAAMibObjects 6 }
+
+	-- 1.3.6.1.4.1.1271.2.1.60.1.7
+	cienaCesAAAServerGroup OBJECT-TYPE
+		SYNTAX DisplayString
+		ACCESS accessible-for-notify
+		STATUS current
+		DESCRIPTION
+			"Server group to which TACACS server belongs."
+	::= { cienaCesAAAMibObjects 7 }
+
+	-- 1.3.6.1.4.1.1271.2.1.60.1.8
+	cienaCesAAATacacsServer OBJECT-TYPE
+		SYNTAX DisplayString
+		ACCESS accessible-for-notify
+		STATUS current
+		DESCRIPTION
+			"IP address of the TACACS server."
+	::= { cienaCesAAAMibObjects 8 }
+
+	-- 1.3.6.1.4.1.1271.2.1.60.1.9
+	cienaCesAAAServerStatus OBJECT-TYPE
+		SYNTAX INTEGER
+		{
+			available(1),
+			unreachable(2)
+		}
+		ACCESS accessible-for-notify
+		STATUS current
+		DESCRIPTION
+			"Status of the TACACS server."
+	::= { cienaCesAAAMibObjects 9 }
+
+	-- 1.3.6.1.4.1.1271.2.1.60.1.10
+	cienaCesAAAAllServerDownStatus OBJECT-TYPE
+		SYNTAX TruthValue
+		ACCESS accessible-for-notify
+		STATUS current
+		DESCRIPTION
+			"Describes if all the TACACS servers are down or not."
+	::= { cienaCesAAAMibObjects 10 }
+
+	-- 1.3.6.1.4.1.1271.2.1.60.1.11
+	cienaCesAAALdapServer OBJECT-TYPE
+		SYNTAX DisplayString
+		ACCESS accessible-for-notify
+		STATUS current
+		DESCRIPTION
+			"IP address or hostname of LDAP server."
+	::= { cienaCesAAAMibObjects 11 }
+
+	-- 1.3.6.1.4.1.1271.2.1.60.1.12
+	cienaCesAAAUser OBJECT-TYPE
+		SYNTAX DisplayString
+		ACCESS accessible-for-notify
+		STATUS current
+		DESCRIPTION
+			"IP address or hostname of LDAP server."
+	::= { cienaCesAAAMibObjects 12 }
+
+	-- 1.3.6.1.4.1.1271.2.1.60.1.13
+	cienaCesAAANacmGroup OBJECT-TYPE
+		SYNTAX DisplayString
+		ACCESS accessible-for-notify
+		STATUS current
+		DESCRIPTION
+			"IP address or hostname of LDAP server."
+	::= { cienaCesAAAMibObjects 13 }
+
+	-- 1.3.6.1.4.1.1271.2.1.60.1.14
+	cienaCesAAALdapServerStatus OBJECT-TYPE
+		SYNTAX INTEGER
+		{
+			available(1),
+			unavailable(2),
+			ruleparseerror(3)
+		}
+		ACCESS accessible-for-notify
+		STATUS current
+		DESCRIPTION
+			"IP address or hostname of LDAP server."
+	::= { cienaCesAAAMibObjects 14 }
+
+	-- 1.3.6.1.4.1.1271.2.2.111
+	cienaCesAAAMIBNotificationPrefix OBJECT IDENTIFIER ::= { cienaCesNotifications 111 }
+
+	-- 1.3.6.1.4.1.1271.2.2.111.0
+	cienaCesAAAMIBNotification OBJECT IDENTIFIER ::= { cienaCesAAAMIBNotificationPrefix 0 }
+
+	-- 1.3.6.1.4.1.1271.2.2.111.0.1
+	cienaCesAAAUserAuthenticationEvent NOTIFICATION-TYPE
+		OBJECTS { cienaGlobalSeverity, cienaGlobalMacAddress, cienaCesAAAUserName, 
+		cienaCesAAAHostIp, cienaCesAAAUserPort, 
+		cienaCesAAAUserAuthenticationServiceType, 
+		cienaCesAAAUserAuthenticationStatus, 
+		cienaCesAAAUserAuthenticationDescription } 
+		STATUS current
+		DESCRIPTION
+			"This notification is generated when an authentication event,
+			as identified by the value of cienaCesAAAUserAuthenticationStatus
+			has occurred."
+	::= { cienaCesAAAMIBNotification 1 }
+
+	-- 1.3.6.1.4.1.1271.2.2.111.0.2
+	cienaCesAAATacacsServerStatusEvent NOTIFICATION-TYPE
+		OBJECTS { cienaGlobalSeverity, cienaGlobalMacAddress, cienaCesAAAServerGroup, 
+		cienaCesAAATacacsServer, cienaCesAAAServerStatus } 
+		STATUS current
+		DESCRIPTION
+			"This notification is generated when a TACACS server is not reachable."
+	::= { cienaCesAAAMIBNotification 2 }
+
+	-- 1.3.6.1.4.1.1271.2.2.111.0.3
+	cienaCesAAAAllTacacsServersDownEvent NOTIFICATION-TYPE
+		OBJECTS { cienaGlobalSeverity, cienaGlobalMacAddress, cienaCesAAAServerGroup, 
+		cienaCesAAAAllServerDownStatus } 
+		STATUS current
+		DESCRIPTION
+			"This notification is generated when all the configured TACACS
+			servers are not reachable."
+	::= { cienaCesAAAMIBNotification 3 }
+
+	-- 1.3.6.1.4.1.1271.2.2.111.0.4
+	cienaCesAAALdapServerStatusEvent NOTIFICATION-TYPE
+		OBJECTS { cienaGlobalSeverity, cienaGlobalMacAddress, cienaCesAAALdapServer, 
+		cienaCesAAAUser, cienaCesAAANacmGroup, cienaCesAAALdapServerStatus } 
+		STATUS current
+		DESCRIPTION
+			"This notification is generated when an LDAP server is not reachable
+			or NACM rule downloaded from LDAP server is not parsed correctly."
+	::= { cienaCesAAAMIBNotification 4 }
+
+	-- 1.3.6.1.4.1.1271.2.2.111.0.5
+	cienaCesAAAAllLdapServersDownEvent NOTIFICATION-TYPE
+		OBJECTS { cienaGlobalSeverity, cienaGlobalMacAddress, 
+		cienaCesAAAAllServerDownStatus } 
+		STATUS current
+		DESCRIPTION
+			"This notification is generated when all the configured LDAP servers
+			are not reachable/available."
+	::= { cienaCesAAAMIBNotification 5 }
+
+END

--- a/tests/Feature/SnmpTraps/CienaCesAAAUserAuthenticationEventTest.php
+++ b/tests/Feature/SnmpTraps/CienaCesAAAUserAuthenticationEventTest.php
@@ -45,11 +45,12 @@ CIENA-CES-AAA-MIB::cienaCesAAAUserAuthenticationServiceType radius
 CIENA-CES-AAA-MIB::cienaCesAAAUserAuthenticationStatus success
 CIENA-CES-AAA-MIB::cienaCesAAAUserAuthenticationDescription User authentication succeeded
 TRAP,
-            'Authentication attempt by cienamcp. User authentication succeeded',
+            'Authentication attempt by lorem. User authentication succeeded',
             'Could not handle CienaCesAAAUserAuthenticationEvent success',
             [Severity::Notice],
         );
     }
+
     public function testAuthFail(): void
     {
         $this->assertTrapLogsMessage(<<<'TRAP'
@@ -71,6 +72,7 @@ TRAP,
             [Severity::Warning],
         );
     }
+
     public function testAuthLogout(): void
     {
         $this->assertTrapLogsMessage(<<<'TRAP'

--- a/tests/Feature/SnmpTraps/CienaCesAAAUserAuthenticationEventTest.php
+++ b/tests/Feature/SnmpTraps/CienaCesAAAUserAuthenticationEventTest.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * CienaCesAAAUserAuthenticationEventTest.php
+ *
+ * -Description-
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * @link       https://www.librenms.org
+ *
+ * @copyright  2019 Heath Barnhart
+ * @author     Heath Barnhart <hbarnhart@kanren.net>
+ */
+
+namespace LibreNMS\Tests\Feature\SnmpTraps;
+
+use LibreNMS\Enum\Severity;
+
+class CienaCesAAAUserAuthenticationEventTest extends SnmpTrapTestCase
+{
+    public function testAuthSuccess(): void
+    {
+        $this->assertTrapLogsMessage(<<<'TRAP'
+{{ hostname }}
+UDP: [{{ ip }}]:57602->[192.168.5.5]:162
+DISMAN-EVENT-MIB::sysUpTimeInstance 0:0:15:22.68
+SNMPv2-MIB::snmpTrapOID.0 CIENA-CES-AAA-MIB::cienaCesAAAUserAuthenticationEvent
+CIENA-GLOBAL-MIB::cienaGlobalSeverity info
+CIENA-GLOBAL-MIB::cienaGlobalMacAddress ac:89:de:ad:be:ef
+CIENA-CES-AAA-MIB::cienaCesAAAUserName lorem
+CIENA-CES-AAA-MIB::cienaCesAAAHost 192.168.251.251
+CIENA-CES-AAA-MIB::cienaCesAAAUserPort 4444
+CIENA-CES-AAA-MIB::cienaCesAAAUserAuthenticationServiceType radius
+CIENA-CES-AAA-MIB::cienaCesAAAUserAuthenticationStatus success
+CIENA-CES-AAA-MIB::cienaCesAAAUserAuthenticationDescription User authentication succeeded
+TRAP,
+            'Authentication attempt by cienamcp. User authentication succeeded',
+            'Could not handle CienaCesAAAUserAuthenticationEvent success',
+            [Severity::Notice],
+        );
+    }
+    public function testAuthFail(): void
+    {
+        $this->assertTrapLogsMessage(<<<'TRAP'
+{{ hostname }}
+UDP: [{{ ip }}]:57602->[192.168.5.5]:162
+DISMAN-EVENT-MIB::sysUpTimeInstance 0:0:15:22.68
+SNMPv2-MIB::snmpTrapOID.0 CIENA-CES-AAA-MIB::cienaCesAAAUserAuthenticationEvent
+CIENA-GLOBAL-MIB::cienaGlobalSeverity info
+CIENA-GLOBAL-MIB::cienaGlobalMacAddress ac:89:de:ad:be:ef
+CIENA-CES-AAA-MIB::cienaCesAAAUserName lorem
+CIENA-CES-AAA-MIB::cienaCesAAAHostIp 10.1.1.1
+CIENA-CES-AAA-MIB::cienaCesAAAUserPort 6564
+CIENA-CES-AAA-MIB::cienaCesAAAUserAuthenticationServiceType radius
+CIENA-CES-AAA-MIB::cienaCesAAAUserAuthenticationStatus failure
+CIENA-CES-AAA-MIB::cienaCesAAAUserAuthenticationDescription User authentication failed
+TRAP,
+            'Authentication attempt by lorem. User authentication failed',
+            'Could not handle CienaCesAAAUserAuthenticationEvent failure',
+            [Severity::Warning],
+        );
+    }
+    public function testAuthLogout(): void
+    {
+        $this->assertTrapLogsMessage(<<<'TRAP'
+{{ hostname }}
+UDP: [{{ ip }}]:57602->[192.168.5.5]:162
+DISMAN-EVENT-MIB::sysUpTimeInstance 0:0:15:22.68
+SNMPv2-MIB::snmpTrapOID.0 CIENA-CES-AAA-MIB::cienaCesAAAUserAuthenticationEvent
+CIENA-GLOBAL-MIB::cienaGlobalSeverity info
+CIENA-GLOBAL-MIB::cienaGlobalMacAddress ac:89:de:ad:be:ef
+CIENA-CES-AAA-MIB::cienaCesAAAUserName lorem
+CIENA-CES-AAA-MIB::cienaCesAAAHostIp 10.10.10.10
+CIENA-CES-AAA-MIB::cienaCesAAAUserPort 8899
+CIENA-CES-AAA-MIB::cienaCesAAAUserAuthenticationServiceType local
+CIENA-CES-AAA-MIB::cienaCesAAAUserAuthenticationStatus success
+CIENA-CES-AAA-MIB::cienaCesAAAUserAuthenticationDescription User logout succeeded
+TRAP,
+            'Authentication attempt by lorem. User logout succeeded',
+            'Could not handle CienaCesAAAUserAuthenticationEvent logout',
+            [Severity::Notice],
+        );
+    }
+}


### PR DESCRIPTION
Handler translates SNMP Traps into user friendly text that goes into the event log. Works for Ciena devices in the Service Delivery Switch family running SAOS 10.9 (39xx, 51xx).

LibreNMS OS ciena-sds

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
