### PR TITLE
Support for TrueNAS-SCALE (merging with existing truenas.yaml)

### DIFF
--- a/includes/definitions/discovery/truenas.yaml
+++ b/includes/definitions/discovery/truenas.yaml
@@ -1,129 +1,429 @@
-mib: FREENAS-MIB
+# TRUENAS-MIB is used by Truenas-SCALE
+# FREENAS-MIB is used by Truenas-CORE and FreeNAS
+
+# Because there is an OIDs overlap between TRUENAS-MIB and FREENAS-MIB 
+# The mib section is left empty to avoid snmpbulkwalk to return unexpected values
+# mib: TRUENAS-MIB:FREENAS-MIB
+
 modules:
+    os:
+        # extract version and hardware fields
+        sysDescr_regex: '/^(TrueNAS-SCALE|TrueNAS|FreeNAS)-(?<version>.*?)(\s\([[:alnum:]]{10}\))?\. Hardware: (?<hardware>.*).*/'
     sensors:
         count:
             data:
                 -
-                    oid: zfsArcSize
-                    value: zfsArcSize
+                    oid: FREENAS-MIB::zfsArcSize
+                    value: FREENAS-MIB::zfsArcSize
                     num_oid: .1.3.6.1.4.1.50536.1.4.1.{{ $index }}
                     descr: 'ARC Size'
                     index: zfsArcSize.{{ $index }}
+                    skip_values:
+                        -
+                            device: sysDescr
+                            op: 'contains'
+                            value: ['TrueNAS-SCALE']                            
                 -
-                    oid: zfsArcMeta
-                    value: zfsArcMeta
+                    oid: FREENAS-MIB::zfsArcMeta
+                    value: FREENAS-MIB::zfsArcMeta
                     num_oid: .1.3.6.1.4.1.50536.1.4.2.{{ $index }}
                     descr: 'ARC Metadata'
                     index: zfsArcMeta.{{ $index }}
+                    skip_values:
+                        -
+                            device: sysDescr
+                            op: 'contains'
+                            value: ['TrueNAS-SCALE'] 
                 -
-                    oid: zfsArcData
-                    value: zfsArcData
+                    oid: FREENAS-MIB::zfsArcData
+                    value: FREENAS-MIB::zfsArcData
                     num_oid: .1.3.6.1.4.1.50536.1.4.3.{{ $index }}
                     descr: 'ARC Data'
                     index: zfsArcData.{{ $index }}
+                    skip_values:
+                        -
+                            device: sysDescr
+                            op: 'contains'
+                            value: ['TrueNAS-SCALE'] 
                 -
-                    oid: zfsArcHits
-                    value: zfsArcHits
+                    oid: FREENAS-MIB::zfsArcHits
+                    value: FREENAS-MIB::zfsArcHits
                     num_oid: .1.3.6.1.4.1.50536.1.4.4.{{ $index }}
                     descr: 'ARC Hits'
                     index: zfsArcHits_rate.{{ $index }}
                     rrd_type: COUNTER
+                    skip_values:
+                        -
+                            device: sysDescr
+                            op: 'contains'
+                            value: ['TrueNAS-SCALE'] 
                 -
-                    oid: zfsArcMisses
-                    value: zfsArcMisses
+                    oid: FREENAS-MIB::zfsArcMisses
+                    value: FREENAS-MIB::zfsArcMisses
                     num_oid: .1.3.6.1.4.1.50536.1.4.5.{{ $index }}
                     descr: 'ARC Misses'
                     index: zfsArcMisses_rate.{{ $index }}
                     rrd_type: COUNTER
+                    skip_values:
+                        -
+                            device: sysDescr
+                            op: 'contains'
+                            value: ['TrueNAS-SCALE'] 
                 -
-                    oid: zfsArcC
-                    value: zfsArcC
+                    oid: FREENAS-MIB::zfsArcC
+                    value: FREENAS-MIB::zfsArcC
                     num_oid: .1.3.6.1.4.1.50536.1.4.6.{{ $index }}
                     descr: 'ARC Target Size (C)'
                     index: zfsArcC.{{ $index }}
+                    skip_values:
+                        -
+                            device: sysDescr
+                            op: 'contains'
+                            value: ['TrueNAS-SCALE'] 
                 -
