### PR TITLE
CLI - Enable setupVenv debug display

### DIFF
--- a/scripts/save-test-data.php
+++ b/scripts/save-test-data.php
@@ -113,7 +113,7 @@ if (isset($options['f'])) {
 
 // Now use the saved data to update the saved database data
 $snmpsim = new Snmpsim();
-$snmpsim->setupVenv();
+$snmpsim->setupVenv(true);
 $snmpsim->start();
 echo "Waiting for snmpsim to initialize...\n";
 $snmpsim->waitForStartup();


### PR DESCRIPTION
If something goes wrong with VENV setup in save-test-data script, currently, it fails silently without giving a chance to the user to find out why. 

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
