### PR TITLE
Fixed a display issue with the menu

### DIFF
--- a/resources/views/layouts/menu.blade.php
+++ b/resources/views/layouts/menu.blade.php
@@ -245,9 +245,8 @@
                                                 {{ ucfirst($map->name) }}
                                             </a></li>
                                         @endforeach
-                                        @if($map_group)</ul>@endif
+                                        @if($map_group)</ul></li>@endif
                                     @endforeach
-                            </li>
                         @endif
                         @admin
                         <li role="presentation" class="divider"></li>


### PR DESCRIPTION
I just did a new install, and the top menu broke when I create a custom map without a group.  The issue is that the <li> is opened on line 238 within the @if($map_group) block, but the </li> on line 250 is not within any group.

Before:
![image](https://github.com/user-attachments/assets/817248e6-591f-43c8-87a7-93e6fb8abb06)

After:
![image](https://github.com/user-attachments/assets/50b88528-ebc3-401f-b7ce-10d067046cfc)


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
