### PR TITLE
Update eaton-sc200.yaml

### DIFF
--- a/includes/definitions/discovery/eaton-sc200.yaml
+++ b/includes/definitions/discovery/eaton-sc200.yaml
@@ -151,3 +151,24 @@ modules:
                       oid: di-Status
                       op: '=='
                       value: "0"
+                -
+                    oid: summary-Alarm-Critical
+                    num_oid: '.1.3.6.1.4.1.1918.2.13.10.110.5.10.0'
+                    descr: 'Alarm Summary Critical'
+                    states:
+                      - { descr: 'OK',      graph: 0, value: 0, generic: 0 }
+                      - { descr: 'Active',  graph: 1, value: 1, generic: 1 }
+                -
+                    oid: summary-Alarm-Major
+                    num_oid: '.1.3.6.1.4.1.1918.2.13.10.110.5.20.0'
+                    descr: 'Alarm Summary Major'
+                    states:
+                      - { descr: 'OK',      graph: 0, value: 0, generic: 0 }
+                      - { descr: 'Active',  graph: 1, value: 1, generic: 1 }
+                -
+                    oid: summary-Alarm-Minor
+                    num_oid: '.1.3.6.1.4.1.1918.2.13.10.110.5.30.0'
+                    descr: 'Alarm Summary Minor'
+                    states:
+                      - { descr: 'OK',      graph: 0, value: 0, generic: 0 }
+                      - { descr: 'Active',  graph: 1, value: 1, generic: 1 }


### PR DESCRIPTION
Adding Alarm Summary Support, which is useful to find out if there is any undiscovered Alarm.

SC200 digital-Input-Table seems to be quite unreliable on SC200 even with "latest and greatest" 4.04 Firmware,
so polling the "Summary Alarm States" makes sense for getting undetected Battery / Misc. Errors.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
