### PR TITLE
Enabling notifications on Matrix client

### DIFF
--- a/LibreNMS/Alert/Transport/Matrix.php
+++ b/LibreNMS/Alert/Transport/Matrix.php
@@ -44,7 +44,7 @@ class Matrix extends Transport
 
         $message = SimpleTemplate::parse($message, $alert_data);
 
-        $body = ['body' => strip_tags($message), 'formatted_body' => "$message", 'msgtype' => 'm.text', 'format' => 'org.matrix.custom.html'];
+        $body = ['body' => strip_tags($message), 'formatted_body' => "$message", 'msgtype' => 'm.notice', 'format' => 'org.matrix.custom.html'];
 
         $res = Http::client()
             ->withToken($authtoken)


### PR DESCRIPTION
Changing 'm.text' to 'm.notice' (line 47) so that when an alert is issued, you get notified on your Matrix client.

The current 'm.text' parameter will silently send you a message, whereas 'm.notice' will send you a message with an alert.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
