### PR TITLE
Added ifAlias support on Multiport Bits Seperate Graphs

### DIFF
--- a/includes/html/graphs/multiport/bits_separate.inc.php
+++ b/includes/html/graphs/multiport/bits_separate.inc.php
@@ -9,8 +9,13 @@ foreach (explode(',', $vars['id']) as $ifid) {
         $port = cleanPort($port);
         $rrd_list[$i]['filename'] = $rrd_file;
         $rrd_list[$i]['descr'] = format_hostname($port) . ' ' . $port['ifDescr'];
-        $rrd_list[$i]['descr_in'] = format_hostname($port);
-        $rrd_list[$i]['descr_out'] = makeshortif($port['label']);
+        if (isset($port['ifAlias'])) {
+            $rrd_list[$i]['descr_in'] = $port['ifAlias'];
+            $rrd_list[$i]['descr_out'] = $port['ifAlias'];
+        } else {
+            $rrd_list[$i]['descr_in'] = format_hostname($port);
+            $rrd_list[$i]['descr_out'] = makeshortif($port['label']);
+        }
         $i++;
     }
 }


### PR DESCRIPTION
Multiport Bits (Seperated) now uses the ifAlias when set.

Before:
<img width="685" alt="Screenshot 2024-06-13 at 17 40 09" src="https://github.com/librenms/librenms/assets/4570297/9f2529b4-f69b-43bb-97c1-adba026221d6">
After:
<img width="685" alt="Screenshot 2024-06-13 at 17 39 52" src="https://github.com/librenms/librenms/assets/4570297/d59fe708-7571-45e4-960f-779be21fba2d">



DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
