### PR TITLE
Added missing form fields from the modal and added JS fix

### DIFF
--- a/resources/views/map/custom-map-modal.blade.php
+++ b/resources/views/map/custom-map-modal.blade.php
@@ -51,6 +51,24 @@
                                     <input class="form-check-input" type="checkbox" role="switch" id="mapreversearrows">
                                 </div>
                             </div>
+                            <div class="form-group row">
+                                <label for="mapopt-zoom" class="col-sm-3 control-label">{{ __('map.custom.edit.map.zoom') }}</label>
+                                <div class="col-sm-9">
+                                    <input class="form-check-input" type="checkbox" role="switch" id="mapopt-zoom">
+                                </div>
+                            </div>
+                            <div class="form-group row">
+                                <label for="mapopt-dragnodes" class="col-sm-3 control-label">{{ __('map.custom.edit.map.dragnodes') }}</label>
+                                <div class="col-sm-9">
+                                    <input class="form-check-input" type="checkbox" role="switch" id="mapopt-dragnodes">
+                                </div>
+                            </div>
+                            <div class="form-group row">
+                                <label for="mapopt-physics" class="col-sm-3 control-label">{{ __('map.custom.edit.map.physics') }}</label>
+                                <div class="col-sm-9">
+                                    <input class="form-check-input" type="checkbox" role="switch" id="mapopt-physics">
+                                </div>
+                            </div>
                             <hr>
                             <div class="row">
                                 <div class="col-sm-12" id="savemap-alert">
@@ -91,6 +109,15 @@
         var height = $("#mapheight").val();
         var node_align = $("#mapnodealign").val();
         var post_options = structuredClone(map_options);
+
+        // Fixes for known issues if the data in the DB is corrupt
+        if (Array.isArray(post_options.physics)) {
+            post_options.physics = {};
+        }
+        if (Array.isArray(post_options.interaction)) {
+            post_options.interaction = {};
+        }
+
         post_options.interaction.zoomView = post_options.interaction.dragView = $("#mapopt-zoom").prop('checked');
         post_options.interaction.dragNodes = $("#mapopt-dragnodes").prop('checked');
         post_options.physics.enabled = $("#mapopt-physics").prop('checked');


### PR DESCRIPTION
This fixes a bug introduced as part of merging changes between the vis options and legend branches.  It re-adds the missing form fields for the vis options, and adds a JS fix for anyone who saved map options while the form fields were missing

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
