### PR TITLE
adding support for pfsense temperature

### DIFF
--- a/includes/definitions/discovery/pfsense.yaml
+++ b/includes/definitions/discovery/pfsense.yaml
@@ -3,3 +3,12 @@ modules:
         sysDescr_regex:
             - '/ (?<version>\d+\.\d\S+) /'
             - '/(?<hardware>aarch64|alpha|amd64|arm\w*|i386|ia64|mips\w*|pc98|powerpc\w*|risc\w*|sparc\w*)/i'
+
+    sensors:
+        temperature:
+            data:
+                -
+                    oid: NET-SNMP-EXTEND-MIB::nsExtendOutput1Line
+                    num_oid: '.1.3.6.1.4.1.8072.1.3.2.3.1.1.8.99.112.117.84.101.109.112.48'
+                    divisor: 1
+                    descr: Temperature


### PR DESCRIPTION
The following files add support for the pfsense temperature , by enabling the gui to graph temperature.
[https://imgur.com/touBuV3](url)

![Screenshot_1](https://github.com/user-attachments/assets/06f051c1-a35a-41ce-b73d-de9fbc67dc47)


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
