### PR TITLE
Fix duplication of processor entries & limit length of type

### DIFF
--- a/LibreNMS/Device/Processor.php
+++ b/LibreNMS/Device/Processor.php
@@ -147,7 +147,7 @@ class Processor extends Model implements DiscoveryModule, PollerModule, Discover
 
         foreach ($processors as $processor) {
             $processor->processor_descr = substr($processor->processor_descr, 0, 64);
-            $processors[] = $processor;
+            $processor->processor_type = substr($processor->processor_type, 0, 16);
         }
 
         if (isset($processors) && is_array($processors)) {

--- a/includes/definitions/discovery/fortiauthenticator.yaml
+++ b/includes/definitions/discovery/fortiauthenticator.yaml
@@ -9,4 +9,4 @@ modules:
             -
                 oid: facSysCpuUsage
                 num_oid: '.1.3.6.1.4.1.12356.113.1.4.{{ $index }}'
-                type: fortiauthenticator
+                type: fortiauth

--- a/misc/discovery_schema.json
+++ b/misc/discovery_schema.json
@@ -157,7 +157,8 @@
                                     },
                                     "value": {"$ref": "#/definitions/oid"},
                                     "type": {
-                                        "type": "string"
+                                        "type": "string",
+                                        "maxLength": 16
                                     },
                                     "skip_values": {
                                         "$ref": "#/definitions/skip_values"

--- a/tests/data/fortiauthenticator.json
+++ b/tests/data/fortiauthenticator.json
@@ -838,7 +838,7 @@
                     "hrDeviceIndex": 0,
                     "processor_oid": ".1.3.6.1.4.1.12356.113.1.4.0",
                     "processor_index": "0",
-                    "processor_type": "fortiauthenticat",
+                    "processor_type": "fortiauth",
                     "processor_usage": 52,
                     "processor_descr": "Processor",
                     "processor_precision": 1,

--- a/tests/data/fortiauthenticator.json
+++ b/tests/data/fortiauthenticator.json
@@ -843,17 +843,6 @@
                     "processor_descr": "Processor",
                     "processor_precision": 1,
                     "processor_perc_warn": 75
-                },
-                {
-                    "entPhysicalIndex": 0,
-                    "hrDeviceIndex": 0,
-                    "processor_oid": ".1.3.6.1.4.1.12356.113.1.4.0",
-                    "processor_index": "0",
-                    "processor_type": "fortiauthenticat",
-                    "processor_usage": 52,
-                    "processor_descr": "Processor",
-                    "processor_precision": 1,
-                    "processor_perc_warn": 75
                 }
             ]
         },


### PR DESCRIPTION
Hello,

while adding support for a new device i stumbled upon a bug: in LibreNMS my device displayed two processors, even though it only has one.

So I looked at the code and found the following foreach loop, which I suppose should only limit the length of the description to 64, but after it the $processors array had an additional processor-entry.
![image](https://github.com/librenms/librenms/assets/31620323/7266b1e2-9c3e-46a9-bdb8-08749e3cded4) ![image](https://github.com/librenms/librenms/assets/31620323/d922f989-018c-4514-b7b8-795c22d692f0)


But when I also saw these duplicate entries with a device that reports the correct number of CPUs, I thought this couldn't be the problem...

After a little digging, I think I found out why this affected me, but not other OSes: Before saving the processor to the database, it checks for an existing entry with the same values but this check didn't work for my processor, as the type of it was longer than 16 characters and was therefore truncated in the database, but not in the model itself.

So this bug only occurs if the processor type is to long.

This PR fixes the duplication of processor entries (I'm not that good at PHP, but I think the `$processors[] = $processor` assignment isn't needed and causes the duplicate entries) and also limits the type property to 16 characters.


#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
