### PR TITLE
Scheduled polling

### DIFF
--- a/app/Console/Commands/DevicePoll.php
+++ b/app/Console/Commands/DevicePoll.php
@@ -4,6 +4,7 @@ namespace App\Console\Commands;
 
 use App\Console\LnmsCommand;
 use App\Events\DevicePolled;
+use App\Jobs\DispatchPollingWork;
 use App\Jobs\PollDevice;
 use App\Models\Device;
 use App\Polling\Measure\MeasurementManager;
@@ -127,24 +128,28 @@ class DevicePoll extends LnmsCommand
         return 1; // failed to poll
     }
 
-    private function dispatchWork()
+    private function dispatchWork(): int
     {
-        \Log::setDefaultDriver('stack');
-        $module_overrides = Module::parseUserOverrides(explode(',', $this->option('modules') ?? ''));
-        $devices = Device::whereDeviceSpec($this->argument('device spec'))->pluck('device_id');
+        $enabled = Config::get('scheduler.poll.enabled');
 
-        if (\config('queue.default') == 'sync') {
-            $this->error('Queue driver is sync, work will run in process.');
-            sleep(1);
+        if (! Config::get('scheduler.poll.enabled')) {
+            $this->error('Scheduler based polling is disabled');
+
+            return 1;
         }
 
-        foreach ($devices as $device_id) {
-            PollDevice::dispatch($device_id, $module_overrides);
+        if ($this->argument('device spec') !== 'all') {
+            $this->error('Dispatch only supports all devices');
+
+            return 1;
         }
 
-        $this->line('Submitted work for ' . $devices->count() . ' devices');
-
-        return 0;
+        $this->line('Dispatching polling work... press ctrl-c to cancel');
+        while(true) {
+            $this->output->write('.');
+            DispatchPollingWork::dispatchSync(); // just do the dispatch work in this process
+            sleep(10);
+        }
     }
 
     private function printModules(array $module_overrides): void

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -3,6 +3,7 @@
 namespace App\Console;
 
 use App\Console\Commands\MaintenanceFetchOuis;
+use App\Jobs\DispatchPollingWork;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
 use Illuminate\Support\Facades\Cache;
@@ -21,6 +22,7 @@ class Kernel extends ConsoleKernel
     protected function schedule(Schedule $schedule): void
     {
         $this->scheduleMarkWorking($schedule);
+        $this->schedulePolling($schedule);
         $this->scheduleMaintenance($schedule);  // should be after all others
     }
 
@@ -88,5 +90,14 @@ class Kernel extends ConsoleKernel
             ->weeklyOn(0, '1:00')
             ->onOneServer()
             ->appendOutputTo($maintenance_log_file);
+    }
+
+    private function schedulePolling(Schedule $schedule): void
+    {
+        if (Config::get('scheduler.poll.enabled')) {
+            $schedule->job(new DispatchPollingWork)
+                ->everyTenSeconds()
+                ->onOneServer();
+        }
     }
 }

--- a/app/Jobs/DispatchPollingWork.php
+++ b/app/Jobs/DispatchPollingWork.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Database\Query\Builder;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use LibreNMS\Config;
+
+class DispatchPollingWork implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+    private string $pollingQueueConnection;
+    private int $find_time;
+    private bool $enabled;
+
+    public function __construct(
+    ) {
+        $this->find_time = Config::get('service_poller_frequency', Config::get('rrd.step', 300)) - 1;
+        $this->enabled = Config::get('scheduler.poll.enabled', false);
+        $default = \config('queue.default');
+        // database minimum driver, redis recommended
+        $this->pollingQueueConnection = $default == 'sync' ? 'database' : $default;
+    }
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        if (! $this->enabled) {
+            return;
+        }
+
+        $devices = DB::table('devices')
+            ->select(['device_id', 'poller_group'])
+            ->where('disabled', 0)
+            ->where(function (Builder $query) {
+                $query->whereNull('last_polled')
+                    ->orWhereRaw('`last_polled` <= DATE_ADD(DATE_ADD(NOW(), INTERVAL -? SECOND), INTERVAL COALESCE(`last_polled_timetaken`, 0) SECOND)', [$this->find_time]);
+            })
+            ->orderBy('last_polled_timetaken', 'desc')
+            ->get();
+
+        Log::info("Due to for polling: " . $devices->pluck('device_id')->implode(','));
+
+        foreach ($devices as $device) {
+                PollDevice::dispatch($device->device_id)
+                    ->onConnection($this->pollingQueueConnection)
+                    ->onQueue($device->poller_group ? "poll-$device->poller_group" : 'poll');
+        }
+    }
+}

