### PR TITLE
Fixed the issues with JetStream lldp discovery

### DIFF
--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -207,40 +207,42 @@ if (($device['os'] == 'routeros') && version_compare($device['version'], '7.7', 
 
     $lldp = SnmpQuery::hideMib()->walk('TPLINK-LLDPINFO-MIB::lldpNeighborInfoEntry')->table();
 
-    foreach ($lldp['lldpNeighborPortIndexId'] as $IndexId => $lldp_data) {
-        if (! is_array($lldp_data)) {
-            // code below will fail so no need to finish this loop occurence.
-            continue;
+    if (is_array($lldp['lldpNeighborPortIndexId'])) {
+        foreach ($lldp['lldpNeighborPortIndexId'] as $IndexId => $lldp_data) {
+            if (! is_array($lldp_data)) {
+                // code below will fail so no need to finish this loop occurence.
+                continue;
+            }
+
+            $local_ifName = $lldp['lldpNeighborPortId'][$IndexId][1];
+            $local_port_id = find_port_id('gigabitEthernet ' . $local_ifName, null, $device['device_id']);
+
+            $remote_device_id = find_device_id($lldp['lldpNeighborDeviceName'][$IndexId][1]);
+            $remote_device_name = $lldp['lldpNeighborDeviceName'][$IndexId][1];
+            $remote_device_sysDescr = $lldp['lldpNeighborDeviceDescr'][$IndexId][1];
+            $remote_device_ip = $lldp['lldpNeighborManageIpAddr'][$IndexId][1];
+            $remote_port_descr = $lldp['lldpNeighborPortIdDescr'][$IndexId][1];
+            $remote_port_id = find_port_id($remote_port_descr, null, $remote_device_id);
+
+            if (! $remote_device_id &&
+                    \LibreNMS\Util\Validate::hostname($remote_device_name) &&
+                    ! can_skip_discovery($remote_device_name, $remote_device_ip) &&
+                    Config::get('autodiscovery.xdp') === true) {
+                $remote_device_id = discover_new_device($remote_device_name, $device, 'LLDP', $local_ifName);
+            }
+
+            discover_link(
+                $local_port_id, //our port id from database
+                'lldp',
+                $remote_port_id, //remote port id from database if applicable
+                $remote_device_name, //remote device name from SNMP walk
+                $remote_port_descr, //remote port description from SNMP walk
+                null,
+                $remote_device_sysDescr, //remote device description from SNMP walk
+                $device['device_id'], //our device id
+                $remote_device_id //remote device id if applicable
+            );
         }
-
-        $local_ifName = $lldp['lldpNeighborPortId'][$IndexId][1];
-        $local_port_id = find_port_id('gigabitEthernet ' . $local_ifName, null, $device['device_id']);
-
-        $remote_device_id = find_device_id($lldp['lldpNeighborDeviceName'][$IndexId][1]);
-        $remote_device_name = $lldp['lldpNeighborDeviceName'][$IndexId][1];
-        $remote_device_sysDescr = $lldp['lldpNeighborDeviceDescr'][$IndexId][1];
-        $remote_device_ip = $lldp['lldpNeighborManageIpAddr'][$IndexId][1];
-        $remote_port_descr = $lldp['lldpNeighborPortIdDescr'][$IndexId][1];
-        $remote_port_id = find_port_id($remote_port_descr, null, $remote_device_id);
-
-        if (! $remote_device_id &&
-                \LibreNMS\Util\Validate::hostname($remote_device_name) &&
-                ! can_skip_discovery($remote_device_name, $remote_device_ip) &&
-                Config::get('autodiscovery.xdp') === true) {
-            $remote_device_id = discover_new_device($remote_device_name, $device, 'LLDP', $local_ifName);
-        }
-
-        discover_link(
-            $local_port_id, //our port id from database
-            'lldp',
-            $remote_port_id, //remote port id from database if applicable
-            $remote_device_name, //remote device name from SNMP walk
-            $remote_port_descr, //remote port description from SNMP walk
-            null,
-            $remote_device_sysDescr, //remote device description from SNMP walk
-            $device['device_id'], //our device id
-            $remote_device_id //remote device id if applicable
-        );
     }
     echo PHP_EOL;
 } else {

--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -205,23 +205,22 @@ if (($device['os'] == 'routeros') && version_compare($device['version'], '7.7', 
 } elseif ($device['os'] == 'jetstream') {
     echo ' JETSTREAM-LLDP MIB: ';
 
-    $lldp_array = SnmpQuery::hideMib()->walk('TPLINK-LLDPINFO-MIB::lldpNeighborInfoEntry')->table();
+    $lldp = SnmpQuery::hideMib()->walk('TPLINK-LLDPINFO-MIB::lldpNeighborInfoEntry')->table();
 
-    foreach ($lldp_array as $key => $lldp) {
-        if (! is_array($lldp['lldpNeighborPortIndexId'])) {
+    foreach ($lldp['lldpNeighborPortIndexId'] as $IndexId => $lldp_data) {
+        if (! is_array($lldp_data)) {
             // code below will fail so no need to finish this loop occurence.
             continue;
         }
-        $IndexId = key($lldp['lldpNeighborPortIndexId']);
 
-        $local_ifName = $lldp['lldpNeighborPortId'][$IndexId];
+        $local_ifName = $lldp['lldpNeighborPortId'][$IndexId][1];
         $local_port_id = find_port_id('gigabitEthernet ' . $local_ifName, null, $device['device_id']);
 
-        $remote_device_id = find_device_id($lldp['lldpNeighborDeviceName'][$IndexId]);
-        $remote_device_name = $lldp['lldpNeighborDeviceName'][$IndexId];
-        $remote_device_sysDescr = $lldp['lldpNeighborDeviceDescr'][$IndexId];
-        $remote_device_ip = $lldp['lldpNeighborManageIpAddr'][$IndexId];
-        $remote_port_descr = $lldp['lldpNeighborPortIdDescr'][$IndexId];
+        $remote_device_id = find_device_id($lldp['lldpNeighborDeviceName'][$IndexId][1]);
+        $remote_device_name = $lldp['lldpNeighborDeviceName'][$IndexId][1];
+        $remote_device_sysDescr = $lldp['lldpNeighborDeviceDescr'][$IndexId][1];
+        $remote_device_ip = $lldp['lldpNeighborManageIpAddr'][$IndexId][1];
+        $remote_port_descr = $lldp['lldpNeighborPortIdDescr'][$IndexId][1];
         $remote_port_id = find_port_id($remote_port_descr, null, $remote_device_id);
 
         if (! $remote_device_id &&


### PR DESCRIPTION
Before hand the lldp neighbours wouldn't be discovered due to the way the data is now returned. Test data is fine and was used to update the code and then test.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
