### PR TITLE
Ignore LibreNMS device groups in Oxidized

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -5,9 +5,9 @@ namespace App\Providers;
 use App\Models\Sensor;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\ServiceProvider;
-use Illuminate\Support\Facades\DB;
 use LibreNMS\Cache\PermissionsCache;
 use LibreNMS\Config;
 use LibreNMS\Util\IP;
@@ -199,13 +199,12 @@ class AppServiceProvider extends ServiceProvider
             }
 
             return false;
-	});
+   });
         Validator::extend('device_group_names', function ($attribute, $value): bool {
             if (is_string($value)) {
                 $value = [$value];
             }
 
-            // Ensure $value is an array
             if (! is_array($value)) {
                 return false;
             }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Facades\DB;
 use LibreNMS\Cache\PermissionsCache;
 use LibreNMS\Config;
 use LibreNMS\Util\IP;
@@ -198,6 +199,26 @@ class AppServiceProvider extends ServiceProvider
             }
 
             return false;
+	});
+        Validator::extend('device_group_names', function ($attribute, $value): bool {
+            if (is_string($value)) {
+                $value = [$value];
+            }
+
+            // Ensure $value is an array
+            if (! is_array($value)) {
+                return false;
+            }
+
+            $validGroupNames = array_map('strtolower', DB::table('device_groups')->pluck('name')->toArray());
+
+            foreach ($value as $groupName) {
+                if (! in_array(strtolower($groupName), $validGroupNames)) {
+                    return false;
+                }
+            }
+
+            return true;
         });
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -199,7 +199,7 @@ class AppServiceProvider extends ServiceProvider
             }
 
             return false;
-   });
+        });
         Validator::extend('device_group_names', function ($attribute, $value): bool {
             if (is_string($value)) {
                 $value = [$value];

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -1596,7 +1596,7 @@ function list_oxidized(Illuminate\Http\Request $request)
     $ignoredDeviceGroupNames = Config::get('oxidized.ignore_device_groups', []);
 
     $ignoredDeviceGroups = [];
-    if (!empty($ignoredDeviceGroupNames)) {
+    if (! empty($ignoredDeviceGroupNames)) {
         $ignoredDeviceGroups = DB::table('device_groups')
                                   ->whereIn('name', $ignoredDeviceGroupNames)
                                   ->pluck('id')
@@ -1604,13 +1604,12 @@ function list_oxidized(Illuminate\Http\Request $request)
     }
 
     $ignoredDeviceIds = [];
-    if (!empty($ignoredDeviceGroups)) {
+    if (! empty($ignoredDeviceGroups)) {
         $ignoredDeviceIds = DB::table('device_group_device')
                               ->whereIn('device_group_id', $ignoredDeviceGroups)
                               ->pluck('device_id')
                               ->toArray();
     }
-
 
     $devices = Device::query()
             ->with('attribs')

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -1218,7 +1218,7 @@ return [
             ],
             'ignore_device_groups' => [
                 'description' => 'Do not backup these LibreNMS groups',
-                'help' => 'If a device is a member of any of these LibreNMS groups it will get ignored.'
+                'help' => 'If a device is a member of any of these LibreNMS groups it will get ignored.',
             ],
         ],
         'password' => [

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -1216,6 +1216,10 @@ return [
                 'description' => 'URL to your Oxidized API',
                 'help' => 'Oxidized API url (For example: http://127.0.0.1:8888)',
             ],
+            'ignore_device_groups' => [
+                'description' => 'Do not backup these LibreNMS groups',
+                'help' => 'If a device is a member of any of these LibreNMS groups it will get ignored.'
+            ],
         ],
         'password' => [
             'min_length' => [

--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -4943,6 +4943,16 @@
                 "value.*": "exists:devices,type"
             }
         },
+	"oxidized.ignore_device_groups": {
+            "default": [],
+	    "type": "array",
+	    "group": "external",
+	    "section": "oxidized",
+	    "order": 9,
+	    "validate": {
+                "value.*": "device_group_names"
+	    }
+	},
         "oxidized.maps": {
             "default": {
                 "os": {

--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -4943,16 +4943,16 @@
                 "value.*": "exists:devices,type"
             }
         },
-	"oxidized.ignore_device_groups": {
+        "oxidized.ignore_device_groups": {
             "default": [],
-	    "type": "array",
-	    "group": "external",
-	    "section": "oxidized",
-	    "order": 9,
-	    "validate": {
+            "type": "array",
+            "group": "external",
+            "section": "oxidized",
+            "order": 9,
+            "validate": {
                 "value.*": "device_group_names"
-	    }
-	},
+            }
+        },
         "oxidized.maps": {
             "default": {
                 "os": {


### PR DESCRIPTION
This allows to ignore whole LibreNMS Groups (dynamic and static) in oxidized.

Before I wasn't really able to filter out specific devices/groups for oxidized on LibreNMS end, now I ignore e.g. offline devices, specific customer devices,...

A new section "Do not backup these LibreNMS groups" got added to Settings -> External -> Oxidized Integration.
Groups added here (by name) will be ignored by the api/v0/oxidized endpoint.
GUI:

![image](https://github.com/user-attachments/assets/e225ae2d-f4b2-4afd-9860-c3ec7e1e6c94)


#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
