### PR TITLE
[RFC] Create a poller for vminfo from ganeti

### DIFF
--- a/LibreNMS/Modules/LegacyModule.php
+++ b/LibreNMS/Modules/LegacyModule.php
@@ -93,8 +93,8 @@ class LegacyModule implements Module
 
     public function shouldPoll(OS $os, ModuleStatus $status): bool
     {
-        // all legacy modules require snmp except ipmi and unix-agent
-        return $status->isEnabledAndDeviceUp($os->getDevice(), check_snmp: ! in_array($this->name, ['ipmi', 'unix-agent']));
+        // all legacy modules require snmp except ipmi and unix-agent and ganeti-vminfo
+        return $status->isEnabledAndDeviceUp($os->getDevice(), check_snmp: ! in_array($this->name, ['ipmi', 'unix-agent', 'ganeti-vminfo']));
     }
 
     public function poll(OS $os, DataStorageInterface $datastore): void

--- a/includes/polling/ganeti-vminfo.inc.php
+++ b/includes/polling/ganeti-vminfo.inc.php
@@ -1,0 +1,102 @@
+<?php
+
+use Illuminate\Support\Str;
+use LibreNMS\Config;
+use LibreNMS\Enum\PowerState;
+
+function uuid_to_vmwVmVMID($uuid) {
+    $hex = str_replace('-', '', $uuid);
+    $bin = pack('h*', $hex);
+    $ints = unpack('L*', $bin);
+    # Truncate value so it fits in a mysql int(11)
+    return ($ints[1] + $ints[2] + $ints[3] + $ints[4]) % 2147483647;
+}
+
+function ganeti_state_to_PowerState($state) {
+    if ($state == 'up') {
+        return PowerState::ON;
+    } elseif ($state == 'down') {
+        return PowerState::OFF;
+    } else {
+        return PowerState::UNKNOWN;
+    }
+}
+
+// FIXME should do the deletion etc in a common file perhaps? like for the sensors
+// Try to discover Libvirt Virtual Machines.
+if (DeviceCache::getPrimary()->getAttrib('ganeti_enabled')) {
+    $ganeti_vmlist = [];
+
+    $ganeti_user = DeviceCache::getPrimary()->getAttrib('ganeti_user');
+    $ganeti_pass = DeviceCache::getPrimary()->getAttrib('ganeti_pass');
+    $ssh_ok = 0;
+
+    # https://ganeti.example.com:5080/2/instances?bulk=1
+    $instances_bulk_text = file_get_contents("https://" . $ganeti_user . ":" . $ganeti_pass . "@" . $device['hostname'] . ":5080/2/instances?bulk=1");
+
+	if ($instances_bulk_text) {
+		$instances_bulk = json_decode($instances_bulk_text, true);
+
+		#| id               | int(10) unsigned     | NO   | PRI | NULL    | auto_increment |
+		#| device_id        | int(10) unsigned     | NO   | MUL | NULL    |                |
+		#| vm_type          | varchar(16)          | NO   |     | vmware  |                |
+		#| vmwVmVMID        | int(11)              | NO   | MUL | NULL    |                |
+		#| vmwVmDisplayName | varchar(128)         | NO   |     | NULL    |                |
+		#| vmwVmGuestOS     | varchar(128)         | NO   |     | NULL    |                |
+		#| vmwVmMemSize     | int(11)              | NO   |     | NULL    |                |
+		#| vmwVmCpus        | int(11)              | NO   |     | NULL    |                |
+		#| vmwVmState       | smallint(5) unsigned | NO   |     | NULL    |                |
+
+		foreach ($instances_bulk as $ganeti_instance) {
+			$vm = array(
+				'vm_type' => 'ganeti',
+				'device_id' => getidbyname($ganeti_instance['pnode']),
+				'vmwVmVMID' => uuid_to_vmwVmVMID($ganeti_instance['uuid']), # truncate this to int(11)
+				'vmwVmDisplayName' => $ganeti_instance['name'],
+				'vmwVmGuestOS' => $ganeti_instance['os'],
+				'vmwVmMemSize' => $ganeti_instance['beparams']['memory'], # or oper_ram ?
+				'vmwVmCpus' => $ganeti_instance['beparams']['vcpus'], # or oper_vcpus ?
+				'vmwVmState' => ganeti_state_to_PowerState($ganeti_instance['admin_state']),
+			);
+
+			$ganeti_vmlist[$vm['vmwVmVMID']] = $vm;
+
+			// Check whether the Virtual Machine is already known for this host.
+			$result = dbFetchRow("SELECT * FROM `vminfo` WHERE `vmwVmVMID` = ? AND `vm_type` = 'ganeti' LIMIT 1", [$vm['vmwVmVMID']]);
+
+			if (is_null($result)) {
+				$inserted_id = dbInsert($vm, 'vminfo');
+				echo '+';
+				log_event("Virtual Machine added: ".$vm['vmwVmDisplayName']." (".$vm['vmwVmMemSize']." MB)", $device, 'vm', 3, $inserted_id);
+			} else {
+				if ($result['vmwVmState'] != $vm['vmwVmState']
+					|| $result['vmwVmDisplayName'] != $vm['vmwVmDisplayName']
+					|| $result['vmwVmCpus'] != $vm['vmwVmCpus']
+					|| $result['vmwVmGuestOS'] != $vm['vmwVmGuestOS']
+					|| $result['vmwVmMemSize'] != $vm['vmwVmMemSize']
+				) {
+					dbUpdate($vm, 'vminfo', "vm_type='ganeti' AND vmwVmVMID=?", [$vm['vmwVmVMID']]);
+					echo 'U';
+					// FIXME eventlog
+				} else {
+					echo '.';
+				}
+			}
+		}
+
+		// Get a list of all the known Virtual Machines for this host.
+		$sql = "SELECT id, vmwVmVMID, vmwVmDisplayName FROM vminfo WHERE vm_type='ganeti'";
+
+		foreach (dbFetchRows($sql) as $db_vm) {
+			// Delete the Virtual Machines that are removed from the host.
+
+			if (!isset($ganeti_vmlist[$db_vm['vmwVmVMID']])) {
+				dbDelete('vminfo', '`id` = ?', [$db_vm['id']]);
+				echo '-';
+				log_event('Virtual Machine removed: ' . $db_vm['vmwVmDisplayName'], $device, 'vm', 4, $db_vm['id']);
+			}
+		}
+	}
+
+    echo "\n";
+}//end if

