### PR TITLE
Left align text for dashboard widgets

### DIFF
--- a/html/css/styles.css
+++ b/html/css/styles.css
@@ -1726,7 +1726,7 @@ tr.search:nth-child(odd) {
 
 .gridster * {
   margin:0;
-  text-align: center;
+  text-align: left;
 }
 
 .grid ul {


### PR DESCRIPTION
Text alignment change for dashboard widget text.

After PR [#16083](https://github.com/librenms/librenms/pull/16083) text was aligned to center for better readability for the summary tables. The knock on effect was that text for all widgets was center aligned rather than left aligned, as it was before. For readability and consistency, I would recommend the alignment set to left.

Examples of test dashboard with varies widgets below. Had to redact text as this was prod system. Hopefully still helpful

Center aligned
![center align](https://github.com/librenms/librenms/assets/2754635/137439ff-4db5-491f-847c-70bf7c79b1d8)

Left aligned
![left align](https://github.com/librenms/librenms/assets/2754635/61536b32-1547-4eab-bf7d-62e885cb211d)


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
