### PR TITLE
Popover fixes on transports page

### DIFF
--- a/includes/html/print-alert-transports.php
+++ b/includes/html/print-alert-transports.php
@@ -43,9 +43,9 @@ foreach (\App\Models\AlertTransport::orderBy('transport_name', 'asc')->get() as 
     // Add action buttons for admin users only
     if (Auth::user()->hasGlobalAdmin()) {
         echo "<div class='btn-group btn-group-sm' role='group'>";
-        echo "<button type='button' class='btn btn-primary btn-sm' data-toggle='modal' data-target='#edit-alert-transport' data-transport_id='" . $transport->transport_id . "' name='edit-alert-rule' data-container='body' data-toggle='popover' data-content='Edit transport'><i class='fa fa-lg fa-pencil' aria-hidden='true'></i></button> ";
-        echo "<button type='button' class='btn btn-danger btn-sm' aria-label='Delete' data-toggle='modal' data-target='#delete-alert-transport' data-transport_id='" . $transport->transport_id . "' name='delete-alert-transport' data-container='body' data-toggle='popover' data-content='Delete transport'><i class='fa fa-lg fa-trash' aria-hidden='true'></i></button>";
-        echo "<button type='button' class='btn btn-warning btn-sm' data-transport_id='" . $transport->transport_id . "' data-transport='{$transport->transport_type}' name='test-transport' id='test-transport' data-toggle='popover' data-content='Test transport'><i class='fa fa-lg fa-check' aria-hidden='true'></i></button> ";
+        echo "<button type='button' class='btn btn-primary btn-sm' data-toggle='modal' data-popover='popover' data-target='#edit-alert-transport' data-transport_id='" . $transport->transport_id . "' name='edit-alert-rule' data-container='body' data-content='Edit transport'><i class='fa fa-lg fa-pencil' aria-hidden='true'></i></button> ";
+        echo "<button type='button' class='btn btn-danger btn-sm' aria-label='Delete' data-toggle='modal' data-target='#delete-alert-transport' data-transport_id='" . $transport->transport_id . "' name='delete-alert-transport' data-container='body' data-popover='popover' data-content='Delete transport'><i class='fa fa-lg fa-trash' aria-hidden='true'></i></button>";
+        echo "<button type='button' class='btn btn-warning btn-sm' data-transport_id='" . $transport->transport_id . "' data-transport='{$transport->transport_type}' name='test-transport' id='test-transport' data-popover='popover' data-content='Test transport'><i class='fa fa-lg fa-check' aria-hidden='true'></i></button> ";
         echo '</div>';
     }
     echo '</td>';
@@ -89,8 +89,8 @@ foreach (dbFetchRows($query) as $group) {
     echo '<td>';
     if (Auth::user()->hasGlobalAdmin()) {
         echo "<div class='btn-group btn-group-sm' role='group'>";
-        echo "<button type='button' class='btn btn-primary btn-sm' data-toggle='modal' data-target='#edit-transport-group' data-group_id='" . $group['id'] . "' data-container='body' data-toggle='popover' data-content='Edit transport group'><i class='fa fa-lg fa-pencil' aria-hidden='true'></i></button> ";
-        echo "<button type='button' class='btn btn-danger btn-sm' aria-label='Delete' data-toggle='modal' data-target='#delete-transport-group' data-group_id='" . $group['id'] . "' data-container='body' data-toggle='popover' data-content='Delete transport group'><i class='fa fa-lg fa-trash' aria-hidden='true'></i></button>";
+        echo "<button type='button' class='btn btn-primary btn-sm' data-toggle='modal' data-popover='popover' data-target='#edit-transport-group' data-group_id='" . $group['id'] . "' data-container='body' data-content='Edit transport group'><i class='fa fa-lg fa-pencil' aria-hidden='true'></i></button> ";
+        echo "<button type='button' class='btn btn-danger btn-sm' aria-label='Delete' data-toggle='modal' data-popover='popover' data-target='#delete-transport-group' data-group_id='" . $group['id'] . "' data-container='body' data-content='Delete transport group'><i class='fa fa-lg fa-trash' aria-hidden='true'></i></button>";
         echo '</div>';
     }
     echo '</td>';
@@ -123,8 +123,9 @@ foreach (dbFetchRows($query) as $group) {
         });
     });
 
