### PR TITLE
Fix for issue #15841

### DIFF
--- a/html/css/styles.css
+++ b/html/css/styles.css
@@ -1726,6 +1726,7 @@ tr.search:nth-child(odd) {
 
 .gridster * {
   margin:0;
+  text-align: center;
 }
 
 .grid ul {


### PR DESCRIPTION
Solution to issue #15841: I add the property "text-align: center;" to class ".gridster *"

BEFORE

![image](https://github.com/librenms/librenms/assets/161634488/b5deb76f-a288-48e7-bac4-9080ffc6564e)


AFTER

![image](https://github.com/librenms/librenms/assets/161634488/17d8d762-600a-4d94-a0cb-e2f4bd7d4db0)


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.



- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
