### PR TITLE
fix splitting of perfdata

### DIFF
--- a/includes/services.inc.php
+++ b/includes/services.inc.php
@@ -247,8 +247,10 @@ function check_service($command)
     // Split out the response and the performance data.
     [$response, $perf] = explode('|', $response_string);
 
-    // Split each performance metric
-    $perf_arr = explode(' ', $perf);
+    // Split performance metrics into an array
+    preg_match_all('/\'[^\']*\'\S*|\S+/', $perf, $perf_arr);
+    // preg_match_all returns a 2D array, we only need the first one
+    $perf_arr = $perf_arr[0];
 
     // Create an array for our metrics.
     $metrics = [];


### PR DESCRIPTION
According to: https://nagios-plugins.org/doc/guidelines.html#AEN200

>  Performance Metrics: 
>   - space separated list of label/value pairs
>   - label can contain any characters except the equals sign or single quote (')
>   - the single quotes for the label are optional. Required if spaces are in the label
>   [..]

The Previous approach was splitting performance data at every space character, which did not work for  performance data like:

`'Rain probability'=80%;;`

This PR fixes this by replacing the `explode` with a regex that matches non-whitespace characters or everything inbetween single quotes + trailing non-whitespace characters


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
