### PR TITLE
Use PHP timezone conversor instead of relying on RrdGraphJS

### DIFF
--- a/includes/html/print-date-selector.inc.php
+++ b/includes/html/print-date-selector.inc.php
@@ -23,19 +23,20 @@
                value="Update"
                onclick="submitCustomRange(this.form);">
     </form>
-    <script src="<?php echo asset('js/RrdGraphJS/moment-timezone-with-data.js'); ?>"></script>
     <script type="text/javascript">
         $(function () {
-            var ds_datefrom = new Date(<?php echo \LibreNMS\Util\Time::parseAt($graph_array['from']); ?>*1000);
-            var ds_dateto = new Date(<?php echo \LibreNMS\Util\Time::parseAt($graph_array['to']); ?>*1000);
-            var ds_tz = '<?php echo session('preferences.timezone'); ?>';
-            if (ds_tz) {
-                ds_datefrom = moment.tz(ds_datefrom, ds_tz);
-                ds_dateto = moment.tz(ds_dateto, ds_tz);
-            } else {
-                ds_datefrom = moment(ds_datefrom);
-                ds_dateto = moment(ds_dateto);
-            }
+            <?php
+            $ds_tz = session('preferences.timezone');
+            $ds_datefrom = new DateTime();
+            $ds_datefrom->setTimezone(new DateTimeZone($ds_tz));
+            $ds_datefrom->setTimestamp($graph_array['from']);
+            $ds_dateto = new DateTime();
+            $ds_dateto->setTimezone(new DateTimeZone($ds_tz));
+            $ds_dateto->setTimestamp($graph_array['to']);
+            ?>
+            var ds_datefrom = new Date('<?php echo $ds_datefrom->format('D M d Y H:i:s O'); ?>');
+            var ds_dateto = new Date('<?php echo $ds_dateto->format('D M d Y H:i:s O'); ?>');
+            var ds_tz = '<?php echo $ds_tz; ?>';
 
             $("#dtpickerfrom").datetimepicker({useCurrent: true, sideBySide: true, useStrict: false, icons: {time: "fa fa-clock-o", date: "fa fa-calendar", up: "fa fa-chevron-up", down: "fa fa-chevron-down", previous: "fa fa-chevron-left", next: "fa fa-chevron-right", today: "fa fa-calendar-check-o", clear: "fa fa-trash-o", close: "fa fa-close"}, defaultDate: ds_datefrom, timeZone: ds_tz});
             $("#dtpickerto").datetimepicker({useCurrent: true, sideBySide: true, useStrict: false, icons: {time: "fa fa-clock-o", date: "fa fa-calendar", up: "fa fa-chevron-up", down: "fa fa-chevron-down", previous: "fa fa-chevron-left", next: "fa fa-chevron-right", today: "fa fa-calendar-check-o", clear: "fa fa-trash-o", close: "fa fa-close"}, defaultDate: ds_dateto, timeZone: ds_tz});


### PR DESCRIPTION
This fixes a frontend issue caused by RrdGraphJS: certain timezones will not work properly because this library isnt kept up to date, and as a result will display an incorrect DST time on certain timezones that have changed the way they work, like mine, America/Mexico_City, which was always displaying one hour ahead of what it really is due to an outdate DST configuration.

My solution is to rely on PHP for timezone conversion, we take the unix time and format it to a timezone then output its resulting date string to a Date javascript object. 

Display time for America/Mexico_City before this patch:
![Capture3](https://github.com/librenms/librenms/assets/43389808/e8668111-94ac-4933-a391-0cfe7d8bd9f9)

After this patch:
![Capture4](https://github.com/librenms/librenms/assets/43389808/00b116a0-0252-485b-91fa-506a0b2d1564)

This issue does not happen in older versions (before commit #15783), because it used to only rely on the server's PHP timezone. 

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
