### PR TITLE
Refactor javascript in custom maps

### DIFF
--- a/lang/en/map.php
+++ b/lang/en/map.php
@@ -128,6 +128,7 @@ return [
             'edge' => [
                 'new' => 'New Edge',
                 'add' => 'Add Edge',
+                'edit' => 'Edit Edge',
                 'defaults_title' => 'Edge Default Config',
                 'from' => 'From',
                 'to' => 'To',

--- a/resources/views/map/custom-background-modal.blade.php
+++ b/resources/views/map/custom-background-modal.blade.php
@@ -196,4 +196,21 @@
             }
         }
     }
+
+    function startBackgroundMapAdjust() {
+        $('#map-editButton,#map-nodeDefaultsButton,#map-edgeDefaultsButton,#map-bgButton').hide();
+        $('#map-bgEndAdjustButton').show();
+    }
+
+    function endBackgroundMapAdjust() {
+        $('#map-editButton,#map-nodeDefaultsButton,#map-edgeDefaultsButton,#map-bgButton').show();
+        $('#map-bgEndAdjustButton').hide();
+
+        document.getElementById('custom-map-bg-geo-map').style.zIndex = '1';
+        const leaflet = get_map('custom-map-bg-geo-map');
+        if (leaflet) {
+            disable_map_interaction(leaflet)
+        }
+        editMapBackground();
+    }
 </script>

--- a/resources/views/map/custom-edge-modal.blade.php
+++ b/resources/views/map/custom-edge-modal.blade.php
@@ -8,27 +8,27 @@
                 <div class="row">
                     <div class="col-md-12">
                         <div class="well well-lg">
-                            <div class="form-group row" id="divEdgeFrom">
+                            <div class="form-group row existing-edge" id="divEdgeFrom">
                                 <label for="edgefrom" class="col-sm-3 control-label">{{ __('map.custom.edit.edge.from') }}</label>
                                 <div class="col-sm-9">
                                     <select id="edgefrom" class="form-control input-sm">
                                     </select>
                                 </div>
                             </div>
-                            <div class="form-group row" id="divEdgeTo">
+                            <div class="form-group row existing-edge" id="divEdgeTo">
                                 <label for="edgeto" class="col-sm-3 control-label">{{ __('map.custom.edit.edge.to') }}</label>
                                 <div class="col-sm-9">
                                     <select id="edgeto" class="form-control input-sm">
                                     </select>
                                 </div>
                             </div>
-                            <div class="form-group row single-node" id="edgePortSearchRow" style="display:none">
+                            <div class="form-group row existing-edge" id="edgePortSearchRow" style="display:none">
                                 <label for="portsearch" class="col-sm-3 control-label">{{ __('map.custom.edit.edge.port_select') }}</label>
                                 <div class="col-sm-9">
                                     <select name="portsearch" id="portsearch" class="form-control"></select>
                                 </div>
                             </div>
-                            <div class="form-group row" id="edgePortRow" style="display:none">
+                            <div class="form-group row existing-edge" id="edgePortRow" style="display:none">
                                 <label for="portclear" class="col-sm-3 control-label">{{ __('Port') }}</label>
                                 <div class="col-sm-7">
                                     <div id="port_name">
@@ -39,7 +39,7 @@
                                     <button type=button class="btn btn-primary" value="save" id="portclear" onclick="edgePortClear();">{{ __('Clear') }}</button>
                                 </div>
                             </div>
-                            <div class="form-group row" id="edgePortReverseRow" style="display:none">
+                            <div class="form-group row existing-edge" id="edgePortReverseRow" style="display:none">
                                 <label for="portreverse" class="col-sm-3 control-label">{{ __('map.custom.edit.edge.reverse') }}</label>
                                 <div class="col-sm-9">
                                     <input class="form-check-input" type="checkbox" role="switch" id="portreverse">
@@ -62,7 +62,7 @@
                                     </select>
                                 </div>
                             </div>
-                            <div class="form-group row single-node">
+                            <div class="form-group row">
                                 <label for="edgetextshow" class="col-sm-3 control-label">{{ __('map.custom.edit.edge.show_usage_percent') }}</label>
                                 <div class="col-sm-9">
                                     <input class="form-check-input" type="checkbox" role="switch" id="edgetextshow">
@@ -103,7 +103,7 @@
                                     <button type=button class="btn btn-primary" value="reset" id="edgecolourtextreset" onclick="$('#edgetextcolour').val(newedgeconf.font.color); $(this).attr('disabled','disabled');">{{ __('Reset') }}</button>
                                 </div>
                             </div>
-                            <div class="form-group row" id="edgeRecenterRow">
+                            <div class="form-group row existing-edge" id="edgeRecenterRow">
                                 <label for="edgerecenter" class="col-sm-3 control-label">{{ __('map.custom.edit.edge.recenter') }}</label>
                                 <div class="col-sm-9">
                                     <input type=checkbox class="form-check-input" value="recenter" id="edgerecenter">
@@ -119,11 +119,225 @@
             </div>
             <div class="modal-footer">
                 <center>
-                    <button type=button class="btn btn-primary" value="savedefaults" id="edge-saveDefaultsButton" data-dismiss="modal" style="display:none" onclick="editEdgeDefaultsSave();">{{ __('map.custom.edit.defaults') }}</button>
-                    <button type=button class="btn btn-primary" value="save" id="edge-saveButton" data-dismiss="modal">{{ __('Save') }}</button>
-                    <button type=button class="btn btn-primary" value="cancel" id="edge-cancelButton" data-dismiss="modal" onclick="editEdgeCancel();">{{ __('Cancel') }}</button>
+                    <button type=button class="btn btn-primary new-edge" value="savedefaults" id="edge-saveDefaultsButton" data-dismiss="modal" style="display:none" onclick="edgeDefaultsSave();">{{ __('map.custom.edit.defaults') }}</button>
+                    <button type=button class="btn btn-primary existing-edge" value="save" id="edge-saveButton" data-dismiss="modal">{{ __('Save') }}</button>
+                    <button type=button class="btn btn-primary" value="cancel" id="edge-cancelButton" data-dismiss="modal" onclick="edgeCancel();">{{ __('Cancel') }}</button>
                 </center>
             </div>
         </div>
     </div>
 </div>
