### PR TITLE
RouterOS: Change the version template

### DIFF
--- a/includes/definitions/discovery/routeros.yaml
+++ b/includes/definitions/discovery/routeros.yaml
@@ -4,7 +4,10 @@ modules:
         features: MIKROTIK-MIB::mtxrLicLevel.0
         features_template: 'Level {{ MIKROTIK-MIB::mtxrLicLevel.0 }}'
         serial: MIKROTIK-MIB::mtxrSerialNumber.0
-        version: MIKROTIK-MIB::mtxrLicVersion.0
+        version:
+            - MIKROTIK-MIB::mtxrLicVersion.0
+            - MIKROTIK-MIB::mtxrFirmwareVersion.0
+        version_template: '{{ MIKROTIK-MIB::mtxrLicVersion.0 }}, Firmware {{ MIKROTIK-MIB::mtxrFirmwareVersion.0 }}'
     sensors:
         pre-cache:
             data:

--- a/tests/data/routeros.json
+++ b/tests/data/routeros.json
@@ -7,7 +7,7 @@
                     "sysObjectID": ".1.3.6.1.4.1.14988.1",
                     "sysDescr": "router",
                     "sysContact": "<private>",
-                    "version": "6.40.5",
+                    "version": "6.40.5, Firmware 6.40.5",
                     "hardware": null,
                     "features": "Level 1",
                     "location": "<private>",


### PR DESCRIPTION
Imitate the template from linksys-ss.yaml, that includes the firmware version

<img width="570" alt="image" src="https://github.com/librenms/librenms/assets/1938389/9419c38d-d928-4059-8eba-ce1d343d68ee">

The addition is the `, Firmware <firmware_version>` part to the OS string
 
#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
