### PR TITLE
docs(install/selinux): set httpd_cache_t type to /opt/librenms/cache

### DIFF
--- a/doc/Installation/Install-LibreNMS.md
+++ b/doc/Installation/Install-LibreNMS.md
@@ -492,6 +492,7 @@ Feel free to tune the performance settings in librenms.conf to meet your needs.
     semanage fcontext -a -t httpd_sys_content_t '/opt/librenms/html(/.*)?'
     semanage fcontext -a -t httpd_sys_rw_content_t '/opt/librenms/(rrd|storage)(/.*)?'
     semanage fcontext -a -t httpd_log_t "/opt/librenms/logs(/.*)?"
+    semanage fcontext -a -t httpd_cache_t '/opt/librenms/cache(/.*)?'
     semanage fcontext -a -t bin_t '/opt/librenms/librenms-service.py'
     restorecon -RFvv /opt/librenms
     setsebool -P httpd_can_sendmail=1


### PR DESCRIPTION
This is to avoid the following error when trying to poll (new install, Fedora 39): 
```
file_put_contents(/opt/librenms/cache/os_defs.cache): Failed to open stream: Permission denied {"exception":"[object] (ErrorException(code: 0): file_put_contents(/opt/librenms/cache/os_defs.cache): Failed to open stream: Permission denied at /opt/librenms/LibreNMS/Util/OS.php:113)"} 
```

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
