### PR TITLE
add some alert template items for CAPEv2

### DIFF
--- a/misc/alert_rules.json
+++ b/misc/alert_rules.json
@@ -794,5 +794,10 @@
     "rule": "(applications.app_type = \"cape\" && application_metrics.metric = \"pending\" && application_metrics.value IS NULL) && (applications.app_type = \"cape\" && application_metrics.metric = \"pending\" && application_metrics.value = \"\")",
     "name": "CAPE metric generation is failing for some reason",
     "severity": "critical"
+  },
+  {
+    "rule": "applications.app_type = \"cape\" AND application_metrics.metric = \"critical\" AND application_metrics.value > 0",
+    "name": "CAPE Criticals > 0",
+    "severity": "critical"
   }
 ]

--- a/misc/alert_rules.json
+++ b/misc/alert_rules.json
@@ -785,37 +785,17 @@
     "severity": "warning"
   },
   {
-    "builder": {
-       "condition":"AND",
-       "rules":[
-         {
-          "condition": "AND",
-          "rules": [
-            {"id":"applications.app_type","field":"applications.app_type","type":"string","input":"text","operator":"equal","value":"cape"},
-            {"id":"application_metrics.metric","field":"application_metrics.metric","type":"string","input":"text","operator":"equal","value":"reported"},
-            {"id":"application_metrics.value","field":"application_metrics.value","type":"integer","input":"text","operator":"equal","value":"0"}
-           ]
-         },
-         {
-          "condition": "AND",
-          "rules": [
-            {"id":"applications.app_type","field":"applications.app_type","type":"string","input":"text","operator":"equal","value":"cape"},
-            {"id":"application_metrics.metric","field":"application_metrics.metric","type":"string","input":"text","operator":"equal","value":"completed"},
-            {"id":"application_metrics.value","field":"application_metrics.value","type":"integer","input":"text","operator":"equal","value":"0"}
-           ]
-         }
-       ]
-    },
-    "name": "CAPE reported = 0 and completed = 0 , nothing is processing",
+    "rule": "applications.app_type = \"cape\" && application_metrics.metric = \"reported\" && application_metrics.value > 0",
+    "name": "CAPE reported = 0, nothing is processing",
     "severity": "critical"
   },
   {
-    "rule": "applications.app_type = \"cape\" AND application_metrics.metric = \"critical\" AND application_metrics.value > 0",
+    "rule": "applications.app_type = \"cape\" && application_metrics.metric = \"critical\" && application_metrics.value > 0",
     "name": "CAPE Criticals > 0",
     "severity": "critical"
   },
   {
-    "rule": "applications.app_type = \"cape\" AND application_metrics.metric = \"error\" AND application_metrics.value > 0",
+    "rule": "applications.app_type = \"cape\" && application_metrics.metric = \"error\" && application_metrics.value > 0",
     "name": "CAPE Errors > 0",
     "severity": "critical"
   }

--- a/misc/alert_rules.json
+++ b/misc/alert_rules.json
@@ -799,5 +799,10 @@
     "rule": "applications.app_type = \"cape\" AND application_metrics.metric = \"critical\" AND application_metrics.value > 0",
     "name": "CAPE Criticals > 0",
     "severity": "critical"
+  },
+  {
+    "rule": "applications.app_type = \"cape\" AND application_metrics.metric = \"error\" AND application_metrics.value > 0",
+    "name": "CAPE Errors > 0",
+    "severity": "critical"
   }
 ]

--- a/misc/alert_rules.json
+++ b/misc/alert_rules.json
@@ -785,14 +785,28 @@
     "severity": "warning"
   },
   {
-    "rule": "(applications.app_type = \"cape\" && application_metrics.metric = \"reported\" && application_metrics.value = 0) && (applications.app_type = \"cape\" && application_metrics.metric = \"completed\" && application_metrics.value = 0)",
+    "builder": {
+       "condition":"AND",
+       "rules":[
+         {
+          "condition": "AND",
+          "rules": [
+            {"id":"applications.app_type","field":"applications.app_type","type":"string","input":"text","operator":"equal","value":"cape"},
+            {"id":"application_metrics.metric","field":"application_metrics.metric","type":"string","input":"text","operator":"equal","value":"reported"},
+            {"id":"application_metrics.value","field":"application_metrics.value","type":"integer","input":"text","operator":"equal","value":"0"}
+           ]
+         },
+         {
+          "condition": "AND",
+          "rules": [
+            {"id":"applications.app_type","field":"applications.app_type","type":"string","input":"text","operator":"equal","value":"cape"},
+            {"id":"application_metrics.metric","field":"application_metrics.metric","type":"string","input":"text","operator":"equal","value":"completed"},
+            {"id":"application_metrics.value","field":"application_metrics.value","type":"integer","input":"text","operator":"equal","value":"0"}
+           ]
+         }
+       ]
+    },
     "name": "CAPE reported = 0 and completed = 0 , nothing is processing",
-    "severity": "critical",
-    "delay": 21600
-  },
-  {
-    "rule": "(applications.app_type = \"cape\" && application_metrics.metric = \"pending\" && application_metrics.value IS NULL) && (applications.app_type = \"cape\" && application_metrics.metric = \"pending\" && application_metrics.value = \"\")",
-    "name": "CAPE metric generation is failing for some reason",
     "severity": "critical"
   },
   {

--- a/misc/alert_rules.json
+++ b/misc/alert_rules.json
@@ -783,5 +783,10 @@
     "rule": "applications.app_type = \"suricata_extract\" && application_metrics.metric = \"zero_sized\" && application_metrics.value > \"0\"",
     "name": "Suricata Extract Submit zero sized files > 0",
     "severity": "warning"
+  },
+  {
+    "rule": "(applications.app_type = \"cape\" && application_metrics.metric = \"reported\" && application_metrics.value = 0) && (applications.app_type = \"cape\" && application_metrics.metric = \"completed\" && application_metrics.value = 0)",
+    "name": "CAPE reported = 0 && completed = 0 , nothing is processing",
+    "severity": "warning"
   }
 ]

--- a/misc/alert_rules.json
+++ b/misc/alert_rules.json
@@ -786,7 +786,13 @@
   },
   {
     "rule": "(applications.app_type = \"cape\" && application_metrics.metric = \"reported\" && application_metrics.value = 0) && (applications.app_type = \"cape\" && application_metrics.metric = \"completed\" && application_metrics.value = 0)",
-    "name": "CAPE reported = 0 && completed = 0 , nothing is processing",
-    "severity": "warning"
+    "name": "CAPE reported = 0 and completed = 0 , nothing is processing",
+    "severity": "critical",
+    "delay": 21600
+  },
+  {
+    "rule": "(applications.app_type = \"cape\" && application_metrics.metric = \"pending\" && application_metrics.value IS NULL) && (applications.app_type = \"cape\" && application_metrics.metric = \"pending\" && application_metrics.value = \"\")",
+    "name": "CAPE metric generation is failing for some reason",
+    "severity": "critical"
   }
 ]


### PR DESCRIPTION
adds...

- CAPE reported = 0 , nothing is processing
- CAPE Criticals > 0
- CAPE Errors > 0   

The first one includes a delay set by default as this is not unexpected, unless it has been happening for a long time, then there is a good chance something is off.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