-                    oid: zfsArcP
-                    value: zfsArcP
+                    oid: FREENAS-MIB::zfsArcP
+                    value: FREENAS-MIB::zfsArcP
                     num_oid: .1.3.6.1.4.1.50536.1.4.7.{{ $index }}
                     descr: 'ARC MRU Target Size (P)'
                     index: zfsArcP.{{ $index }}
+                    skip_values:
+                        -
+                            device: sysDescr
+                            op: 'contains'
+                            value: ['TrueNAS-SCALE'] 
                 -
-                    oid: zfsArcMissPercent
-                    value: zfsArcMissPercent
-                    num_oid: .1.3.6.1.4.1.50536.1.4.8.{{ $index }}
-                    descr: 'ARC Miss Percent'
-                    index: zfsArcMissPercent.{{ $index }}
-                -
-                    oid: zfsArcHitRatio
-                    value: zfsArcHitRatio
-                    num_oid: .1.3.6.1.4.1.50536.1.4.9.{{ $index }}
-                    descr: 'ARC Hit Ratio'
-                    index: zfsArcHitRatio.{{ $index }}
-                -
-                    oid: zfsArcMissRatio
-                    value: zfsArcMissRatio
-                    num_oid: .1.3.6.1.4.1.50536.1.4.10.{{ $index }}
-                    descr: 'ARC Miss Ratio'
-                    index: zfsArcMissRatio.{{ $index }}
-                -
-                    oid: zfsL2ArcHits
-                    value: zfsL2ArcHits
+                    oid: FREENAS-MIB::zfsL2ArcHits
+                    value: FREENAS-MIB::zfsL2ArcHits
                     num_oid: .1.3.6.1.4.1.50536.1.5.1.{{ $index }}
                     descr: 'L2ARC Hits'
                     index: zfsL2ArcHits_rate.{{ $index }}
                     rrd_type: COUNTER
+                    skip_values:
+                        -
+                            device: sysDescr
+                            op: 'contains'
+                            value: ['TrueNAS-SCALE'] 
                 -
-                    oid: zfsL2ArcMisses
-                    value: zfsL2ArcMisses
+                    oid: FREENAS-MIB::zfsL2ArcMisses
+                    value: FREENAS-MIB::zfsL2ArcMisses
                     num_oid: .1.3.6.1.4.1.50536.1.5.2.{{ $index }}
                     descr: 'L2ARC Misses'
                     index: zfsL2ArcMisses_rate.{{ $index }}
                     rrd_type: COUNTER
+                    skip_values:
+                        -
+                            device: sysDescr
+                            op: 'contains'
+                            value: ['TrueNAS-SCALE'] 
                 -
-                    oid: zfsL2ArcRead
-                    value: zfsL2ArcRead
+                    oid: FREENAS-MIB::zfsL2ArcRead
+                    value: FREENAS-MIB::zfsL2ArcRead
                     num_oid: .1.3.6.1.4.1.50536.1.5.3.{{ $index }}
                     descr: 'L2ARC Reads'
                     index: zfsL2ArcRead_rate.{{ $index }}
                     rrd_type: COUNTER
+                    skip_values:
+                        -
+                            device: sysDescr
+                            op: 'contains'
+                            value: ['TrueNAS-SCALE'] 
                 -
-                    oid: zfsL2ArcWrite
-                    value: zfsL2ArcWrite
+                    oid: FREENAS-MIB::zfsL2ArcWrite
+                    value: FREENAS-MIB::zfsL2ArcWrite
                     num_oid: .1.3.6.1.4.1.50536.1.5.4.{{ $index }}
                     descr: 'L2ARC Writes'
                     index: zfsL2ArcWrite_rate.{{ $index }}
                     rrd_type: COUNTER
+                    skip_values:
+                        -
+                            device: sysDescr
+                            op: 'contains'
+                            value: ['TrueNAS-SCALE'] 
                 -
-                    oid: zfsL2ArcSize
-                    value: zfsL2ArcSize
+                    oid: FREENAS-MIB::zfsL2ArcSize
+                    value: FREENAS-MIB::zfsL2ArcSize
                     num_oid: .1.3.6.1.4.1.50536.1.5.5.{{ $index }}
                     descr: 'L2ARC Size'
                     index: zfsL2ArcSize.{{ $index }}
