### PR TITLE
Documentation: Sensor state support improvements (state translations with string/numeric values and others)

### DIFF
--- a/doc/Developing/Sensor-State-Support.md
+++ b/doc/Developing/Sensor-State-Support.md
@@ -41,20 +41,20 @@ sensor(state_index) where these values are actually returned from.*
 ```
 
  ### Generic States translations
+
 LibreNMS offers flexibility in handling sensor states, which can be represented as either strings or numbers via SNMP. 
 
-If the sensor state input is a string (i.e. "ONLINE") librenms will use the the 'descr' field and translate it to the desired generic state (0, 1, 2 or 3)
+If the sensor state input is a string (i.e. "ONLINE") librenms will use the the 'descr' field and finally translate it to the desired generic state (0, 1, 2 or 3)
 - { value: 0, **descr: online**, graph: 1, **generic: 0** }
 
-If the sensor state input is a number (i.e. "4" that represents the offline state) librenms will use the 'value' field and translate it to the desired generic state (0, 1, 2 or 3).  
+If the sensor state input is a number (i.e. "4" that represents the offline state) librenms will use the 'value' field and finally translate it to the desired generic state (0, 1, 2 or 3).  
 - { **value: 0**, descr: offline, graph: 1, **generic: 2** }
-Note: the desc field here is used to visualize the value on screen, but not as an input.
 
-The translations works like this: description -> value -> generic & graph fields
-https://github.com/librenms/librenms/blob/7d450345dff29d31d52eeaf7193028c6d5ffbf67/includes/discovery/functions.inc.php#L661
+!!! note
+    Here the descr field is used to visualize the value on screen, but not as an input to translate to a generic state because the state input is a number.
+    For more details check a code example[ here](https://github.com/librenms/librenms/blob/0fbaaf7a7473bba6d346cb8bcb80d95324836c98/includes/discovery/functions.inc.php#L683C13-L683C55).
 
-
-## Example
+## YAML Example
 
 For YAML based state discovery:
 

--- a/doc/Developing/Sensor-State-Support.md
+++ b/doc/Developing/Sensor-State-Support.md
@@ -4,23 +4,25 @@
 
 This section will explain how to implement support for sensor state. It will also cover the basic concepts of sensor state monitoring.
 
-Sensor state support in LibreNMS allows users to monitor and visualize the status of sensors that report qualitative states, rather than numerical values, in a more understandable and efficient manner. Instead of displaying raw numeric values, LibreNMS translates those values into generic states, such as "OK", "Warning", "Critical", and "Unknown".
+LibreNMS simplifies sensor state monitoring by translating raw values into understandable generic states like "OK", "Warning", "Critical", and "Unknown", enabling consistent visualization and easier analysis.
 
 ## Key Concepts
 
-For sensor state monitoring, we have 4 DB tables we need to concentrate about.
-
-We will just briefly tie a comment to each one of them.
+For sensor state monitoring, we have 4 DB tables we need to concentrate about. These tables act as a bridge between the raw information provided by each sensor and the standardized representation (generic state) that LibreNMS uses for visualization and alert generation.
 
 ### Table: sensors
 
 *Each time a sensor needs to be polled, the system needs to know which
-sensor is it that it need to poll, at what oid is this sensor located
-and what class the sensor is etc. This information is fetched from the sensors table.*
+sensor (regardless of its type) is it that it needs to poll and its description, 
+at what oid is this sensor located, what class the sensor is, etc.*
+
+### Table: sensors_to_state_indexes
+
+*Is as you might have guessed, where the sensor_id is mapped to a state_index_id.*
 
 ### Table: state_indexes
 
-*Is where we keep track of which state sensors we monitor.*
+*Is where we keep track of the state information we monitor.*
 
 ### Table: state_translations
 
@@ -38,9 +40,6 @@ sensor(state_index) where these values are actually returned from.*
 3 = Unknown
 ```
 
-### Table: sensors_to_state_indexes
-
-*Is as you might have guessed, where the sensor_id is mapped to a state_index_id.*
 
 ## Example
 

