### PR TITLE
Throw exception when mail delivery fails

### DIFF
--- a/LibreNMS/Alert/Transport/Mail.php
+++ b/LibreNMS/Alert/Transport/Mail.php
@@ -26,6 +26,7 @@ namespace LibreNMS\Alert\Transport;
 use LibreNMS\Alert\AlertUtil;
 use LibreNMS\Alert\Transport;
 use LibreNMS\Config;
+use LibreNMS\Exceptions\AlertTransportDeliveryException;
 
 class Mail extends Transport
 {
@@ -48,7 +49,13 @@ class Mail extends Transport
             $msg = preg_replace("/(?<!\r)\n/", "\r\n", $alert_data['msg']);
         }
 
-        return \LibreNMS\Util\Mail::send($emails, $alert_data['title'], $msg, $html, $this->config['bcc'] ?? false, $this->config['attach-graph'] ?? null);
+        try {
+            return \LibreNMS\Util\Mail::send($emails, $alert_data['title'], $msg, $html, $this->config['bcc'] ?? false, $this->config['attach-graph'] ?? null);
+        } catch (\PHPMailer\PHPMailer\Exception $e) {
+            throw new AlertTransportDeliveryException($alert_data, 0, $e->errorMessage());
+        } catch (Exception $e) {
+            throw new AlertTransportDeliveryException($alert_data, 0, $e->getMessage());
+        }
     }
 
     public static function configTemplate(): array

--- a/LibreNMS/Alert/Transport/Mail.php
+++ b/LibreNMS/Alert/Transport/Mail.php
@@ -23,6 +23,7 @@
 
 namespace LibreNMS\Alert\Transport;
 
+use Exception;
 use LibreNMS\Alert\AlertUtil;
 use LibreNMS\Alert\Transport;
 use LibreNMS\Config;

--- a/LibreNMS/Util/Mail.php
+++ b/LibreNMS/Util/Mail.php
@@ -127,7 +127,7 @@ class Mail
             return $mail->send();
         }
 