+                    skip_values:
+                        -
+                            device: sysDescr
+                            op: 'contains'
+                            value: ['TrueNAS-SCALE'] 
                 -
-                    oid: zfsZilstatOps1sec
-                    value: zfsZilstatOps1sec
+                    oid: FREENAS-MIB::zfsZilstatOps1sec
+                    value: FREENAS-MIB::zfsZilstatOps1sec
                     num_oid: .1.3.6.1.4.1.50536.1.6.1.{{ $index }}
                     descr: 'ZIL Operations last second'
                     index: zfsZilstatOps1sec.{{ $index }}
+                    skip_values:
+                        -
+                            device: sysDescr
+                            op: 'contains'
+                            value: ['TrueNAS-SCALE'] 
                 -
-                    oid: zfsZilstatOps5sec
-                    value: zfsZilstatOps5sec
+                    oid: FREENAS-MIB::zfsZilstatOps5sec
+                    value: FREENAS-MIB::zfsZilstatOps5sec
                     num_oid: .1.3.6.1.4.1.50536.1.6.2.{{ $index }}
                     descr: 'ZIL Operations last 5 seconds'
                     index: zfsZilstatOps5sec.{{ $index }}
+                    skip_values:
+                        -
+                            device: sysDescr
+                            op: 'contains'
+                            value: ['TrueNAS-SCALE'] 
                 -
-                    oid: zfsZilstatOps10sec
-                    value: zfsZilstatOps10sec
+                    oid: FREENAS-MIB::zfsZilstatOps10sec
+                    value: FREENAS-MIB::zfsZilstatOps10sec
                     num_oid: .1.3.6.1.4.1.50536.1.6.3.{{ $index }}
                     descr: 'ZIL Operations last 10 seconds'
                     index: zfsZilstatOps10sec.{{ $index }}
