### PR TITLE
FS centec switch transceiver temperature not showing

### DIFF
--- a/includes/discovery/sensors/temperature/fs-centec.inc.php
+++ b/includes/discovery/sensors/temperature/fs-centec.inc.php
@@ -27,7 +27,7 @@ foreach ($tempTable as $ifIndex => $current) {
                 'entPhysicalIndex' => $ifIndex,
                 'entPhysicalIndex_measured' => 'port',
                 'user_func' => 'fsParseChannelValue',
-                'group' => $ifName,
+                'group' => 'transceiver',
             ]));
 
             break; // only discover one sensor


### PR DESCRIPTION
Fix transceiver temperature discovery so it shows up with the transceiver

Currently no test data for this

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
