### PR TITLE
API - allow add device to override sysLocation

### DIFF
--- a/doc/API/Devices.md
+++ b/doc/API/Devices.md
@@ -1216,6 +1216,7 @@ Fields:
 - port_association_mode: method to identify ports: ifIndex (default), ifName, ifDescr, ifAlias
 - poller_group: This is the poller_group id used for distributed poller setup. Defaults to 0.
 - location or location_id: set the location by text or location id
+- override_sysLocation: force use of the location/location_id: and not the value returned by sysLocation
 
 Options:
 

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -413,6 +413,7 @@ function add_device(Illuminate\Http\Request $request)
             'display',
             'overwrite_ip',
             'location_id',
+            'override_sysLocation',
             'port',
             'transport',
             'poller_group',


### PR DESCRIPTION
This is an extension of #15469 which allows setting location when adding a device.
I've noticed that the location set during the add_device API call gets overwritten by whatever is set in sysLocation during device discovery.

I'd like to force the use of the location from our network inventory and not what is set on device.


#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