+
+<script>
+    var port_search_device_id_1 = 0;
+    var port_search_device_id_2 = 0;
+
+    function edgePortClear() {
+        $("#portsearch").val('');
+        $("#portsearch").trigger('change');
+        $("#port_id").val("");
+        $("#port_name").text("");
+        $("#edgePortSearchRow").show();
+        $("#edgePortRow").hide();
+        $("#edgePortReverseRow").hide();
+    }
+
+    function edgePortSelect(e) {
+        var id = e.params.data.id;
+        var name = e.params.data.text;
+        var reverse = e.params.data.device_id != port_search_device_id_1;
+        $("#port_id").val(id);
+        $("#port_name").text(name);
+        $("#portreverse").bootstrapSwitch('state', reverse);
+
+        $("#edgePortSearchRow").hide();
+        $("#edgePortRow").show();
+        $("#edgePortReverseRow").show();
+    }
+
+    function edgeSave(event) {
+        edgedata = event.data.data;
+
+        edgeNodesUpdate(edgedata.id, $("#edgefrom").val(), $("#edgeto").val(), edgedata.edge1.from, edgedata.edge2.from);
+
+        $("#edge-saveButton").off("click");
+        edgedata.edge1.smooth.type = $("#edgestyle").val();
+        edgedata.edge2.smooth.type = $("#edgestyle").val();
+        edgedata.edge1.from = $("#edgefrom").val();
+        edgedata.edge2.from = $("#edgeto").val();
+        edgedata.edge1.font.face = edgedata.edge2.font.face = $("#edgetextface").val();
+        edgedata.edge1.font.size = edgedata.edge2.font.size = $("#edgetextsize").val();
+        edgedata.edge1.font.color = edgedata.edge2.font.color = $("#edgetextcolour").val();
+        edgedata.edge1.label = edgedata.edge2.label = edgeLabel($("#edgetextshow").prop('checked'), $("#edgebpsshow").prop('checked'), null);
+        edgedata.edge1.title = edgedata.edge2.title = $("#port_id").val();
+        let newlabel = $("#edgelabel").val() || '';
+        if (newlabel == '' && edgedata.mid.label != '') {
+            $("#map-renderButton").show();
+        }
+        edgedata.mid.label = newlabel;
+
+        if(edgedata.id) {
+            if($("#port_id").val()) {
+                edge_port_map[edgedata.id] = {port_id: $("#port_id").val(), port_name: $("#port_name").text(), reverse: $("#portreverse")[0].checked}
+            } else {
+                delete edge_port_map[edgedata.id];
+            }
+        }
+
+        // Special case for curved lines
+        if(edgedata.edge2.smooth.type == "curvedCW") {
+            edgedata.edge2.smooth.type = "curvedCCW";
+        } else if (edgedata.edge2.smooth.type == "curvedCCW") {
+            edgedata.edge2.smooth.type = "curvedCW";
+        }
+
+        if(edgedata.add) {
+            network_nodes.add([edgedata.mid]);
+            network_nodes.flush();
+            network_edges.add([edgedata.edge1, edgedata.edge2]);
+            network_edges.flush();
+        } else {
+            network_edges.update([edgedata.edge1, edgedata.edge2]);
+            network_nodes.update([edgedata.mid]);
+
+            if($("#edgerecenter").is(":checked")) {
+                var pos = network.getPositions([edgedata.edge1.from, edgedata.edge2.from]);
+                const mid_pos = getMidPos(edgedata.id, edgedata.edge1.from, edgedata.edge2.from);
+
+                edgedata.mid.x = mid_pos.x;
+                edgedata.mid.y = mid_pos.y;
+                network_nodes.update([edgedata.mid]);
+                $("#map-renderButton").show();
+            }
+
+            // Blank labels need to be selected to update.  Select both to ensure this happens
+            if(! edgedata.edge1.label) {
+                network_edges.flush();
+                network.selectEdges([edgedata.edge2.id]);
+                // Redraw to make sure the above change is reflected in the view before we select the next edge
+                network.redraw();
+                // Select the first edge, which will trigger another update
+                network.selectEdges([edgedata.edge1.id]);
+            }
+        }
+        $("#edgerecenter").prop( "checked", false );
+        $("#map-saveDataButton").show();
+    }
+
+    function edgeEditDefaults() {
+        $("#edgeModalLabel").text('{{ __('map.custom.edit.edge.defaults_title') }}');
+
+        $("#edgestyle").val(newedgeconf.smooth.type);
+        $("#edgetextface").val(newedgeconf.font.face);
+        $("#edgetextsize").val(newedgeconf.font.size);
+        $("#edgetextcolour").val(newedgeconf.font.color);
+        $("#edgetextshow").bootstrapSwitch('state', (newedgeconf.label.includes('xx%') || newedgeconf.label.includes('true')));
+        $("#edgebpsshow").bootstrapSwitch('state', (newedgeconf.label.includes('bps')));
+        $('#edgecolourtextreset').attr('disabled', 'disabled');
+
+        $(".existing-edge").hide();
+        $(".new-edge").show();
+
+        $('#edgeModal').modal({backdrop: 'static', keyboard: false}, 'show');
+    }
+
+    function edgeEdit(edgedata) {
+        if(edgedata.add) {
+            $("#edgeModalLabel").text('{{ __('map.custom.edit.edge.add') }}');
+        } else {
+            $("#edgeModalLabel").text('{{ __('map.custom.edit.edge.edit') }}');
+        }
+
+        $("#portsearch").val('');
+        $("#portsearch").trigger('change');
+        var nodes = network_nodes.get({
+          fields: ['id', 'label'],
+          filter: function (item) {
+            // We do not want to be able to link to the mid nodes
+            return (!item.id.endsWith("_mid"));
+          },
+        });
+        $("#edgefrom").find('option').remove().end();
+        $("#edgeto").find('option').remove().end();
+        $.each( nodes, function( node_idx, node ) {
+            if (! node.id.endsWith('_mid') && ! node.id.startsWith("legend_")) {
+                $("#edgefrom").append('<option value="' + node.id + '">' + node.label+ '</option>');
+                $("#edgeto").append('<option value="' + node.id + '">' + node.label+ '</option>');
+            }
+        });
+        $("#edgefrom").val(edgedata.edge1.from);
+        $("#edgeto").val(edgedata.edge2.from);
+
+        edgePortSearchUpdate($("#edgefrom").val(), $("#edgeto").val(), edgedata.id);
+        checkColourReset(edgedata.edge1.font.color, newedgeconf.font.color, "edgecolourtextreset");
+
+        $("#edgestyle").val(edgedata.edge1.smooth.type);
+        $("#edgetextface").val(edgedata.edge1.font.face);
+        $("#edgetextsize").val(edgedata.edge1.font.size);
+        $("#edgetextcolour").val(edgedata.edge1.font.color);
+        $("#edgetextshow").bootstrapSwitch('state', (edgedata.edge1.label != null && edgedata.edge1.label.includes('xx%')));
+        $("#edgebpsshow").bootstrapSwitch('state', (edgedata.edge1.label != null && edgedata.edge1.label.includes('bps')));
+        $("#edgelabel").val('label' in edgedata.mid ? edgedata.mid.label : '');
+
+        $(".existing-edge").show();
+        $(".new-edge").hide();
+        $("#edge-saveButton").on("click", {data: edgedata}, edgeSave);
+
+        $('#edgeModal').modal({backdrop: 'static', keyboard: false}, 'show');
+    }
+
+    function edgePortSearchUpdate(node1_id, node2_id, edge_id) {
+        node1 = network_nodes.get(node1_id);
+        node2 = network_nodes.get(node2_id);
+
+        if(isNaN(node1.title) && isNaN(node2.title)) {
+            // Neither node has a device - clear port config
+            $("#port_id").val("");
+            $("#edgePortRow").hide();
+            $("#edgePortReverseRow").hide();
+            $("#edgePortSearchRow").hide();
+            return;
+        }
+        if(edge_id in edge_port_map) {
+            $("#port_id").val(edge_port_map[edge_id].port_id);
+            $("#port_name").text(edge_port_map[edge_id].port_name);
+            $("#portreverse").bootstrapSwitch('state', edge_port_map[edge_id].reverse);
+            $("#edgePortRow").show();
+            $("#edgePortReverseRow").show();
+            $("#edgePortSearchRow").hide();
+        } else {
+            $("#port_id").val("");
+            $("#portreverse").bootstrapSwitch('state', false);
+            $("#edgePortRow").hide();
+            $("#edgePortReverseRow").hide();
+            $("#edgePortSearchRow").show();
+        }
+        port_search_device_id_1 = (node1.id in node_device_map) ? node_device_map[node1.id].device_id : 0;
+        port_search_device_id_2 = (node2.id in node_device_map) ? node_device_map[node2.id].device_id : 0;
+    }
+
+    function edgeCancel(event) {
+        $("#edge-saveButton").off("click");
+    }
+
+    function edgeDefaultsSave() {
+        newedgeconf.smooth.type = $("#edgestyle").val();
+        newedgeconf.font.face = $("#edgetextface").val();
+        newedgeconf.font.size = $("#edgetextsize").val();
+        newedgeconf.font.color = $("#edgetextcolour").val();
+        newedgeconf.label = edgeLabel($("#edgetextshow").prop('checked'), $("#edgebpsshow").prop('checked'), '');
+        $("#map-saveDataButton").show();
+    }
+
+    $(document).ready(function () {
+        init_select2('#portsearch', 'port', function(params) {
+            return {
+                limit: 100,
+                devices: [port_search_device_id_1, port_search_device_id_2],
+                term: params.term,
+                page: params.page || 1
+            }
+        }, '', '{{ __('map.custom.edit.edge.port_select') }}', {dropdownParent: $('#edgeModal')});
+        $("#portsearch").on("select2:select", edgePortSelect);
+   });
+</script>

