### PR TITLE
handle $app_data['disks'] not being set for SMART app page display

### DIFF
--- a/includes/html/pages/device/apps/smart.inc.php
+++ b/includes/html/pages/device/apps/smart.inc.php
@@ -13,7 +13,9 @@ $drives = [];
 
 $app_data = $app->data;
 
-array_multisort(array_keys($app_data['disks']), SORT_ASC, $app_data['disks']);
+if (isset($app_data['disks']) && is_array ($app_data['disks'])) {
+    array_multisort(array_keys($app_data['disks']), SORT_ASC, $app_data['disks']);
+}
 
 foreach ($app_data['disks'] as $label => $disk_data) {
     $disk = $label;

--- a/includes/html/pages/device/apps/smart.inc.php
+++ b/includes/html/pages/device/apps/smart.inc.php
@@ -13,7 +13,7 @@ $drives = [];
 
 $app_data = $app->data;
 
-if (isset($app_data['disks']) && is_array ($app_data['disks'])) {
+if (isset($app_data['disks']) && is_array($app_data['disks'])) {
     array_multisort(array_keys($app_data['disks']), SORT_ASC, $app_data['disks']);
 }
 


### PR DESCRIPTION
xref: https://github.com/librenms/librenms/issues/16068

This should always be populated post polling. This prevents it from failing if it has not been polled yet.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
