### PR TITLE
Widget hot refresh & worldmap cleanup

### DIFF
--- a/app/Http/Controllers/Widgets/WorldMapController.php
+++ b/app/Http/Controllers/Widgets/WorldMapController.php
@@ -67,7 +67,7 @@ class WorldMapController extends WidgetController
             'group' => 'int',
         ]);
 
-        return response()->json($this->getMarkerData($request, $request->status ?? [0,1], $request->group ?? 0));
+        return response()->json($this->getMarkerData($request, $request->status ?? [0, 1], $request->group ?? 0));
     }
 
     public function getMarkerData(Request $request, array $status, int $device_group_id): array
@@ -89,7 +89,7 @@ class WorldMapController extends WidgetController
                     return false;
                 }
 
-                 return true;
+                return true;
             })->map(function (Device $device) {
                 return [
                     'name' => $device->displayName(),

--- a/app/Http/Controllers/Widgets/WorldMapController.php
+++ b/app/Http/Controllers/Widgets/WorldMapController.php
@@ -39,11 +39,11 @@ class WorldMapController extends WidgetController
     {
         $this->defaults = [
             'title' => null,
-            'title_url' => Config::get('leaflet.tile_url', '{s}.tile.openstreetmap.org'),
-            'init_lat' => Config::get('leaflet.default_lat', 51.4800),
-            'init_lng' => Config::get('leaflet.default_lng', 0),
-            'init_zoom' => Config::get('leaflet.default_zoom', 2.1),
-            'group_radius' => Config::get('leaflet.group_radius', 80),
+            'init_lat' => Config::get('leaflet.default_lat'),
+            'init_lng' => Config::get('leaflet.default_lng'),
+            'init_zoom' => Config::get('leaflet.default_zoom'),
+            'init_layer' => Config::get('geoloc.layer'),
+            'group_radius' => Config::get('leaflet.group_radius'),
             'status' => '0,1',
             'device_group' => null,
         ];
@@ -55,6 +55,15 @@ class WorldMapController extends WidgetController
         $settings['dimensions'] = $request->get('dimensions');
         $settings['status'] = array_map('intval', explode(',', $settings['status']));
         $settings['group'] = (int) $settings['device_group'];
+        $settings['map_config'] = [
+            'engine' => Config::get('geoloc.engine'),
+            'api_key' => Config::get('geoloc.api_key'),
+            'tile_url' => Config::get('leaflet.tile_url'),
+            'lat' => $settings['init_lat'],
+            'lng' => $settings['init_lng'],
+            'zoom' => $settings['init_zoom'],
+            'layer' => $settings['init_layer'],
+        ];
 
         return view('widgets.worldmap', $settings);
     }

--- a/app/Http/Controllers/Widgets/WorldMapController.php
+++ b/app/Http/Controllers/Widgets/WorldMapController.php
@@ -53,7 +53,8 @@ class WorldMapController extends WidgetController
     {
         $settings = $this->getSettings();
         $settings['dimensions'] = $request->get('dimensions');
-        $settings['devices'] = $this->getMarkerData(array_map('intval', explode(',', $settings['status'])), (int) $settings['device_group']);
+        $settings['status'] = array_map('intval', explode(',', $settings['status']));
+        $settings['group'] = (int) $settings['device_group'];
 
         return view('widgets.worldmap', $settings);
     }
@@ -61,12 +62,12 @@ class WorldMapController extends WidgetController
     public function getData(Request $request): JsonResponse
     {
         $this->validate($request, [
-            'status' => 'required|array',
+            'status' => 'array',
             'status.*' => 'int',
             'group' => 'int',
         ]);
 
-        return response()->json($this->getMarkerData($request, $request->status, $request->group));
+        return response()->json($this->getMarkerData($request, $request->status ?? [0,1], $request->group ?? 0));
     }
 
     public function getMarkerData(Request $request, array $status, int $device_group_id): array
@@ -97,7 +98,7 @@ class WorldMapController extends WidgetController
                     'icon' => $device->icon,
                     'url' => Url::deviceUrl($device),
                     // status: 0 = down, 1 = up, 3 = down + under maintenance
-                    'status' => $device->status || $device->isUnderMaintenance() ? 3 : 0,
+                    'status' => (int) ($device->status ?: ($device->isUnderMaintenance() ? 3 : 0)),
                 ];
             })->values()->all();
     }

--- a/app/Http/Controllers/Widgets/WorldMapController.php
+++ b/app/Http/Controllers/Widgets/WorldMapController.php
@@ -54,7 +54,6 @@ class WorldMapController extends WidgetController
         $settings = $this->getSettings();
         $settings['dimensions'] = $request->get('dimensions');
         $settings['status'] = array_map('intval', explode(',', $settings['status']));
-        $settings['group'] = (int) $settings['device_group'];
         $settings['map_config'] = [
             'engine' => Config::get('geoloc.engine'),
             'api_key' => Config::get('geoloc.api_key'),
@@ -73,10 +72,10 @@ class WorldMapController extends WidgetController
         $this->validate($request, [
             'status' => 'array',
             'status.*' => 'int',
-            'group' => 'int',
+            'device_group' => 'int',
         ]);
 
-        return response()->json($this->getMarkerData($request, $request->status ?? [0, 1], $request->group ?? 0));
+        return response()->json($this->getMarkerData($request, $request->status ?? [0, 1], $request->device_group ?? 0));
     }
 
     public function getMarkerData(Request $request, array $status, int $device_group_id): array

--- a/app/Http/Controllers/Widgets/WorldMapController.php
+++ b/app/Http/Controllers/Widgets/WorldMapController.php
@@ -26,8 +26,10 @@
 namespace App\Http\Controllers\Widgets;
 
 use App\Models\Device;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use LibreNMS\Config;
+use LibreNMS\Util\Url;
 
 class WorldMapController extends WidgetController
 {
@@ -40,7 +42,7 @@ class WorldMapController extends WidgetController
             'title_url' => Config::get('leaflet.tile_url', '{s}.tile.openstreetmap.org'),
             'init_lat' => Config::get('leaflet.default_lat', 51.4800),
             'init_lng' => Config::get('leaflet.default_lng', 0),
-            'init_zoom' => Config::get('leaflet.default_zoom', 2),
+            'init_zoom' => Config::get('leaflet.default_zoom', 2.1),
             'group_radius' => Config::get('leaflet.group_radius', 80),
             'status' => '0,1',
             'device_group' => null,
@@ -50,17 +52,30 @@ class WorldMapController extends WidgetController
     public function getView(Request $request)
     {
         $settings = $this->getSettings();
-        $status = explode(',', $settings['status']);
-
         $settings['dimensions'] = $request->get('dimensions');
+        $settings['devices'] = $this->getMarkerData(array_map('intval', explode(',', $settings['status'])), (int) $settings['device_group']);
 
-        $devices = Device::hasAccess($request->user())
+        return view('widgets.worldmap', $settings);
+    }
+
+    public function getData(Request $request): JsonResponse
+    {
+        $this->validate($request, [
+            'status' => 'required|array',
+            'status.*' => 'int',
+            'group' => 'int',
+        ]);
+
+        return response()->json($this->getMarkerData($request, $request->status, $request->group));
+    }
+
+    public function getMarkerData(Request $request, array $status, int $device_group_id): array
+    {
+        return Device::hasAccess($request->user())
             ->with('location')
             ->isActive()
             ->whereIn('status', $status)
-            ->when($settings['device_group'], function ($query) use ($settings) {
-                $query->inDeviceGroup($settings['device_group']);
-            })
+            ->when($device_group_id, fn ($q) => $q->inDeviceGroup($device_group_id))
             ->get()
             ->filter(function ($device) use ($status) {
                 /** @var Device $device */
@@ -68,31 +83,23 @@ class WorldMapController extends WidgetController
                     return false;
                 }
 
-                // add extra data
-                /** @phpstan-ignore-next-line */
-                $device->markerIcon = 'greenMarker';
-                /** @phpstan-ignore-next-line */
-                $device->zOffset = 0;
-
-                if ($device->status == 0) {
-                    $device->markerIcon = 'redMarker';
-                    $device->zOffset = 10000;
-
-                    if ($device->isUnderMaintenance()) {
-                        if (in_array(0, $status)) {
-                            return false;
-                        }
-                        $device->markerIcon = 'blueMarker';
-                        $device->zOffset = 5000;
-                    }
+                // hide devices under maintenance if only showing down devices
+                if ($status == [0] && $device->isUnderMaintenance()) {
+                    return false;
                 }
 
-                return true;
-            });
-
-        $settings['devices'] = $devices;
-
-        return view('widgets.worldmap', $settings);
+                 return true;
+            })->map(function (Device $device) {
+                return [
+                    'name' => $device->displayName(),
+                    'lat' => $device->location->lat,
+                    'lng' => $device->location->lng,
+                    'icon' => $device->icon,
+                    'url' => Url::deviceUrl($device),
+                    // status: 0 = down, 1 = up, 3 = down + under maintenance
+                    'status' => $device->status || $device->isUnderMaintenance() ? 3 : 0,
+                ];
+            })->values()->all();
     }
 
     public function getSettingsView(Request $request)

--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -47,6 +47,7 @@
          'path' => storage_path('debugbar'), // For file driver
          'connection' => null,   // Leave null for default connection (Redis/PDO)
          'provider' => '', // Instance of StorageInterface for custom driver
