### PR TITLE
Fix error from MikroTik routers when updating BGP peer info

### DIFF
--- a/includes/polling/bgp-peers.inc.php
+++ b/includes/polling/bgp-peers.inc.php
@@ -402,6 +402,21 @@ if (! empty($peers)) {
                             'bgpPeerLastError' => 'bgpPeerLastErrorCode',
                             'bgpPeerIface' => 'bgpPeerIface',
                         ];
+		    } elseif ($device['os'] == 'routeros') {
+			$peer_identifier = $peer['bgpPeerIdentifier'];
+			$mib = 'BGP4-MIB';
+			// RouterOS as of 7.15.2 does not support bgpPeerInUpdateElapsedTime.
+                        $oid_map = [
+                            'bgpPeerState' => 'bgpPeerState',
+                            'bgpPeerAdminStatus' => 'bgpPeerAdminStatus',
+                            'bgpPeerInUpdates' => 'bgpPeerInUpdates',
+                            'bgpPeerOutUpdates' => 'bgpPeerOutUpdates',
+                            'bgpPeerInTotalMessages' => 'bgpPeerInTotalMessages',
+                            'bgpPeerOutTotalMessages' => 'bgpPeerOutTotalMessages',
+                            'bgpPeerFsmEstablishedTime' => 'bgpPeerFsmEstablishedTime',
+                            'bgpPeerLocalAddr' => 'bgpLocalAddr', // silly db field name
+                            'bgpPeerLastError' => 'bgpPeerLastErrorCode',
+                        ];
                     } else {
                         $peer_identifier = $peer['bgpPeerIdentifier'];
                         $mib = 'BGP4-MIB';

--- a/includes/polling/bgp-peers.inc.php
+++ b/includes/polling/bgp-peers.inc.php
@@ -402,10 +402,10 @@ if (! empty($peers)) {
                             'bgpPeerLastError' => 'bgpPeerLastErrorCode',
                             'bgpPeerIface' => 'bgpPeerIface',
                         ];
-		    } elseif ($device['os'] == 'routeros') {
-			$peer_identifier = $peer['bgpPeerIdentifier'];
-			$mib = 'BGP4-MIB';
-			// RouterOS as of 7.15.2 does not support bgpPeerInUpdateElapsedTime.
+                    } elseif ($device['os'] == 'routeros') {
+                        $peer_identifier = $peer['bgpPeerIdentifier'];
+                        $mib = 'BGP4-MIB';
+                        // RouterOS as of 7.15.2 does not support bgpPeerInUpdateElapsedTime.
                         $oid_map = [
                             'bgpPeerState' => 'bgpPeerState',
                             'bgpPeerAdminStatus' => 'bgpPeerAdminStatus',

--- a/includes/polling/bgp-peers.inc.php
+++ b/includes/polling/bgp-peers.inc.php
@@ -402,21 +402,6 @@ if (! empty($peers)) {
                             'bgpPeerLastError' => 'bgpPeerLastErrorCode',
                             'bgpPeerIface' => 'bgpPeerIface',
                         ];
-                    } elseif ($device['os'] == 'routeros') {
-                        $peer_identifier = $peer['bgpPeerIdentifier'];
-                        $mib = 'BGP4-MIB';
-                        // RouterOS as of 7.15.2 does not support bgpPeerInUpdateElapsedTime.
-                        $oid_map = [
-                            'bgpPeerState' => 'bgpPeerState',
-                            'bgpPeerAdminStatus' => 'bgpPeerAdminStatus',
-                            'bgpPeerInUpdates' => 'bgpPeerInUpdates',
-                            'bgpPeerOutUpdates' => 'bgpPeerOutUpdates',
-                            'bgpPeerInTotalMessages' => 'bgpPeerInTotalMessages',
-                            'bgpPeerOutTotalMessages' => 'bgpPeerOutTotalMessages',
-                            'bgpPeerFsmEstablishedTime' => 'bgpPeerFsmEstablishedTime',
-                            'bgpPeerLocalAddr' => 'bgpLocalAddr', // silly db field name
-                            'bgpPeerLastError' => 'bgpPeerLastErrorCode',
-                        ];
                     } else {
                         $peer_identifier = $peer['bgpPeerIdentifier'];
                         $mib = 'BGP4-MIB';
@@ -527,6 +512,7 @@ if (! empty($peers)) {
         $peer_data['bgpPeerOutUpdates'] = set_numeric($peer_data['bgpPeerOutUpdates']);
         $peer_data['bgpPeerInTotalMessages'] = set_numeric($peer_data['bgpPeerInTotalMessages']);
         $peer_data['bgpPeerOutTotalMessages'] = set_numeric($peer_data['bgpPeerOutTotalMessages']);
+        $peer_data['bgpPeerInUpdateElapsedTime'] = set_numeric($peer_data['bgpPeerInUpdateElapsedTime']);
 
         $fields = [
             'bgpPeerOutUpdates' => $peer_data['bgpPeerOutUpdates'],


### PR DESCRIPTION
RouterOS doesn't support the bgpPeerInUpdateElapsedTime object, so when LibreNMS does to insert a peer update into the database from a MikroTik router, you see the following error:

SQLSTATE[22007]: Invalid datetime format: 1366 Incorrect integer value: '' for column `librenms`.`bgpPeers`.`bgpPeerInUpdateElapsedTime` at row 2 (Connection: mysql, SQL: UPDATE `bgpPeers` set `bgpPeerAdminStatus`=start,`bgpPeerInUpdateElapsedTime`=...

To fix this, special-case routeros and note that the object is not yet supported.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
