### PR TITLE
Format Oxidized update time

### DIFF
--- a/includes/html/functions.inc.php
+++ b/includes/html/functions.inc.php
@@ -959,12 +959,21 @@ function get_oxidized_nodes_list()
             continue;
         }
 
+        // Convert UTC time string to local timezone set
+        $utc_time = $object['time'];
+        $utc_date = new DateTime($utc_time, new DateTimeZone('UTC'));
+        $local_timezone = new DateTimeZone(date_default_timezone_get());
+        $local_date = $utc_date->setTimezone($local_timezone); 
+
+        // Generate local time string
+        $formatted_local_time = $local_date->format('Y-m-d H:i:s T'); 
+        
         echo '<tr>
         <td>' . $device['device_id'] . '</td>
         <td>' . $object['name'] . '</td>
         <td>' . $device['sysName'] . '</td>
         <td>' . $object['status'] . '</td>
-        <td>' . $object['time'] . '</td>
+        <td>' . $formatted_local_time . '</td>
         <td>' . $object['model'] . '</td>
         <td>' . $object['group'] . '</td>
         <td></td>

--- a/includes/html/functions.inc.php
+++ b/includes/html/functions.inc.php
@@ -963,10 +963,10 @@ function get_oxidized_nodes_list()
         $utc_time = $object['time'];
         $utc_date = new DateTime($utc_time, new DateTimeZone('UTC'));
         $local_timezone = new DateTimeZone(date_default_timezone_get());
-        $local_date = $utc_date->setTimezone($local_timezone); 
+        $local_date = $utc_date->setTimezone($local_timezone);
 
         // Generate local time string
-        $formatted_local_time = $local_date->format('Y-m-d H:i:s T'); 
+        $formatted_local_time = $local_date->format('Y-m-d H:i:s T');
         
         echo '<tr>
         <td>' . $device['device_id'] . '</td>

--- a/includes/html/functions.inc.php
+++ b/includes/html/functions.inc.php
@@ -967,7 +967,7 @@ function get_oxidized_nodes_list()
 
         // Generate local time string
         $formatted_local_time = $local_date->format('Y-m-d H:i:s T');
-        
+
         echo '<tr>
         <td>' . $device['device_id'] . '</td>
         <td>' . $object['name'] . '</td>


### PR DESCRIPTION
Format Oxidized update time to local timezone (instead of UTC)

Oxidized Timezone was only displayed in UTC instead of local time zone.

See also https://community.librenms.org/t/oxidized-tuning/7899/

This should fix it.

<img width="1315" alt="Screenshot of new UI" src="https://github.com/user-attachments/assets/2a727b30-6177-49d4-933b-fff82c65c7d8">

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
