### PR TITLE
Add nfsen_base to config_definitions.json

### DIFF
--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -4547,6 +4547,15 @@
             },
             "type": "array"
         },
+        "nfsen_base": {
+            "default": [
+                "/varnfsen"
+            ],
+            "group": "external",
+            "section": "nfsen",
+            "order": 10,
+            "type": "array"
+        },
         "nfsen_split_char": {
             "group": "external",
             "section": "nfsen",

--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -4549,7 +4549,7 @@
         },
         "nfsen_base": {
             "default": [
-                "/varnfsen"
+                "/var/nfsen"
             ],
             "group": "external",
             "section": "nfsen",


### PR DESCRIPTION
Added nfsen_base so that nfsen stats feature works.  I had to add as an array as it was the way I was able to make it work, even though another type may make more sense from a user interface perspective.  I put it in order 10 as there seemed to be a gap there, but one could argue that it should be higher and other nfsen items renumbered.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
