### PR TITLE
Adva 150CC - Exclude nemihubshelf (150CM)

### DIFF
--- a/includes/definitions/adva_fsp150.yaml
+++ b/includes/definitions/adva_fsp150.yaml
@@ -12,5 +12,4 @@ discovery:
     -
         sysObjectID:
             - .1.3.6.1.4.1.2544.1.12.1.1.
-        sysObjectID_except:
-            - .1.3.6.1.4.1.2544.1.12.1.1.1 #Exclude 150CM nemihubshelf (different OS, and failing to respond to most OID/crashing)
+        sysDescr_except: ['FSP150CM-HUB'] #Exclude 150CM nemihubshelf (different OS, and failing to respond to most OID/crashing)

--- a/includes/definitions/adva_fsp150.yaml
+++ b/includes/definitions/adva_fsp150.yaml
@@ -4,6 +4,7 @@ type: network
 icon: adva
 group: ADVA
 ifname: true
+mib_dir: adva
 over:
     - { graph: device_bits, text: Traffic }
     - { graph: device_temperature, text: Temperature }
@@ -11,4 +12,5 @@ discovery:
     -
         sysObjectID:
             - .1.3.6.1.4.1.2544.1.12.1.1.
-mib_dir: adva
+        sysObjectID_except:
+            - .1.3.6.1.4.1.2544.1.12.1.1.1 #Exclude 150CM nemihubshelf (different OS, and failing to respond to most OID/crashing)


### PR DESCRIPTION
The SysObject ADVA list is messy. "nemihubshelf" device is a 150CM, and crashes when discovered and polled as a 150CC. This PR excludes them from being discovered wrongly. 
I'll try to find an OS definition that does not crash them, and submit a PR if I succeed.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
