### PR TITLE
Updated ping command to explicitly use sync when dispatching job

### DIFF
--- a/ping.php
+++ b/ping.php
@@ -33,4 +33,4 @@ if (isset($options['g'])) {
     $groups = [];
 }
 
-PingCheck::dispatch($groups);
+PingCheck::dispatchSync($groups);


### PR DESCRIPTION
Use dispatchSync() in the ping.php command to make sure the command always runs it in the foreground if job queuing is enabled

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
