### PR TITLE
Nac polling improvement

### DIFF
--- a/LibreNMS/Modules/Nac.php
+++ b/LibreNMS/Modules/Nac.php
@@ -83,7 +83,7 @@ class Nac implements Module
             //filter out historical entries
             $existing_entries = $os->getDevice()->portsNac()
                 ->where('historical', 0)
-                ->keyBy('mac_address');
+                ->get()->keyBy('mac_address');
 
             // update existing models
             foreach ($nac_entries as $nac_entry) {

--- a/LibreNMS/Modules/Nac.php
+++ b/LibreNMS/Modules/Nac.php
@@ -81,11 +81,9 @@ class Nac implements Module
 
             $nac_entries = $os->pollNac()->keyBy('mac_address');
             //filter out historical entries
-            $existing_entries = $os->getDevice()->portsNac->keyBy('mac_address')->filter(function ($value, $key) {
-                if ($value['historical'] == 0) {
-                    return $value;
-                }
-            });
+            $existing_entries = $os->getDevice()->portsNac()
+                ->where('historical', 0)
+                ->keyBy('mac_address');
 
             // update existing models
             foreach ($nac_entries as $nac_entry) {


### PR DESCRIPTION
Was loading all nac entries from the DB, then filtering them. Now it only loads non-historical entries off the bat. All this because the filter was returning the wrong type...

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
