### PR TITLE
Fix downtime in corner cases

### DIFF
--- a/app/Models/Device.php
+++ b/app/Models/Device.php
@@ -279,7 +279,13 @@ class Device extends BaseModel
      */
     public function downSince(): Carbon
     {
-        return Carbon::createFromTimestamp((int) $this->getCurrentOutage()?->going_down);
+        $deviceOutage = $this->getCurrentOutage();
+
+        if ($deviceOutage) {
+            return Carbon::createFromTimestamp((int) $deviceOutage->going_down);
+        }
+
+        return $this->last_polled ?? Carbon::now();
     }
 
     /**


### PR DESCRIPTION
If somehow device outage wasn't recorded, fall back to last_polled or now instead of 0
This should not happen in normal operation

fixes #15634


#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