+                    skip_values:
+                        -
+                            device: sysDescr
+                            op: 'contains'
+                            value: ['TrueNAS-SCALE'] 
+                -
+                    oid: TRUENAS-MIB::zfsArcSize
+                    value: TRUENAS-MIB::zfsArcSize
+                    num_oid: .1.3.6.1.4.1.50536.1.3.1.{{ $index }}
+                    descr: 'ARC Size (scale)'
+                    index: zfsArcSize.{{ $index }}
+                    skip_values:
+                        -
+                            device: sysDescr
+                            op: 'not_contains'
+                            value: ['TrueNAS-SCALE']
+                -
+                    oid: TRUENAS-MIB::zfsArcMeta
+                    value: TRUENAS-MIB::zfsArcMeta
+                    num_oid: .1.3.6.1.4.1.50536.1.3.2.{{ $index }}
+                    descr: 'ARC Metadata (scale)'
+                    index: zfsArcMeta.{{ $index }}
+                    skip_values:
+                        -
+                            device: sysDescr
+                            op: 'not_contains'
+                            value: ['TrueNAS-SCALE']
+                -
+                    oid: TRUENAS-MIB::zfsArcData
+                    value: TRUENAS-MIB::zfsArcData
+                    num_oid: .1.3.6.1.4.1.50536.1.3.3.{{ $index }}
+                    descr: 'ARC Data (scale)'
+                    index: zfsArcData.{{ $index }}
+                    skip_values:
+                        -
+                            device: sysDescr
+                            op: 'not_contains'
+                            value: ['TrueNAS-SCALE']
+                -
+                    oid: TRUENAS-MIB::zfsArcHits
+                    value: TRUENAS-MIB::zfsArcHits
+                    num_oid: .1.3.6.1.4.1.50536.1.3.4.{{ $index }}
+                    descr: 'ARC Hits (scale)'
+                    index: zfsArcHits_rate.{{ $index }}
+                    rrd_type: COUNTER
+                    skip_values:
+                        -
+                            device: sysDescr
+                            op: 'not_contains'
+                            value: ['TrueNAS-SCALE']
+                -
+                    oid: TRUENAS-MIB::zfsArcMisses
+                    value: TRUENAS-MIB::zfsArcMisses
+                    num_oid: .1.3.6.1.4.1.50536.1.3.5.{{ $index }}
+                    descr: 'ARC Misses'
+                    index: zfsArcMisses_rate.{{ $index }}
+                    rrd_type: COUNTER
+                    skip_values:
+                        -
+                            device: sysDescr
+                            op: 'not_contains'
+                            value: ['TrueNAS-SCALE']
+                -
+                    oid: TRUENAS-MIB::zfsArcC
+                    value: TRUENAS-MIB::zfsArcC
+                    num_oid: .1.3.6.1.4.1.50536.1.3.6.{{ $index }}
+                    descr: 'ARC Target Size (C) (truenas)'
+                    index: zfsArcC.{{ $index }}
+                    skip_values:
+                        -
+                            device: sysDescr
+                            op: 'not_contains'
+                            value: ['TrueNAS-SCALE']
+                # -
+                #     oid: zfsArcP
+                #     value: zfsArcP
+                #     num_oid: .1.3.6.1.4.1.50536.1.3.7.{{ $index }}
+                #     descr: 'ARC MRU Target Size (P)'
+                #     index: zfsArcP.{{ $index }}
+                -
+                    oid: TRUENAS-MIB::zfsL2ArcHits
+                    value: TRUENAS-MIB::zfsL2ArcHits
+                    num_oid: .1.3.6.1.4.1.50536.1.4.1.{{ $index }}
+                    descr: 'L2ARC Hits'
+                    index: zfsL2ArcHits_rate.{{ $index }}
+                    rrd_type: COUNTER
+                    skip_values:
+                        -
+                            device: sysDescr
+                            op: 'not_contains'
+                            value: ['TrueNAS-SCALE']
+                -
+                    oid: TRUENAS-MIB::zfsL2ArcMisses
+                    value: TRUENAS-MIB::zfsL2ArcMisses
+                    num_oid: .1.3.6.1.4.1.50536.1.4.2.{{ $index }}
+                    descr: 'L2ARC Misses'
+                    index: zfsL2ArcMisses_rate.{{ $index }}
+                    rrd_type: COUNTER
+                    skip_values:
+                        -
+                            device: sysDescr
+                            op: 'not_contains'
+                            value: ['TrueNAS-SCALE']
+                -
+                    oid: TRUENAS-MIB::zfsL2ArcRead
+                    value: TRUENAS-MIB::zfsL2ArcRead
+                    num_oid: .1.3.6.1.4.1.50536.1.4.3.{{ $index }}
+                    descr: 'L2ARC Reads'
+                    index: zfsL2ArcRead_rate.{{ $index }}
+                    rrd_type: COUNTER
+                    skip_values:
+                        -
+                            device: sysDescr
+                            op: 'not_contains'
+                            value: ['TrueNAS-SCALE']
+                -
+                    oid: TRUENAS-MIB::zfsL2ArcWrite
+                    value: TRUENAS-MIB::zfsL2ArcWrite
+                    num_oid: .1.3.6.1.4.1.50536.1.4.4.{{ $index }}
+                    descr: 'L2ARC Writes'
+                    index: zfsL2ArcWrite_rate.{{ $index }}
+                    rrd_type: COUNTER
+                    skip_values:
+                        -
+                            device: sysDescr
+                            op: 'not_contains'
+                            value: ['TrueNAS-SCALE']
+                -
+                    oid: TRUENAS-MIB::zfsL2ArcSize
+                    value: TRUENAS-MIB::zfsL2ArcSize
+                    num_oid: .1.3.6.1.4.1.50536.1.4.5.{{ $index }}
+                    descr: 'L2ARC Size'
+                    index: zfsL2ArcSize.{{ $index }}
+                    skip_values:
+                        -
+                            device: sysDescr
+                            op: 'not_contains'
+                            value: ['TrueNAS-SCALE']
+                -
+                    oid: TRUENAS-MIB::zfsZilstatOps1sec
+                    value: TRUENAS-MIB::zfsZilstatOps1sec
+                    num_oid: .1.3.6.1.4.1.50536.1.5.1.{{ $index }}
+                    descr: 'ZIL Operations last second'
+                    index: zfsZilstatOps1sec.{{ $index }}
+                    skip_values:
+                        -
+                            device: sysDescr
+                            op: 'not_contains'
+                            value: ['TrueNAS-SCALE']
+                -
+                    oid: TRUENAS-MIB::zfsZilstatOps5sec
+                    value: TRUENAS-MIB::zfsZilstatOps5sec
+                    num_oid: .1.3.6.1.4.1.50536.1.5.2.{{ $index }}
+                    descr: 'ZIL Operations last 5 seconds'
+                    index: zfsZilstatOps5sec.{{ $index }}
+                    skip_values:
+                        -
+                            device: sysDescr
+                            op: 'not_contains'
+                            value: ['TrueNAS-SCALE']
+                -
+                    oid: TRUENAS-MIB::zfsZilstatOps10sec
+                    value: TRUENAS-MIB::zfsZilstatOps10sec
+                    num_oid: .1.3.6.1.4.1.50536.1.5.3.{{ $index }}
+                    descr: 'ZIL Operations last 10 seconds'
+                    index: zfsZilstatOps10sec.{{ $index }}
+                    skip_values:
+                        -
+                            device: sysDescr
+                            op: 'not_contains'
+                            value: ['TrueNAS-SCALE']
+        percent:
+            data:
+                -  
+                    oid: FREENAS-MIB::zfsArcMissPercent
+                    value: FREENAS-MIB::zfsArcMissPercent
+                    num_oid: .1.3.6.1.4.1.50536.1.4.8.{{ $index }}
+                    descr: 'ARC Miss Percent'
+                    index: zfsArcMissPercent.{{ $index }}
+                    skip_values:
+                        -
+                            device: sysDescr
+                            op: 'contains'
+                            value: ['TrueNAS-SCALE']
+                -
+                    oid: FREENAS-MIB::zfsArcCacheHitRatio
+                    value: FREENAS-MIB::zfsArcCacheHitRatio
+                    num_oid: .1.3.6.1.4.1.50536.1.4.9.{{ $index }}
+                    descr: 'ARC Cache Hit Ratio Percentage'
+                    index: zfsArcCacheHitRatio.{{ $index }}
+                    skip_values:
+                        -
+                            device: sysDescr
+                            op: 'contains'
+                            value: ['TrueNAS-SCALE']
+                -
+                    oid: FREENAS-MIB::zfsArcCacheMissRatio
+                    value: FREENAS-MIB::zfsArcCacheMissRatio
+                    num_oid: .1.3.6.1.4.1.50536.1.4.10.{{ $index }}
+                    descr: 'ARC Cache Miss Ratio Percentage'
+                    index: zfsArcCacheMissRatio.{{ $index }}
+                    skip_values:
+                        -
+                            device: sysDescr
+                            op: 'contains'
+                            value: ['TrueNAS-SCALE']
+                -                            
+                    oid: TRUENAS-MIB::zfsArcMissPercent
+                    value: TRUENAS-MIB::zfsArcMissPercent
+                    num_oid: .1.3.6.1.4.1.50536.1.3.8.{{ $index }}
+                    descr: 'ARC Miss Percent'
+                    index: zfsArcMissPercent.{{ $index }}
+                    skip_values:
+                        -
+                            device: sysDescr
+                            op: 'not_contains'
+                            value: ['TrueNAS-SCALE']
+                -
+                    oid: TRUENAS-MIB::zfsArcCacheHitRatio
+                    value: TRUENAS-MIB::zfsArcCacheHitRatio
+                    num_oid: .1.3.6.1.4.1.50536.1.3.9.{{ $index }}
+                    descr: 'Arc Cache Hit Ratio Percentage'
+                    index: zfsArcCacheHitRatio.{{ $index }}
+                    skip_values:
+                        -
+                            device: sysDescr
+                            op: 'not_contains'
+                            value: ['TrueNAS-SCALE']
+                -
+                    oid: TRUENAS-MIB::zfsArcCacheMissRatio
+                    value: TRUENAS-MIB::zfsArcCacheMissRatio
+                    num_oid: .1.3.6.1.4.1.50536.1.3.10.{{ $index }}
+                    descr: 'Arc Cache Miss Ratio Percentage'
+                    index: zfsArcCacheMissRatio.{{ $index }}
+                    skip_values:
+                        -
+                            device: sysDescr
+                            op: 'not_contains'
+                            value: ['TrueNAS-SCALE']                    
         state:
             data:
                 -
