### PR TITLE
Fixing chronyd application log message variable bug/typo.

### DIFF
--- a/includes/polling/applications/chronyd.inc.php
+++ b/includes/polling/applications/chronyd.inc.php
@@ -103,7 +103,7 @@ if (count($added_sources) > 0 || count($removed_sources) > 0) {
     $app->data = ['sources' => $sources]; // save sources
     $log_message = 'Chronyd Source Change:';
     $log_message .= count($added_sources) > 0 ? ' Added ' . implode(',', $added_sources) : '';
-    $log_message .= count($removed_sources) > 0 ? ' Removed ' . implode(',', $added_sources) : '';
+    $log_message .= count($removed_sources) > 0 ? ' Removed ' . implode(',', $removed_sources) : '';
     log_event($log_message, $device, 'application');
 }
 


### PR DESCRIPTION
Quick fix of the chronyd application logging when a source is removed.  Should display the removed sources instead of the added sources again (if the former exist).

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [X] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
