### PR TITLE
Fix normal users UI widget AlertLog Stats

### DIFF
--- a/includes/html/table/alertlog-stats.inc.php
+++ b/includes/html/table/alertlog-stats.inc.php
@@ -35,6 +35,7 @@ if (Auth::user()->hasGlobalRead()) {
     $sql = " FROM `alert_log` AS E LEFT JOIN devices AS D ON E.device_id=D.device_id RIGHT JOIN alert_rules AS R ON E.rule_id=R.id WHERE $where";
 } else {
     $device_ids = Permissions::devicesForUser()->toArray() ?: [0];
+    // @phpstan-ignore-next-line
     $sql = " FROM `alert_log` AS E LEFT JOIN devices AS D ON E.device_id=D.device_id RIGHT JOIN alert_rules AS R ON E.rule_id=R.id WHERE $where AND E.device_id IN " . dbGenPlaceholders(count($device_ids));
     $param = array_merge($param, $device_ids);
 }

--- a/includes/html/table/alertlog-stats.inc.php
+++ b/includes/html/table/alertlog-stats.inc.php
@@ -34,8 +34,9 @@ if (isset($vars['min_severity'])) {
 if (Auth::user()->hasGlobalRead()) {
     $sql = " FROM `alert_log` AS E LEFT JOIN devices AS D ON E.device_id=D.device_id RIGHT JOIN alert_rules AS R ON E.rule_id=R.id WHERE $where";
 } else {
-    $sql = " FROM `alert_log` AS E LEFT JOIN devices AS D ON E.device_id=D.device_id RIGHT JOIN alert_rules AS R ON E.rule_id=R.id RIGHT JOIN devices_perms AS P ON E.device_id = P.device_id WHERE $where AND P.user_id = ?";
-    $param[] = [Auth::id()];
+    $device_ids = Permissions::devicesForUser()->toArray() ?: [0];
+    $sql = " FROM `alert_log` AS E LEFT JOIN devices AS D ON E.device_id=D.device_id RIGHT JOIN alert_rules AS R ON E.rule_id=R.id WHERE $where AND E.device_id IN " . dbGenPlaceholders(count($device_ids));
+    $param = array_merge($param, $device_ids);
 }
 
 if (isset($searchPhrase) && ! empty($searchPhrase)) {


### PR DESCRIPTION
Please give a short description what your pull request is for

For a "normal" user, the widget is empty.
The new code use the same logic as implemented on alert & alert log widget for user authorizations on device_id.

Inspiration : https://github.com/librenms/librenms/blob/master/includes/html/table/alertlog.inc.php#L49

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