--- a/app/Jobs/PollDevice.php
+++ b/app/Jobs/PollDevice.php
@@ -9,6 +9,7 @@ use App\Polling\Measure\Measurement;
 use App\Polling\Measure\MeasurementManager;
 use Carbon\Carbon;
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
@@ -23,10 +24,11 @@ use LibreNMS\Util\Dns;
 use LibreNMS\Util\Module;
 use Throwable;
 
-class PollDevice implements ShouldQueue
+class PollDevice implements ShouldQueue, ShouldBeUnique
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
+    public int $uniqueFor = 3600;
     private ?\App\Models\Device $device = null;
     private ?array $deviceArray = null;
     /**
@@ -44,10 +46,20 @@ class PollDevice implements ShouldQueue
     ) {
     }
 
+    public function displayName(): string
+    {
+        return "PollDevice:$this->device_id";
+    }
+
+    public function uniqueId(): string
+    {
+        return $this->device_id;
+    }
+
     /**
      * Execute the job.
      */
-    public function handle()
+    public function handle(): void
     {
         $this->initDevice();
         PollingDevice::dispatch($this->device);
@@ -99,6 +111,10 @@ class PollDevice implements ShouldQueue
         if ($measurement->getDuration() > Config::get('rrd.step')) {
             Eventlog::log('Polling took longer than ' . round(Config::get('rrd.step') / 60, 2) .
                 ' minutes!  This will cause gaps in graphs.', $this->device, 'system', Severity::Error);
+        }
+
+        if (! $this->device->status) {
+            throw new \Exception('Failed to poll device');
         }
 
         DevicePolled::dispatch($this->device);

--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -5714,6 +5714,10 @@
             "default": true,
             "type": "boolean"
         },
+        "scheduler.poll.enabled": {
+            "default": false,
+            "type": "boolean"
+        },
         "service_poller_enabled": {
             "default": true,
             "group": "poller",

--- a/misc/db_schema.yaml
+++ b/misc/db_schema.yaml
@@ -942,6 +942,18 @@ isis_adjacencies:
     isis_adjacencies_device_id_index: { Name: isis_adjacencies_device_id_index, Columns: [device_id], Unique: false, Type: BTREE }
     isis_adjacencies_ifindex_index: { Name: isis_adjacencies_ifindex_index, Columns: [ifIndex], Unique: false, Type: BTREE }
     isis_adjacencies_port_id_index: { Name: isis_adjacencies_port_id_index, Columns: [port_id], Unique: false, Type: BTREE }
+jobs:
+  Columns:
+    - { Field: id, Type: 'bigint unsigned', 'Null': false, Extra: auto_increment }
+    - { Field: queue, Type: varchar(255), 'Null': false, Extra: '' }
+    - { Field: payload, Type: longtext, 'Null': false, Extra: '' }
+    - { Field: attempts, Type: 'tinyint unsigned', 'Null': false, Extra: '' }
+    - { Field: reserved_at, Type: 'int unsigned', 'Null': true, Extra: '' }
+    - { Field: available_at, Type: 'int unsigned', 'Null': false, Extra: '' }
+    - { Field: created_at, Type: 'int unsigned', 'Null': false, Extra: '' }
+  Indexes:
+    PRIMARY: { Name: PRIMARY, Columns: [id], Unique: true, Type: BTREE }
+    jobs_queue_index: { Name: jobs_queue_index, Columns: [queue], Unique: false, Type: BTREE }
 juniAtmVp:
   Columns:
     - { Field: id, Type: 'bigint unsigned', 'Null': false, Extra: auto_increment }


### PR DESCRIPTION
To enable automatic scheduling of work, set `lnms config:set scheduler.poll.enabled true` If you are not running the scheduler(you should be) you can run `lnms device:poll all --dispatch` to dispatch work This will use the database queue connection by default (you must run the migration included in this PR) run workers by running `QUEUE_CONNECTION=database lnms queue:listen --queue=poll --timeout=600`

It is suggested to use redis queue by setting `QUEUE_CONNECTION=redis` in .env For performance, you should run `lnms queue:work --queue=poll --timeout=600 --max-jobs=1000` (queue:work for long running process, --max-jobs=1000 to quit after 1000 jobs) Use supervisord to manage workers and restart them if they fail/exit.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
