### PR TITLE
Add customoid type to graph widget

### DIFF
--- a/LibreNMS/Util/Graph.php
+++ b/LibreNMS/Util/Graph.php
@@ -188,7 +188,7 @@ class Graph
 
     public static function getTypes(): array
     {
-        return ['device', 'port', 'application', 'munin', 'service'];
+        return ['device', 'port', 'application', 'munin', 'service', 'customoid'];
     }
 
     /**

--- a/app/Http/Controllers/Select/CustomoidController.php
+++ b/app/Http/Controllers/Select/CustomoidController.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Controllers\Select;
+
+use App\Models\Customoid;
+
+class CustomoidController extends SelectController
+{
+    /**
+     * Defines the base query for this resource
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Builder
+     */
+    protected function baseQuery($request)
+    {
+        return Customoid::hasAccess($request->user())
+            ->with(['device' => function ($query) {
+                $query->select('device_id', 'hostname', 'sysName', 'display');
+            }])
+            ->select('customoid_id', 'customoid_descr', 'device_id');
+    }
+
+    /**
+     * @param  Customoid  $customoid
+     */
+    public function formatItem($customoid)
+    {
+        return [
+            'id' => $customoid->customoid_id,
+            'text' => $customoid->device->shortDisplayName() . ' (' . $customoid->customoid_descr . ')',
+        ];
+    }
+}

--- a/app/Http/Controllers/Widgets/GraphController.php
+++ b/app/Http/Controllers/Widgets/GraphController.php
@@ -31,6 +31,7 @@ use App\Models\Device;
 use App\Models\MuninPlugin;
 use App\Models\Port;
 use App\Models\Service;
+use App\Models\Customoid;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\View\View;
@@ -52,6 +53,7 @@ class GraphController extends WidgetController
         'graph_application' => null,
         'graph_munin' => null,
         'graph_service' => null,
+        'graph_customoid' => null,
         'graph_ports' => [],
         'graph_custom' => [],
         'graph_manual' => null,
@@ -94,7 +96,11 @@ class GraphController extends WidgetController
             if ($service = Service::find($settings['graph_service'])) {
                 return $service->device->displayName() . ' / ' . $service->service_type . ' (' . $service->service_desc . ')' . ' / ' . $settings['graph_type'];
             }
+        } elseif ($type == 'customoid') {
+            if ($customoid = Customoid::find($settings['graph_customoid'])) {
+                return $customoid->device->displayName() . ' / ' . $type . ' / ' . $customoid->customoid_descr;
         }
+    }
 
         // fall back for types where we couldn't find the item
         if ($settings['graph_type']) {
@@ -145,6 +151,11 @@ class GraphController extends WidgetController
         }
         $data['service_text'] = isset($service) ? $service->device->displayName() . ' - ' . $service->service_type . ' (' . $service->service_desc . ')' : __('Service does not exist');
 
