### PR TITLE
Fix setting the device wrong field in module tests

### DIFF
--- a/LibreNMS/Util/ModuleTestHelper.php
+++ b/LibreNMS/Util/ModuleTestHelper.php
@@ -568,7 +568,7 @@ class ModuleTestHelper
         try {
             $new_device = new Device([
                 'hostname' => $snmpsim->ip,
-                'version' => 'v2c',
+                'snmpver' => 'v2c',
                 'community' => $this->file_name,
                 'port' => $snmpsim->port,
                 'disabled' => 1, // disable to block normal pollers


### PR DESCRIPTION
Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
