### PR TITLE
Stop services from being checked when device is offline and service does not have an IP set

### DIFF
--- a/check-services.php
+++ b/check-services.php
@@ -58,7 +58,7 @@ foreach (dbFetchRows($sql, $params) as $service) {
     // Run the polling function if service is enabled and the associated device is up, "Disable ICMP Test" option is not enabled,
     // or service hostname/ip is different from associated device
     if (! $service['service_disabled'] && ($service['status'] == 1 || ($service['status'] == 0 && $service['status_reason'] === 'snmp') ||
-        $service['attrib_value'] === 'true' || ($service['service_ip'] !== $service['hostname'] &&
+        $service['attrib_value'] === 'true' || (! is_null($service['service_ip']) && $service['service_ip'] !== $service['hostname'] &&
         $service['service_ip'] !== inet6_ntop($service['ip'])))) {
         poll_service($service);
         $polled_services++;


### PR DESCRIPTION
While looking into why we get service alerts for devices that are offline, I discovered that in our database the services.service_ip is always null.  There is a test in the check-services php file that is meant to disable the service check when the device is offline, but it does not work if the service_ip is null.

This PR causes the service check to not run if the device is offline and the service_ip is null, which I believe is the desired behaviour.

The issue was introduced between in commit 24d84aec9d1f22b31b25e12358940c96c8a1060d

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
