### PR TITLE
Fix for AD Lookup in our environment

### DIFF
--- a/LibreNMS/Authentication/ActiveDirectoryAuthorizer.php
+++ b/LibreNMS/Authentication/ActiveDirectoryAuthorizer.php
@@ -91,7 +91,7 @@ class ActiveDirectoryAuthorizer extends AuthorizerBase
         }
 
         // special character handling
-        $group_dn = addcslashes($result[0]['dn'], '()#');
+        $group_dn = addcslashes($result[0]['dn'], '()#\\');
 
         $search = ldap_search(
             $connection,


### PR DESCRIPTION
Fixes an issue with AD group lookup in my organizations AD environment.

Since we have spaces in our group names, the returned results will have back slashes in front of the spaces to escape them. This seems to break the following ldap search unless those backslashes are escaped.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
