### PR TITLE
Fix WirelessSensor incorrect model

### DIFF
--- a/app/Models/WirelessSensor.php
+++ b/app/Models/WirelessSensor.php
@@ -28,7 +28,7 @@ namespace App\Models;
 class WirelessSensor extends DeviceRelatedModel
 {
     public $timestamps = false;
-    protected $primaryKey = 'sensors_id';
+    protected $primaryKey = 'sensor_id';
 
     // ---- Helper Functions ----
 


### PR DESCRIPTION
I discovered this when running an alert template with the following line:
{{ $value[‘sensor_descr’] }} {{ $value[‘sensor_class’] }}: {{ \App\Models\WirelessSensor::find($value[‘sensor_id’])->sensor_current }}

When this template runs, it generates the following error:
Warning! Fallback template used due to error in template Wireless Client Count: SQLSTATE[42S22]: Column not found: 1054 Unknown column ‘wireless_sensors.sensors_id’ in ‘where clause’ (Connection: mysql, SQL: select * from wireless_sensors where wireless_sensors.sensors_id = 1 limit 1) (View: /opt/librenms/storage/framework/views/5c8803782286d32eaafd0eedadc65f57.blade.php)

I updated the line:
protected $primaryKey = ‘sensors_id’
to the following:
protected $primaryKey = ‘sensor_id’

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
