### PR TITLE
Remove enable_ports_poe

### DIFF
--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -1743,10 +1743,6 @@
             "default": false,
             "type": "boolean"
         },
-        "enable_ports_poe": {
-            "default": false,
-            "type": "boolean"
-        },
         "enable_pseudowires": {
             "default": true,
             "type": "boolean"


### PR DESCRIPTION
Cfg setting is not used anywhere in the code. Only mention of it anywhere is in a notification saying it's been deprecated.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
