### PR TITLE
Indicate when a linked custom map has down devices

### DIFF
--- a/app/Http/Controllers/Maps/CustomMapDataController.php
+++ b/app/Http/Controllers/Maps/CustomMapDataController.php
@@ -139,6 +139,12 @@ class CustomMapDataController extends Controller
 
         foreach ($map->nodes as $node) {
             $nodeid = $node->custom_map_node_id;
+            if ($node->linked_custom_map_id > 0) {
+                $nodes_down = CustomMapNode::where('custom_map_id', $node->linked_custom_map_id)->whereRelation('device', 'status', 0)->get();
+                if (count($nodes_down) > 0) {
+                    $node->colour_bg = 'darkred';
+                }
+            }
             $nodes[$nodeid] = [
                 'custom_map_node_id' => $node->custom_map_node_id,
                 'device_id' => $node->device_id,


### PR DESCRIPTION
Requested and tested in https://community.librenms.org/t/change-map-link-node-color-when-a-device-is-down/26242

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
