### PR TITLE
Docs: Remove indentation causing faulty rendering

### DIFF
--- a/doc/Support/Configuration.md
+++ b/doc/Support/Configuration.md
@@ -954,33 +954,34 @@ lnms config:set os.iosxe.disabled_sensors_regex '/PEM Iout/'
 Mounted storage / mount points to ignore in discovery and polling.
 
 !!! setting "discovery/storage"
-   ```bash
-    lnms config:set ignore_mount_removable true
-    lnms config:set ignore_mount_network true
-    lnms config:set ignore_mount_optical true
 
-    lnms config:set ignore_mount.+ /kern
-    lnms config:set ignore_mount.+ /mnt/cdrom
-    lnms config:set ignore_mount.+ /proc
-    lnms config:set ignore_mount.+ /dev
+```bash
+lnms config:set ignore_mount_removable true
+lnms config:set ignore_mount_network true
+lnms config:set ignore_mount_optical true
 
-    lnms config:set ignore_mount_string.+ packages
-    lnms config:set ignore_mount_string.+ devfs
-    lnms config:set ignore_mount_string.+ procfs
-    lnms config:set ignore_mount_string.+ UMA
-    lnms config:set ignore_mount_string.+ MALLOC
+lnms config:set ignore_mount.+ /kern
+lnms config:set ignore_mount.+ /mnt/cdrom
+lnms config:set ignore_mount.+ /proc
+lnms config:set ignore_mount.+ /dev
 
-    lnms config:set ignore_mount_regexp.+ '/on: \/packages/'
-    lnms config:set ignore_mount_regexp.+ '/on: \/dev/'
-    lnms config:set ignore_mount_regexp.+ '/on: \/proc/'
-    lnms config:set ignore_mount_regexp.+ '/on: \/junos^/'
-    lnms config:set ignore_mount_regexp.+ '/on: \/junos\/dev/'
-    lnms config:set ignore_mount_regexp.+ '/on: \/jail\/dev/'
-    lnms config:set ignore_mount_regexp.+ '/^(dev|proc)fs/'
-    lnms config:set ignore_mount_regexp.+ '/^\/dev\/md0/'
-    lnms config:set ignore_mount_regexp.+ '/^\/var\/dhcpd\/dev,/'
-    lnms config:set ignore_mount_regexp.+ '/UMA/'
-    ```
+lnms config:set ignore_mount_string.+ packages
+lnms config:set ignore_mount_string.+ devfs
+lnms config:set ignore_mount_string.+ procfs
+lnms config:set ignore_mount_string.+ UMA
+lnms config:set ignore_mount_string.+ MALLOC
+
+lnms config:set ignore_mount_regexp.+ '/on: \/packages/'
+lnms config:set ignore_mount_regexp.+ '/on: \/dev/'
+lnms config:set ignore_mount_regexp.+ '/on: \/proc/'
+lnms config:set ignore_mount_regexp.+ '/on: \/junos^/'
+lnms config:set ignore_mount_regexp.+ '/on: \/junos\/dev/'
+lnms config:set ignore_mount_regexp.+ '/on: \/jail\/dev/'
+lnms config:set ignore_mount_regexp.+ '/^(dev|proc)fs/'
+lnms config:set ignore_mount_regexp.+ '/^\/dev\/md0/'
+lnms config:set ignore_mount_regexp.+ '/^\/var\/dhcpd\/dev,/'
+lnms config:set ignore_mount_regexp.+ '/UMA/'
+```
 
 Custom storage warning percentage
 


### PR DESCRIPTION
There was a small indentation error causing faulty rendering on https://docs.librenms.org/Support/Configuration/#storage-configuration

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
