### PR TITLE
[webui] Ports: correct sorting order when using ifName

### DIFF
--- a/app/Http/Controllers/Device/Tabs/PortsController.php
+++ b/app/Http/Controllers/Device/Tabs/PortsController.php
@@ -373,6 +373,11 @@ class PortsController implements DeviceTab
             ->when(! $this->settings['ignored'], fn (Builder $q, $disabled) => $q->where('ignore', 0))
             ->when($this->settings['admin'] != 'any', fn (Builder $q, $admin) => $q->where('ifAdminStatus', $this->settings['admin']))
             ->when($this->settings['status'] != 'any', fn (Builder $q, $admin) => $q->where('ifOperStatus', $this->settings['status']))
+            ->when($this->settings['sort'] == 'port', fn (Builder $q, $sort) => $q
+                ->orderByRaw('SOUNDEX(ifName) ' . $this->settings['order'])
+                ->orderByRaw('CHAR_LENGTH(ifName) ' . $this->settings['order'])
+                ->orderByRaw('lower(ifName) ' . $this->settings['order'])
+            )
             ->orderBy($orderBy, $this->settings['order']);
     }
 


### PR DESCRIPTION
fix incorrect sorting order when using ifName as sort key

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
