### PR TITLE
Custom Map widget unselected

### DIFF
--- a/app/Http/Controllers/Widgets/CustomMapController.php
+++ b/app/Http/Controllers/Widgets/CustomMapController.php
@@ -48,7 +48,7 @@ class CustomMapController extends WidgetController
 
         $data['map'] = CustomMap::find($data['custom_map']);
         if (! $data['map']) {
-            abort(404, 'Custom map not found or not defined');
+           return __('map.custom.widget.not_found');
         }
         $data['base_url'] = Config::get('base_url');
         $data['background_config'] = $data['map']->getBackgroundConfig();

--- a/lang/en/map.php
+++ b/lang/en/map.php
@@ -173,5 +173,8 @@ return [
                 'height_pixels' => 'Height in pixels must be at least 200',
             ],
         ],
+        'widget' => [
+            'not_found' => 'No map selected.  Edit widget to select map.',
+        ],
     ],
 ];


### PR DESCRIPTION
display helpful text when no map is selected instead of sending a 404 from the backend.

![image](https://github.com/user-attachments/assets/32289967-96ab-4a16-9ccc-040b0d150aa0)


#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