--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -5085,6 +5085,13 @@
             "type": "boolean",
             "default": false
         },
+        "poller_modules.ganeti-vminfo": {
+            "order": 350,
+            "group": "poller",
+            "section": "poller_modules",
+            "default": false,
+            "type": "boolean"
+        },
         "poller_modules.unix-agent": {
             "order": 420,
             "group": "poller",


### PR DESCRIPTION
https://github.com/ganeti/ganeti is a pretty neat system for managing multiple vm's on a cluster of machines.

This adds a poller module for libremns to poll the ganeti master endpoint for which vm's are running on which host and populating that into librenms.

This is currently a bit rough around the edges, as no ui for configuration exists, so create a ping-only device which monitors the ganeti master ip, and configure it by insert'ing the relevant attributes into the database:
insert into devices_attribs(device_id,attrib_type,attrib_value) VALUES (<ganeti_master_alias_device_id>,'ganeti_enabled',1); insert into devices_attribs(device_id,attrib_type,attrib_value) VALUES (<ganeti_master_alias_device_id>,'ganeti_user','librenms'); insert into devices_attribs(device_id,attrib_type,attrib_value) VALUES (<ganeti_master_alias_device_id>,'ganeti_pass','librenms');

This code should probably get a web ui to configure this and some tests before it's merged.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