--- a/resources/views/map/custom-edge-modal.blade.php
+++ b/resources/views/map/custom-edge-modal.blade.php
@@ -132,6 +132,14 @@
     var port_search_device_id_1 = 0;
     var port_search_device_id_2 = 0;
 
+    function edgeCheckColourReset(itemColour, defaultColour, resetControlId) {
+        if(!itemColour || itemColour.toLowerCase() == defaultColour.toLowerCase()) {
+            $("#" + resetControlId).attr('disabled','disabled');
+        } else {
+            $("#" + resetControlId).removeAttr('disabled');
+        }
+    }
+
     function edgePortClear() {
         $("#portsearch").val('');
         $("#portsearch").trigger('change');
@@ -269,7 +277,7 @@
         $("#edgeto").val(edgedata.edge2.from);
 
         edgePortSearchUpdate($("#edgefrom").val(), $("#edgeto").val(), edgedata.id);
-        checkColourReset(edgedata.edge1.font.color, newedgeconf.font.color, "edgecolourtextreset");
+        edgeCheckColourReset(edgedata.edge1.font.color, newedgeconf.font.color, "edgecolourtextreset");
 
         $("#edgestyle").val(edgedata.edge1.smooth.type);
         $("#edgetextface").val(edgedata.edge1.font.face);

--- a/resources/views/map/custom-edge-modal.blade.php
+++ b/resources/views/map/custom-edge-modal.blade.php
@@ -74,7 +74,7 @@
                                     <input class="form-check-input" type="checkbox" role="switch" id="edgebpsshow">
                                 </div>
                             </div>
-                            <div class="form-group row">
+                            <div class="form-group row existing-edge">
                                 <label for="edgelabel" class="col-sm-3 control-label">{{ __('map.custom.edit.edge.label') }}</label>
                                 <div class="col-sm-9">
                                     <input type=text id="edgelabel" class="form-control input-sm" value="" />

--- a/resources/views/map/custom-edit.blade.php
+++ b/resources/views/map/custom-edit.blade.php
@@ -16,8 +16,8 @@
       <button type=button value="mapedit" id="map-editButton" class="btn btn-primary" onclick="editMapSettings()">{{ __('map.custom.edit.map.edit') }}</button>
       <button type=button value="mapbg" id="map-bgButton" class="btn btn-primary" onclick="editMapBackground()">{{ __('map.custom.edit.bg.title') }}</button>
       <button type=button value="mapbg" id="map-bgEndAdjustButton" class="btn btn-primary" onclick="endBackgroundMapAdjust()" style="display:none">{{ __('map.custom.edit.bg.adjust_map_finish') }}</button>
-      <button type=button value="editnodedefaults" id="map-nodeDefaultsButton" class="btn btn-primary" onclick="editNodeDefaults()">{{ __('map.custom.edit.node.edit_defaults') }}</button>
-      <button type=button value="editedgedefaults" id="map-edgeDefaultsButton" class="btn btn-primary" onclick="editEdgeDefaults()">{{ __('map.custom.edit.edge.edit_defaults') }}</button>
+      <button type=button value="editnodedefaults" id="map-nodeDefaultsButton" class="btn btn-primary" onclick="nodeEdit(newnodeconf)">{{ __('map.custom.edit.node.edit_defaults') }}</button>
+      <button type=button value="editedgedefaults" id="map-edgeDefaultsButton" class="btn btn-primary" onclick="edgeEditDefaults()">{{ __('map.custom.edit.edge.edit_defaults') }}</button>
     </div>
     <div class="col-md-2">
       <center>
@@ -232,21 +232,17 @@
         // Set up the triggers for adding and editing map items
         options['manipulation']['addNode'] = function (data, callback) {
                 callback(null);
-                $("#nodeModalLabel").text('{{ __('map.custom.edit.node.add') }}');
                 var node = structuredClone(newnodeconf);
                 node.id = "new" + newcount++;
                 node.label = "New Node";
                 node.x = node_align ? Math.round(data.x / node_align) * node_align : data.x;
                 node.y = node_align ? Math.round(data.y / node_align) * node_align : data.y;
                 node.add = true;
-                $(".single-node").show();
-                editNode(node, editNodeSave);
+                nodeEdit(node);
             }
         options['manipulation']['editNode'] = function (data, callback) {
                 callback(null);
-                $("#nodeModalLabel").text('{{ __('map.custom.edit.node.edit') }}');
-                $(".single-node").show();
-                editNode(data, editNodeSave);
+                checkEditNode(data);
             }
         options['manipulation']['deleteNode'] = function (data, callback) {
                 callback(null);
@@ -299,8 +295,7 @@
 
                 var edgedata = {id: edgeid, mid: mid, edge1: edge1, edge2: edge2, add: true}
 
-                $("#edgeModalLabel").text('{{ __('map.custom.edit.edge.add') }}');
-                editEdge(edgedata, editEdgeSave);
+                edgeEdit(edgedata);
             }
         options['manipulation']['editEdge'] = { editWithoutDrag: editExistingEdge };
         options['manipulation']['deleteEdge'] = function (data, callback) {
@@ -329,7 +324,7 @@
                 node = network_nodes.get(node_id);
                 $("#nodeModalLabel").text('{{ __('map.custom.edit.node.edit') }}');
                 $(".single-node").show();
-                editNode(node, editNodeSave);
+                checkEditNode(node);
             } else if (properties.edges.length > 0) {
                 edge_id = properties.edges[0].split("_")[0];
                 edge = network_edges.get(edge_id + "_to");
@@ -377,8 +372,6 @@
     var newedgeconf = @json($newedge_conf);
     var newnodeconf = @json($newnode_conf);
     var newcount = 1;
-    var port_search_device_id_1 = 0;
-    var port_search_device_id_2 = 0;
 
     // Make sure the new edge config has an appropriate label value
     if (!("label" in newedgeconf)) {
@@ -567,105 +560,6 @@
         $('#bgModal').modal('show');
     }
 
-    function nodeStyleChange() {
-        var nodestyle = $("#nodestyle").val();
-        if(nodestyle == 'icon') {
-            $("#nodeIconRow").show();
-        } else {
-            $("#nodeIconRow").hide();
-        }
-        if(nodestyle == 'image' || nodestyle == 'circularImage') {
-            $("#nodeImageRow").show();
-        } else {
-            $("#nodeImageRow").hide();
-        }
-    }
-
-    function nodeDeviceSelect(e) {
-        var id = e.params.data.id;
-        var name = e.params.data.text;
-        $("#device_id").val(id);
-        $("#device_name").text(name);
-        $("#nodelabel").val(name.split(".")[0].split(" ")[0]);
-        $("#device_image").val(e.params.data.icon);
-        $("#nodeDeviceSearchRow").hide();
-        $("#nodeMapLinkRow").hide();
-        $("#deviceiconimage").show();
-        $("#nodeDeviceRow").show();
-    }
-
-    function nodeDeviceClear() {
-        $("#devicesearch").val('');
-        $("#devicesearch").trigger('change');
-        $("#device_id").val("");
-        $("#device_name").text("");
-        $("#device_image").val("");
-        $("#nodeDeviceRow").hide();
-        $("#deviceiconimage").hide();
-        $("#nodeDeviceSearchRow").show();
-        $("#nodeMapLinkRow").show();
-
-        // Reset device style if we were using the device image
-        if(($("#nodestyle").val() == "image" || $("#nodestyle").val() == "circularImage") && !$("#nodeimage").val()){
-            $("#nodestyle").val(newnodeconf.shape);
-            $("#nodeImageRow").hide();
-            setNodeImage();
-        }
-    }
-
-    function nodeMapLinkChange() {
-        if($("#maplink").val()) {
-            $("#nodeDeviceSearchRow").hide();
-        } else {
-            $("#nodeDeviceSearchRow").show();
-        }
-    }
-
-    function setNodeImage() {
-        // If the selected option is not visible, select the top option
-        if($("#nodeimage option:selected").css('display') == 'none') {
-            $("#nodeimage").val($("#nodeimage option:eq(1)").val());
-        }
-        // Set the image preview src
-        if($("#nodeimage").val()) {
-            $("#nodeimagepreview").attr("src", custom_image_base + $("#nodeimage").val());
-        } else {
-            $("#nodeimagepreview").attr("src", $("#device_image").val());
-        }
-    }
-
-    function setNodeIcon() {
-        var newcode = $("#nodeicon").val();
-        $("#nodeiconpreview").text(String.fromCharCode(parseInt(newcode, 16)));
-    }
-
-    function editNodeDefaults() {
-        $("#nodeModalLabel").text('{{ __('map.custom.edit.node.defaults_title') }}');
-        $(".single-node").hide();
-        var node = structuredClone(newnodeconf);
-        editNode(node, editNodeDefaultsSave);
-    }
-
-    function editNodeDefaultsSave() {
-        newnodeconf.shape = $("#nodestyle").val();
-        newnodeconf.font.face = $("#nodetextface").val();
-        newnodeconf.font.size = $("#nodetextsize").val();
-        newnodeconf.font.color = $("#nodetextcolour").val();
-        newnodeconf.color.background = $("#nodecolourbg").val();
-        newnodeconf.color.border = $("#nodecolourbdr").val();
-        if(newnodeconf.shape == "icon") {
-            newnodeconf.icon = {face: 'FontAwesome', code: String.fromCharCode(parseInt($("#nodeicon").val(), 16)), size: $("#nodesize").val(), color: newnodeconf.color.border};
-        } else {
-            newnodeconf.icon = {};
-        }
-        if(newnodeconf.shape == "image" || newnodeconf.shape == "circularImage") {
-            newnodeconf.image = {unselected: custom_image_base + $("#nodeimage").val()};
-        } else {
-            delete newnodeconf.image;
-        }
-        $("#map-saveDataButton").show();
-    }
-
     function checkColourReset(itemColour, defaultColour, resetControlId) {
         if(!itemColour || itemColour.toLowerCase() == defaultColour.toLowerCase()) {
             $("#" + resetControlId).attr('disabled','disabled');
@@ -674,10 +568,7 @@
         }
     }
 
-    function editNode(data, callback) {
-        $("#devicesearch").val('');
-        $("#devicesearch").trigger('change');
-
+    function checkEditNode(data) {
         // If we have an ID that is non numeric, we can check node type further
         if(data.id && isNaN(data.id)) {
             // Editing a mid point node triggers editing the edge
@@ -692,219 +583,7 @@
                 return;
             }
         }
-
-        if(data.id in node_device_map) {
-            // Nodes is linked to a device
-            $("#device_id").val(node_device_map[data.id].device_id);
-            $("#device_name").text(node_device_map[data.id].device_name);
-            // Hide device selection row
-            $("#nodeDeviceSearchRow").hide();
-            $("#nodeMapLinkRow").hide();
-            // Show device image as an option
-            $("#deviceiconimage").show();
-            $("#device_image").val(node_device_map[data.id].device_image);
-        } else {
-            // Node is not linked to a device
-            $("#device_id").val("");
-            $("#device_name").text("");
-            // Hide the selected device row
-            $("#nodeDeviceRow").hide();
-            // Hide device image as an option
-            $("#deviceiconimage").hide();
-            $("#device_image").val("");
-        }
-        if(data.title && data.title.toString().startsWith("map:")) {
-            // Hide device selection row
-            $("#nodeDeviceSearchRow").hide();
-            $("#maplink").val(data.title.replace("map:",""));
-        }
-        $("#nodelabel").val(data.label);
-        $("#nodestyle").val(data.shape);
-        // Show or hide the image selection if the shape is an image type
-        if(data.shape == "image" || data.shape == "circularImage") {
-            $("#nodeImageRow").show();
-            if(data.image.unselected.indexOf(custom_image_base) == 0) {
-                $("#nodeimage").val(data.image.unselected.replace(custom_image_base, ""));
-            } else {
-                $("#nodeimage").val("");
-            }
-        } else {
-            $("#nodeImageRow").hide();
-            $("#nodeimage").val("");
-        }
-        setNodeImage();
-        // Show or hide the icon selection if the shape is icon
-        if(data.shape == "icon") {
-            $("#nodeicon").val(data.icon.code.charCodeAt(0).toString(16));
-            $("#nodeIconRow").show();
-        } else {
-            $("#nodeIconRow").hide();
-        }
-        $("#nodesize").val(data.size);
-        $("#nodetextface").val(data.font.face);
-        $("#nodetextsize").val(data.font.size);
-        $("#nodetextcolour").val(data.font.color);
-        if(data.color && data.color.background) {
-            $("#nodecolourbg").val(data.color.background);
-            $("#nodecolourbdr").val(data.color.border);
-        } else {
-            // The background colour is blank because a device has been selected - start with defaults
-            $("#nodecolourbg").val(newnodeconf.color.background);
-            $("#nodecolourbdr").val(newnodeconf.color.border);
-        }
-
-        checkColourReset(data.font.color, newnodeconf.font.color, "nodecolourtextreset");
-        checkColourReset(data.color.background, newnodeconf.color.background, "nodecolourbgreset");
-        checkColourReset(data.color.border, newnodeconf.color.border, "nodecolourbdrreset");
-
-        if(data.id) {
-            $("#node-saveButton").on("click", {data: data}, callback);
-            $("#node-saveButton").show();
-            $("#node-saveDefaultsButton").hide();
-        } else {
-            $("#node-saveButton").hide();
-            $("#node-saveDefaultsButton").show();
-        }
-        $('#nodeModal').modal({backdrop: 'static', keyboard: false}, 'show');
-    }
-
-    function editNodeSave(event) {
-        node = event.data.data;
-
-        editNodeHide();
-
-        if($("#device_id").val()) {
-            node.title = $("#device_id").val();
-        } else if($("#maplink").val()) {
-            node.title = "map:" + $("#maplink").val();
-        } else {
-            node.title = '';
-        }
-        // Update the node with the selected values on success and run the callback
-        node.label = $("#nodelabel").val();
-        node.shape = $("#nodestyle").val();
-        node.font.face = $("#nodetextface").val();
-        node.font.size = parseInt($("#nodetextsize").val());
-        node.font.color = $("#nodetextcolour").val();
-        node.color = {highlight: {}, hover: {}};
-        node.color.background = node.color.highlight.background = node.color.hover.background = $("#nodecolourbg").val();
-        node.color.border = node.color.highlight.border = node.color.hover.border = $("#nodecolourbdr").val();
-        node.size = $("#nodesize").val();
-        if(node.shape == "image" || node.shape == "circularImage") {
-            if($("#nodeimage").val()) {
-                node.image = {unselected: custom_image_base + $("#nodeimage").val()};
-            } else {
-                node.image = {unselected: $("#device_image").val()};
-            }
-        } else {
-            node.image = {};
-        }
-        if(node.shape == "icon") {
-            node.icon = {face: 'FontAwesome', code: String.fromCharCode(parseInt($("#nodeicon").val(), 16)), size: $("#nodesize").val(), color: node.color.border};
-        } else {
-            node.icon = {};
-        }
-        if(node.add) {
-            delete node.add;
-            network_nodes.add(node);
-        } else {
-            network_nodes.update(node);
-        }
-
-        if(node.id) {
-            if($("#device_id").val()) {
-                node_device_map[node.id] = {device_id: $("#device_id").val(), device_name: $("#device_name").text(), device_image: $("#device_image").val()}
-            } else {
-                delete node_device_map[node.id];
-            }
-        }
-
-        $("#map-saveDataButton").show();
-        $("#map-renderButton").show();
-    }
-
-    function editNodeCancel(event) {
-        editNodeHide();
-    }
-
-    function editNodeHide() {
-        $("#node-saveButton").off("click");
-    }
-
-    function updateEdgePortSearch(node1_id, node2_id, edge_id) {
-        node1 = network_nodes.get(node1_id);
-        node2 = network_nodes.get(node2_id);
-
-        if(isNaN(node1.title) && isNaN(node2.title)) {
-            // Neither node has a device - clear port config
-            $("#port_id").val("");
-            $("#edgePortRow").hide();
-            $("#edgePortReverseRow").hide();
-            $("#edgePortSearchRow").hide();
-            return;
-        }
-        if(edge_id in edge_port_map) {
-            $("#port_id").val(edge_port_map[edge_id].port_id);
-            $("#port_name").text(edge_port_map[edge_id].port_name);
-            $("#portreverse").bootstrapSwitch('state', edge_port_map[edge_id].reverse);
-            $("#edgePortRow").show();
-            $("#edgePortReverseRow").show();
-            $("#edgePortSearchRow").hide();
-        } else {
-            $("#port_id").val("");
-            $("#portreverse").bootstrapSwitch('state', false);
-            $("#edgePortRow").hide();
-            $("#edgePortReverseRow").hide();
-            $("#edgePortSearchRow").show();
-        }
-        port_search_device_id_1 = (node1.id in node_device_map) ? node_device_map[node1.id].device_id : 0;
-        port_search_device_id_2 = (node2.id in node_device_map) ? node_device_map[node2.id].device_id : 0;
-    }
-
-    function edgePortSelect(e) {
-        var id = e.params.data.id;
-        var name = e.params.data.text;
-        var reverse = e.params.data.device_id != port_search_device_id_1;
-        $("#port_id").val(id);
-        $("#port_name").text(name);
-        $("#portreverse").bootstrapSwitch('state', reverse);
-
-        $("#edgePortSearchRow").hide();
-        $("#edgePortRow").show();
-        $("#edgePortReverseRow").show();
-    }
-
-    function edgePortClear() {
-        $("#portsearch").val('');
-        $("#portsearch").trigger('change');
-        $("#port_id").val("");
-        $("#port_name").text("");
-        $("#edgePortSearchRow").show();
-        $("#edgePortRow").hide();
-        $("#edgePortReverseRow").hide();
-    }
-
-    function editEdgeDefaults() {
-        $("#edgeModalLabel").text('{{ __('map.custom.edit.edge.defaults_title') }}');
-        $("#divEdgeFrom").hide();
-        $("#divEdgeTo").hide();
-        $("#edgePortRow").hide();
-        $("#edgePortReverseRow").hide();
-        $("#edgePortSearchRow").hide();
-        $("#edgeRecenterRow").hide();
-        $("#edgelabel").hide();
-
-        $("#edgestyle").val(newedgeconf.smooth.type);
-        $("#edgetextface").val(newedgeconf.font.face);
-        $("#edgetextsize").val(newedgeconf.font.size);
-        $("#edgetextcolour").val(newedgeconf.font.color);
-        $("#edgetextshow").bootstrapSwitch('state', (newedgeconf.label.includes('xx%') || newedgeconf.label.includes('true')));
-        $("#edgebpsshow").bootstrapSwitch('state', (newedgeconf.label.includes('bps')));
-        $('#edgecolourtextreset').attr('disabled', 'disabled');
-
-        $("#edge-saveButton").hide();
-        $("#edge-saveDefaultsButton").show();
-        $('#edgeModal').modal({backdrop: 'static', keyboard: false}, 'show');
+        nodeEdit(data);
     }
 
     function edgeLabel(show_pct, show_bps, default_val) {
@@ -924,134 +603,6 @@
         return default_val;
     }
 
-    function editEdgeDefaultsSave() {
-        editEdgeHide();
-        newedgeconf.smooth.type = $("#edgestyle").val();
-        newedgeconf.font.face = $("#edgetextface").val();
-        newedgeconf.font.size = $("#edgetextsize").val();
-        newedgeconf.font.color = $("#edgetextcolour").val();
-        newedgeconf.label = edgeLabel($("#edgetextshow").prop('checked'), $("#edgebpsshow").prop('checked'), '');
-        $("#map-saveDataButton").show();
-    }
-
-    function editEdge(edgedata, callback) {
-        $("#portsearch").val('');
-        $("#portsearch").trigger('change');
-        var nodes = network_nodes.get({
-          fields: ['id', 'label'],
-          filter: function (item) {
-            // We do not want to be able to link to the mid nodes
-            return (!item.id.endsWith("_mid"));
-          },
-        });
-        $("#edgefrom").find('option').remove().end();
-        $("#edgeto").find('option').remove().end();
-        $.each( nodes, function( node_idx, node ) {
-            $("#edgefrom").append('<option value="' + node.id + '">' + node.label+ '</option>');
-            $("#edgeto").append('<option value="' + node.id + '">' + node.label+ '</option>');
-        });
-        $("#edgefrom").val(edgedata.edge1.from);
-        $("#edgeto").val(edgedata.edge2.from);
-
-        updateEdgePortSearch($("#edgefrom").val(), $("#edgeto").val(), edgedata.id);
-        checkColourReset(edgedata.edge1.font.color, newedgeconf.font.color, "edgecolourtextreset");
-
-        $("#edgestyle").val(edgedata.edge1.smooth.type);
-        $("#edgetextface").val(edgedata.edge1.font.face);
-        $("#edgetextsize").val(edgedata.edge1.font.size);
-        $("#edgetextcolour").val(edgedata.edge1.font.color);
-        $("#edgetextshow").bootstrapSwitch('state', (edgedata.edge1.label != null && edgedata.edge1.label.includes('xx%')));
-        $("#edgebpsshow").bootstrapSwitch('state', (edgedata.edge1.label != null && edgedata.edge1.label.includes('bps')));
-        $("#edgelabel").val('label' in edgedata.mid ? edgedata.mid.label : '');
-
-        $("#edgeRecenterRow").show();
-        $("#divEdgeFrom").show();
-        $("#divEdgeTo").show();
-        $("#edgelabel").show();
-        $("#edge-saveButton").show();
-        $("#edge-saveDefaultsButton").hide();
-        $("#edge-saveButton").on("click", {data: edgedata}, callback);
-
-        $('#edgeModal').modal({backdrop: 'static', keyboard: false}, 'show');
-    }
-
-    function editEdgeSave(event) {
-        edgedata = event.data.data;
-
-        edgeNodesUpdate(edgedata.id, $("#edgefrom").val(), $("#edgeto").val(), edgedata.edge1.from, edgedata.edge2.from);
-
-        editEdgeHide();
-        edgedata.edge1.smooth.type = $("#edgestyle").val();
-        edgedata.edge2.smooth.type = $("#edgestyle").val();
-        edgedata.edge1.from = $("#edgefrom").val();
-        edgedata.edge2.from = $("#edgeto").val();
-        edgedata.edge1.font.face = edgedata.edge2.font.face = $("#edgetextface").val();
-        edgedata.edge1.font.size = edgedata.edge2.font.size = $("#edgetextsize").val();
-        edgedata.edge1.font.color = edgedata.edge2.font.color = $("#edgetextcolour").val();
-        edgedata.edge1.label = edgedata.edge2.label = edgeLabel($("#edgetextshow").prop('checked'), $("#edgebpsshow").prop('checked'), null);
-        edgedata.edge1.title = edgedata.edge2.title = $("#port_id").val();
-	let newlabel = $("#edgelabel").val() || '';
-	if (newlabel == '' && edgedata.mid.label != '') {
-            $("#map-renderButton").show();
-	}
-        edgedata.mid.label = newlabel;
-
-        if(edgedata.id) {
-            if($("#port_id").val()) {
-                edge_port_map[edgedata.id] = {port_id: $("#port_id").val(), port_name: $("#port_name").text(), reverse: $("#portreverse")[0].checked}
-            } else {
-                delete edge_port_map[edgedata.id];
-            }
-        }
-
-        // Special case for curved lines
-        if(edgedata.edge2.smooth.type == "curvedCW") {
-            edgedata.edge2.smooth.type = "curvedCCW";
-        } else if (edgedata.edge2.smooth.type == "curvedCCW") {
-            edgedata.edge2.smooth.type = "curvedCW";
-        }
-
-        if(edgedata.add) {
-            network_nodes.add([edgedata.mid]);
-            network_nodes.flush();
-            network_edges.add([edgedata.edge1, edgedata.edge2]);
-            network_edges.flush();
-        } else {
-            network_edges.update([edgedata.edge1, edgedata.edge2]);
-            network_nodes.update([edgedata.mid]);
-
-            if($("#edgerecenter").is(":checked")) {
-                var pos = network.getPositions([edgedata.edge1.from, edgedata.edge2.from]);
-                const mid_pos = getMidPos(edgedata.id, edgedata.edge1.from, edgedata.edge2.from);
-
-                edgedata.mid.x = mid_pos.x;
-                edgedata.mid.y = mid_pos.y;
-                network_nodes.update([edgedata.mid]);
-                $("#map-renderButton").show();
-            }
-
-            // Blank labels need to be selected to update.  Select both to ensure this happens
-            if(! edgedata.edge1.label) {
-                network_edges.flush();
-                network.selectEdges([edgedata.edge2.id]);
-                // Redraw to make sure the above change is reflected in the view before we select the next edge
-                network.redraw();
-                // Select the first edge, which will trigger another update
-                network.selectEdges([edgedata.edge1.id]);
-            }
-        }
-        $("#edgerecenter").prop( "checked", false );
-        $("#map-saveDataButton").show();
-    }
-
-    function editEdgeCancel(event) {
-        editEdgeHide();
-    }
-
-    function editEdgeHide() {
-        $("#edge-saveButton").off("click");
-    }
-
     function editExistingEdge (edge, callback) {
         if(callback) {
             callback(null);
@@ -1069,8 +620,7 @@
 
         var edgedata = {id: edgeinfo[0], mid: mid, edge1: edge1, edge2: edge2}
 
-        $("#edgeModalLabel").text("Edit Edge");
-        editEdge(edgedata, editEdgeSave);
+        edgeEdit(edgedata);
     }
 
     function deleteEdge(edgeid) {
@@ -1230,41 +780,12 @@
         }).observe(targetNode, {attributes: false, childList: true, subtree: false});
     }
 
-    function startBackgroundMapAdjust() {
-        $('#map-editButton,#map-nodeDefaultsButton,#map-edgeDefaultsButton,#map-bgButton').hide();
-        $('#map-bgEndAdjustButton').show();
-    }
-
-    function endBackgroundMapAdjust() {
-        $('#map-editButton,#map-nodeDefaultsButton,#map-edgeDefaultsButton,#map-bgButton').show();
-        $('#map-bgEndAdjustButton').hide();
-
-        document.getElementById('custom-map-bg-geo-map').style.zIndex = '1';
-        const leaflet = get_map('custom-map-bg-geo-map');
-        if (leaflet) {
-            disable_map_interaction(leaflet)
-        }
-        editMapBackground();
-    }
-
     $(document).ready(function () {
-        init_select2('#devicesearch', 'device', {limit: 100}, '', '{{ __('map.custom.edit.node.device_select') }}', {dropdownParent: $('#nodeModal')});
-        $("#devicesearch").on("select2:select", nodeDeviceSelect);
-
-        init_select2('#portsearch', 'port', function(params) {
-            return {
-                limit: 100,
-                devices: [port_search_device_id_1, port_search_device_id_2],
-                term: params.term,
-                page: params.page || 1
-            }
-        }, '', '{{ __('map.custom.edit.edge.port_select') }}', {dropdownParent: $('#edgeModal')});
-        $("#portsearch").on("select2:select", edgePortSelect);
-
         refreshMap();
 
         // watch for addNode/editNode
-        observeEditMode();    });
+        observeEditMode();
+   });
 </script>
 @endsection
 

