### PR TITLE
Fix graph row responsive

### DIFF
--- a/app/View/Components/Graph.php
+++ b/app/View/Components/Graph.php
@@ -136,11 +136,19 @@ class Graph extends Component
      */
     public function filterAttributes($value, $key): bool
     {
-        return ! in_array($key, [
+        $filtered = [
             'legend',
             'height',
             'loading',
-        ]);
+        ];
+
+        // do not add class and style to the image, add them to the outer link
+        if ($this->link) {
+            $filtered[] = 'class';
+            $filtered[] = 'style';
+        }
+
+        return ! in_array($key, $filtered);
     }
 
     private function getSrc(): string

--- a/resources/views/components/graph.blade.php
+++ b/resources/views/components/graph.blade.php
@@ -1,1 +1,1 @@
-<img width="{{ $width }}" height="{{ $height }}" src="{{ $src }}" alt="{{ $type }}" {{ $attributes->merge(['class' => 'graph-image'])->filter($filterAttributes) }} {{ $attributes->only('loading') }}>
+<img width="{{ $width }}" height="{{ $height }}" src="{{ $src }}" alt="{{ $type }}" {{ $attributes->filter($filterAttributes)->merge(['class' => 'graph-image']) }} {{ $attributes->only('loading') }}>

--- a/resources/views/components/linked-graph.blade.php
+++ b/resources/views/components/linked-graph.blade.php
@@ -1,1 +1,1 @@
-<a href="{{ $link }}" {{ $attributes->filter($filterAttributes) }}>@include('components.graph')</a>
+<a href="{{ $link }}" {{ $attributes->only(['class', 'style']) }}>@include('components.graph')</a>


### PR DESCRIPTION
Width classes were double added to graphs when linked, so it was 1/8 width instead of 1/4 width
Filter class and style from inner image when using a linked graph

fixes: #16529

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
