### PR TITLE
Update discovery-protocols.inc.php to treat lldpV2RemPortId when Hexadecimal

### DIFF
--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -303,13 +303,30 @@ if (($device['os'] == 'routeros') && version_compare($device['version'], '7.7', 
         'lldpV2RemManAddrOID' => 'lldpRemManAddrOID',
     ];
 
-    if (! empty($lldpv2_array)) {
+    if (!empty($lldpv2_array)) {
         // map it to lldp_array
         foreach ($lldpv2_array as $lldpV2RemTimeMark => $value) {
             foreach ($value as $lldpV2RemLocalIfIndex => $value) {
                 foreach ($value as $lldpV2RemLocalDestMACAddress => $value) {
                     foreach ($value as $lldpV2RemIndex => $lldpv2_array_entries) {
                         foreach ($lldpv2_array_entries as $key => $value) {
+                            // Check if 'lldpV2RemPortIdSubtype' is of type 'interfaceName(5)' and create the variable $rem_port_id_subtype to use it later
+                            if ($key === 'lldpV2RemPortIdSubtype' && $value == '5') {
+                                $rem_port_id_subtype = '5';  // Assign the port subtype
+                            }
+    
+                            // Check if 'lldpV2RemPortId' should be converted to ASCII
+                            if ($key === 'lldpV2RemPortId' && $rem_port_id_subtype === '5') {
+                                // Remove colons to check if it's a hexadecimal string
+                                $hex_value = str_replace(':', '', $value);
+                                if (ctype_xdigit($hex_value)) {
+                                    // Convert the hexadecimal value to ASCII
+                                    $value = hex2bin($hex_value);                                                    
+                                    // Update the value of lldpV2RemPortId to ASCII
+                                    $lldp_array[$lldpV2RemTimeMark][$lldpV2RemLocalIfIndex][$lldpV2RemIndex]['lldpV2RemPortId'] = $value;
+                                }
+                            }
+
                             $newKey = $mapV2toV1[$key] ?? $key;
                             $lldp_array[$lldpV2RemTimeMark][$lldpV2RemLocalIfIndex][$lldpV2RemIndex][$newKey] = $value;
                         }

--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -2,6 +2,7 @@
 
 use LibreNMS\Config;
 use LibreNMS\Util\IP;
+use LibreNMS\Util\StringHelpers;
 
 global $link_exists;
 

--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -313,8 +313,7 @@ if (($device['os'] == 'routeros') && version_compare($device['version'], '7.7', 
                             // Check if 'lldpV2RemPortIdSubtype' is of type 'interfaceName(5)' and create the variable $rem_port_id_subtype to use it later
                             if ($key === 'lldpV2RemPortIdSubtype' && $value == '5') {
                                 $rem_port_id_subtype = '5';  // Assign the port subtype
-                            }
-    
+                            }                         
                             // Check if 'lldpV2RemPortId' should be converted to ASCII
                             if ($key === 'lldpV2RemPortId' && $rem_port_id_subtype === '5') {
                                 // Remove colons to check if it's a hexadecimal string
@@ -326,7 +325,6 @@ if (($device['os'] == 'routeros') && version_compare($device['version'], '7.7', 
                                     $lldp_array[$lldpV2RemTimeMark][$lldpV2RemLocalIfIndex][$lldpV2RemIndex]['lldpV2RemPortId'] = $value;
                                 }
                             }
-
                             $newKey = $mapV2toV1[$key] ?? $key;
                             $lldp_array[$lldpV2RemTimeMark][$lldpV2RemLocalIfIndex][$lldpV2RemIndex][$newKey] = $value;
                         }

--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -303,7 +303,7 @@ if (($device['os'] == 'routeros') && version_compare($device['version'], '7.7', 
         'lldpV2RemManAddrOID' => 'lldpRemManAddrOID',
     ];
 
-    if (!empty($lldpv2_array)) {
+    if (! empty($lldpv2_array)) {
         // map it to lldp_array
         foreach ($lldpv2_array as $lldpV2RemTimeMark => $value) {
             foreach ($value as $lldpV2RemLocalIfIndex => $value) {


### PR DESCRIPTION
When using the LLDP-V2-MIB, the device may reply with lldpV2RemPortId as hexadecimal. To convert it to a string, this update checks if the lldpV2RemPortIdSubtype is '5' = "interfaceName(5)"; if so, the code removes the character ":" from the value of lldpV2RemPortId and tests if it is hexadecimal. If the test is positive, it translates it into a string.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
