### PR TITLE
Added read permission test to the custom map model

### DIFF
--- a/app/Models/CustomMap.php
+++ b/app/Models/CustomMap.php
@@ -82,7 +82,7 @@ class CustomMap extends BaseModel
 
     public function hasReadAccess(User $user): bool
     {
-        $results = $this->query()->where('custom_map_id',$this->custom_map_id)->withCount([
+        $results = $this->query()->where('custom_map_id', $this->custom_map_id)->withCount([
             'nodes as device_nodes_count' => function (Builder $q) {
                 $q->whereNotNull('device_id');
             },
@@ -100,7 +100,7 @@ class CustomMap extends BaseModel
         }
 
         // Allow access if the user has access to all devices linked to the map
-        return ($results[0]->device_nodes_count === $results[0]->device_nodes_allowed_count);
+        return $results[0]->device_nodes_count === $results[0]->device_nodes_allowed_count;
     }
 
     public function scopeHasAccess($query, User $user)

--- a/app/Models/CustomMap.php
+++ b/app/Models/CustomMap.php
@@ -89,18 +89,17 @@ class CustomMap extends BaseModel
             'nodes as device_nodes_allowed_count' => function (Builder $q) use ($user) {
                 $this->hasDeviceAccess($q, $user, 'custom_map_nodes');
             },
-        ])->get();
+        ])
+            ->havingRaw('device_nodes_count = device_nodes_allowed_count')
+            ->having('device_nodes_count', '>', 0)
+            ->get();
 
-        if (count($results) !== 1) {
-            return false; // No access if we didn't get exactly 1 row returned
+        if (count($results) === 1) {
+            // Allow access if the user has access to all devices on the map
+            return true;
         }
 
-        if ($results[0]->device_nodes_count === 0) {
-            return false; // No access if there are no devices
-        }
-
-        // Allow access if the user has access to all devices linked to the map
-        return $results[0]->device_nodes_count === $results[0]->device_nodes_allowed_count;
+        return false;
     }
 
     public function scopeHasAccess($query, User $user)

--- a/app/Policies/CustomMapPolicy.php
+++ b/app/Policies/CustomMapPolicy.php
@@ -29,7 +29,7 @@ class CustomMapPolicy
      */
     public function view(User $user, CustomMap $customMap): bool
     {
-        return $user->hasGlobalRead() || $customMap->hasAccess();
+        return $user->hasGlobalRead() || $customMap->hasReadAccess($user);
     }
 
     /**
@@ -45,7 +45,7 @@ class CustomMapPolicy
      */
     public function update(User $user, CustomMap $customMap): bool
     {
-        return $user->hasGlobalRead() || $customMap->hasAccess();
+        return false;
     }
 
     /**


### PR DESCRIPTION
This adds a read permission test to the custom map model, which makes sure a user has access to all devices on a custom map before allowing access.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
