### PR TITLE
Create Alertops.php

### DIFF
--- a/LibreNMS/Alert/Transport/Alertops.php
+++ b/LibreNMS/Alert/Transport/Alertops.php
@@ -52,7 +52,7 @@ class Alertops extends Transport
             'rule' => $alert_data['rule'],
             'name' => $alert_data['name'],
             'proc' => $alert_data['proc'],
-            'timestamp' => $alert_data['timestamp']
+            'timestamp' => $alert_data['timestamp'],
         ];
 
         $res = Http::client()->post($url, ['json' => $data]);

--- a/LibreNMS/Alert/Transport/Alertops.php
+++ b/LibreNMS/Alert/Transport/Alertops.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * AlertOps API Transport
+ *
+ * @license GPL
+ */
+
+namespace LibreNMS\Alert\Transport;
+
+use LibreNMS\Alert\Transport;
+use LibreNMS\Exceptions\AlertTransportDeliveryException;
+use LibreNMS\Util\Http;
+
+class Alertops extends Transport
+{
+    public function deliverAlert(array $alert_data): bool
+    {
+        $url = $this->config['alertops-url'];
+
+        $data = [
+            'device_id' => $alert_data['device_id'],
+            'hostname' => $alert_data['hostname'],
+            'sysName' => $alert_data['sysName'],
+            'sysDescr' => $alert_data['sysDescr'],
+            'sysContact' => $alert_data['sysContact'],
+            'os' => $alert_data['os'],
+            'type' => $alert_data['type'],
+            'ip' => $alert_data['ip'],
+            'hardware' => $alert_data['hardware'],
+            'version' => $alert_data['version'],
+            'features' => $alert_data['features'],
+            'serial' => $alert_data['serial'],
+            'location' => $alert_data['location'],
+            'uptime' => $alert_data['uptime'],
+            'uptime_short' => $alert_data['uptime_short'],
+            'uptime_long' => $alert_data['uptime_long'],
+            'description' => $alert_data['description'],
+            'notes' => $alert_data['notes'],
+            'alert_notes' => $alert_data['alert_notes'],
+            'ping_timestamp' => $alert_data['ping_timestamp'],
+            'ping_loss' => $alert_data['ping_loss'],
+            'ping_min' => $alert_data['ping_min'],
+            'ping_max' => $alert_data['ping_max'],
+            'ping_avg' => $alert_data['ping_avg'],
+            'title' => $alert_data['title'],
+            'elapsed' => $alert_data['elapsed'],
+            'builder' => $alert_data['builder'],
+            'id' => $alert_data['id'],
+            'uid' => $alert_data['uid'],
+            'state' => $alert_data['state'],
+            'severity' => $alert_data['severity'],
+            'rule' => $alert_data['rule'],
+            'name' => $alert_data['name'],
+            'proc' => $alert_data['proc'],
+            'timestamp' => $alert_data['timestamp'],
+            'transport' => $alert_data['transport'],
+            'transport_name' => $alert_data['transport_name']
+        ];
+
+        $res = Http::client()->post($url, ['json' => $data]);
+
+        if ($res->successful()) {
+            return true;
+        }
+
+        throw new AlertTransportDeliveryException($alert_data, $res->status(), $res->body(), '', $alert_data);
+    }
+
+    public static function configTemplate(): array
+    {
+        return [
+            'config' => [
+                [
+                    'title' => 'Webhook URL',
+                    'name' => 'alertops-url',
+                    'descr' => 'AlertOps Webhook URL',
+                    'type' => 'text',
+                ],
+            ],
+            'validation' => [
+                'alertops-url' => 'required|url',
+            ],
+        ];
+    }
+}

--- a/LibreNMS/Alert/Transport/Alertops.php
+++ b/LibreNMS/Alert/Transport/Alertops.php
@@ -52,9 +52,7 @@ class Alertops extends Transport
             'rule' => $alert_data['rule'],
             'name' => $alert_data['name'],
             'proc' => $alert_data['proc'],
-            'timestamp' => $alert_data['timestamp'],
-            'transport' => $alert_data['transport'],
-            'transport_name' => $alert_data['transport_name']
+            'timestamp' => $alert_data['timestamp']
         ];
 
         $res = Http::client()->post($url, ['json' => $data]);


### PR DESCRIPTION
This is a request to add this Transport publicly, so alerts can be sent to AlertOps' webhook endpoint - AlertOps is an alerting/notification tool. (https://alertops.com/)

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
