### PR TITLE
F5-Loadbalancer module to support an expiration check of the installed certificates

### DIFF
--- a/app/Http/Controllers/Device/Tabs/LoadBalancerController.php
+++ b/app/Http/Controllers/Device/Tabs/LoadBalancerController.php
@@ -71,6 +71,9 @@ class LoadBalancerController implements DeviceTab
             if (isset($component_count['f5-gtm-pool'])) {
                 $this->tabs[] = 'gtm_pool';
             }
+            if (isset($component_count['f5-cert'])) {
+                $this->tabs[] = 'f5-cert';
+            }
         }
     }
 

--- a/includes/discovery/loadbalancers/f5-ltm.inc.php
+++ b/includes/discovery/loadbalancers/f5-ltm.inc.php
@@ -157,7 +157,7 @@ if (! empty($f5CertEntry) || ! empty($ltmBwcEntry) || ! empty($ltmVirtualServEnt
             // expiration value from snmpwalk is in seconds since 01.01.1970
             // we substract the current time, to get the time left until expiration
             // and convert it into days, for better human readability
-            $result['daysLeft'] = intval(( $array[$CERT_BASE_OID_NAME] - getdate()[0]) / (3600 * 24));
+            $result['daysLeft'] = intval(($array[$CERT_BASE_OID_NAME] - getdate()[0]) / (3600 * 24));
             // UID might be to long for use in a RRD filename, use a hash instead
             $result['hash'] = hash('crc32', $result['UID']);
 

--- a/includes/discovery/loadbalancers/f5-ltm.inc.php
+++ b/includes/discovery/loadbalancers/f5-ltm.inc.php
@@ -31,7 +31,7 @@ $components = $components[$device['device_id']] ?? [];
 
 // We extracted all the components for this device, now lets only get the LTM ones.
 $keep = [];
-$types = [$module, 'bigip', 'f5-ltm-bwc', 'f5-ltm-vs', 'f5-ltm-pool', 'f5-ltm-poolmember'];
+$types = [$module, 'bigip', 'f5-ltm-bwc', 'f5-ltm-vs', 'f5-ltm-pool', 'f5-ltm-poolmember', 'f5-cert'];
 foreach ($components as $k => $v) {
     foreach ($types as $type) {
         if ($v['type'] == $type) {
@@ -43,6 +43,19 @@ $components = $keep;
 
 // Begin our master array, all other values will be processed into this array.
 $tblBigIP = [];
+
+// Cert OIDs
+$f5CertOID = '.1.3.6.1.4.1.3375.2.1.15.1.2.1.5';
+//$f5CertEntry = [];
+// check for installed certs
+$f5CertEntry = snmpwalk_group($device, $f5CertOID, 'F5-BIGIP-SYSTEM-MIB');
+//If no Certs are found skip this part
+if (! empty($f5CertEntry)) {
+    d_echo("Found Certificates!");
+} else {
+    d_echo("No Certificates found\n");
+}
+
 
 // Virtual Server Data
 $ltmVirtualServOID = [
@@ -125,9 +138,57 @@ if (! empty($ltmBwcEntry['name'])) {
  * False == no object found - this is not an error, OID doesn't exist.
  * null  == timeout or something else that caused an error, OID may exist but we couldn't get it.
  */
-if (! empty($ltmBwcEntry) || ! empty($ltmVirtualServEntry) || ! empty($ltmPoolEntry) || ! empty($ltmPoolMemberEntry)) {
+if (! empty($f5CertEntry) || ! empty($ltmBwcEntry) || ! empty($ltmVirtualServEntry) || ! empty($ltmPoolEntry) || ! empty($ltmPoolMemberEntry)) {
     // No Nulls, lets go....
     d_echo("Objects Found:\n");
+
+    // Process Certificates
+    $CERT_BASE_OID_NAME = 'sysCertificateFileObjectExpirationDate';
+    $CERT_THRESHOLD_WARNING = 30;	// If Cert expires in less than this value (in days) => status = warning
+    $CERT_THRESHOLD_CRITICAL = 10;	// If Cert expires in less than this value (in days) => status = critical
+
+    if (is_array($f5CertEntry)) {
+	foreach ($f5CertEntry as $cert => $array) {
+	    $result = [];
+
+	    $result['type'] = 'f5-cert';
+	    $result['UID'] = $cert;
+	    $result['label'] = $cert;
+	    $result['raw'] = $array[$CERT_BASE_OID_NAME];
+	    // expiration value from snmpwalk is in seconds since 01.01.1970
+	    // we substract the current time, to get the time left until expiration
+	    // and convert it into days, for better human readability
+	    $result['daysLeft'] = intval(( $array[$CERT_BASE_OID_NAME] - getdate()[0]) / (3600 * 24));
+	    // UID might be to long for use in a RRD filename, use a hash instead
+	    $result['hash'] = hash('crc32', $result['UID']);
+
+	    //let's check when the cert expires
+	    if ($result['daysLeft'] <= 0) {
+	        $result['status'] = 2;
+		$result['error'] = "CRITICAL: Certificate is expired!";
+	    } elseif ($result['daysLeft'] <= $CERT_THRESHOLD_CRITICAL) {
+	        $result['status'] = 2;
+		$result['error'] = "CRITICAL: Certificate is about to expire in " . $result['daysLeft'] . " days!";
+	    } elseif ($result['daysLeft'] <= $CERT_THRESHOLD_WARNING) {
+                $result['status'] = 1;
+                $result['error'] = "WARNING: Certificate is about to expire in " . $result['daysLeft'] . " days!";
+	    } else {
+		$result['status'] = 0;
+		$result['error'] = "";
+	    }
+
+	    // Do we have any results
+            if (count($result) > 0) {
+                // Let's log some debugging
+                d_echo("\n\n" . $result['type'] . ' - ' . $result['label'] . ': ' . $result['daysLeft'] . "\n");
+                d_echo('    Status:  ' . $result['status'] . "\n");
+                d_echo('    Message: ' . $result['error'] . "\n");
+
+                // Add this result to the master array.
+                $tblBigIP[] = $result;
+            }
+	}
+    }
 
     // Process the Virtual Servers
     if (is_array($ltmVirtualServEntry['name'])) {
@@ -314,6 +375,7 @@ if (! empty($ltmBwcEntry) || ! empty($ltmVirtualServEntry) || ! empty($ltmPoolEn
      *
      * Let's loop over the SNMP data to see if we need to ADD or UPDATE any components.
      */
+
     foreach ($tblBigIP as $key => $array) {
         $component_key = false;
 

--- a/includes/discovery/loadbalancers/f5-ltm.inc.php
+++ b/includes/discovery/loadbalancers/f5-ltm.inc.php
@@ -164,24 +164,24 @@ if (! empty($f5CertEntry) || ! empty($ltmBwcEntry) || ! empty($ltmVirtualServEnt
             //let's check when the cert expires
             if ($result['daysLeft'] <= 0) {
                 $result['status'] = 2;
-                $result['error'] = "CRITICAL: Certificate is expired!";
+                $result['error'] = 'CRITICAL: Certificate is expired!';
             } elseif ($result['daysLeft'] <= $CERT_THRESHOLD_CRITICAL) {
                 $result['status'] = 2;
-                $result['error'] = "CRITICAL: Certificate is about to expire in " . $result['daysLeft'] . " days!";
+                $result['error'] = 'CRITICAL: Certificate is about to expire in ' . $result['daysLeft'] . ' days!';
             } elseif ($result['daysLeft'] <= $CERT_THRESHOLD_WARNING) {
                 $result['status'] = 1;
-                $result['error'] = "WARNING: Certificate is about to expire in " . $result['daysLeft'] . " days!";
+                $result['error'] = 'WARNING: Certificate is about to expire in ' . $result['daysLeft'] . ' days!';
             } else {
                 $result['status'] = 0;
-                $result['error'] = "";
+                $result['error'] = '';
             }
 
             // Do we have any results
             if (count($result) > 0) {
                 // Let's log some debugging
-                d_echo("\n\n" . $result['type'] . ' - ' . $result['label'] . ': ' . $result['daysLeft'] . "\n");
-                d_echo('    Status:  ' . $result['status'] . "\n");
-                d_echo('    Message: ' . $result['error'] . "\n");
+                d_echo('\n\n' . $result['type'] . ' - ' . $result['label'] . ': ' . $result['daysLeft'] . '\n');
+                d_echo('    Status:  ' . $result['status'] . '\n');
+                d_echo('    Message: ' . $result['error'] . '\n');
 
                 // Add this result to the master array.
                 $tblBigIP[] = $result;

--- a/includes/discovery/loadbalancers/f5-ltm.inc.php
+++ b/includes/discovery/loadbalancers/f5-ltm.inc.php
@@ -51,11 +51,10 @@ $f5CertOID = '.1.3.6.1.4.1.3375.2.1.15.1.2.1.5';
 $f5CertEntry = snmpwalk_group($device, $f5CertOID, 'F5-BIGIP-SYSTEM-MIB');
 //If no Certs are found skip this part
 if (! empty($f5CertEntry)) {
-    d_echo("Found Certificates!");
+    d_echo('Found Certificates!');
 } else {
-    d_echo("No Certificates found\n");
+    d_echo('No Certificates found\n');
 }
-
 
 // Virtual Server Data
 $ltmVirtualServOID = [
@@ -148,36 +147,36 @@ if (! empty($f5CertEntry) || ! empty($ltmBwcEntry) || ! empty($ltmVirtualServEnt
     $CERT_THRESHOLD_CRITICAL = 10;	// If Cert expires in less than this value (in days) => status = critical
 
     if (is_array($f5CertEntry)) {
-	foreach ($f5CertEntry as $cert => $array) {
-	    $result = [];
+        foreach ($f5CertEntry as $cert => $array) {
+            $result = [];
 
-	    $result['type'] = 'f5-cert';
-	    $result['UID'] = $cert;
-	    $result['label'] = $cert;
-	    $result['raw'] = $array[$CERT_BASE_OID_NAME];
-	    // expiration value from snmpwalk is in seconds since 01.01.1970
-	    // we substract the current time, to get the time left until expiration
-	    // and convert it into days, for better human readability
-	    $result['daysLeft'] = intval(( $array[$CERT_BASE_OID_NAME] - getdate()[0]) / (3600 * 24));
-	    // UID might be to long for use in a RRD filename, use a hash instead
-	    $result['hash'] = hash('crc32', $result['UID']);
+            $result['type'] = 'f5-cert';
+            $result['UID'] = $cert;
+            $result['label'] = $cert;
+            $result['raw'] = $array[$CERT_BASE_OID_NAME];
+            // expiration value from snmpwalk is in seconds since 01.01.1970
+            // we substract the current time, to get the time left until expiration
+            // and convert it into days, for better human readability
+            $result['daysLeft'] = intval(( $array[$CERT_BASE_OID_NAME] - getdate()[0]) / (3600 * 24));
+            // UID might be to long for use in a RRD filename, use a hash instead
+            $result['hash'] = hash('crc32', $result['UID']);
 
-	    //let's check when the cert expires
-	    if ($result['daysLeft'] <= 0) {
-	        $result['status'] = 2;
-		$result['error'] = "CRITICAL: Certificate is expired!";
-	    } elseif ($result['daysLeft'] <= $CERT_THRESHOLD_CRITICAL) {
-	        $result['status'] = 2;
-		$result['error'] = "CRITICAL: Certificate is about to expire in " . $result['daysLeft'] . " days!";
-	    } elseif ($result['daysLeft'] <= $CERT_THRESHOLD_WARNING) {
+            //let's check when the cert expires
+            if ($result['daysLeft'] <= 0) {
+                $result['status'] = 2;
+                $result['error'] = "CRITICAL: Certificate is expired!";
+            } elseif ($result['daysLeft'] <= $CERT_THRESHOLD_CRITICAL) {
+                $result['status'] = 2;
+                $result['error'] = "CRITICAL: Certificate is about to expire in " . $result['daysLeft'] . " days!";
+            } elseif ($result['daysLeft'] <= $CERT_THRESHOLD_WARNING) {
                 $result['status'] = 1;
                 $result['error'] = "WARNING: Certificate is about to expire in " . $result['daysLeft'] . " days!";
-	    } else {
-		$result['status'] = 0;
-		$result['error'] = "";
-	    }
+            } else {
+                $result['status'] = 0;
+                $result['error'] = "";
+            }
 
-	    // Do we have any results
+            // Do we have any results
             if (count($result) > 0) {
                 // Let's log some debugging
                 d_echo("\n\n" . $result['type'] . ' - ' . $result['label'] . ': ' . $result['daysLeft'] . "\n");
@@ -187,7 +186,7 @@ if (! empty($f5CertEntry) || ! empty($ltmBwcEntry) || ! empty($ltmVirtualServEnt
                 // Add this result to the master array.
                 $tblBigIP[] = $result;
             }
-	}
+        }
     }
 
     // Process the Virtual Servers

--- a/includes/html/pages/device/loadbalancer.inc.php
+++ b/includes/html/pages/device/loadbalancer.inc.php
@@ -1,5 +1,4 @@
 <?php
-
 $link_array = [
     'page' => 'device',
     'device' => $device['device_id'],
@@ -14,6 +13,7 @@ $type_text['ltm_pool'] = 'LTM Pools';                   // F5 BigIP
 $type_text['ltm_bwc'] = 'LTM Bandwidth Controller';     // F5 BigIP
 $type_text['gtm_wide'] = 'GTM Wide IPs';                // F5 BigIP
 $type_text['gtm_pool'] = 'GTM Pools';                   // F5 BigIP
+$type_text['f5-cert'] = 'Certificates';                 // F5 BigIP
 
 print_optionbar_start();
 

--- a/includes/html/pages/device/loadbalancer.inc.php
+++ b/includes/html/pages/device/loadbalancer.inc.php
@@ -1,4 +1,5 @@
 <?php
+
 $link_array = [
     'page' => 'device',
     'device' => $device['device_id'],

--- a/includes/html/pages/device/loadbalancer/f5-cert.inc.php
+++ b/includes/html/pages/device/loadbalancer/f5-cert.inc.php
@@ -1,0 +1,83 @@
+<?php
+/*
+ * LibreNMS module to Display data from F5 BigIP LTM Devices
+ *
+ * Copyright (c) 2016 Aaron Daniels <aaron@daniels.id.au>
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.  Please see LICENSE.txt at the top level of
+ * the source code distribution for details.
+ */
+
+$component = new LibreNMS\Component();
+$components = $component->getComponents($device['device_id'], ['filter' => ['ignore' => ['=', 0]]]);
+
+// We only care about our device id.
+$components = $components[$device['device_id']];
+
+// We extracted all the components for this device, now lets only get the LTM ones.
+$keep = [];
+$types = [$module, 'f5-cert'];
+foreach ($components as $k => $v) {
+    foreach ($types as $type) {
+        if ($v['type'] == $type) {
+            $keep[$k] = $v;
+        }
+    }
+}
+$components = $keep;
+
+/*
+ * if (is_file('includes/html/pages/device/loadbalancer/' . $vars['subtype'] . '.inc.php')) {
+ *     include 'includes/html/pages/device/loadbalancer/' . $vars['subtype'] . '.inc.php';
+ * } else {
+ *     include 'includes/html/pages/device/loadbalancer/ltm_pool_all.inc.php';
+ * }//end if
+ */
+//echo '<script>console.log("' . $type . '");</script>';
+
+?>
+<table id='grid' data-toggle='bootgrid' class='table table-condensed table-responsive table-striped'>
+    <thead>
+    <tr>
+        <th data-column-id="cert">Certificate</th>
+        <th data-column-id="daysleft" data-type="numeric">Days left until expiration</th>
+        <th data-column-id="status" data-visible="false">Status</th>
+        <th data-column-id="message">Status</th>
+    </tr>
+    </thead>
+    <tbody>
+    <?php
+    foreach ($components as $cert => $array) {
+        if ($array['type'] != 'f5-cert') {
+            continue;
+        }
+        if ($array['status'] != 0) {
+            $message = $array['error'];
+            $status = 2;
+        } else {
+            $message = 'Ok';
+            $status = '';
+        } ?>
+        <tr <?php echo $error; ?>>
+            <td><?php echo $array['label']; ?></td>
+            <td><?php echo $array['daysLeft']; ?></td>
+            <td><?php echo $status; ?></td>
+            <td><?php echo $message; ?></td>
+        </tr>
+        <?php
+    }
+    ?>
+    </tbody>
+</table>
+<script type="text/javascript">
+    $("#grid").bootgrid({
+        caseSensitive: false,
+        statusMappings: {
+            2: "danger"
+        },
+    })
+</script>
+

--- a/includes/polling/loadbalancers/f5-ltm.inc.php
+++ b/includes/polling/loadbalancers/f5-ltm.inc.php
@@ -86,18 +86,18 @@ if (! empty($components)) {
         $hash = $array['hash'];
         $rrd_name = [$type, $label, $hash];
 
-	if ($type == 'f5-cert') {
-	    $CERT_BASE_OID_NAME = 'sysCertificateFileObjectExpirationDate';
-	    $CERT_THRESHOLD_WARNING = 30;       // If Cert expires in less than this value (in days) => status = warning
-	    $CERT_THRESHOLD_CRITICAL = 10;      // If Cert expires in less than this value (in days) => status = critical
+        if ($type == 'f5-cert') {
+            $CERT_BASE_OID_NAME = 'sysCertificateFileObjectExpirationDate';
+            $CERT_THRESHOLD_WARNING = 30;       // If Cert expires in less than this value (in days) => status = warning
+            $CERT_THRESHOLD_CRITICAL = 10;      // If Cert expires in less than this value (in days) => status = critical
 
             // expiration value from snmpwalk is in seconds since 01.01.1970
             // we substract the current time, to get the time left until expiration
-	    // and convert it into days, for better human readability
-	    $array['daysLeft'] = intval(( $f5_stats['f5-cert'][$UID][$CERT_BASE_OID_NAME] - getdate()[0]) / (3600 * 24));
-	    $array['raw'] = $f5_stats['f5-cert'][$UID][$CERT_BASE_OID_NAME];
+            // and convert it into days, for better human readability
+            $array['daysLeft'] = intval(( $f5_stats['f5-cert'][$UID][$CERT_BASE_OID_NAME] - getdate()[0]) / (3600 * 24));
+            $array['raw'] = $f5_stats['f5-cert'][$UID][$CERT_BASE_OID_NAME];
 
-	    // Let's log some debugging
+            // Let's log some debugging
             d_echo("\n\nComponent: " . $key . "\n");
             d_echo('    Type: ' . $type . "\n");
             d_echo('    Label: ' . $label . "\n");
@@ -105,22 +105,22 @@ if (! empty($components)) {
             d_echo('    RAW: ' . $array['raw'] . "\n");
 
 
-	     //let's check when the cert expires
+            //let's check when the cert expires
             if ($array['daysLeft'] <= 0) {
                 $array['status'] = 2;
-                $array['error'] = "CRITICAL: Certificate is expired!";
+                $array['error'] = 'CRITICAL: Certificate is expired!';
             } elseif ($array['daysLeft'] <= $CERT_THRESHOLD_CRITICAL) {
                 $array['status'] = 2;
-                $array['error'] = "CRITICAL: Certificate is about to expire in " . $array['daysLeft'] . " days!";
+                $array['error'] = 'CRITICAL: Certificate is about to expire in ' . $array['daysLeft'] . ' days!';
             } elseif ($array['daysLeft'] <= $CERT_THRESHOLD_WARNING) {
                 $array['status'] = 1;
-                $array['error'] = "WARNING: Certificate is about to expire in " . $array['daysLeft'] . " days!";
+                $array['error'] = 'WARNING: Certificate is about to expire in ' . $array['daysLeft'] . ' days!';
             } else {
                 $array['status'] = 0;
-                $array['error'] = "";
+                $array['error'] = '';
             }
 
-	} elseif ($type == 'f5-ltm-bwc') {
+        } elseif ($type == 'f5-ltm-bwc') {
             $rrd_def = RrdDefinition::make()
                 ->addDataset('pktsin', 'COUNTER', 0)
                 ->addDataset('bytesin', 'COUNTER', 0)

--- a/includes/polling/loadbalancers/f5-ltm.inc.php
+++ b/includes/polling/loadbalancers/f5-ltm.inc.php
@@ -94,7 +94,7 @@ if (! empty($components)) {
             // expiration value from snmpwalk is in seconds since 01.01.1970
             // we substract the current time, to get the time left until expiration
             // and convert it into days, for better human readability
-            $array['daysLeft'] = intval(( $f5_stats['f5-cert'][$UID][$CERT_BASE_OID_NAME] - getdate()[0]) / (3600 * 24));
+            $array['daysLeft'] = intval(($f5_stats['f5-cert'][$UID][$CERT_BASE_OID_NAME] - getdate()[0]) / (3600 * 24));
             $array['raw'] = $f5_stats['f5-cert'][$UID][$CERT_BASE_OID_NAME];
 
             // Let's log some debugging

--- a/includes/polling/loadbalancers/f5-ltm.inc.php
+++ b/includes/polling/loadbalancers/f5-ltm.inc.php
@@ -33,7 +33,7 @@ $components = $components[$device['device_id']] ?? [];
 
 // We extracted all the components for this device, now lets only get the LTM ones.
 $keep = [];
-$types = ['f5-ltm-vs', 'f5-ltm-bwc', 'f5-ltm-pool', 'f5-ltm-poolmember'];
+$types = ['f5-ltm-vs', 'f5-ltm-bwc', 'f5-ltm-pool', 'f5-ltm-poolmember', 'f5-cert'];
 foreach ($components as $k => $v) {
     foreach ($types as $type) {
         if ($v['type'] == $type) {
@@ -46,6 +46,8 @@ $components = $keep;
 // Only collect SNMP data if we have enabled components
 if (! empty($components)) {
     // Let's gather the stats..
+    $f5_stats['f5-cert'] = snmpwalk_group($device, '.1.3.6.1.4.1.3375.2.1.15.1.2.1.5', 'F5-BIGIP-SYSTEM-MIB');
+
     $f5_stats['ltmVirtualServStatEntryPktsin'] = snmpwalk_array_num($device, '.1.3.6.1.4.1.3375.2.2.10.2.3.1.6', 0);
     $f5_stats['ltmVirtualServStatEntryPktsout'] = snmpwalk_array_num($device, '.1.3.6.1.4.1.3375.2.2.10.2.3.1.8', 0);
     $f5_stats['ltmVirtualServStatEntryBytesin'] = snmpwalk_array_num($device, '.1.3.6.1.4.1.3375.2.2.10.2.3.1.7', 0);
@@ -84,7 +86,41 @@ if (! empty($components)) {
         $hash = $array['hash'];
         $rrd_name = [$type, $label, $hash];
 
-        if ($type == 'f5-ltm-bwc') {
+	if ($type == 'f5-cert') {
+	    $CERT_BASE_OID_NAME = 'sysCertificateFileObjectExpirationDate';
+	    $CERT_THRESHOLD_WARNING = 30;       // If Cert expires in less than this value (in days) => status = warning
+	    $CERT_THRESHOLD_CRITICAL = 10;      // If Cert expires in less than this value (in days) => status = critical
+
+            // expiration value from snmpwalk is in seconds since 01.01.1970
+            // we substract the current time, to get the time left until expiration
+	    // and convert it into days, for better human readability
+	    $array['daysLeft'] = intval(( $f5_stats['f5-cert'][$UID][$CERT_BASE_OID_NAME] - getdate()[0]) / (3600 * 24));
+	    $array['raw'] = $f5_stats['f5-cert'][$UID][$CERT_BASE_OID_NAME];
+
+	    // Let's log some debugging
+            d_echo("\n\nComponent: " . $key . "\n");
+            d_echo('    Type: ' . $type . "\n");
+            d_echo('    Label: ' . $label . "\n");
+            d_echo('    Days until expiration: ' . $array['daysLeft'] . "\n");
+            d_echo('    RAW: ' . $array['raw'] . "\n");
+
+
+	     //let's check when the cert expires
+            if ($array['daysLeft'] <= 0) {
+                $array['status'] = 2;
+                $array['error'] = "CRITICAL: Certificate is expired!";
+            } elseif ($array['daysLeft'] <= $CERT_THRESHOLD_CRITICAL) {
+                $array['status'] = 2;
+                $array['error'] = "CRITICAL: Certificate is about to expire in " . $array['daysLeft'] . " days!";
+            } elseif ($array['daysLeft'] <= $CERT_THRESHOLD_WARNING) {
+                $array['status'] = 1;
+                $array['error'] = "WARNING: Certificate is about to expire in " . $array['daysLeft'] . " days!";
+            } else {
+                $array['status'] = 0;
+                $array['error'] = "";
+            }
+
+	} elseif ($type == 'f5-ltm-bwc') {
             $rrd_def = RrdDefinition::make()
                 ->addDataset('pktsin', 'COUNTER', 0)
                 ->addDataset('bytesin', 'COUNTER', 0)
@@ -102,6 +138,7 @@ if (! empty($components)) {
             d_echo("\n\nComponent: " . $key . "\n");
             d_echo('    Type: ' . $type . "\n");
             d_echo('    Label: ' . $label . "\n");
+
         } elseif ($type == 'f5-ltm-vs') {
             $rrd_def = RrdDefinition::make()
                 ->addDataset('pktsin', 'COUNTER', 0)

--- a/includes/polling/loadbalancers/f5-ltm.inc.php
+++ b/includes/polling/loadbalancers/f5-ltm.inc.php
@@ -104,7 +104,6 @@ if (! empty($components)) {
             d_echo('    Days until expiration: ' . $array['daysLeft'] . "\n");
             d_echo('    RAW: ' . $array['raw'] . "\n");
 
-
             //let's check when the cert expires
             if ($array['daysLeft'] <= 0) {
                 $array['status'] = 2;
@@ -119,7 +118,6 @@ if (! empty($components)) {
                 $array['status'] = 0;
                 $array['error'] = '';
             }
-
         } elseif ($type == 'f5-ltm-bwc') {
             $rrd_def = RrdDefinition::make()
                 ->addDataset('pktsin', 'COUNTER', 0)
@@ -138,7 +136,6 @@ if (! empty($components)) {
             d_echo("\n\nComponent: " . $key . "\n");
             d_echo('    Type: ' . $type . "\n");
             d_echo('    Label: ' . $label . "\n");
-
         } elseif ($type == 'f5-ltm-vs') {
             $rrd_def = RrdDefinition::make()
                 ->addDataset('pktsin', 'COUNTER', 0)


### PR DESCRIPTION
These patches extend the F5-Loadbalancer module to support an expiration check of the installed certificates.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
