### PR TITLE
UI: Dark theme improvements (aesthetics and readability)

### DIFF
--- a/html/css/styles.css
+++ b/html/css/styles.css
@@ -1582,7 +1582,6 @@ tr.search:nth-child(odd) {
   max-height: 90px;
   text-align: center;
   float: left;
-  /* background-color: #e9e9e9; */
   border: solid 1px;
   border-color: #e9e9e9;
 }

--- a/html/css/styles.css
+++ b/html/css/styles.css
@@ -357,7 +357,6 @@ A.purple:visited, a.purple, .purple { color: #740074; }
   max-height:180px;
   text-align: center;
   float: left;
-  background-color: #f5f5f5;
 }
 
 .tablehead {

--- a/html/css/styles.css
+++ b/html/css/styles.css
@@ -1582,7 +1582,7 @@ tr.search:nth-child(odd) {
   text-align: center;
   float: left;
   border: solid 1px;
-  border-color: #e9e9e9;
+  border-color: #b2b6af;
 }
 
 .example-sports .league-name {
@@ -2205,7 +2205,6 @@ label {
     max-height: 170px;
     text-align: center;
     float: left;
-    background-color: #f5f5f5;
 }
 
 .device-table-metrics span {

--- a/html/css/styles.css
+++ b/html/css/styles.css
@@ -1572,7 +1572,8 @@ tr.search:nth-child(odd) {
 }
 
 .minigraph-div {
-  display: block;
+  display: flex;
+  justify-content: center;
   padding: 3px;
   margin: 3px;
   min-width: 183px;
@@ -1581,7 +1582,7 @@ tr.search:nth-child(odd) {
   max-height: 90px;
   text-align: center;
   float: left;
-  background-color: #e9e9e9;
+  /* background-color: #e9e9e9; */
   border: solid 1px;
   border-color: #e9e9e9;
 }


### PR DESCRIPTION
This change improves the dark theme aesthetic and readability (it also improves the light theme too a little).

-  Removes a grey bright background that is shown when using the dark theme in some graphs.
- Centered minigraphs within their frames for proper alignment.
- Improves the page device i.e.: http://localhost/devices/format=graph_bits/from=-24hour/to=now/
- Improves the page all ports i.e.: http://localhost/ports/format=graph_errors/
- Improves the pages with minigraphs i.e.: http://localhost/device/1/ports/mini_graphs?type=upkts

**Dark Mode (before and after):**
![before - after (dark theme)](https://github.com/user-attachments/assets/796f6e1a-5236-44b1-b41b-6225176a259c)

**Light Mode (before and after):**
![before - after (light theme)](https://github.com/user-attachments/assets/67d83614-f52f-41a1-826a-a7d76fb31e7f)


Tested with:
 - Mozilla Firefox 130.0.1 (64-bit)
 - Chrome Version 129.0.6668.90 (Build oficial) (64 bits

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
