### PR TITLE
Fix icmp service only having packet loss graph

### DIFF
--- a/includes/services.inc.php
+++ b/includes/services.inc.php
@@ -154,8 +154,14 @@ function poll_service($service)
 
         // Set the DS in the DB if it is blank.
         $DS = [];
-        foreach ($perf as $k => $v) {
-            $DS[$k] = $v['uom'];
+        if (isset($check_ds)) {
+            foreach (json_decode($check_ds) as $k => $v) {
+                $DS[$k] = $v;
+            }
+        } else {
+            foreach ($perf as $k => $v) {
+                $DS[$k] = $v['uom'];
+            }
         }
         d_echo('Service DS: ' . json_encode($DS, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) . "\n");
         if (($service['service_ds'] == '{}') || ($service['service_ds'] == '')) {
@@ -164,8 +170,8 @@ function poll_service($service)
 
         // rrd definition
         $rrd_def = new RrdDefinition();
-        foreach ($perf as $k => $v) {
-            if (($v['uom'] == 'c') && ! preg_match('/[Uu]ptime/', $k)) {
+        foreach ($DS as $k => $v) {
+            if (($v == 'c') && ! preg_match('/[Uu]ptime/', $k)) {
                 // This is a counter, create the DS as such
                 $rrd_def->addDataset($k, 'COUNTER', 0);
             } else {

--- a/includes/services.inc.php
+++ b/includes/services.inc.php
@@ -85,8 +85,14 @@ function poll_service($service)
 
         // Set the DS in the DB if it is blank.
         $DS = [];
-        foreach ($perf as $k => $v) {
-            $DS[$k] = ['uom' => $v['uom'], 'full_name' => $v['full_name']];
+        if (isset($check_ds)) {
+            foreach (json_decode($check_ds) as $k => $v) {
+                $DS[$k] = $v;
+            }
+        } else {
+            foreach ($perf as $k => $v) {
+                $DS[$k] = $v['uom'];
+            }
         }
         d_echo('Service DS: ' . json_encode($DS, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) . "\n");
         if (($service['service_ds'] == '{}') || ($service['service_ds'] == '')) {
@@ -95,8 +101,8 @@ function poll_service($service)
 
         // rrd definition
         $rrd_def = new RrdDefinition();
-        foreach ($perf as $k => $v) {
-            if (($v['uom'] == 'c') && ! preg_match('/[Uu]ptime/', (string) $k)) {
+        foreach ($DS as $k => $v) {
+            if (($v == 'c') && ! preg_match('/[Uu]ptime/', $k)) {
                 // This is a counter, create the DS as such
                 $rrd_def->addDataset($k, 'COUNTER', 0);
             } else {

--- a/includes/services.inc.php
+++ b/includes/services.inc.php
@@ -86,7 +86,7 @@ function poll_service($service)
         // Set the DS in the DB if it is blank.
         $DS = [];
 
-        /** @var object $check_ds */
+        /** @var string $check_ds */
         if (isset($check_ds)) {
             foreach (json_decode($check_ds) as $k => $v) {
                 $DS[$k] = ['uom' => $v, 'full_name' => $k];

--- a/includes/services.inc.php
+++ b/includes/services.inc.php
@@ -85,6 +85,8 @@ function poll_service($service)
 
         // Set the DS in the DB if it is blank.
         $DS = [];
+
+        /** @var object $check_ds */
         if (isset($check_ds)) {
             foreach (json_decode($check_ds) as $k => $v) {
                 $DS[$k] = ['uom' => $v, 'full_name' => $k];

--- a/includes/services.inc.php
+++ b/includes/services.inc.php
@@ -87,11 +87,11 @@ function poll_service($service)
         $DS = [];
         if (isset($check_ds)) {
             foreach (json_decode($check_ds) as $k => $v) {
-                $DS[$k] = $v;
+                $DS[$k] = ['uom' => $v, 'full_name' => $k];
             }
         } else {
             foreach ($perf as $k => $v) {
-                $DS[$k] = $v['uom'];
+                $DS[$k] = ['uom' => $v['uom'], 'full_name' => $v['full_name']];
             }
         }
         d_echo('Service DS: ' . json_encode($DS, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) . "\n");
@@ -102,7 +102,7 @@ function poll_service($service)
         // rrd definition
         $rrd_def = new RrdDefinition();
         foreach ($DS as $k => $v) {
-            if (($v == 'c') && ! preg_match('/[Uu]ptime/', $k)) {
+            if (($v == 'c') && ! preg_match('/[Uu]ptime/', (string) $k)) {
                 // This is a counter, create the DS as such
                 $rrd_def->addDataset($k, 'COUNTER', 0);
             } else {

--- a/includes/services.inc.php
+++ b/includes/services.inc.php
@@ -86,9 +86,8 @@ function poll_service($service)
         // Set the DS in the DB if it is blank.
         $DS = [];
 
-        /** @var string $check_ds */
         if (isset($check_ds)) {
-            foreach (json_decode($check_ds) as $k => $v) {
+            foreach (json_decode($check_ds) as $k => $v) { /** @phpstan-ignore variable.undefined (Branch only reached if $check_ds is set) */
                 $DS[$k] = ['uom' => $v, 'full_name' => $k];
             }
         } else {

--- a/includes/services/check_icmp.inc.php
+++ b/includes/services/check_icmp.inc.php
@@ -3,10 +3,10 @@
 // check_cmd is the command that is run to execute the check
 $check_cmd = \LibreNMS\Config::get('nagios_plugins') . '/check_icmp ' . $service['service_param'] . ' ' . ($service['service_ip'] ? $service['service_ip'] : $service['hostname']);
 
-if (isset($rrd_filename)) {
-    // Check DS is a json array of the graphs that are available
-    $check_ds = '{"rta":"s","rtmax":"s","rtmin":"s","pl":"%"}';
+// Check DS is a json array of the graphs that are available
+$check_ds = '{"rta":"s","rtmax":"s","rtmin":"s","pl":"%"}';
 
+if (isset($rrd_filename)) {
     // Build the graph data
     $check_graph = [];
     $check_graph['rta'] = ' DEF:DS0=' . $rrd_filename . ':rta:AVERAGE ';

--- a/includes/services/check_icmp.inc.php
+++ b/includes/services/check_icmp.inc.php
@@ -3,10 +3,10 @@
 // check_cmd is the command that is run to execute the check
 $check_cmd = \App\Facades\LibrenmsConfig::get('nagios_plugins') . '/check_icmp ' . $service['service_param'] . ' ' . ($service['service_ip'] ?: $service['hostname']);
 
-if (isset($rrd_filename)) {
-    // Check DS is a json array of the graphs that are available
-    $check_ds = '{"rta":"s","rtmax":"s","rtmin":"s","pl":"%"}';
+// Check DS is a json array of the graphs that are available
+$check_ds = '{"rta":"s","rtmax":"s","rtmin":"s","pl":"%"}';
 
+if (isset($rrd_filename)) {
     // Build the graph data
     $check_graph = [];
     $check_graph['rta'][] = 'DEF:DS0=' . $rrd_filename . ':rta:AVERAGE';


### PR DESCRIPTION
Currently there is an issue with icmp service. If upon creation there is no icmp reply the output of the check_icmp command only contains the packet loss:

```
# /usr/lib/monitoring-plugins/check_icmp -H 1.1.1.1
CRITICAL - 1.1.1.1: rta nan, lost 100%|pl=100%;40;80;0;100
```

This then causes two issues internally:
1. The RRD file gets created with only the packet loss data source and the additional data sources will not get added even after there is an icmp reply (and so output from check_icmp containing the full dataset)
2. On creation the service_ds column is set to `{}`. During the first update the service_ds column in the database gets updated, but this is based on the output of the check_icmp command. So if there is no icmp reply it will only add the packet loss into service_ds. There will be no further updates to the service_ds column as with the current logic this only happens if the value of the service_ds column is blank or `{}`.

Ultimately this means that the service will only ever show a packet loss graph and the RRD file will only contain data for packet loss, even after receiving icmp replies. Once icmp replies are being received deleting the RRD file doesn't fix the issue as the value in the service_ds column in the database is still incorrect. Both the RRD file and the value in the service_ds column needs to be fixed OR the service needs to be recreated.

The changes in this PR aim to fix the above internal issues by making the below changes:

1. Move the definition of the `$check_ds` variable outside of the `isset($rrd_filename)` condition in `includes/services/check_icmp.inc.php`

My understanding is that this condition is only met when the `includes/services/check_icmp.inc.php` file is included in `includes/html/graphs/service/graph.inc.php`.

The purpose of moving this definition outside the condition is so we have access to a full definition of the data sources that we are expecting when there is an icmp reply and so we can use this definition to create the RRD file with all the data sources as well as use the definition to update the service_ds column in the database setting it's value to the full dataset.

Moving this definition outside the condition shouldn't (or just barely) impact performance.

I have noticed there is a similar definition in `includes/services/check_load.inc.php` and `includes/services/check_mysql.inc.php`. I wasn't able to confirm if these service types are affected by the same issue or not. It might be that they are also affected and moving the definition outside the condition in these files would fix the issue.

2. Conditional value assignment to `$DS` variable in `includes/services.inc.php` function `poll_service`

If condition `isset($check_ds)` is true we iterate through `json_decode($check_ds)` (instead of `$perf`) to generate the data sources (`$DS`). If the condition is false we iterate through `$perf` (this is following the unconditional original code) to generate the data sources.

In the original code the `$DS` variable is only used to update the service_ds column. Please see change 3 below where we will make additional use of this variable.

The addition of this condition should only affect the icmp, load and mysql services as these are the only services defining the `$check_ds` variable. All other services should follow the false branch of the condition and so will be using the original code.

3. Change `$rrd_def` value to be generated from `$DS` instead of `$perf`

Since the original code used to generate the value of `$DS` from `$perf` this should not make any practical difference for any service following the false branch of the condition mentioned in change 2 (see above). For the services following the true branch (as per the description in change 2 this should only be the services icmp, load and mysql) it will change the value of `$rrd_def` to be the full dataset.

4. Change condition `$v['uom'] == 'c' to `$v == 'c'` to determine if a data source is a counter

This change is required as a consequence of change 3 (see above). The items in the `$perf` array are an array per data source, containing an item for the value and an item for unit of measure. The items in the `$DS` array are a string per data source with the value for the unit of measure. Please see below for the difference in data structure.

```
$perf: Array
(
    [pl] => Array
        (
            [value] => 100
            [uom] => %
        )

)
```

vs.

```
$DS: Array
(
    [rta] => s
    [rtmax] => s
    [rtmin] => s
    [pl] => %
)
```

Please note my understanding of the LibreNMS code is not complete and this PR is only a best effort attempt to make an optimal change to fix the issue described. Any criticism or comments are welcome.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.

