### PR TITLE
InfluxDBv2 allow filter by group and disable debug by default

### DIFF
--- a/LibreNMS/Data/Store/InfluxDBv2.php
+++ b/LibreNMS/Data/Store/InfluxDBv2.php
@@ -91,7 +91,7 @@ class InfluxDBv2 extends BaseDatastore
 
         if (empty($tmp_fields)) {
             Log::warning('All fields empty, skipping update', ['orig_fields' => $fields]);
-            
+
             return;
         }
 

--- a/LibreNMS/Data/Store/InfluxDBv2.php
+++ b/LibreNMS/Data/Store/InfluxDBv2.php
@@ -72,7 +72,7 @@ class InfluxDBv2 extends BaseDatastore
                 // The group name will always be parsed as lowercase, even when uppercase in the GUI.
                 if (in_array(strtoupper($group->name), array_map('strtoupper', $excluded_groups))) {
                     Log::warning('Skipped parsing to InfluxDBv2, device is in group: ' . $group->name);
-    
+
                     return;
                 }
             }

--- a/LibreNMS/Data/Store/InfluxDBv2.php
+++ b/LibreNMS/Data/Store/InfluxDBv2.php
@@ -26,8 +26,8 @@
 
 namespace LibreNMS\Data\Store;
 
-use App\Polling\Measure\Measurement;
 use App\Models\Device;
+use App\Polling\Measure\Measurement;
 use InfluxDB2\Client;
 use InfluxDB2\Model\WritePrecision;
 use InfluxDB2\Point;
@@ -69,6 +69,7 @@ class InfluxDBv2 extends BaseDatastore
             // The group name will always be parsed as lowercase, even when uppercase in the GUI.
             if (in_array(strtoupper($group->name), array_map('strtoupper', Config::get('influxdbv2.groups-exclude')))) {
                 Log::warning("Skipped parsing to InfluxDBv2, device is in group: " . $group->name);
+
                 return;
             }
         }

--- a/LibreNMS/Data/Store/InfluxDBv2.php
+++ b/LibreNMS/Data/Store/InfluxDBv2.php
@@ -26,7 +26,7 @@
 
 namespace LibreNMS\Data\Store;
 
-use App\Models\Device;
+use App\Facades\DeviceCache;
 use App\Polling\Measure\Measurement;
 use InfluxDB2\Client;
 use InfluxDB2\Model\WritePrecision;
