### PR TITLE
Fix device display name xss vulnerabilities

### DIFF
--- a/LibreNMS/Util/Url.php
+++ b/LibreNMS/Util/Url.php
@@ -51,11 +51,11 @@ class Url
     public static function deviceLink($device, $text = '', $vars = [], $start = 0, $end = 0, $escape_text = 1, $overlib = 1)
     {
         if (! $device instanceof Device || ! $device->hostname) {
-            return (string) $text;
+            return $escape_text ? htmlentities($text) : (string) $text;
         }
 
         if (! $device->canAccess(Auth::user())) {
-            return $device->displayName();
+            return $escape_text ? htmlentities($device->displayName()) : $device->displayName();
         }
 
         if (! $start) {
@@ -79,30 +79,31 @@ class Url
         $url = Url::deviceUrl($device, $vars);
 
         // beginning of overlib box contains large hostname followed by hardware & OS details
-        $contents = '<div><span class="list-large">' . $device->displayName() . '</span>';
+        // because we are injecting this into javascript htmlentities alone won't work, so strip_tags too
+        $contents = '<div><span class="list-large">' . htmlentities(strip_tags($device->displayName())) . '</span>';
         $devinfo = '';
         if ($device->hardware) {
-            $devinfo .= htmlentities($device->hardware);
+            $devinfo .= $device->hardware;
         }
 
         if ($device->os) {
-            $devinfo .= ($devinfo ? ' - ' : '') . htmlentities(Config::getOsSetting($device->os, 'text'));
+            $devinfo .= ($devinfo ? ' - ' : '') . Config::getOsSetting($device->os, 'text');
         }
 
         if ($device->version) {
-            $devinfo .= ($devinfo ? ' - ' : '') . htmlentities($device->version);
+            $devinfo .= ($devinfo ? ' - ' : '') . $device->version;
         }
 
         if ($device->features) {
-            $devinfo .= ' (' . htmlentities($device->features) . ')';
+            $devinfo .= ' (' . $device->features . ')';
         }
 
         if ($devinfo) {
-            $contents .= '<br />' . $devinfo;
+            $contents .= '<br />' . htmlentities(strip_tags($devinfo));
         }
 
         if ($device->location_id) {
-            $contents .= '<br />' . htmlentities($device->location ?? '');
+            $contents .= '<br />' . htmlentities(strip_tags($device->location ?? ''));
         }
 
         $contents .= '</div><br />';

--- a/includes/html/common/availability-map.inc.php
+++ b/includes/html/common/availability-map.inc.php
@@ -287,33 +287,34 @@ if (defined('SHOW_SETTINGS')) {
                     $serviceState = 'down';
                     $service_down_count++;
                 }
-                $service_system_name = htmlentities(format_hostname($service));
+                $device_name = format_hostname($service);
+                $service_descr = " - ${service['service_type']} - ${service['service_desc']}";
 
                 if (Config::get('webui.availability_map_compact') == 0) {
                     if ($directpage == 'yes') {
                         $deviceIcon = getIconTag($service);
                         $temp_output[] = '
-                        <a href="' . \LibreNMS\Util\Url::generate(['page' => 'device', 'device' => $service['device_id'], 'tab' => 'services']) . '" title="' . $service_system_name . ' - ' . $service['service_type'] . ' - ' . $service['service_desc'] . '">
+                        <a href="' . \LibreNMS\Util\Url::generate(['page' => 'device', 'device' => $service['device_id'], 'tab' => 'services']) . '" title="' . htmlentities($device_name . $service_descr) . '">
                             <div class="service-availability ' . $serviceState . '" style="width:' . Config::get('webui.availability_map_box_size') . 'px;">
                                 <span class="service-name-label label ' . $serviceLabel . ' label-font-border">' . $service['service_type'] . '</span>
                                 <span class="availability-label label ' . $serviceLabel . ' label-font-border">' . $serviceState . '</span>
                                 <span class="device-icon">' . $deviceIcon . '</span><br>
-                                <span class="small">' . shorthost($service_system_name) . '</span>
+                                <span class="small">' . htmlentities(shorthost($device_name)) . '</span>
                             </div>
                         </a>';
                     } else {
-                        $serviceText = $service['service_type'] . ' - ' . $serviceState;
+                        $serviceText = htmlentities($service['service_type']) . ' - ' . $serviceState;
                         if ($settings['color_only_select'] == 1) {
                             $serviceText = ' ';
                             $serviceLabel .= ' widget-availability-fixed';
                         }
                         $temp_output[] = '
-                        <a href="' . \LibreNMS\Util\Url::generate(['page' => 'device', 'device' => $service['device_id'], 'tab' => 'services']) . '" title="' . shorthost($service_system_name) . ' - ' . $service['service_type'] . ' - ' . $service['service_desc'] . '">
+                        <a href="' . \LibreNMS\Util\Url::generate(['page' => 'device', 'device' => $service['device_id'], 'tab' => 'services']) . '" title="' . htmlentities(shorthost($device_name) . $service_descr) . '">
                             <span class="label ' . $serviceLabel . ' widget-availability label-font-border">' . $serviceText . '</span>
                         </a>';
                     }
                 } else {
-                    $temp_output[] = "<a href='" . \LibreNMS\Util\Url::generate(['page' => 'device', 'device' => $service['device_id'], 'tab' => 'services']) . "' title='${service_system_name} - ${service['service_type']} - ${service['service_desc']}'><div class='" . $serviceLabelOld . "' style='width:${compact_tile}px;height:${compact_tile}px;'></div></a>";
+                    $temp_output[] = "<a href='" . \LibreNMS\Util\Url::generate(['page' => 'device', 'device' => $service['device_id'], 'tab' => 'services']) . "' title='$device_name$service_descr'><div class='" . $serviceLabelOld . "' style='width:${compact_tile}px;height:${compact_tile}px;'></div></a>";
                 }
             }
         } else {

--- a/includes/html/common/availability-map.inc.php
+++ b/includes/html/common/availability-map.inc.php
@@ -231,7 +231,7 @@ if (defined('SHOW_SETTINGS')) {
                 $host_maintenance_count++;
             }
 
-            $device_system_name = format_hostname($device);
+            $device_system_name = htmlentities(format_hostname($device));
 
             if (Config::get('webui.availability_map_compact') == 0) {
                 if ($directpage == 'yes') {
@@ -287,7 +287,7 @@ if (defined('SHOW_SETTINGS')) {
                     $serviceState = 'down';
                     $service_down_count++;
                 }
-                $service_system_name = format_hostname($service);
+                $service_system_name = htmlentities(format_hostname($service));
 
                 if (Config::get('webui.availability_map_compact') == 0) {
                     if ($directpage == 'yes') {

--- a/includes/html/pages/edituser.inc.php
+++ b/includes/html/pages/edituser.inc.php
@@ -80,7 +80,7 @@ if (! Auth::user()->hasGlobalAdmin()) {
 
         $device_perms = dbFetchRows('SELECT * from devices_perms as P, devices as D WHERE `user_id` = ? AND D.device_id = P.device_id', [$user_data['user_id']]);
         foreach ($device_perms as $device_perm) {
-            echo '<tr><td><strong>' . format_hostname($device_perm) . "</td><td> <a href='edituser/action=deldevperm/user_id=" . $vars['user_id'] . '/device_id=' . $device_perm['device_id'] . "'><i class='fa fa-trash fa-lg icon-theme' aria-hidden='true'></i></a></strong></td></tr>";
+            echo '<tr><td><strong>' . htmlentities(format_hostname($device_perm)) . "</td><td> <a href='edituser/action=deldevperm/user_id=" . $vars['user_id'] . '/device_id=' . $device_perm['device_id'] . "'><i class='fa fa-trash fa-lg icon-theme' aria-hidden='true'></i></a></strong></td></tr>";
             $access_list[] = $device_perm['device_id'];
             $permdone = 'yes';
         }


### PR DESCRIPTION
of note is we now strip tags in overlib popups because it is extremely difficult for htmlentities alone to fix the issue due to overlib injecting it into the dom decoded.

https://github.com/librenms/librenms/security/advisories/GHSA-4m5r-w2rq-q54q

fixes #16559

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
