### PR TITLE
Use overwrite_ip in Smokeping target generator when set

### DIFF
--- a/app/Console/Commands/SmokepingGenerateCommand.php
+++ b/app/Console/Commands/SmokepingGenerateCommand.php
@@ -130,6 +130,7 @@ class SmokepingGenerateCommand extends LnmsCommand
             $smokelist[$device->type][$device->hostname] = [
                 'transport' => $device->transport,
                 'displayname' => $device->displayName(),
+                'overwrite_ip' => $device->overwrite_ip,
             ];
         }
 
@@ -325,7 +326,11 @@ class SmokepingGenerateCommand extends LnmsCommand
                     $lines[] = sprintf('   probe = %s', $this->balanceProbes($config['transport'], $probeCount));
                 }
 
-                $lines[] = sprintf('   host = %s', $hostname);
+                if ($config['overwrite_ip']) {
+                    $lines[] = sprintf('   host = %s', $config['overwrite_ip']);
+                } else {
+                    $lines[] = sprintf('   host = %s', $hostname);
+                }
                 $lines[] = '';
             }
         }


### PR DESCRIPTION
In our environment we're unable to use DNS to resolve internal hostnames. We've been using overwrite_ip to get around this which is not considered by the Smokeping target generation script. This small small change adds a conditional to use the overwrite_ip device setting when set.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