-                    oid: zpoolTable
-                    value: zpoolHealth
+                    oid: FREENAS-MIB::zpoolTable
+                    value: FREENAS-MIB::zpoolHealth
                     num_oid: .1.3.6.1.4.1.50536.1.1.1.1.7.{{ $index }}
-                    descr: 'ZPool: {{ $zpoolDescr }}'
+                    descr: 'ZPool: {{ $FREENAS-MIB::zpoolDescr }}'
                     index: zpoolHealth.{{ $index }}
                     states:
                         - { value: 0, descr: online, graph: 1, generic: 0 }
@@ -132,3 +432,26 @@ modules:
                         - { value: 3, descr: offline, graph: 1, generic: 2 }
                         - { value: 4, descr: unavail, graph: 1, generic: 2 }
                         - { value: 5, descr: removed, graph: 1, generic: 2 }
+                    skip_values:
+                        -
+                            device: sysDescr
+                            op: 'contains'
+                            value: ['TrueNAS-SCALE']  
+                -
+                    oid: TRUENAS-MIB::zpoolTable
+                    value: TRUENAS-MIB::zpoolHealth
+                    num_oid: .1.3.6.1.4.1.50536.1.1.1.1.3.{{ $index }}
+                    descr: 'ZPool: {{ $TRUENAS-MIB::zpoolName }}'
+                    index: zpoolHealth.{{ $index }}
+                    states:
+                        - { value: 0, descr: ONLINE, graph: 1, generic: 0 }
+                        - { value: 1, descr: DEGRADED, graph: 1, generic: 1 }
+                        - { value: 2, descr: FAULTED, graph: 1, generic: 2 }
+                        - { value: 3, descr: OFFLINE, graph: 1, generic: 2 }
+                        - { value: 4, descr: UNAVAIL, graph: 1, generic: 2 }
+                        - { value: 5, descr: REMOVED, graph: 1, generic: 2 }
+                    skip_values:
+                        -
+                            device: sysDescr
+                            op: 'not_contains'
+                            value: ['TrueNAS-SCALE']  

