### PR TITLE
Fixed XSS in Wireless and Health pages

### DIFF
--- a/includes/html/pages/health.inc.php
+++ b/includes/html/pages/health.inc.php
@@ -64,7 +64,7 @@ $type_text = [
     'percent' => 'Percent',
 ];
 
-$active_metric = basename($vars['metric'] ?? 'processor');
+$active_metric = basename((array_key_exists($vars['metric'], $type_text) ? $vars['metric'] : 'processor'));
 
 $vars['view'] = $vars['view'] ?? 'detail';
 $link_array = ['page' => 'health'];

--- a/includes/html/pages/health.inc.php
+++ b/includes/html/pages/health.inc.php
@@ -64,7 +64,7 @@ $type_text = [
     'percent' => 'Percent',
 ];
 
-$active_metric = basename((array_key_exists($vars['metric'], $type_text) ? $vars['metric'] : 'processor'));
+$active_metric = basename(array_key_exists($vars['metric'], $type_text) ? $vars['metric'] : 'processor');
 
 $vars['view'] = $vars['view'] ?? 'detail';
 $link_array = ['page' => 'health'];

--- a/includes/html/pages/wireless.inc.php
+++ b/includes/html/pages/wireless.inc.php
@@ -29,7 +29,7 @@ use LibreNMS\Device\WirelessSensor;
 $sensors = dbFetchColumn('SELECT `sensor_class` FROM `wireless_sensors` GROUP BY `sensor_class`');
 $valid_wireless_types = array_intersect_key(WirelessSensor::getTypes(), array_flip($sensors));
 
-$class = basename($vars['metric'] ?? key($valid_wireless_types));
+$class = basename((array_key_exists($vars['metric'], $valid_wireless_types) ? $vars['metric'] : key($valid_wireless_types)));
 $vars['view'] = basename($vars['view'] ?? 'nographs');
 
 $link_array = ['page' => 'wireless'];

--- a/includes/html/pages/wireless.inc.php
+++ b/includes/html/pages/wireless.inc.php
@@ -29,7 +29,7 @@ use LibreNMS\Device\WirelessSensor;
 $sensors = dbFetchColumn('SELECT `sensor_class` FROM `wireless_sensors` GROUP BY `sensor_class`');
 $valid_wireless_types = array_intersect_key(WirelessSensor::getTypes(), array_flip($sensors));
 
-$class = basename((array_key_exists($vars['metric'], $valid_wireless_types) ? $vars['metric'] : key($valid_wireless_types)));
+$class = basename(array_key_exists($vars['metric'], $valid_wireless_types) ? $vars['metric'] : key($valid_wireless_types));
 $vars['view'] = basename($vars['view'] ?? 'nographs');
 
 $link_array = ['page' => 'wireless'];


### PR DESCRIPTION
Rather than sanitizing the output I've chosen to bolster the default option if the metric key doesn't exist.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
