### PR TITLE
update App docs for linux_softnet_stat as it no longer needs Gzip::Faster

### DIFF
--- a/doc/Extensions/Applications.md
+++ b/doc/Extensions/Applications.md
@@ -1372,7 +1372,7 @@ extend linux_config_files /etc/snmp/linux_config_files.py
 1: Install the depends, which on a Debian based system would be as below.
 ```
 # Debian
-apt-get install -y cpanminus libfile-slurp-perl libmime-base64-perl libjson-perl
+apt-get install -y libfile-slurp-perl libmime-base64-perl libjson-perl
 # generic cpanm
 cpanm JSON File::Slurp MIME::Base64
 ```

--- a/doc/Extensions/Applications.md
+++ b/doc/Extensions/Applications.md
@@ -1371,8 +1371,10 @@ extend linux_config_files /etc/snmp/linux_config_files.py
 
 1: Install the depends, which on a Debian based system would be as below.
 ```
-apt-get install -y cpanminus zlib1g-dev
-cpanm File::Slurp MIME::Base64 JSON Gzip::Faster
+# Debian
+apt-get install -y cpanminus libfile-slurp-perl libmime-base64-perl libjson-perl
+# generic cpanm
+cpanm JSON File::Slurp MIME::Base64
 ```
 
 2. Download the script into the desired host.


### PR DESCRIPTION
Now uses IO::Compress::Gzip which comes default with Perl.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
