### PR TITLE
add bgp peer description to alert_detail

### DIFF
--- a/includes/html/functions.inc.php
+++ b/includes/html/functions.inc.php
@@ -746,6 +746,7 @@ function alert_details($details)
                     'proto' => 'bgp',
                 ]) .
                 "'>" . $tmp_alerts['bgpPeerIdentifier'] . '</a>';
+            $fault_detail .= ', Desc '. $tmp_alerts['bgpPeerDescr'] ?? '';
             $fault_detail .= ', AS' . $tmp_alerts['bgpPeerRemoteAs'];
             $fault_detail .= ', State ' . $tmp_alerts['bgpPeerState'];
             $fallback = false;

--- a/includes/html/functions.inc.php
+++ b/includes/html/functions.inc.php
@@ -746,7 +746,7 @@ function alert_details($details)
                     'proto' => 'bgp',
                 ]) .
                 "'>" . $tmp_alerts['bgpPeerIdentifier'] . '</a>';
-            $fault_detail .= ', Desc '. $tmp_alerts['bgpPeerDescr'] ?? '';
+            $fault_detail .= ', Desc ' . $tmp_alerts['bgpPeerDescr'] ?? '';
             $fault_detail .= ', AS' . $tmp_alerts['bgpPeerRemoteAs'];
             $fault_detail .= ', State ' . $tmp_alerts['bgpPeerState'];
             $fallback = false;


### PR DESCRIPTION
Adds BGP peer description to alert_detail

![image](https://github.com/user-attachments/assets/ddabbc4f-3a51-4b0e-a6e6-62cde8ad0060)


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
