### PR TITLE
Arubaos vpnsensors

### DIFF
--- a/includes/definitions/discovery/arubaos.yaml
+++ b/includes/definitions/discovery/arubaos.yaml
@@ -18,3 +18,11 @@ modules:
                 value: WLSX-SYSTEMEXT-MIB::sysExtProcessorLoad
                 num_oid: '.1.3.6.1.4.1.14823.2.2.1.2.1.13.1.3.{{ $index }}'
                 descr: WLSX-SYSTEMEXT-MIB::sysExtProcessorDescr
+    sensors:
+        count:
+            data:
+                -
+                    oid: WLSX-USER-MIB::wlsxNumOfUsersVPN
+                    num_oid: '.1.3.6.1.4.1.14823.2.2.1.4.1.4.2.0'
+                    descr: 'Active VPN sessions'
+                    index: 'vpnsessions'

--- a/includes/html/graphs/device/arubacontroller_vpnsessions.inc.php
+++ b/includes/html/graphs/device/arubacontroller_vpnsessions.inc.php
@@ -1,0 +1,13 @@
+<?php
+
+require 'includes/html/graphs/common.inc.php';
+
+$rrd_filename = Rrd::name($device['hostname'], 'sensor-count-arubaos-vpnsessions');
+$ds = 'sensor';
+$colour_area = '9999cc';
+$colour_line = '0000cc';
+$colour_area_max = 'aaaaacc';
+$scale_min = 0;
+$unit_text = 'Active Tunnels';
+
+require 'includes/html/graphs/generic_simplex.inc.php';


### PR DESCRIPTION
This adds ArubaOS WLSX-USER-MIB::wlsxNumOfUsersVPN OID which allows the polling of active vpn connections to the ArubaOS platform. The second file is a graph file that adds the ability to add it to a dashboard.