### PR TITLE
Port down list now matches the menu

### DIFF
--- a/app/Http/Controllers/Table/PortsController.php
+++ b/app/Http/Controllers/Table/PortsController.php
@@ -125,7 +125,7 @@ class PortsController extends TableController
             ->when($request->get('state'), function (Builder $query, $state) {
                 switch ($state) {
                     case 'down':
-                        return $query->where('ifAdminStatus', 'up')->where('ifOperStatus', 'down');
+                        return $query->where('ifAdminStatus', 'up')->where('ifOperStatus', '!=', 'up');
                     case 'up':
                         return $query->where('ifAdminStatus', 'up')->where('ifOperStatus', 'up');
                     case 'admindown':

--- a/app/Models/Port.php
+++ b/app/Models/Port.php
@@ -151,7 +151,7 @@ class Port extends DeviceRelatedModel
     public function scopeIsDeleted($query)
     {
         return $query->where([
-            ['deleted', 1],
+            [$this->qualifyColumn('deleted'), 1],
         ]);
     }
 
@@ -162,7 +162,7 @@ class Port extends DeviceRelatedModel
     public function scopeIsNotDeleted($query)
     {
         return $query->where([
-            ['deleted', 0],
+            [$this->qualifyColumn('deleted'), 0],
         ]);
     }
 
@@ -173,10 +173,10 @@ class Port extends DeviceRelatedModel
     public function scopeIsUp($query)
     {
         return $query->where([
-            ['deleted', '=', 0],
-            ['ignore', '=', 0],
-            ['disabled', '=', 0],
-            ['ifOperStatus', '=', 'up'],
+            [$this->qualifyColumn('deleted'), '=', 0],
+            [$this->qualifyColumn('ignore'), '=', 0],
+            [$this->qualifyColumn('disabled'), '=', 0],
+            [$this->qualifyColumn('ifOperStatus'), '=', 'up'],
         ]);
     }
 
@@ -187,11 +187,11 @@ class Port extends DeviceRelatedModel
     public function scopeIsDown($query)
     {
         return $query->where([
-            ['deleted', '=', 0],
-            ['ignore', '=', 0],
-            ['disabled', '=', 0],
-            ['ifOperStatus', '!=', 'up'],
-            ['ifAdminStatus', '=', 'up'],
+            [$this->qualifyColumn('deleted'), '=', 0],
+            [$this->qualifyColumn('ignore'), '=', 0],
+            [$this->qualifyColumn('disabled'), '=', 0],
+            [$this->qualifyColumn('ifOperStatus'), '!=', 'up'],
+            [$this->qualifyColumn('ifAdminStatus'), '=', 'up'],
         ]);
     }
 
@@ -202,10 +202,10 @@ class Port extends DeviceRelatedModel
     public function scopeIsShutdown($query)
     {
         return $query->where([
-            ['deleted', '=', 0],
-            ['ignore', '=', 0],
-            ['disabled', '=', 0],
-            ['ifAdminStatus', '=', 'down'],
+            [$this->qualifyColumn('deleted'), '=', 0],
+            [$this->qualifyColumn('ignore'), '=', 0],
+            [$this->qualifyColumn('disabled'), '=', 0],
+            [$this->qualifyColumn('ifAdminStatus'), '=', 'down'],
         ]);
     }
 
@@ -216,8 +216,8 @@ class Port extends DeviceRelatedModel
     public function scopeIsIgnored($query)
     {
         return $query->where([
-            ['deleted', '=', 0],
-            ['ignore', '=', 1],
+            [$this->qualifyColumn('deleted'), '=', 0],
+            [$this->qualifyColumn('ignore'), '=', 1],
         ]);
     }
 
@@ -228,8 +228,8 @@ class Port extends DeviceRelatedModel
     public function scopeIsDisabled($query)
     {
         return $query->where([
-            ['deleted', '=', 0],
-            ['disabled', '=', 1],
+            [$this->qualifyColumn('deleted'), '=', 0],
+            [$this->qualifyColumn('disabled'), '=', 1],
         ]);
     }
 
@@ -240,13 +240,13 @@ class Port extends DeviceRelatedModel
     public function scopeHasErrors($query)
     {
         return $query->where([
-            ['deleted', '=', 0],
-            ['ignore', '=', 0],
-            ['disabled', '=', 0],
+            [$this->qualifyColumn('deleted'), '=', 0],
+            [$this->qualifyColumn('ignore'), '=', 0],
+            [$this->qualifyColumn('disabled'), '=', 0],
         ])->where(function ($query) {
             /** @var Builder $query */
-            $query->where('ifInErrors_delta', '>', 0)
-                ->orWhere('ifOutErrors_delta', '>', 0);
+            $query->where($this->qualifyColumn('ifInErrors_delta'), '>', 0)
+                ->orWhere($this->qualifyColumn('ifOutErrors_delta'), '>', 0);
         });
     }
 
@@ -257,8 +257,8 @@ class Port extends DeviceRelatedModel
     public function scopeIsValid($query)
     {
         return $query->where([
-            ['deleted', '=', 0],
-            ['disabled', '=', 0],
+            [$this->qualifyColumn('deleted'), '=', 0],
+            [$this->qualifyColumn('disabled'), '=', 0],
         ]);
     }
 
@@ -272,7 +272,7 @@ class Port extends DeviceRelatedModel
         return $query->whereIn($query->qualifyColumn('port_id'), function ($query) use ($portGroup) {
             $query->select('port_id')
                 ->from('port_group_port')
-                ->where('port_group_id', $portGroup);
+                ->where($this->qualifyColumn('port_group_id'), $portGroup);
         });
     }
 


### PR DESCRIPTION
Fixes #13464

The menu item for Down ports filters on ports != up but the page you click through didn't, I've updated the filter to match the same behaviour on the ports page.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
