### PR TITLE
WebUI - Dark mode menu fix

### DIFF
--- a/html/css/dark.css
+++ b/html/css/dark.css
@@ -3697,7 +3697,7 @@
   @media (min-width: 768px) {
     .navbar-right .dropdown-menu {
       right: 0;
-      left: auto;
+      /* left: auto; !! - let dropdowns.less handle */
     }
     .navbar-right .dropdown-menu-left {
       right: auto;


### PR DESCRIPTION
Related to: https://github.com/librenms/librenms/issues/16095

No longer has menu overlap.
![image](https://github.com/librenms/librenms/assets/5092581/dcf7f203-33cb-4067-8e38-5cb580ed9a55)

Doesn't seem to have any negative impact on other sub-dropdown.
![image](https://github.com/librenms/librenms/assets/5092581/2bc82ce3-15bd-44e7-b32d-b44d974abe1a)


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