+         'open' => true,
      ],
 
      /*

--- a/html/css/styles.css
+++ b/html/css/styles.css
@@ -1776,10 +1776,8 @@ tr.search:nth-child(odd) {
     background-color: #000000;
     color: #ffffff;
     text-align: center;
-    -webkit-border-top-left-radius: 4px;
-     -moz-border-top-right-radius: 4px;
-          border-top-left-radius: 4px;
-          border-top-right-radius: 4px;
+    border-top-left-radius: 4px;
+    border-top-right-radius: 4px;
 }
 
 .mapTooltip {
@@ -1966,10 +1964,12 @@ label {
 .edit-widget, .close-widget { cursor: pointer; }
 .widget_body {
     padding: 0.8em;
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
     overflow-y: auto;
     overflow-x: hidden;
     width: 100%;
-    height: calc(100% - 38px);
+    height: calc(100% - 2.6em);
     cursor: auto;
     text-align: center;
 }
@@ -2014,6 +2014,20 @@ label {
 .service-name-label {
   float:left;
   margin:-8px;
+}
+
+.widget_body:has(> .worldmap_widget) {
+    padding: 0;
+}
+.worldmap_widget {
+    width: 100%;
+    height: 100%;
+    text-align: left;
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
+}
+.worldmap_widget a:hover {
+    text-decoration: none;
 }
 
 .report-up {

--- a/html/js/librenms.js
+++ b/html/js/librenms.js
@@ -303,9 +303,9 @@ function init_map(id, config = {}) {
     let baseMaps = {};
 
     if (config.engine === 'google' && config.api_key) {
+        leaflet.setMaxZoom(21);
         loadjs('https://maps.googleapis.com/maps/api/js?key=' + config.api_key, function () {
             loadjs('js/Leaflet.GoogleMutant.js', function () {
-                leaflet.maxZoom = 21;
                 const roads = L.gridLayer.googleMutant({
                     type: 'roadmap'	// valid values are 'roadmap', 'satellite', 'terrain' and 'hybrid'
                 });
@@ -323,8 +323,8 @@ function init_map(id, config = {}) {
             });
         });
     } else if (config.engine === 'bing' && config.api_key) {
+        leaflet.setMaxZoom(18);
         loadjs('js/leaflet-bing-layer.min.js', function () {
-            leaflet.maxZoom = 18;
             const roads = L.tileLayer.bing({
                 bingMapsKey: config.api_key,
                 imagerySet: 'RoadOnDemand'
@@ -343,8 +343,8 @@ function init_map(id, config = {}) {
             leaflet.layerControl._container.style.display = (config.readonly ? 'none' : 'block');
         });
     } else if (config.engine === 'mapquest' && config.api_key) {
+        leaflet.setMaxZoom(20);
         loadjs('https://www.mapquestapi.com/sdk/leaflet/v2.2/mq-map.js?key=' + config.api_key, function () {
-            leaflet.maxZoom = 20;
             const roads = MQ.mapLayer();
             const satellite = MQ.hybridLayer();
 
@@ -357,6 +357,7 @@ function init_map(id, config = {}) {
             leaflet.layerControl._container.style.display = (config.readonly ? 'none' : 'block');
         });
     } else {
+        leaflet.setMaxZoom(20);
         const tile_url = config.tile_url ? config.tile_url : '{s}.tile.openstreetmap.org';
         const osm = L.tileLayer('//' + tile_url + '/{z}/{x}/{y}.png', {
             maxZoom: 19,

--- a/html/js/librenms.js
+++ b/html/js/librenms.js
@@ -305,6 +305,7 @@ function init_map(id, config = {}) {
     if (config.engine === 'google' && config.api_key) {
         loadjs('https://maps.googleapis.com/maps/api/js?key=' + config.api_key, function () {
             loadjs('js/Leaflet.GoogleMutant.js', function () {
+                leaflet.maxZoom = 21;
                 const roads = L.gridLayer.googleMutant({
                     type: 'roadmap'	// valid values are 'roadmap', 'satellite', 'terrain' and 'hybrid'
                 });
@@ -323,6 +324,7 @@ function init_map(id, config = {}) {
         });
     } else if (config.engine === 'bing' && config.api_key) {
         loadjs('js/leaflet-bing-layer.min.js', function () {
+            leaflet.maxZoom = 18;
             const roads = L.tileLayer.bing({
                 bingMapsKey: config.api_key,
                 imagerySet: 'RoadOnDemand'
@@ -342,6 +344,7 @@ function init_map(id, config = {}) {
         });
     } else if (config.engine === 'mapquest' && config.api_key) {
         loadjs('https://www.mapquestapi.com/sdk/leaflet/v2.2/mq-map.js?key=' + config.api_key, function () {
+            leaflet.maxZoom = 20;
             const roads = MQ.mapLayer();
             const satellite = MQ.hybridLayer();
 

--- a/html/js/librenms.js
+++ b/html/js/librenms.js
@@ -359,21 +359,10 @@ function init_map(id, config = {}) {
     } else {
         leaflet.setMaxZoom(20);
         const tile_url = config.tile_url ? config.tile_url : '{s}.tile.openstreetmap.org';
-        const osm = L.tileLayer('//' + tile_url + '/{z}/{x}/{y}.png', {
+        L.tileLayer('//' + tile_url + '/{z}/{x}/{y}.png', {
             maxZoom: 19,
             attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
-        });
-
-        // var esri = L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}', {
-        //     attribution: 'Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community'
-        // });
-        //
-        // baseMaps = {
-        //     "OpenStreetMap": osm,
-        //     "Satellite": esri
-        // };
-        // leaflet.layerControl = L.control.layers(baseMaps, null, {position: 'bottomleft'}).addTo(leaflet);
-        osm.addTo(leaflet);
+        }).addTo(leaflet);
     }
 
     // disable all interaction
@@ -401,6 +390,83 @@ function destroy_map(id) {
         leaflet.remove();
         delete window.maps[id];
     }
+}
+
+function populate_map_markers(map_id, group_radius = 10, status = [0,1], device_group = 0) {
+    $.ajax({
+        type: "GET",
+        url: ajax_url + '/dash/worldmap',
+        dataType: "json",
+        data: { status: status, device_group: device_group },
+        success: function (data) {
+            var redMarker = L.AwesomeMarkers.icon({
+                icon: 'server',
+                markerColor: 'red', prefix: 'fa', iconColor: 'white'
+            });
+            var blueMarker = L.AwesomeMarkers.icon({
+                icon: 'server',
+                markerColor: 'blue', prefix: 'fa', iconColor: 'white'
+            });
+            var greenMarker = L.AwesomeMarkers.icon({
+                icon: 'server',
+                markerColor: 'green', prefix: 'fa', iconColor: 'white'
+            });
+
+            var markers = data.map((device) => {
+                var markerData = {title: device.name};
+                switch (device.status) {
+                    case 0: // down
+                        markerData.icon = redMarker;
+                        markerData.zIndexOffset = 5000;
+                        break;
+                    case 3: // down + maintenance
+                        markerData.icon = blueMarker;
+                        markerData.zIndexOffset = 10000;
+                        break;
+                    default: // up
+                        markerData.icon = greenMarker;
+                        markerData.zIndexOffset = 0;
+                }
+
+                var marker = L.marker(new L.LatLng(device.lat, device.lng), markerData);
+                marker.bindPopup(`<a href="${device.url}"><img src="${device.icon}" width="32" height="32" alt=""> ${device.name}</a>`);
+                return marker;
+            });
+
+            var map = get_map(map_id);
+            if (! map.markerCluster) {
+                map.markerCluster = L.markerClusterGroup({
+                    maxClusterRadius: group_radius,
+                    iconCreateFunction: function (cluster) {
+                        var markers = cluster.getAllChildMarkers();
+                        var color = "green";
+                        var newClass = "Cluster marker-cluster marker-cluster-small leaflet-zoom-animated leaflet-clickable";
+                        for (var i = 0; i < markers.length; i++) {
+                            if (markers[i].options.icon.options.markerColor == "blue" && color != "red") {
+                                color = "blue";
+                            }
+                            if (markers[i].options.icon.options.markerColor == "red") {
+                                color = "red";
+                            }
+                        }
+                        return L.divIcon({
+                            html: cluster.getChildCount(),
+                            className: color + newClass,
+                            iconSize: L.point(40, 40)
+                        });
+                    }
+                });
+
+                map.addLayer(map.markerCluster);
+            }
+
+            map.markerCluster.clearLayers();
+            map.markerCluster.addLayers(markers);
+        },
+        error: function(error){
+            toastr.error(error.statusText);
+        }
+    });
 }
 
 function disable_map_interaction(leaflet) {

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -763,6 +763,10 @@ return [
                 'description' => 'Attempt to Geocode Locations',
                 'help' => 'Try to lookup latitude and longitude via geocoding API during polling',
             ],
+            'layer' => [
+                'description' => 'Initial Map Layer',
+                'help' => 'Initial map layer to display when showing various Geo Maps',
+            ],
         ],
         'graphite' => [
             'enable' => [

--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -1883,6 +1883,26 @@
                 ]
             }
         },
+        "geoloc.layer": {
+            "default": "Streets",
+            "group": "external",
+            "section": "location",
+            "order": 7,
+            "type": "select",
+            "options": {
+                "Streets":  "Streets",
+                "Sattelite": "Sattelite"
+            },
+            "when": {
+                "setting": "geoloc.engine",
+                "operator": "in",
+                "value": [
+                    "google",
+                    "mapquest",
+                    "bing"
+                ]
+            }
+        },
         "github_api": {
             "default": "https://api.github.com/repos/librenms/librenms/",
             "type": "text"

--- a/resources/views/layouts/librenmsv1.blade.php
+++ b/resources/views/layouts/librenmsv1.blade.php
@@ -42,7 +42,7 @@
     <link href="{{ asset('css/query-builder.default.min.css') }}" rel="stylesheet">
     <link href="{{ asset('css/app.css') }}" rel="stylesheet">
     <link href="{{ asset('css/bootstrap.min.css') }}" rel="stylesheet">
-    <link href="{{ asset(LibreNMS\Config::get('stylesheet', 'css/styles.css')) }}?ver=20230928" rel="stylesheet">
+    <link href="{{ asset(LibreNMS\Config::get('stylesheet', 'css/styles.css')) }}?ver=22052024" rel="stylesheet">
     <link href="{{ asset('css/' . LibreNMS\Config::get('applied_site_style', 'light') . '.css?ver=632417643') }}" rel="stylesheet">
     @foreach(LibreNMS\Config::get('webui.custom_css', []) as $custom_css)
         <link href="{{ $custom_css }}" rel="stylesheet">

--- a/resources/views/layouts/librenmsv1.blade.php
+++ b/resources/views/layouts/librenmsv1.blade.php
@@ -76,7 +76,7 @@
         });
         var ajax_url = "{{ url('/ajax') }}";
     </script>
-    <script src="{{ asset('js/librenms.js?ver=12052024') }}"></script>
+    <script src="{{ asset('js/librenms.js?ver=22052024') }}"></script>
     <script type="text/javascript" src="{{ asset('js/overlib_mini.js') }}"></script>
     <script type="text/javascript" src="{{ asset('js/flasher.min.js?ver=0.6.1') }}"></script>
     <script type="text/javascript" src="{{ asset('js/toastr.min.js?ver=05072021') }}"></script>

--- a/resources/views/overview/default.blade.php
+++ b/resources/views/overview/default.blade.php
@@ -620,11 +620,12 @@
     }
 
     function grab_data(id, data_type) {
+        const refresh = $('#widget_body_' + id).parent().data('refresh');
         widget_reload(id, data_type);
 
         setTimeout(function () {
             grab_data(id, data_type);
-        }, ($parent.data('refresh') > 0 ? $parent.data('refresh') : 60) * 1000);
+        }, (refresh > 0 ? refresh : 60) * 1000);
     }
 
     // make sure gridster stays disabled when the window is resized

--- a/resources/views/overview/default.blade.php
+++ b/resources/views/overview/default.blade.php
@@ -609,6 +609,7 @@
             success: function (data) {
                 if (data.status === 'ok') {
                     $('#widget_title_' + id).html(data.title);
+                    $widget_body.children().unbind().html("").remove(); // clear old contents and unbind events
                     $widget_body.html(data.html);
                     $widget_body.parent().data('settings', data.show_settings).data('refresh', data.settings.refresh);
                 } else {

--- a/resources/views/overview/default.blade.php
+++ b/resources/views/overview/default.blade.php
@@ -629,7 +629,16 @@
     }
 
     // make sure gridster stays disabled when the window is resized
+    var resizeTrigger = null;
     addEvent(window, "resize", function(event) {
+        // emit resize event, but only once every 100ms
+        if (resizeTrigger === null) {
+            resizeTrigger = setTimeout(() => {
+                resizeTrigger = null;
+                $('.widget_body').children().first().trigger('resize');
+            }, 100);
+        }
+
         setTimeout(function(){
             if(!gridster_state) {
                 gridster.disable();

--- a/resources/views/overview/default.blade.php
+++ b/resources/views/overview/default.blade.php
@@ -584,16 +584,17 @@
 
     function widget_reload(id, data_type, forceDomInject) {
         const $widget_body = $('#widget_body_' + id);
-        const $widget_bootgrid = $('#widget_body_' + id + ' .bootgrid-table');
         const settings = $widget_body.parent().data('settings') == 1 ? 1 : 0;
+        const $widget = $widget_body.children().first();
+        const reload = $widget.data('reload'); // should this function reload widget html?
 
         if (settings === 1 || forceDomInject) {
-            $widget_bootgrid.bootgrid('destroy');
-            $('#widget_body_' + id + ' *').off();
-        } else if ($widget_bootgrid[0] && $widget_bootgrid.data('ajax') === true) {
-            // Check to see if a bootgrid already exists and has ajax reloading enabled.
-            // If so, use bootgrid to refresh the data instead of injecting the DOM in request.
-            return $widget_bootgrid.bootgrid('reload');
+            $widget.trigger('destroy', $widget); // send destroy event
+        } else {
+            $widget.trigger('refresh', $widget); // send refresh event
+            if (reload === false) {
+                return; // skip html reload
+            }
         }
 
         $.ajax({

--- a/resources/views/widgets/alertlog.blade.php
+++ b/resources/views/widgets/alertlog.blade.php
@@ -1,5 +1,5 @@
-<div class="table-responsive">
-    <table id="alertlog_{{ $id }}" class="table table-hover table-condensed alerts" data-ajax="true">
+<div id="alertlog_container-{{ $id }}" class="table-responsive" data-reload="false">
+    <table id="alertlog_{{ $id }}" class="table table-hover table-condensed alerts">
         <thead>
         <tr>
             <th data-column-id="status" data-sortable="false"></th>
@@ -12,48 +12,58 @@
     </table>
 </div>
 <script>
-    var grid = $("#alertlog_{{ $id }}").bootgrid({
-        ajax: true,
-        rowCount: [50, 100, 250, -1],
-        navigation: ! {{ $hidenavigation }},
-        post: function () {
-            return {
-                id: "alertlog",
-                device_id: "",
-                device_group: "{{ $device_group }}",
-                state: '{{ $state }}',
-                min_severity: '{{ $min_severity }}',
-            };
-        },
-        url: "ajax_table.php"
-    }).on("loaded.rs.jquery.bootgrid", function () {
+    $(function () {
+        var grid = $("#alertlog_{{ $id }}").bootgrid({
+            ajax: true,
+            rowCount: [50, 100, 250, -1],
+            navigation: ! {{ $hidenavigation }},
+            post: function () {
+                return {
+                    id: "alertlog",
+                    device_id: "",
+                    device_group: "{{ $device_group }}",
+                    state: '{{ $state }}',
+                    min_severity: '{{ $min_severity }}',
+                };
+            },
+            url: "ajax_table.php"
+        }).on("loaded.rs.jquery.bootgrid", function () {
 
-        var results = $("div.infos").text().split(" ");
-        low = results[1] - 1;
-        high = results[3];
-        max = high - low;
-        search = $('.search-field').val();
+            var results = $("div.infos").text().split(" ");
+            low = results[1] - 1;
+            high = results[3];
+            max = high - low;
+            search = $('.search-field').val();
 
-        grid.find(".incident-toggle").each(function () {
-            $(this).parent().addClass('incident-toggle-td');
-        }).on("click", function (e) {
-            var target = $(this).data("target");
-            $(target).collapse('toggle');
-            $(this).toggleClass('fa-plus fa-minus');
-        });
-        grid.find(".incident").each(function () {
-            $(this).parent().addClass('col-lg-4 col-md-4 col-sm-4 col-xs-4');
-            $(this).parent().parent().on("mouseenter", function () {
-                $(this).find(".incident-toggle").fadeIn(200);
-            }).on("mouseleave", function () {
-                $(this).find(".incident-toggle").fadeOut(200);
-            }).on("click", "td:not(.incident-toggle-td)", function () {
-                var target = $(this).parent().find(".incident-toggle").data("target");
-                if ($(this).parent().find(".incident-toggle").hasClass('fa-plus')) {
-                    $(this).parent().find(".incident-toggle").toggleClass('fa-plus fa-minus');
-                    $(target).collapse('toggle');
-                }
+            grid.find(".incident-toggle").each(function () {
+                $(this).parent().addClass('incident-toggle-td');
+            }).on("click", function (e) {
+                var target = $(this).data("target");
+                $(target).collapse('toggle');
+                $(this).toggleClass('fa-plus fa-minus');
             });
+            grid.find(".incident").each(function () {
+                $(this).parent().addClass('col-lg-4 col-md-4 col-sm-4 col-xs-4');
+                $(this).parent().parent().on("mouseenter", function () {
+                    $(this).find(".incident-toggle").fadeIn(200);
+                }).on("mouseleave", function () {
+                    $(this).find(".incident-toggle").fadeOut(200);
+                }).on("click", "td:not(.incident-toggle-td)", function () {
+                    var target = $(this).parent().find(".incident-toggle").data("target");
+                    if ($(this).parent().find(".incident-toggle").hasClass('fa-plus')) {
+                        $(this).parent().find(".incident-toggle").toggleClass('fa-plus fa-minus');
+                        $(target).collapse('toggle');
+                    }
+                });
+            });
+        });
+
+        $('#alertlog_container-{{ $id }}').on('refresh', function (event) {
+            grid.bootgrid('reload');
+        });
+        $('#alertlog_container-{{ $id }}').on('destroy', function (event) {
+            grid.bootgrid('destroy');
+            delete grid;
         });
     });
 </script>

--- a/resources/views/widgets/alertlog.blade.php
+++ b/resources/views/widgets/alertlog.blade.php
@@ -1,18 +1,20 @@
-<div id="alertlog_container-{{ $id }}" class="table-responsive" data-reload="false">
-    <table id="alertlog_{{ $id }}" class="table table-hover table-condensed alerts">
-        <thead>
-        <tr>
-            <th data-column-id="status" data-sortable="false"></th>
-            <th data-column-id="time_logged" data-order="desc">{{ __('Timestamp') }}</th>
-            <th data-column-id="details" data-sortable="false">&nbsp;</th>
-            <th data-column-id="hostname">{{ __('Device') }}</th>
-            <th data-column-id="alert">{{ __('Alert') }}</th>
-        </tr>
-        </thead>
-    </table>
+<div id="alertlog_container-{{ $id }}" data-reload="false">
+    <div class="table-responsive">
+        <table id="alertlog_{{ $id }}" class="table table-hover table-condensed alerts">
+            <thead>
+            <tr>
+                <th data-column-id="status" data-sortable="false"></th>
+                <th data-column-id="time_logged" data-order="desc">{{ __('Timestamp') }}</th>
+                <th data-column-id="details" data-sortable="false">&nbsp;</th>
+                <th data-column-id="hostname">{{ __('Device') }}</th>
+                <th data-column-id="alert">{{ __('Alert') }}</th>
+            </tr>
+            </thead>
+        </table>
+    </div>
 </div>
 <script>
-    $(function () {
+    (function () {
         var grid = $("#alertlog_{{ $id }}").bootgrid({
             ajax: true,
             rowCount: [50, 100, 250, -1],
@@ -28,13 +30,6 @@
             },
             url: "ajax_table.php"
         }).on("loaded.rs.jquery.bootgrid", function () {
-
-            var results = $("div.infos").text().split(" ");
-            low = results[1] - 1;
-            high = results[3];
-            max = high - low;
-            search = $('.search-field').val();
-
             grid.find(".incident-toggle").each(function () {
                 $(this).parent().addClass('incident-toggle-td');
             }).on("click", function (e) {
@@ -65,5 +60,5 @@
             grid.bootgrid('destroy');
             delete grid;
         });
-    });
+    })();
 </script>

--- a/resources/views/widgets/alertlog_stats.blade.php
+++ b/resources/views/widgets/alertlog_stats.blade.php
@@ -1,5 +1,5 @@
-<div class="table-responsive">
-    <table id="alertlog-stats_{{ $id }}" class="table table-hover table-condensed table-striped" data-ajax="true">
+<div id="alertlog_stats_container-{{ $id }}" class="table-responsive" data-reload="false">
+    <table id="alertlog_stats-{{ $id }}" class="table table-hover table-condensed table-striped">
         <thead>
         <tr>
             <th data-column-id="count">{{ __('Count') }}</th>
@@ -10,18 +10,28 @@
     </table>
 </div>
 <script>
-    $("#alertlog-stats_{{ $id }}").bootgrid({
-        ajax: true,
-        rowCount: [50, 100, 250, -1],
-        navigation: ! {{ $hidenavigation }},
-        post: function () {
-            return {
-                id: "alertlog-stats",
-                device_id: "",
-                min_severity: '{{ $min_severity }}',
-                time_interval: '{{ $time_interval }}'
-            };
-        },
-        url: "ajax_table.php"
+    $(function () {
+        var grid = $("#alertlog_stats-{{ $id }}").bootgrid({
+            ajax: true,
+            rowCount: [50, 100, 250, -1],
+            navigation: ! {{ $hidenavigation }},
+            post: function () {
+                return {
+                    id: "alertlog-stats",
+                    device_id: "",
+                    min_severity: '{{ $min_severity }}',
+                    time_interval: '{{ $time_interval }}'
+                };
+            },
+            url: "ajax_table.php"
+        });
+
+        $('#alertlog_stats_container-{{ $id }}').on('refresh', function (event) {
+            grid.bootgrid('reload');
+        });
+        $('#alertlog_stats_container-{{ $id }}').on('destroy', function (event) {
+            grid.bootgrid('destroy');
+            delete grid;
+        });
     });
 </script>

--- a/resources/views/widgets/alertlog_stats.blade.php
+++ b/resources/views/widgets/alertlog_stats.blade.php
@@ -1,16 +1,18 @@
-<div id="alertlog_stats_container-{{ $id }}" class="table-responsive" data-reload="false">
-    <table id="alertlog_stats-{{ $id }}" class="table table-hover table-condensed table-striped">
-        <thead>
-        <tr>
-            <th data-column-id="count">{{ __('Count') }}</th>
-            <th data-column-id="hostname">{{ __('Device') }}</th>
-            <th data-column-id="alert_rule">{{ __('Alert rule') }}</th>
-        </tr>
-        </thead>
-    </table>
+<div id="alertlog_stats_container-{{ $id }}" data-reload="false">
+    <div class="table-responsive">
+        <table id="alertlog_stats-{{ $id }}" class="table table-hover table-condensed table-striped">
+            <thead>
+            <tr>
+                <th data-column-id="count">{{ __('Count') }}</th>
+                <th data-column-id="hostname">{{ __('Device') }}</th>
+                <th data-column-id="alert_rule">{{ __('Alert rule') }}</th>
+            </tr>
+            </thead>
+        </table>
+    </div>
 </div>
 <script>
-    $(function () {
+    (function () {
         var grid = $("#alertlog_stats-{{ $id }}").bootgrid({
             ajax: true,
             rowCount: [50, 100, 250, -1],
@@ -33,5 +35,5 @@
             grid.bootgrid('destroy');
             delete grid;
         });
-    });
+    })();
 </script>

--- a/resources/views/widgets/alerts.blade.php
+++ b/resources/views/widgets/alerts.blade.php
@@ -1,5 +1,5 @@
-<div class="table-responsive">
-    <table id="alerts_{{ $id }}" class="table table-hover table-condensed alerts" data-ajax="true">
+<div id="alerts_container-{{ $id }}" class="table-responsive" data-reload="false">
+    <table id="alerts-{{ $id }}" class="table table-hover table-condensed alerts">
         <thead>
         <tr>
             <th data-column-id="severity"></th>
@@ -16,60 +16,70 @@
     </table>
 </div>
 <script>
-    var alerts_grid = $("#alerts_{{ $id }}").bootgrid({
-        ajax: true,
-        requestHandler: request => ({
-            ...request,
-            id: "alerts",
-            acknowledged: '{{ $acknowledged }}',
-            unreachable: '{{ $unreachable }}',
-            fired: '{{ $fired }}',
-            min_severity: '{{ $min_severity }}',
-            group: '{{ $device_group }}',
-            proc: '{{ $proc }}',
-            sort: '{{ $sort }}',
-            uncollapse_key_count: '{{ $uncollapse_key_count }}',
-            device_id: '{{ $device }}'
-        }),
-        responseHandler: response => {
-            $("#widget_title_counter_{{ $id }}").text(response.total ? ` (${response.total})` : '')
+    $(function () {
+        var alerts_grid = $("#alerts-{{ $id }}").bootgrid({
+            ajax: true,
+            requestHandler: request => ({
+                ...request,
+                id: "alerts",
+                acknowledged: '{{ $acknowledged }}',
+                unreachable: '{{ $unreachable }}',
+                fired: '{{ $fired }}',
+                min_severity: '{{ $min_severity }}',
+                group: '{{ $device_group }}',
+                proc: '{{ $proc }}',
+                sort: '{{ $sort }}',
+                uncollapse_key_count: '{{ $uncollapse_key_count }}',
+                device_id: '{{ $device }}'
+            }),
+            responseHandler: response => {
+                $("#widget_title_counter_{{ $id }}").text(response.total ? ` (${response.total})` : '')
 
-            return response
-        },
-        url: "ajax_table.php",
-        navigation: ! {{ $hidenavigation }},
-        rowCount: [50, 100, 250, -1]
-    }).on("loaded.rs.jquery.bootgrid", function() {
-        alerts_grid = $(this);
-        alerts_grid.find(".incident-toggle").each( function() {
-            $(this).parent().addClass('incident-toggle-td');
-        }).on("click", function(e) {
-            var target = $(this).data("target");
-            $(target).collapse('toggle');
-            $(this).toggleClass('fa-plus fa-minus');
-        });
-        alerts_grid.find(".incident").each( function() {
-            $(this).parent().addClass('col-lg-4 col-md-4 col-sm-4 col-xs-4');
-            $(this).parent().parent().on("mouseenter", function() {
-                $(this).find(".incident-toggle").fadeIn(200);
-            }).on("mouseleave", function() {
-                $(this).find(".incident-toggle").fadeOut(200);
+                return response
+            },
+            url: "ajax_table.php",
+            navigation: ! {{ $hidenavigation }},
+            rowCount: [50, 100, 250, -1]
+        }).on("loaded.rs.jquery.bootgrid", function() {
+            alerts_grid = $(this);
+            alerts_grid.find(".incident-toggle").each( function() {
+                $(this).parent().addClass('incident-toggle-td');
+            }).on("click", function(e) {
+                var target = $(this).data("target");
+                $(target).collapse('toggle');
+                $(this).toggleClass('fa-plus fa-minus');
+            });
+            alerts_grid.find(".incident").each( function() {
+                $(this).parent().addClass('col-lg-4 col-md-4 col-sm-4 col-xs-4');
+                $(this).parent().parent().on("mouseenter", function() {
+                    $(this).find(".incident-toggle").fadeIn(200);
+                }).on("mouseleave", function() {
+                    $(this).find(".incident-toggle").fadeOut(200);
+                });
+            });
+            alerts_grid.find(".command-ack-alert").on("click", function(e) {
+                e.preventDefault();
+                var alert_state = $(this).data("alert_state");
+                var alert_id = $(this).data('alert_id');
+                $('#ack_alert_id').val(alert_id);
+                $('#ack_alert_state').val(alert_state);
+                $('#ack_msg').val('');
+                $("#alert_ack_modal").modal('show');
+            });
+            alerts_grid.find(".command-alert-note").on("click", function(e) {
+                e.preventDefault();
+                var alert_id = $(this).data('alert_id');
+                $('#alert_id').val(alert_id);
+                $("#alert_notes_modal").modal('show');
             });
         });
-        alerts_grid.find(".command-ack-alert").on("click", function(e) {
-            e.preventDefault();
-            var alert_state = $(this).data("alert_state");
-            var alert_id = $(this).data('alert_id');
-            $('#ack_alert_id').val(alert_id);
-            $('#ack_alert_state').val(alert_state);
-            $('#ack_msg').val('');
-            $("#alert_ack_modal").modal('show');
+
+        $('#alerts_container-{{ $id }}').on('refresh', function (event) {
+            grid.bootgrid('reload');
         });
-        alerts_grid.find(".command-alert-note").on("click", function(e) {
-            e.preventDefault();
-            var alert_id = $(this).data('alert_id');
-            $('#alert_id').val(alert_id);
-            $("#alert_notes_modal").modal('show');
+        $('#alerts_container-{{ $id }}').on('destroy', function (event) {
+            grid.bootgrid('destroy');
+            delete grid;
         });
     });
 </script>

--- a/resources/views/widgets/alerts.blade.php
+++ b/resources/views/widgets/alerts.blade.php
@@ -1,22 +1,24 @@
-<div id="alerts_container-{{ $id }}" class="table-responsive" data-reload="false">
-    <table id="alerts-{{ $id }}" class="table table-hover table-condensed alerts">
-        <thead>
-        <tr>
-            <th data-column-id="severity"></th>
-            <th data-column-id="timestamp">{{ __('Timestamp') }}</th>
-            <th data-column-id="rule">{{ __('Rule') }}</th>
-            <th data-column-id="details" data-sortable="false"></th>
-            <th data-column-id="hostname">{{ __('Hostname') }}</th>
-            <th data-column-id="location" data-visible="{{ $location ? 'true' : 'false' }}">{{ __('Location') }}</th>
-            <th data-column-id="ack_ico" data-sortable="false">{{ __('ACK') }}</th>
-            <th data-column-id="notes" data-sortable="false">{{ __('Notes') }}</th>
-            <th data-column-id="proc" data-sortable="false" data-visible="{{ $proc ? 'true' : 'false' }}">URL</th>
-        </tr>
-        </thead>
-    </table>
+<div id="alerts_container-{{ $id }}" data-reload="false">
+    <div class="table-responsive">
+        <table id="alerts-{{ $id }}" class="table table-hover table-condensed alerts">
+            <thead>
+            <tr>
+                <th data-column-id="severity"></th>
+                <th data-column-id="timestamp">{{ __('Timestamp') }}</th>
+                <th data-column-id="rule">{{ __('Rule') }}</th>
+                <th data-column-id="details" data-sortable="false"></th>
+                <th data-column-id="hostname">{{ __('Hostname') }}</th>
+                <th data-column-id="location" data-visible="{{ $location ? 'true' : 'false' }}">{{ __('Location') }}</th>
+                <th data-column-id="ack_ico" data-sortable="false">{{ __('ACK') }}</th>
+                <th data-column-id="notes" data-sortable="false">{{ __('Notes') }}</th>
+                <th data-column-id="proc" data-sortable="false" data-visible="{{ $proc ? 'true' : 'false' }}">URL</th>
+            </tr>
+            </thead>
+        </table>
+    </div>
 </div>
 <script>
-    $(function () {
+    (function () {
         var alerts_grid = $("#alerts-{{ $id }}").bootgrid({
             ajax: true,
             requestHandler: request => ({
@@ -75,11 +77,11 @@
         });
 
         $('#alerts_container-{{ $id }}').on('refresh', function (event) {
-            grid.bootgrid('reload');
+            alerts_grid.bootgrid('reload');
         });
         $('#alerts_container-{{ $id }}').on('destroy', function (event) {
-            grid.bootgrid('destroy');
-            delete grid;
+            alerts_grid.bootgrid('destroy');
+            delete alerts_grid;
         });
-    });
+    })();
 </script>

--- a/resources/views/widgets/eventlog.blade.php
+++ b/resources/views/widgets/eventlog.blade.php
@@ -1,5 +1,5 @@
-<div class="table-responsive">
-    <table id="eventlog" class="table table-hover table-condensed table-striped" data-ajax="true">
+<div  id="eventlog_container-{{ $id }}" class="table-responsive">
+    <table id="eventlog-{{ $id }}" class="table table-hover table-condensed table-striped" data-ajax="true">
         <thead>
         <tr>
             <th data-column-id="datetime" data-order="desc">{{ __('Timestamp') }}</th>
@@ -12,18 +12,28 @@
     </table>
 </div>
 <script>
-    $("#eventlog").bootgrid({
-        ajax: true,
-        rowCount: [50, 100, 250, -1],
-        navigation: ! {{ $hidenavigation }},
-        post: function ()
-        {
-            return {
-                device: "{{ $device }}",
-                device_group: "{{ $device_group }}",
-                eventtype: "{{ $eventtype }}"
-            };
-        },
-        url: "{{ url('/ajax/table/eventlog') }}"
+    $(function () {
+        var grid = $("#eventlog-{{ $id }}").bootgrid({
+            ajax: true,
+            rowCount: [50, 100, 250, -1],
+            navigation: ! {{ $hidenavigation }},
+            post: function ()
+            {
+                return {
+                    device: "{{ $device }}",
+                    device_group: "{{ $device_group }}",
+                    eventtype: "{{ $eventtype }}"
+                };
+            },
+            url: "{{ url('/ajax/table/eventlog') }}"
+        });
+
+        $('#eventlog_container-{{ $id }}').on('refresh', function (event) {
+            grid.bootgrid('reload');
+        });
+        $('#eventlog_container-{{ $id }}').on('destroy', function (event) {
+            grid.bootgrid('destroy');
+            delete grid;
+        });
     });
 </script>

--- a/resources/views/widgets/eventlog.blade.php
+++ b/resources/views/widgets/eventlog.blade.php
@@ -1,15 +1,17 @@
-<div  id="eventlog_container-{{ $id }}" class="table-responsive">
-    <table id="eventlog-{{ $id }}" class="table table-hover table-condensed table-striped" data-ajax="true">
-        <thead>
-        <tr>
-            <th data-column-id="datetime" data-order="desc">{{ __('Timestamp') }}</th>
-            <th data-column-id="type">{{ __('Type') }}</th>
-            <th data-column-id="device_id">{{ __('Hostname') }}</th>
-            <th data-column-id="message">{{ __('Message') }}</th>
-            <th data-column-id="username">{{ __('User') }}</th>
-        </tr>
-        </thead>
-    </table>
+<div id="eventlog_container-{{ $id }}" data-reload="false">
+    <div class="table-responsive">
+        <table id="eventlog-{{ $id }}" class="table table-hover table-condensed table-striped">
+            <thead>
+            <tr>
+                <th data-column-id="datetime" data-order="desc">{{ __('Timestamp') }}</th>
+                <th data-column-id="type">{{ __('Type') }}</th>
+                <th data-column-id="device_id">{{ __('Hostname') }}</th>
+                <th data-column-id="message">{{ __('Message') }}</th>
+                <th data-column-id="username">{{ __('User') }}</th>
+            </tr>
+            </thead>
+        </table>
+    </div>
 </div>
 <script>
     $(function () {

--- a/resources/views/widgets/graylog.blade.php
+++ b/resources/views/widgets/graylog.blade.php
@@ -1,5 +1,5 @@
-<div class="table-responsive">
-    <table id="graylog-{{ $id }}" class="table table-hover table-condensed graylog" data-ajax="true">
+<div id="graylog_container-{{ $id }}" class="table-responsive" data-reload="false">
+    <table id="graylog-{{ $id }}" class="table table-hover table-condensed graylog">
         <thead>
         <tr>
             <th data-column-id="severity" data-sortable="false"></th>
@@ -15,28 +15,38 @@
 </div>
 
 <script>
-    $("#graylog-{{ $id }}").bootgrid({
-        ajax: true,
-        rowCount: ['{{ $limit }}', 25,50,100,250,-1],
-        navigation: ! {{ $hidenavigation }},
-        formatters: {
-            "browserTime": function(column, row) {
-                @config('graylog.timezone')
-                    return row.timestamp;
-                @else
-                    return moment.parseZone(row.timestamp).local().format("YYYY-MM-DD HH:MM:SS");
-                @endconfig
-            }
-        },
-        post: function ()
-        {
-            return {
-                stream: "{{ $stream }}",
-                device: "{{ $device }}",
-                range: "{{ $range }}",
-                loglevel: "{{ $loglevel }}"
-            };
-        },
-        url: "{{ url('/ajax/table/graylog') }}"
+    $(function () {
+        var grid = $("#graylog-{{ $id }}").bootgrid({
+            ajax: true,
+            rowCount: ['{{ $limit }}', 25,50,100,250,-1],
+            navigation: ! {{ $hidenavigation }},
+            formatters: {
+                "browserTime": function(column, row) {
+                    @config('graylog.timezone')
+                        return row.timestamp;
+                    @else
+                        return moment.parseZone(row.timestamp).local().format("YYYY-MM-DD HH:MM:SS");
+                    @endconfig
+                }
+            },
+            post: function ()
+            {
+                return {
+                    stream: "{{ $stream }}",
+                    device: "{{ $device }}",
+                    range: "{{ $range }}",
+                    loglevel: "{{ $loglevel }}"
+                };
+            },
+            url: "{{ url('/ajax/table/graylog') }}"
+        });
+
+        $('#graylog_container-{{ $id }}').on('refresh', function (event) {
+            grid.bootgrid('reload');
+        });
+        $('#graylog_container-{{ $id }}').on('destroy', function (event) {
+            grid.bootgrid('destroy');
+            delete grid;
+        });
     });
 </script>

--- a/resources/views/widgets/graylog.blade.php
+++ b/resources/views/widgets/graylog.blade.php
@@ -1,21 +1,23 @@
-<div id="graylog_container-{{ $id }}" class="table-responsive" data-reload="false">
-    <table id="graylog-{{ $id }}" class="table table-hover table-condensed graylog">
-        <thead>
-        <tr>
-            <th data-column-id="severity" data-sortable="false"></th>
-            <th data-column-id="origin">{{ __('Origin') }}</th>
-            <th data-column-id="timestamp" data-formatter="browserTime">{{ __('Timestamp') }}</th>
-            <th data-column-id="level" data-sortable="false">{{ __('Level') }}</th>
-            <th data-column-id="source">{{ __('Source') }}</th>
-            <th data-column-id="message" data-sortable="false">{{ __('Message') }}</th>
-            <th data-column-id="facility" data-sortable="false">{{ __('Facility') }}</th>
-        </tr>
-        </thead>
-    </table>
+<div id="graylog_container-{{ $id }}" data-reload="false">
+    <div class="table-responsive">
+        <table id="graylog-{{ $id }}" class="table table-hover table-condensed graylog">
+            <thead>
+            <tr>
+                <th data-column-id="severity" data-sortable="false"></th>
+                <th data-column-id="origin">{{ __('Origin') }}</th>
+                <th data-column-id="timestamp" data-formatter="browserTime">{{ __('Timestamp') }}</th>
+                <th data-column-id="level" data-sortable="false">{{ __('Level') }}</th>
+                <th data-column-id="source">{{ __('Source') }}</th>
+                <th data-column-id="message" data-sortable="false">{{ __('Message') }}</th>
+                <th data-column-id="facility" data-sortable="false">{{ __('Facility') }}</th>
+            </tr>
+            </thead>
+        </table>
+    </div>
 </div>
 
 <script>
-    $(function () {
+    (function () {
         var grid = $("#graylog-{{ $id }}").bootgrid({
             ajax: true,
             rowCount: ['{{ $limit }}', 25,50,100,250,-1],
@@ -48,5 +50,5 @@
             grid.bootgrid('destroy');
             delete grid;
         });
-    });
+    })();
 </script>

--- a/resources/views/widgets/settings/base.blade.php
+++ b/resources/views/widgets/settings/base.blade.php
@@ -1,4 +1,4 @@
-<form role="form" class="dashboard-widget-settings" onsubmit="widget_settings(this); return false;">
+<form role="form" class="dashboard-widget-settings" onsubmit="widget_settings(this); return false;" data-reload="false">
     @csrf
     @yield('form')
 

--- a/resources/views/widgets/settings/worldmap.blade.php
+++ b/resources/views/widgets/settings/worldmap.blade.php
@@ -23,6 +23,14 @@
     </div>
 
     <div class="form-group">
+        <label for="init_layer-{{ $id }}" class="control-label">{{ __('Initial Layer') }}</label>
+        <select class="form-control" name="init_layer" id="init_layer-{{ $id }}">
+            <option value="Streets" @if($init_layer == 'Streets') selected @endif>{{ __('Streets') }}</option>
+            <option value="Satellite" @if($init_layer == 'Satellite') selected @endif>{{ __('Satellite') }}</option>
+        </select>
+    </div>
+
+    <div class="form-group">
         <label for="group_radius-{{ $id }}" class="control-label">{{ __('Grouping radius') }}</label>
         <input class="form-control" name="group_radius" id="group_radius-{{ $id }}" type="number" value="{{ $group_radius }}" placeholder="{{ __('default 80') }}">
     </div>

--- a/resources/views/widgets/syslog.blade.php
+++ b/resources/views/widgets/syslog.blade.php
@@ -1,20 +1,22 @@
-<div id="syslog_container-{{ $id }}" class="table-responsive" data-reload="false">
-    <table id="syslog-{{ $id }}" class="table table-hover table-condensed table-striped">
-        <thead>
-        <tr>
-            <th data-column-id="label"></th>
-            <th data-column-id="timestamp" data-order="desc">{{ __('Timestamp') }}</th>
-            <th data-column-id="level">{{ __('Level') }}</th>
-            <th data-column-id="device_id">{{ __('Hostname') }}</th>
-            <th data-column-id="program">{{ __('Program') }}</th>
-            <th data-column-id="msg">{{ __('Message') }}</th>
-            <th data-column-id="priority">{{ __('Priority') }}</th>
-        </tr>
-        </thead>
-    </table>
+<div id="syslog_container-{{ $id }}" data-reload="false">
+    <div class="table-responsive">
+        <table id="syslog-{{ $id }}" class="table table-hover table-condensed table-striped">
+            <thead>
+            <tr>
+                <th data-column-id="label"></th>
+                <th data-column-id="timestamp" data-order="desc">{{ __('Timestamp') }}</th>
+                <th data-column-id="level">{{ __('Level') }}</th>
+                <th data-column-id="device_id">{{ __('Hostname') }}</th>
+                <th data-column-id="program">{{ __('Program') }}</th>
+                <th data-column-id="msg">{{ __('Message') }}</th>
+                <th data-column-id="priority">{{ __('Priority') }}</th>
+            </tr>
+            </thead>
+        </table>
+    </div>
 </div>
 <script type="application/javascript">
-    $(function () {
+    (function () {
         var grid = $("#syslog-{{ $id }}").bootgrid({
             ajax: true,
             rowCount: [50, 100, 250, -1],
@@ -37,5 +39,5 @@
             grid.bootgrid('destroy');
             delete grid;
         });
-    });
+    })();
 </script>

--- a/resources/views/widgets/syslog.blade.php
+++ b/resources/views/widgets/syslog.blade.php
@@ -1,5 +1,5 @@
-<div class="table-responsive">
-    <table id="syslog" class="table table-hover table-condensed table-striped" data-ajax="true">
+<div id="syslog_container-{{ $id }}" class="table-responsive" data-reload="false">
+    <table id="syslog-{{ $id }}" class="table table-hover table-condensed table-striped">
         <thead>
         <tr>
             <th data-column-id="label"></th>
@@ -14,18 +14,28 @@
     </table>
 </div>
 <script type="application/javascript">
-    $("#syslog").bootgrid({
-        ajax: true,
-        rowCount: [50, 100, 250, -1],
-        navigation: ! {{ $hidenavigation }},
-        post: function ()
-        {
-            return {
-                device: '{{ $device ?: '' }}',
-                device_group: '{{ $device_group }}',
-                level: '{{ $level }}'
-            };
-        },
-        url: "{{ url('/ajax/table/syslog') }}"
+    $(function () {
+        var grid = $("#syslog-{{ $id }}").bootgrid({
+            ajax: true,
+            rowCount: [50, 100, 250, -1],
+            navigation: ! {{ $hidenavigation }},
+            post: function ()
+            {
+                return {
+                    device: '{{ $device ?: '' }}',
+                    device_group: '{{ $device_group }}',
+                    level: '{{ $level }}'
+                };
+            },
+            url: "{{ url('/ajax/table/syslog') }}"
+        });
+
+        $('#syslog_container-{{ $id }}').on('refresh', function (event) {
+            grid.bootgrid('reload');
+        });
+        $('#syslog_container-{{ $id }}').on('destroy', function (event) {
+            grid.bootgrid('destroy');
+            delete grid;
+        });
     });
 </script>

--- a/resources/views/widgets/worldmap.blade.php
+++ b/resources/views/widgets/worldmap.blade.php
@@ -1,127 +1,33 @@
-<div id="worldmap_widget-{{ $id }}" class="leaflet-map" data-reload="false"></div>
-
-<style>
-    .leaflet-map {
-        width: 100%;
-        height: 100%;
-        text-align: left;
-        border-bottom-left-radius: 4px;
-        border-bottom-right-radius: 4px;
-    }
-    .leaflet-map a:hover {
-        text-decoration: none;
-    }
-</style>
+<div id="worldmap_widget-{{ $id }}" class="worldmap_widget" data-reload="false"></div>
 
 <script type="application/javascript">
     (function () {
-        var map_id = 'worldmap_widget-{{ $id }}';
-        var status = {{ Js::from($status) }};
-        var group = {{ (int) $group }};
-        var map_config = {{ Js::from($map_config) }};
-
-        function init_marker_cluster(map) {
-            if (! map.markerCluster) {
-                  map.markerCluster = L.markerClusterGroup({
-                    maxClusterRadius: '{{ $group_radius }}',
-                    iconCreateFunction: function (cluster) {
-                        var markers = cluster.getAllChildMarkers();
-                        var color = "green";
-                        var newClass = "Cluster marker-cluster marker-cluster-small leaflet-zoom-animated leaflet-clickable";
-                        for (var i = 0; i < markers.length; i++) {
-                            if (markers[i].options.icon.options.markerColor == "blue" && color != "red") {
-                                color = "blue";
-                            }
-                            if (markers[i].options.icon.options.markerColor == "red") {
-                                color = "red";
-                            }
-                        }
-                        return L.divIcon({
-                            html: cluster.getChildCount(),
-                            className: color + newClass,
-                            iconSize: L.point(40, 40)
-                        });
-                    }
-                });
-
-                map.addLayer(map.markerCluster);
-            }
-        }
-
-        function populate_markers(map) {
-            $.ajax({
-                type: "GET",
-                url: '{{ route('widget.worldmap.data') }}',
-                dataType: "json",
-                data: { status: status, group: group }, // FIXME add correct values
-                success: function (data) {
-                    var redMarker = L.AwesomeMarkers.icon({
-                        icon: 'server',
-                        markerColor: 'red', prefix: 'fa', iconColor: 'white'
-                    });
-                    var blueMarker = L.AwesomeMarkers.icon({
-                        icon: 'server',
-                        markerColor: 'blue', prefix: 'fa', iconColor: 'white'
-                    });
-                    var greenMarker = L.AwesomeMarkers.icon({
-                        icon: 'server',
-                        markerColor: 'green', prefix: 'fa', iconColor: 'white'
-                    });
-
-                    var markers = data.map((device) => {
-                        var markerData = {title: device.name};
-                        switch (device.status) {
-                            case 0: // down
-                                markerData.icon = redMarker;
-                                markerData.zIndexOffset = 5000;
-                                break;
-                            case 3: // down + maintenance
-                                markerData.icon = blueMarker;
-                                markerData.zIndexOffset = 10000;
-                                break;
-                            default: // up
-                                markerData.icon = greenMarker;
-                                markerData.zIndexOffset = 0;
-                        }
-
-                        var marker = L.marker(new L.LatLng(device.lat, device.lng), markerData);
-                        marker.bindPopup(`<a href="${device.url}"><img src="${device.icon}" width="32" height="32" alt=""> ${device.name}</a>`);
-                        return marker;
-                    });
-
-                    map.markerCluster.clearLayers();
-                    map.markerCluster.addLayers(markers);
-                },
-                error: function(){
-                    toastr.error(data.message);
-                }
-            });
-        }
-
-        function register_listeners(map) {
-            map.scrollWheelZoom.disable();
-            $('#' + map_id).on('click', function (event) {
-                map.scrollWheelZoom.enable();
-            }).on('mouseleave', function (event) {
-                map.scrollWheelZoom.disable();
-            }).on('resize', function (event) {
-                map.invalidateSize();
-            }).on('refresh', function (event) {
-                map.invalidateSize();
-                populate_markers(map);
-            }).on('destroy', function (event) {
-                destroy_map(map_id);
-            });
-        }
+        const map_id = 'worldmap_widget-{{ $id }}';
+        const status = {{ Js::from($status) }};
+        const device_group = {{ (int) $device_group }};
+        const map_config = {{ Js::from($map_config) }};
+        const group_radius = {{ (int) $group_radius }};
 
         loadjs('js/leaflet.js', function () {
             loadjs('js/leaflet.markercluster.js', function () {
                 loadjs('js/leaflet.awesome-markers.min.js', function () {
                     loadjs('js/L.Control.Locate.min.js', function () {
-                        var map = init_map(map_id, map_config);
-                        init_marker_cluster(map);
-                        populate_markers(map);
-                        register_listeners(map);
+                        init_map(map_id, map_config).scrollWheelZoom.disable();
+                        populate_map_markers(map_id, group_radius, status, device_group);
+
+                        // register listeners
+                        $('#' + map_id).on('click', function (event) {
+                            get_map(map_id).scrollWheelZoom.enable();
+                        }).on('mouseleave', function (event) {
+                            get_map(map_id).scrollWheelZoom.disable();
+                        }).on('resize', function (event) {
+                            get_map(map_id).invalidateSize();
+                        }).on('refresh', function (event) {
+                            get_map(map_id).invalidateSize();
+                            populate_map_markers(map_id, group_radius, status, device_group);
+                        }).on('destroy', function (event) {
+                            destroy_map(map_id);
+                        });
                     });
                 });
             });

--- a/resources/views/widgets/worldmap.blade.php
+++ b/resources/views/widgets/worldmap.blade.php
@@ -5,11 +5,12 @@
 
 <script type="application/javascript">
     $(function () {
-        var map;
+        var map_id = 'leaflet-map-{{ $id }}';
         var status = {{ Js::from($status) }};
         var group = {{ (int) $group }};
+        var map_config = {{ Js::from($map_config) }};
 
-        function init_marker_cluster() {
+        function init_marker_cluster(map) {
             if (! map.markerCluster) {
                   map.markerCluster = L.markerClusterGroup({
                     maxClusterRadius: '{{ $group_radius }}',
@@ -78,6 +79,7 @@
                         return marker;
                     });
 
+                    var map = get_map(map_id);
                     map.markerCluster.clearLayers();
                     map.markerCluster.addLayers(markers);
                 },
@@ -91,31 +93,22 @@
             populate_markers();
         })
         $('#leaflet-map-{{ $id }}').on('destroy', function (event) {
-            map.off();
-            map.remove();
-            delete map;
+            destroy_map(map_id);
         })
 
         loadjs('js/leaflet.js', function () {
             loadjs('js/leaflet.markercluster.js', function () {
                 loadjs('js/leaflet.awesome-markers.min.js', function () {
-                    map = L.map('leaflet-map-{{ $id }}', {zoomSnap: 0.1}).setView(['{{ $init_lat }}', '{{ $init_lng }}'], '{{ sprintf('%01.1f', $init_zoom) }}');
-                    L.tileLayer('//{{ $title_url }}/{z}/{x}/{y}.png', {
-                        attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
-                    }).addTo(map);
-
-                    init_marker_cluster();
+                    var map = init_map(map_id, map_config);
+                    init_marker_cluster(map);
                     populate_markers();
 
                     map.scrollWheelZoom.disable();
-                    $(document).ready(function () {
-                        $("#leaflet-map-{{ $id }}").on("click", function (event) {
-                            map.scrollWheelZoom.enable();
-                        }).on("mouseleave", function (event) {
-                            map.scrollWheelZoom.disable();
-                        });
+                    $("#leaflet-map-{{ $id }}").on("click", function (event) {
+                        map.scrollWheelZoom.enable();
+                    }).on("mouseleave", function (event) {
+                        map.scrollWheelZoom.disable();
                     });
-
                 });
             });
         });

--- a/resources/views/widgets/worldmap.blade.php
+++ b/resources/views/widgets/worldmap.blade.php
@@ -1,74 +1,123 @@
-<div id="leaflet-map-{{ $id }}" style="width: {{ $dimensions['x'] }}px; height: {{ $dimensions['y'] }}px;" data-refresh="0"></div>
+<div id="leaflet-map-{{ $id }}"
+     style="width: {{ $dimensions['x'] }}px; height: {{ $dimensions['y'] }}px;"
+     data-reload="false"
+></div>
 
 <script type="application/javascript">
-    loadjs('js/leaflet.js', function() {
-    loadjs('js/leaflet.markercluster.js', function () {
-    loadjs('js/leaflet.awesome-markers.min.js', function () {
-        var map = L.map('leaflet-map-{{ $id }}', { zoomSnap: 0.1 } ).setView(['{{ $init_lat }}', '{{ $init_lng }}'], '{{ sprintf('%01.1f', $init_zoom) }}');
-        L.tileLayer('//{{ $title_url }}/{z}/{x}/{y}.png', {
-            attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
-        }).addTo(map);
+    $(function () {
+        var map;
+        var status = {{ Js::from($status) }};
+        var group = {{ (int) $group }};
 
-        var markers = L.markerClusterGroup({
-            maxClusterRadius: '{{ $group_radius }}',
-            iconCreateFunction: function (cluster) {
-                var markers = cluster.getAllChildMarkers();
-                var color = "green";
-                var newClass = "Cluster marker-cluster marker-cluster-small leaflet-zoom-animated leaflet-clickable";
-                for (var i = 0; i < markers.length; i++) {
-                    if (markers[i].options.icon.options.markerColor == "blue" && color != "red") {
-                        color = "blue";
+        function init_marker_cluster() {
+            if (! map.markerCluster) {
+                  map.markerCluster = L.markerClusterGroup({
+                    maxClusterRadius: '{{ $group_radius }}',
+                    iconCreateFunction: function (cluster) {
+                        var markers = cluster.getAllChildMarkers();
+                        var color = "green";
+                        var newClass = "Cluster marker-cluster marker-cluster-small leaflet-zoom-animated leaflet-clickable";
+                        for (var i = 0; i < markers.length; i++) {
+                            if (markers[i].options.icon.options.markerColor == "blue" && color != "red") {
+                                color = "blue";
+                            }
+                            if (markers[i].options.icon.options.markerColor == "red") {
+                                color = "red";
+                            }
+                        }
+                        return L.divIcon({
+                            html: cluster.getChildCount(),
+                            className: color + newClass,
+                            iconSize: L.point(40, 40)
+                        });
                     }
-                    if (markers[i].options.icon.options.markerColor == "red") {
-                        color = "red";
-                    }
+                });
+
+                map.addLayer(map.markerCluster);
+            }
+        }
+
+        function populate_markers() {
+            $.ajax({
+                type: "GET",
+                url: '{{ route('widget.worldmap.data') }}',
+                dataType: "json",
+                data: { status: status, group: group }, // FIXME add correct values
+                success: function (data) {
+                    var redMarker = L.AwesomeMarkers.icon({
+                        icon: 'server',
+                        markerColor: 'red', prefix: 'fa', iconColor: 'white'
+                    });
+                    var blueMarker = L.AwesomeMarkers.icon({
+                        icon: 'server',
+                        markerColor: 'blue', prefix: 'fa', iconColor: 'white'
+                    });
+                    var greenMarker = L.AwesomeMarkers.icon({
+                        icon: 'server',
+                        markerColor: 'green', prefix: 'fa', iconColor: 'white'
+                    });
+
+                    var markers = data.map((device) => {
+                        var markerData = {title: device.name};
+                        switch (device.status) {
+                            case 0: // down
+                                markerData.icon = redMarker;
+                                markerData.zIndexOffset = 5000;
+                                break;
+                            case 3: // down + maintenance
+                                markerData.icon = blueMarker;
+                                markerData.zIndexOffset = 10000;
+                                break;
+                            default: // up
+                                markerData.icon = greenMarker;
+                                markerData.zIndexOffset = 0;
+                        }
+
+                        var marker = L.marker(new L.LatLng(device.lat, device.lng), markerData);
+                        marker.bindPopup(`<a href="${device.url}"><img src="${device.icon}" width="32" height="32" alt=""> ${device.name}</a>`);
+                        return marker;
+                    });
+
+                    map.markerCluster.clearLayers();
+                    map.markerCluster.addLayers(markers);
+                },
+                error: function(){
+                    toastr.error(data.message);
                 }
-                return L.divIcon({ html: cluster.getChildCount(), className: color+newClass, iconSize: L.point(40, 40) });
-            }
-        });
-        var redMarker = L.AwesomeMarkers.icon({
-            icon: 'server',
-            markerColor: 'red', prefix: 'fa', iconColor: 'white'
-        });
-        var blueMarker = L.AwesomeMarkers.icon({
-            icon: 'server',
-            markerColor: 'blue', prefix: 'fa', iconColor: 'white'
-        });
-        var greenMarker = L.AwesomeMarkers.icon({
-            icon: 'server',
-            markerColor: 'green', prefix: 'fa', iconColor: 'white'
-        });
+            });
+        }
 
-        var devices = {{ Js::from($devices) }};
+        $('#leaflet-map-{{ $id }}').on('refresh', function (event) {
+            populate_markers();
+        })
+        $('#leaflet-map-{{ $id }}').on('destroy', function (event) {
+            map.off();
+            map.remove();
+            delete map;
+        })
 
-        devices.forEach((device) => {
-            var markerData = {title: device.name};
-            switch (device.status) {
-                case 0: // down
-                    markerData.icon = redMarker;
-                    markerData.zIndexOffset = 5000;
-                case 3: // down + maintenance
-                    markerData.icon = blueMarker;
-                    markerData.zIndexOffset = 10000;
-                default: // up
-                    markerData.icon = greenMarker;
-                    markerData.zIndexOffset = 0;
-            }
+        loadjs('js/leaflet.js', function () {
+            loadjs('js/leaflet.markercluster.js', function () {
+                loadjs('js/leaflet.awesome-markers.min.js', function () {
+                    map = L.map('leaflet-map-{{ $id }}', {zoomSnap: 0.1}).setView(['{{ $init_lat }}', '{{ $init_lng }}'], '{{ sprintf('%01.1f', $init_zoom) }}');
+                    L.tileLayer('//{{ $title_url }}/{z}/{x}/{y}.png', {
+                        attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+                    }).addTo(map);
 
-            var marker = L.marker(new L.LatLng(device.lat, device.lng), markerData);
-            marker.bindPopup(`<a href="${device.url}"><img src="${device.icon}" width="32" height="32" alt=""> ${device.name}</a>`);
-            markers.addLayer(marker);
-        });
+                    init_marker_cluster();
+                    populate_markers();
 
-        map.addLayer(markers);
-        map.scrollWheelZoom.disable();
-        $(document).ready(function() {
-            $("#leaflet-map-{{ $id }}").on("click", function (event) {
-                map.scrollWheelZoom.enable();
-            }).on("mouseleave", function (event) {
-                map.scrollWheelZoom.disable();
+                    map.scrollWheelZoom.disable();
+                    $(document).ready(function () {
+                        $("#leaflet-map-{{ $id }}").on("click", function (event) {
+                            map.scrollWheelZoom.enable();
+                        }).on("mouseleave", function (event) {
+                            map.scrollWheelZoom.disable();
+                        });
+                    });
+
+                });
             });
         });
-
-    });});});
+    })
 </script>

--- a/resources/views/widgets/worldmap.blade.php
+++ b/resources/views/widgets/worldmap.blade.php
@@ -99,15 +99,17 @@
         loadjs('js/leaflet.js', function () {
             loadjs('js/leaflet.markercluster.js', function () {
                 loadjs('js/leaflet.awesome-markers.min.js', function () {
-                    var map = init_map(map_id, map_config);
-                    init_marker_cluster(map);
-                    populate_markers();
+                    loadjs('js/L.Control.Locate.min.js', function () {
+                        var map = init_map(map_id, map_config);
+                        init_marker_cluster(map);
+                        populate_markers();
 
-                    map.scrollWheelZoom.disable();
-                    $("#leaflet-map-{{ $id }}").on("click", function (event) {
-                        map.scrollWheelZoom.enable();
-                    }).on("mouseleave", function (event) {
                         map.scrollWheelZoom.disable();
+                        $("#leaflet-map-{{ $id }}").on("click", function (event) {
+                            map.scrollWheelZoom.enable();
+                        }).on("mouseleave", function (event) {
+                            map.scrollWheelZoom.disable();
+                        });
                     });
                 });
             });

--- a/resources/views/widgets/worldmap.blade.php
+++ b/resources/views/widgets/worldmap.blade.php
@@ -1,5 +1,5 @@
 <div id="leaflet-map-{{ $id }}"
-     style="width: {{ $dimensions['x'] }}px; height: {{ $dimensions['y'] }}px;"
+     style="width: 100%; height: 100%;"
      data-reload="false"
 ></div>
 
@@ -38,7 +38,7 @@
             }
         }
 
-        function populate_markers() {
+        function populate_markers(map) {
             $.ajax({
                 type: "GET",
                 url: '{{ route('widget.worldmap.data') }}',
@@ -79,7 +79,6 @@
                         return marker;
                     });
 
-                    var map = get_map(map_id);
                     map.markerCluster.clearLayers();
                     map.markerCluster.addLayers(markers);
                 },
@@ -90,7 +89,9 @@
         }
 
         $('#leaflet-map-{{ $id }}').on('refresh', function (event) {
-            populate_markers();
+            var map = get_map(map_id);
+            map.invalidateSize();
+            populate_markers(map);
         })
         $('#leaflet-map-{{ $id }}').on('destroy', function (event) {
             destroy_map(map_id);
@@ -102,7 +103,7 @@
                     loadjs('js/L.Control.Locate.min.js', function () {
                         var map = init_map(map_id, map_config);
                         init_marker_cluster(map);
-                        populate_markers();
+                        populate_markers(map);
 
                         map.scrollWheelZoom.disable();
                         $("#leaflet-map-{{ $id }}").on("click", function (event) {

--- a/resources/views/widgets/worldmap.blade.php
+++ b/resources/views/widgets/worldmap.blade.php
@@ -1,11 +1,21 @@
-<div id="leaflet-map-{{ $id }}"
-     style="width: 100%; height: 100%;"
-     data-reload="false"
-></div>
+<div id="worldmap_widget-{{ $id }}" class="leaflet-map" data-reload="false"></div>
+
+<style>
+    .leaflet-map {
+        width: 100%;
+        height: 100%;
+        text-align: left;
+        border-bottom-left-radius: 4px;
+        border-bottom-right-radius: 4px;
+    }
+    .leaflet-map a:hover {
+        text-decoration: none;
+    }
+</style>
 
 <script type="application/javascript">
-    $(function () {
-        var map_id = 'leaflet-map-{{ $id }}';
+    (function () {
+        var map_id = 'worldmap_widget-{{ $id }}';
         var status = {{ Js::from($status) }};
         var group = {{ (int) $group }};
         var map_config = {{ Js::from($map_config) }};
@@ -88,18 +98,21 @@
             });
         }
 
-        $('#leaflet-map-{{ $id }}').on('resize', function (event) {
-            get_map(map_id).invalidateSize();
-        })
-
-        $('#leaflet-map-{{ $id }}').on('refresh', function (event) {
-            var map = get_map(map_id);
-            map.invalidateSize();
-            populate_markers(map);
-        })
-        $('#leaflet-map-{{ $id }}').on('destroy', function (event) {
-            destroy_map(map_id);
-        })
+        function register_listeners(map) {
+            map.scrollWheelZoom.disable();
+            $('#' + map_id).on('click', function (event) {
+                map.scrollWheelZoom.enable();
+            }).on('mouseleave', function (event) {
+                map.scrollWheelZoom.disable();
+            }).on('resize', function (event) {
+                map.invalidateSize();
+            }).on('refresh', function (event) {
+                map.invalidateSize();
+                populate_markers(map);
+            }).on('destroy', function (event) {
+                destroy_map(map_id);
+            });
+        }
 
         loadjs('js/leaflet.js', function () {
             loadjs('js/leaflet.markercluster.js', function () {
@@ -108,16 +121,10 @@
                         var map = init_map(map_id, map_config);
                         init_marker_cluster(map);
                         populate_markers(map);
-
-                        map.scrollWheelZoom.disable();
-                        $("#leaflet-map-{{ $id }}").on("click", function (event) {
-                            map.scrollWheelZoom.enable();
-                        }).on("mouseleave", function (event) {
-                            map.scrollWheelZoom.disable();
-                        });
+                        register_listeners(map);
                     });
                 });
             });
         });
-    })
+    })();
 </script>

--- a/resources/views/widgets/worldmap.blade.php
+++ b/resources/views/widgets/worldmap.blade.php
@@ -88,6 +88,10 @@
             });
         }
 
+        $('#leaflet-map-{{ $id }}').on('resize', function (event) {
+            get_map(map_id).invalidateSize();
+        })
+
         $('#leaflet-map-{{ $id }}').on('refresh', function (event) {
             var map = get_map(map_id);
             map.invalidateSize();

--- a/routes/web.php
+++ b/routes/web.php
@@ -237,7 +237,8 @@ Route::middleware(['auth'])->group(function () {
             Route::post('top-devices', 'TopDevicesController');
             Route::post('top-interfaces', 'TopInterfacesController');
             Route::post('top-errors', 'TopErrorsController');
-            Route::post('worldmap', 'WorldMapController');
+            Route::post('worldmap', 'WorldMapController')->name('widget.worldmap');
+            Route::get('worldmap', 'WorldMapController@getData')->name('widget.worldmap.data');
             Route::post('alertlog-stats', 'AlertlogStatsController');
         });
     });


### PR DESCRIPTION
Better handling of widget refresh. Hopefully less memory leaks :)
Allow widgets to opt out of html reload (if html already loaded)
Add refresh and destroy events for widgets
Update worldmap and bootgrid based widgets to use new events
Added worldmap features

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