--- a/mibs/ixsystems/TRUENAS-MIB
+++ b/mibs/ixsystems/TRUENAS-MIB
@@ -293,7 +293,7 @@ zfsArcMissPercent OBJECT-TYPE
     STATUS     current
     DESCRIPTION
         "Arc Miss Percentage.
-        (Note: Floating precision sent across SNMP as a String"
+        Note: Floating precision sent across SNMP as a String"
     ::= { arc 8 }
 
 zfsArcCacheHitRatio OBJECT-TYPE
@@ -302,7 +302,7 @@ zfsArcCacheHitRatio OBJECT-TYPE
     STATUS     current
     DESCRIPTION
         "Arc Cache Hit Ration Percentage.
-        (Note: Floating precision sent across SNMP as a String"
+        Note: Floating precision sent across SNMP as a String"
     ::= { arc 9 }
 
 zfsArcCacheMissRatio OBJECT-TYPE
@@ -311,7 +311,7 @@ zfsArcCacheMissRatio OBJECT-TYPE
     STATUS     current
     DESCRIPTION
         "Arc Cache Miss Ration Percentage.
-        (Note: Floating precision sent across SNMP as a String"
+        Note: Floating precision sent across SNMP as a String"
     ::= { arc 10 }
 
 zfsL2ArcHits OBJECT-TYPE


### PR DESCRIPTION
Includes support for TrueNAS-SCALE (as a merge with truenas.yaml that has suport for Truenas-CORE / FreeNAS).

TrueNAS-SCALE uses TRUENAS-MIB; TrueNAS-CORE uses FREENAS-MIB.
Many OIDs overlap and have different meaning.

Rationale of this approach:
- All the editions are considered the same os wether it is SCALE  or CORE, no matter if there are different products editions with different underlying operative systems (linux / freebsd).
- Much longer and complex truenas.yaml
- Conditionals with skip_values are used on each OID and FREENAS-MIB:: or TRUENAS-MIB:: to avoid overlaps.

Fixes #14881 

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