+        if ($primary == 'customoid' && $data['graph_customoid']) {
+            $customoid = Customoid::with('device')->find($data['graph_customoid']);
+        }
+        $data['customoid_text'] = isset($customoid) ? $customoid->device->displayName() . ' - ' . $customoid->customoid_descr : __('Custom OID does not exist');
+
         $data['graph_ports'] = Port::whereIntegerInRaw('port_id', $data['graph_ports'])
             ->select('ports.device_id', 'port_id', 'ifAlias', 'ifName', 'ifDescr')
             ->with(['device' => function ($query) {
@@ -187,6 +198,12 @@ class GraphController extends WidgetController
             if ($service = Service::find($settings['graph_service'])) {
                 $params[] = 'device=' . $service->device_id;
                 $params[] = 'id=' . $service->service_id;
+            }
+        } elseif ($type == 'customoid') {
+            if ($customoid = Customoid::find($settings['graph_customoid'])) {
+                $params[] = 'device=' . $customoid->device_id;
+                $params[] = 'id=' . $customoid->customoid_id;
+                $settings['graph_type'] = 'customoid_' . $customoid->customoid_descr ;
             }
         } elseif ($type == 'aggregate') {
             $aggregate_type = $this->getGraphType(false);
@@ -270,6 +287,7 @@ class GraphController extends WidgetController
             $settings['graph_application'] = $this->convertLegacySettingId($settings['graph_application'], 'app_id');
             $settings['graph_munin'] = $this->convertLegacySettingId($settings['graph_munin'], 'mplug_id');
             $settings['graph_service'] = $this->convertLegacySettingId($settings['graph_service'], 'service_id');
+            $settings['graph_customoid'] = $this->convertLegacySettingId($settings['graph_customoid'], 'customoid_id');
             $settings['graph_bill'] = $this->convertLegacySettingId($settings['graph_bill'], 'bill_id');
 
             $settings['graph_custom'] = (array) $settings['graph_custom'];

--- a/app/Http/Controllers/Widgets/GraphController.php
+++ b/app/Http/Controllers/Widgets/GraphController.php
@@ -27,11 +27,11 @@ namespace App\Http\Controllers\Widgets;
 
 use App\Models\Application;
 use App\Models\Bill;
+use App\Models\Customoid;
 use App\Models\Device;
 use App\Models\MuninPlugin;
 use App\Models\Port;
 use App\Models\Service;
-use App\Models\Customoid;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\View\View;
@@ -99,8 +99,8 @@ class GraphController extends WidgetController
         } elseif ($type == 'customoid') {
             if ($customoid = Customoid::find($settings['graph_customoid'])) {
                 return $customoid->device->displayName() . ' / ' . $type . ' / ' . $customoid->customoid_descr;
+            }
         }
-    }
 
         // fall back for types where we couldn't find the item
         if ($settings['graph_type']) {
@@ -203,7 +203,7 @@ class GraphController extends WidgetController
             if ($customoid = Customoid::find($settings['graph_customoid'])) {
                 $params[] = 'device=' . $customoid->device_id;
                 $params[] = 'id=' . $customoid->customoid_id;
-                $settings['graph_type'] = 'customoid_' . $customoid->customoid_descr ;
+                $settings['graph_type'] = 'customoid_' . $customoid->customoid_descr;
             }
         } elseif ($type == 'aggregate') {
             $aggregate_type = $this->getGraphType(false);

--- a/app/Models/Customoid.php
+++ b/app/Models/Customoid.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Models;
+
+class Customoid extends DeviceRelatedModel
+{
+    public $timestamps = false;
+    protected $primaryKey = 'customoid_id';
+}

--- a/resources/views/widgets/settings/graph.blade.php
+++ b/resources/views/widgets/settings/graph.blade.php
@@ -78,6 +78,14 @@
         @endif
         </select>
     </div>
+    <div class="form-group graph_select_extra-{{ $id }}" id="graph_select_customoid-{{ $id }}" style="display: none;">
+        <label for="graph_customoid-{{ $id }}" class="control-label">{{ __('Customoid') }}</label>
+        <select class="form-control" id="graph_customoid-{{ $id }}" name="graph_customoid" data-placeholder="{{ __('Select a custom OID') }}">
+        @if($graph_customoid)
+            <option value="{{ $graph_customoid }}">{{ $customoid_text }}</option>
+        @endif
+        </select>
+    </div>
     <div class="form-group graph_select_extra-{{ $id }}" id="graph_select_bill-{{ $id }}" style="display: none;">
         <label for="graph_bill-{{ $id }}" class="control-label">{{ __('Bill') }}</label>
         <select class="form-control" id="graph_bill-{{ $id }}" name="graph_bill" data-placeholder="{{ __('Select a bill') }}">
@@ -121,6 +129,7 @@
         }, '{{ $graph_application ?: '' }}');
         init_select2('#graph_munin-{{ $id }}', 'munin', {limit: 100}, '{{ $graph_munin ?: '' }}');
         init_select2('#graph_service-{{ $id }}', 'service', {limit: 100}, '{{ $graph_service ?: '' }}');
+        init_select2('#graph_customoid-{{ $id }}', 'customoid', {limit: 100}, '{{ $graph_customoid ?: '' }}');
         init_select2('#graph_bill-{{ $id }}', 'bill', {limit: 100}, '{{ $graph_bill ?: '' }}');
         init_select2('#graph_custom-{{ $id }}', 'graph-aggregate', {}, false);
         init_select2('#graph_ports-{{ $id }}', 'port', {limit: 100}, {{ $graph_port_ids }});

--- a/routes/web.php
+++ b/routes/web.php
@@ -188,6 +188,7 @@ Route::middleware(['auth'])->group(function () {
             Route::get('munin', 'MuninPluginController')->name('ajax.select.munin');
             Route::get('role', 'RoleController')->name('ajax.select.role');
             Route::get('service', 'ServiceController')->name('ajax.select.service');
+            Route::get('customoid', 'CustomoidController')->name('ajax.select.customoid');
             Route::get('template', 'ServiceTemplateController')->name('ajax.select.template');
             Route::get('poller-group', 'PollerGroupController')->name('ajax.select.poller-group');
             Route::get('port', 'PortController')->name('ajax.select.port');


### PR DESCRIPTION
Add Custom OID to graphs widget so they can be added to dashboards.

Some requests at:

https://community.librenms.org/t/custom-oid-graphs-on-dashboards/11211/2
https://community.librenms.org/t/add-custom-oid-graph-to-device-overview-page/24043

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
