### PR TITLE
Fix graph row lazy loading

### DIFF
--- a/app/View/Components/Graph.php
+++ b/app/View/Components/Graph.php
@@ -130,6 +130,7 @@ class Graph extends Component
         return ! in_array($key, [
             'legend',
             'height',
+            'loading',
         ]);
     }
 

--- a/resources/views/components/graph.blade.php
+++ b/resources/views/components/graph.blade.php
@@ -1,1 +1,1 @@
-<img width="{{ $width }}" height="{{ $height }}" src="{{ $src }}" alt="{{ $type }}" {{ $attributes->merge(['class' => 'graph-image'])->filter($filterAttributes) }}>
+<img width="{{ $width }}" height="{{ $height }}" src="{{ $src }}" alt="{{ $type }}" {{ $attributes->merge(['class' => 'graph-image'])->filter($filterAttributes) }} {{ $attributes->only('loading') }}>

--- a/resources/views/components/linked-graph.blade.php
+++ b/resources/views/components/linked-graph.blade.php
@@ -1,1 +1,1 @@
-<a href="{{ $link }}" {{ $attributes->filter($filterAttributes) }}><img width="{{ $width }}" height="{{ $height }}" src="{{ $src }}" alt="{{ $type }}" class="graph-image"></a>
+<a href="{{ $link }}" {{ $attributes->filter($filterAttributes) }}><img width="{{ $width }}" height="{{ $height }}" src="{{ $src }}" alt="{{ $type }}" class="graph-image" {{ $attributes->only('loading') }}></a>


### PR DESCRIPTION
Loading attribute was on the wrong element
will speed up initial page loads for pages with lots of graphs in popups

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