-    $("[data-toggle='popover']").popover({
+    $("[data-popover='popover']").popover({
         trigger: 'hover',
-        placement: 'top'
+        placement: 'top',
+        container: 'body'
     });
 </script>

--- a/includes/html/print-alert-transports.php
+++ b/includes/html/print-alert-transports.php
@@ -43,8 +43,8 @@ foreach (\App\Models\AlertTransport::orderBy('transport_name', 'asc')->get() as 
     // Add action buttons for admin users only
     if (Auth::user()->hasGlobalAdmin()) {
         echo "<div class='btn-group btn-group-sm' role='group'>";
-        echo "<button type='button' class='btn btn-primary btn-sm' data-toggle='modal' data-popover='popover' data-target='#edit-alert-transport' data-transport_id='" . $transport->transport_id . "' name='edit-alert-rule' data-container='body' data-content='Edit transport'><i class='fa fa-lg fa-pencil' aria-hidden='true'></i></button> ";
-        echo "<button type='button' class='btn btn-danger btn-sm' aria-label='Delete' data-toggle='modal' data-target='#delete-alert-transport' data-transport_id='" . $transport->transport_id . "' name='delete-alert-transport' data-container='body' data-popover='popover' data-content='Delete transport'><i class='fa fa-lg fa-trash' aria-hidden='true'></i></button>";
+        echo "<button type='button' class='btn btn-primary btn-sm' data-toggle='modal' data-popover='popover' data-target='#edit-alert-transport' data-transport_id='" . $transport->transport_id . "' name='edit-alert-rule' data-content='Edit transport'><i class='fa fa-lg fa-pencil' aria-hidden='true'></i></button> ";
+        echo "<button type='button' class='btn btn-danger btn-sm' aria-label='Delete' data-toggle='modal' data-target='#delete-alert-transport' data-transport_id='" . $transport->transport_id . "' name='delete-alert-transport' data-popover='popover' data-content='Delete transport'><i class='fa fa-lg fa-trash' aria-hidden='true'></i></button>";
         echo "<button type='button' class='btn btn-warning btn-sm' data-transport_id='" . $transport->transport_id . "' data-transport='{$transport->transport_type}' name='test-transport' id='test-transport' data-popover='popover' data-content='Test transport'><i class='fa fa-lg fa-check' aria-hidden='true'></i></button> ";
         echo '</div>';
     }
@@ -89,8 +89,8 @@ foreach (dbFetchRows($query) as $group) {
     echo '<td>';
     if (Auth::user()->hasGlobalAdmin()) {
         echo "<div class='btn-group btn-group-sm' role='group'>";
-        echo "<button type='button' class='btn btn-primary btn-sm' data-toggle='modal' data-popover='popover' data-target='#edit-transport-group' data-group_id='" . $group['id'] . "' data-container='body' data-content='Edit transport group'><i class='fa fa-lg fa-pencil' aria-hidden='true'></i></button> ";
-        echo "<button type='button' class='btn btn-danger btn-sm' aria-label='Delete' data-toggle='modal' data-popover='popover' data-target='#delete-transport-group' data-group_id='" . $group['id'] . "' data-container='body' data-content='Delete transport group'><i class='fa fa-lg fa-trash' aria-hidden='true'></i></button>";
+        echo "<button type='button' class='btn btn-primary btn-sm' data-toggle='modal' data-popover='popover' data-target='#edit-transport-group' data-group_id='" . $group['id'] . "' data-content='Edit transport group'><i class='fa fa-lg fa-pencil' aria-hidden='true'></i></button> ";
+        echo "<button type='button' class='btn btn-danger btn-sm' aria-label='Delete' data-toggle='modal' data-popover='popover' data-target='#delete-transport-group' data-group_id='" . $group['id'] . "' data-content='Delete transport group'><i class='fa fa-lg fa-trash' aria-hidden='true'></i></button>";
         echo '</div>';
     }
     echo '</td>';


### PR DESCRIPTION
When viewing the alert transports, there are a few issues with the popovers on the action buttons on the right side of the screen:
- For the buttons that trigger a dialog, they seemed not to show the popover at all, since they had two `data-toggle` attributes on the HTML element. I changed the popovers to use a dedicated `data-popover` attribute instead, so they wouldn't clash with the modal setup.
- For the "Test Transport" button, the top of the popover was cut off for me, so I could only see the "Transport" part of the text. I added `container: 'body'` for the popovers to fix this, which I believe is making it higher up in the DOM, so other elements aren't obscuring it.

Here's the page in question, showing the now working popup for Test Transport:

<img width="1121" alt="Screenshot 2024-10-11 at 10 00 00 AM" src="https://github.com/user-attachments/assets/46b088a4-3f5b-4c8e-ada3-b0ab7c4d49c3">

This is my first PR, so definitely let me know if anything should be done differently.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