@@ -63,7 +63,7 @@ class InfluxDBv2 extends BaseDatastore
      */
     public function put($device, $measurement, $tags, $fields)
     {
-        $device_data = Device::find($device['device_id']);
+        $device_data = DeviceCache::get($device['device_id']);
         $device_groups = $device_data->groups;
         foreach ($device_groups as $group) {
             // The group name will always be parsed as lowercase, even when uppercase in the GUI.

--- a/LibreNMS/Data/Store/InfluxDBv2.php
+++ b/LibreNMS/Data/Store/InfluxDBv2.php
@@ -64,13 +64,17 @@ class InfluxDBv2 extends BaseDatastore
     public function put($device, $measurement, $tags, $fields)
     {
         $device_data = DeviceCache::get($device['device_id']);
-        $device_groups = $device_data->groups;
-        foreach ($device_groups as $group) {
-            // The group name will always be parsed as lowercase, even when uppercase in the GUI.
-            if (in_array(strtoupper($group->name), array_map('strtoupper', Config::get('influxdbv2.groups-exclude')))) {
-                Log::warning('Skipped parsing to InfluxDBv2, device is in group: ' . $group->name);
+        $excluded_groups = Config::get('influxdbv2.groups-exclude');
 
-                return;
+        if (! empty($excluded_groups)) {
+            $device_groups = $device_data->groups;
+            foreach ($device_groups as $group) {
+                // The group name will always be parsed as lowercase, even when uppercase in the GUI.
+                if (in_array(strtoupper($group->name), array_map('strtoupper', $excluded_groups))) {
+                    Log::warning('Skipped parsing to InfluxDBv2, device is in group: ' . $group->name);
+    
+                    return;
+                }
             }
         }
 

--- a/LibreNMS/Data/Store/InfluxDBv2.php
+++ b/LibreNMS/Data/Store/InfluxDBv2.php
@@ -68,7 +68,7 @@ class InfluxDBv2 extends BaseDatastore
         foreach ($device_groups as $group) {
             // The group name will always be parsed as lowercase, even when uppercase in the GUI.
             if (in_array(strtoupper($group->name), array_map('strtoupper', Config::get('influxdbv2.groups-exclude')))) {
-                Log::warning("Skipped parsing to InfluxDBv2, device is in group: " . $group->name);
+                Log::warning('Skipped parsing to InfluxDBv2, device is in group: ' . $group->name);
 
                 return;
             }

--- a/LibreNMS/Data/Store/InfluxDBv2.php
+++ b/LibreNMS/Data/Store/InfluxDBv2.php
@@ -61,15 +61,13 @@ class InfluxDBv2 extends BaseDatastore
      * @param  array|mixed  $fields  The data to update in an associative array, the order must be consistent with rrd_def,
      *                               single values are allowed and will be paired with $measurement
      */
-
-
     public function put($device, $measurement, $tags, $fields)
     {
         // Transform $device['ip'] to be ingestable by inNetworks
         $ip = IP::parse($device['ip']);
 
         if ($ip->inNetworks(Config::get('influxdbv2.nets-exclude'))) {
-          return;
+            return;
         }
 
         $stat = Measurement::start('write');
@@ -93,6 +91,7 @@ class InfluxDBv2 extends BaseDatastore
 
         if (empty($tmp_fields)) {
             Log::warning('All fields empty, skipping update', ['orig_fields' => $fields]);
+            
             return;
         }
 
@@ -152,7 +151,7 @@ class InfluxDBv2 extends BaseDatastore
             'org' => $organization,
             'precision' => WritePrecision::S,
             'allow_redirects' => $allow_redirects,
-            'debug' => $debug
+            'debug' => $debug,
         ]);
 
         return $client;

--- a/doc/Extensions/metrics/InfluxDBv2.md
+++ b/doc/Extensions/metrics/InfluxDBv2.md
@@ -40,7 +40,7 @@ continue to function as normal.
     lnms config:set influxdbv2.allow_redirect true
     lmns config:set influxdbv2.organization 'librenms'
     lmns config:set influxdbv2.debug false
-    lmns config:set influxdbv2.nets-exclude ["10.10.10.10/24","20.20.20.20/32"]
+    lmns config:set influxdbv2.groups-exclude ["group_name_1","group_name_2"]
     ```
 
 The same data stored within rrd will be sent to InfluxDB and

--- a/doc/Extensions/metrics/InfluxDBv2.md
+++ b/doc/Extensions/metrics/InfluxDBv2.md
@@ -39,8 +39,12 @@ continue to function as normal.
     lnms config:set influxdbv2.token 'admin'
     lnms config:set influxdbv2.allow_redirect true
     lmns config:set influxdbv2.organization 'librenms'
+    lmns config:set influxdbv2.debug false
+    lmns config:set influxdbv2.nets-exclude ["10.10.10.10/24","20.20.20.20/32"]
     ```
 
 The same data stored within rrd will be sent to InfluxDB and
 recorded. You can then create graphs within Grafana or InfluxDB to display the
 information you need.
+
+Please note that polling will slow down when the poller isn't able to reach or write data to InfluxDBv2.

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -982,9 +982,9 @@ return [
                 'description' => 'Debug',
                 'help' => 'To enable or disable verbose output to CLI',
             ],
-            'nets-exclude' => [
-                'description' => 'Excluded networks',
-                'help' => 'Networks excluded from sending data to InfluxDBv2',
+            'groups-exclude' => [
+                'description' => 'Excluded device groups',
+                'help' => 'Device groups excluded from sending data to InfluxDBv2',
             ],
         ],
         'ipmitool' => [

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -978,7 +978,14 @@ return [
                 'description' => 'Allow Redirects',
                 'help' => 'To allow redirect from the InfluxDB server',
             ],
-
+            'debug' => [
+                'description' => 'Debug',
+                'help' => 'To enable or disable verbose output to CLI',
+            ],
+            'nets-exclude' => [
+                'description' => 'Excluded networks',
+                'help' => 'Networks excluded from sending data to InfluxDBv2',
+            ],
         ],
         'ipmitool' => [
             'description' => 'Path to ipmtool',

--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -4122,6 +4122,21 @@
             "section": "influxdbv2",
             "order": 7
         },
+        "influxdbv2.debug": {
+            "default": false,
+            "type": "boolean",
+            "group": "poller",
+            "section": "influxdbv2",
+            "order": 8
+        },
+        "influxdbv2.nets-exclude": {
+            "group": "poller",
+            "section": "influxdbv2",
+            "order": 9,
+            "type": "array",
+            "default": [
+            ]
+        },
         "install_dir": {
             "type": "directory"
         },

--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -4129,7 +4129,7 @@
             "section": "influxdbv2",
             "order": 8
         },
-        "influxdbv2.nets-exclude": {
+        "influxdbv2.groups-exclude": {
             "group": "poller",
             "section": "influxdbv2",
             "order": 9,


### PR DESCRIPTION
**Please give a short description what your pull request is for**

- Addition of the option to turn debug logging of the InfluxDBv2 datastore off instead of it always being on. 
- Addition of the ability to exclude networks from logging data to InfluxDBv2.
  - This may be useful when: 
    - You have multiple customers on the same platform, but don't want the data from all customers in InfluxDBv2.
    - You run a poller for specific devices in an environment that wont be able to reach the InfluxDBv2 database.

**Screenshot of the InfluxDBv2 Datastore settings**
![image](https://github.com/librenms/librenms/assets/14372332/269ec1d3-60ca-4f03-afcb-bb08ffd4733f)

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [X] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
