### PR TITLE
Fix default config for custom map height and width

### DIFF
--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -1074,7 +1074,7 @@
             "order": 22
         },
         "custom_map.height": {
-            "default": "1800px",
+            "default": "800px",
             "type": "text",
             "group": "webui",
             "section": "custom-map",
@@ -1161,7 +1161,7 @@
             "order": 23
         },
         "custom_map.width": {
-            "default": "800px",
+            "default": "1800px",
             "type": "text",
             "group": "webui",
             "section": "custom-map",


### PR DESCRIPTION
All other code indicates that the default for custom maps is 1800x800 (to fit on a landscape full HD screen).  This updates the config definition to match the rest of the code.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
