### PR TITLE
Use 2 decimal places for bps numbers

### DIFF
--- a/app/Http/Controllers/Maps/CustomMapDataController.php
+++ b/app/Http/Controllers/Maps/CustomMapDataController.php
@@ -294,7 +294,7 @@ class CustomMapDataController extends Controller
 
     private function rateString(int $rate): string
     {
-        return Number::formatSi($rate, 0, 0, 'bps');
+        return Number::formatSi($rate, 2, 3, 'bps');
     }
 
     private function snmpSpeed(string $speeds): int


### PR DESCRIPTION
Make custom maps show 3 significant figures for all bps throughputs numbers.  As an example, this allows users to see whether 1Gbps is 1.04Gbps or 1.49Gbps, while leaving longer numbers like 546Mbps unchanged.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
