### PR TITLE
[webui] fix port_row.blade generate vlan link

### DIFF
--- a/resources/views/device/tabs/ports/includes/port_row.blade.php
+++ b/resources/views/device/tabs/ports/includes/port_row.blade.php
@@ -67,7 +67,7 @@
         @endif
         @if($port->vlans->isNotEmpty())
             <div class="tw-text-blue-800">
-                <a href="{{ \LibreNMS\Util\Url::deviceUrl($device->device_id, ['tab' => 'vlans']) }}">
+                <a href="{{ \LibreNMS\Util\Url::deviceUrl($port->device_id, ['tab' => 'vlans']) }}">
                     @if($port->vlans->count() > 1)
                         <span title="{{ $port->vlans->pluck('vlan')->implode(',') }}">{{ __('port.vlan_count', ['count' => $port->vlans->count()]) }}</span>
                     @elseif($port->vlans->count() == 1 || $port->ifVlan)


### PR DESCRIPTION
Vlan page link is not genetared correctly in
resources/views/device/tabs/ports/includes/port_row.blade.php

before:
http:  //gitnms.srv.soada/device/0/vlans

after:
http:  //gitnms.srv.soada/device/10003/vlans



DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
