### PR TITLE
fix path related issues for ss and systemd applications

### DIFF
--- a/includes/polling/applications/ss.inc.php
+++ b/includes/polling/applications/ss.inc.php
@@ -1,9 +1,9 @@
 <?php
 
+use LibreNMS\Config;
 use LibreNMS\Exceptions\JsonAppException;
 use LibreNMS\Exceptions\JsonAppMissingKeysException;
 use LibreNMS\RRD\RrdDefinition;
-use LibreNMS\Config;
 
 require_once Config::get('install_dir') . '/includes/ss-shared.inc.php';
 

--- a/includes/polling/applications/ss.inc.php
+++ b/includes/polling/applications/ss.inc.php
@@ -1,10 +1,11 @@
 <?php
 
-require_once 'includes/ss-shared.inc.php';
-
 use LibreNMS\Exceptions\JsonAppException;
 use LibreNMS\Exceptions\JsonAppMissingKeysException;
 use LibreNMS\RRD\RrdDefinition;
+use LibreNMS\Config;
+
+require_once Config::get('install_dir') . 'includes/ss-shared.inc.php';
 
 $name = 'ss';
 $output_success = 'OK';

--- a/includes/polling/applications/ss.inc.php
+++ b/includes/polling/applications/ss.inc.php
@@ -5,7 +5,7 @@ use LibreNMS\Exceptions\JsonAppMissingKeysException;
 use LibreNMS\RRD\RrdDefinition;
 use LibreNMS\Config;
 
-require_once Config::get('install_dir') . 'includes/ss-shared.inc.php';
+require_once Config::get('install_dir') . '/includes/ss-shared.inc.php';
 
 $name = 'ss';
 $output_success = 'OK';

--- a/includes/polling/applications/systemd.inc.php
+++ b/includes/polling/applications/systemd.inc.php
@@ -1,9 +1,9 @@
 <?php
 
+use LibreNMS\Config;
 use LibreNMS\Exceptions\JsonAppException;
 use LibreNMS\Exceptions\JsonAppMissingKeysException;
 use LibreNMS\RRD\RrdDefinition;
-use LibreNMS\Config;
 
 require_once Config::get('install_dir') . '/includes/systemd-shared.inc.php';
 

--- a/includes/polling/applications/systemd.inc.php
+++ b/includes/polling/applications/systemd.inc.php
@@ -1,10 +1,11 @@
 <?php
 
-require_once 'includes/systemd-shared.inc.php';
-
 use LibreNMS\Exceptions\JsonAppException;
 use LibreNMS\Exceptions\JsonAppMissingKeysException;
 use LibreNMS\RRD\RrdDefinition;
+use LibreNMS\Config;
+
+require_once Config::get('install_dir') . 'includes/systemd-shared.inc.php';
 
 $name = 'systemd';
 $output = 'OK';

--- a/includes/polling/applications/systemd.inc.php
+++ b/includes/polling/applications/systemd.inc.php
@@ -5,7 +5,7 @@ use LibreNMS\Exceptions\JsonAppMissingKeysException;
 use LibreNMS\RRD\RrdDefinition;
 use LibreNMS\Config;
 
-require_once Config::get('install_dir') . 'includes/systemd-shared.inc.php';
+require_once Config::get('install_dir') . '/includes/systemd-shared.inc.php';
 
 $name = 'systemd';
 $output = 'OK';


### PR DESCRIPTION
Ensure systemd and SS work properly when poller is called when CWD is not the the base install dir.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
