### PR TITLE
Maps - Keep edge black when link is 0 bps

### DIFF
--- a/app/Http/Controllers/Maps/CustomMapDataController.php
+++ b/app/Http/Controllers/Maps/CustomMapDataController.php
@@ -125,8 +125,8 @@ class CustomMapDataController extends Controller
                     $edges[$edgeid]['colour_to'] = $this->speedColour($edges[$edgeid]['port_topct']);
                     $edges[$edgeid]['colour_from'] = $this->speedColour($edges[$edgeid]['port_frompct']);
                 }
-                $edges[$edgeid]['port_topct'] = round($edges[$edgeid]['port_topct'],2);
-                $edges[$edgeid]['port_frompct'] = round($edges[$edgeid]['port_frompct'],2);
+                $edges[$edgeid]['port_topct'] = round($edges[$edgeid]['port_topct'], 2);
+                $edges[$edgeid]['port_frompct'] = round($edges[$edgeid]['port_frompct'], 2);
                 $edges[$edgeid]['port_tobps'] = $this->rateString($rateto);
                 $edges[$edgeid]['port_frombps'] = $this->rateString($ratefrom);
                 $edges[$edgeid]['width_to'] = $this->speedWidth($speedto);

--- a/app/Http/Controllers/Maps/CustomMapDataController.php
+++ b/app/Http/Controllers/Maps/CustomMapDataController.php
@@ -114,8 +114,8 @@ class CustomMapDataController extends Controller
                     $edges[$edgeid]['port_topct'] = -1.0;
                     $edges[$edgeid]['port_frompct'] = -1.0;
                 } else {
-                    $edges[$edgeid]['port_topct'] = round($rateto / $speedto * 100.0, 2);
-                    $edges[$edgeid]['port_frompct'] = round($ratefrom / $speedfrom * 100.0, 2);
+                    $edges[$edgeid]['port_topct'] = $rateto / $speedto * 100.0;
+                    $edges[$edgeid]['port_frompct'] = $ratefrom / $speedfrom * 100.0;
                 }
                 if ($edge->port->ifOperStatus != 'up') {
                     // If the port is not online, show the same as speed unknown
@@ -125,6 +125,8 @@ class CustomMapDataController extends Controller
                     $edges[$edgeid]['colour_to'] = $this->speedColour($edges[$edgeid]['port_topct']);
                     $edges[$edgeid]['colour_from'] = $this->speedColour($edges[$edgeid]['port_frompct']);
                 }
+                $edges[$edgeid]['port_topct'] = round($edges[$edgeid]['port_topct'],2);
+                $edges[$edgeid]['port_frompct'] = round($edges[$edgeid]['port_frompct'],2);
                 $edges[$edgeid]['port_tobps'] = $this->rateString($rateto);
                 $edges[$edgeid]['port_frombps'] = $this->rateString($ratefrom);
                 $edges[$edgeid]['width_to'] = $this->speedWidth($speedto);
@@ -305,8 +307,8 @@ class CustomMapDataController extends Controller
     {
         // For the maths below, the 5.1 is worked out as 255 / 50
         // (255 being the max colour value and 50 is the max of the $pct calculation)
-        if ($pct < 0) {
-            // Black if we can't determine the percentage (link down or speed 0)
+        if ($pct <= 0) {
+            // Black if we can't determine the percentage (link down or speed 0), or link speed strictly 0
             return '#000000';
         } elseif ($pct < 50) {
             // 100% green and slowly increase the red until we get to yellow


### PR DESCRIPTION
This make it a little bit clearer on a map where you have active-standby devices (firewall, appliances etc). The standby device will be surrounded by mostly black edges.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
