### PR TITLE
Fix double escaping sysname in device dependencies

### DIFF
--- a/includes/html/forms/get-host-dependencies.inc.php
+++ b/includes/html/forms/get-host-dependencies.inc.php
@@ -73,7 +73,7 @@ if (! Auth::user()->hasGlobalAdmin()) {
                     }
 
                     $hostname = format_hostname($myrow);
-                    $sysname = htmlspecialchars(($hostname == $myrow['sysName']) ? $myrow['hostname'] : $myrow['sysName']);
+                    $sysname = $hostname == $myrow['sysName'] ? $myrow['hostname'] : $myrow['sysName'];
                     array_push($res_arr, ['deviceid' => $myrow['id'], 'hostname' => $hostname, 'sysname' => $sysname, 'parent' => $parent, 'parentid' => $myrow['parentid']]);
                 }
                 $status = ['current' => $_POST['current'], 'rowCount' => $_POST['rowCount'], 'rows' => $res_arr, 'total' => $rec_count];


### PR DESCRIPTION
I double checked that we aren't missing any escapes elsewhere on sysname and it looks good.

#16447

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
