### PR TITLE
Change custom map editor icon

### DIFF
--- a/resources/views/layouts/menu.blade.php
+++ b/resources/views/layouts/menu.blade.php
@@ -251,7 +251,7 @@
                         @endif
                         @admin
                         <li role="presentation" class="divider"></li>
-                        <li><a href="{{ route('maps.custom.index') }}"><i class="fa fa-map-marked fa-fw fa-lg"
+                        <li><a href="{{ route('maps.custom.index') }}"><i class="fa fa-pen-to-square fa-fw fa-lg"
                                                                           aria-hidden="true"></i> {{ __('Custom Map Editor') }}
                             </a></li>
                         @endadmin


### PR DESCRIPTION
Edit icon makes more sense than map icon and makes it visually distinct from maps above it in the menu.

![image](https://github.com/librenms/librenms/assets/39462/cd281b15-64e3-4f17-9968-dfbe1a2fdee0)

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
