### PR TITLE
Fix port link device missing

### DIFF
--- a/resources/views/components/port-link.blade.php
+++ b/resources/views/components/port-link.blade.php
@@ -1,7 +1,7 @@
 <x-popup>
     @include('components.port-link_basic')
     <x-slot name="title">
-        <div class="tw-text-xl tw-font-bold">{{ $port->device->displayName() }} - {{ $label }}</div>
+        <div class="tw-text-xl tw-font-bold">{{ $port->device?->displayName() }} - {{ $label }}</div>
         <div>{{ $description }}</div>
     </x-slot>
     <x-slot name="body">


### PR DESCRIPTION
Fixes ports that somehow do not have a device trying to be linked to.

https://community.librenms.org/t/selecting-the-ports-menu-for-each-device-switches-to-an-error-page/24764/7

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
