### PR TITLE
Fix port neighbors unknown local port

### DIFF
--- a/lang/en/port.php
+++ b/lang/en/port.php
@@ -25,6 +25,7 @@ return [
         'links' => 'Neighbors',
         'xdsl' => 'xDSL',
     ],
+    'unknown_port' => 'Unknown Port',
     'vlan_count' => 'VLANs: :count',
     'vlan_label' => 'VLAN: :label',
     'xdsl' => [

--- a/resources/views/device/tabs/ports/links.blade.php
+++ b/resources/views/device/tabs/ports/links.blade.php
@@ -10,9 +10,14 @@
         </thead>
         @foreach($data['links'] as $link)
             <tr>
-                <td><x-port-link :port="$link->port"></x-port-link>
-                    @if($link->port->getLabel() !== $link->port->getDescription() )
-                        <br />{{ $link->port->getDescription() }}
+                <td>
+                    @if($link->port)
+                        <x-port-link :port="$link->port"></x-port-link>
+                        @if($link->port->getLabel() !== $link->port->getDescription() )
+                            <br />{{ $link->port->getDescription() }}
+                        @endif
+                    @else
+                        {{ __('port.unknown_port') }}
                     @endif
                 </td>
                 <td>


### PR DESCRIPTION
Fix issue when somehow the local port is unknown.  Likely this is faulty polling or snmp implementation.

fixes #16126

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
