### PR TITLE
Don't run poller validations when there are no devices

### DIFF
--- a/LibreNMS/Validations/Poller/CheckActivePoller.php
+++ b/LibreNMS/Validations/Poller/CheckActivePoller.php
@@ -25,6 +25,7 @@
 
 namespace LibreNMS\Validations\Poller;
 
+use App\Models\Device;
 use App\Models\Poller;
 use App\Models\PollerCluster;
 use LibreNMS\ValidationResult;
@@ -54,6 +55,6 @@ class CheckActivePoller implements \LibreNMS\Interfaces\Validation
      */
     public function enabled(): bool
     {
-        return true;
+        return Device::exists();
     }
 }

--- a/LibreNMS/Validations/Poller/CheckDispatcherService.php
+++ b/LibreNMS/Validations/Poller/CheckDispatcherService.php
@@ -25,6 +25,7 @@
 
 namespace LibreNMS\Validations\Poller;
 
+use App\Models\Device;
 use App\Models\Poller;
 use App\Models\PollerCluster;
 use LibreNMS\ValidationResult;

--- a/LibreNMS/Validations/Poller/CheckDispatcherService.php
+++ b/LibreNMS/Validations/Poller/CheckDispatcherService.php
@@ -48,7 +48,7 @@ class CheckDispatcherService implements \LibreNMS\Interfaces\Validation
      */
     public function enabled(): bool
     {
-        return true;
+        return Device::exists();
     }
 
     private function checkDispatchService(): ValidationResult


### PR DESCRIPTION


#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
