### PR TITLE
Fix ifAlias encoding

### DIFF
--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -678,7 +678,7 @@ foreach ($ports as $port) {
                 } else {
                     $current_oid = $this_port['ifAlias'];
                 }
-                // prevent invalid non-utf8 characters
+                // Prevent invalid non-utf8 characters
                 $current_oid = mb_convert_encoding($current_oid, 'UTF-8', mb_detect_encoding($current_oid, mb_list_encodings(), true));
             }
             if ($oid == 'ifSpeed') {

--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -6,7 +6,6 @@ use LibreNMS\RRD\RrdDefinition;
 use LibreNMS\Util\Debug;
 use LibreNMS\Util\Mac;
 use LibreNMS\Util\Number;
-use LibreNMS\Util\StringHelpers;
 
 // Build SNMP Cache Array
 $data_oids = [

--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -679,7 +679,8 @@ foreach ($ports as $port) {
                 } else {
                     $current_oid = $this_port['ifAlias'];
                 }
-                $current_oid = StringHelpers::inferEncoding($current_oid); // prevent invalid non-utf8 characters
+                // prevent invalid non-utf8 characters
+                $current_oid = mb_convert_encoding($current_oid, 'UTF-8', mb_detect_encoding($current_oid, mb_list_encodings(), true)); 
             }
             if ($oid == 'ifSpeed') {
                 $ifSpeed_override = DeviceCache::getPrimary()->getAttrib('ifSpeed:' . $port['ifName']);

--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -679,7 +679,7 @@ foreach ($ports as $port) {
                     $current_oid = $this_port['ifAlias'];
                 }
                 // prevent invalid non-utf8 characters
-                $current_oid = mb_convert_encoding($current_oid, 'UTF-8', mb_detect_encoding($current_oid, mb_list_encodings(), true)); 
+                $current_oid = mb_convert_encoding($current_oid, 'UTF-8', mb_detect_encoding($current_oid, mb_list_encodings(), true));
             }
             if ($oid == 'ifSpeed') {
                 $ifSpeed_override = DeviceCache::getPrimary()->getAttrib('ifSpeed:' . $port['ifName']);


### PR DESCRIPTION
Please give a short description what your pull request is for

In some cases the ifAlias isn't sanitized as expected and stop all the port polling process for the device.
This solution is not ideal but currently work flawlessly in 300K ports environment.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.