### PR TITLE
Use Device Displayname when editing Maintenances

### DIFF
--- a/includes/html/list/devices.inc.php
+++ b/includes/html/list/devices.inc.php
@@ -22,6 +22,9 @@
  * @copyright  2018 Tony Murray
  * @author     Tony Murray <murraytony@gmail.com>
  */
+
+use App\Facades\DeviceCache;
+
 $query = '';
 $where = [];
 $params = [];
@@ -62,7 +65,7 @@ $sql = "SELECT `device_id`, `hostname`, `sysName`, `display` FROM `devices` $que
 $devices = array_map(function ($device) {
     return [
         'id' => $device['device_id'],
-        'text' => format_hostname($device),
+        'text' => DeviceCache::get($device['device_id'])->displayName(),
     ];
 }, dbFetchRows($sql, $params));
 


### PR DESCRIPTION
Endgoal is to have displayname show when editing a Maintenance


Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
