### PR TITLE
set `default_role` when registering instead of at every login

### DIFF
--- a/app/Http/Controllers/Auth/SocialiteController.php
+++ b/app/Http/Controllers/Auth/SocialiteController.php
@@ -147,13 +147,17 @@ class SocialiteController extends Controller
         $user->realname = $this->buildRealName();
 
         $user->save();
+
+        $default_role = LibreNMSConfig::get('auth.socialite.default_role');
+        if ($default_role !== null && $default_role != 'none') {
+            $user->setRoles([$default_role], true);
+        }
     }
 
     private function setRolesFromClaim(string $provider, $user): bool
     {
         $scopes = LibreNMSConfig::get('auth.socialite.scopes');
         $claims = LibreNMSConfig::get('auth.socialite.claims');
-        $default_role = LibreNMSConfig::get('auth.socialite.default_role');
 
         if (is_array($scopes) &&
             $this->socialite_user instanceof \Laravel\Socialite\AbstractUser &&
@@ -172,12 +176,6 @@ class SocialiteController extends Controller
 
                 return true;
             }
-        }
-
-        if ($default_role !== null && $default_role != 'none') {
-            $user->setRoles([$default_role], false);
-
-            return true;
         }
 
         return false;


### PR DESCRIPTION
This is a fix for #16218 where I move the `default_role` check to register phase instead of getting them from claims which overwrites roles at each login for implementations where you have no claims. 

The reason for not having claims is that you (as me) might not want to have a group in your organizations idP for librenms but instead allow all members to login with a default role like `global-read` for instance. And then just promote selected individuals to admins based on need. 

I have tested this in my production environment with both existing users and newly created users and your role is not overwritten with `default_role` at second login after registration. 

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
