### PR TITLE
 Storage Module - wrong default regex /on: \/junos^/ should be /on: \/junos$/

### DIFF
--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -3955,7 +3955,7 @@
                 "/on: \\/packages/",
                 "/on: \\/dev/",
                 "/on: \\/proc/",
-                "/on: \\/junos^/",
+                "/on: \\/junos$/",
                 "/on: \\/junos\\/dev/",
                 "/on: \\/jail\\/dev/",
                 "/^(dev|proc)fs/",


### PR DESCRIPTION
fixes #16112 

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
