### PR TITLE
Updated github apply/remove to clear route and view cache

### DIFF
--- a/scripts/github-apply
+++ b/scripts/github-apply
@@ -8,7 +8,6 @@ for pr in "$@"
         ''|*[!0-9]*) echo "You must specify a PR number to apply a patch" ;;
         *) curl -s https://patch-diff.githubusercontent.com/raw/librenms/librenms/pull/"${pr}".diff | git apply --exclude=*.png -v ;;
     esac
-    php artisan view:clear
-    php artisan route:clear
+    php artisan optimize:clear
 done
 

--- a/scripts/github-apply
+++ b/scripts/github-apply
@@ -8,5 +8,7 @@ for pr in "$@"
         ''|*[!0-9]*) echo "You must specify a PR number to apply a patch" ;;
         *) curl -s https://patch-diff.githubusercontent.com/raw/librenms/librenms/pull/"${pr}".diff | git apply --exclude=*.png -v ;;
     esac
+    php artisan view:clear
+    php artisan route:clear
 done
 

--- a/scripts/github-remove
+++ b/scripts/github-remove
@@ -19,8 +19,7 @@ def confirm(question):
             sys.stdout.write("Please respond with 'yes' or 'no'  (or 'y' or 'n').\n")
 
 def clear_cache():
-    call(["php", "artisan", "view:clear"])
-    call(["php", "artisan", "route:clear"])
+    call(["php", "artisan", "optimize:clear"])
 
 librenms_dir = dirname(dirname(abspath(__file__)))
 

--- a/scripts/github-remove
+++ b/scripts/github-remove
@@ -18,6 +18,9 @@ def confirm(question):
         else:
             sys.stdout.write("Please respond with 'yes' or 'no'  (or 'y' or 'n').\n")
 
+def clear_cache():
+    call(["php", "artisan", "view:clear"])
+    call(["php", "artisan", "route:clear"])
 
 librenms_dir = dirname(dirname(abspath(__file__)))
 
@@ -57,9 +60,12 @@ if args.discard:
         if args.vendor:
             call(["git", "clean",  "-x",  "-d",  "-f",  "vendor/"], cwd=librenms_dir)
 
+        clear_cache();
+
 elif args.save:
     msg = "github-remove saved on "+str(datetime.datetime.now())
     call(["git", "stash", "save", msg], cwd=librenms_dir)
+    clear_cache()
 
 elif args.restore:
     p = Popen(["git", "stash", "list"], stdout=subprocess.PIPE)
@@ -70,3 +76,5 @@ elif args.restore:
         call(["git", "stash", "pop"], cwd=librenms_dir)
     else:
         print("Last stash was not created by " + __file__ + ". Aborting.")
+
+    clear_cache()


### PR DESCRIPTION
When running apply or remove, we now clear the view and route cache via artisan command.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
