### PR TITLE
Make device text and links dark red when the connected device is offline

### DIFF
--- a/app/Http/Controllers/Maps/CustomMapDataController.php
+++ b/app/Http/Controllers/Maps/CustomMapDataController.php
@@ -169,7 +169,10 @@ class CustomMapDataController extends Controller
                     $device_style = $this->nodeDisabledStyle();
                 } elseif (! $node->device->status) {
                     $device_style = $this->nodeDownStyle();
-                    $nodes[$nodeid]['text_colour'] = 'darkred';
+                    // Change the text colour as long as we have not been requested by the editor
+                    if ($request->headers->get('referer') && ! str_ends_with(parse_url($request->headers->get('referer'), PHP_URL_PATH), '/edit')) {
+                        $nodes[$nodeid]['text_colour'] = 'darkred';
+                    }
                 } else {
                     $device_style = $this->nodeUpStyle();
                 }

--- a/app/Http/Controllers/Maps/CustomMapDataController.php
+++ b/app/Http/Controllers/Maps/CustomMapDataController.php
@@ -117,7 +117,10 @@ class CustomMapDataController extends Controller
                     $edges[$edgeid]['port_topct'] = $rateto / $speedto * 100.0;
                     $edges[$edgeid]['port_frompct'] = $ratefrom / $speedfrom * 100.0;
                 }
-                if ($edge->port->ifOperStatus != 'up') {
+                if (! $edge->port->device->status) {
+                    $edges[$edgeid]['colour_to'] = 'darkred';
+                    $edges[$edgeid]['colour_from'] = 'darkred';
+                } elseif ($edge->port->ifOperStatus != 'up') {
                     // If the port is not online, show the same as speed unknown
                     $edges[$edgeid]['colour_to'] = $this->speedColour(-1.0);
                     $edges[$edgeid]['colour_from'] = $this->speedColour(-1.0);
@@ -166,6 +169,7 @@ class CustomMapDataController extends Controller
                     $device_style = $this->nodeDisabledStyle();
                 } elseif (! $node->device->status) {
                     $device_style = $this->nodeDownStyle();
+                    $nodes[$nodeid]['text_colour'] = 'darkred';
                 } else {
                     $device_style = $this->nodeUpStyle();
                 }


### PR DESCRIPTION
When a device goes offline in custom maps, this changes the text on the custom map node, and the line colour for any ports to dark red, so it is clear that the data on the map is not current.

All devices in the map below are offline, but in the before image below everything looks good, while in the after map it is clearer that everything is offline.

Before:
![image](https://github.com/user-attachments/assets/f7289124-b46f-443b-9462-06a6d8126956)

After:
![image](https://github.com/user-attachments/assets/20605266-0419-41bd-b4e5-7a86cecb40d6)


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
