### PR TITLE
Fixes access to attributes to assign roles from scopes and claims

### DIFF
--- a/app/Http/Controllers/Auth/SocialiteController.php
+++ b/app/Http/Controllers/Auth/SocialiteController.php
@@ -164,7 +164,13 @@ class SocialiteController extends Controller
             ! empty($claims)
         ) {
             $roles = [];
-            $attributes = $this->socialite_user->getRaw();
+            $attributes = [];
+            $attribute_list = $this->socialite_user->getRaw();
+            foreach ($attribute_list as $a) {
+                $attribute_name = $a->getName();
+                $attribute_values = $a->getAllAttributeValues();
+                $attributes[$attribute_name] = $attribute_values;
+            }
 
             foreach ($scopes as $scope) {
                 foreach (Arr::wrap($attributes[$scope] ?? []) as $scope_data) {


### PR DESCRIPTION
Attributes were incorrectly being read from the user object resulting in no roles being assigned from attributes when using SAML/SSO role based access control.
Converts a list of objects to an array based on key & values. eg: attributes["name"] = "John Smith" which the subsequent code expects.

Hoping a pull request will get more traction rather than just submitting a bug report.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
