### PR TITLE
Custom Map vis.js options

### DIFF
--- a/app/Http/Controllers/Maps/CustomMapController.php
+++ b/app/Http/Controllers/Maps/CustomMapController.php
@@ -77,6 +77,19 @@ class CustomMapController extends Controller
                     'enabled' => false,
                 ],
             ],
+            'map_options' => [
+                'interaction' => [
+                    'dragNodes' => false,
+                    'dragView' => false,
+                    'zoomView' => false,
+                ],
+                'manipulation' => [
+                    'enabled' => false,
+                ],
+                'physics' => [
+                    'enabled' => false,
+                ],
+            ],
         ]);
     }
 
@@ -133,6 +146,7 @@ class CustomMapController extends Controller
             'newedge_conf' => $map->newedgeconfig,
             'newnode_conf' => $map->newnodeconfig,
             'map_conf' => $map->options,
+            'map_options' => $map->options,
             'background_type' => $map->background_type,
             'background_config' => $map->getBackgroundConfig(),
             'edit' => true,
@@ -211,6 +225,7 @@ class CustomMapController extends Controller
     public function update(CustomMapSettingsRequest $request, CustomMap $map): JsonResponse
     {
         $map->fill($request->validated());
+        $map->options = json_decode($request->options);
         $map->save(); // save to get ID
 
         return response()->json([
@@ -221,6 +236,7 @@ class CustomMapController extends Controller
             'height' => $map->height,
             'reverse_arrows' => $map->reverse_arrows,
             'edge_separation' => $map->edge_separation,
+            'options' => $map->options,
         ]);
     }
 

--- a/app/Http/Requests/CustomMapSettingsRequest.php
+++ b/app/Http/Requests/CustomMapSettingsRequest.php
@@ -58,6 +58,7 @@ class CustomMapSettingsRequest extends FormRequest
             'legend_font_size' => 'integer',
             'legend_hide_invalid' => 'boolean',
             'legend_hide_overspeed' => 'boolean',
+            'options' => 'string',
         ];
     }
 }

--- a/lang/en/map.php
+++ b/lang/en/map.php
@@ -67,6 +67,9 @@ return [
                     'hideinvalid' => 'Hide Invalid',
                     'hideoverspeed' => 'Hide 100%+',
                 ],
