### PR TITLE
LLDP Discovery - LldpRemPortId convert to string when in HEX

### DIFF
--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -303,13 +303,30 @@ if (($device['os'] == 'routeros') && version_compare($device['version'], '7.7', 
         'lldpV2RemManAddrOID' => 'lldpRemManAddrOID',
     ];
 
-    if (! empty($lldpv2_array)) {
+    if (!empty($lldpv2_array)) {
         // map it to lldp_array
         foreach ($lldpv2_array as $lldpV2RemTimeMark => $value) {
             foreach ($value as $lldpV2RemLocalIfIndex => $value) {
                 foreach ($value as $lldpV2RemLocalDestMACAddress => $value) {
                     foreach ($value as $lldpV2RemIndex => $lldpv2_array_entries) {
                         foreach ($lldpv2_array_entries as $key => $value) {
+                            // Check if 'lldpV2RemPortIdSubtype' is of type 'interfaceName(5)' and create the variable $rem_port_id_subtype to use it later
+                            if ($key === 'lldpV2RemPortIdSubtype' && $value == '5') {
+                                $rem_port_id_subtype = '5';  // Assign the port subtype
+                            }
+    
+                            // Check if 'lldpV2RemPortId' should be converted to ASCII
+                            if ($key === 'lldpV2RemPortId' && $rem_port_id_subtype === '5') {
+                                // Remove colons to check if it's a hexadecimal string
+                                $hex_value = str_replace(':', '', $value);
+                                if (ctype_xdigit($hex_value)) {
+                                    // Convert the hexadecimal value to ASCII
+                                    $value = hex2bin($hex_value);                                                    
+                                    // Update the value of lldpV2RemPortId to ASCII
+                                    $lldp_array[$lldpV2RemTimeMark][$lldpV2RemLocalIfIndex][$lldpV2RemIndex]['lldpV2RemPortId'] = $value;
+                                }
+                            }
+
                             $newKey = $mapV2toV1[$key] ?? $key;
                             $lldp_array[$lldpV2RemTimeMark][$lldpV2RemLocalIfIndex][$lldpV2RemIndex][$newKey] = $value;
                         }

--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -2,6 +2,7 @@
 
 use LibreNMS\Config;
 use LibreNMS\Util\IP;
+use LibreNMS\Util\StringHelpers;
 
 global $link_exists;
 

--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -313,8 +313,7 @@ if (($device['os'] == 'routeros') && version_compare($device['version'], '7.7', 
                             // Check if 'lldpV2RemPortIdSubtype' is of type 'interfaceName(5)' and create the variable $rem_port_id_subtype to use it later
                             if ($key === 'lldpV2RemPortIdSubtype' && $value == '5') {
                                 $rem_port_id_subtype = '5';  // Assign the port subtype
-                            }
-    
+                            }                         
                             // Check if 'lldpV2RemPortId' should be converted to ASCII
                             if ($key === 'lldpV2RemPortId' && $rem_port_id_subtype === '5') {
                                 // Remove colons to check if it's a hexadecimal string
@@ -326,7 +325,6 @@ if (($device['os'] == 'routeros') && version_compare($device['version'], '7.7', 
                                     $lldp_array[$lldpV2RemTimeMark][$lldpV2RemLocalIfIndex][$lldpV2RemIndex]['lldpV2RemPortId'] = $value;
                                 }
                             }
-
                             $newKey = $mapV2toV1[$key] ?? $key;
                             $lldp_array[$lldpV2RemTimeMark][$lldpV2RemLocalIfIndex][$lldpV2RemIndex][$newKey] = $value;
                         }

--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -341,9 +341,9 @@ if (($device['os'] == 'routeros') && version_compare($device['version'], '7.7', 
 
             foreach ($lldp_instance as $entry_instance => $lldp) {
                 // If lldpRemPortIdSubtype is 5 and lldpRemPortId is hex, convert it to ASCII.
-				if ($lldp['lldpRemPortIdSubtype'] == 5 && ctype_xdigit(str_replace([' ', ':', '-'], '', strtolower($lldp['lldpRemPortId'])))) {
-					$lldp['lldpRemPortId'] = StringHelpers::hexToAscii($lldp['lldpRemPortId'], ':');
-				}
+                if ($lldp['lldpRemPortIdSubtype'] == 5 && ctype_xdigit(str_replace([' ', ':', '-'], '', strtolower($lldp['lldpRemPortId'])))) {
+                    $lldp['lldpRemPortId'] = StringHelpers::hexToAscii($lldp['lldpRemPortId'], ':');
+                }
                 // normalize MAC address if present
                 $remote_port_mac = '';
                 $remote_port_name = $lldp['lldpRemPortId'];

--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -303,7 +303,7 @@ if (($device['os'] == 'routeros') && version_compare($device['version'], '7.7', 
         'lldpV2RemManAddrOID' => 'lldpRemManAddrOID',
     ];
 
-    if (!empty($lldpv2_array)) {
+    if (! empty($lldpv2_array)) {
         // map it to lldp_array
         foreach ($lldpv2_array as $lldpV2RemTimeMark => $value) {
             foreach ($value as $lldpV2RemLocalIfIndex => $value) {

--- a/tests/data/panos_vsys.json
+++ b/tests/data/panos_vsys.json
@@ -13942,12 +13942,193 @@
                     "active": 1,
                     "protocol": "lldp",
                     "remote_hostname": "acme-xxx-sr-001",
-                    "remote_port": "31:30:47:45:32:2f:34:2f:30:2f:37 (32303a32383a33653a36653a65333a3131)",
+                    "remote_port": "10GE2/4/0/7 (32303a32383a33653a36653a65333a3131)",
                     "remote_platform": null,
                     "remote_version": "Huawei Versatile Routing Platform Software\nVRP (R) software, Version 8.150 (CE12800 V200R002C50SPC800)\r\nCopyright (C) 2012-2017 Huawei Technologies Co., Ltd.\r\nHUAWEI CE12804S",
                     "ifAlias": "ethernet1/12",
                     "ifDescr": "ethernet1/12",
                     "ifName": "ethernet1/12"
+                }
+            ]
+        }
+    },
+    "ports-stack": {
+        "discovery": {
+            "ports_stack": [
+                {
+                    "high_ifIndex": 300000000,
+                    "low_ifIndex": 300000001,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 300000000,
+                    "low_ifIndex": 300000002,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 300000000,
+                    "low_ifIndex": 300000004,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 300000000,
+                    "low_ifIndex": 300000005,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 400000000,
+                    "low_ifIndex": 400000001,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 400000000,
+                    "low_ifIndex": 400000002,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 400000000,
+                    "low_ifIndex": 400000101,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 400000000,
+                    "low_ifIndex": 400000102,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 400000000,
+                    "low_ifIndex": 400000103,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 400000000,
+                    "low_ifIndex": 400000107,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 400000000,
+                    "low_ifIndex": 400000108,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 400000000,
+                    "low_ifIndex": 400000109,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 400000000,
+                    "low_ifIndex": 400000201,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 400000000,
+                    "low_ifIndex": 400000202,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 400000000,
+                    "low_ifIndex": 400000301,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 400000000,
+                    "low_ifIndex": 400000302,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 400000000,
+                    "low_ifIndex": 400000303,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 400000000,
+                    "low_ifIndex": 400000304,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 400000000,
+                    "low_ifIndex": 400000306,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 400000000,
+                    "low_ifIndex": 400000401,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 400000000,
+                    "low_ifIndex": 400000501,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 500050000,
+                    "low_ifIndex": 500050010,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 500050000,
+                    "low_ifIndex": 500050030,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 500050000,
+                    "low_ifIndex": 500050035,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 500050000,
+                    "low_ifIndex": 500050060,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 500050000,
+                    "low_ifIndex": 500050070,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 500050000,
+                    "low_ifIndex": 500050075,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 500050000,
+                    "low_ifIndex": 500050121,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 500050000,
+                    "low_ifIndex": 500050200,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 500050000,
+                    "low_ifIndex": 500050220,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 500050000,
+                    "low_ifIndex": 500050251,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 500050000,
+                    "low_ifIndex": 500050255,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 500050000,
+                    "low_ifIndex": 500050290,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 500050000,
+                    "low_ifIndex": 500050300,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 500050000,
+                    "low_ifIndex": 500050320,
+                    "ifStackStatus": "active"
                 }
             ]
         }


### PR DESCRIPTION
When the LldpRemPortId is retrieved using LldpV2RemPortId, it may be in hexadecimal format. In such cases, this update will convert the LldpRemPortId to ASCII.

Before Fix:
![datacom-dmos-lldpv2-remote-port-hex-value](https://github.com/user-attachments/assets/86c053ef-d7a0-4c92-b8e3-20641eec831f)

After Fix:
![datacom-dmos-lldpv2-remote-port-string-value](https://github.com/user-attachments/assets/3f0860b4-a3d1-4160-9b55-56ae08648618)


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
