### PR TITLE
Add support for Prometheus pushgateway basic auth

### DIFF
--- a/LibreNMS/Data/Store/Prometheus.php
+++ b/LibreNMS/Data/Store/Prometheus.php
@@ -51,6 +51,12 @@ class Prometheus extends BaseDatastore
 
         $this->client = Http::client()->baseUrl($this->base_uri);
 
+        $user = Config::get('prometheus.user', '');
+        $passwd = Config::get('prometheus.password', '');
+        if ($user && $passwd) {
+            $this->client = $this->client->withBasicAuth($user, $passwd);
+        }
+
         $this->prefix = Config::get('prometheus.prefix', '');
         if ($this->prefix) {
             $this->prefix = "$this->prefix" . '_';

--- a/doc/Extensions/metrics/Prometheus.md
+++ b/doc/Extensions/metrics/Prometheus.md
@@ -35,6 +35,14 @@ continue to function as normal.
     lnms config:set prometheus.prefix 'librenms'
     ```
 
+If your pushgateway uses basic authentication, configure the following:
+
+!!! setting "poller/prometheus"
+    ```bash
+    lnms config:set prometheus.user username
+    lnms config:set prometheus.password password
+    ```
+
 ## Prefix
 
 Setting the 'prefix' option will cause all metric names to begin with 

--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -5524,6 +5524,20 @@
             "section": "prometheus",
             "order": 4
         },
+        "prometheus.user": {
+            "default": "",
+            "type": "text",
+            "group": "poller",
+            "section": "prometheus",
+            "order": 5
+        },
+        "prometheus.password": {
+            "default": "",
+            "type": "text",
+            "group": "poller",
+            "section": "prometheus",
+            "order": 6
+        },
         "public_status": {
             "default": false,
             "group": "auth",


### PR DESCRIPTION
You can configure the pushgateway to support basic auth.  Add support for specifying those credentials.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
