### PR TITLE
Updated nvidia poller app: handle slightly changed nvidia-smi output …

### DIFF
--- a/includes/polling/applications/nvidia.inc.php
+++ b/includes/polling/applications/nvidia.inc.php
@@ -33,7 +33,7 @@ $metrics = [];
 foreach ($gpuArray as $index => $gpu) {
     $stats = explode(',', $gpu);
     $stats_count = count($stats);
-    if ($stats_count == 22) {
+    if ($stats_count == 22 || $stats_count == 23) {
         [$gpu, $pwr, $temp, $memtemp, $sm, $mem, $enc, $dec, $jpg, $ofa,
             $mclk, $pclk, $pviol, $tviol, $fb, $bar1, $ccpm, $sbecc, $dbecc,
             $pci, $rxpci, $txpci] = $stats;


### PR DESCRIPTION
After my previous update (librenms#15756) to make the nvidia poller app compatible with an increased number of measurements of newer ``nvidia-smi`` Nvidia changed the output formatting slightly like it already happened in the past (librenms#14736). This changes will make die poller app compatible with this new formatting while it will still support older formatting and older versions of ``nvidia-smi``-data.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