+                'zoom' => 'Pan and Zoom',
+                'dragnodes' => 'Move Nodes',
+                'physics' => 'Physics Engine',
             ],
             'node' => [
                 'new' => 'New Node',

--- a/resources/views/map/custom-edit.blade.php
+++ b/resources/views/map/custom-edit.blade.php
@@ -96,7 +96,6 @@
     var node_device_map = {};
     var custom_image_base = "{{ $base_url }}images/custommap/icons/";
     var network_options = {{ Js::from($map_conf) }};
-    var map_options = {{ Js::from($map_options) }};
 
     function edgeNodesRemove(nm_id, edgeid) {
         // Remove old item from map if it exists

--- a/resources/views/map/custom-edit.blade.php
+++ b/resources/views/map/custom-edit.blade.php
@@ -95,7 +95,8 @@
     var edge_nodes_map = [];
     var node_device_map = {};
     var custom_image_base = "{{ $base_url }}images/custommap/icons/";
-    var network_options = {{ Js::from($map_conf) }}
+    var network_options = {{ Js::from($map_conf) }};
+    var map_options = {{ Js::from($map_options) }};
 
     function edgeNodesRemove(nm_id, edgeid) {
         // Remove old item from map if it exists
@@ -484,10 +485,11 @@
         // Re-create the network because network.setSize() blanks out the map
         CreateNetwork();
 
-        editMapCancel();
+        $('#mapModal').modal('hide');
     }
 
     function editMapCancel() {
+        mapSettingsReset();
         $('#mapModal').modal('hide');
     }
 

--- a/resources/views/map/custom-manage.blade.php
+++ b/resources/views/map/custom-manage.blade.php
@@ -59,6 +59,9 @@
 @section('scripts')
     @routes
 <script type="text/javascript">
+    var network_options = {{ Js::from($map_conf) }};
+    var legend = {{ Js::from($legend) }};
+
     $('#mapDeleteModal').on('show.bs.modal', () => {
         let $mapDeleteModalLabel = $('#mapDeleteModalLabel');
         $mapDeleteModalLabel.text($mapDeleteModalLabel.data('text').replace(':name', pendingMapToDelete.name));

--- a/resources/views/map/custom-map-modal.blade.php
+++ b/resources/views/map/custom-map-modal.blade.php
@@ -126,6 +126,7 @@
     var map_name = "{{ $name ?? '' }}";
     var map_node_align = {{ $node_align ?? 10 }};
     var map_edge_separation = {{ $edge_separation ?? 10 }};
+    var map_options = {{ Js::from($map_options) }};
 
     function saveMapSettings() {
         $("#map-saveButton").attr('disabled','disabled');

--- a/resources/views/map/custom-map-modal.blade.php
+++ b/resources/views/map/custom-map-modal.blade.php
@@ -12,7 +12,7 @@
                             <div class="form-group row">
                                 <label for="mapname" class="col-sm-3 control-label">{{ __('map.custom.edit.map.name') }}</label>
                                 <div class="col-sm-9">
-                                    <input type="text" id="mapname" name="mapname" class="form-control input-sm" value="{{ $name ?? '' }}">
+                                    <input type="text" id="mapname" name="mapname" class="form-control input-sm">
                                 </div>
                             </div>
                             <div class="form-group row">
@@ -24,25 +24,25 @@
                             <div class="form-group row">
                                 <label for="mapwidth" class="col-sm-3 control-label">{{ __('map.custom.edit.map.width') }}</label>
                                 <div class="col-sm-9">
-                                    <input type="text" id="mapwidth" name="mapwidth" class="form-control input-sm" value="{{ $map_conf['width'] ?? '1800px' }}">
+                                    <input type="text" id="mapwidth" name="mapwidth" class="form-control input-sm">
                                 </div>
                             </div>
                             <div class="form-group row">
                                 <label for="mapheight" class="col-sm-3 control-label">{{ __('map.custom.edit.map.height') }}</label>
                                 <div class="col-sm-9">
-                                    <input type="text" id="mapheight" name="mapheight" class="form-control input-sm" value="{{ $map_conf['height'] ?? '800px' }}">
+                                    <input type="text" id="mapheight" name="mapheight" class="form-control input-sm">
                                 </div>
                             </div>
                             <div class="form-group row">
                                 <label for="mapnodealign" class="col-sm-3 control-label">{{ __('map.custom.edit.map.alignment') }}</label>
                                 <div class="col-sm-9">
-                                    <input type="number" id="mapnodealign" name="mapnodealign" class="form-control input-sm" value="{{ $node_align ?? 10 }}">
+                                    <input type="number" id="mapnodealign" name="mapnodealign" class="form-control input-sm">
                                 </div>
                             </div>
                             <div class="form-group row">
                                 <label for="mapedgesep" class="col-sm-3 control-label">{{ __('map.custom.edit.map.edgeseparation') }}</label>
                                 <div class="col-sm-9">
-                                    <input type="number" id="mapedgesep" name="mapedgesep" class="form-control input-sm" value="{{ $edge_separation ?? 10 }}">
+                                    <input type="number" id="mapedgesep" name="mapedgesep" class="form-control input-sm">
                                 </div>
                             </div>
                             <div class="form-group row">
@@ -60,13 +60,13 @@
                             <div class="form-group row maplegend">
                                 <label for="maplegendfontsize" class="col-sm-4 control-label">{{ __('map.custom.edit.map.legend.font_size') }}</label>
                                 <div class="col-sm-8">
-                                    <input type=number id="maplegendfontsize" class="form-control input-sm" value={{ $legend['font_size'] }} />
+                                    <input type=number id="maplegendfontsize" class="form-control input-sm" />
                                 </div>
                             </div>
                             <div class="form-group row maplegend">
                                 <label for="maplegendsteps" class="col-sm-4 control-label">{{ __('map.custom.edit.map.legend.steps') }}</label>
                                 <div class="col-sm-8">
-                                    <input type=number id="maplegendsteps" class="form-control input-sm" value={{ $legend['steps'] }} />
+                                    <input type=number id="maplegendsteps" class="form-control input-sm" />
                                 </div>
                             </div>
                             <div class="form-group row maplegend">
@@ -79,6 +79,24 @@
                                 <label for="maplegendhideoverspeed" class="col-sm-4 control-label">{{ __('map.custom.edit.map.legend.hideoverspeed') }}</label>
                                 <div class="col-sm-8">
                                     <input class="form-check-input" type="checkbox" role="switch" id="maplegendhideoverspeed">
+                                </div>
+                            </div>
+                            <div class="form-group row">
+                                <label for="mapopt-zoom" class="col-sm-3 control-label">{{ __('map.custom.edit.map.zoom') }}</label>
+                                <div class="col-sm-9">
+                                    <input class="form-check-input" type="checkbox" role="switch" id="mapopt-zoom">
+                                </div>
+                            </div>
+                            <div class="form-group row">
+                                <label for="mapopt-dragnodes" class="col-sm-3 control-label">{{ __('map.custom.edit.map.dragnodes') }}</label>
+                                <div class="col-sm-9">
+                                    <input class="form-check-input" type="checkbox" role="switch" id="mapopt-dragnodes">
+                                </div>
+                            </div>
+                            <div class="form-group row">
+                                <label for="mapopt-physics" class="col-sm-3 control-label">{{ __('map.custom.edit.map.physics') }}</label>
+                                <div class="col-sm-9">
+                                    <input class="form-check-input" type="checkbox" role="switch" id="mapopt-physics">
                                 </div>
                             </div>
                             <hr>
@@ -105,6 +123,9 @@
     var edge_sep = {{$edge_separation}};
     var reverse_arrows = {{$reverse_arrows}};
     var legend = @json($legend);
+    var map_name = "{{ $name ?? '' }}";
+    var map_node_align = {{ $node_align ?? 10 }};
+    var map_edge_separation = {{ $edge_separation ?? 10 }};
 
     function saveMapSettings() {
         $("#map-saveButton").attr('disabled','disabled');
@@ -116,6 +137,10 @@
         var width = $("#mapwidth").val();
         var height = $("#mapheight").val();
         var node_align = $("#mapnodealign").val();
+        var post_options = structuredClone(map_options);
+        post_options.interaction.zoomView = post_options.interaction.dragView = $("#mapopt-zoom").prop('checked');
+        post_options.interaction.dragNodes = $("#mapopt-dragnodes").prop('checked');
+        post_options.physics.enabled = $("#mapopt-physics").prop('checked');
 
         var mapwdith = 100;
         if (!isNaN(width)) {
@@ -176,6 +201,7 @@
                 legend_font_size: legend.font_size,
                 legend_hide_invalid: legend.hide_invalid,
                 legend_hide_overspeed: legend.hide_overspeed,
+                options: JSON.stringify(post_options),
             },
             dataType: 'json',
             type: method
@@ -205,14 +231,30 @@
         }
     }
 
-    $(document).ready(function () {
-        if(legend.x < 0 || legend.y < 0) {
-            $(".maplegend").hide();
-        }
+    function mapSettingsReset() {
         $("#mapreversearrows").bootstrapSwitch('state', Boolean(reverse_arrows));
         $("#maplegend").bootstrapSwitch('state', (legend.x >= 0 && legend.y >= 0));
         $("#maplegendhideinvalid").bootstrapSwitch('state', Boolean(legend.hide_invalid));
         $("#maplegendhideoverspeed").bootstrapSwitch('state', Boolean(legend.hide_overspeed));
+        $("#mapopt-zoom").bootstrapSwitch('state', Boolean(map_options.interaction.zoomView));
+        $("#mapopt-dragnodes").bootstrapSwitch('state', Boolean(map_options.interaction.dragNodes));
+        $("#mapopt-physics").bootstrapSwitch('state', Boolean(map_options.physics.enabled));
+        if(legend.x < 0 || legend.y < 0) {
+            $(".maplegend").hide();
+        } else {
+            $(".maplegend").show();
+        }
+        $("#mapname").val(map_name);
+        $("#mapwidth").val(network_options.width);
+        $("#mapheight").val(network_options.height);
+        $("#mapnodealign").val(map_node_align);
+        $("#mapedgesep").val(map_edge_separation);
+        $("#maplegendfontsize").val(legend.font_size);
+        $("#maplegendsteps").val(legend.steps);
+    }
+
+    $(document).ready(function () {
+        mapSettingsReset();
         init_select2("#mapmenugroup", "custom-map-menu-group", {}, @json($menu_group ?? null), "{{ __('map.custom.edit.map.no_group') }}", {
             tags: true,
             createTag: function (params) {


### PR DESCRIPTION
This provides a blueprint for setting the vis.js options for a map from the UI.  The main useful option is allowing panning and zooming of a map, although node dragging and the physics engine have also been added as options.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
