### PR TITLE
Add support for snmpsim-lextudio

### DIFF
--- a/LibreNMS/Util/Snmpsim.php
+++ b/LibreNMS/Util/Snmpsim.php
@@ -78,7 +78,7 @@ class Snmpsim
             passthru($this->getCmd(false) . ' --validate-data');
 
             if (! is_executable($this->findSnmpsimd())) {
-                echo "\nCould not find snmpsim, you can install it with 'pip install snmpsim'.  If it is already installed, make sure snmpsimd or snmpsimd.py is in PATH\n";
+                echo "\nCould not find snmpsim, you can install it with 'pip install snmpsim-lextudio'.  If it is already installed, make sure snmpsimd, snmpsim-command-responder or snmpsimd.py is in PATH\n";
             } else {
                 echo "\nFailed to start Snmpsim. Scroll up for error.\n";
             }
@@ -179,7 +179,10 @@ class Snmpsim
     {
         $cmd = Config::locateBinary('snmpsimd');
         if (! is_executable($cmd)) {
-            $cmd = Config::locateBinary('snmpsimd.py');
+            $cmd = Config::locateBinary('snmpsim-command-responder');
+            if (! is_executable($cmd)) {
+                $cmd = Config::locateBinary('snmpsimd.py');
+            }
         }
 
         return $cmd;


### PR DESCRIPTION
Ilya Etingof, the author of the original snmpsim/pysnmp projects passed away on 10-Aug-2022.
His snmpsim version doesn't work anymore with the current python version (3.12).
This adds compatibility for the https://github.com/lextudio/snmpsim fork, which works with python 3.12.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [X] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
