### PR TITLE
Fix smokeping generator for TCP transport

### DIFF
--- a/app/Console/Commands/SmokepingGenerateCommand.php
+++ b/app/Console/Commands/SmokepingGenerateCommand.php
@@ -374,7 +374,7 @@ class SmokepingGenerateCommand extends LnmsCommand
      */
     private function balanceProbes($transport, $probeCount)
     {
-        if ($transport === 'udp') {
+        if ($transport === 'udp' || $transport === 'tcp') {
             if ($probeCount === $this->ip4count) {
                 $this->ip4count = 0;
             }


### PR DESCRIPTION
Right now if you have SNMP set to `tcp` the smokeping generator will assume IPv6 because it only treats `udp` as IPv4.

This patch fixes that by treating both `tcp` and `udp` as IPv4.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [X] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
