### PR TITLE
extend update for wireguard, correct is_int to is_numeric for polling purposes, and clean up the app page

### DIFF
--- a/includes/html/pages/device/apps/wireguard.inc.php
+++ b/includes/html/pages/device/apps/wireguard.inc.php
@@ -24,7 +24,7 @@ $label =
     (! isset($vars['wg_page']) && ! isset($vars['interface']))
             ? '<span class="pagemenu-selected">All Interfaces</span>'
             : 'All Interfaces';
-    echo generate_link($label, $link_array);
+echo generate_link($label, $link_array);
 if (count($returned_data) > 0) {
     echo ' | ';
     $label =

--- a/includes/html/pages/device/apps/wireguard.inc.php
+++ b/includes/html/pages/device/apps/wireguard.inc.php
@@ -15,6 +15,9 @@ $link_array = [
 $interface_client_map = $app->data['mappings'] ?? [];
 $returned_data = $app->data['data'] ?? [];
 
+// put interfaces in order
+ksort($interface_client_map);
+
 print_optionbar_start();
 
 $label =
@@ -67,8 +70,11 @@ foreach ($interface_client_map as $interface => $client_list) {
     $i++;
 }
 
-//
+// if we have a interface specified and it exists, print a list of peers
 if (isset($vars['interface']) && isset($interface_client_map[$vars['interface']])) {
+    // order the peer information for the interface
+    asort($interface_client_map[$vars['interface']]);
+
     $i = 0;
     echo '<br>Peers: ';
     foreach ($interface_client_map[$vars['interface']] as $peer_key => $peer) {
@@ -103,7 +109,9 @@ if (isset($vars['wg_page']) and $vars['wg_page'] == 'details') {
         ],
         'rows' => [],
     ];
+    ksort($returned_data);
     foreach ($returned_data as $returned_data_key => $interface) {
+        ksort($interface);
         $port = Port::with('device')->firstWhere(['ifName' => $returned_data_key, 'device_id' => $device['device_id']]);
         if (isset($port)) {
             $interface_info_raw = true;

--- a/includes/html/pages/device/apps/wireguard.inc.php
+++ b/includes/html/pages/device/apps/wireguard.inc.php
@@ -36,11 +36,30 @@ echo ' | Interfaces: ';
 $i = 0;
 foreach ($interface_client_map as $interface => $client_list) {
     $label =
-        $vars['interface'] == $interface
+        ($vars['interface'] == $interface && ! isset($vars['wg_page']))
             ? '<span class="pagemenu-selected">' . $interface . '</span>'
             : $interface;
 
     echo generate_link($label, $link_array, ['interface' => $interface]);
+
+    echo '(';
+
+    $label =
+        ($vars['interface'] == $interface && $vars['wg_page'] == 'peer_bw')
+            ? '<span class="pagemenu-selected">' . 'BW' . '</span>'
+            : 'BW';
+
+    echo generate_link($label, $link_array, ['interface' => $interface, 'wg_page' => 'peer_bw']);
+
+    echo ', ';
+
+    $label =
+        ($vars['interface'] == $interface && $vars['wg_page'] == 'peer_last')
+            ? '<span class="pagemenu-selected">' . 'Last' . '</span>'
+            : 'Last';
+    echo generate_link($label, $link_array, ['interface' => $interface, 'wg_page' => 'peer_last']);
+
+    echo ')';
 
     if ($i < count(array_keys($interface_client_map)) - 1) {
         echo ', ';
@@ -51,7 +70,7 @@ foreach ($interface_client_map as $interface => $client_list) {
 //
 if (isset($vars['interface']) && isset($interface_client_map[$vars['interface']])) {
     $i = 0;
-    echo '<br>Clients: ';
+    echo '<br>Peers: ';
     foreach ($interface_client_map[$vars['interface']] as $peer_key => $peer) {
         $label =
             $vars['client'] == $peer
@@ -200,6 +219,32 @@ if (isset($vars['wg_page']) and $vars['wg_page'] == 'details') {
             'description' => 'Total Wireguard Traffic',
         ],
     ];
+} elseif (isset($vars['interface']) && ! isset($vars['client']) && $vars['wg_page'] == 'peer_bw') {
+    $graphs = [
+        'interface_total' => [
+            'type' => 'wireguard_traffic',
+            'description' => 'Total Wireguard Traffic, ' . $vars['interface'],
+            'interface' => $vars['interface'],
+        ],
+    ];
+    foreach ($interface_client_map[$vars['interface']] as $peer_key => $peer) {
+        $graphs['peer_bw_' . $peer] = [
+            'type' => 'wireguard_traffic',
+            'description' => 'Peer Traffic, ' . $vars['interface'] . ' - ' . $peer,
+            'interface' => $vars['interface'],
+            'client' => $peer,
+        ];
+    }
+} elseif (isset($vars['interface']) && ! isset($vars['client']) && $vars['wg_page'] == 'peer_last') {
+    $graphs = [];
+    foreach ($interface_client_map[$vars['interface']] as $peer_key => $peer) {
+        $graphs['peer_last_' . $peer] = [
+            'type' => 'wireguard_time',
+            'description' => 'Peer Minutes Since Last Handshake , ' . $vars['interface'] . ' - ' . $peer,
+            'interface' => $vars['interface'],
+            'client' => $peer,
+        ];
+    }
 } elseif (isset($vars['interface']) && ! isset($vars['client'])) {
     $graphs = [
         'interface_total' => [
@@ -212,13 +257,13 @@ if (isset($vars['wg_page']) and $vars['wg_page'] == 'details') {
     $graphs = [
         'client_bw' => [
             'type' => 'wireguard_traffic',
-            'description' => 'Client Traffic, ' . $vars['interface'] . ' - ' . $vars['client'],
+            'description' => 'Peer Traffic, ' . $vars['interface'] . ' - ' . $vars['client'],
             'interface' => $vars['interface'],
             'client' => $vars['client'],
         ],
         'client_handshake' => [
             'type' => 'wireguard_time',
-            'description' => 'Client Minutes Since Last Handshake , ' . $vars['interface'] . ' - ' . $vars['client'],
+            'description' => 'Peer Minutes Since Last Handshake , ' . $vars['interface'] . ' - ' . $vars['client'],
             'interface' => $vars['interface'],
             'client' => $vars['client'],
         ],

--- a/includes/html/pages/device/apps/wireguard.inc.php
+++ b/includes/html/pages/device/apps/wireguard.inc.php
@@ -303,11 +303,11 @@ if (isset($vars['wg_page']) and $vars['wg_page'] == 'details') {
                     }
                 }
             }
-
+            $peer['pubkey'] = generate_link($peer['pubkey'], $link_array, ['interface' => $returned_data_key, 'client' => $interface_key]);
             $row = [
                 ['data' => $name, 'raw' => $name_raw],
                 ['data' => $interface_info, 'raw' => $interface_info_raw],
-                ['data' => $peer['pubkey']],
+                ['data' => $peer['pubkey'], 'raw' => true],
                 ['data' => $peer['bytes_rcvd']],
                 ['data' => $peer['bytes_sent']],
                 ['data' => $peer['endpoint_host'], 'raw' => $endpoint_raw],

--- a/includes/html/pages/device/apps/wireguard.inc.php
+++ b/includes/html/pages/device/apps/wireguard.inc.php
@@ -303,7 +303,7 @@ if (isset($vars['wg_page']) and $vars['wg_page'] == 'details') {
                     }
                 }
             }
-            $peer['pubkey'] = generate_link($peer['pubkey'], $link_array, ['interface' => $returned_data_key, 'client' => $interface_key]);
+            $peer['pubkey'] = generate_link(htmlspecialchars($peer['pubkey']), $link_array, ['interface' => $returned_data_key, 'client' => $interface_key]);
             $row = [
                 ['data' => $name, 'raw' => $name_raw],
                 ['data' => $interface_info, 'raw' => $interface_info_raw],

--- a/includes/html/pages/device/apps/wireguard.inc.php
+++ b/includes/html/pages/device/apps/wireguard.inc.php
@@ -24,15 +24,15 @@ $label =
     (! isset($vars['wg_page']) && ! isset($vars['interface']))
             ? '<span class="pagemenu-selected">All Interfaces</span>'
             : 'All Interfaces';
-if (count($returned_data) > 0) {
     echo generate_link($label, $link_array);
+if (count($returned_data) > 0) {
     echo ' | ';
     $label =
         $vars['wg_page'] == 'details'
         ? '<span class="pagemenu-selected">Details</span>'
         : 'Details';
+    echo generate_link($label, $link_array, ['wg_page' => 'details']);
 }
-echo generate_link($label, $link_array, ['wg_page' => 'details']);
 echo ' | Interfaces: ';
 
 // generate interface links on the host application page

--- a/includes/html/pages/device/apps/wireguard.inc.php
+++ b/includes/html/pages/device/apps/wireguard.inc.php
@@ -76,7 +76,7 @@ if (isset($vars['interface']) && isset($interface_client_map[$vars['interface']]
             $vars['client'] == $peer
             ? '<span class="pagemenu-selected">' . $peer . '</span>'
             : $peer;
-        echo generate_link($label, $link_array, ['interface' => $interface, 'client'=>$peer]);
+        echo generate_link($label, $link_array, ['interface' => $interface, 'client' => $peer]);
 
         if ($i < count(array_keys($interface_client_map[$vars['interface']])) - 1) {
             echo ', ';

--- a/includes/html/pages/device/apps/wireguard.inc.php
+++ b/includes/html/pages/device/apps/wireguard.inc.php
@@ -104,9 +104,9 @@ if (isset($vars['interface']) &&
     if (isset($peer['hostname'])) {
         $peer_dev = Device::firstWhere(['hostname' => $peer['hostname']]);
         if (isset($peer_dev)) {
-            echo generate_device_link(['device_id' => $peer_dev->device_id], $name)."<br>\n";
+            echo generate_device_link(['device_id' => $peer_dev->device_id], $name) . "<br>\n";
         } else {
-            echo htmlspecialchars($peer['hostname'])."<br>\n";
+            echo htmlspecialchars($peer['hostname']) . "<br>\n";
         }
     } else {
         echo "*unknown*<br>\n";
@@ -115,7 +115,7 @@ if (isset($vars['interface']) &&
     if (is_null($peer['pubkey'])) {
         echo "*hidden*<br>\n";
     } else {
-        echo htmlspecialchars($peer['pubkey'])."<br>\n";
+        echo htmlspecialchars($peer['pubkey']) . "<br>\n";
     }
     echo 'Interface: ';
     $port = Port::with('device')->firstWhere(['ifName' => $vars['interface'], 'device_id' => $device['device_id']]);
@@ -125,9 +125,9 @@ if (isset($vars['interface']) &&
             'port_id' => $port->port_id,
             'ifName' => $port->ifName,
             'device_id' => $port->device_id,
-        ])."<br>\n";
+        ]) . "<br>\n";
     } else {
-        echo htmlspecialchars($vars['interface'])."<br>\n";
+        echo htmlspecialchars($vars['interface']) . "<br>\n";
     }
     echo 'Endpoint Host: ';
     if (preg_match('/^[\:A-Fa-f0-9]+$/', $peer['endpoint_host'])) {
@@ -137,7 +137,7 @@ if (isset($vars['interface']) &&
     }
     if (isset($ip_info)) {
         $port = Port::with('device')->firstWhere(['port_id' => $ip_info->port_id]);
-        echo $peer['endpoint_host']. '(' . generate_device_link(['device_id' => $port->device_id]) . ', ' .
+        echo $peer['endpoint_host'] . '(' . generate_device_link(['device_id' => $port->device_id]) . ', ' .
             generate_port_link([
                 'label' => $port->label,
                 'port_id' => $port->port_id,
@@ -145,10 +145,10 @@ if (isset($vars['interface']) &&
                 'device_id' => $port->device_id,
             ]) . ")<br>\n";
     } else {
-        echo htmlspecialchars($peer['endpoint_host'])."<br>\n";
+        echo htmlspecialchars($peer['endpoint_host']) . "<br>\n";
     }
-    echo 'Endpoint Port: '.htmlspecialchars($peer['endpoint_port'])."<br>\n";
-    echo 'Minutes Since Last Handshake: '.htmlspecialchars($peer['minutes_since_last_handshake'])."<br>\n";
+    echo 'Endpoint Port: ' . htmlspecialchars($peer['endpoint_port']) . "<br>\n";
+    echo 'Minutes Since Last Handshake: ' . htmlspecialchars($peer['minutes_since_last_handshake']) . "<br>\n";
     echo 'Allowed IPs: ';
     $allowed_ips = '';
     if (isset($peer['allowed_ips']) && ! is_null($peer['allowed_ips']) && is_array($peer['allowed_ips'])) {
@@ -188,7 +188,7 @@ if (isset($vars['interface']) &&
             }
         }
     }
-    echo $allowed_ips."<br>\n";
+    echo $allowed_ips . "<br>\n";
 }
 
 print_optionbar_end();

--- a/includes/polling/applications/wireguard.inc.php
+++ b/includes/polling/applications/wireguard.inc.php
@@ -170,11 +170,13 @@ $mappings_updated = false;
 // get old mappings
 $old_mappings = $app->data['mappings'] ?? [];
 
+// update here even if there are no added or reel in any changes for table info display
+$app->data = ['mappings' => $mappings, 'data' => $interface_client_map];
+
 // check for interface changes
 $added_interfaces = array_diff_key($mappings, $old_mappings);
 $removed_interfaces = array_diff_key($old_mappings, $mappings);
 if (count($added_interfaces) > 0 || count($removed_interfaces) > 0) {
-    $app->data = ['mappings' => $mappings];
     $mappings_updated = true;
     $log_message = 'Wireguard Interfaces Change:';
     $log_message .=

--- a/includes/polling/applications/wireguard.inc.php
+++ b/includes/polling/applications/wireguard.inc.php
@@ -84,24 +84,24 @@ foreach ($interface_client_map as $interface => $client_list) {
         }
 
         array_push($mappings[$finterface], $fclient);
-        $bytes_rcvd = is_int($client_data['bytes_rcvd'])
+        $bytes_rcvd = is_numeric($client_data['bytes_rcvd'])
             ? $client_data['bytes_rcvd']
             : null;
-        $bytes_sent = is_int($client_data['bytes_sent'])
+        $bytes_sent = is_numeric($client_data['bytes_sent'])
             ? $client_data['bytes_sent']
             : null;
-        $minutes_since_last_handshake = is_int(
+        $minutes_since_last_handshake = is_numeric(
             $client_data['minutes_since_last_handshake']
         )
             ? $client_data['minutes_since_last_handshake']
             : null;
 
-        if (is_int($bytes_rcvd)) {
+        if (is_numeric($bytes_rcvd)) {
             $bytes_rcvd_total_intf += $bytes_rcvd;
             $bytes_rcvd_total += $bytes_rcvd;
         }
 
-        if (is_int($bytes_sent)) {
+        if (is_numeric($bytes_sent)) {
             $bytes_sent_total_intf += $bytes_sent;
             $bytes_sent_total += $bytes_sent;
         }

--- a/tests/data/linux_wireguard-v1.json
+++ b/tests/data/linux_wireguard-v1.json
@@ -44,7 +44,7 @@
                     "app_state_prev": "UNKNOWN",
                     "app_status": "",
                     "app_instance": "",
-                    "data": "{\"mappings\":{\"wg0\":[\"client1.domain.com\",\"client2\",\"my_phone\",\"it_admin.domain.org\",\"computer\"]}}",
+                    "data": "{\"mappings\":{\"wg0\":[\"client1.domain.com\",\"client2\",\"my_phone\",\"it_admin.domain.org\",\"computer\"]},\"data\":{\"wg0\":{\"client1.domain.com\":{\"minutes_since_last_handshake\":null,\"bytes_rcvd\":0,\"bytes_sent\":0},\"client2\":{\"minutes_since_last_handshake\":null,\"bytes_rcvd\":0,\"bytes_sent\":0},\"my_phone\":{\"minutes_since_last_handshake\":null,\"bytes_rcvd\":0,\"bytes_sent\":0},\"it_admin.domain.org\":{\"minutes_since_last_handshake\":null,\"bytes_rcvd\":0,\"bytes_sent\":0},\"computer\":{\"minutes_since_last_handshake\":2,\"bytes_rcvd\":14891148,\"bytes_sent\":105501824}}}}",
                     "deleted_at": null
                 }
             ],


### PR DESCRIPTION
The new extend has capabilities to automatically resolve pubkeys to a name, potentially negating the need to use a config.

old: https://i.imgur.com/BAQwkUt.png

new totals/all page: https://i.imgur.com/IO4pPoC.png
new details page: https://i.imgur.com/vPg4Lrs.png
new interface page: https://i.imgur.com/IfRDeh3.png
new interface peer bw page: https://i.imgur.com/fQgxxzx.png
new interface peer last handshake page: https://i.imgur.com/lcJqlNg.png
new interface peer page: https://i.imgur.com/KBEwcNB.png

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
