### PR TITLE
Update LLDP-V2-TC-MIB (Remote Port Ids are shown as Hex value)

### DIFF
--- a/mibs/LLDP-V2-TC-MIB
+++ b/mibs/LLDP-V2-TC-MIB
@@ -216,7 +216,6 @@ LldpV2PortIdSubtype ::= TEXTUAL-CONVENTION
     }
 
 LldpV2PortId ::= TEXTUAL-CONVENTION
-    DISPLAY-HINT "1x:"
     STATUS      current
     DESCRIPTION
             "This TC describes the format of a port identifier string.


### PR DESCRIPTION
When the device supports only LLDP-V2, the LLDP Remote Ports (LLDP Neighbors) are shown as Hex Value instead of ASCII String (SnmpAdminString). It occurs because the LLDP-V2-TC-MIB converts de orignal ASCII value to Hex value, to fix that I removed de line as shown bellow:

LldpV2PortId ::= TEXTUAL-CONVENTION
DISPLAY-HINT "1x:" <---------- LINE REMOVED
STATUS current
DESCRIPTION
"This TC describes the format of a port identifier string.
Objects of this type are always used with an associated
LldpPortIdSubtype object, which identifies the format of the
particular LldpPortId object instance.

Before correction:
![datacom-dmos-lldpv2-remote-port-hex-value](https://github.com/user-attachments/assets/fefe9964-7918-4622-8793-e64462a32396)
After correction:
![datacom-dmos-lldpv2-remote-port-string-value](https://github.com/user-attachments/assets/e584a376-c029-458c-8a56-2ae0408c54c2)



DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
