### PR TITLE
Change port pagination default to 32

### DIFF
--- a/app/Http/Controllers/Device/Tabs/PortsController.php
+++ b/app/Http/Controllers/Device/Tabs/PortsController.php
@@ -116,7 +116,7 @@ class PortsController implements DeviceTab
 
         /** @var Collection<Port>|LengthAwarePaginator<Port> $ports */
         $ports = $this->getFilteredPortsQuery($device, $request, $relationships)
-            ->paginate(fn($total) => $this->perPage == 'all' ? $total : (int)$this->perPage) // @phpstan-ignore-line missing closure type
+            ->paginate(fn ($total) => $this->perPage == 'all' ? $total : (int)$this->perPage) // @phpstan-ignore-line missing closure type
             ->appends('perPage', $this->perPage);
 
         $data = [

--- a/app/Http/Controllers/Device/Tabs/PortsController.php
+++ b/app/Http/Controllers/Device/Tabs/PortsController.php
@@ -41,7 +41,7 @@ use LibreNMS\Interfaces\UI\DeviceTab;
 class PortsController implements DeviceTab
 {
     private bool $detail = false;
-    private int|string $perPage = 15;
+    private int|string $perPage = 32;
     private string $sortOrder = 'asc';
     private string $sortColumn = 'default';
 
@@ -332,7 +332,7 @@ class PortsController implements DeviceTab
 
     private function getFilteredPortsQuery(Device $device, Request $request, array $relationships = []): Builder
     {
-        $this->perPage = $request->input('perPage', 15);
+        $this->perPage = $request->input('perPage', 32);
         $this->sortOrder = $request->input('order', 'asc');
         $this->sortColumn = $request->input('sort', 'default');
 

--- a/app/Http/Controllers/Device/Tabs/PortsController.php
+++ b/app/Http/Controllers/Device/Tabs/PortsController.php
@@ -116,7 +116,7 @@ class PortsController implements DeviceTab
 
         /** @var Collection<Port>|LengthAwarePaginator<Port> $ports */
         $ports = $this->getFilteredPortsQuery($device, $request, $relationships)
-            ->paginate(fn ($total) => $this->perPage == 'all' ? $total : (int) $this->perPage)
+            ->paginate(fn($total) => $this->perPage == 'all' ? $total : (int)$this->perPage) // @phpstan-ignore-line missing closure type
             ->appends('perPage', $this->perPage);
 
         $data = [

--- a/app/Http/Controllers/Device/Tabs/PortsController.php
+++ b/app/Http/Controllers/Device/Tabs/PortsController.php
@@ -116,7 +116,7 @@ class PortsController implements DeviceTab
 
         /** @var Collection<Port>|LengthAwarePaginator<Port> $ports */
         $ports = $this->getFilteredPortsQuery($device, $request, $relationships)
-            ->paginate(fn ($total) => $this->perPage == 'all' ? $total : (int)$this->perPage) // @phpstan-ignore-line missing closure type
+            ->paginate(fn ($total) => $this->perPage == 'all' ? $total : (int) $this->perPage) // @phpstan-ignore-line missing closure type
             ->appends('perPage', $this->perPage);
 
         $data = [

--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -5214,6 +5214,62 @@
             "default": true,
             "type": "boolean"
         },
+        "ports_ui.default_sort": {
+            "order": 10,
+            "group": "webui",
+            "section": "ports",
+            "default": "ifIndex",
+            "type": "select",
+            "options": [
+                "ifIndex",
+                "mac",
+                "media",
+                "port",
+                "speed",
+                "traffic"
+            ]
+        },
+        "ports_ui.show_disabled": {
+            "order": 50,
+            "group": "webui",
+            "section": "ports",
+            "default": false,
+            "type": "boolean"
+        },
+        "ports_ui.show_ignored": {
+            "order": 60,
+            "group": "webui",
+            "section": "ports",
+            "default": false,
+            "type": "boolean"
+        },
+        "ports_ui.filter_admin_status": {
+            "order": 70,
+            "group": "webui",
+            "section": "ports",
+            "default": "up",
+            "type": "select",
+            "options": [
+                "up",
+                "down",
+                "any"
+            ]
+        },
+        "ports_ui.filter_oper_status": {
+            "order": 80,
+            "group": "webui",
+            "section": "ports",
+            "default": "up",
+            "type": "select",
+            "options": [
+                "up",
+                "down",
+                "notPresent",
+                "lowerLayerDown",
+                "unknown",
+                "any"
+            ]
+        },
         "port_descr_parser": {
             "default": "includes/port-descr-parser.inc.php",
             "type": "text"

--- a/resources/views/device/tabs/ports/detail.blade.php
+++ b/resources/views/device/tabs/ports/detail.blade.php
@@ -19,8 +19,7 @@
     <div class="tw-flex tw-flex-row-reverse tw-m-3">
         {{ $data['ports']->links('pagination::tailwind', ['perPage' => $data['perPage']]) }}
         @isset($data['perPage'])
-            <x-select :options="['15', '25', '100', 'all']"
-                      {{-- location.herf = --}}
+            <x-select :options="['16', '32', '128', 'all']"
                       x-on:change="
                       const params = new URLSearchParams(window.location.search);
                       params.set('perPage', $event.target.value);


### PR DESCRIPTION
that way this includes all ports for most switches. Most port counts are base 2, so change pagination options to match

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
