### PR TITLE
Do not allow the legend nodes to trigger the node edit modal

### DIFF
--- a/resources/views/map/custom-edit.blade.php
+++ b/resources/views/map/custom-edit.blade.php
@@ -650,11 +650,21 @@
     function editNode(data, callback) {
         $("#devicesearch").val('');
         $("#devicesearch").trigger('change');
-        if(data.id && isNaN(data.id) && data.id.endsWith("_mid")) {
-            edge = network_edges.get((data.id.split("_")[0]) + "_to");
-            editExistingEdge(edge, null);
-            return;
+
+        // If we have an ID that is non numeric, we can check node type further
+        if(data.id && isNaN(data.id)) {
+            // Editing a mid point node triggers editing the edge
+            if(data.id.endsWith("_mid")) {
+                edge = network_edges.get((data.id.split("_")[0]) + "_to");
+                editExistingEdge(edge, null);
+                return;
+            }
+            // Legend nodes cannot be edited
+            if (data.id.startsWith("legend_") ) {
+                return;
+            }
         }
+
         if(data.id in node_device_map) {
             // Nodes is linked to a device
             $("#device_id").val(node_device_map[data.id].device_id);

--- a/resources/views/map/custom-edit.blade.php
+++ b/resources/views/map/custom-edit.blade.php
@@ -659,6 +659,7 @@
                 editExistingEdge(edge, null);
                 return;
             }
+
             // Legend nodes cannot be edited
             if (data.id.startsWith("legend_") ) {
                 return;


### PR DESCRIPTION
Double-clicking on the legend nodes incorrectly triggers the node edit modal.  This PR fixes this behaviour.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
