### PR TITLE
add some more alert rules for checking for smart self test failures

### DIFF
--- a/misc/alert_rules.json
+++ b/misc/alert_rules.json
@@ -798,5 +798,35 @@
     "rule": "applications.app_type = \"cape\" && application_metrics.metric = \"error\" && application_metrics.value > 0",
     "name": "CAPE Errors > 0",
     "severity": "critical"
+  },
+  {
+    "rule": "applications.app_type = \"smart\" && application_metrics.metric like \"%fail%\" && application_metrics.value > \"0\"",
+    "builder": {"condition":"AND","rules":[
+                                           {"id":"applications.app_type","field":"applications.app_type","type":"string","input":"text","operator":"equal","value":"smart"},
+                                           {"id":"application_metrics.metric","field":"application_metrics.metric","type":"string","input":"text","operator":"regex","value":"disk.*fail.*"},
+                                           {"id":"application_metrics.value","field":"application_metrics.value","type":"string","input":"number","operator":"greater_or_equal","value":"0"}
+                                         ],"valid":false},
+    "name": "SMART: one or more disk is has failures",
+    "severity": "critical"
+  },
+  {
+    "rule": "applications.app_type = \"smart\" && application_metrics.metric like \"%fail%\" && application_metrics.value > \"0\"",
+    "builder": {"condition":"AND","rules":[
+                                           {"id":"applications.app_type","field":"applications.app_type","type":"string","input":"text","operator":"equal","value":"smart"},
+                                           {"id":"application_metrics.metric","field":"application_metrics.metric","type":"string","input":"text","operator":"regex","value":"disk.*readfailure"},
+                                           {"id":"application_metrics.value","field":"application_metrics.value","type":"string","input":"number","operator":"greater_or_equal","value":"0"}
+                                         ],"valid":false},
+    "name": "SMART: one or more disk is has self test read failures",
+    "severity": "critical"
+  },
+  {
+    "rule": "applications.app_type = \"smart\" && application_metrics.metric like \"%fail%\" && application_metrics.value > \"0\"",
+    "builder": {"condition":"AND","rules":[
+                                           {"id":"applications.app_type","field":"applications.app_type","type":"string","input":"text","operator":"equal","value":"smart"},
+                                           {"id":"application_metrics.metric","field":"application_metrics.metric","type":"string","input":"text","operator":"regex","value":"disk.*unknownfail"},
+                                           {"id":"application_metrics.value","field":"application_metrics.value","type":"string","input":"number","operator":"greater_or_equal","value":"0"}
+                                         ],"valid":false},
+    "name": "SMART: one or more disk is has self test unknown failures",
+    "severity": "critical"
   }
 ]

--- a/misc/alert_rules.json
+++ b/misc/alert_rules.json
@@ -800,31 +800,28 @@
     "severity": "critical"
   },
   {
-    "rule": "applications.app_type = \"smart\" && application_metrics.metric like \"%fail%\" && application_metrics.value > \"0\"",
     "builder": {"condition":"AND","rules":[
                                            {"id":"applications.app_type","field":"applications.app_type","type":"string","input":"text","operator":"equal","value":"smart"},
                                            {"id":"application_metrics.metric","field":"application_metrics.metric","type":"string","input":"text","operator":"regex","value":"disk.*fail.*"},
-                                           {"id":"application_metrics.value","field":"application_metrics.value","type":"string","input":"number","operator":"greater_or_equal","value":"0"}
+                                           {"id":"application_metrics.value","field":"application_metrics.value","type":"string","input":"number","operator":"greater_or_equal","value":"1"}
                                          ],"valid":false},
     "name": "SMART: one or more disk is has failures",
     "severity": "critical"
   },
   {
-    "rule": "applications.app_type = \"smart\" && application_metrics.metric like \"%fail%\" && application_metrics.value > \"0\"",
     "builder": {"condition":"AND","rules":[
                                            {"id":"applications.app_type","field":"applications.app_type","type":"string","input":"text","operator":"equal","value":"smart"},
                                            {"id":"application_metrics.metric","field":"application_metrics.metric","type":"string","input":"text","operator":"regex","value":"disk.*readfailure"},
-                                           {"id":"application_metrics.value","field":"application_metrics.value","type":"string","input":"number","operator":"greater_or_equal","value":"0"}
+                                           {"id":"application_metrics.value","field":"application_metrics.value","type":"string","input":"number","operator":"greater_or_equal","value":"1"}
                                          ],"valid":false},
     "name": "SMART: one or more disk is has self test read failures",
     "severity": "critical"
   },
   {
-    "rule": "applications.app_type = \"smart\" && application_metrics.metric like \"%fail%\" && application_metrics.value > \"0\"",
     "builder": {"condition":"AND","rules":[
                                            {"id":"applications.app_type","field":"applications.app_type","type":"string","input":"text","operator":"equal","value":"smart"},
                                            {"id":"application_metrics.metric","field":"application_metrics.metric","type":"string","input":"text","operator":"regex","value":"disk.*unknownfail"},
-                                           {"id":"application_metrics.value","field":"application_metrics.value","type":"string","input":"number","operator":"greater_or_equal","value":"0"}
+                                           {"id":"application_metrics.value","field":"application_metrics.value","type":"string","input":"number","operator":"greater_or_equal","value":"1"}
                                          ],"valid":false},
     "name": "SMART: one or more disk is has self test unknown failures",
     "severity": "critical"


### PR DESCRIPTION
Adds three more alert rules for SMART. The first one checks for any sort of self test failures. The second checks for read failures. The third checks for unknown failures.

Created this after finding some disks won't consider themselves unhealth even if they can't pass a self test.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
