### PR TITLE
Add link on alert-rules page to display active alerts for rule

### DIFF
--- a/html/css/dark.css
+++ b/html/css/dark.css
@@ -2521,14 +2521,14 @@
   .table > thead > tr.warning > th,
   .table > tbody > tr.warning > th,
   .table > tfoot > tr.warning > th {
-    background-color: #f89406;
+    background-color: #ba6f05;
   }
   .table-hover > tbody > tr > td.warning:hover,
   .table-hover > tbody > tr > th.warning:hover,
   .table-hover > tbody > tr.warning:hover > td,
   .table-hover > tbody > tr:hover > .warning,
   .table-hover > tbody > tr.warning:hover > th {
-    background-color: #df8505;
+    background-color: #a76404;
   }
   .table > thead > tr > td.danger,
   .table > tbody > tr > td.danger,

--- a/includes/html/common/alerts.inc.php
+++ b/includes/html/common/alerts.inc.php
@@ -165,6 +165,7 @@ if (defined('SHOW_SETTINGS')) {
 ';
 } else {
     $alert_id = $vars['alert_id'] ?? 0;
+    $rule_id = $vars['rule_id'] ?? '';
     $device_id = $device['device_id'];
     $acknowledged = $widget_settings['acknowledged'] ?? '';
     $fired = $widget_settings['fired'] ?? '';
@@ -257,6 +258,10 @@ var alerts_grid = $("#alerts_' . $unique_id . '").bootgrid({
         return {
             id: "alerts",
 ';
+
+    if (is_numeric($rule_id)) {
+        $common_output[] = "rule_id: '$rule_id',\n";
+    }
     if (is_numeric($alert_id)) {
         $common_output[] = "alert_id: '$alert_id',\n";
     }

--- a/includes/html/print-alert-rules.php
+++ b/includes/html/print-alert-rules.php
@@ -260,7 +260,7 @@ foreach ($rule_list as $rule) {
 
     // Name
 
-    echo '<td>' . $rule['name'] . '</td>';
+    echo '<td><a href="' . url('alerts?rule_id='.$rule['id']) .'" data-container="body" data-toggle="popover" data-placement="right" data-content="View active alerts for this rule" target="_blank">' . $rule['name'] . '</a></td>';
 
     // Devices (and Groups)
 
@@ -317,7 +317,7 @@ foreach ($rule_list as $rule) {
     }
     if (! $devices && ! $groups && ! $locations) {
         // All Devices
-        echo '<a href="' . url('devices') . '" data-container="body" data-toggle="popover" data-placement=" . $popover_position . " data-content="View All Devices" target="_blank">All Devices</a><br>';
+        echo '<a href="' . url('devices') . '" data-container="body" data-toggle="popover" data-placement="' . $popover_position . '" data-content="View All Devices" target="_blank">All Devices</a><br>';
     }
 
     echo '</td>';

--- a/includes/html/print-alert-rules.php
+++ b/includes/html/print-alert-rules.php
@@ -385,7 +385,7 @@ foreach ($rule_list as $rule) {
 
     $status_popover = 'top';
 
-    echo "<td><span data-toggle='popover' data-placement='$status_popover' data-content='$status_msg' id='alert-rule-" . $rule['id'] . "' class='fa fa-fw fa-2x fa-" . $ico . ' text-' . $col . "'></span> ";
+    echo "<td><a href=" . url('alerts/rule_id='.$rule['id']) ."><span data-toggle='popover' data-placement='$status_popover' data-content='$status_msg' id='alert-rule-" . $rule['id'] . "' class='fa fa-fw fa-2x fa-" . $ico . ' text-' . $col . "'></span></a>";
     if ($rule_extra['mute'] === true) {
         echo "<div data-toggle='popover' data-content='Alerts for " . $rule['name'] . " are muted' class='fa fa-fw fa-2x fa-volume-off text-primary' aria-hidden='true'></div>";
     }

--- a/includes/html/print-alert-rules.php
+++ b/includes/html/print-alert-rules.php
@@ -260,7 +260,7 @@ foreach ($rule_list as $rule) {
 
     // Name
 
-    echo '<td><a href="' . url('alerts?rule_id='.$rule['id']) .'" data-container="body" data-toggle="popover" data-placement="right" data-content="View active alerts for this rule" target="_blank">' . $rule['name'] . '</a></td>';
+    echo '<td><a href="' . url('alerts/rule_id='.$rule['id']) .'" data-container="body" data-toggle="popover" data-placement="right" data-content="View active alerts for this rule" target="_blank">' . $rule['name'] . '</a></td>';
 
     // Devices (and Groups)
 

--- a/includes/html/table/alerts.inc.php
+++ b/includes/html/table/alerts.inc.php
@@ -26,6 +26,11 @@ $alert_states = [
 
 $show_recovered = false;
 
+if (is_numeric($vars['rule_id']) && $vars['rule_id'] > 0) {
+    $where .= ' AND `alerts`.`rule_id` = ?';
+    $param[] = $vars['rule_id'];
+}
+
 if (is_numeric($vars['alert_id']) && $vars['alert_id'] > 0) {
     $where .= ' AND `alerts`.`id` = ?';
     $param[] = $vars['alert_id'];


### PR DESCRIPTION
Make the alert-rule name and warning icon clickable.  This redirects you to a page which shows active alerts for that rule.

![image](https://github.com/user-attachments/assets/18390e6b-255f-4f03-8f56-0bcc3d03edb0)

![image](https://github.com/user-attachments/assets/ab8ec687-f127-4dbb-b59c-8db74c138562)

Lower the brightness of the warning rows in dark mode so the warning icon is visible without hovering and your eyes hurt less.

Before:
![image](https://github.com/user-attachments/assets/22de0573-2d9d-42e3-88cc-bcaed253f11d)

After:
![image](https://github.com/user-attachments/assets/be18f358-fb06-4409-b81e-f8a5d2c2973e)


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
