### PR TITLE
add skip_values to iosxr hsrp

### DIFF
--- a/includes/definitions/discovery/iosxr.yaml
+++ b/includes/definitions/discovery/iosxr.yaml
@@ -17,3 +17,8 @@ modules:
                         - { value:  4, generic: 1, graph: 0, descr: 'speak' }
                         - { value:  5, generic: 0, graph: 0, descr: 'standby' }
                         - { value:  6, generic: 0, graph: 0, descr: 'active' }
+                    skip_values:
+                        -
+                          oid: cHsrpGrpVirtualIpAddr
+                          op: '='
+                          value: '0.0.0.0'


### PR DESCRIPTION
Device will provide HSRP state of other equipment on the network (that this device isn't participating with) with group of 0.0.0.0

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
