### PR TITLE
Dell sensor fix variable leaking

### DIFF
--- a/includes/discovery/sensors/fanspeed/dell.inc.php
+++ b/includes/discovery/sensors/fanspeed/dell.inc.php
@@ -16,11 +16,11 @@ $cur_oid = '.1.3.6.1.4.1.674.10892.1.700.12.1.6.';
 if (is_array($temp)) {
     foreach ($temp as $index => $entry) {
         $descr = $temp[$index]['coolingDeviceLocationName'];
-        (isset($temp[$index]['coolingDeviceReading']) ? $value = $temp[$index]['coolingDeviceReading'] : $value = null;
-        (isset($temp[$index]['coolingDeviceLowerCriticalThreshold']) ? $lowlimit = $temp[$index]['coolingDeviceLowerCriticalThreshold'] : $lowlimit = null;
-        (isset($temp[$index]['coolingDeviceLowerNonCriticalThreshold']) ? $low_warn_limit = $temp[$index]['coolingDeviceLowerNonCriticalThreshold'] : $low_warn_limit = null;
-        (isset($temp[$index]['coolingDeviceUpperNonCriticalThreshold']) ? $warnlimit = $temp[$index]['coolingDeviceUpperNonCriticalThreshold'] : $warnlimit = null;
-        (isset($temp[$index]['coolingDeviceUpperCriticalThreshold']) ? $limit = $temp[$index]['coolingDeviceUpperCriticalThreshold'] : $limit = null;
+        (isset($temp[$index]['coolingDeviceReading'])) ? $value = $temp[$index]['coolingDeviceReading'] : $value = null;
+        (isset($temp[$index]['coolingDeviceLowerCriticalThreshold'])) ? $lowlimit = $temp[$index]['coolingDeviceLowerCriticalThreshold'] : $lowlimit = null;
+        (isset($temp[$index]['coolingDeviceLowerNonCriticalThreshold'])) ? $low_warn_limit = $temp[$index]['coolingDeviceLowerNonCriticalThreshold'] : $low_warn_limit = null;
+        (isset($temp[$index]['coolingDeviceUpperNonCriticalThreshold'])) ? $warnlimit = $temp[$index]['coolingDeviceUpperNonCriticalThreshold'] : $warnlimit = null;
+        (isset($temp[$index]['coolingDeviceUpperCriticalThreshold'])) ? $limit = $temp[$index]['coolingDeviceUpperCriticalThreshold'] : $limit = null;
 
         discover_sensor(null, 'fanspeed', $device, $cur_oid . $index, $index, 'dell', $descr, '0', '1', $lowlimit, $low_warn_limit, $warnlimit, $limit, $value, 'snmp', $index);
 

--- a/includes/discovery/sensors/fanspeed/dell.inc.php
+++ b/includes/discovery/sensors/fanspeed/dell.inc.php
@@ -16,31 +16,11 @@ $cur_oid = '.1.3.6.1.4.1.674.10892.1.700.12.1.6.';
 if (is_array($temp)) {
     foreach ($temp as $index => $entry) {
         $descr = $temp[$index]['coolingDeviceLocationName'];
-        if (isset($temp[$index]['coolingDeviceReading'])) {
-            $value = $temp[$index]['coolingDeviceReading'];
-        } else {
-            $value = null;
-        }
-        if (isset($temp[$index]['coolingDeviceLowerCriticalThreshold'])) {
-            $lowlimit = $temp[$index]['coolingDeviceLowerCriticalThreshold'];
-        } else {
-            $lowlimit = null;
-        }
-        if (isset($temp[$index]['coolingDeviceLowerNonCriticalThreshold'])) {
-            $low_warn_limit = $temp[$index]['coolingDeviceLowerNonCriticalThreshold'];
-        } else {
-            $low_warn_limit = null;
-        }
-        if (isset($temp[$index]['coolingDeviceUpperNonCriticalThreshold'])) {
-            $warnlimit = $temp[$index]['coolingDeviceUpperNonCriticalThreshold'];
-        } else {
-            $warnlimit = null;
-        }
-        if (isset($temp[$index]['coolingDeviceUpperCriticalThreshold'])) {
-            $limit = $temp[$index]['coolingDeviceUpperCriticalThreshold'];
-        } else {
-            $limit = null;
-        }
+        (isset($temp[$index]['coolingDeviceReading']) ? $value = $temp[$index]['coolingDeviceReading'] : $value = null;
+        (isset($temp[$index]['coolingDeviceLowerCriticalThreshold']) ? $lowlimit = $temp[$index]['coolingDeviceLowerCriticalThreshold'] : $lowlimit = null;
+        (isset($temp[$index]['coolingDeviceLowerNonCriticalThreshold']) ? $low_warn_limit = $temp[$index]['coolingDeviceLowerNonCriticalThreshold'] : $low_warn_limit = null;
+        (isset($temp[$index]['coolingDeviceUpperNonCriticalThreshold']) ? $warnlimit = $temp[$index]['coolingDeviceUpperNonCriticalThreshold'] : $warnlimit = null;
+        (isset($temp[$index]['coolingDeviceUpperCriticalThreshold']) ? $limit = $temp[$index]['coolingDeviceUpperCriticalThreshold'] : $limit = null;
 
         discover_sensor(null, 'fanspeed', $device, $cur_oid . $index, $index, 'dell', $descr, '0', '1', $lowlimit, $low_warn_limit, $warnlimit, $limit, $value, 'snmp', $index);
 

--- a/includes/discovery/sensors/fanspeed/dell.inc.php
+++ b/includes/discovery/sensors/fanspeed/dell.inc.php
@@ -16,11 +16,31 @@ $cur_oid = '.1.3.6.1.4.1.674.10892.1.700.12.1.6.';
 if (is_array($temp)) {
     foreach ($temp as $index => $entry) {
         $descr = $temp[$index]['coolingDeviceLocationName'];
-        $value = $temp[$index]['coolingDeviceReading'];
-        $lowlimit = $temp[$index]['coolingDeviceLowerCriticalThreshold'];
-        $low_warn_limit = $temp[$index]['coolingDeviceLowerNonCriticalThreshold'];
-        $warnlimit = $temp[$index]['coolingDeviceUpperNonCriticalThreshold'];
-        $limit = $temp[$index]['coolingDeviceUpperCriticalThreshold'];
+        if (isset($temp[$index]['coolingDeviceReading']) {
+                $value = $temp[$index]['coolingDeviceReading'];
+        } else {
+                $value = null;
+        }
+        if (isset($temp[$index]['coolingDeviceLowerCriticalThreshold']) {
+                $lowlimit = $temp[$index]['coolingDeviceLowerCriticalThreshold'];
+        } else {
+                $lowlimit = null;
+        }
+        if (isset($temp[$index]['coolingDeviceLowerNonCriticalThreshold']) {
+                $low_warn_limit = $temp[$index]['coolingDeviceLowerNonCriticalThreshold'];
+        } else {
+                $low_warn_limit = null;
+        }
+        if (isset($temp[$index]['coolingDeviceUpperNonCriticalThreshold']) {
+                $warnlimit = $temp[$index]['coolingDeviceUpperNonCriticalThreshold'];
+        } else {
+                $warnlimit = null;
+        }
+        if (isset($temp[$index]['coolingDeviceUpperCriticalThreshold']) {
+                $limit = $temp[$index]['coolingDeviceUpperCriticalThreshold'];
+        } else {
+                $limit = null;
+        }
 
         discover_sensor(null, 'fanspeed', $device, $cur_oid . $index, $index, 'dell', $descr, '0', '1', $lowlimit, $low_warn_limit, $warnlimit, $limit, $value, 'snmp', $index);
         

--- a/includes/discovery/sensors/fanspeed/dell.inc.php
+++ b/includes/discovery/sensors/fanspeed/dell.inc.php
@@ -17,29 +17,29 @@ if (is_array($temp)) {
     foreach ($temp as $index => $entry) {
         $descr = $temp[$index]['coolingDeviceLocationName'];
         if (isset($temp[$index]['coolingDeviceReading']) {
-                $value = $temp[$index]['coolingDeviceReading'];
+            $value = $temp[$index]['coolingDeviceReading'];
         } else {
-                $value = null;
+            $value = null;
         }
         if (isset($temp[$index]['coolingDeviceLowerCriticalThreshold']) {
-                $lowlimit = $temp[$index]['coolingDeviceLowerCriticalThreshold'];
+            $lowlimit = $temp[$index]['coolingDeviceLowerCriticalThreshold'];
         } else {
-                $lowlimit = null;
+            $lowlimit = null;
         }
         if (isset($temp[$index]['coolingDeviceLowerNonCriticalThreshold']) {
                 $low_warn_limit = $temp[$index]['coolingDeviceLowerNonCriticalThreshold'];
         } else {
-                $low_warn_limit = null;
+            $low_warn_limit = null;
         }
         if (isset($temp[$index]['coolingDeviceUpperNonCriticalThreshold']) {
-                $warnlimit = $temp[$index]['coolingDeviceUpperNonCriticalThreshold'];
+            $warnlimit = $temp[$index]['coolingDeviceUpperNonCriticalThreshold'];
         } else {
-                $warnlimit = null;
+            $warnlimit = null;
         }
         if (isset($temp[$index]['coolingDeviceUpperCriticalThreshold']) {
-                $limit = $temp[$index]['coolingDeviceUpperCriticalThreshold'];
+            $limit = $temp[$index]['coolingDeviceUpperCriticalThreshold'];
         } else {
-                $limit = null;
+            $limit = null;
         }
 
         discover_sensor(null, 'fanspeed', $device, $cur_oid . $index, $index, 'dell', $descr, '0', '1', $lowlimit, $low_warn_limit, $warnlimit, $limit, $value, 'snmp', $index);

--- a/includes/discovery/sensors/fanspeed/dell.inc.php
+++ b/includes/discovery/sensors/fanspeed/dell.inc.php
@@ -23,5 +23,14 @@ if (is_array($temp)) {
         $limit = $temp[$index]['coolingDeviceUpperCriticalThreshold'];
 
         discover_sensor(null, 'fanspeed', $device, $cur_oid . $index, $index, 'dell', $descr, '0', '1', $lowlimit, $low_warn_limit, $warnlimit, $limit, $value, 'snmp', $index);
+        
+        unset(
+            $descr,
+            $value,
+            $lowlimit,
+            $low_warn_limit,
+            $warnlimit,
+            $limit
+        );
     }
 }

--- a/includes/discovery/sensors/fanspeed/dell.inc.php
+++ b/includes/discovery/sensors/fanspeed/dell.inc.php
@@ -16,27 +16,27 @@ $cur_oid = '.1.3.6.1.4.1.674.10892.1.700.12.1.6.';
 if (is_array($temp)) {
     foreach ($temp as $index => $entry) {
         $descr = $temp[$index]['coolingDeviceLocationName'];
-        if (isset($temp[$index]['coolingDeviceReading']) {
+        if (isset($temp[$index]['coolingDeviceReading'])) {
             $value = $temp[$index]['coolingDeviceReading'];
         } else {
             $value = null;
         }
-        if (isset($temp[$index]['coolingDeviceLowerCriticalThreshold']) {
+        if (isset($temp[$index]['coolingDeviceLowerCriticalThreshold'])) {
             $lowlimit = $temp[$index]['coolingDeviceLowerCriticalThreshold'];
         } else {
             $lowlimit = null;
         }
-        if (isset($temp[$index]['coolingDeviceLowerNonCriticalThreshold']) {
+        if (isset($temp[$index]['coolingDeviceLowerNonCriticalThreshold'])) {
                 $low_warn_limit = $temp[$index]['coolingDeviceLowerNonCriticalThreshold'];
         } else {
             $low_warn_limit = null;
         }
-        if (isset($temp[$index]['coolingDeviceUpperNonCriticalThreshold']) {
+        if (isset($temp[$index]['coolingDeviceUpperNonCriticalThreshold'])) {
             $warnlimit = $temp[$index]['coolingDeviceUpperNonCriticalThreshold'];
         } else {
             $warnlimit = null;
         }
-        if (isset($temp[$index]['coolingDeviceUpperCriticalThreshold']) {
+        if (isset($temp[$index]['coolingDeviceUpperCriticalThreshold'])) {
             $limit = $temp[$index]['coolingDeviceUpperCriticalThreshold'];
         } else {
             $limit = null;

--- a/includes/discovery/sensors/fanspeed/dell.inc.php
+++ b/includes/discovery/sensors/fanspeed/dell.inc.php
@@ -27,7 +27,7 @@ if (is_array($temp)) {
             $lowlimit = null;
         }
         if (isset($temp[$index]['coolingDeviceLowerNonCriticalThreshold'])) {
-                $low_warn_limit = $temp[$index]['coolingDeviceLowerNonCriticalThreshold'];
+            $low_warn_limit = $temp[$index]['coolingDeviceLowerNonCriticalThreshold'];
         } else {
             $low_warn_limit = null;
         }
@@ -43,7 +43,7 @@ if (is_array($temp)) {
         }
 
         discover_sensor(null, 'fanspeed', $device, $cur_oid . $index, $index, 'dell', $descr, '0', '1', $lowlimit, $low_warn_limit, $warnlimit, $limit, $value, 'snmp', $index);
-        
+
         unset(
             $descr,
             $value,

--- a/includes/discovery/sensors/power/dell.inc.php
+++ b/includes/discovery/sensors/power/dell.inc.php
@@ -29,11 +29,31 @@ foreach ((array) $temp as $index => $entry) {
     $descr = $entry['amperageProbeLocationName'];
     if ($entry['amperageProbeType'] === 'amperageProbeTypeIsSystemWatts') {
         $divisor = 1;
-        $value = $entry['amperageProbeReading'];
-        $lowlimit = $entry['amperageProbeLowerCriticalThreshold'] / $divisor;
-        $low_warn_limit = $entry['amperageProbeLowerCriticalThreshold'] / $divisor;
-        $warnlimit = $entry['amperageProbeUpperNonCriticalThreshold'] / $divisor;
-        $limit = $entry['amperageProbeUpperCriticalThreshold'] / $divisor;
+        if (isset($entry['amperageProbeReading'])) {
+                $value = $entry['amperageProbeReading'];
+        } else {
+                $value = null;
+        }
+        if (isset($entry['amperageProbeLowerCriticalThreshold'])) {
+                $lowlimit = $entry['amperageProbeLowerCriticalThreshold'] / $divisor;
+        } else {
+                $lowlimit = null;
+        }
+        if (isset($entry['amperageProbeLowerCriticalThreshold'])) {
+                $low_warn_limit = $entry['amperageProbeLowerCriticalThreshold'] / $divisor;
+        } else {
+                $low_warn_limit = null;
+        }
+        if (isset($entry['amperageProbeUpperNonCriticalThreshold'])) {
+                $warnlimit = $entry['amperageProbeUpperNonCriticalThreshold'] / $divisor;
+        } else {
+                $warnlimit = null;
+        }
+        if (isset($entry['amperageProbeUpperCriticalThreshold'])) {
+                $limit = $entry['amperageProbeUpperCriticalThreshold'] / $divisor;
+        } else {
+                $limit = null;
+        }
 
         discover_sensor(null, 'power', $device, $cur_oid . $index, $index, 'dell', $descr, $divisor, '1', $lowlimit, $low_warn_limit, $warnlimit, $limit, $value, 'snmp', $index);
     }

--- a/includes/discovery/sensors/power/dell.inc.php
+++ b/includes/discovery/sensors/power/dell.inc.php
@@ -29,31 +29,11 @@ foreach ((array) $temp as $index => $entry) {
     $descr = $entry['amperageProbeLocationName'];
     if ($entry['amperageProbeType'] === 'amperageProbeTypeIsSystemWatts') {
         $divisor = 1;
-        if (isset($entry['amperageProbeReading'])) {
-            $value = $entry['amperageProbeReading'];
-        } else {
-            $value = null;
-        }
-        if (isset($entry['amperageProbeLowerCriticalThreshold'])) {
-            $lowlimit = $entry['amperageProbeLowerCriticalThreshold'] / $divisor;
-        } else {
-            $lowlimit = null;
-        }
-        if (isset($entry['amperageProbeLowerCriticalThreshold'])) {
-            $low_warn_limit = $entry['amperageProbeLowerCriticalThreshold'] / $divisor;
-        } else {
-            $low_warn_limit = null;
-        }
-        if (isset($entry['amperageProbeUpperNonCriticalThreshold'])) {
-            $warnlimit = $entry['amperageProbeUpperNonCriticalThreshold'] / $divisor;
-        } else {
-            $warnlimit = null;
-        }
-        if (isset($entry['amperageProbeUpperCriticalThreshold'])) {
-            $limit = $entry['amperageProbeUpperCriticalThreshold'] / $divisor;
-        } else {
-            $limit = null;
-        }
+        (isset($entry['amperageProbeReading'])) ? $value = $entry['amperageProbeReading'] : $value = null;
+        (isset($entry['amperageProbeLowerCriticalThreshold'])) ? $lowlimit = $entry['amperageProbeLowerCriticalThreshold'] / $divisor : $lowlimit = null;
+        (isset($entry['amperageProbeLowerCriticalThreshold'])) ? $low_warn_limit = $entry['amperageProbeLowerCriticalThreshold'] / $divisor : $low_warn_limit = null;
+        (isset($entry['amperageProbeUpperNonCriticalThreshold'])) ? $warnlimit = $entry['amperageProbeUpperNonCriticalThreshold'] / $divisor : $warnlimit = null;
+        (isset($entry['amperageProbeUpperCriticalThreshold'])) ? $limit = $entry['amperageProbeUpperCriticalThreshold'] / $divisor : $limit = null;
 
         discover_sensor(null, 'power', $device, $cur_oid . $index, $index, 'dell', $descr, $divisor, '1', $lowlimit, $low_warn_limit, $warnlimit, $limit, $value, 'snmp', $index);
     }

--- a/includes/discovery/sensors/power/dell.inc.php
+++ b/includes/discovery/sensors/power/dell.inc.php
@@ -30,29 +30,29 @@ foreach ((array) $temp as $index => $entry) {
     if ($entry['amperageProbeType'] === 'amperageProbeTypeIsSystemWatts') {
         $divisor = 1;
         if (isset($entry['amperageProbeReading'])) {
-                $value = $entry['amperageProbeReading'];
+            $value = $entry['amperageProbeReading'];
         } else {
-                $value = null;
+            $value = null;
         }
         if (isset($entry['amperageProbeLowerCriticalThreshold'])) {
-                $lowlimit = $entry['amperageProbeLowerCriticalThreshold'] / $divisor;
+            $lowlimit = $entry['amperageProbeLowerCriticalThreshold'] / $divisor;
         } else {
-                $lowlimit = null;
+            $lowlimit = null;
         }
         if (isset($entry['amperageProbeLowerCriticalThreshold'])) {
-                $low_warn_limit = $entry['amperageProbeLowerCriticalThreshold'] / $divisor;
+            $low_warn_limit = $entry['amperageProbeLowerCriticalThreshold'] / $divisor;
         } else {
-                $low_warn_limit = null;
+            $low_warn_limit = null;
         }
         if (isset($entry['amperageProbeUpperNonCriticalThreshold'])) {
-                $warnlimit = $entry['amperageProbeUpperNonCriticalThreshold'] / $divisor;
+            $warnlimit = $entry['amperageProbeUpperNonCriticalThreshold'] / $divisor;
         } else {
-                $warnlimit = null;
+            $warnlimit = null;
         }
         if (isset($entry['amperageProbeUpperCriticalThreshold'])) {
-                $limit = $entry['amperageProbeUpperCriticalThreshold'] / $divisor;
+            $limit = $entry['amperageProbeUpperCriticalThreshold'] / $divisor;
         } else {
-                $limit = null;
+            $limit = null;
         }
 
         discover_sensor(null, 'power', $device, $cur_oid . $index, $index, 'dell', $descr, $divisor, '1', $lowlimit, $low_warn_limit, $warnlimit, $limit, $value, 'snmp', $index);

--- a/includes/discovery/sensors/power/dell.inc.php
+++ b/includes/discovery/sensors/power/dell.inc.php
@@ -36,16 +36,16 @@ foreach ((array) $temp as $index => $entry) {
         $limit = $entry['amperageProbeUpperCriticalThreshold'] / $divisor;
 
         discover_sensor(null, 'power', $device, $cur_oid . $index, $index, 'dell', $descr, $divisor, '1', $lowlimit, $low_warn_limit, $warnlimit, $limit, $value, 'snmp', $index);
-
-        unset(
-            $descr,
-            $value,
-            $lowlimit,
-            $low_warn_limit,
-            $warnlimit,
-            $limit
-        );
     }
+
+    unset(
+        $descr,
+        $value,
+        $lowlimit,
+        $low_warn_limit,
+        $warnlimit,
+        $limit
+    );
 }
 
 unset(

--- a/includes/discovery/sensors/power/dell.inc.php
+++ b/includes/discovery/sensors/power/dell.inc.php
@@ -36,6 +36,15 @@ foreach ((array) $temp as $index => $entry) {
         $limit = $entry['amperageProbeUpperCriticalThreshold'] / $divisor;
 
         discover_sensor(null, 'power', $device, $cur_oid . $index, $index, 'dell', $descr, $divisor, '1', $lowlimit, $low_warn_limit, $warnlimit, $limit, $value, 'snmp', $index);
+
+        unset(
+            $descr,
+            $value,
+            $lowlimit,
+            $low_warn_limit,
+            $warnlimit,
+            $limit
+        );
     }
 }
 

--- a/includes/discovery/sensors/temperature/dell.inc.php
+++ b/includes/discovery/sensors/temperature/dell.inc.php
@@ -17,12 +17,41 @@ $divisor = '10';
 if (is_array($temp)) {
     foreach ($temp as $index => $entry) {
         $descr = $temp[$index]['temperatureProbeLocationName'];
-        $value = $temp[$index]['temperatureProbeReading'] / $divisor;
-        $lowlimit = $temp[$index]['temperatureProbeLowerCriticalThreshold'] / $divisor;
-        $low_warn_limit = $temp[$index]['temperatureProbeLowerNonCriticalThreshold'] / $divisor;
-        $warnlimit = $temp[$index]['temperatureProbeUpperNonCriticalThreshold'] / $divisor;
-        $limit = $temp[$index]['temperatureProbeUpperCriticalThreshold'] / $divisor;
-
+        if (isset($temp[$index]['temperatureProbeReading'])) {
+            $value = $temp[$index]['temperatureProbeReading'] / $divisor;
+        } else {
+            $value = null;
+        }
+        if (isset($temp[$index]['temperatureProbeLowerCriticalThreshold'])) {
+            $lowlimit = $temp[$index]['temperatureProbeLowerCriticalThreshold'] / $divisor;
+        } else {
+            $lowlimit = null;
+        }
+        if (isset($temp[$index]['temperatureProbeLowerNonCriticalThreshold'])) {
+            $low_warn_limit = $temp[$index]['temperatureProbeLowerNonCriticalThreshold'] / $divisor;
+        } else {
+            $low_warn_limit = null;
+        }
+        if (isset($temp[$index]['temperatureProbeUpperNonCriticalThreshold'])) {
+            $warnlimit = $temp[$index]['temperatureProbeUpperNonCriticalThreshold'] / $divisor;
+        } else {
+            $warnlimit = null;
+        }
+        if (isset($temp[$index]['temperatureProbeUpperCriticalThreshold'])) {
+            $limit = $temp[$index]['temperatureProbeUpperCriticalThreshold'] / $divisor;
+        } else {
+            $limit = null;
+        }
+        
         discover_sensor(null, 'temperature', $device, $cur_oid . $index, $index, 'dell', $descr, $divisor, '1', $lowlimit, $low_warn_limit, $warnlimit, $limit, $value, 'snmp', $index);
+
+        unset(
+            $descr,
+            $value,
+            $lowlimit,
+            $low_warn_limit,
+            $warnlimit,
+            $limit
+        );
     }
 }

--- a/includes/discovery/sensors/temperature/dell.inc.php
+++ b/includes/discovery/sensors/temperature/dell.inc.php
@@ -42,7 +42,7 @@ if (is_array($temp)) {
         } else {
             $limit = null;
         }
-        
+
         discover_sensor(null, 'temperature', $device, $cur_oid . $index, $index, 'dell', $descr, $divisor, '1', $lowlimit, $low_warn_limit, $warnlimit, $limit, $value, 'snmp', $index);
 
         unset(

--- a/includes/discovery/sensors/temperature/dell.inc.php
+++ b/includes/discovery/sensors/temperature/dell.inc.php
@@ -17,31 +17,11 @@ $divisor = '10';
 if (is_array($temp)) {
     foreach ($temp as $index => $entry) {
         $descr = $temp[$index]['temperatureProbeLocationName'];
-        if (isset($temp[$index]['temperatureProbeReading'])) {
-            $value = $temp[$index]['temperatureProbeReading'] / $divisor;
-        } else {
-            $value = null;
-        }
-        if (isset($temp[$index]['temperatureProbeLowerCriticalThreshold'])) {
-            $lowlimit = $temp[$index]['temperatureProbeLowerCriticalThreshold'] / $divisor;
-        } else {
-            $lowlimit = null;
-        }
-        if (isset($temp[$index]['temperatureProbeLowerNonCriticalThreshold'])) {
-            $low_warn_limit = $temp[$index]['temperatureProbeLowerNonCriticalThreshold'] / $divisor;
-        } else {
-            $low_warn_limit = null;
-        }
-        if (isset($temp[$index]['temperatureProbeUpperNonCriticalThreshold'])) {
-            $warnlimit = $temp[$index]['temperatureProbeUpperNonCriticalThreshold'] / $divisor;
-        } else {
-            $warnlimit = null;
-        }
-        if (isset($temp[$index]['temperatureProbeUpperCriticalThreshold'])) {
-            $limit = $temp[$index]['temperatureProbeUpperCriticalThreshold'] / $divisor;
-        } else {
-            $limit = null;
-        }
+        (isset($temp[$index]['temperatureProbeReading'])) ? $value = $temp[$index]['temperatureProbeReading'] / $divisor : $value = null;
+        (isset($temp[$index]['temperatureProbeLowerCriticalThreshold'])) ? $lowlimit = $temp[$index]['temperatureProbeLowerCriticalThreshold'] / $divisor : $lowlimit = null;
+        (isset($temp[$index]['temperatureProbeLowerNonCriticalThreshold'])) ? $low_warn_limit = $temp[$index]['temperatureProbeLowerNonCriticalThreshold'] / $divisor : $low_warn_limit = null;
+        (isset($temp[$index]['temperatureProbeUpperNonCriticalThreshold'])) ? $warnlimit = $temp[$index]['temperatureProbeUpperNonCriticalThreshold'] / $divisor : $warnlimit = null;
+        (isset($temp[$index]['temperatureProbeUpperCriticalThreshold'])) ? $limit = $temp[$index]['temperatureProbeUpperCriticalThreshold'] / $divisor : $limit = null;
 
         discover_sensor(null, 'temperature', $device, $cur_oid . $index, $index, 'dell', $descr, $divisor, '1', $lowlimit, $low_warn_limit, $warnlimit, $limit, $value, 'snmp', $index);
 

--- a/includes/discovery/sensors/voltage/dell.inc.php
+++ b/includes/discovery/sensors/voltage/dell.inc.php
@@ -27,32 +27,32 @@ $cur_oid = '.1.3.6.1.4.1.674.10892.1.600.20.1.6.';
 
 foreach ((array) $temp as $index => $entry) {
     $descr = $entry['voltageProbeLocationName'];
-    if ($entry['voltageProbeType'] != 'voltageProbeTypeIsDiscrete') {
+    if ($entry['voltageProbeType'] != 'voltageProbeTypeIsDiscrete')) {
         $divisor = 1000;
         if (isset($entry['voltageProbeReading']) {
-                $value = $entry['voltageProbeReading'];
+            $value = $entry['voltageProbeReading'];
         } else {
-                $value = null;
+            $value = null;
         }
-        if (isset($entry['voltageProbeLowerCriticalThreshold']) {
-                $lowlimit = $entry['voltageProbeLowerCriticalThreshold'] / $divisor;
+        if (isset($entry['voltageProbeLowerCriticalThreshold'])) {
+            $lowlimit = $entry['voltageProbeLowerCriticalThreshold'] / $divisor;
         } else {
-                $lowlimit = null;
+            $lowlimit = null;
         }
-        if (isset($entry['voltageProbeLowerCriticalThreshold']) {
-                $low_warn_limit = $entry['voltageProbeLowerCriticalThreshold'] / $divisor;
+        if (isset($entry['voltageProbeLowerCriticalThreshold'])) {
+            $low_warn_limit = $entry['voltageProbeLowerCriticalThreshold'] / $divisor;
         } else {
-                $low_warn_limit = null;
+            $low_warn_limit = null;
         }
-        if (isset($entry['voltageProbeUpperNonCriticalThreshold']) {
-                $warnlimit = $entry['voltageProbeUpperNonCriticalThreshold'] / $divisor;
+        if (isset($entry['voltageProbeUpperNonCriticalThreshold'])) {
+            $warnlimit = $entry['voltageProbeUpperNonCriticalThreshold'] / $divisor;
         } else {
-                $warnlimit = null;
+            $warnlimit = null;
         }
-        if (isset($entry['voltageProbeUpperCriticalThreshold']) {
-                $limit = $entry['voltageProbeUpperCriticalThreshold'] / $divisor;
+        if (isset($entry['voltageProbeUpperCriticalThreshold'])) {
+            $limit = $entry['voltageProbeUpperCriticalThreshold'] / $divisor;
         } else {
-                $limit = null;
+            $limit = null;
         }
 
         discover_sensor(null, 'voltage', $device, $cur_oid . $index, $index, 'dell', $descr, $divisor, '1', $lowlimit, $low_warn_limit, $warnlimit, $limit, $value, 'snmp', $index);

--- a/includes/discovery/sensors/voltage/dell.inc.php
+++ b/includes/discovery/sensors/voltage/dell.inc.php
@@ -27,7 +27,7 @@ $cur_oid = '.1.3.6.1.4.1.674.10892.1.600.20.1.6.';
 
 foreach ((array) $temp as $index => $entry) {
     $descr = $entry['voltageProbeLocationName'];
-    if ($entry['voltageProbeType'] != 'voltageProbeTypeIsDiscrete')) {
+    if ($entry['voltageProbeType'] != 'voltageProbeTypeIsDiscrete') {
         $divisor = 1000;
         if (isset($entry['voltageProbeReading']) {
             $value = $entry['voltageProbeReading'];

--- a/includes/discovery/sensors/voltage/dell.inc.php
+++ b/includes/discovery/sensors/voltage/dell.inc.php
@@ -37,6 +37,15 @@ foreach ((array) $temp as $index => $entry) {
 
         discover_sensor(null, 'voltage', $device, $cur_oid . $index, $index, 'dell', $descr, $divisor, '1', $lowlimit, $low_warn_limit, $warnlimit, $limit, $value, 'snmp', $index);
     }
+
+    unset(
+        $descr,
+        $value,
+        $lowlimit,
+        $low_warn_limit,
+        $warnlimit,
+        $limit
+    );
 }
 
 unset(

--- a/includes/discovery/sensors/voltage/dell.inc.php
+++ b/includes/discovery/sensors/voltage/dell.inc.php
@@ -29,11 +29,31 @@ foreach ((array) $temp as $index => $entry) {
     $descr = $entry['voltageProbeLocationName'];
     if ($entry['voltageProbeType'] != 'voltageProbeTypeIsDiscrete') {
         $divisor = 1000;
-        $value = $entry['voltageProbeReading'];
-        $lowlimit = $entry['voltageProbeLowerCriticalThreshold'] / $divisor;
-        $low_warn_limit = $entry['voltageProbeLowerCriticalThreshold'] / $divisor;
-        $warnlimit = $entry['voltageProbeUpperNonCriticalThreshold'] / $divisor;
-        $limit = $entry['voltageProbeUpperCriticalThreshold'] / $divisor;
+        if (isset($entry['voltageProbeReading']) {
+                $value = $entry['voltageProbeReading'];
+        } else {
+                $value = null;
+        }
+        if (isset($entry['voltageProbeLowerCriticalThreshold']) {
+                $lowlimit = $entry['voltageProbeLowerCriticalThreshold'] / $divisor;
+        } else {
+                $lowlimit = null;
+        }
+        if (isset($entry['voltageProbeLowerCriticalThreshold']) {
+                $low_warn_limit = $entry['voltageProbeLowerCriticalThreshold'] / $divisor;
+        } else {
+                $low_warn_limit = null;
+        }
+        if (isset($entry['voltageProbeUpperNonCriticalThreshold']) {
+                $warnlimit = $entry['voltageProbeUpperNonCriticalThreshold'] / $divisor;
+        } else {
+                $warnlimit = null;
+        }
+        if (isset($entry['voltageProbeUpperCriticalThreshold']) {
+                $limit = $entry['voltageProbeUpperCriticalThreshold'] / $divisor;
+        } else {
+                $limit = null;
+        }
 
         discover_sensor(null, 'voltage', $device, $cur_oid . $index, $index, 'dell', $descr, $divisor, '1', $lowlimit, $low_warn_limit, $warnlimit, $limit, $value, 'snmp', $index);
     }

--- a/includes/discovery/sensors/voltage/dell.inc.php
+++ b/includes/discovery/sensors/voltage/dell.inc.php
@@ -29,7 +29,7 @@ foreach ((array) $temp as $index => $entry) {
     $descr = $entry['voltageProbeLocationName'];
     if ($entry['voltageProbeType'] != 'voltageProbeTypeIsDiscrete') {
         $divisor = 1000;
-        if (isset($entry['voltageProbeReading']) {
+        if (isset($entry['voltageProbeReading'])) {
             $value = $entry['voltageProbeReading'];
         } else {
             $value = null;

--- a/includes/discovery/sensors/voltage/dell.inc.php
+++ b/includes/discovery/sensors/voltage/dell.inc.php
@@ -29,31 +29,11 @@ foreach ((array) $temp as $index => $entry) {
     $descr = $entry['voltageProbeLocationName'];
     if ($entry['voltageProbeType'] != 'voltageProbeTypeIsDiscrete') {
         $divisor = 1000;
-        if (isset($entry['voltageProbeReading'])) {
-            $value = $entry['voltageProbeReading'];
-        } else {
-            $value = null;
-        }
-        if (isset($entry['voltageProbeLowerCriticalThreshold'])) {
-            $lowlimit = $entry['voltageProbeLowerCriticalThreshold'] / $divisor;
-        } else {
-            $lowlimit = null;
-        }
-        if (isset($entry['voltageProbeLowerCriticalThreshold'])) {
-            $low_warn_limit = $entry['voltageProbeLowerCriticalThreshold'] / $divisor;
-        } else {
-            $low_warn_limit = null;
-        }
-        if (isset($entry['voltageProbeUpperNonCriticalThreshold'])) {
-            $warnlimit = $entry['voltageProbeUpperNonCriticalThreshold'] / $divisor;
-        } else {
-            $warnlimit = null;
-        }
-        if (isset($entry['voltageProbeUpperCriticalThreshold'])) {
-            $limit = $entry['voltageProbeUpperCriticalThreshold'] / $divisor;
-        } else {
-            $limit = null;
-        }
+        (isset($entry['voltageProbeReading'])) ? $value = $entry['voltageProbeReading'] : $value = null;
+        (isset($entry['voltageProbeLowerCriticalThreshold'])) ? $lowlimit = $entry['voltageProbeLowerCriticalThreshold'] / $divisor : $lowlimit = null;
+        (isset($entry['voltageProbeLowerCriticalThreshold'])) ? $low_warn_limit = $entry['voltageProbeLowerCriticalThreshold'] / $divisor : $low_warn_limit = null;
+        (isset($entry['voltageProbeUpperNonCriticalThreshold'])) ? $warnlimit = $entry['voltageProbeUpperNonCriticalThreshold'] / $divisor : $warnlimit = null;
+        (isset($entry['voltageProbeUpperCriticalThreshold'])) ? $limit = $entry['voltageProbeUpperCriticalThreshold'] / $divisor : $limit = null;
 
         discover_sensor(null, 'voltage', $device, $cur_oid . $index, $index, 'dell', $descr, $divisor, '1', $lowlimit, $low_warn_limit, $warnlimit, $limit, $value, 'snmp', $index);
     }


### PR DESCRIPTION
Dell sensor additions were setting variables that leaked to the next includes, leading to zeros being populated in fields they did not belong in.  Zeros were being set for voltages and temperatures in the warning areas when no value was set on the device, leading to warn status on devices.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
