### PR TITLE
Fix fping bulk

### DIFF
--- a/LibreNMS/Data/Source/Fping.php
+++ b/LibreNMS/Data/Source/Fping.php
@@ -127,9 +127,7 @@ class Fping
                             $partial = '';
                         } catch (FpingUnparsableLine $e) {
                             // handle possible partial line (only save it if it is the last line of output)
-                            if ($index === array_key_last($lines)) {
-                                $partial = $e->unparsedLine;
-                            }
+                            $partial = $index === array_key_last($lines) ? $e->unparsedLine : '';
                         }
                     }
                 }

--- a/LibreNMS/Data/Source/Fping.php
+++ b/LibreNMS/Data/Source/Fping.php
@@ -117,7 +117,8 @@ class Fping
         $process->run(function ($type, $output) use ($callback, &$partial) {
             // stdout contains individual ping responses, stderr contains summaries
             if ($type == Process::ERR) {
-                foreach (explode(PHP_EOL, $output) as $line) {
+                $lines = explode(PHP_EOL, $output);
+                foreach ($lines as $index => $line) {
                     if ($line) {
                         Log::debug("Fping OUTPUT|$line PARTIAL|$partial");
                         try {
@@ -125,8 +126,10 @@ class Fping
                             call_user_func($callback, $response);
                             $partial = '';
                         } catch (FpingUnparsableLine $e) {
-                            // handle possible partial line
-                            $partial = $e->unparsedLine;
+                            // handle possible partial line (only save it if it is the last line of output)
+                            if ($index === array_key_last($lines)) {
+                                $partial = $e->unparsedLine;
+                            }
                         }
                     }
                 }

--- a/tests/FpingTest.php
+++ b/tests/FpingTest.php
@@ -154,6 +154,7 @@ OUT;
         $process->shouldReceive('getCommandLine');
         $process->shouldReceive('run')->withArgs(function ($callback) {
             // simulate incremental output (not always one full line per callback)
+            call_user_func($callback, Process::ERR, "ICMP unreachable\n"); // this line should be ignored
             call_user_func($callback, Process::ERR, "192.168.1.4 : xmt/rcv/%loss = 3/3/0%, min/avg/max = 0.62/0.71/0.93\nhostname    : xmt/rcv/%loss = 3/0/100%");
             call_user_func($callback, Process::ERR, "invalid:characters!: Name or service not known\n\n1.1.1.1 : xmt/rcv/%loss = 3/2/33%");
             call_user_func($callback, Process::ERR, ", min/avg/max = 0.024/0.037/0.054\n");


### PR DESCRIPTION
When an ICMP unreachable message was returned (stderr), the output processing would save it as if it were a partial line, breaking parsing.
Only save a line as partial if it is the last line of the output (not ending in a new line)

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
