### PR TITLE
 MS Teams alert: replace messagecard with adaptivecard #16190 

### DIFF
--- a/LibreNMS/Alert/Transport/Msteams.php
+++ b/LibreNMS/Alert/Transport/Msteams.php
@@ -69,7 +69,6 @@ class Msteams extends Transport
         $client->withBody($data, 'application/json');
         $res = $client->post($this->config['msteam-url'], $data);
 
-
         if ($res->successful()) {
             return true;
         }

--- a/LibreNMS/Alert/Transport/Msteams.php
+++ b/LibreNMS/Alert/Transport/Msteams.php
@@ -42,8 +42,8 @@ class Msteams extends Transport
         "items": [
           {
             "type": "TextBlock",
-            "text": "'. $alert_data['title'] .'",
-            "color": "'. $translate_color .'",
+            "text": "' . $alert_data['title'] . '",
+            "color": "' . $translate_color . '",
             "weight": "bolder",
             "size": "medium"
           }
@@ -54,7 +54,7 @@ class Msteams extends Transport
         "items": [
           {
             "type": "TextBlock",
-            "text": "'. strip_tags($alert_data['msg'], '<strong><em><h1><h2><h3><strike><ul><ol><li><pre><blockquote><a><img><p>') .'",
+            "text": "' . strip_tags($alert_data['msg'], '<strong><em><h1><h2><h3><strike><ul><ol><li><pre><blockquote><a><img><p>') . '",
             "wrap": true
           }
         ]
@@ -74,7 +74,7 @@ class Msteams extends Transport
             return true;
         }
 
-        throw new AlertTransportDeliveryException($alert_data, $res->status(), $res->body(), $data['text'], $data);
+        throw new AlertTransportDeliveryException($alert_data, $res->status(), $res->body(), $data, $data);
     }
 
     public static function configTemplate(): array

--- a/LibreNMS/Alert/Transport/Msteams.php
+++ b/LibreNMS/Alert/Transport/Msteams.php
@@ -22,25 +22,53 @@ class Msteams extends Transport
 
     public function deliverAlert(array $alert_data): bool
     {
-        $data = [
-            'title' => $alert_data['title'],
-            'themeColor' => self::getColorForState($alert_data['state']),
-            'text' => strip_tags($alert_data['msg'], '<strong><em><h1><h2><h3><strike><ul><ol><li><pre><blockquote><a><img><p>'),
-            'summary' => $alert_data['title'],
-        ];
-
+        $translate_color = $alert_data['state'] == '1'
+            ? 'Attention'
+            : 'Good';
+        $data = '
+{
+       "type":"message",
+       "attachments":[
+          {
+             "contentType":"application/vnd.microsoft.card.adaptive",
+             "contentUrl":null,
+             "content":{
+                "$schema":"http://adaptivecards.io/schemas/adaptive-card.json",
+                        "type": "AdaptiveCard",
+                        "version": "1.4",
+    "body": [
+      {
+        "type": "Container",
+        "items": [
+          {
+            "type": "TextBlock",
+            "text": "'. $alert_data['title'] .'",
+            "color": "'. $translate_color .'",
+            "weight": "bolder",
+            "size": "medium"
+          }
+        ]
+      },
+      {
+        "type": "Container",
+        "items": [
+          {
+            "type": "TextBlock",
+            "text": "'. strip_tags($alert_data['msg'], '<strong><em><h1><h2><h3><strike><ul><ol><li><pre><blockquote><a><img><p>') .'",
+            "wrap": true
+          }
+        ]
+      }
+    ]
+   }
+  }
+ ]
+}  
+';
         $client = Http::client();
-
-        // template will contain raw json
-        if ($this->config['use-json'] === 'on') {
-            $msg = $alert_data['uid'] === '000'
-                ? $this->messageCard() // use pre-made MessageCard for tests
-                : $alert_data['msg'];
-
-            $client->withBody($msg, 'application/json');
-        }
-
+        $client->withBody($data, 'application/json');
         $res = $client->post($this->config['msteam-url'], $data);
+
 
         if ($res->successful()) {
             return true;
@@ -54,66 +82,15 @@ class Msteams extends Transport
         return [
             'config' => [
                 [
-                    'title' => 'Webhook URL',
+                    'title' => 'Flow URL',
                     'name' => 'msteam-url',
-                    'descr' => 'Microsoft Teams Webhook URL',
+                    'descr' => 'Microsoft Teams workflow URL',
                     'type' => 'text',
-                ],
-                [
-                    'title' => 'Use JSON?',
-                    'name' => 'use-json',
-                    'descr' => 'Compose MessageCard with JSON rather than Markdown. Your template must be valid MessageCard JSON',
-                    'type' => 'checkbox',
-                    'default' => false,
                 ],
             ],
             'validation' => [
                 'msteam-url' => 'required|url',
             ],
         ];
-    }
-
-    private function messageCard(): string
-    {
-        return '{
-    "@context": "https://schema.org/extensions",
-    "@type": "MessageCard",
-    "potentialAction": [
-        {
-            "@type": "OpenUri",
-            "name": "View MessageCard Reference",
-            "targets": [
-                {
-                    "os": "default",
-                    "uri": "https://learn.microsoft.com/en-us/outlook/actionable-messages/message-card-reference"
-                }
-            ]
-        },
-        {
-            "@type": "OpenUri",
-            "name": "View LibreNMS Website",
-            "targets": [
-                {
-                    "os": "default",
-                    "uri": "https://www.librenms.org/"
-                }
-            ]
-        }
-    ],
-    "sections": [
-        {
-            "facts": [
-                {
-                    "name": "Next Action:",
-                    "value": "Make your alert template emit valid MessageCard Json"
-                }
-            ],
-            "text": "You have successfully sent a pre-formatted MessageCard message to teams."
-        }
-    ],
-    "summary": "Test Successful",
-    "themeColor": "0072C6",
-    "title": "Test MessageCard"
-}';
     }
 }


### PR DESCRIPTION
removes the old, deprecated webhook messagecard method, which will soon stop working, in favor of adaptivecard.
(it also removes the json slider)

Currently the adaptivecard is hardcoded and shows the users message (which can just be markdown).
In the future, a fuller edit could perhaps allow for the user to create the raw adaptivecard in the UI?

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
