### PR TITLE
Added a white background to custom map labels to make them more readable

### DIFF
--- a/resources/views/map/custom-js.blade.php
+++ b/resources/views/map/custom-js.blade.php
@@ -99,7 +99,7 @@
             node_cfg.borderWidth = node.border_width;
             node_cfg.x = node.x_pos;
             node_cfg.y = node.y_pos;
-            node_cfg.font = {face: node.text_face, size: node.text_size, color: node.text_colour};
+            node_cfg.font = {face: node.text_face, size: node.text_size, color: node.text_colour, background: "#FFFFFF"};
             node_cfg.size = node.size;
             node_cfg.color = {background: node.colour_bg_view, border: node.colour_bdr_view};
             if(node.style == "icon") {
@@ -131,7 +131,7 @@
                 arrows = {to: {enabled: true, scaleFactor: 0.6}, from: {enabled: false}};
             }
 
-            var edge_cfg = {id: edgeid + "_" + fromto, to: edgeid + "_mid", arrows: arrows, font: {face: edge.text_face, size: edge.text_size, color: edge.text_colour}, smooth: {type: edge.style}};
+            var edge_cfg = {id: edgeid + "_" + fromto, to: edgeid + "_mid", arrows: arrows, font: {face: edge.text_face, size: edge.text_size, color: edge.text_colour, background: "#FFFFFF"}, smooth: {type: edge.style}};
             if (fromto == "from") {
                 edge_cfg.from = edge.custom_map_node1_id;
                 var port_pct = Boolean(reverse_arrows) ? edge.port_topct : edge.port_frompct;

--- a/resources/views/map/custom-js.blade.php
+++ b/resources/views/map/custom-js.blade.php
@@ -99,7 +99,7 @@
             node_cfg.borderWidth = node.border_width;
             node_cfg.x = node.x_pos;
             node_cfg.y = node.y_pos;
-            node_cfg.font = {face: node.text_face, size: node.text_size, color: node.text_colour, background: "#FFFFFF"};
+            node_cfg.font = {face: node.text_face, size: node.text_size, color: node.text_colour};
             node_cfg.size = node.size;
             node_cfg.color = {background: node.colour_bg_view, border: node.colour_bdr_view};
             if(node.style == "icon") {
@@ -120,6 +120,9 @@
                 }
             } else {
                 node_cfg.image = {};
+            }
+            if(! ["ellipse", "circle", "database", "box", "text"].includes(node.style)) {
+                node_cfg.font.background = "#FFFFFF";
             }
             return node_cfg;
         },


### PR DESCRIPTION
This adds a white background to the custom map labels to make them more readable.

Before:
![image](https://github.com/user-attachments/assets/df5a471e-335f-46ae-9eb1-7c8a7ba027ca)

After:
![image](https://github.com/user-attachments/assets/912a7bf1-5bcf-43ad-941e-b2a4da2faf36)


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