-        return 'No contacts found';
+        throw new Exception('No contacts found');
     }
 
     /**

--- a/LibreNMS/Util/Mail.php
+++ b/LibreNMS/Util/Mail.php
@@ -103,25 +103,25 @@ class Mail
                 $mail->isHTML();
             }
             switch (strtolower(trim(Config::get('email_backend')))) {
-            case 'sendmail':
-                $mail->Mailer = 'sendmail';
-                $mail->Sendmail = Config::get('email_sendmail_path');
-                break;
-            case 'smtp':
-                $mail->isSMTP();
-                $mail->Host = Config::get('email_smtp_host');
-                $mail->Timeout = Config::get('email_smtp_timeout');
-                $mail->SMTPAuth = Config::get('email_smtp_auth');
-                $mail->SMTPSecure = Config::get('email_smtp_secure');
-                $mail->Port = Config::get('email_smtp_port');
-                $mail->Username = Config::get('email_smtp_username');
-                $mail->Password = Config::get('email_smtp_password');
-                $mail->SMTPAutoTLS = Config::get('email_auto_tls');
-                $mail->SMTPDebug = 0;
-                break;
-            default:
-                $mail->Mailer = 'mail';
-                break;
+                case 'sendmail':
+                    $mail->Mailer = 'sendmail';
+                    $mail->Sendmail = Config::get('email_sendmail_path');
+                    break;
+                case 'smtp':
+                    $mail->isSMTP();
+                    $mail->Host = Config::get('email_smtp_host');
+                    $mail->Timeout = Config::get('email_smtp_timeout');
+                    $mail->SMTPAuth = Config::get('email_smtp_auth');
+                    $mail->SMTPSecure = Config::get('email_smtp_secure');
+                    $mail->Port = Config::get('email_smtp_port');
+                    $mail->Username = Config::get('email_smtp_username');
+                    $mail->Password = Config::get('email_smtp_password');
+                    $mail->SMTPAutoTLS = Config::get('email_auto_tls');
+                    $mail->SMTPDebug = 0;
+                    break;
+                default:
+                    $mail->Mailer = 'mail';
+                    break;
             }
 
             return $mail->send();

--- a/LibreNMS/Util/Mail.php
+++ b/LibreNMS/Util/Mail.php
@@ -29,6 +29,7 @@ use Exception;
 use LibreNMS\Config;
 use LibreNMS\Exceptions\RrdGraphException;
 use PHPMailer\PHPMailer\PHPMailer;
+use PHPMailer\PHPMailer\SMTP;
 
 class Mail
 {

--- a/LibreNMS/Util/Mail.php
+++ b/LibreNMS/Util/Mail.php
@@ -29,7 +29,6 @@ use Exception;
 use LibreNMS\Config;
 use LibreNMS\Exceptions\RrdGraphException;
 use PHPMailer\PHPMailer\PHPMailer;
-use PHPMailer\PHPMailer\SMTP;
 
 class Mail
 {

--- a/LibreNMS/Util/Mail.php
+++ b/LibreNMS/Util/Mail.php
@@ -69,65 +69,61 @@ class Mail
      * @param  string  $subject
      * @param  string  $message
      * @param  bool  $html
-     * @return bool|string
+     * @return bool
+     *
+     * @throws Exception if mail delivery fails.
      */
     public static function send($emails, $subject, $message, bool $html = false, bool $bcc = false, ?bool $embedGraphs = null)
     {
         if (is_array($emails) || ($emails = self::parseEmails($emails))) {
             d_echo("Attempting to email $subject to: " . implode('; ', array_keys($emails)) . PHP_EOL);
             $mail = new PHPMailer(true);
-            try {
-                $mail->Hostname = php_uname('n');
+            $mail->Hostname = php_uname('n');
 
-                foreach (self::parseEmails(Config::get('email_from')) as $from => $from_name) {
-                    $mail->setFrom($from, $from_name);
-                }
-
-                // add addresses
-                $addMethod = $bcc ? 'addBcc' : 'addAddress';
-                foreach ($emails as $email => $email_name) {
-                    $mail->$addMethod($email, $email_name);
-                }
-
-                $mail->Subject = $subject;
-                $mail->XMailer = Config::get('project_name');
-                $mail->CharSet = 'utf-8';
-                $mail->WordWrap = 76;
-                $mail->Body = $message;
-                if ($embedGraphs ?? Config::get('email_attach_graphs')) {
-                    self::embedGraphs($mail, $html);
-                }
-                if ($html) {
-                    $mail->isHTML();
-                }
-                switch (strtolower(trim(Config::get('email_backend')))) {
-                    case 'sendmail':
-                        $mail->Mailer = 'sendmail';
-                        $mail->Sendmail = Config::get('email_sendmail_path');
-                        break;
-                    case 'smtp':
-                        $mail->isSMTP();
-                        $mail->Host = Config::get('email_smtp_host');
-                        $mail->Timeout = Config::get('email_smtp_timeout');
-                        $mail->SMTPAuth = Config::get('email_smtp_auth');
-                        $mail->SMTPSecure = Config::get('email_smtp_secure');
-                        $mail->Port = Config::get('email_smtp_port');
-                        $mail->Username = Config::get('email_smtp_username');
-                        $mail->Password = Config::get('email_smtp_password');
-                        $mail->SMTPAutoTLS = Config::get('email_auto_tls');
-                        $mail->SMTPDebug = 0;
-                        break;
-                    default:
-                        $mail->Mailer = 'mail';
-                        break;
-                }
-
-                return $mail->send();
-            } catch (\PHPMailer\PHPMailer\Exception $e) {
-                return $e->errorMessage();
-            } catch (Exception $e) {
-                return $e->getMessage();
+            foreach (self::parseEmails(Config::get('email_from')) as $from => $from_name) {
+                $mail->setFrom($from, $from_name);
             }
+
+            // add addresses
+            $addMethod = $bcc ? 'addBcc' : 'addAddress';
+            foreach ($emails as $email => $email_name) {
+                $mail->$addMethod($email, $email_name);
+            }
+
+            $mail->Subject = $subject;
+            $mail->XMailer = Config::get('project_name');
+            $mail->CharSet = 'utf-8';
+            $mail->WordWrap = 76;
+            $mail->Body = $message;
+            if ($embedGraphs ?? Config::get('email_attach_graphs')) {
+                self::embedGraphs($mail, $html);
+            }
+            if ($html) {
+                $mail->isHTML();
+            }
+            switch (strtolower(trim(Config::get('email_backend')))) {
+            case 'sendmail':
+                $mail->Mailer = 'sendmail';
+                $mail->Sendmail = Config::get('email_sendmail_path');
+                break;
+            case 'smtp':
+                $mail->isSMTP();
+                $mail->Host = Config::get('email_smtp_host');
+                $mail->Timeout = Config::get('email_smtp_timeout');
+                $mail->SMTPAuth = Config::get('email_smtp_auth');
+                $mail->SMTPSecure = Config::get('email_smtp_secure');
+                $mail->Port = Config::get('email_smtp_port');
+                $mail->Username = Config::get('email_smtp_username');
+                $mail->Password = Config::get('email_smtp_password');
+                $mail->SMTPAutoTLS = Config::get('email_auto_tls');
+                $mail->SMTPDebug = 0;
+                break;
+            default:
+                $mail->Mailer = 'mail';
+                break;
+            }
+
+            return $mail->send();
         }
 
         return 'No contacts found';


### PR DESCRIPTION
Currently the `Mail` transport returns a string when delivery fails. This doesn't seem to be recognized by the system as an error. You can see this pretty easily by doing the following:

- Go into Global Settings, Alerting tab, and set the Email Options to have slightly misconfigured SMTP settings (e.g. use the wrong port)
- Go into Alerts -> Alert Transports and Create Alert Transport
- Set up a transport using Mail
- Click the Test Transport button
- It will indicate delivery was successful, even though it wasn't

This PR updates the `Mail` util to throw an exception on failure, instead of catching it and returning a string. Then, in the `Mail` transport, it catches exceptions and translates them to `AlertTransportDeliveryException`, since that seems to be the documented way to indicate failure.

With this change, you can repeat the test above and it will tell you that the delivery failed 🎉 

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
