### PR TITLE
ArubaOS - Addtional support to poll Active VPN sessions

### DIFF
--- a/includes/definitions/discovery/arubaos.yaml
+++ b/includes/definitions/discovery/arubaos.yaml
@@ -18,3 +18,11 @@ modules:
                 value: WLSX-SYSTEMEXT-MIB::sysExtProcessorLoad
                 num_oid: '.1.3.6.1.4.1.14823.2.2.1.2.1.13.1.3.{{ $index }}'
                 descr: WLSX-SYSTEMEXT-MIB::sysExtProcessorDescr
+    sensors:
+        count:
+            data:
+                -
+                    oid: WLSX-USER-MIB::wlsxNumOfUsersVPN
+                    num_oid: '.1.3.6.1.4.1.14823.2.2.1.4.1.4.2.0'
+                    descr: 'Active VPN sessions'
+                    index: 'vpnsessions'

--- a/includes/html/graphs/device/arubacontroller_vpnsessions.inc.php
+++ b/includes/html/graphs/device/arubacontroller_vpnsessions.inc.php
@@ -1,0 +1,13 @@
+<?php
+
+require 'includes/html/graphs/common.inc.php';
+
+$rrd_filename = Rrd::name($device['hostname'], 'sensor-count-arubaos-vpnsessions');
+$ds = 'sensor';
+$colour_area = '9999cc';
+$colour_line = '0000cc';
+$colour_area_max = 'aaaaacc';
+$scale_min = 0;
+$unit_text = 'Active Tunnels';
+
+require 'includes/html/graphs/generic_simplex.inc.php';


### PR DESCRIPTION
This commit changes two files in the LibreNMS repo, to enable polling of the ArubaOS OID that reports active vpn sessions.

The first file is the arubaos.yaml discovery file to enable polling of the following OID WLSX-USER-MIB::wlsxNumOfUsersVPN(OID: .1.3.6.1.4.1.14823.2.2.1.4.1.4.2.0). 

The second file  arubacontroller_vpnsessions.inc.php is a graphing file to allow the use of this sensor on a dashboard.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