--- a/doc/Developing/Sensor-State-Support.md
+++ b/doc/Developing/Sensor-State-Support.md
@@ -40,6 +40,19 @@ sensor(state_index) where these values are actually returned from.*
 3 = Unknown
 ```
 
+ ### Generic States translations
+LibreNMS offers flexibility in handling sensor states, which can be represented as either strings or numbers via SNMP. 
+
+If the sensor state input is a string (i.e. "ONLINE") librenms will use the the 'descr' field and translate it to the desired generic state (0, 1, 2 or 3)
+- { value: 0, **descr: online**, graph: 1, **generic: 0** }
+
+If the sensor state input is a number (i.e. "4" that represents the offline state) librenms will use the 'value' field and translate it to the desired generic state (0, 1, 2 or 3).  
+- { **value: 0**, descr: offline, graph: 1, **generic: 2** }
+Note: the desc field here is used to visualize the value on screen, but not as an input.
+
+The translations works like this: description -> value -> generic & graph fields
+https://github.com/librenms/librenms/blob/7d450345dff29d31d52eeaf7193028c6d5ffbf67/includes/discovery/functions.inc.php#L661
+
 
 ## Example
 

--- a/doc/Developing/Sensor-State-Support.md
+++ b/doc/Developing/Sensor-State-Support.md
@@ -2,9 +2,9 @@
 
 ### Introduction
 
-In this section we are briefly going to walk through, what it takes to
-write sensor state support. We will also briefly get around the
-concepts of the current sensor state monitoring.
+This section will explain how to implement support for sensor state. It will also cover the basic concepts of sensor state monitoring.
+
+Sensor state support in LibreNMS allows users to monitor and visualize the status of sensors that report qualitative states, rather than numerical values, in a more understandable and efficient manner. Instead of displaying raw numeric values, LibreNMS translates those values into generic states, such as "OK", "Warning", "Critical", and "Unknown".
 
 ### Logic
 

--- a/doc/Developing/Sensor-State-Support.md
+++ b/doc/Developing/Sensor-State-Support.md
@@ -2,13 +2,19 @@
 
 ## Introduction
 
-This section will explain how to implement support for sensor state. It will also cover the basic concepts of sensor state monitoring.
+This section will explain how to implement support for sensor state. 
+It will also cover the basic concepts of sensor state monitoring.
 
-LibreNMS simplifies sensor state monitoring by translating raw values into understandable generic states like "OK", "Warning", "Critical", and "Unknown", enabling consistent visualization and easier analysis.
+LibreNMS simplifies sensor state monitoring by translating raw values 
+into understandable generic states like "OK", "Warning", "Critical", and 
+"Unknown", enabling consistent visualization and easier analysis.
 
 ## Key Concepts
 
-For sensor state monitoring, we have 4 DB tables we need to concentrate about. These tables act as a bridge between the raw information provided by each sensor and the standardized representation (generic state) that LibreNMS uses for visualization and alert generation.
+For sensor state monitoring, we have 4 DB tables we need to concentrate about. 
+These tables act as a bridge between the raw information provided by each sensor 
+and the standardized representation (generic state) that LibreNMS uses 
+for visualization and alert generation.
 
 ### Table: sensors
 
@@ -18,7 +24,8 @@ at what oid is this sensor located, what class the sensor is, etc.*
 
 ### Table: sensors_to_state_indexes
 
-*Is as you might have guessed, where the sensor_id is mapped to a state_index_id.*
+*Is as you might have guessed, where the sensor_id is mapped 
+to a state_index_id.*
 
 ### Table: state_indexes
 
@@ -42,17 +49,23 @@ sensor(state_index) where these values are actually returned from.*
 
  ### Generic States translations
 
-LibreNMS offers flexibility in handling sensor states, which can be represented as either strings or numbers via SNMP. 
+LibreNMS offers flexibility in handling sensor states, which can be represented 
+as either strings or numbers via SNMP. 
 
-If the sensor state input is a string (i.e. "ONLINE") librenms will use the the 'descr' field and finally translate it to the desired generic state (0, 1, 2 or 3)
+If the sensor state input is a string (i.e. "ONLINE") 
+librenms will use the 'descr' field and finally translate it to the desired 
+generic state (0, 1, 2 or 3)
 - { value: 4, **descr: online**, graph: 1, **generic: 0** }
 
-If the sensor state input is a number (i.e. "4" that represents the offline state) librenms will use the 'value' field and finally translate it to the desired generic state (0, 1, 2 or 3).  
+If the sensor state input is a number (i.e. "4" representing the offline state) 
+librenms will use the 'value' field and finally translate it to the desired 
+generic state (0, 1, 2 or 3).  
 - { **value: 0**, descr: offline, graph: 1, **generic: 2** }
 
 !!! note
-    Here the descr field is used to visualize the value on screen, but not as an input to translate to a generic state because the state input is a number.
-    For more details check a code example[ here](https://github.com/librenms/librenms/blob/0fbaaf7a7473bba6d346cb8bcb80d95324836c98/includes/discovery/functions.inc.php#L683C13-L683C55).
+    Here the descr field is used as a label to visualize the value on screen, 
+    but not as an input to translate to a generic state because the state input
+    is a number.
 
 ## YAML Example
 
@@ -122,7 +135,8 @@ For advanced state discovery:
 
 This example will be based on a Cisco power supply sensor and is all
 it takes to have sensor state support for Cisco power supplies in Cisco
-switches. The file should be located in /includes/discovery/sensors/state/cisco.inc.php.
+switches. The file should be located in 
+/includes/discovery/sensors/state/cisco.inc.php.
 
 ```php
 <?php

