### PR TITLE
Fix unaligned Leaflet Awesome marker icons

### DIFF
--- a/html/css/styles.css
+++ b/html/css/styles.css
@@ -1738,6 +1738,9 @@ tr.search:nth-child(odd) {
     line-height: 100%;
 }
 
+.gridster .awesome-marker {
+  text-align: center;
+}
 
 .gridster {
     margin: 0 auto;


### PR DESCRIPTION
Fix commit 'Update styles.css (#16138)' which disaligns Leaflet Awesome marker icons

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
