### PR TITLE
Add value 0 to HP Physical Drive Status (meaning no disk is inserted)

### DIFF
--- a/includes/discovery/sensors/state/hp.inc.php
+++ b/includes/discovery/sensors/state/hp.inc.php
@@ -20,12 +20,13 @@
  * @link       https://www.librenms.org
  *
  * @copyright  2017 Neil Lathwood
- * @author     Neil Lathwood <neil@lathwood.co.uk>
+ * @author     Neil Lathwood <neil@lathwood.co.uk>, Rudy Broersma <r.broersma@ctnet.nl>
  */
 
 // One could add more entries from deviceGroup, but this will do as a start
 $tables = [
     ['cpqDaPhyDrvStatus', '.1.3.6.1.4.1.232.3.2.5.1.1.6.', 'Status', 'CPQIDA-MIB', [
+        ['value' => 0, 'generic' => 3, 'graph' => 0, 'descr' => 'noDisk'],
         ['value' => 1, 'generic' => 3, 'graph' => 0, 'descr' => 'other'],
         ['value' => 2, 'generic' => 0, 'graph' => 0, 'descr' => 'ok'],
         ['value' => 3, 'generic' => 2, 'graph' => 0, 'descr' => 'failed'],


### PR DESCRIPTION
This tiny patch adds the value of 0 to the state translation. Prior to this patch slots without a disk inserted would show 'OK' (in capitals) because LibreNMS didnt have a state translation for the value 0.

After this patch it shows 'noDisk'.

![afbeelding](https://github.com/user-attachments/assets/37da84b5-1293-4b2b-9ce8-ffab7aada30b)


#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [X] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