--- a/doc/Developing/Sensor-State-Support.md
+++ b/doc/Developing/Sensor-State-Support.md
@@ -45,7 +45,7 @@ sensor(state_index) where these values are actually returned from.*
 LibreNMS offers flexibility in handling sensor states, which can be represented as either strings or numbers via SNMP. 
 
 If the sensor state input is a string (i.e. "ONLINE") librenms will use the the 'descr' field and finally translate it to the desired generic state (0, 1, 2 or 3)
-- { value: 0, **descr: online**, graph: 1, **generic: 0** }
+- { value: 4, **descr: online**, graph: 1, **generic: 0** }
 
 If the sensor state input is a number (i.e. "4" that represents the offline state) librenms will use the 'value' field and finally translate it to the desired generic state (0, 1, 2 or 3).  
 - { **value: 0**, descr: offline, graph: 1, **generic: 2** }

--- a/doc/Developing/Sensor-State-Support.md
+++ b/doc/Developing/Sensor-State-Support.md
@@ -1,33 +1,28 @@
 # Sensor State Support
 
-### Introduction
+## Introduction
 
 This section will explain how to implement support for sensor state. It will also cover the basic concepts of sensor state monitoring.
 
 Sensor state support in LibreNMS allows users to monitor and visualize the status of sensors that report qualitative states, rather than numerical values, in a more understandable and efficient manner. Instead of displaying raw numeric values, LibreNMS translates those values into generic states, such as "OK", "Warning", "Critical", and "Unknown".
 
-### Logic
+## Key Concepts
 
 For sensor state monitoring, we have 4 DB tables we need to concentrate about.
 
-- sensors
-- state_indexes
-- state_translations
-- sensors_to_state_indexes
-
 We will just briefly tie a comment to each one of them.
 
-#### Sensors
+### Table: sensors
 
 *Each time a sensor needs to be polled, the system needs to know which
 sensor is it that it need to poll, at what oid is this sensor located
 and what class the sensor is etc. This information is fetched from the sensors table.*
 
-#### state_indexes
+### Table: state_indexes
 
 *Is where we keep track of which state sensors we monitor.*
 
-#### state_translations
+### Table: state_translations
 
 *Is where we map the possible returned state sensor values to a
 generic LibreNMS value, in order to make displaying and alerting more
@@ -43,11 +38,11 @@ sensor(state_index) where these values are actually returned from.*
 3 = Unknown
 ```
 
-#### sensors_to_state_indexes
+### Table: sensors_to_state_indexes
 
 *Is as you might have guessed, where the sensor_id is mapped to a state_index_id.*
 
-### Example
+## Example
 
 For YAML based state discovery:
 
@@ -109,7 +104,7 @@ modules:
                         - { value: 5, generic: 2, graph: 0, descr: failure }
 ```
 
-### Advanced Example
+## Advanced Example
 
 For advanced state discovery:
 


### PR DESCRIPTION
This PR improves the documentation for sensor states.  This undocumented behavior would have been helpful when I was working with a new device discoveries. 

These improvements aim to make the documentation easier to understand (I hope you like it):
- A new section on state translations has been added, clarifying how LibreNMS handles string and numeric state values. 
- It has a Improved formatting, revised titles and notes.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
