### PR TITLE
Canonicalise IPv6 address before searching for peers

### DIFF
--- a/includes/html/pages/device/routing/bgp.inc.php
+++ b/includes/html/pages/device/routing/bgp.inc.php
@@ -162,7 +162,7 @@ foreach (dbFetchRows("SELECT * FROM `bgpPeers` WHERE `device_id` = ? $extra_sql 
     $query = 'SELECT * FROM ipv6_addresses AS A, ports AS I, devices AS D WHERE ';
     $query .= '(A.ipv6_address = ? AND I.port_id = A.port_id)';
     $query .= ' AND D.device_id = I.device_id';
-    $ipv6_host = dbFetchRow($query, [$peerIdentifierIp->uncompressed()]);
+    $ipv6_host = dbFetchRow($query, [$peerIdentifierIp?->uncompressed()]);
 
     if ($ipv4_host) {
         $peerhost = $ipv4_host;
@@ -222,7 +222,7 @@ foreach (dbFetchRows("SELECT * FROM `bgpPeers` WHERE `device_id` = ? $extra_sql 
     $link_array['page'] = 'graphs';
     unset($link_array['height'], $link_array['width'], $link_array['legend']);
     $link = \LibreNMS\Util\Url::generate($link_array);
-    $peeraddresslink = '<span class=list-large>' . \LibreNMS\Util\Url::overlibLink($link, $peerIdentifierIp->compressed(), \LibreNMS\Util\Url::graphTag($graph_array_zoom)) . '</span>';
+    $peeraddresslink = '<span class=list-large>' . \LibreNMS\Util\Url::overlibLink($link, $peerIdentifierIp?->compressed(), \LibreNMS\Util\Url::graphTag($graph_array_zoom)) . '</span>';
 
     if ($peer['bgpPeerLastErrorCode'] == 0 && $peer['bgpPeerLastErrorSubCode'] == 0) {
         $last_error = $peer['bgpPeerLastErrorText'];

--- a/includes/html/pages/device/routing/bgp.inc.php
+++ b/includes/html/pages/device/routing/bgp.inc.php
@@ -123,7 +123,7 @@ foreach (dbFetchRows("SELECT * FROM `bgpPeers` WHERE `device_id` = ? $extra_sql 
 
     // load the peer identifier into an object
     $peer['bgpPeerIdentifierObject'] = IP::parse($peer['bgpPeerIdentifier'], true);
-    
+
     if ($peer['bgpPeerState'] == 'established') {
         $col = 'green';
     } else {

--- a/includes/html/pages/device/routing/bgp.inc.php
+++ b/includes/html/pages/device/routing/bgp.inc.php
@@ -122,7 +122,7 @@ foreach (dbFetchRows("SELECT * FROM `bgpPeers` WHERE `device_id` = ? $extra_sql 
     unset($peerhost, $peername);
 
     // load the peer identifier into an object
-    $peer['bgpPeerIdentifierObject'] = IP::parse($peer['bgpPeerIdentifier'], true);
+    $peerIdentifierIp = IP::parse($peer['bgpPeerIdentifier'], true);
 
     if ($peer['bgpPeerState'] == 'established') {
         $col = 'green';
@@ -162,7 +162,7 @@ foreach (dbFetchRows("SELECT * FROM `bgpPeers` WHERE `device_id` = ? $extra_sql 
     $query = 'SELECT * FROM ipv6_addresses AS A, ports AS I, devices AS D WHERE ';
     $query .= '(A.ipv6_address = ? AND I.port_id = A.port_id)';
     $query .= ' AND D.device_id = I.device_id';
-    $ipv6_host = dbFetchRow($query, [$peer['bgpPeerIdentifierObject']->uncompressed()]);
+    $ipv6_host = dbFetchRow($query, [$peerIdentifierIp->uncompressed()]);
 
     if ($ipv4_host) {
         $peerhost = $ipv4_host;
@@ -201,9 +201,6 @@ foreach (dbFetchRows("SELECT * FROM `bgpPeers` WHERE `device_id` = ? $extra_sql 
         // Build a list of valid AFI/SAFI for this peer
     }
 
-    // make ipv6 look pretty
-    $peer['bgpPeerIdentifierPretty'] = (string) $peer['bgpPeerIdentifierObject'];
-
     // display overlib graphs
     $graph_array = [];
     $graph_array['type'] = 'bgp_updates';
@@ -225,7 +222,7 @@ foreach (dbFetchRows("SELECT * FROM `bgpPeers` WHERE `device_id` = ? $extra_sql 
     $link_array['page'] = 'graphs';
     unset($link_array['height'], $link_array['width'], $link_array['legend']);
     $link = \LibreNMS\Util\Url::generate($link_array);
-    $peeraddresslink = '<span class=list-large>' . \LibreNMS\Util\Url::overlibLink($link, $peer['bgpPeerIdentifierPretty'], \LibreNMS\Util\Url::graphTag($graph_array_zoom)) . '</span>';
+    $peeraddresslink = '<span class=list-large>' . \LibreNMS\Util\Url::overlibLink($link, $peerIdentifierIp->compressed(), \LibreNMS\Util\Url::graphTag($graph_array_zoom)) . '</span>';
 
     if ($peer['bgpPeerLastErrorCode'] == 0 && $peer['bgpPeerLastErrorSubCode'] == 0) {
         $last_error = $peer['bgpPeerLastErrorText'];

--- a/includes/html/pages/device/routing/bgp.inc.php
+++ b/includes/html/pages/device/routing/bgp.inc.php
@@ -121,7 +121,7 @@ foreach (dbFetchRows("SELECT * FROM `bgpPeers` WHERE `device_id` = ? $extra_sql 
     unset($alert);
     unset($peerhost, $peername);
 
-    // load the peer identifier in to an object
+    // load the peer identifier into an object
     $peer['bgpPeerIdentifierObject'] = IP::parse($peer['bgpPeerIdentifier'], true);
     
     if ($peer['bgpPeerState'] == 'established') {
@@ -202,7 +202,7 @@ foreach (dbFetchRows("SELECT * FROM `bgpPeers` WHERE `device_id` = ? $extra_sql 
     }
 
     // make ipv6 look pretty
-    $peer['bgpPeerIdentifierPretty'] = (string) $peer['bgpPeerIdentifier'];
+    $peer['bgpPeerIdentifierPretty'] = (string) $peer['bgpPeerIdentifierObject'];
 
     // display overlib graphs
     $graph_array = [];

--- a/includes/html/pages/device/routing/bgp.inc.php
+++ b/includes/html/pages/device/routing/bgp.inc.php
@@ -121,6 +121,9 @@ foreach (dbFetchRows("SELECT * FROM `bgpPeers` WHERE `device_id` = ? $extra_sql 
     unset($alert);
     unset($peerhost, $peername);
 
+    // load the peer identifier in to an object
+    $peer['bgpPeerIdentifierObject'] = IP::parse($peer['bgpPeerIdentifier'], true);
+    
     if ($peer['bgpPeerState'] == 'established') {
         $col = 'green';
     } else {
@@ -159,7 +162,7 @@ foreach (dbFetchRows("SELECT * FROM `bgpPeers` WHERE `device_id` = ? $extra_sql 
     $query = 'SELECT * FROM ipv6_addresses AS A, ports AS I, devices AS D WHERE ';
     $query .= '(A.ipv6_address = ? AND I.port_id = A.port_id)';
     $query .= ' AND D.device_id = I.device_id';
-    $ipv6_host = dbFetchRow($query, [$peer['bgpPeerIdentifier']]);
+    $ipv6_host = dbFetchRow($query, [$peer['bgpPeerIdentifierObject']->uncompressed()]);
 
     if ($ipv4_host) {
         $peerhost = $ipv4_host;
@@ -199,7 +202,7 @@ foreach (dbFetchRows("SELECT * FROM `bgpPeers` WHERE `device_id` = ? $extra_sql 
     }
 
     // make ipv6 look pretty
-    $peer['bgpPeerIdentifier'] = (string) IP::parse($peer['bgpPeerIdentifier'], true);
+    $peer['bgpPeerIdentifierPretty'] = (string) $peer['bgpPeerIdentifier'];
 
     // display overlib graphs
     $graph_array = [];
@@ -222,7 +225,7 @@ foreach (dbFetchRows("SELECT * FROM `bgpPeers` WHERE `device_id` = ? $extra_sql 
     $link_array['page'] = 'graphs';
     unset($link_array['height'], $link_array['width'], $link_array['legend']);
     $link = \LibreNMS\Util\Url::generate($link_array);
-    $peeraddresslink = '<span class=list-large>' . \LibreNMS\Util\Url::overlibLink($link, $peer['bgpPeerIdentifier'], \LibreNMS\Util\Url::graphTag($graph_array_zoom)) . '</span>';
+    $peeraddresslink = '<span class=list-large>' . \LibreNMS\Util\Url::overlibLink($link, $peer['bgpPeerIdentifierPretty'], \LibreNMS\Util\Url::graphTag($graph_array_zoom)) . '</span>';
 
     if ($peer['bgpPeerLastErrorCode'] == 0 && $peer['bgpPeerLastErrorSubCode'] == 0) {
         $last_error = $peer['bgpPeerLastErrorText'];


### PR DESCRIPTION
JunOS (and probably other platforms) compress the peer identifier, but the code searches the uncompressed database field.

The existing behaviour isn't great either - it clobbers the value of bgpPeerIdentifier.

So, to fix it this change saves an IP object and operates on that, then only uses the pretty value for rendering - SQL queries use the unmodified version.

Without this change, none of our IPv6 peers have their neighbour linked on the BGP page.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
