### PR TITLE
Moved the API token to be generated server side to resolve XSS

### DIFF
--- a/includes/html/forms/token-item-create.inc.php
+++ b/includes/html/forms/token-item-create.inc.php
@@ -18,17 +18,13 @@ if (! Auth::user()->hasGlobalAdmin()) {
     exit('ERROR: You need to be admin');
 }
 
-if (! is_numeric($_POST['user_id']) || ! isset($_POST['token'])) {
+$token =  bin2hex(openssl_random_pseudo_bytes(16));
+
+if (! is_numeric($_POST['user_id'])) {
     echo 'ERROR: error with data, please ensure a valid user and token have been specified.';
     exit;
-} elseif (strlen($_POST['token']) > 32) {
-    echo 'ERROR: The token is more than 32 characters';
-    exit;
-} elseif (strlen($_POST['token']) < 16) {
-    echo 'ERROR: The token is less than 16 characters';
-    exit;
 } else {
-    $create = dbInsert(['user_id' => $_POST['user_id'], 'token_hash' => $_POST['token'], 'description' => $_POST['description']], 'api_tokens');
+    $create = dbInsert(['user_id' => $_POST['user_id'], 'token_hash' => $token, 'description' => $_POST['description']], 'api_tokens');
     if ($create > '0') {
         echo 'API token has been created';
         Session::put('api_token', true);

--- a/includes/html/forms/token-item-create.inc.php
+++ b/includes/html/forms/token-item-create.inc.php
@@ -18,7 +18,7 @@ if (! Auth::user()->hasGlobalAdmin()) {
     exit('ERROR: You need to be admin');
 }
 
-$token =  bin2hex(openssl_random_pseudo_bytes(16));
+$token = bin2hex(openssl_random_pseudo_bytes(16));
 
 if (! is_numeric($_POST['user_id'])) {
     echo 'ERROR: error with data, please ensure a valid user and token have been specified.';

--- a/includes/html/pages/api-access.inc.php
+++ b/includes/html/pages/api-access.inc.php
@@ -17,9 +17,7 @@ use App\Models\User;
 use LibreNMS\Authentication\LegacyAuth;
 
 if (Auth::user()->hasGlobalAdmin()) {
-    if (empty($_POST['token'])) {
-        $_POST['token'] = bin2hex(openssl_random_pseudo_bytes(16));
-    } ?>
+?>
   <div class="modal fade" id="confirm-delete" tabindex="-1" role="dialog" aria-labelledby="Delete" aria-hidden="true">
     <div class="modal-dialog modal-sm">
       <div class="modal-content">
@@ -62,14 +60,6 @@ if (Auth::user()->hasGlobalAdmin()) {
         echo '<option value="' . $user->user_id . '">' . htmlentities($user->username) . ' (' . htmlentities($user->auth_type) . ')</option>';
     } ?>
                 </select>
-              </div>
-            </div>
-            <div class="form-group">
-              <label for="token" class="col-sm-2 control-label">Token: </label>
-              <div class="col-sm-8">
-                <input type="text" class="form-control" id="token" name="token" value="<?php echo htmlspecialchars($_POST['token']); ?>" readonly>
-              </div>
-              <div class="col-sm-2">
               </div>
             </div>
             <div class="form-group">
@@ -147,10 +137,10 @@ if (Auth::user()->hasGlobalAdmin()) {
 
         echo '
         <tr id="' . $api->id . '" ' . $color . '>
-          <td>' . $user_details->username . '</td>
-          <td>' . $user_details->auth_type . '</td>
-          <td>' . $api->token_hash . '</td>
-          <td><button class="btn btn-info btn-xs" data-toggle="modal" data-target="#display-qr" data-token_hash="' . $api->token_hash . '"><i class="fa fa-qrcode" ></i></button></td>
+          <td>' . htmlentities($user_details->username) . '</td>
+          <td>' . htmlentities($user_details->auth_type) . '</td>
+          <td>' . htmlentities($api->token_hash) . '</td>
+          <td><button class="btn btn-info btn-xs" data-toggle="modal" data-target="#display-qr" data-token_hash="' . htmlentities($api->token_hash) . '"><i class="fa fa-qrcode" ></i></button></td>
           <td>' . htmlspecialchars($api->description) . '</td>
           <td><input type="checkbox" name="token-status" data-token_id="' . $api->id . '" data-off-text="No" data-on-text="Yes" data-on-color="danger" ' . $api_disabled . ' data-size="mini"></td>
           <td><button type="button" class="btn btn-danger btn-xs" id="' . $api->id . '" data-token_id="' . $api->id . '" data-toggle="modal" data-target="#confirm-delete">Delete</button></td>


### PR DESCRIPTION
Removed the ability to leverage XSS for the API access tokens.

https://github.com/librenms/librenms/security/advisories/GHSA-gfwr-xqmj-j27v

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
