### PR TITLE
fix for wrong graph being referenced

### DIFF
--- a/includes/definitions/eatonupsm2.yaml
+++ b/includes/definitions/eatonupsm2.yaml
@@ -8,7 +8,7 @@ mib_dir: eaton
 over:
     - { graph: device_voltage, text: Voltage }
     - { graph: device_current, text: Current }
-    - { graph: device_frequency, text: Load }
+    - { graph: device_load, text: Load }
 discovery:
     -
         sysObjectID: .1.3.6.1.4.1.534.1


### PR DESCRIPTION
I realized that one of the "minigraphs" in the 'header' for my UPSes didn't make any sense at all. Simple fix.


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
