### PR TITLE
Port link component easier graphs

### DIFF
--- a/app/View/Components/PortLink.php
+++ b/app/View/Components/PortLink.php
@@ -87,7 +87,6 @@ class PortLink extends Component
         return array_map(function ($graph_vars) {
             return array_merge([
                 'from' => '-1d',
-                'type' => 'port_bits',
                 'legend' => 'yes',
                 'text' => '',
             ], Arr::wrap($graph_vars));

--- a/resources/views/components/port-link.blade.php
+++ b/resources/views/components/port-link.blade.php
@@ -7,7 +7,8 @@
     <x-slot name="body">
         <div>
             @foreach($graphs as $graph)
-                <x-graph-row loading="lazy" :port="$port" :type="$graph['type'] ?? 'port_bits'" :title="$graph['title'] ?? null" :graphs="$fillDefaultVars($graph['vars'] ?? [])"></x-graph-row>
+                <x-graph-row loading="lazy" :port="$port" :type="$graph['type'] ?? 'port_bits'" :title="$graph['title'] ?? null"
+                             :graphs="$fillDefaultVars($graph['vars'] ?? [['from' => '-1d'], ['from' => '-7d'], ['from' => '-30d'], ['from' => '-1y']])"/>
             @endforeach
         </div>
     </x-slot>


### PR DESCRIPTION
Allow type variable to pass into graphs of graph row 
default 4 graph display so caller doesn't have to specify timeframes if they just what the default

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