--- a/resources/views/map/custom-edit.blade.php
+++ b/resources/views/map/custom-edit.blade.php
@@ -560,14 +560,6 @@
         $('#bgModal').modal('show');
     }
 
-    function checkColourReset(itemColour, defaultColour, resetControlId) {
-        if(!itemColour || itemColour.toLowerCase() == defaultColour.toLowerCase()) {
-            $("#" + resetControlId).attr('disabled','disabled');
-        } else {
-            $("#" + resetControlId).removeAttr('disabled');
-        }
-    }
-
     function checkEditNode(data) {
         // If we have an ID that is non numeric, we can check node type further
         if(data.id && isNaN(data.id)) {

--- a/resources/views/map/custom-node-modal.blade.php
+++ b/resources/views/map/custom-node-modal.blade.php
@@ -405,6 +405,7 @@
 
     function nodeDefaultsSave() {
         newnodeconf.shape = $("#nodestyle").val();
+        newnodeconf.size = $("#nodesize").val();
         newnodeconf.font.face = $("#nodetextface").val();
         newnodeconf.font.size = $("#nodetextsize").val();
         newnodeconf.font.color = $("#nodetextcolour").val();

--- a/resources/views/map/custom-node-modal.blade.php
+++ b/resources/views/map/custom-node-modal.blade.php
@@ -68,7 +68,7 @@
                             <div class="form-group row" id="nodeImageRow">
                                 <label for="nodeimage" class="col-sm-3 control-label">{{ __('map.custom.edit.node.image') }}</label>
                                 <div class="col-sm-6">
-                                    <select id="nodeimage" class="form-control input-sm" onchange="setNodeImage();">
+                                    <select id="nodeimage" class="form-control input-sm" onchange="nodeSetImage();">
                                         <option value="" id="deviceiconimage">{{ __('map.custom.edit.node.style_options.device_image') }}</option>
                                         @foreach($images as $imgfile => $imglabel)
                                             <option value="{{$imgfile}}">{{$imglabel}}</option>
@@ -82,7 +82,7 @@
                             <div class="form-group row" id="nodeIconRow">
                                 <label for="nodeicon" class="col-sm-3 control-label">{{ __('map.custom.edit.node.icon') }}</label>
                                 <div class="col-sm-6">
-                                    <select id="nodeicon" class="form-control input-sm" onchange="setNodeIcon();">
+                                    <select id="nodeicon" class="form-control input-sm" onchange="nodeSetIcon();">
                                         <option value="f233">{{ __('map.custom.edit.node.icon_options.server')  }}</option>
                                         <option value="f390">{{ __('map.custom.edit.node.icon_options.desktop')  }}</option>
                                         <option value="f7c0">{{ __('map.custom.edit.node.icon_options.dish')  }}</option>
@@ -158,11 +158,273 @@
             </div>
             <div class="modal-footer">
                 <center>
-                    <button type=button class="btn btn-primary" value="savedefaults" id="node-saveDefaultsButton" data-dismiss="modal" style="display:none" onclick="editNodeDefaultsSave();">{{ __('map.custom.edit.defaults') }}</button>
+                    <button type=button class="btn btn-primary" value="savedefaults" id="node-saveDefaultsButton" data-dismiss="modal" style="display:none" onclick="nodeDefaultsSave();">{{ __('map.custom.edit.defaults') }}</button>
                     <button type=button class="btn btn-primary" value="save" id="node-saveButton" data-dismiss="modal">{{ __('Save') }}</button>
-                    <button type=button class="btn btn-primary" value="cancel" id="node-cancelButton" data-dismiss="modal" onclick="editNodeCancel();">{{ __('Cancel') }}</button>
+                    <button type=button class="btn btn-primary" value="cancel" id="node-cancelButton" data-dismiss="modal" onclick="nodeCancel();">{{ __('Cancel') }}</button>
                 </center>
             </div>
         </div>
     </div>
 </div>
+
+<script>
+    function nodeCheckColourReset(itemColour, defaultColour, resetControlId) {
+        if(!itemColour || itemColour.toLowerCase() == defaultColour.toLowerCase()) {
+            $("#" + resetControlId).attr('disabled','disabled');
+        } else {
+            $("#" + resetControlId).removeAttr('disabled');
+        }
+    }
+
+    function nodeMapLinkChange() {
+        if($("#maplink").val()) {
+            $("#nodeDeviceSearchRow").hide();
+        } else {
+            $("#nodeDeviceSearchRow").show();
+        }
+    }
+
+    function nodeSetIcon() {
+        var newcode = $("#nodeicon").val();
+        $("#nodeiconpreview").text(String.fromCharCode(parseInt(newcode, 16)));
+    }
+
+    function nodeSetImage() {
+        // If the selected option is not visible, select the top option
+        if($("#nodeimage option:selected").css('display') == 'none') {
+            $("#nodeimage").val($("#nodeimage option:eq(1)").val());
+        }
+        // Set the image preview src
+        if($("#nodeimage").val()) {
+            $("#nodeimagepreview").attr("src", custom_image_base + $("#nodeimage").val());
+        } else {
+            $("#nodeimagepreview").attr("src", $("#device_image").val());
+        }
+    }
+
+    function nodeStyleChange() {
+        var nodestyle = $("#nodestyle").val();
+        if(nodestyle == 'icon') {
+            $("#nodeIconRow").show();
+        } else {
+            $("#nodeIconRow").hide();
+        }
+        if(nodestyle == 'image' || nodestyle == 'circularImage') {
+            $("#nodeImageRow").show();
+        } else {
+            $("#nodeImageRow").hide();
+        }
+    }
+
+    function nodeDeviceSelect(e) {
+        var id = e.params.data.id;
+        var name = e.params.data.text;
+        $("#device_id").val(id);
+        $("#device_name").text(name);
+        $("#nodelabel").val(name.split(".")[0].split(" ")[0]);
+        $("#device_image").val(e.params.data.icon);
+        $("#nodeDeviceSearchRow").hide();
+        $("#nodeMapLinkRow").hide();
+        $("#deviceiconimage").show();
+        $("#nodeDeviceRow").show();
+    }
+
+    function nodeDeviceClear() {
+        $("#devicesearch").val('');
+        $("#devicesearch").trigger('change');
+        $("#device_id").val("");
+        $("#device_name").text("");
+        $("#device_image").val("");
+        $("#nodeDeviceRow").hide();
+        $("#deviceiconimage").hide();
+        $("#nodeDeviceSearchRow").show();
+        $("#nodeMapLinkRow").show();
+
+        // Reset device style if we were using the device image
+        if(($("#nodestyle").val() == "image" || $("#nodestyle").val() == "circularImage") && !$("#nodeimage").val()){
+            $("#nodestyle").val(newnodeconf.shape);
+            $("#nodeImageRow").hide();
+            nodeSetImage();
+        }
+    }
+
+    function nodeCancel(event) {
+        $("#node-saveButton").off("click");
+    }
+
+    function nodeSave(event) {
+        node = event.data.data;
+
+        $("#node-saveButton").off("click");
+
+        if($("#device_id").val()) {
+            node.title = $("#device_id").val();
+        } else if($("#maplink").val()) {
+            node.title = "map:" + $("#maplink").val();
+        } else {
+            node.title = '';
+        }
+        // Update the node with the selected values on success and run the callback
+        node.label = $("#nodelabel").val();
+        node.shape = $("#nodestyle").val();
+        node.font.face = $("#nodetextface").val();
+        node.font.size = parseInt($("#nodetextsize").val());
+        node.font.color = $("#nodetextcolour").val();
+        node.color = {highlight: {}, hover: {}};
+        node.color.background = node.color.highlight.background = node.color.hover.background = $("#nodecolourbg").val();
+        node.color.border = node.color.highlight.border = node.color.hover.border = $("#nodecolourbdr").val();
+        node.size = $("#nodesize").val();
+        if(node.shape == "image" || node.shape == "circularImage") {
+            if($("#nodeimage").val()) {
+                node.image = {unselected: custom_image_base + $("#nodeimage").val()};
+            } else {
+                node.image = {unselected: $("#device_image").val()};
+            }
+        } else {
+            node.image = {};
+        }
+        if(node.shape == "icon") {
+            node.icon = {face: 'FontAwesome', code: String.fromCharCode(parseInt($("#nodeicon").val(), 16)), size: $("#nodesize").val(), color: node.color.border};
+        } else {
+            node.icon = {};
+        }
+        if(node.add) {
+            delete node.add;
+            network_nodes.add(node);
+        } else {
+            network_nodes.update(node);
+        }
+
+        if(node.id) {
+            if($("#device_id").val()) {
+                node_device_map[node.id] = {device_id: $("#device_id").val(), device_name: $("#device_name").text(), device_image: $("#device_image").val()}
+            } else {
+                delete node_device_map[node.id];
+            }
+        }
+
+        $("#map-saveDataButton").show();
+        $("#map-renderButton").show();
+    }
+
+    function nodeEdit(nodeconf) {
+        if (!nodeconf.id) {
+            $("#nodeModalLabel").text('{{ __('map.custom.edit.node.defaults_title') }}');
+            $(".single-node").hide();
+        } else if(nodeconf.add) {
+            $("#nodeModalLabel").text('{{ __('map.custom.edit.node.add') }}');
+            $(".single-node").show();
+        } else {
+            $("#nodeModalLabel").text('{{ __('map.custom.edit.node.edit') }}');
+            $(".single-node").show();
+        }
+
+        $("#devicesearch").val('');
+        $("#devicesearch").trigger('change');
+
+        if(nodeconf.id in node_device_map) {
+            // Nodes is linked to a device
+            $("#device_id").val(node_device_map[nodeconf.id].device_id);
+            $("#device_name").text(node_device_map[nodeconf.id].device_name);
+            // Hide device selection row
+            $("#nodeDeviceSearchRow").hide();
+            $("#nodeMapLinkRow").hide();
+            // Show device image as an option
+            $("#deviceiconimage").show();
+            $("#device_image").val(node_device_map[nodeconf.id].device_image);
+        } else {
+            // Node is not linked to a device
+            $("#device_id").val("");
+            $("#device_name").text("");
+            // Hide the selected device row
+            $("#nodeDeviceRow").hide();
+            // Hide device image as an option
+            $("#deviceiconimage").hide();
+            $("#device_image").val("");
+        }
+        if(nodeconf.title && nodeconf.title.toString().startsWith("map:")) {
+            // Hide device selection row
+            $("#nodeDeviceSearchRow").hide();
+            $("#maplink").val(nodeconf.title.replace("map:",""));
+        } else {
+            $("#maplink").val("");
+        }
+        $("#nodelabel").val(nodeconf.label);
+        $("#nodestyle").val(nodeconf.shape);
+
+        // Show or hide the image selection if the shape is an image type
+        if(nodeconf.shape == "image" || nodeconf.shape == "circularImage") {
+            $("#nodeImageRow").show();
+            if(nodeconf.image.unselected.indexOf(custom_image_base) == 0) {
+                $("#nodeimage").val(nodeconf.image.unselected.replace(custom_image_base, ""));
+            } else {
+                $("#nodeimage").val("");
+            }
+        } else {
+            $("#nodeImageRow").hide();
+            $("#nodeimage").val("");
+        }
+        nodeSetImage();
+
+        // Show or hide the icon selection if the shape is icon
+        if(nodeconf.shape == "icon") {
+            $("#nodeicon").val(nodeconf.icon.code.charCodeAt(0).toString(16));
+            $("#nodeIconRow").show();
+        } else {
+            $("#nodeIconRow").hide();
+        }
+        nodeSetIcon();
+
+        $("#nodesize").val(nodeconf.size);
+        $("#nodetextface").val(nodeconf.font.face);
+        $("#nodetextsize").val(nodeconf.font.size);
+        $("#nodetextcolour").val(nodeconf.font.color);
+        if(nodeconf.color && nodeconf.color.background) {
+            $("#nodecolourbg").val(nodeconf.color.background);
+            $("#nodecolourbdr").val(nodeconf.color.border);
+        } else {
+            // The background colour is blank because a device has been selected - start with defaults
+            $("#nodecolourbg").val(newnodeconf.color.background);
+            $("#nodecolourbdr").val(newnodeconf.color.border);
+        }
+
+        nodeCheckColourReset(nodeconf.font.color, newnodeconf.font.color, "nodecolourtextreset");
+        nodeCheckColourReset(nodeconf.color.background, newnodeconf.color.background, "nodecolourbgreset");
+        nodeCheckColourReset(nodeconf.color.border, newnodeconf.color.border, "nodecolourbdrreset");
+
+        if(nodeconf.id) {
+            $("#node-saveButton").on("click", {data: nodeconf}, nodeSave);
+            $("#node-saveButton").show();
+            $("#node-saveDefaultsButton").hide();
+        } else {
+            $("#node-saveButton").hide();
+            $("#node-saveDefaultsButton").show();
+        }
+        $('#nodeModal').modal({backdrop: 'static', keyboard: false}, 'show');
+    }
+
+    function nodeDefaultsSave() {
+        newnodeconf.shape = $("#nodestyle").val();
+        newnodeconf.font.face = $("#nodetextface").val();
+        newnodeconf.font.size = $("#nodetextsize").val();
+        newnodeconf.font.color = $("#nodetextcolour").val();
+        newnodeconf.color.background = $("#nodecolourbg").val();
+        newnodeconf.color.border = $("#nodecolourbdr").val();
+        if(newnodeconf.shape == "icon") {
+            newnodeconf.icon = {face: 'FontAwesome', code: String.fromCharCode(parseInt($("#nodeicon").val(), 16)), size: $("#nodesize").val(), color: newnodeconf.color.border};
+        } else {
+            newnodeconf.icon = {};
+        }
+        if(newnodeconf.shape == "image" || newnodeconf.shape == "circularImage") {
+            newnodeconf.image = {unselected: custom_image_base + $("#nodeimage").val()};
+        } else {
+            delete newnodeconf.image;
+        }
+        $("#map-saveDataButton").show();
+    }
+
+    $(document).ready(function () {
+        init_select2('#devicesearch', 'device', {limit: 100}, '', '{{ __('map.custom.edit.node.device_select') }}', {dropdownParent: $('#nodeModal')});
+        $("#devicesearch").on("select2:select", nodeDeviceSelect);
+    });
+</script>

--- a/resources/views/map/custom-view.blade.php
+++ b/resources/views/map/custom-view.blade.php
@@ -218,7 +218,7 @@
                     var mid_x = edge.mid_x;
                     var mid_y = edge.mid_y;
 
-                    var mid = {id: edgeid + "_mid", shape: "dot", size: 0, x: mid_x, y: mid_y, label: screenshot ? '' : edge.label};
+                    var mid = {id: edgeid + "_mid", shape: "dot", size: 0, x: mid_x, y: mid_y, label: screenshot ? '' : edge.label, font: {face: edge.text_face, size: edge.text_size, color: edge.text_colour}};
 
                     if (Boolean(reverse_arrows)) {
                         arrows = {from: {enabled: true, scaleFactor: 0.6}, to: {enabled: false}};


### PR DESCRIPTION
The bulk of this work is to move the javascript for editing nodes and edges into their respective blades.  This should make it easier to add new options in future, because the javascript and the controls are in the same file.

I have also fixed the following bugs:
 - The "Linked Map" drop-down correctly resets to "Select map..." when adding or editing a node where this option is not selected
 - The node icon preview updates to the correct icon when the modal pops up
 - The "Edit Edge" modal header uses the translation function instead of being hard-coded to English


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
