### PR TITLE
F5 Loadbalancers, use full path for includes

### DIFF
--- a/includes/polling/loadbalancers.inc.php
+++ b/includes/polling/loadbalancers.inc.php
@@ -10,13 +10,13 @@
  */
 
 if ($device['os'] == 'f5') {
-    if (file_exists(Config::get('install_dir') . "includes/polling/loadbalancers/f5-ltm.inc.php")) {
-        include Config::get('install_dir') . "includes/polling/loadbalancers/f5-ltm.inc.php";
+    if (file_exists(Config::get('install_dir') . 'includes/polling/loadbalancers/f5-ltm.inc.php')) {
+        include Config::get('install_dir') . 'includes/polling/loadbalancers/f5-ltm.inc.php';
     }
-    if (file_exists(Config::get('install_dir') . "includes/polling/loadbalancers/f5-gtm.inc.php")) {
-        include Config::get('install_dir') . "includes/polling/loadbalancers/f5-gtm.inc.php";
+    if (file_exists(Config::get('install_dir') . 'includes/polling/loadbalancers/f5-gtm.inc.php')) {
+        include Config::get('install_dir') . 'includes/polling/loadbalancers/f5-gtm.inc.php';
     }
-    if (file_exists(Config::get('install_dir') . "includes/polling/loadbalancers/f5-ltm-currconns.inc.php")) {
-        include Config::get('install_dir') . "includes/polling/loadbalancers/f5-ltm-currconns.inc.php";
+    if (file_exists(Config::get('install_dir') . 'includes/polling/loadbalancers/f5-ltm-currconns.inc.php')) {
+        include Config::get('install_dir') . 'includes/polling/loadbalancers/f5-ltm-currconns.inc.php';
     }
 }

--- a/includes/polling/loadbalancers.inc.php
+++ b/includes/polling/loadbalancers.inc.php
@@ -10,7 +10,13 @@
  */
 
 if ($device['os'] == 'f5') {
-    include 'includes/polling/loadbalancers/f5-ltm.inc.php';
-    include 'includes/polling/loadbalancers/f5-gtm.inc.php';
-    include 'includes/polling/loadbalancers/f5-ltm-currconns.inc.php';
+    if (file_exists(Config::get('install_dir') . "includes/polling/loadbalancers/f5-ltm.inc.php")) {
+        include Config::get('install_dir') . "includes/polling/loadbalancers/f5-ltm.inc.php";
+    }
+    if (file_exists(Config::get('install_dir') . "includes/polling/loadbalancers/f5-gtm.inc.php")) {
+        include Config::get('install_dir') . "includes/polling/loadbalancers/f5-gtm.inc.php";
+    }
+    if (file_exists(Config::get('install_dir') . "includes/polling/loadbalancers/f5-ltm-currconns.inc.php")) {
+        include Config::get('install_dir') . "includes/polling/loadbalancers/f5-ltm-currconns.inc.php";
+    }
 }


### PR DESCRIPTION
Please give a short description what your pull request is for

My dispatchers python script are called without providing the working directory.
For this reason, the F5 Loadbalancers module was not loading. (hard to find as no logs/errors).
I finally understood that it could be the case as manually calling the lnms device:poll work when we are in the work dir.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
