### PR TITLE
Add support for Cisco ISA devices

### DIFF
--- a/includes/definitions/asa.yaml
+++ b/includes/definitions/asa.yaml
@@ -34,4 +34,4 @@ discovery_modules:
 discovery:
     -
         sysDescr_regex:
-            - '/^Cisco Adaptive Security Appliance/'
+            - '/^Cisco (Adaptive|Industrial) Security Appliance/'


### PR DESCRIPTION
Add support for Cisco ISA devices to Cisco ASA definition.

The Cisco ASA definition matches ASA devices using the text "Cisco Adaptive Security Appliance" whereas the Cisco ISA devices present this as "Cisco Industrial Security Appliance" however they are otherwise identical in functionality.

This pull request simply updates the regular expression to allow for both to match.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.