### PR TITLE
Fix Ciena-sds Entity Discovery

### DIFF
--- a/LibreNMS/OS/CienaSds.php
+++ b/LibreNMS/OS/CienaSds.php
@@ -166,7 +166,7 @@ class CienaSds extends OS
 
         foreach ($transceivers as $index => $contents) {
             $portIndex = $interfaceIndexMapping[$index]['IF-MIB::ifIndex'];
-            if (!empty($contents['cienaCesEttpConfigName'])){
+            if (!empty($contents['cienaCesEttpConfigName'])) {
                 $nameArr = explode('/', $contents['cienaCesEttpConfigName']);
                 $slotIndex = isset($nameArr[1]) ? $nameArr[0] : 1;
 

--- a/LibreNMS/OS/CienaSds.php
+++ b/LibreNMS/OS/CienaSds.php
@@ -158,14 +158,12 @@ class CienaSds extends OS
         }));
 
         // Interface stuff
-        $interfaceIndexMapping = SnmpQuery::walk('IF-MIB::ifIndex')->table(1);
         $transceivers = SnmpQuery::hideMib()->enumStrings()->walk([
             'CIENA-CES-PORT-MIB::cienaCesEttpConfigTable',
             'CIENA-CES-PORT-XCVR-MIB::cienaCesPortXcvrTable',
         ])->table(1);
 
         foreach ($transceivers as $index => $contents) {
-            $portIndex = $interfaceIndexMapping[$index]['IF-MIB::ifIndex'];
             if (! empty($contents['cienaCesEttpConfigName'])) {
                 $nameArr = explode('/', $contents['cienaCesEttpConfigName']);
                 $slotIndex = isset($nameArr[1]) ? $nameArr[0] : 1;
@@ -177,7 +175,7 @@ class CienaSds extends OS
                     'entPhysicalName' => $contents['cienaCesEttpConfigName'],
                     'entPhysicalContainedIn' => '55' . $slotIndex,
                     'entPhysicalParentRelPos' => $index,
-                    'ifIndex' => $portIndex,
+                    'ifIndex' => $index,
                 ]));
             }
 

--- a/LibreNMS/OS/CienaSds.php
+++ b/LibreNMS/OS/CienaSds.php
@@ -166,7 +166,7 @@ class CienaSds extends OS
 
         foreach ($transceivers as $index => $contents) {
             $portIndex = $interfaceIndexMapping[$index]['IF-MIB::ifIndex'];
-            if (!empty($contents['cienaCesEttpConfigName'])) {
+            if (! empty($contents['cienaCesEttpConfigName'])) {
                 $nameArr = explode('/', $contents['cienaCesEttpConfigName']);
                 $slotIndex = isset($nameArr[1]) ? $nameArr[0] : 1;
 

--- a/mibs/ciena/CIENA-CES-PORT-XCVR-MIB
+++ b/mibs/ciena/CIENA-CES-PORT-XCVR-MIB
@@ -3,991 +3,1066 @@
  -- CIENA-CES-PORT-XCVR-MIB.my
  --
 
- CIENA-CES-PORT-XCVR-MIB DEFINITIONS ::= BEGIN
+  CIENA-CES-PORT-XCVR-MIB DEFINITIONS ::= BEGIN
 
- IMPORTS 		
-   Integer32, Unsigned32, NOTIFICATION-TYPE, OBJECT-TYPE, MODULE-IDENTITY			
-	    FROM SNMPv2-SMI			
-   DisplayString
-	    FROM SNMPv2-TC						
-   cienaCesNotifications, cienaCesConfig
-       FROM CIENA-SMI
-   cienaGlobalSeverity, cienaGlobalMacAddress
-   	   FROM CIENA-GLOBAL-MIB;
-	
-	
- cienaCesPortXcvrMIB MODULE-IDENTITY
-          LAST-UPDATED "201901030000Z"
-          ORGANIZATION "Ciena Corp."
-          CONTACT-INFO
-          "   Mib Meister
-              7035 Ridge Road
-              Hanover, Maryland 21076
-              USA
-              Phone:  +1 800 921 1144
-              Email:  support@ciena.com" 
-          DESCRIPTION
-                   "This module defines the port XCVR related notifications."
-          REVISION
-                   "201901030000Z"
-          DESCRIPTION
-                   "Add Rx/Tx power High/LowWarning Notifications."
-          REVISION
-                   "201809280000Z"
-          DESCRIPTION
-                   "Added cfp, qsfpPlus and qsfp28 in cienaCesPortXcvrIdentiferType.
-                    Added unit information."
-          REVISION
-                   "201806150000Z"
-          DESCRIPTION
-                   "Added a new object cienaCesPortXcvrFecMode."
-             REVISION
-                   "201706070000Z"
-          DESCRIPTION
-                   "Updated contact info."
-             REVISION
-                   "201610070000Z"
-          DESCRIPTION
-                   "Added a new object cienaCesPortXcvrUncertifiedNotification."
-             REVISION
-                   "201108230000Z"
-          DESCRIPTION
-                   "Added a new object cienaCesPortXcvrTxOutputPower."
-             REVISION
-                   "201107060000Z"
-          DESCRIPTION
-                   "Corrected Units changed watts to uW in descriptions."
-       ::= { cienaCesConfig 9 }
-						
- --
- -- Node definitions
- --
-	
- cienaCesPortXcvrMIBObjects OBJECT IDENTIFIER ::= { cienaCesPortXcvrMIB 1 }
- 
- cienaCesPortXcvr  OBJECT IDENTIFIER ::= { cienaCesPortXcvrMIBObjects 1 }
+	IMPORTS
+		cienaGlobalMacAddress
+			FROM CIENA-GLOBAL-MIB
+		cienaCommon, cienaCesConfig, cienaCesNotifications
+			FROM CIENA-SMI
+		CienaGlobalSeverity
+			FROM CIENA-TC
+		enterprises, Unsigned32, MODULE-IDENTITY,
+		OBJECT-IDENTITY, NOTIFICATION-TYPE
+			FROM SNMPv2-SMI
+		DisplayString, MacAddress, TEXTUAL-CONVENTION
+			FROM SNMPv2-TC;
 
- cienaCesPortXcvrNotif  OBJECT IDENTIFIER ::= { cienaCesPortXcvrMIBObjects 2 }
+--
+-- Node definitions
+--
+	-- 1.3.6.1.4.1.1271.2.1.9
+	cienaCesPortXcvrMIB MODULE-IDENTITY
+		LAST-UPDATED "202212070000Z"		-- December 7, 2022 at 00:00 GMT (202212070000Z)
+		ORGANIZATION
+			"Ciena Corp."
+		CONTACT-INFO
+			"   Mib Meister
+			7035 Ridge Road
+			Hanover, Maryland 21076
+			USA
+			Phone:  +1 800 921 1144
+			Email:  support@ciena.com"
+		DESCRIPTION
+			"This module defines the port XCVR related notifications."
+		REVISION "202212070000Z"		-- December 7, 2022 at 00:00 GMT (202212070000Z)
+		DESCRIPTION
+			"Added new objects cienaCesPortXcvrPwrUsage,cienaCesPortXcvrPortNumber
+			and cienaCesPortXcvrPortName to cienaCesPortXcvrTable."
+		REVISION "202103240000Z"		-- March 24, 2021 at 00:00 GMT (202103240000Z)
+		DESCRIPTION
+			"Added a new object cienaCesPortXcvrNotifPortName."
+		REVISION "201907250000Z"		-- July 25, 2019 at 00:00 GMT (201907250000Z)
+		DESCRIPTION
+			"Added cfp2Dco(17) in cienaCesPortXcvrIdentiferType."
+		REVISION "201901030000Z"		-- January 3, 2019 at 00:00 GMT (201901030000Z)
+		DESCRIPTION
+			"Add Rx/Tx power High/LowWarning Notifications."
+		REVISION "201809280000Z"		-- September 28, 2018 at 00:00 GMT (201809280000Z)
+		DESCRIPTION
+			"Added cfp, qsfpPlus and qsfp28 in cienaCesPortXcvrIdentiferType.
+			Added unit information."
+		REVISION "201806150000Z"		-- June 15, 2018 at 00:00 GMT (201806150000Z)
+		DESCRIPTION
+			"Added a new object cienaCesPortXcvrFecMode."
+		REVISION "201805150000Z"		-- May 15, 2018 at 00:00 GMT (201805150000Z)
+		DESCRIPTION
+			"Add TxHigh/LowWarning Notifications"
+		REVISION "201804200000Z"		-- April 20, 2018 at 00:00 GMT (201804200000Z)
+		DESCRIPTION
+			"Add RxHigh/LowWarning Notifications"
+		REVISION "201706070000Z"		-- June 7, 2017 at 00:00 GMT (201706070000Z)
+		DESCRIPTION
+			"Updated contact info."
+		REVISION "201610070000Z"		-- October 7, 2016 at 00:00 GMT (201610070000Z)
+		DESCRIPTION
+			"Added a new object cienaCesPortXcvrUncertifiedNotification."
+		REVISION "201108230000Z"		-- August 23, 2011 at 00:00 GMT (201108230000Z)
+		DESCRIPTION
+			"Added a new object cienaCesPortXcvrTxOutputPower."
+		REVISION "201107060000Z"		-- July 6, 2011 at 00:00 GMT (201107060000Z)
+		DESCRIPTION
+			"Corrected Units changed watts to uW in descriptions."
+	::= { cienaCesConfig 9 }
 
- -- Notifications 
-  
- cienaCesPortXcvrMIBNotificationPrefix  OBJECT IDENTIFIER ::= { cienaCesNotifications 9 } 
- cienaCesPortXcvrMIBNotifications       OBJECT IDENTIFIER ::=  
-                       { cienaCesPortXcvrMIBNotificationPrefix 0 }
+	-- 1.3.6.1.4.1.1271.2.1.9.1
+	cienaCesPortXcvrMIBObjects OBJECT IDENTIFIER ::= { cienaCesPortXcvrMIB 1 }
 
- -- Conformance information 
- 
- cienaCesPortXcvrMIBConformance OBJECT IDENTIFIER ::= { cienaCesPortXcvrMIB 3 } 
- cienaCesPortXcvrMIBCompliances OBJECT IDENTIFIER ::= { cienaCesPortXcvrMIBConformance 1 } 		
- cienaCesPortXcvrMIBGroups      OBJECT IDENTIFIER ::= { cienaCesPortXcvrMIBConformance 2 }
+	-- 1.3.6.1.4.1.1271.2.1.9.1.1
+	cienaCesPortXcvr OBJECT IDENTIFIER ::= { cienaCesPortXcvrMIBObjects 1 }
 
-		
- cienaCesPortXcvrTable OBJECT-TYPE
-    SYNTAX      SEQUENCE OF CienaCesPortXcvrEntry
-    MAX-ACCESS  not-accessible
-    STATUS      current
-    DESCRIPTION
-	    "This table contains descriptions and settings for each of the 
-	     physical transceiver devices."
-    ::= { cienaCesPortXcvr 1 }
-		 
- cienaCesPortXcvrEntry OBJECT-TYPE
-    SYNTAX        CienaCesPortXcvrEntry
-    MAX-ACCESS    not-accessible
-    STATUS        current
-    DESCRIPTION "The transceiver device entry."
-    INDEX { cienaCesPortXcvrId }
-    ::= { cienaCesPortXcvrTable 1 }
+	-- 1.3.6.1.4.1.1271.2.1.9.1.1.1
+	cienaCesPortXcvrTable OBJECT-TYPE
+		SYNTAX SEQUENCE OF CienaCesPortXcvrEntry
+		ACCESS not-accessible
+		STATUS current
+		DESCRIPTION
+			"This table contains descriptions and settings for each of the 
+			physical transceiver devices."
+	::= { cienaCesPortXcvr 1 }
 
- CienaCesPortXcvrEntry ::= SEQUENCE {     
-    cienaCesPortXcvrId                                		INTEGER,    
-    cienaCesPortXcvrOperState                         		INTEGER,  
-    cienaCesPortXcvrTemperature	                     		INTEGER, 
-	cienaCesPortXcvrVcc				                 		INTEGER,
-    cienaCesPortXcvrBias				                 	INTEGER,
-    cienaCesPortXcvrRxPower		 	                 		INTEGER, 
-    cienaCesPortXcvrHighTempAlarmThreshold	         		Integer32,
-    cienaCesPortXcvrLowTempAlarmThreshold	         		Integer32,
-    cienaCesPortXcvrHighVccAlarmThreshold	         		Integer32,
-    cienaCesPortXcvrLowVccAlarmThreshold	             	Integer32,
-    cienaCesPortXcvrHighBiasAlarmThreshold	         		Integer32,
-    cienaCesPortXcvrLowBiasAlarmThreshold	         		Integer32,
-    cienaCesPortXcvrHighTxPwAlarmThreshold	         		Integer32,
-    cienaCesPortXcvrLowTxPwAlarmThreshold	         		Integer32,
-    cienaCesPortXcvrHighRxPwAlarmThreshold	         		Integer32,
-    cienaCesPortXcvrLowRxPwAlarmThreshold	         		Integer32,
-	cienaCesPortXcvrNotifChassisIndex						Unsigned32,
-	cienaCesPortXcvrNotifShelfIndex							Unsigned32, 
-	cienaCesPortXcvrNotifSlotIndex							Unsigned32, 
-	cienaCesPortXcvrNotifPortNumber							Unsigned32,
-    cienaCesPortXcvrIdentiferType   	                    INTEGER,
-    cienaCesPortXcvrExtIdentiferType                  		INTEGER,
-    cienaCesPortXcvrConnectorType                     	    INTEGER, 
-    cienaCesPortXcvrType		                            INTEGER,
-    cienaCesPortXcvrAdminState		   		                INTEGER,
-    cienaCesPortXcvrVendorName	 	                	    DisplayString,
-    cienaCesPortXcvrVendorOUI	 	                        OCTET STRING,
-    cienaCesPortXcvrVendorPartNum                           DisplayString,    
-    cienaCesPortXcvrRevNum                                  DisplayString,
-    cienaCesPortXcvrSerialNum	                            DisplayString,
-    cienaCesPortXcvrMfgDate		                            DisplayString,
-    cienaCesPortXcvrWaveLength	                            INTEGER,
-    cienaCesPortXcvrTxState		                            INTEGER,
-    cienaCesPortXcvrTxFaultStatus                           INTEGER,
-    cienaCesPortXcvrTxOutputPower	                 		INTEGER,
-    cienaCesPortXcvrFecMode                                 INTEGER
- }
-
- cienaCesPortXcvrId OBJECT-TYPE
-    SYNTAX           INTEGER (1..65535)
-    MAX-ACCESS       not-accessible
-    STATUS           current
-    DESCRIPTION
-	    "The ID for the transceiver."
-    ::= { cienaCesPortXcvrEntry 1 } 
-
- cienaCesPortXcvrOperState OBJECT-TYPE
-    SYNTAX           INTEGER {
-                        disabled(1),
-                        enabled(2),
-                        loopback(3),
-                        notPresent(4),
-                        faulted(5)
-                     }
-    MAX-ACCESS       read-only
-    STATUS           current
-    DESCRIPTION
-	    "The operational state of the transceiver."
-    ::= { cienaCesPortXcvrEntry 2 }
-
- cienaCesPortXcvrTemperature OBJECT-TYPE
-    SYNTAX        INTEGER (1..65535)
-    UNITS         "celsius"
-    MAX-ACCESS    read-only
-    STATUS        current
-    DESCRIPTION
-        "The temperature of the transceiver.
-         Units are celsius."
-    ::= { cienaCesPortXcvrEntry 3 }
- 
- cienaCesPortXcvrVcc OBJECT-TYPE
-    SYNTAX        INTEGER (1..65535)
-    UNITS         "mV"
-    MAX-ACCESS    read-only
-    STATUS        current
-    DESCRIPTION
-         "The voltage of the transceiver.
-          Units are milli volts"
-    ::= { cienaCesPortXcvrEntry 4 }
- 
- cienaCesPortXcvrBias OBJECT-TYPE
-    SYNTAX        INTEGER (1..65535)
-    UNITS         "mA"
-    MAX-ACCESS    read-only
-    STATUS        current
-    DESCRIPTION
-        "The bias of the transceiver.
-         Units are milli amps"
-    ::= { cienaCesPortXcvrEntry 5 }
-
- cienaCesPortXcvrRxPower OBJECT-TYPE
-    SYNTAX        INTEGER (1..65535)
-    UNITS         "uW"
-    MAX-ACCESS    read-only
-    STATUS        current
-    DESCRIPTION
-	    "The measured receive power of the transceiver. 
-	     Units are micro watts."
-   ::= { cienaCesPortXcvrEntry 6 }
-
-  cienaCesPortXcvrHighTempAlarmThreshold OBJECT-TYPE
-    SYNTAX        Integer32
-    UNITS         "celsius"
-    MAX-ACCESS    read-only
-    STATUS        current
-    DESCRIPTION
-        "Indicates the higher threshold for the temperature alarm.
-         Units are celsius."
-    ::= { cienaCesPortXcvrEntry 7 }
-  
-  cienaCesPortXcvrLowTempAlarmThreshold OBJECT-TYPE
-    SYNTAX        Integer32
-    UNITS         "celsius"
-    MAX-ACCESS    read-only
-    STATUS        current
-    DESCRIPTION
-        "Indicates the lower threshold for the temperature alarm.
-         Units are celsius."
-    ::= { cienaCesPortXcvrEntry 8 } 
-
-  cienaCesPortXcvrHighVccAlarmThreshold OBJECT-TYPE
-    SYNTAX        Integer32
-    UNITS         "mV"
-    MAX-ACCESS    read-only
-    STATUS        current
-    DESCRIPTION
-        "Indicates the higher threshold for the voltage alarm.
-         Units are milli volts"
-    ::= { cienaCesPortXcvrEntry 9 }
-  
-  cienaCesPortXcvrLowVccAlarmThreshold OBJECT-TYPE
-    SYNTAX        Integer32
-    UNITS         "mV"
-    MAX-ACCESS    read-only
-    STATUS        current
-    DESCRIPTION
-        "Indicates the lower threshold for the voltage alarm.
-         Units are milli volts"
-    ::= { cienaCesPortXcvrEntry 10 }
- 
- cienaCesPortXcvrHighBiasAlarmThreshold OBJECT-TYPE
-    SYNTAX        Integer32
-    UNITS         "mA"
-    MAX-ACCESS    read-only
-    STATUS        current
-    DESCRIPTION
-        "Indicates the higher threshold for the bias alarm.
-         Units are milli amps"
-    ::= { cienaCesPortXcvrEntry 11 }
-
- cienaCesPortXcvrLowBiasAlarmThreshold OBJECT-TYPE
-    SYNTAX        Integer32
-    UNITS         "mA"
-    MAX-ACCESS    read-only
-    STATUS        current
-    DESCRIPTION
-        "Indicates the lower threshold for the bias alarm.
-         Units are milli amps"
-    ::= { cienaCesPortXcvrEntry 12 }
-
- cienaCesPortXcvrHighTxPwAlarmThreshold OBJECT-TYPE
-    SYNTAX        Integer32
-    UNITS         "uW"
-    MAX-ACCESS    read-only
-    STATUS        current
-    DESCRIPTION
-	    "Indicates the higher threshold for the Tx power alarm.
-	     Units are micro watts"
-    ::= { cienaCesPortXcvrEntry 13 }
-
- cienaCesPortXcvrLowTxPwAlarmThreshold OBJECT-TYPE
-    SYNTAX        Integer32
-    UNITS         "uW"
-    MAX-ACCESS    read-only
-    STATUS        current
-    DESCRIPTION
-	    "Indicates the lower threshold for the Tx power alarm.
-	     Units are micro watts."
-    ::= { cienaCesPortXcvrEntry 14 }
-
-  cienaCesPortXcvrHighRxPwAlarmThreshold OBJECT-TYPE
-    SYNTAX        Integer32
-    UNITS         "uW"
-    MAX-ACCESS    read-only
-    STATUS        current
-    DESCRIPTION
-	    "Indicates the higher threshold for the Rx power alarm.
-	     Units are micro watts."
-    ::= { cienaCesPortXcvrEntry 15 }
-
-  cienaCesPortXcvrLowRxPwAlarmThreshold OBJECT-TYPE
-    SYNTAX        Integer32
-    UNITS         "uW"
-    MAX-ACCESS    read-only
-    STATUS        current
-    DESCRIPTION
-	    "Indicates the lower threshold for the Rx power alarm.
-	     Units are micro watts."
-    ::= { cienaCesPortXcvrEntry 16 }
- 
- cienaCesPortXcvrNotifChassisIndex          OBJECT-TYPE
-     SYNTAX          Unsigned32 (1..1)
-     MAX-ACCESS      accessible-for-notify
-     STATUS          current
-     DESCRIPTION
-           "Indicates the chassis index for the port used for trap definition."               
-     ::= { cienaCesPortXcvrEntry 17 }
-     
- cienaCesPortXcvrNotifShelfIndex          OBJECT-TYPE
-     SYNTAX          Unsigned32 (1..1)
-     MAX-ACCESS      accessible-for-notify
-     STATUS          current
-     DESCRIPTION
-           "Indicates the shelf index for the port used for trap definition."               
-     ::= { cienaCesPortXcvrEntry 18 }
-
- cienaCesPortXcvrNotifSlotIndex          OBJECT-TYPE
-     SYNTAX          Unsigned32 (1..7)
-     MAX-ACCESS      accessible-for-notify
-     STATUS          current
-     DESCRIPTION
-           "Indicates the slot index for the port used for trap definition."
-     ::= { cienaCesPortXcvrEntry 19 }
-
- cienaCesPortXcvrNotifPortNumber		OBJECT-TYPE
- 	SYNTAX			Unsigned32(1..65535)
- 	MAX-ACCESS		accessible-for-notify
- 	STATUS			current
- 	DESCRIPTION
- 		"Indicates the port number for the corresponding PGID
- 		used for trap definition."
- 	::= { cienaCesPortXcvrEntry 20 }
-   
- cienaCesPortXcvrIdentiferType OBJECT-TYPE
-    SYNTAX           INTEGER {
-                       unknown(1),
-		               gbic(2),
-		               solderedType(3),
-		               sfp(4),
-                       xbi(5),
-                       xenpak(6),
-                       xfp(7),
-                       xff(8),
-                       xfpe(9),
-                       xpak(10),
-                       x2(11),
-		               reserved(12),
-		               vendorSpecific(13),
-                       cfp(14),
-                       qsfpPlus(15),  
-                       qsfp28(16)
-                     }
-    MAX-ACCESS       read-only
-    STATUS           current
-    DESCRIPTION
-	    "Type for the transceiver."
-    ::= { cienaCesPortXcvrEntry 21 }
-   
- cienaCesPortXcvrExtIdentiferType OBJECT-TYPE
-    SYNTAX           INTEGER 
-    MAX-ACCESS       read-only
-    STATUS           current
-    DESCRIPTION
-	    "Extended identifier type represents for this transceiver."
-    ::= { cienaCesPortXcvrEntry 22 }
-
- cienaCesPortXcvrConnectorType OBJECT-TYPE
-    SYNTAX     		 INTEGER (1..65535)
-    MAX-ACCESS       read-only
-    STATUS           current
-    DESCRIPTION
-	    "Type of connector:
- 
-	       	   unknown(1)
-		       sc(2)
-		       fiberChannelStyle1(3)
-		       fiberChannelStyle2(4)
-		       bnc/tnc(5)
-		       coaxialHeader(6)
-		       fiberJack(7)
-		       lc(8)
-		       mt-rj(9)
-		       mu(10)
-		       sg(11)
-		       opticalPitTail(12)
-		       reserved(13..32)
-		       hssdc(33)
-		       copperPitTail(34)
-		       reserved(35..128)
-		       vendorSpecific(129..256)"
-    ::= { cienaCesPortXcvrEntry 23 }
-
- cienaCesPortXcvrType OBJECT-TYPE
-    SYNTAX           INTEGER (1..65535)
-    MAX-ACCESS       read-only
-    STATUS           current
-    DESCRIPTION
-	    "Type of transceiver."
-    ::= { cienaCesPortXcvrEntry 24 }
-
- cienaCesPortXcvrVendorName OBJECT-TYPE
-    SYNTAX        DisplayString
-    MAX-ACCESS    read-only
-    STATUS        current
-    DESCRIPTION
-	    "String containing this transceiver's vendor name."
-    ::= { cienaCesPortXcvrEntry 25 }
-
- cienaCesPortXcvrVendorOUI OBJECT-TYPE
-    SYNTAX        OCTET STRING(SIZE(0..255))
-    MAX-ACCESS    read-only
-    STATUS        current
-    DESCRIPTION
-	    "String containing this transceiver's vendor OUI."
-    ::= { cienaCesPortXcvrEntry 26 }
-
- cienaCesPortXcvrVendorPartNum OBJECT-TYPE
-    SYNTAX        DisplayString
-    MAX-ACCESS    read-only
-    STATUS        current
-    DESCRIPTION
-	    "String containing this transceiver's vendor part number."
-    ::= { cienaCesPortXcvrEntry 27 }
- 	
- cienaCesPortXcvrRevNum   OBJECT-TYPE
-    SYNTAX         DisplayString
-    MAX-ACCESS     read-only
-    STATUS         current
-    DESCRIPTION
-	    "String containing this tranceiver's part revision number."
-    ::= { cienaCesPortXcvrEntry 28 }
-
- cienaCesPortXcvrSerialNum   OBJECT-TYPE
-    SYNTAX         DisplayString
-    MAX-ACCESS     read-only
-    STATUS         current
-    DESCRIPTION
-	    "String containing this tranceiver's part serial number."
-    ::= { cienaCesPortXcvrEntry 29 } 		
-
- cienaCesPortXcvrMfgDate OBJECT-TYPE
-    SYNTAX        DisplayString
-    MAX-ACCESS    read-only
-    STATUS        current
-    DESCRIPTION
-	    "String containing this transceiver's manufactured date."
-    ::= { cienaCesPortXcvrEntry 30 }
-
- cienaCesPortXcvrWaveLength OBJECT-TYPE
-    SYNTAX        INTEGER (1..65535)
-    MAX-ACCESS    read-only
-    STATUS        current
-    DESCRIPTION
-	    "The wavelength of the transceiver. Units are nano meter."
-    ::= { cienaCesPortXcvrEntry 31 }
-
- cienaCesPortXcvrTxState OBJECT-TYPE
-    SYNTAX       INTEGER {	
-		      enabled(1),
-		      disabled(2)
-	         }
-    MAX-ACCESS   read-only
-    STATUS       current
-    DESCRIPTION
-	    "Indicates whether this transceiver is currently set to transmit."
-    ::= { cienaCesPortXcvrEntry 32 }		
- 		
- cienaCesPortXcvrTxFaultStatus OBJECT-TYPE
-    SYNTAX        INTEGER {	
-		       fault(1),
-		       noFault(2)
-	     	  }
-    MAX-ACCESS    read-only
-    STATUS        current
-    DESCRIPTION
-	    "Indicates the fault status of this transceiver."
-    ::= { cienaCesPortXcvrEntry 33 }
-
- cienaCesPortXcvrAdminState OBJECT-TYPE
-    SYNTAX           INTEGER {
-                        disabled(1),
-                        enabled(2),
-                        loopback(3)                        
-                     }
-    MAX-ACCESS       read-only
-    STATUS           current
-    DESCRIPTION
-	    "The administrative state of the transceiver."
-    ::= { cienaCesPortXcvrEntry 34 }
-   
-  cienaCesPortXcvrTxOutputPower OBJECT-TYPE
-    SYNTAX        INTEGER (1..65535)
-    UNITS         "uW"
-    MAX-ACCESS    read-only
-    STATUS        current
-    DESCRIPTION
-	    "The measured transmitted output power of the transceiver. 
-	     Units are micro watts."
-    ::= { cienaCesPortXcvrEntry 35 }
-
-  cienaCesPortXcvrFecMode OBJECT-TYPE
-    SYNTAX        INTEGER {
-                        none(1),	
-                        gfec(2),
-                        efec(3)
-                  }
-    MAX-ACCESS    read-only
-    STATUS        current
-    DESCRIPTION
-        "This represents the transceiver's FEC Mode.
-         gfec means generic forward error correction,
-         efec means enhanced forward error correction."
-   ::= { cienaCesPortXcvrEntry 36 }
+	-- 1.3.6.1.4.1.1271.2.1.9.1.1.1.1
+	cienaCesPortXcvrEntry OBJECT-TYPE
+		SYNTAX CienaCesPortXcvrEntry
+		ACCESS not-accessible
+		STATUS current
+		DESCRIPTION
+			"The transceiver device entry."
+		INDEX { cienaCesPortXcvrId } 
+	::= { cienaCesPortXcvrTable 1 }
 
 
- --
- -- notification
- --
- cienaCesPortXcvrEventType OBJECT-TYPE
-    SYNTAX         INTEGER {
-                        inserted(1),
-                        removed(2)
-                   }                         
-    MAX-ACCESS     read-only
-    STATUS         current
-    DESCRIPTION
-	    "Indicates if the transceiver specified by the ciena54XXPortXcvrId has come up, 
-	     gone down or has been selected."
-    ::= { cienaCesPortXcvrNotif 1}
-
-  cienaCesPortXcvrErrorType OBJECT-TYPE
-    SYNTAX         INTEGER {
-                        none(0),
-                        chksumFailed(1),
-                        opticalFault(2)                        
-                   }
-    MAX-ACCESS     accessible-for-notify
-    STATUS         current
-    DESCRIPTION
-	    "Indicates if the transceiver specified by the cienaCesPortXcvrId is faulted because of 
-	     checksum failure or optical fault. This object only makes sense if the transceiver has 
-	     been detected faulted; otherwise it returns 'none'."
-    ::= { cienaCesPortXcvrNotif 2 } 
- 
- cienaCesPortXcvrRemovedNotification NOTIFICATION-TYPE
-	OBJECTS	{   cienaGlobalSeverity, 
-				cienaGlobalMacAddress,            
-     			cienaCesPortXcvrNotifChassisIndex,
-        		cienaCesPortXcvrNotifShelfIndex,
-        		cienaCesPortXcvrNotifSlotIndex,
-        		cienaCesPortXcvrNotifPortNumber
+	CienaCesPortXcvrEntry ::= SEQUENCE
+		{
+		cienaCesPortXcvrId INTEGER,
+		cienaCesPortXcvrOperState INTEGER,
+		cienaCesPortXcvrTemperature INTEGER,
+		cienaCesPortXcvrVcc INTEGER,
+		cienaCesPortXcvrBias INTEGER,
+		cienaCesPortXcvrRxPower INTEGER,
+		cienaCesPortXcvrHighTempAlarmThreshold Integer32,
+		cienaCesPortXcvrLowTempAlarmThreshold Integer32,
+		cienaCesPortXcvrHighVccAlarmThreshold Integer32,
+		cienaCesPortXcvrLowVccAlarmThreshold Integer32,
+		cienaCesPortXcvrHighBiasAlarmThreshold Integer32,
+		cienaCesPortXcvrLowBiasAlarmThreshold Integer32,
+		cienaCesPortXcvrHighTxPwAlarmThreshold Integer32,
+		cienaCesPortXcvrLowTxPwAlarmThreshold Integer32,
+		cienaCesPortXcvrHighRxPwAlarmThreshold Integer32,
+		cienaCesPortXcvrLowRxPwAlarmThreshold Integer32,
+		cienaCesPortXcvrNotifChassisIndex Unsigned32,
+		cienaCesPortXcvrNotifShelfIndex Unsigned32,
+		cienaCesPortXcvrNotifSlotIndex Unsigned32,
+		cienaCesPortXcvrNotifPortNumber Unsigned32,
+		cienaCesPortXcvrIdentiferType INTEGER,
+		cienaCesPortXcvrExtIdentiferType INTEGER,
+		cienaCesPortXcvrConnectorType INTEGER,
+		cienaCesPortXcvrType INTEGER,
+		cienaCesPortXcvrAdminState INTEGER,
+		cienaCesPortXcvrVendorName DisplayString,
+		cienaCesPortXcvrVendorOUI OCTET STRING,
+		cienaCesPortXcvrVendorPartNum DisplayString,
+		cienaCesPortXcvrRevNum DisplayString,
+		cienaCesPortXcvrSerialNum DisplayString,
+		cienaCesPortXcvrMfgDate DisplayString,
+		cienaCesPortXcvrWaveLength INTEGER,
+		cienaCesPortXcvrTxState INTEGER,
+		cienaCesPortXcvrTxFaultStatus INTEGER,
+		cienaCesPortXcvrTxOutputPower INTEGER,
+		cienaCesPortXcvrFecMode INTEGER,
+		cienaCesPortXcvrNotifPortName DisplayString,
+		cienaCesPortXcvrPwrUsage Unsigned32,
+		cienaCesPortXcvrPortNumber Unsigned32,
+		cienaCesPortXcvrPortName DisplayString
 		}
-	STATUS	current
-	DESCRIPTION
-		"A cienaCesPortXcvrRemovedNotification is sent if the transceiver has been removed. 
-		To enable the device to send this notification: cienaCesPortXcvrLinkStateChangeTrapState, 
-		cienaCesLogicalPortConfigPortAllTrapState, and cienaCesPortAllTrapState need to be set to 
-		enabled. These objects are set to enabled by default. Variable bindings include: 
-		cienaGlobalSeverity, cienaGlobalMacAddress, cienaCesPortXcvrNotifChassisIndex, 
-		cienaCesPortXcvrNotifShelfIndex, cienaCesPortXcvrNotifSlotIndex, and 
-		cienaCesPortXcvrNotifPortNumber."
+
+	-- 1.3.6.1.4.1.1271.2.1.9.1.1.1.1.1
+	cienaCesPortXcvrId OBJECT-TYPE
+		SYNTAX INTEGER (1..65535)
+		ACCESS not-accessible
+		STATUS current
+		DESCRIPTION
+			"The ID for the transceiver."
+	::= { cienaCesPortXcvrEntry 1 }
+
+	-- 1.3.6.1.4.1.1271.2.1.9.1.1.1.1.2
+	cienaCesPortXcvrOperState OBJECT-TYPE
+		SYNTAX INTEGER
+		{
+			disabled(1),
+			enabled(2),
+			loopback(3),
+			notPresent(4),
+			faulted(5)
+		}
+		ACCESS read-only
+		STATUS current
+		DESCRIPTION
+			"The operational state of the transceiver."
+	::= { cienaCesPortXcvrEntry 2 }
+
+	-- 1.3.6.1.4.1.1271.2.1.9.1.1.1.1.3
+	cienaCesPortXcvrTemperature OBJECT-TYPE
+		SYNTAX INTEGER (1..65535)
+		UNITS
+			"celsius"
+		ACCESS read-only
+		STATUS current
+		DESCRIPTION
+			"The temperature of the transceiver.
+			Units are celsius."
+	::= { cienaCesPortXcvrEntry 3 }
+
+	-- 1.3.6.1.4.1.1271.2.1.9.1.1.1.1.4
+	cienaCesPortXcvrVcc OBJECT-TYPE
+		SYNTAX INTEGER (1..65535)
+		UNITS
+			"mV"
+		ACCESS read-only
+		STATUS current
+		DESCRIPTION
+			"The voltage of the transceiver.
+			Units are milli volts"
+	::= { cienaCesPortXcvrEntry 4 }
+
+	-- 1.3.6.1.4.1.1271.2.1.9.1.1.1.1.5
+	cienaCesPortXcvrBias OBJECT-TYPE
+		SYNTAX INTEGER (1..65535)
+		UNITS
+			"mA"
+		ACCESS read-only
+		STATUS current
+		DESCRIPTION
+			"The bias of the transceiver.
+			Units are milli amps"
+	::= { cienaCesPortXcvrEntry 5 }
+
+	-- 1.3.6.1.4.1.1271.2.1.9.1.1.1.1.6
+	cienaCesPortXcvrRxPower OBJECT-TYPE
+		SYNTAX INTEGER (1..65535)
+		UNITS
+			"uW"
+		ACCESS read-only
+		STATUS current
+		DESCRIPTION
+			"The measured receive power of the transceiver. 
+			Units are micro watts."
+	::= { cienaCesPortXcvrEntry 6 }
+
+	-- 1.3.6.1.4.1.1271.2.1.9.1.1.1.1.7
+	cienaCesPortXcvrHighTempAlarmThreshold OBJECT-TYPE
+		SYNTAX Integer32
+		UNITS
+			"celsius"
+		ACCESS read-only
+		STATUS current
+		DESCRIPTION
+			"Indicates the higher threshold for the temperature alarm.
+			Units are celsius."
+	::= { cienaCesPortXcvrEntry 7 }
+
+	-- 1.3.6.1.4.1.1271.2.1.9.1.1.1.1.8
+	cienaCesPortXcvrLowTempAlarmThreshold OBJECT-TYPE
+		SYNTAX Integer32
+		UNITS
+			"celsius"
+		ACCESS read-only
+		STATUS current
+		DESCRIPTION
+			"Indicates the lower threshold for the temperature alarm.
+			Units are celsius."
+	::= { cienaCesPortXcvrEntry 8 }
+
+	-- 1.3.6.1.4.1.1271.2.1.9.1.1.1.1.9
+	cienaCesPortXcvrHighVccAlarmThreshold OBJECT-TYPE
+		SYNTAX Integer32
+		UNITS
+			"mV"
+		ACCESS read-only
+		STATUS current
+		DESCRIPTION
+			"Indicates the higher threshold for the voltage alarm.
+			Units are milli volts"
+	::= { cienaCesPortXcvrEntry 9 }
+
+	-- 1.3.6.1.4.1.1271.2.1.9.1.1.1.1.10
+	cienaCesPortXcvrLowVccAlarmThreshold OBJECT-TYPE
+		SYNTAX Integer32
+		UNITS
+			"mV"
+		ACCESS read-only
+		STATUS current
+		DESCRIPTION
+			"Indicates the lower threshold for the voltage alarm.
+			Units are milli volts"
+	::= { cienaCesPortXcvrEntry 10 }
+
+	-- 1.3.6.1.4.1.1271.2.1.9.1.1.1.1.11
+	cienaCesPortXcvrHighBiasAlarmThreshold OBJECT-TYPE
+		SYNTAX Integer32
+		UNITS
+			"mA"
+		ACCESS read-only
+		STATUS current
+		DESCRIPTION
+			"Indicates the higher threshold for the bias alarm.
+			Units are milli amps"
+	::= { cienaCesPortXcvrEntry 11 }
+
+	-- 1.3.6.1.4.1.1271.2.1.9.1.1.1.1.12
+	cienaCesPortXcvrLowBiasAlarmThreshold OBJECT-TYPE
+		SYNTAX Integer32
+		UNITS
+			"mA"
+		ACCESS read-only
+		STATUS current
+		DESCRIPTION
+			"Indicates the lower threshold for the bias alarm.
+			Units are milli amps"
+	::= { cienaCesPortXcvrEntry 12 }
+
+	-- 1.3.6.1.4.1.1271.2.1.9.1.1.1.1.13
+	cienaCesPortXcvrHighTxPwAlarmThreshold OBJECT-TYPE
+		SYNTAX Integer32
+		UNITS
+			"uW"
+		ACCESS read-only
+		STATUS current
+		DESCRIPTION
+			"Indicates the higher threshold for the Tx power alarm.
+			Units are micro watts"
+	::= { cienaCesPortXcvrEntry 13 }
+
+	-- 1.3.6.1.4.1.1271.2.1.9.1.1.1.1.14
+	cienaCesPortXcvrLowTxPwAlarmThreshold OBJECT-TYPE
+		SYNTAX Integer32
+		UNITS
+			"uW"
+		ACCESS read-only
+		STATUS current
+		DESCRIPTION
+			"Indicates the lower threshold for the Tx power alarm.
+			Units are micro watts."
+	::= { cienaCesPortXcvrEntry 14 }
+
+	-- 1.3.6.1.4.1.1271.2.1.9.1.1.1.1.15
+	cienaCesPortXcvrHighRxPwAlarmThreshold OBJECT-TYPE
+		SYNTAX Integer32
+		UNITS
+			"uW"
+		ACCESS read-only
+		STATUS current
+		DESCRIPTION
+			"Indicates the higher threshold for the Rx power alarm.
+			Units are micro watts."
+	::= { cienaCesPortXcvrEntry 15 }
+
+	-- 1.3.6.1.4.1.1271.2.1.9.1.1.1.1.16
+	cienaCesPortXcvrLowRxPwAlarmThreshold OBJECT-TYPE
+		SYNTAX Integer32
+		UNITS
+			"uW"
+		ACCESS read-only
+		STATUS current
+		DESCRIPTION
+			"Indicates the lower threshold for the Rx power alarm.
+			Units are micro watts."
+	::= { cienaCesPortXcvrEntry 16 }
+
+	-- 1.3.6.1.4.1.1271.2.1.9.1.1.1.1.17
+	cienaCesPortXcvrNotifChassisIndex OBJECT-TYPE
+		SYNTAX Unsigned32 (1)
+		ACCESS accessible-for-notify
+		STATUS current
+		DESCRIPTION
+			"Indicates the chassis index for the port used for trap definition."
+	::= { cienaCesPortXcvrEntry 17 }
+
+	-- 1.3.6.1.4.1.1271.2.1.9.1.1.1.1.18
+	cienaCesPortXcvrNotifShelfIndex OBJECT-TYPE
+		SYNTAX Unsigned32 (1)
+		ACCESS accessible-for-notify
+		STATUS current
+		DESCRIPTION
+			"Indicates the shelf index for the port used for trap definition."
+	::= { cienaCesPortXcvrEntry 18 }
+
+	-- 1.3.6.1.4.1.1271.2.1.9.1.1.1.1.19
+	cienaCesPortXcvrNotifSlotIndex OBJECT-TYPE
+		SYNTAX Unsigned32 (1..7)
+		ACCESS accessible-for-notify
+		STATUS current
+		DESCRIPTION
+			"Indicates the slot index for the port used for trap definition."
+	::= { cienaCesPortXcvrEntry 19 }
+
+	-- 1.3.6.1.4.1.1271.2.1.9.1.1.1.1.20
+	cienaCesPortXcvrNotifPortNumber OBJECT-TYPE
+		SYNTAX Unsigned32 (1..65535)
+		ACCESS accessible-for-notify
+		STATUS current
+		DESCRIPTION
+			"Indicates the port number for the corresponding PGID
+			used for trap definition."
+	::= { cienaCesPortXcvrEntry 20 }
+
+	-- 1.3.6.1.4.1.1271.2.1.9.1.1.1.1.21
+	cienaCesPortXcvrIdentiferType OBJECT-TYPE
+		SYNTAX INTEGER
+		{
+			unknown(1),
+			gbic(2),
+			solderedType(3),
+			sfp(4),
+			xbi(5),
+			xenpak(6),
+			xfp(7),
+			xff(8),
+			xfpe(9),
+			xpak(10),
+			x2(11),
+			reserved(12),
+			vendorSpecific(13),
+			cfp(14),
+			qsfpPlus(15),
+			qsfp28(16),
+			cfp2Dco(17)
+		}
+		ACCESS read-only
+		STATUS current
+		DESCRIPTION
+			"Type for the transceiver."
+	::= { cienaCesPortXcvrEntry 21 }
+
+	-- 1.3.6.1.4.1.1271.2.1.9.1.1.1.1.22
+	cienaCesPortXcvrExtIdentiferType OBJECT-TYPE
+		SYNTAX INTEGER
+		ACCESS read-only
+		STATUS current
+		DESCRIPTION
+			"Extended identifier type represents for this transceiver."
+	::= { cienaCesPortXcvrEntry 22 }
+
+	-- 1.3.6.1.4.1.1271.2.1.9.1.1.1.1.23
+	cienaCesPortXcvrConnectorType OBJECT-TYPE
+		SYNTAX INTEGER (1..65535)
+		ACCESS read-only
+		STATUS current
+		DESCRIPTION
+			"Type of connector:
+			
+			unknown(1)
+			sc(2)
+			fiberChannelStyle1(3)
+			fiberChannelStyle2(4)
+			bnc/tnc(5)
+			coaxialHeader(6)
+			fiberJack(7)
+			lc(8)
+			mt-rj(9)
+			mu(10)
+			sg(11)
+			opticalPitTail(12)
+			reserved(13..32)
+			hssdc(33)
+			copperPitTail(34)
+			reserved(35..128)
+			vendorSpecific(129..256)"
+	::= { cienaCesPortXcvrEntry 23 }
+
+	-- 1.3.6.1.4.1.1271.2.1.9.1.1.1.1.24
+	cienaCesPortXcvrType OBJECT-TYPE
+		SYNTAX INTEGER (1..65535)
+		ACCESS read-only
+		STATUS current
+		DESCRIPTION
+			"Type of transceiver."
+	::= { cienaCesPortXcvrEntry 24 }
+
+	-- 1.3.6.1.4.1.1271.2.1.9.1.1.1.1.25
+	cienaCesPortXcvrVendorName OBJECT-TYPE
+		SYNTAX DisplayString
+		ACCESS read-only
+		STATUS current
+		DESCRIPTION
+			"String containing this transceiver's vendor name."
+	::= { cienaCesPortXcvrEntry 25 }
+
+	-- 1.3.6.1.4.1.1271.2.1.9.1.1.1.1.26
+	cienaCesPortXcvrVendorOUI OBJECT-TYPE
+		SYNTAX OCTET STRING (SIZE (0..255))
+		ACCESS read-only
+		STATUS current
+		DESCRIPTION
+			"String containing this transceiver's vendor OUI."
+	::= { cienaCesPortXcvrEntry 26 }
+
+	-- 1.3.6.1.4.1.1271.2.1.9.1.1.1.1.27
+	cienaCesPortXcvrVendorPartNum OBJECT-TYPE
+		SYNTAX DisplayString
+		ACCESS read-only
+		STATUS current
+		DESCRIPTION
+			"String containing this transceiver's vendor part number."
+	::= { cienaCesPortXcvrEntry 27 }
+
+	-- 1.3.6.1.4.1.1271.2.1.9.1.1.1.1.28
+	cienaCesPortXcvrRevNum OBJECT-TYPE
+		SYNTAX DisplayString
+		ACCESS read-only
+		STATUS current
+		DESCRIPTION
+			"String containing this tranceiver's part revision number."
+	::= { cienaCesPortXcvrEntry 28 }
+
+	-- 1.3.6.1.4.1.1271.2.1.9.1.1.1.1.29
+	cienaCesPortXcvrSerialNum OBJECT-TYPE
+		SYNTAX DisplayString
+		ACCESS read-only
+		STATUS current
+		DESCRIPTION
+			"String containing this tranceiver's part serial number."
+	::= { cienaCesPortXcvrEntry 29 }
+
+	-- 1.3.6.1.4.1.1271.2.1.9.1.1.1.1.30
+	cienaCesPortXcvrMfgDate OBJECT-TYPE
+		SYNTAX DisplayString
+		ACCESS read-only
+		STATUS current
+		DESCRIPTION
+			"String containing this transceiver's manufactured date."
+	::= { cienaCesPortXcvrEntry 30 }
+
+	-- 1.3.6.1.4.1.1271.2.1.9.1.1.1.1.31
+	cienaCesPortXcvrWaveLength OBJECT-TYPE
+		SYNTAX INTEGER (1..65535)
+		ACCESS read-only
+		STATUS current
+		DESCRIPTION
+			"The wavelength of the transceiver. Units are nano meter."
+	::= { cienaCesPortXcvrEntry 31 }
+
+	-- 1.3.6.1.4.1.1271.2.1.9.1.1.1.1.32
+	cienaCesPortXcvrTxState OBJECT-TYPE
+		SYNTAX INTEGER
+		{
+			enabled(1),
+			disabled(2)
+		}
+		ACCESS read-only
+		STATUS current
+		DESCRIPTION
+			"Indicates whether this transceiver is currently set to transmit."
+	::= { cienaCesPortXcvrEntry 32 }
+
+	-- 1.3.6.1.4.1.1271.2.1.9.1.1.1.1.33
+	cienaCesPortXcvrTxFaultStatus OBJECT-TYPE
+		SYNTAX INTEGER
+		{
+			fault(1),
+			noFault(2)
+		}
+		ACCESS read-only
+		STATUS current
+		DESCRIPTION
+			"Indicates the fault status of this transceiver."
+	::= { cienaCesPortXcvrEntry 33 }
+
+	-- 1.3.6.1.4.1.1271.2.1.9.1.1.1.1.34
+	cienaCesPortXcvrAdminState OBJECT-TYPE
+		SYNTAX INTEGER
+		{
+			disabled(1),
+			enabled(2),
+			loopback(3)
+		}
+		ACCESS read-only
+		STATUS current
+		DESCRIPTION
+			"The administrative state of the transceiver."
+	::= { cienaCesPortXcvrEntry 34 }
+
+	-- 1.3.6.1.4.1.1271.2.1.9.1.1.1.1.35
+	cienaCesPortXcvrTxOutputPower OBJECT-TYPE
+		SYNTAX INTEGER (1..65535)
+		UNITS
+			"uW"
+		ACCESS read-only
+		STATUS current
+		DESCRIPTION
+			"The measured transmitted output power of the transceiver. 
+			Units are micro watts."
+	::= { cienaCesPortXcvrEntry 35 }
+
+	-- 1.3.6.1.4.1.1271.2.1.9.1.1.1.1.36
+	cienaCesPortXcvrFecMode OBJECT-TYPE
+		SYNTAX INTEGER
+		{
+			none(1),
+			gfec(2),
+			efec(3)
+		}
+		ACCESS read-only
+		STATUS current
+		DESCRIPTION
+			"This represents the transceiver's FEC Mode.
+			gfec means generic forward error correction,
+			efec means enhanced forward error correction."
+	::= { cienaCesPortXcvrEntry 36 }
+
+	-- 1.3.6.1.4.1.1271.2.1.9.1.1.1.1.37
+	cienaCesPortXcvrNotifPortName OBJECT-TYPE
+		SYNTAX DisplayString
+		ACCESS accessible-for-notify
+		STATUS current
+		DESCRIPTION
+			"Indicates the port name for the corresponding PGID
+			used for trap definition."
+	::= { cienaCesPortXcvrEntry 37 }
+
+	-- 1.3.6.1.4.1.1271.2.1.9.1.1.1.1.38
+	cienaCesPortXcvrPwrUsage OBJECT-TYPE
+		SYNTAX Unsigned32
+		UNITS
+			"uW"
+		ACCESS read-only
+		STATUS current
+		DESCRIPTION
+			"The measured power consumed by the transceiver.
+			Units are micro watts."
+	::= { cienaCesPortXcvrEntry 38 }
+
+	-- 1.3.6.1.4.1.1271.2.1.9.1.1.1.1.39
+	cienaCesPortXcvrPortNumber OBJECT-TYPE
+		SYNTAX Unsigned32 (1..65535)
+		ACCESS read-only
+		STATUS current
+		DESCRIPTION
+			"Indicates the port name for the corresponding PGID"
+	::= { cienaCesPortXcvrEntry 39 }
+
+	-- 1.3.6.1.4.1.1271.2.1.9.1.1.1.1.40
+	cienaCesPortXcvrPortName OBJECT-TYPE
+		SYNTAX DisplayString
+		ACCESS read-only
+		STATUS current
+		DESCRIPTION
+			"Indicates the port name for the corresponding PGID"
+	::= { cienaCesPortXcvrEntry 40 }
+
+	-- 1.3.6.1.4.1.1271.2.1.9.1.2
+	cienaCesPortXcvrNotif OBJECT IDENTIFIER ::= { cienaCesPortXcvrMIBObjects 2 }
+
+	-- 1.3.6.1.4.1.1271.2.1.9.1.2.1
+	cienaCesPortXcvrEventType OBJECT-TYPE
+		SYNTAX INTEGER
+		{
+			inserted(1),
+			removed(2)
+		}
+		ACCESS read-only
+		STATUS current
+		DESCRIPTION
+			"Indicates if the transceiver specified by the ciena54XXPortXcvrId has come up, 
+			gone down or has been selected."
+	::= { cienaCesPortXcvrNotif 1 }
+
+	-- 1.3.6.1.4.1.1271.2.1.9.1.2.2
+	cienaCesPortXcvrErrorType OBJECT-TYPE
+		SYNTAX INTEGER
+		{
+			none(0),
+			chksumFailed(1),
+			opticalFault(2)
+		}
+		ACCESS accessible-for-notify
+		STATUS current
+		DESCRIPTION
+			"Indicates if the transceiver specified by the cienaCesPortXcvrId is faulted because of 
+			checksum failure or optical fault. This object only makes sense if the transceiver has 
+			been detected faulted; otherwise it returns 'none'."
+	::= { cienaCesPortXcvrNotif 2 }
+
+	-- 1.3.6.1.4.1.1271.2.1.9.3
+	cienaCesPortXcvrMIBConformance OBJECT IDENTIFIER ::= { cienaCesPortXcvrMIB 3 }
+
+	-- 1.3.6.1.4.1.1271.2.1.9.3.1
+	cienaCesPortXcvrMIBCompliances OBJECT IDENTIFIER ::= { cienaCesPortXcvrMIBConformance 1 }
+
+	-- 1.3.6.1.4.1.1271.2.1.9.3.2
+	cienaCesPortXcvrMIBGroups OBJECT IDENTIFIER ::= { cienaCesPortXcvrMIBConformance 2 }
+
+	-- 1.3.6.1.4.1.1271.2.2.9
+	cienaCesPortXcvrMIBNotificationPrefix OBJECT IDENTIFIER ::= { cienaCesNotifications 9 }
+
+	-- 1.3.6.1.4.1.1271.2.2.9.0
+	cienaCesPortXcvrMIBNotifications OBJECT IDENTIFIER ::= { cienaCesPortXcvrMIBNotificationPrefix 0 }
+
+	-- 1.3.6.1.4.1.1271.2.2.9.0.1
+	cienaCesPortXcvrRemovedNotification NOTIFICATION-TYPE
+		OBJECTS { cienaGlobalSeverity, cienaGlobalMacAddress, 
+		cienaCesPortXcvrNotifChassisIndex, cienaCesPortXcvrNotifShelfIndex, 
+		cienaCesPortXcvrNotifSlotIndex, cienaCesPortXcvrNotifPortNumber, 
+		cienaCesPortXcvrNotifPortName } 
+		STATUS current
+		DESCRIPTION
+			"A cienaCesPortXcvrRemovedNotification is sent if the transceiver has been removed. 
+			To enable the device to send this notification: cienaCesPortXcvrLinkStateChangeTrapState, 
+			cienaCesLogicalPortConfigPortAllTrapState, and cienaCesPortAllTrapState need to be set to 
+			enabled. These objects are set to enabled by default. Variable bindings include: 
+			cienaGlobalSeverity, cienaGlobalMacAddress, cienaCesPortXcvrNotifChassisIndex, 
+			cienaCesPortXcvrNotifShelfIndex, cienaCesPortXcvrNotifSlotIndex, cienaCesPortXcvrNotifPortNumber
+			and cienaCesPortXcvrNotifPortName."
 	::= { cienaCesPortXcvrMIBNotifications 1 }
 
- cienaCesPortXcvrInsertedNotification NOTIFICATION-TYPE
-	OBJECTS	{   cienaGlobalSeverity, 
-				cienaGlobalMacAddress,            
-     			cienaCesPortXcvrNotifChassisIndex,
-        		cienaCesPortXcvrNotifShelfIndex,
-        		cienaCesPortXcvrNotifSlotIndex,
-        		cienaCesPortXcvrNotifPortNumber
-		}
-	STATUS	current
-	DESCRIPTION
-		"A cienaCesPortXcvrInsertedNotification is sent if the transceiver has been inserted. To 
-		enable the device to send this notification: cienaCesPortXcvrLinkStateChangeTrapState, 
-		cienaCesLogicalPortConfigPortAllTrapState, and cienaCesPortAllTrapState need to be set to 
-		enabled. These objects are set to enabled by default. Variable bindings include: 
-		cienaGlobalSeverity, cienaGlobalMacAddress, cienaCesPortXcvrNotifChassisIndex, 
-		cienaCesPortXcvrNotifShelfIndex, cienaCesPortXcvrNotifSlotIndex, and 
-		cienaCesPortXcvrNotifPortNumber."
+	-- 1.3.6.1.4.1.1271.2.2.9.0.2
+	cienaCesPortXcvrInsertedNotification NOTIFICATION-TYPE
+		OBJECTS { cienaGlobalSeverity, cienaGlobalMacAddress, 
+		cienaCesPortXcvrNotifChassisIndex, cienaCesPortXcvrNotifShelfIndex, 
+		cienaCesPortXcvrNotifSlotIndex, cienaCesPortXcvrNotifPortNumber, 
+		cienaCesPortXcvrNotifPortName } 
+		STATUS current
+		DESCRIPTION
+			"A cienaCesPortXcvrInsertedNotification is sent if the transceiver has been inserted. To 
+			enable the device to send this notification: cienaCesPortXcvrLinkStateChangeTrapState, 
+			cienaCesLogicalPortConfigPortAllTrapState, and cienaCesPortAllTrapState need to be set to 
+			enabled. These objects are set to enabled by default. Variable bindings include: 
+			cienaGlobalSeverity, cienaGlobalMacAddress, cienaCesPortXcvrNotifChassisIndex, 
+			cienaCesPortXcvrNotifShelfIndex, cienaCesPortXcvrNotifSlotIndex, cienaCesPortXcvrNotifPortNumber
+			and cienaCesPortXcvrNotifPortName."
 	::= { cienaCesPortXcvrMIBNotifications 2 }
 
- cienaCesPortXcvrErrorTypeNotification NOTIFICATION-TYPE
-	OBJECTS	{	cienaGlobalSeverity,
-				cienaGlobalMacAddress,                
-        		cienaCesPortXcvrNotifChassisIndex,
-        		cienaCesPortXcvrNotifShelfIndex,
-        		cienaCesPortXcvrNotifSlotIndex,
-        		cienaCesPortXcvrNotifPortNumber,
-				cienaCesPortXcvrErrorType        
-		}
-	STATUS	current
-	DESCRIPTION
-		"A cienaCesPortXcvrErrorTypeNotification is sent if the transceiver is detected to be faulted.
-		The reason for the failure is specified by cienaCesPortXcvrErrorType. To enable the device to 
-		send this notification: cienaCesPortXcvrErrorTrapState, cienaCesLogicalPortConfigPortAllTrapState,
-		and cienaCesPortAllTrapState need to be set to enabled. These objects are enabled by default. 
-		Variable bindings include: cienaGlobalSeverity, cienaGlobalMacAddress, 
-		cienaCesPortXcvrNotifChassisIndex, cienaCesPortXcvrNotifShelfIndex, cienaCesPortXcvrNotifSlotIndex, 
-		cienaCesPortXcvrNotifPortNumber, and cienaCesPortXcvrErrorType."
-::= { cienaCesPortXcvrMIBNotifications 5 }
+	-- 1.3.6.1.4.1.1271.2.2.9.0.5
+	cienaCesPortXcvrErrorTypeNotification NOTIFICATION-TYPE
+		OBJECTS { cienaGlobalSeverity, cienaGlobalMacAddress, 
+		cienaCesPortXcvrNotifChassisIndex, cienaCesPortXcvrNotifShelfIndex, 
+		cienaCesPortXcvrNotifSlotIndex, cienaCesPortXcvrNotifPortNumber, 
+		cienaCesPortXcvrErrorType, cienaCesPortXcvrNotifPortName } 
+		STATUS current
+		DESCRIPTION
+			"A cienaCesPortXcvrErrorTypeNotification is sent if the transceiver is detected to be faulted.
+			The reason for the failure is specified by cienaCesPortXcvrErrorType. To enable the device to 
+			send this notification: cienaCesPortXcvrErrorTrapState, cienaCesLogicalPortConfigPortAllTrapState,
+			and cienaCesPortAllTrapState need to be set to enabled. These objects are enabled by default. 
+			Variable bindings include: cienaGlobalSeverity, cienaGlobalMacAddress, 
+			cienaCesPortXcvrNotifChassisIndex, cienaCesPortXcvrNotifShelfIndex, cienaCesPortXcvrNotifSlotIndex, 
+			cienaCesPortXcvrNotifPortNumber, cienaCesPortXcvrErrorType and cienaCesPortXcvrNotifPortName."
+	::= { cienaCesPortXcvrMIBNotifications 5 }
 
- cienaCesPortXcvrTempHighNotification NOTIFICATION-TYPE
-	OBJECTS	{   cienaGlobalSeverity, 
-				cienaGlobalMacAddress,            
-   			    cienaCesPortXcvrNotifChassisIndex,
-        		cienaCesPortXcvrNotifShelfIndex,
-        		cienaCesPortXcvrNotifSlotIndex,
-        		cienaCesPortXcvrNotifPortNumber
-		}
-	STATUS	current
-	DESCRIPTION
-		"A cienaCesPortXcvrTempHighNotification is sent if the transceiver temperature exceeds the 
-		threshold. To enable the device to send this notification: cienaCesPortXcvrTempChangeTrapState, 
-		cienaCesLogicalPortConfigPortAllTrapState, and cienaCesPortAllTrapState need to be set to enabled.
-		These objects are set to enabled by default. Variable bindings include: cienaGlobalSeverity,
-		cienaGlobalMacAddress, cienaCesPortXcvrNotifChassisIndex, cienaCesPortXcvrNotifShelfIndex, 
-		cienaCesPortXcvrNotifSlotIndex, and cienaCesPortXcvrNotifPortNumber."
+	-- 1.3.6.1.4.1.1271.2.2.9.0.6
+	cienaCesPortXcvrTempHighNotification NOTIFICATION-TYPE
+		OBJECTS { cienaGlobalSeverity, cienaGlobalMacAddress, 
+		cienaCesPortXcvrNotifChassisIndex, cienaCesPortXcvrNotifShelfIndex, 
+		cienaCesPortXcvrNotifSlotIndex, cienaCesPortXcvrNotifPortNumber, 
+		cienaCesPortXcvrNotifPortName } 
+		STATUS current
+		DESCRIPTION
+			"A cienaCesPortXcvrTempHighNotification is sent if the transceiver temperature exceeds the 
+			threshold. To enable the device to send this notification: cienaCesPortXcvrTempChangeTrapState, 
+			cienaCesLogicalPortConfigPortAllTrapState, and cienaCesPortAllTrapState need to be set to enabled.
+			These objects are set to enabled by default. Variable bindings include: cienaGlobalSeverity,
+			cienaGlobalMacAddress, cienaCesPortXcvrNotifChassisIndex, cienaCesPortXcvrNotifShelfIndex, 
+			cienaCesPortXcvrNotifSlotIndex, cienaCesPortXcvrNotifPortNumber and cienaCesPortXcvrNotifPortName."
 	::= { cienaCesPortXcvrMIBNotifications 6 }
- 
- cienaCesPortXcvrTempLowNotification NOTIFICATION-TYPE
-	OBJECTS	{   cienaGlobalSeverity,
-				cienaGlobalMacAddress,             
-        		cienaCesPortXcvrNotifChassisIndex,
-        		cienaCesPortXcvrNotifShelfIndex,
-        		cienaCesPortXcvrNotifSlotIndex,
-        		cienaCesPortXcvrNotifPortNumber
-		}
-	STATUS	current
-	DESCRIPTION
-		"A cienaCesPortXcvrTempLowNotification is sent if the transceiver temperature falls below the 
-		threshold. To enable the device to send this notification: cienaCesPortXcvrTempChangeTrapState, 
-		cienaCesLogicalPortConfigPortAllTrapState, and cienaCesPortAllTrapState need to be set to enabled.
-		These objects are set to enabled by default. Variable bindings include: cienaGlobalSeverity,
-		cienaGlobalMacAddress, cienaCesPortXcvrNotifChassisIndex, cienaCesPortXcvrNotifShelfIndex,
-		cienaCesPortXcvrNotifSlotIndex, and cienaCesPortXcvrNotifPortNumber."
+
+	-- 1.3.6.1.4.1.1271.2.2.9.0.7
+	cienaCesPortXcvrTempLowNotification NOTIFICATION-TYPE
+		OBJECTS { cienaGlobalSeverity, cienaGlobalMacAddress, 
+		cienaCesPortXcvrNotifChassisIndex, cienaCesPortXcvrNotifShelfIndex, 
+		cienaCesPortXcvrNotifSlotIndex, cienaCesPortXcvrNotifPortNumber, 
+		cienaCesPortXcvrNotifPortName } 
+		STATUS current
+		DESCRIPTION
+			"A cienaCesPortXcvrTempLowNotification is sent if the transceiver temperature falls below the 
+			threshold. To enable the device to send this notification: cienaCesPortXcvrTempChangeTrapState, 
+			cienaCesLogicalPortConfigPortAllTrapState, and cienaCesPortAllTrapState need to be set to enabled.
+			These objects are set to enabled by default. Variable bindings include: cienaGlobalSeverity,
+			cienaGlobalMacAddress, cienaCesPortXcvrNotifChassisIndex, cienaCesPortXcvrNotifShelfIndex,
+			cienaCesPortXcvrNotifSlotIndex, cienaCesPortXcvrNotifPortNumber and cienaCesPortXcvrNotifPortName."
 	::= { cienaCesPortXcvrMIBNotifications 7 }
 
- cienaCesPortXcvrTempNormalNotification NOTIFICATION-TYPE
-	OBJECTS	{   cienaGlobalSeverity,  
-				cienaGlobalMacAddress,           
-        		cienaCesPortXcvrNotifChassisIndex,
-        		cienaCesPortXcvrNotifShelfIndex,
-        		cienaCesPortXcvrNotifSlotIndex,
-        		cienaCesPortXcvrNotifPortNumber
-		}
-	STATUS	current
-	DESCRIPTION
-		"A cienaCesPortXcvrTempNormalNotification is sent when the transceiver temperature returns to 
-		normal state.  To enable the device to send this notification: cienaCesPortXcvrTempChangeTrapState, 
-		cienaCesLogicalPortConfigPortAllTrapState, and cienaCesPortAllTrapState need to be set to enabled.
-		These objects are set to enabled by default. Variable bindings include: cienaGlobalSeverity,
-		cienaGlobalMacAddress, cienaCesPortXcvrNotifChassisIndex, cienaCesPortXcvrNotifShelfIndex,
-		cienaCesPortXcvrNotifSlotIndex, and cienaCesPortXcvrNotifPortNumber."
+	-- 1.3.6.1.4.1.1271.2.2.9.0.8
+	cienaCesPortXcvrTempNormalNotification NOTIFICATION-TYPE
+		OBJECTS { cienaGlobalSeverity, cienaGlobalMacAddress, 
+		cienaCesPortXcvrNotifChassisIndex, cienaCesPortXcvrNotifShelfIndex, 
+		cienaCesPortXcvrNotifSlotIndex, cienaCesPortXcvrNotifPortNumber, 
+		cienaCesPortXcvrNotifPortName } 
+		STATUS current
+		DESCRIPTION
+			"A cienaCesPortXcvrTempNormalNotification is sent when the transceiver temperature returns to 
+			normal state.  To enable the device to send this notification: cienaCesPortXcvrTempChangeTrapState, 
+			cienaCesLogicalPortConfigPortAllTrapState, and cienaCesPortAllTrapState need to be set to enabled.
+			These objects are set to enabled by default. Variable bindings include: cienaGlobalSeverity,
+			cienaGlobalMacAddress, cienaCesPortXcvrNotifChassisIndex, cienaCesPortXcvrNotifShelfIndex,
+			cienaCesPortXcvrNotifSlotIndex, cienaCesPortXcvrNotifPortNumber and cienaCesPortXcvrNotifPortName."
 	::= { cienaCesPortXcvrMIBNotifications 8 }
- 
- cienaCesPortXcvrVoltageHighNotification NOTIFICATION-TYPE
-	OBJECTS	{   cienaGlobalSeverity, 
-				cienaGlobalMacAddress,            
-        		cienaCesPortXcvrNotifChassisIndex,
-        		cienaCesPortXcvrNotifShelfIndex,
-        		cienaCesPortXcvrNotifSlotIndex,
-        		cienaCesPortXcvrNotifPortNumber
-		}
-	STATUS	current
-	DESCRIPTION
-		"A cienaCesPortXcvrVoltageHighNotification is sent if the transceiver voltage exceeds the 
-		threshold. To enable the device to send this notification: cienaCesPortXcvrVoltageChangeTrapState, 
-		cienaCesLogicalPortConfigPortAllTrapState, cienaCesPortAllTrapState needs to be set to enabled
-       These objects are set to enabled by default. Variable bindings include: 
-       cienaGlobalSeverity, cienaGlobalMacAddress, cienaCesPortXcvrNotifChassisIndex,
-       cienaCesPortXcvrNotifShelfIndex, cienaCesPortXcvrNotifSlotIndex, and 
-       cienaCesPortXcvrNotifPortNumber."
+
+	-- 1.3.6.1.4.1.1271.2.2.9.0.9
+	cienaCesPortXcvrVoltageHighNotification NOTIFICATION-TYPE
+		OBJECTS { cienaGlobalSeverity, cienaGlobalMacAddress, 
+		cienaCesPortXcvrNotifChassisIndex, cienaCesPortXcvrNotifShelfIndex, 
+		cienaCesPortXcvrNotifSlotIndex, cienaCesPortXcvrNotifPortNumber, 
+		cienaCesPortXcvrNotifPortName } 
+		STATUS current
+		DESCRIPTION
+			"A cienaCesPortXcvrVoltageHighNotification is sent if the transceiver voltage exceeds the 
+			threshold. To enable the device to send this notification: cienaCesPortXcvrVoltageChangeTrapState, 
+			cienaCesLogicalPortConfigPortAllTrapState, cienaCesPortAllTrapState needs to be set to enabled
+			     These objects are set to enabled by default. Variable bindings include: 
+			     cienaGlobalSeverity, cienaGlobalMacAddress, cienaCesPortXcvrNotifChassisIndex,
+			     cienaCesPortXcvrNotifShelfIndex, cienaCesPortXcvrNotifSlotIndex, cienaCesPortXcvrNotifPortNumber and
+			     cienaCesPortXcvrNotifPortName."
 	::= { cienaCesPortXcvrMIBNotifications 9 }
- 
- cienaCesPortXcvrVoltageLowNotification NOTIFICATION-TYPE
-	OBJECTS	{   cienaGlobalSeverity,  
-				cienaGlobalMacAddress,           
-        		cienaCesPortXcvrNotifChassisIndex,
-        		cienaCesPortXcvrNotifShelfIndex,
-        		cienaCesPortXcvrNotifSlotIndex,
-        		cienaCesPortXcvrNotifPortNumber
-		}
-	STATUS	current
-	DESCRIPTION
-		"A cienaCesPortXcvrVoltageLowNotification is sent if the transceiver voltage falls below the 
-		threshold. To enable the device to send this notification: cienaCesPortXcvrVoltageChangeTrapState,
-		cienaCesLogicalPortConfigPortAllTrapState, and cienaCesPortAllTrapState need to be set to enabled.
-		These objects are set to enabled by default. Variable bindings include: cienaGlobalSeverity,
-		cienaGlobalMacAddress, cienaCesPortXcvrNotifChassisIndex, cienaCesPortXcvrNotifShelfIndex,
-		cienaCesPortXcvrNotifSlotIndex, and cienaCesPortXcvrNotifPortNumber."
+
+	-- 1.3.6.1.4.1.1271.2.2.9.0.10
+	cienaCesPortXcvrVoltageLowNotification NOTIFICATION-TYPE
+		OBJECTS { cienaGlobalSeverity, cienaGlobalMacAddress, 
+		cienaCesPortXcvrNotifChassisIndex, cienaCesPortXcvrNotifShelfIndex, 
+		cienaCesPortXcvrNotifSlotIndex, cienaCesPortXcvrNotifPortNumber, 
+		cienaCesPortXcvrNotifPortName } 
+		STATUS current
+		DESCRIPTION
+			"A cienaCesPortXcvrVoltageLowNotification is sent if the transceiver voltage falls below the 
+			threshold. To enable the device to send this notification: cienaCesPortXcvrVoltageChangeTrapState,
+			cienaCesLogicalPortConfigPortAllTrapState, and cienaCesPortAllTrapState need to be set to enabled.
+			These objects are set to enabled by default. Variable bindings include: cienaGlobalSeverity,
+			cienaGlobalMacAddress, cienaCesPortXcvrNotifChassisIndex, cienaCesPortXcvrNotifShelfIndex,
+			cienaCesPortXcvrNotifSlotIndex, cienaCesPortXcvrNotifPortNumber and cienaCesPortXcvrNotifPortName."
 	::= { cienaCesPortXcvrMIBNotifications 10 }
 
- cienaCesPortXcvrVoltageNormalNotification NOTIFICATION-TYPE
-	OBJECTS	{   cienaGlobalSeverity, 
-				cienaGlobalMacAddress,            
-        		cienaCesPortXcvrNotifChassisIndex,
-        		cienaCesPortXcvrNotifShelfIndex,
-        		cienaCesPortXcvrNotifSlotIndex,
-        		cienaCesPortXcvrNotifPortNumber
-		}
-	STATUS	current
-	DESCRIPTION
-		"A cienaCesPortXcvrVoltageNormalNotification is sent when the transceiver voltage returns back
-		to normal state. To enable the device to send this notification: cienaCesPortXcvrVoltageChangeTrapState,
-		cienaCesLogicalPortConfigPortAllTrapState, and cienaCesPortAllTrapState need to be set to enabled.
-		These objects are set to enabled by default. Variable bindings include: cienaGlobalSeverity,
-		cienaGlobalMacAddress, cienaCesPortXcvrNotifChassisIndex, cienaCesPortXcvrNotifShelfIndex, 
-		cienaCesPortXcvrNotifSlotIndex, and cienaCesPortXcvrNotifPortNumber."
+	-- 1.3.6.1.4.1.1271.2.2.9.0.11
+	cienaCesPortXcvrVoltageNormalNotification NOTIFICATION-TYPE
+		OBJECTS { cienaGlobalSeverity, cienaGlobalMacAddress, 
+		cienaCesPortXcvrNotifChassisIndex, cienaCesPortXcvrNotifShelfIndex, 
+		cienaCesPortXcvrNotifSlotIndex, cienaCesPortXcvrNotifPortNumber, 
+		cienaCesPortXcvrNotifPortName } 
+		STATUS current
+		DESCRIPTION
+			"A cienaCesPortXcvrVoltageNormalNotification is sent when the transceiver voltage returns back
+			to normal state. To enable the device to send this notification: cienaCesPortXcvrVoltageChangeTrapState,
+			cienaCesLogicalPortConfigPortAllTrapState, and cienaCesPortAllTrapState need to be set to enabled.
+			These objects are set to enabled by default. Variable bindings include: cienaGlobalSeverity,
+			cienaGlobalMacAddress, cienaCesPortXcvrNotifChassisIndex, cienaCesPortXcvrNotifShelfIndex, 
+			cienaCesPortXcvrNotifSlotIndex, cienaCesPortXcvrNotifPortNumber and cienaCesPortXcvrNotifPortName."
 	::= { cienaCesPortXcvrMIBNotifications 11 }
- 
- cienaCesPortXcvrBiasHighNotification NOTIFICATION-TYPE
-	OBJECTS	{   cienaGlobalSeverity,  
-				cienaGlobalMacAddress,           
-        		cienaCesPortXcvrNotifChassisIndex,
-        		cienaCesPortXcvrNotifShelfIndex,
-        		cienaCesPortXcvrNotifSlotIndex,
-        		cienaCesPortXcvrNotifPortNumber
-		}
-	STATUS	current
-	DESCRIPTION
-		"A cienaCesPortXcvrBiasHighNotification is sent if the transceiver bias exceeds the 
-		threshold. To enable the device to send this notification: cienaCesPortXcvrBiasChangeTrapState,
-		cienaCesLogicalPortConfigPortAllTrapState, and cienaCesPortAllTrapState need to be set to enabled.
-		These objects are set to enabled by default. Variable bindings include: cienaGlobalSeverity, 
-		cienaGlobalMacAddress, cienaCesPortXcvrNotifChassisIndex, cienaCesPortXcvrNotifShelfIndex, 
-		cienaCesPortXcvrNotifSlotIndex, and cienaCesPortXcvrNotifPortNumber."
+
+	-- 1.3.6.1.4.1.1271.2.2.9.0.12
+	cienaCesPortXcvrBiasHighNotification NOTIFICATION-TYPE
+		OBJECTS { cienaGlobalSeverity, cienaGlobalMacAddress, 
+		cienaCesPortXcvrNotifChassisIndex, cienaCesPortXcvrNotifShelfIndex, 
+		cienaCesPortXcvrNotifSlotIndex, cienaCesPortXcvrNotifPortNumber, 
+		cienaCesPortXcvrNotifPortName } 
+		STATUS current
+		DESCRIPTION
+			"A cienaCesPortXcvrBiasHighNotification is sent if the transceiver bias exceeds the 
+			threshold. To enable the device to send this notification: cienaCesPortXcvrBiasChangeTrapState,
+			cienaCesLogicalPortConfigPortAllTrapState, and cienaCesPortAllTrapState need to be set to enabled.
+			These objects are set to enabled by default. Variable bindings include: cienaGlobalSeverity, 
+			cienaGlobalMacAddress, cienaCesPortXcvrNotifChassisIndex, cienaCesPortXcvrNotifShelfIndex, 
+			cienaCesPortXcvrNotifSlotIndex, cienaCesPortXcvrNotifPortNumber and cienaCesPortXcvrNotifPortName."
 	::= { cienaCesPortXcvrMIBNotifications 12 }
- 
- cienaCesPortXcvrBiasLowNotification NOTIFICATION-TYPE
-	OBJECTS	{   cienaGlobalSeverity, 
-				cienaGlobalMacAddress,            
-        		cienaCesPortXcvrNotifChassisIndex,
-        	    cienaCesPortXcvrNotifShelfIndex,
-        		cienaCesPortXcvrNotifSlotIndex,
-        		cienaCesPortXcvrNotifPortNumber
-		}
-	STATUS	current
-	DESCRIPTION
-		"A cienaCesPortXcvrBiasLowNotification is sent if the transceiver bias falls below the 
-		threshold. To enable the device to send this notification: cienaCesPortXcvrBiasChangeTrapState, 
-		cienaCesLogicalPortConfigPortAllTrapState, and cienaCesPortAllTrapState need to be set to enabled.
-		These objects are set to enabled by default. Variable bindings include: cienaGlobalSeverity,
-		cienaGlobalMacAddress, cienaCesPortXcvrNotifChassisIndex, cienaCesPortXcvrNotifShelfIndex, 
-		cienaCesPortXcvrNotifSlotIndex, and cienaCesPortXcvrNotifPortNumber."
+
+	-- 1.3.6.1.4.1.1271.2.2.9.0.13
+	cienaCesPortXcvrBiasLowNotification NOTIFICATION-TYPE
+		OBJECTS { cienaGlobalSeverity, cienaGlobalMacAddress, 
+		cienaCesPortXcvrNotifChassisIndex, cienaCesPortXcvrNotifShelfIndex, 
+		cienaCesPortXcvrNotifSlotIndex, cienaCesPortXcvrNotifPortNumber, 
+		cienaCesPortXcvrNotifPortName } 
+		STATUS current
+		DESCRIPTION
+			"A cienaCesPortXcvrBiasLowNotification is sent if the transceiver bias falls below the 
+			threshold. To enable the device to send this notification: cienaCesPortXcvrBiasChangeTrapState, 
+			cienaCesLogicalPortConfigPortAllTrapState, and cienaCesPortAllTrapState need to be set to enabled.
+			These objects are set to enabled by default. Variable bindings include: cienaGlobalSeverity,
+			cienaGlobalMacAddress, cienaCesPortXcvrNotifChassisIndex, cienaCesPortXcvrNotifShelfIndex, 
+			cienaCesPortXcvrNotifSlotIndex, cienaCesPortXcvrNotifPortNumber and cienaCesPortXcvrNotifPortName."
 	::= { cienaCesPortXcvrMIBNotifications 13 }
 
- cienaCesPortXcvrBiasNormalNotification NOTIFICATION-TYPE
-	OBJECTS	{   cienaGlobalSeverity,  
-				cienaGlobalMacAddress,           
-        		cienaCesPortXcvrNotifChassisIndex,
-        		cienaCesPortXcvrNotifShelfIndex,
-        	    cienaCesPortXcvrNotifSlotIndex,
-        		cienaCesPortXcvrNotifPortNumber
-		}
-	STATUS	current
-	DESCRIPTION
-		"A cienaCesPortXcvrBiasNormalNotification is sent when the transceiver bias returns to normal 
-		state. To enable the device to send this notification: cienaCesPortXcvrBiasChangeTrapState, 
-		cienaCesLogicalPortConfigPortAllTrapState, and cienaCesPortAllTrapState need to be set to enabled.
-		These objects are set to enabled by default. Variable bindings include: cienaGlobalSeverity,
-		cienaGlobalMacAddress, cienaCesPortXcvrNotifChassisIndex, cienaCesPortXcvrNotifShelfIndex, 
-		cienaCesPortXcvrNotifSlotIndex, and cienaCesPortXcvrNotifPortNumber."
+	-- 1.3.6.1.4.1.1271.2.2.9.0.14
+	cienaCesPortXcvrBiasNormalNotification NOTIFICATION-TYPE
+		OBJECTS { cienaGlobalSeverity, cienaGlobalMacAddress, 
+		cienaCesPortXcvrNotifChassisIndex, cienaCesPortXcvrNotifShelfIndex, 
+		cienaCesPortXcvrNotifSlotIndex, cienaCesPortXcvrNotifPortNumber, 
+		cienaCesPortXcvrNotifPortName } 
+		STATUS current
+		DESCRIPTION
+			"A cienaCesPortXcvrBiasNormalNotification is sent when the transceiver bias returns to normal 
+			state. To enable the device to send this notification: cienaCesPortXcvrBiasChangeTrapState, 
+			cienaCesLogicalPortConfigPortAllTrapState, and cienaCesPortAllTrapState need to be set to enabled.
+			These objects are set to enabled by default. Variable bindings include: cienaGlobalSeverity,
+			cienaGlobalMacAddress, cienaCesPortXcvrNotifChassisIndex, cienaCesPortXcvrNotifShelfIndex, 
+			cienaCesPortXcvrNotifSlotIndex, cienaCesPortXcvrNotifPortNumber and cienaCesPortXcvrNotifPortName."
 	::= { cienaCesPortXcvrMIBNotifications 14 }
- 
- cienaCesPortXcvrTxPowerHighNotification NOTIFICATION-TYPE
-	OBJECTS	{    cienaGlobalSeverity,
-				 cienaGlobalMacAddress,            
-        		 cienaCesPortXcvrNotifChassisIndex,
-        		 cienaCesPortXcvrNotifShelfIndex,
-        		 cienaCesPortXcvrNotifSlotIndex,
-        		 cienaCesPortXcvrNotifPortNumber
-		}
-	STATUS	current
-	DESCRIPTION
-		"A cienaCesPortXcvrTxPowerHighNotification is sent if the transceiver TxPower exceeds the 
-		threshold. To enable the device to send this notification: cienaCesPortXcvrTxPowerChangeTrapState,
-		cienaCesLogicalPortConfigPortAllTrapState, and cienaCesPortAllTrapState need to be set to enabled.
-		These objects are set to enabled by default. Variable bindings include: cienaGlobalSeverity,
-		cienaGlobalMacAddress, cienaCesPortXcvrNotifChassisIndex, cienaCesPortXcvrNotifShelfIndex, 
-		cienaCesPortXcvrNotifSlotIndex, and cienaCesPortXcvrNotifPortNumber."
+
+	-- 1.3.6.1.4.1.1271.2.2.9.0.15
+	cienaCesPortXcvrTxPowerHighNotification NOTIFICATION-TYPE
+		OBJECTS { cienaGlobalSeverity, cienaGlobalMacAddress, 
+		cienaCesPortXcvrNotifChassisIndex, cienaCesPortXcvrNotifShelfIndex, 
+		cienaCesPortXcvrNotifSlotIndex, cienaCesPortXcvrNotifPortNumber, 
+		cienaCesPortXcvrNotifPortName } 
+		STATUS current
+		DESCRIPTION
+			"A cienaCesPortXcvrTxPowerHighNotification is sent if the transceiver TxPower exceeds the 
+			threshold. To enable the device to send this notification: cienaCesPortXcvrTxPowerChangeTrapState,
+			cienaCesLogicalPortConfigPortAllTrapState, and cienaCesPortAllTrapState need to be set to enabled.
+			These objects are set to enabled by default. Variable bindings include: cienaGlobalSeverity,
+			cienaGlobalMacAddress, cienaCesPortXcvrNotifChassisIndex, cienaCesPortXcvrNotifShelfIndex, 
+			cienaCesPortXcvrNotifSlotIndex, cienaCesPortXcvrNotifPortNumber and cienaCesPortXcvrNotifPortName."
 	::= { cienaCesPortXcvrMIBNotifications 15 }
- 
- cienaCesPortXcvrTxPowerLowNotification NOTIFICATION-TYPE
-	OBJECTS	{   cienaGlobalSeverity,  
-				cienaGlobalMacAddress,           
-        		cienaCesPortXcvrNotifChassisIndex,
-        		cienaCesPortXcvrNotifShelfIndex,
-        		cienaCesPortXcvrNotifSlotIndex,
-        		cienaCesPortXcvrNotifPortNumber
-		}
-	STATUS	current
-	DESCRIPTION
-		"A cienaCesPortXcvrTxPowerLowNotification is sent if the transceiver TxPower falls below 
-		the threshold. To enable the device to send this notification: cienaCesPortXcvrTxPowerChangeTrapState, 
-		cienaCesLogicalPortConfigPortAllTrapState, and cienaCesPortAllTrapState need to be set to enabled.
-		These objects are set to enabled by default. Variable bindings include: cienaGlobalSeverity,
-		cienaGlobalMacAddress, cienaCesPortXcvrNotifChassisIndex, cienaCesPortXcvrNotifShelfIndex, 
-		cienaCesPortXcvrNotifSlotIndex, and cienaCesPortXcvrNotifPortNumber."
+
+	-- 1.3.6.1.4.1.1271.2.2.9.0.16
+	cienaCesPortXcvrTxPowerLowNotification NOTIFICATION-TYPE
+		OBJECTS { cienaGlobalSeverity, cienaGlobalMacAddress, 
+		cienaCesPortXcvrNotifChassisIndex, cienaCesPortXcvrNotifShelfIndex, 
+		cienaCesPortXcvrNotifSlotIndex, cienaCesPortXcvrNotifPortNumber, 
+		cienaCesPortXcvrNotifPortName } 
+		STATUS current
+		DESCRIPTION
+			"A cienaCesPortXcvrTxPowerLowNotification is sent if the transceiver TxPower falls below 
+			the threshold. To enable the device to send this notification: cienaCesPortXcvrTxPowerChangeTrapState, 
+			cienaCesLogicalPortConfigPortAllTrapState, and cienaCesPortAllTrapState need to be set to enabled.
+			These objects are set to enabled by default. Variable bindings include: cienaGlobalSeverity,
+			cienaGlobalMacAddress, cienaCesPortXcvrNotifChassisIndex, cienaCesPortXcvrNotifShelfIndex, 
+			cienaCesPortXcvrNotifSlotIndex, cienaCesPortXcvrNotifPortNumber and cienaCesPortXcvrNotifPortName."
 	::= { cienaCesPortXcvrMIBNotifications 16 }
 
- cienaCesPortXcvrTxPowerNormalNotification NOTIFICATION-TYPE
-	OBJECTS	{   cienaGlobalSeverity, 
-				cienaGlobalMacAddress,            
-        		cienaCesPortXcvrNotifChassisIndex,
-        		cienaCesPortXcvrNotifShelfIndex,
-        		cienaCesPortXcvrNotifSlotIndex,
-        		cienaCesPortXcvrNotifPortNumber
-		}
-	STATUS	current
-	DESCRIPTION
-		"A cienaCesPortXcvrTxPowerNormalNotification is sent when the transceiver TxPower returns to 
-		normal state. To enable the device to send this notification: cienaCesPortXcvrTxPowerChangeTrapState,
-		cienaCesLogicalPortConfigPortAllTrapState, and cienaCesPortAllTrapState need to be set to enabled. 
-		These above values are set to enabled by default. Variable bindings include: cienaGlobalSeverity,
-       cienaGlobalMacAddress, cienaCesPortXcvrNotifChassisIndex, cienaCesPortXcvrNotifShelfIndex, 
-       cienaCesPortXcvrNotifSlotIndex, and cienaCesPortXcvrNotifPortNumber."
+	-- 1.3.6.1.4.1.1271.2.2.9.0.17
+	cienaCesPortXcvrTxPowerNormalNotification NOTIFICATION-TYPE
+		OBJECTS { cienaGlobalSeverity, cienaGlobalMacAddress, 
+		cienaCesPortXcvrNotifChassisIndex, cienaCesPortXcvrNotifShelfIndex, 
+		cienaCesPortXcvrNotifSlotIndex, cienaCesPortXcvrNotifPortNumber, 
+		cienaCesPortXcvrNotifPortName } 
+		STATUS current
+		DESCRIPTION
+			"A cienaCesPortXcvrTxPowerNormalNotification is sent when the transceiver TxPower returns to 
+			normal state. To enable the device to send this notification: cienaCesPortXcvrTxPowerChangeTrapState,
+			cienaCesLogicalPortConfigPortAllTrapState, and cienaCesPortAllTrapState need to be set to enabled. 
+			These above values are set to enabled by default. Variable bindings include: cienaGlobalSeverity,
+			     cienaGlobalMacAddress, cienaCesPortXcvrNotifChassisIndex, cienaCesPortXcvrNotifShelfIndex, 
+			     cienaCesPortXcvrNotifSlotIndex, cienaCesPortXcvrNotifPortNumber and cienaCesPortXcvrNotifPortName."
 	::= { cienaCesPortXcvrMIBNotifications 17 }
- 
- cienaCesPortXcvrRxPowerHighNotification NOTIFICATION-TYPE
-	OBJECTS	{   cienaGlobalSeverity, 
-				cienaGlobalMacAddress,            
-        	    cienaCesPortXcvrNotifChassisIndex,
-        	    cienaCesPortXcvrNotifShelfIndex,
-        		cienaCesPortXcvrNotifSlotIndex,
-        		cienaCesPortXcvrNotifPortNumber
-		}
-	STATUS	current
-	DESCRIPTION
-		"A cienaCesPortXcvrRxPowerHighNotification is sent if the transceiver RxPower exceeds 
-		the threshold. To enable the device to send this notification: cienaCesPortXcvrRxPowerChangeTrapState, 
-		cienaCesLogicalPortConfigPortAllTrapState, and cienaCesPortAllTrapState need to be set to enabled. 
-		These objects are set to enabled by default. Variable bindings include: cienaGlobalSeverity, 
-		cienaGlobalMacAddress, cienaCesPortXcvrNotifChassisIndex, cienaCesPortXcvrNotifShelfIndex,
-		cienaCesPortXcvrNotifSlotIndex, and cienaCesPortXcvrNotifPortNumber."
+
+	-- 1.3.6.1.4.1.1271.2.2.9.0.18
+	cienaCesPortXcvrRxPowerHighNotification NOTIFICATION-TYPE
+		OBJECTS { cienaGlobalSeverity, cienaGlobalMacAddress, 
+		cienaCesPortXcvrNotifChassisIndex, cienaCesPortXcvrNotifShelfIndex, 
+		cienaCesPortXcvrNotifSlotIndex, cienaCesPortXcvrNotifPortNumber, 
+		cienaCesPortXcvrNotifPortName } 
+		STATUS current
+		DESCRIPTION
+			"A cienaCesPortXcvrRxPowerHighNotification is sent if the transceiver RxPower exceeds 
+			the threshold. To enable the device to send this notification: cienaCesPortXcvrRxPowerChangeTrapState, 
+			cienaCesLogicalPortConfigPortAllTrapState, and cienaCesPortAllTrapState need to be set to enabled. 
+			These objects are set to enabled by default. Variable bindings include: cienaGlobalSeverity, 
+			cienaGlobalMacAddress, cienaCesPortXcvrNotifChassisIndex, cienaCesPortXcvrNotifShelfIndex,
+			cienaCesPortXcvrNotifSlotIndex, cienaCesPortXcvrNotifPortNumber and cienaCesPortXcvrNotifPortName."
 	::= { cienaCesPortXcvrMIBNotifications 18 }
- 
- cienaCesPortXcvrRxPowerLowNotification NOTIFICATION-TYPE
-	OBJECTS	{   cienaGlobalSeverity, 
-				cienaGlobalMacAddress,            
-        		cienaCesPortXcvrNotifChassisIndex,
-        		cienaCesPortXcvrNotifShelfIndex,
-        		cienaCesPortXcvrNotifSlotIndex,
-        		cienaCesPortXcvrNotifPortNumber
-		}
-	STATUS	current
-	DESCRIPTION
-		"A cienaCesPortXcvrRxPowerLowNotification is sent if the transceiver RxPower falls below
-		the the threshold. To enable the device to send this notification: 
-		cienaCesPortXcvrRxPowerChangeTrapState, cienaCesLogicalPortConfigPortAllTrapState,
-		cienaCesPortAllTrapState needs to be set to enabled. These objects are set to enabled 
-		by default. Variable bindings include: cienaGlobalSeverity, cienaGlobalMacAddress, 
-		cienaCesPortXcvrNotifChassisIndex, cienaCesPortXcvrNotifShelfIndex, cienaCesPortXcvrNotifSlotIndex, 
-		and cienaCesPortXcvrNotifPortNumber."
+
+	-- 1.3.6.1.4.1.1271.2.2.9.0.19
+	cienaCesPortXcvrRxPowerLowNotification NOTIFICATION-TYPE
+		OBJECTS { cienaGlobalSeverity, cienaGlobalMacAddress, 
+		cienaCesPortXcvrNotifChassisIndex, cienaCesPortXcvrNotifShelfIndex, 
+		cienaCesPortXcvrNotifSlotIndex, cienaCesPortXcvrNotifPortNumber, 
+		cienaCesPortXcvrNotifPortName } 
+		STATUS current
+		DESCRIPTION
+			"A cienaCesPortXcvrRxPowerLowNotification is sent if the transceiver RxPower falls below
+			the the threshold. To enable the device to send this notification: 
+			cienaCesPortXcvrRxPowerChangeTrapState, cienaCesLogicalPortConfigPortAllTrapState,
+			cienaCesPortAllTrapState needs to be set to enabled. These objects are set to enabled 
+			by default. Variable bindings include: cienaGlobalSeverity, cienaGlobalMacAddress, 
+			cienaCesPortXcvrNotifChassisIndex, cienaCesPortXcvrNotifShelfIndex, cienaCesPortXcvrNotifSlotIndex, 
+			cienaCesPortXcvrNotifPortNumber and cienaCesPortXcvrNotifPortName."
 	::= { cienaCesPortXcvrMIBNotifications 19 }
 
- cienaCesPortXcvrRxPowerNormalNotification NOTIFICATION-TYPE
-	OBJECTS	{   cienaGlobalSeverity,  
-				cienaGlobalMacAddress,           
-        	    cienaCesPortXcvrNotifChassisIndex,
-        	    cienaCesPortXcvrNotifShelfIndex,
-        	    cienaCesPortXcvrNotifSlotIndex,
-        	    cienaCesPortXcvrNotifPortNumber
-		}
-	STATUS	current
-	DESCRIPTION
-		"A cienaCesPortXcvrRxPowerNormalNotification is sent when the transceiver RxPower returns 
-		to normal state. To enable the device to send this notification: 
-		cienaCesPortXcvrRxPowerChangeTrapState, cienaCesLogicalPortConfigPortAllTrapState, and 
-		cienaCesPortAllTrapState needs to be set to enabled. These objects are set to enabled by 
-		default. Variable bindings include: cienaGlobalSeverity, cienaGlobalMacAddress, 
-		cienaCesPortXcvrNotifChassisIndex, cienaCesPortXcvrNotifShelfIndex, cienaCesPortXcvrNotifSlotIndex, 
-		and cienaCesPortXcvrNotifPortNumber."
+	-- 1.3.6.1.4.1.1271.2.2.9.0.20
+	cienaCesPortXcvrRxPowerNormalNotification NOTIFICATION-TYPE
+		OBJECTS { cienaGlobalSeverity, cienaGlobalMacAddress, 
+		cienaCesPortXcvrNotifChassisIndex, cienaCesPortXcvrNotifShelfIndex, 
+		cienaCesPortXcvrNotifSlotIndex, cienaCesPortXcvrNotifPortNumber, 
+		cienaCesPortXcvrNotifPortName } 
+		STATUS current
+		DESCRIPTION
+			"A cienaCesPortXcvrRxPowerNormalNotification is sent when the transceiver RxPower returns 
+			to normal state. To enable the device to send this notification: 
+			cienaCesPortXcvrRxPowerChangeTrapState, cienaCesLogicalPortConfigPortAllTrapState, and 
+			cienaCesPortAllTrapState needs to be set to enabled. These objects are set to enabled by 
+			default. Variable bindings include: cienaGlobalSeverity, cienaGlobalMacAddress, 
+			cienaCesPortXcvrNotifChassisIndex, cienaCesPortXcvrNotifShelfIndex, cienaCesPortXcvrNotifSlotIndex, 
+			cienaCesPortXcvrNotifPortNumber and cienaCesPortXcvrNotifPortName."
 	::= { cienaCesPortXcvrMIBNotifications 20 }
-   
-  cienaCesPortXcvrSpeedInfoMissingNotification NOTIFICATION-TYPE
-	OBJECTS	{   	  cienaGlobalSeverity,   
-					  cienaGlobalMacAddress,          
-        			  cienaCesPortXcvrNotifChassisIndex,
-        			  cienaCesPortXcvrNotifShelfIndex,
-        			  cienaCesPortXcvrNotifSlotIndex,
-        			  cienaCesPortXcvrNotifPortNumber
-		}
-	STATUS	current
-	DESCRIPTION
-		"A cienaCesPortXcvrSpeedInfoMissingNotification is sent if the transceiver speed 
-		information is not found. To enable the device to send this notification: 
-		cienaCesPortXcvrSpeedInfoTrapState, cienaCesLogicalPortConfigPortAllTrapState, and 
-		cienaCesPortAllTrapState need to be set to enabled. These objects are set to enabled 
-		by default. Variable bindings include: cienaGlobalSeverity, cienaGlobalMacAddress, 
+
+	-- 1.3.6.1.4.1.1271.2.2.9.0.21
+	cienaCesPortXcvrSpeedInfoMissingNotification NOTIFICATION-TYPE
+		OBJECTS { cienaGlobalSeverity, cienaGlobalMacAddress, 
 		cienaCesPortXcvrNotifChassisIndex, cienaCesPortXcvrNotifShelfIndex, 
-		cienaCesPortXcvrNotifSlotIndex, and cienaCesPortXcvrNotifPortNumber."
+		cienaCesPortXcvrNotifSlotIndex, cienaCesPortXcvrNotifPortNumber, 
+		cienaCesPortXcvrNotifPortName } 
+		STATUS current
+		DESCRIPTION
+			"A cienaCesPortXcvrSpeedInfoMissingNotification is sent if the transceiver speed 
+			information is not found. To enable the device to send this notification: 
+			cienaCesPortXcvrSpeedInfoTrapState, cienaCesLogicalPortConfigPortAllTrapState, and 
+			cienaCesPortAllTrapState need to be set to enabled. These objects are set to enabled 
+			by default. Variable bindings include: cienaGlobalSeverity, cienaGlobalMacAddress, 
+			cienaCesPortXcvrNotifChassisIndex, cienaCesPortXcvrNotifShelfIndex, 
+			cienaCesPortXcvrNotifSlotIndex, cienaCesPortXcvrNotifPortNumber and cienaCesPortXcvrNotifPortName."
 	::= { cienaCesPortXcvrMIBNotifications 21 }
-  
-  cienaCesPortXcvrUncertifiedNotification NOTIFICATION-TYPE
-	OBJECTS	{   	  cienaGlobalSeverity,   
-					  cienaGlobalMacAddress,          
-        			  cienaCesPortXcvrNotifChassisIndex,
-        			  cienaCesPortXcvrNotifShelfIndex,
-        			  cienaCesPortXcvrNotifSlotIndex,
-        			  cienaCesPortXcvrNotifPortNumber
-		}
-	STATUS	current
-	DESCRIPTION
-		"A cienaCesPortXcvrUncertifiedNotification is sent if the transceiver is not 
-		certified for use by Ciena. To enable the device to send this notification: 
-		cienaCesPortXcvrUncertifiedTrapState,  cienaCesLogicalPortConfigPortAllTrapState, 
-		and cesPortAllTrapState need to be set to enabled. cienaCesPortXcvrUncertifiedTrapState 
-		is set to disabled by default. Variable bindings include: cienaGlobalSeverity, cienaGlobalMacAddress, 
+
+	-- 1.3.6.1.4.1.1271.2.2.9.0.22
+	cienaCesPortXcvrUncertifiedNotification NOTIFICATION-TYPE
+		OBJECTS { cienaGlobalSeverity, cienaGlobalMacAddress, 
 		cienaCesPortXcvrNotifChassisIndex, cienaCesPortXcvrNotifShelfIndex, 
-		cienaCesPortXcvrNotifSlotIndex, and cienaCesPortXcvrNotifPortNumber."
+		cienaCesPortXcvrNotifSlotIndex, cienaCesPortXcvrNotifPortNumber, 
+		cienaCesPortXcvrNotifPortName } 
+		STATUS current
+		DESCRIPTION
+			"A cienaCesPortXcvrUncertifiedNotification is sent if the transceiver is not 
+			certified for use by Ciena. To enable the device to send this notification: 
+			cienaCesPortXcvrUncertifiedTrapState,  cienaCesLogicalPortConfigPortAllTrapState, 
+			and cesPortAllTrapState need to be set to enabled. cienaCesPortXcvrUncertifiedTrapState 
+			is set to disabled by default. Variable bindings include: cienaGlobalSeverity, cienaGlobalMacAddress, 
+			cienaCesPortXcvrNotifChassisIndex, cienaCesPortXcvrNotifShelfIndex, 
+			cienaCesPortXcvrNotifSlotIndex, cienaCesPortXcvrNotifPortNumber and cienaCesPortXcvrNotifPortName."
 	::= { cienaCesPortXcvrMIBNotifications 22 }
 
- cienaCesPortXcvrRxPowerHighWarningNotification NOTIFICATION-TYPE
-   OBJECTS  {   cienaGlobalSeverity, 
-                cienaGlobalMacAddress,            
-                cienaCesPortXcvrNotifChassisIndex,
-                cienaCesPortXcvrNotifShelfIndex,
-                cienaCesPortXcvrNotifSlotIndex,
-                cienaCesPortXcvrNotifPortNumber
-      }
-   STATUS   current
-   DESCRIPTION
-      "A cienaCesPortXcvrRxPowerHighWarningNotification is sent if the transceiver RxPower exceeds 
-      the threshold. To enable the device to send this notification: cienaCesPortXcvrRxPowerChangeTrapState, 
-      cienaCesLogicalPortConfigPortAllTrapState, and cienaCesPortAllTrapState need to be set to enabled. 
-      These objects are set to enabled by default. Variable bindings include: cienaGlobalSeverity, 
-      cienaGlobalMacAddress, cienaCesPortXcvrNotifChassisIndex, cienaCesPortXcvrNotifShelfIndex,
-      cienaCesPortXcvrNotifSlotIndex, and cienaCesPortXcvrNotifPortNumber."
-   ::= { cienaCesPortXcvrMIBNotifications 23 }
- 
- cienaCesPortXcvrRxPowerLowWarningNotification NOTIFICATION-TYPE
-   OBJECTS  {   cienaGlobalSeverity, 
-                cienaGlobalMacAddress,            
-                cienaCesPortXcvrNotifChassisIndex,
-                cienaCesPortXcvrNotifShelfIndex,
-                cienaCesPortXcvrNotifSlotIndex,
-                cienaCesPortXcvrNotifPortNumber
-      }
-   STATUS   current
-   DESCRIPTION
-      "A cienaCesPortXcvrRxPowerLowWarningNotification is sent if the transceiver RxPower falls below
-      the the threshold. To enable the device to send this notification: 
-      cienaCesPortXcvrRxPowerChangeTrapState, cienaCesLogicalPortConfigPortAllTrapState,
-      cienaCesPortAllTrapState needs to be set to enabled. These objects are set to enabled 
-      by default. Variable bindings include: cienaGlobalSeverity, cienaGlobalMacAddress, 
-      cienaCesPortXcvrNotifChassisIndex, cienaCesPortXcvrNotifShelfIndex, cienaCesPortXcvrNotifSlotIndex, 
-      and cienaCesPortXcvrNotifPortNumber."
-   ::= { cienaCesPortXcvrMIBNotifications 24 }
+	-- 1.3.6.1.4.1.1271.2.2.9.0.23
+	cienaCesPortXcvrRxPowerHighWarningNotification NOTIFICATION-TYPE
+		OBJECTS { cienaGlobalSeverity, cienaGlobalMacAddress, 
+		cienaCesPortXcvrNotifChassisIndex, cienaCesPortXcvrNotifShelfIndex, 
+		cienaCesPortXcvrNotifSlotIndex, cienaCesPortXcvrNotifPortNumber, 
+		cienaCesPortXcvrNotifPortName } 
+		STATUS current
+		DESCRIPTION
+			"A cienaCesPortXcvrRxPowerHighWarningNotification is sent if the transceiver RxPower exceeds 
+			the threshold. To enable the device to send this notification: cienaCesPortXcvrRxPowerChangeTrapState, 
+			cienaCesLogicalPortConfigPortAllTrapState, and cienaCesPortAllTrapState need to be set to enabled. 
+			These objects are set to enabled by default. Variable bindings include: cienaGlobalSeverity, 
+			cienaGlobalMacAddress, cienaCesPortXcvrNotifChassisIndex, cienaCesPortXcvrNotifShelfIndex,
+			cienaCesPortXcvrNotifSlotIndex, cienaCesPortXcvrNotifPortNumber and cienaCesPortXcvrNotifPortName."
+	::= { cienaCesPortXcvrMIBNotifications 23 }
 
- cienaCesPortXcvrTxPowerHighWarningNotification NOTIFICATION-TYPE
-   OBJECTS  {   cienaGlobalSeverity, 
-                cienaGlobalMacAddress,            
-                cienaCesPortXcvrNotifChassisIndex,
-                cienaCesPortXcvrNotifShelfIndex,
-                cienaCesPortXcvrNotifSlotIndex,
-                cienaCesPortXcvrNotifPortNumber
-      }
-   STATUS   current
-   DESCRIPTION
-      "A cienaCesPortXcvrTxPowerHighWarningNotification is sent if the transceiver TxPower exceeds 
-      the threshold. To enable the device to send this notification: cienaCesPortXcvrTxPowerChangeTrapState, 
-      cienaCesLogicalPortConfigPortAllTrapState, and cienaCesPortAllTrapState need to be set to enabled. 
-      These objects are set to enabled by default. Variable bindings include: cienaGlobalSeverity, 
-      cienaGlobalMacAddress, cienaCesPortXcvrNotifChassisIndex, cienaCesPortXcvrNotifShelfIndex,
-      cienaCesPortXcvrNotifSlotIndex, and cienaCesPortXcvrNotifPortNumber."
-   ::= { cienaCesPortXcvrMIBNotifications 25 }
- 
- cienaCesPortXcvrTxPowerLowWarningNotification NOTIFICATION-TYPE
-   OBJECTS  {   cienaGlobalSeverity, 
-                cienaGlobalMacAddress,            
-                cienaCesPortXcvrNotifChassisIndex,
-                cienaCesPortXcvrNotifShelfIndex,
-                cienaCesPortXcvrNotifSlotIndex,
-                cienaCesPortXcvrNotifPortNumber
-      }
-   STATUS   current
-   DESCRIPTION
-      "A cienaCesPortXcvrTxPowerLowWarningNotification is sent if the transceiver TxPower falls below
-      the the threshold. To enable the device to send this notification: 
-      cienaCesPortXcvrTxPowerChangeTrapState, cienaCesLogicalPortConfigPortAllTrapState,
-      cienaCesPortAllTrapState needs to be set to enabled. These objects are set to enabled 
-      by default. Variable bindings include: cienaGlobalSeverity, cienaGlobalMacAddress, 
-      cienaCesPortXcvrNotifChassisIndex, cienaCesPortXcvrNotifShelfIndex, cienaCesPortXcvrNotifSlotIndex, 
-      and cienaCesPortXcvrNotifPortNumber."
-   ::= { cienaCesPortXcvrMIBNotifications 26 }
+	-- 1.3.6.1.4.1.1271.2.2.9.0.24
+	cienaCesPortXcvrRxPowerLowWarningNotification NOTIFICATION-TYPE
+		OBJECTS { cienaGlobalSeverity, cienaGlobalMacAddress, 
+		cienaCesPortXcvrNotifChassisIndex, cienaCesPortXcvrNotifShelfIndex, 
+		cienaCesPortXcvrNotifSlotIndex, cienaCesPortXcvrNotifPortNumber, 
+		cienaCesPortXcvrNotifPortName } 
+		STATUS current
+		DESCRIPTION
+			"A cienaCesPortXcvrRxPowerLowWarningNotification is sent if the transceiver RxPower falls below
+			the the threshold. To enable the device to send this notification: 
+			cienaCesPortXcvrRxPowerChangeTrapState, cienaCesLogicalPortConfigPortAllTrapState,
+			cienaCesPortAllTrapState needs to be set to enabled. These objects are set to enabled 
+			by default. Variable bindings include: cienaGlobalSeverity, cienaGlobalMacAddress, 
+			cienaCesPortXcvrNotifChassisIndex, cienaCesPortXcvrNotifShelfIndex, cienaCesPortXcvrNotifSlotIndex, 
+			cienaCesPortXcvrNotifPortNumber and cienaCesPortXcvrNotifPortName."
+	::= { cienaCesPortXcvrMIBNotifications 24 }
 
- END
+	-- 1.3.6.1.4.1.1271.2.2.9.0.25
+	cienaCesPortXcvrTxPowerHighWarningNotification NOTIFICATION-TYPE
+		OBJECTS { cienaGlobalSeverity, cienaGlobalMacAddress, 
+		cienaCesPortXcvrNotifChassisIndex, cienaCesPortXcvrNotifShelfIndex, 
+		cienaCesPortXcvrNotifSlotIndex, cienaCesPortXcvrNotifPortNumber, 
+		cienaCesPortXcvrNotifPortName } 
+		STATUS current
+		DESCRIPTION
+			"A cienaCesPortXcvrTxPowerHighWarningNotification is sent if the transceiver TxPower exceeds 
+			the threshold. To enable the device to send this notification: cienaCesPortXcvrTxPowerChangeTrapState, 
+			cienaCesLogicalPortConfigPortAllTrapState, and cienaCesPortAllTrapState need to be set to enabled. 
+			These objects are set to enabled by default. Variable bindings include: cienaGlobalSeverity, 
+			cienaGlobalMacAddress, cienaCesPortXcvrNotifChassisIndex, cienaCesPortXcvrNotifShelfIndex,
+			cienaCesPortXcvrNotifSlotIndex, cienaCesPortXcvrNotifPortNumber and cienaCesPortXcvrNotifPortName."
+	::= { cienaCesPortXcvrMIBNotifications 25 }
+
+	-- 1.3.6.1.4.1.1271.2.2.9.0.26
+	cienaCesPortXcvrTxPowerLowWarningNotification NOTIFICATION-TYPE
+		OBJECTS { cienaGlobalSeverity, cienaGlobalMacAddress, 
+		cienaCesPortXcvrNotifChassisIndex, cienaCesPortXcvrNotifShelfIndex, 
+		cienaCesPortXcvrNotifSlotIndex, cienaCesPortXcvrNotifPortNumber, 
+		cienaCesPortXcvrNotifPortName } 
+		STATUS current
+		DESCRIPTION
+			"A cienaCesPortXcvrTxPowerLowWarningNotification is sent if the transceiver TxPower falls below
+			the the threshold. To enable the device to send this notification: 
+			cienaCesPortXcvrTxPowerChangeTrapState, cienaCesLogicalPortConfigPortAllTrapState,
+			cienaCesPortAllTrapState needs to be set to enabled. These objects are set to enabled 
+			by default. Variable bindings include: cienaGlobalSeverity, cienaGlobalMacAddress, 
+			cienaCesPortXcvrNotifChassisIndex, cienaCesPortXcvrNotifShelfIndex, cienaCesPortXcvrNotifSlotIndex, 
+			cienaCesPortXcvrNotifPortNumber and cienaCesPortXcvrNotifPortName."
+	::= { cienaCesPortXcvrMIBNotifications 26 }
+
+END
 
  --
  -- CIENA-CES-PORT-XCVR-MIB

--- a/tests/data/ciena-sds.json
+++ b/tests/data/ciena-sds.json
@@ -36145,11 +36145,30 @@
                     "ifIndex": null
                 },
                 {
+                    "entPhysicalIndex": 57,
+                    "entPhysicalDescr": "port  850 nm  transceiver manufactured 08/23/18 ",
+                    "entPhysicalClass": "sensor",
+                    "entPhysicalName": null,
+                    "entPhysicalHardwareRev": "000A",
+                    "entPhysicalFirmwareRev": null,
+                    "entPhysicalSoftwareRev": null,
+                    "entPhysicalAlias": null,
+                    "entPhysicalAssetID": null,
+                    "entPhysicalIsFRU": "true",
+                    "entPhysicalModelName": "SFP-10GSR-85",
+                    "entPhysicalVendorType": null,
+                    "entPhysicalSerialNum": "S1812345678",
+                    "entPhysicalContainedIn": 56212,
+                    "entPhysicalParentRelPos": -1,
+                    "entPhysicalMfgName": "FS",
+                    "ifIndex": null
+                },
+                {
                     "entPhysicalIndex": 401,
                     "entPhysicalDescr": null,
                     "entPhysicalClass": "container",
                     "entPhysicalName": "Modules",
-                    "entPhysicalHardwareRev": "",
+                    "entPhysicalHardwareRev": null,
                     "entPhysicalFirmwareRev": null,
                     "entPhysicalSoftwareRev": null,
                     "entPhysicalAlias": null,
@@ -36168,7 +36187,7 @@
                     "entPhysicalDescr": null,
                     "entPhysicalClass": "container",
                     "entPhysicalName": "Power Supplies",
-                    "entPhysicalHardwareRev": "",
+                    "entPhysicalHardwareRev": null,
                     "entPhysicalFirmwareRev": null,
                     "entPhysicalSoftwareRev": null,
                     "entPhysicalAlias": null,
@@ -36503,7 +36522,7 @@
                     "entPhysicalContainedIn": 551,
                     "entPhysicalParentRelPos": 1,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100001
+                    "ifIndex": 1
                 },
                 {
                     "entPhysicalIndex": 562,
@@ -36522,7 +36541,7 @@
                     "entPhysicalContainedIn": 551,
                     "entPhysicalParentRelPos": 2,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100002
+                    "ifIndex": 2
                 },
                 {
                     "entPhysicalIndex": 563,
@@ -36541,7 +36560,7 @@
                     "entPhysicalContainedIn": 551,
                     "entPhysicalParentRelPos": 3,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100003
+                    "ifIndex": 3
                 },
                 {
                     "entPhysicalIndex": 564,
@@ -36560,7 +36579,7 @@
                     "entPhysicalContainedIn": 551,
                     "entPhysicalParentRelPos": 4,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100004
+                    "ifIndex": 4
                 },
                 {
                     "entPhysicalIndex": 565,
@@ -36579,7 +36598,7 @@
                     "entPhysicalContainedIn": 551,
                     "entPhysicalParentRelPos": 5,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100005
+                    "ifIndex": 5
                 },
                 {
                     "entPhysicalIndex": 566,
@@ -36598,7 +36617,7 @@
                     "entPhysicalContainedIn": 551,
                     "entPhysicalParentRelPos": 6,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100006
+                    "ifIndex": 6
                 },
                 {
                     "entPhysicalIndex": 567,
@@ -36617,7 +36636,7 @@
                     "entPhysicalContainedIn": 551,
                     "entPhysicalParentRelPos": 7,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100007
+                    "ifIndex": 7
                 },
                 {
                     "entPhysicalIndex": 568,
@@ -36636,7 +36655,7 @@
                     "entPhysicalContainedIn": 551,
                     "entPhysicalParentRelPos": 8,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100008
+                    "ifIndex": 8
                 },
                 {
                     "entPhysicalIndex": 569,
@@ -36655,7 +36674,7 @@
                     "entPhysicalContainedIn": 551,
                     "entPhysicalParentRelPos": 9,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100009
+                    "ifIndex": 9
                 },
                 {
                     "entPhysicalIndex": 5117,
@@ -36921,7 +36940,7 @@
                     "entPhysicalContainedIn": 551,
                     "entPhysicalParentRelPos": 10,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100010
+                    "ifIndex": 10
                 },
                 {
                     "entPhysicalIndex": 5611,
@@ -36940,7 +36959,7 @@
                     "entPhysicalContainedIn": 551,
                     "entPhysicalParentRelPos": 11,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100011
+                    "ifIndex": 11
                 },
                 {
                     "entPhysicalIndex": 5612,
@@ -36959,7 +36978,7 @@
                     "entPhysicalContainedIn": 551,
                     "entPhysicalParentRelPos": 12,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100012
+                    "ifIndex": 12
                 },
                 {
                     "entPhysicalIndex": 5613,
@@ -36978,7 +36997,7 @@
                     "entPhysicalContainedIn": 551,
                     "entPhysicalParentRelPos": 13,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100013
+                    "ifIndex": 13
                 },
                 {
                     "entPhysicalIndex": 5614,
@@ -36997,7 +37016,7 @@
                     "entPhysicalContainedIn": 551,
                     "entPhysicalParentRelPos": 14,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100014
+                    "ifIndex": 14
                 },
                 {
                     "entPhysicalIndex": 5615,
@@ -37016,7 +37035,7 @@
                     "entPhysicalContainedIn": 551,
                     "entPhysicalParentRelPos": 15,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100015
+                    "ifIndex": 15
                 },
                 {
                     "entPhysicalIndex": 5616,
@@ -37035,7 +37054,7 @@
                     "entPhysicalContainedIn": 551,
                     "entPhysicalParentRelPos": 16,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100016
+                    "ifIndex": 16
                 },
                 {
                     "entPhysicalIndex": 5617,
@@ -37054,7 +37073,7 @@
                     "entPhysicalContainedIn": 551,
                     "entPhysicalParentRelPos": 17,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100017
+                    "ifIndex": 17
                 },
                 {
                     "entPhysicalIndex": 5618,
@@ -37073,7 +37092,7 @@
                     "entPhysicalContainedIn": 551,
                     "entPhysicalParentRelPos": 18,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100018
+                    "ifIndex": 18
                 },
                 {
                     "entPhysicalIndex": 5619,
@@ -37092,7 +37111,7 @@
                     "entPhysicalContainedIn": 551,
                     "entPhysicalParentRelPos": 19,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100019
+                    "ifIndex": 19
                 },
                 {
                     "entPhysicalIndex": 5620,
@@ -37111,7 +37130,7 @@
                     "entPhysicalContainedIn": 551,
                     "entPhysicalParentRelPos": 20,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100020
+                    "ifIndex": 20
                 },
                 {
                     "entPhysicalIndex": 5621,
@@ -37130,7 +37149,7 @@
                     "entPhysicalContainedIn": 551,
                     "entPhysicalParentRelPos": 21,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100021
+                    "ifIndex": 21
                 },
                 {
                     "entPhysicalIndex": 5622,
@@ -37149,7 +37168,7 @@
                     "entPhysicalContainedIn": 551,
                     "entPhysicalParentRelPos": 22,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100022
+                    "ifIndex": 22
                 },
                 {
                     "entPhysicalIndex": 5623,
@@ -37168,7 +37187,7 @@
                     "entPhysicalContainedIn": 551,
                     "entPhysicalParentRelPos": 23,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100023
+                    "ifIndex": 23
                 },
                 {
                     "entPhysicalIndex": 5624,
@@ -37187,7 +37206,7 @@
                     "entPhysicalContainedIn": 551,
                     "entPhysicalParentRelPos": 24,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100024
+                    "ifIndex": 24
                 },
                 {
                     "entPhysicalIndex": 5625,
@@ -37206,7 +37225,7 @@
                     "entPhysicalContainedIn": 551,
                     "entPhysicalParentRelPos": 25,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100025
+                    "ifIndex": 25
                 },
                 {
                     "entPhysicalIndex": 5626,
@@ -37225,7 +37244,7 @@
                     "entPhysicalContainedIn": 551,
                     "entPhysicalParentRelPos": 26,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100026
+                    "ifIndex": 26
                 },
                 {
                     "entPhysicalIndex": 5627,
@@ -37244,7 +37263,7 @@
                     "entPhysicalContainedIn": 551,
                     "entPhysicalParentRelPos": 27,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100027
+                    "ifIndex": 27
                 },
                 {
                     "entPhysicalIndex": 5628,
@@ -37263,7 +37282,7 @@
                     "entPhysicalContainedIn": 551,
                     "entPhysicalParentRelPos": 28,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100028
+                    "ifIndex": 28
                 },
                 {
                     "entPhysicalIndex": 5629,
@@ -37282,7 +37301,7 @@
                     "entPhysicalContainedIn": 551,
                     "entPhysicalParentRelPos": 29,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100029
+                    "ifIndex": 29
                 },
                 {
                     "entPhysicalIndex": 5630,
@@ -37301,7 +37320,7 @@
                     "entPhysicalContainedIn": 551,
                     "entPhysicalParentRelPos": 30,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100030
+                    "ifIndex": 30
                 },
                 {
                     "entPhysicalIndex": 5631,
@@ -37320,7 +37339,7 @@
                     "entPhysicalContainedIn": 551,
                     "entPhysicalParentRelPos": 31,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100031
+                    "ifIndex": 31
                 },
                 {
                     "entPhysicalIndex": 5632,
@@ -37339,7 +37358,7 @@
                     "entPhysicalContainedIn": 551,
                     "entPhysicalParentRelPos": 32,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100032
+                    "ifIndex": 32
                 },
                 {
                     "entPhysicalIndex": 5633,
@@ -37358,7 +37377,7 @@
                     "entPhysicalContainedIn": 551,
                     "entPhysicalParentRelPos": 33,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100033
+                    "ifIndex": 33
                 },
                 {
                     "entPhysicalIndex": 5634,
@@ -37377,7 +37396,7 @@
                     "entPhysicalContainedIn": 551,
                     "entPhysicalParentRelPos": 34,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100034
+                    "ifIndex": 34
                 },
                 {
                     "entPhysicalIndex": 5635,
@@ -37396,7 +37415,7 @@
                     "entPhysicalContainedIn": 551,
                     "entPhysicalParentRelPos": 35,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100035
+                    "ifIndex": 35
                 },
                 {
                     "entPhysicalIndex": 5636,
@@ -37415,7 +37434,7 @@
                     "entPhysicalContainedIn": 551,
                     "entPhysicalParentRelPos": 36,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100036
+                    "ifIndex": 36
                 },
                 {
                     "entPhysicalIndex": 5637,
@@ -37434,7 +37453,7 @@
                     "entPhysicalContainedIn": 551,
                     "entPhysicalParentRelPos": 37,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100037
+                    "ifIndex": 37
                 },
                 {
                     "entPhysicalIndex": 5638,
@@ -37453,7 +37472,7 @@
                     "entPhysicalContainedIn": 551,
                     "entPhysicalParentRelPos": 38,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100038
+                    "ifIndex": 38
                 },
                 {
                     "entPhysicalIndex": 5639,
@@ -37472,7 +37491,7 @@
                     "entPhysicalContainedIn": 551,
                     "entPhysicalParentRelPos": 39,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100039
+                    "ifIndex": 39
                 },
                 {
                     "entPhysicalIndex": 5640,
@@ -37491,7 +37510,7 @@
                     "entPhysicalContainedIn": 551,
                     "entPhysicalParentRelPos": 40,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100040
+                    "ifIndex": 40
                 },
                 {
                     "entPhysicalIndex": 5641,
@@ -37510,7 +37529,7 @@
                     "entPhysicalContainedIn": 551,
                     "entPhysicalParentRelPos": 41,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100041
+                    "ifIndex": 41
                 },
                 {
                     "entPhysicalIndex": 5642,
@@ -37529,7 +37548,7 @@
                     "entPhysicalContainedIn": 551,
                     "entPhysicalParentRelPos": 42,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100042
+                    "ifIndex": 42
                 },
                 {
                     "entPhysicalIndex": 5643,
@@ -37548,7 +37567,7 @@
                     "entPhysicalContainedIn": 551,
                     "entPhysicalParentRelPos": 43,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100043
+                    "ifIndex": 43
                 },
                 {
                     "entPhysicalIndex": 5644,
@@ -37567,7 +37586,7 @@
                     "entPhysicalContainedIn": 551,
                     "entPhysicalParentRelPos": 44,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100044
+                    "ifIndex": 44
                 },
                 {
                     "entPhysicalIndex": 5665,
@@ -37586,7 +37605,7 @@
                     "entPhysicalContainedIn": 552,
                     "entPhysicalParentRelPos": 65,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100065
+                    "ifIndex": 65
                 },
                 {
                     "entPhysicalIndex": 5666,
@@ -37605,7 +37624,7 @@
                     "entPhysicalContainedIn": 552,
                     "entPhysicalParentRelPos": 66,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100066
+                    "ifIndex": 66
                 },
                 {
                     "entPhysicalIndex": 5667,
@@ -37624,7 +37643,7 @@
                     "entPhysicalContainedIn": 552,
                     "entPhysicalParentRelPos": 67,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100067
+                    "ifIndex": 67
                 },
                 {
                     "entPhysicalIndex": 5668,
@@ -37643,7 +37662,7 @@
                     "entPhysicalContainedIn": 552,
                     "entPhysicalParentRelPos": 68,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100068
+                    "ifIndex": 68
                 },
                 {
                     "entPhysicalIndex": 5669,
@@ -37662,7 +37681,7 @@
                     "entPhysicalContainedIn": 552,
                     "entPhysicalParentRelPos": 69,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100069
+                    "ifIndex": 69
                 },
                 {
                     "entPhysicalIndex": 5670,
@@ -37681,7 +37700,7 @@
                     "entPhysicalContainedIn": 552,
                     "entPhysicalParentRelPos": 70,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100070
+                    "ifIndex": 70
                 },
                 {
                     "entPhysicalIndex": 5671,
@@ -37700,7 +37719,7 @@
                     "entPhysicalContainedIn": 552,
                     "entPhysicalParentRelPos": 71,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100071
+                    "ifIndex": 71
                 },
                 {
                     "entPhysicalIndex": 5672,
@@ -37719,7 +37738,7 @@
                     "entPhysicalContainedIn": 552,
                     "entPhysicalParentRelPos": 72,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100072
+                    "ifIndex": 72
                 },
                 {
                     "entPhysicalIndex": 56129,
@@ -37738,7 +37757,7 @@
                     "entPhysicalContainedIn": 553,
                     "entPhysicalParentRelPos": 129,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100129
+                    "ifIndex": 129
                 },
                 {
                     "entPhysicalIndex": 56130,
@@ -37757,7 +37776,7 @@
                     "entPhysicalContainedIn": 553,
                     "entPhysicalParentRelPos": 130,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100130
+                    "ifIndex": 130
                 },
                 {
                     "entPhysicalIndex": 56131,
@@ -37776,7 +37795,7 @@
                     "entPhysicalContainedIn": 553,
                     "entPhysicalParentRelPos": 131,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100131
+                    "ifIndex": 131
                 },
                 {
                     "entPhysicalIndex": 56132,
@@ -37795,7 +37814,7 @@
                     "entPhysicalContainedIn": 553,
                     "entPhysicalParentRelPos": 132,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100132
+                    "ifIndex": 132
                 },
                 {
                     "entPhysicalIndex": 56133,
@@ -37814,7 +37833,7 @@
                     "entPhysicalContainedIn": 553,
                     "entPhysicalParentRelPos": 133,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100133
+                    "ifIndex": 133
                 },
                 {
                     "entPhysicalIndex": 56134,
@@ -37833,7 +37852,7 @@
                     "entPhysicalContainedIn": 553,
                     "entPhysicalParentRelPos": 134,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100134
+                    "ifIndex": 134
                 },
                 {
                     "entPhysicalIndex": 56135,
@@ -37852,7 +37871,7 @@
                     "entPhysicalContainedIn": 553,
                     "entPhysicalParentRelPos": 135,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100135
+                    "ifIndex": 135
                 },
                 {
                     "entPhysicalIndex": 56136,
@@ -37871,7 +37890,7 @@
                     "entPhysicalContainedIn": 553,
                     "entPhysicalParentRelPos": 136,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100136
+                    "ifIndex": 136
                 },
                 {
                     "entPhysicalIndex": 56193,
@@ -37890,7 +37909,7 @@
                     "entPhysicalContainedIn": 554,
                     "entPhysicalParentRelPos": 193,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100193
+                    "ifIndex": 193
                 },
                 {
                     "entPhysicalIndex": 56194,
@@ -37909,7 +37928,7 @@
                     "entPhysicalContainedIn": 554,
                     "entPhysicalParentRelPos": 194,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100194
+                    "ifIndex": 194
                 },
                 {
                     "entPhysicalIndex": 56195,
@@ -37928,7 +37947,7 @@
                     "entPhysicalContainedIn": 554,
                     "entPhysicalParentRelPos": 195,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100195
+                    "ifIndex": 195
                 },
                 {
                     "entPhysicalIndex": 56196,
@@ -37947,7 +37966,7 @@
                     "entPhysicalContainedIn": 554,
                     "entPhysicalParentRelPos": 196,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100196
+                    "ifIndex": 196
                 },
                 {
                     "entPhysicalIndex": 56197,
@@ -37966,7 +37985,7 @@
                     "entPhysicalContainedIn": 554,
                     "entPhysicalParentRelPos": 197,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100197
+                    "ifIndex": 197
                 },
                 {
                     "entPhysicalIndex": 56198,
@@ -37985,7 +38004,7 @@
                     "entPhysicalContainedIn": 554,
                     "entPhysicalParentRelPos": 198,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100198
+                    "ifIndex": 198
                 },
                 {
                     "entPhysicalIndex": 56199,
@@ -38004,7 +38023,7 @@
                     "entPhysicalContainedIn": 554,
                     "entPhysicalParentRelPos": 199,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100199
+                    "ifIndex": 199
                 },
                 {
                     "entPhysicalIndex": 56200,
@@ -38023,7 +38042,7 @@
                     "entPhysicalContainedIn": 554,
                     "entPhysicalParentRelPos": 200,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100200
+                    "ifIndex": 200
                 },
                 {
                     "entPhysicalIndex": 56201,
@@ -38042,7 +38061,7 @@
                     "entPhysicalContainedIn": 554,
                     "entPhysicalParentRelPos": 201,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100201
+                    "ifIndex": 201
                 },
                 {
                     "entPhysicalIndex": 56202,
@@ -38061,7 +38080,7 @@
                     "entPhysicalContainedIn": 554,
                     "entPhysicalParentRelPos": 202,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100202
+                    "ifIndex": 202
                 },
                 {
                     "entPhysicalIndex": 56203,
@@ -38080,7 +38099,7 @@
                     "entPhysicalContainedIn": 554,
                     "entPhysicalParentRelPos": 203,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100203
+                    "ifIndex": 203
                 },
                 {
                     "entPhysicalIndex": 56204,
@@ -38099,7 +38118,7 @@
                     "entPhysicalContainedIn": 554,
                     "entPhysicalParentRelPos": 204,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100204
+                    "ifIndex": 204
                 },
                 {
                     "entPhysicalIndex": 56205,
@@ -38118,7 +38137,7 @@
                     "entPhysicalContainedIn": 554,
                     "entPhysicalParentRelPos": 205,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100205
+                    "ifIndex": 205
                 },
                 {
                     "entPhysicalIndex": 56206,
@@ -38137,7 +38156,7 @@
                     "entPhysicalContainedIn": 554,
                     "entPhysicalParentRelPos": 206,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100206
+                    "ifIndex": 206
                 },
                 {
                     "entPhysicalIndex": 56207,
@@ -38156,7 +38175,7 @@
                     "entPhysicalContainedIn": 554,
                     "entPhysicalParentRelPos": 207,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100207
+                    "ifIndex": 207
                 },
                 {
                     "entPhysicalIndex": 56208,
@@ -38175,7 +38194,7 @@
                     "entPhysicalContainedIn": 554,
                     "entPhysicalParentRelPos": 208,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100208
+                    "ifIndex": 208
                 },
                 {
                     "entPhysicalIndex": 56209,
@@ -38194,7 +38213,7 @@
                     "entPhysicalContainedIn": 554,
                     "entPhysicalParentRelPos": 209,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100209
+                    "ifIndex": 209
                 },
                 {
                     "entPhysicalIndex": 56210,
@@ -38213,7 +38232,7 @@
                     "entPhysicalContainedIn": 554,
                     "entPhysicalParentRelPos": 210,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100210
+                    "ifIndex": 210
                 },
                 {
                     "entPhysicalIndex": 56211,
@@ -38232,7 +38251,7 @@
                     "entPhysicalContainedIn": 554,
                     "entPhysicalParentRelPos": 211,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100211
+                    "ifIndex": 211
                 },
                 {
                     "entPhysicalIndex": 56212,
@@ -38251,7 +38270,7 @@
                     "entPhysicalContainedIn": 554,
                     "entPhysicalParentRelPos": 212,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100212
+                    "ifIndex": 212
                 },
                 {
                     "entPhysicalIndex": 56213,
@@ -38270,7 +38289,7 @@
                     "entPhysicalContainedIn": 554,
                     "entPhysicalParentRelPos": 213,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100213
+                    "ifIndex": 213
                 },
                 {
                     "entPhysicalIndex": 56214,
@@ -38289,7 +38308,7 @@
                     "entPhysicalContainedIn": 554,
                     "entPhysicalParentRelPos": 214,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100214
+                    "ifIndex": 214
                 },
                 {
                     "entPhysicalIndex": 56215,
@@ -38308,7 +38327,7 @@
                     "entPhysicalContainedIn": 554,
                     "entPhysicalParentRelPos": 215,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100215
+                    "ifIndex": 215
                 },
                 {
                     "entPhysicalIndex": 56216,
@@ -38327,7 +38346,7 @@
                     "entPhysicalContainedIn": 554,
                     "entPhysicalParentRelPos": 216,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100216
+                    "ifIndex": 216
                 },
                 {
                     "entPhysicalIndex": 56217,
@@ -38346,7 +38365,7 @@
                     "entPhysicalContainedIn": 554,
                     "entPhysicalParentRelPos": 217,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100217
+                    "ifIndex": 217
                 },
                 {
                     "entPhysicalIndex": 56218,
@@ -38365,7 +38384,7 @@
                     "entPhysicalContainedIn": 554,
                     "entPhysicalParentRelPos": 218,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100218
+                    "ifIndex": 218
                 },
                 {
                     "entPhysicalIndex": 56219,
@@ -38384,7 +38403,7 @@
                     "entPhysicalContainedIn": 554,
                     "entPhysicalParentRelPos": 219,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100219
+                    "ifIndex": 219
                 },
                 {
                     "entPhysicalIndex": 56220,
@@ -38403,7 +38422,7 @@
                     "entPhysicalContainedIn": 554,
                     "entPhysicalParentRelPos": 220,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100220
+                    "ifIndex": 220
                 },
                 {
                     "entPhysicalIndex": 56221,
@@ -38422,7 +38441,7 @@
                     "entPhysicalContainedIn": 554,
                     "entPhysicalParentRelPos": 221,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100221
+                    "ifIndex": 221
                 },
                 {
                     "entPhysicalIndex": 56222,
@@ -38441,7 +38460,7 @@
                     "entPhysicalContainedIn": 554,
                     "entPhysicalParentRelPos": 222,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100222
+                    "ifIndex": 222
                 },
                 {
                     "entPhysicalIndex": 56223,
@@ -38460,463 +38479,7 @@
                     "entPhysicalContainedIn": 554,
                     "entPhysicalParentRelPos": 223,
                     "entPhysicalMfgName": null,
-                    "ifIndex": 100223
-                },
-                {
-                    "entPhysicalIndex": 100001,
-                    "entPhysicalDescr": " qsfpPlus transceiver manufactured 18/10/20 ",
-                    "entPhysicalClass": "sensor",
-                    "entPhysicalName": null,
-                    "entPhysicalHardwareRev": "",
-                    "entPhysicalFirmwareRev": null,
-                    "entPhysicalSoftwareRev": null,
-                    "entPhysicalAlias": null,
-                    "entPhysicalAssetID": null,
-                    "entPhysicalIsFRU": "true",
-                    "entPhysicalModelName": "323637322D30325630322001",
-                    "entPhysicalVendorType": null,
-                    "entPhysicalSerialNum": "S1812345678",
-                    "entPhysicalContainedIn": 561,
-                    "entPhysicalParentRelPos": -1,
-                    "entPhysicalMfgName": "",
-                    "ifIndex": null
-                },
-                {
-                    "entPhysicalIndex": 100003,
-                    "entPhysicalDescr": "CIENA qsfp28 transceiver manufactured 03/02/20 ",
-                    "entPhysicalClass": "sensor",
-                    "entPhysicalName": null,
-                    "entPhysicalHardwareRev": "",
-                    "entPhysicalFirmwareRev": null,
-                    "entPhysicalSoftwareRev": null,
-                    "entPhysicalAlias": null,
-                    "entPhysicalAssetID": null,
-                    "entPhysicalIsFRU": "true",
-                    "entPhysicalModelName": "160-9400-900",
-                    "entPhysicalVendorType": null,
-                    "entPhysicalSerialNum": "AVAGCN1234FG1234",
-                    "entPhysicalContainedIn": 563,
-                    "entPhysicalParentRelPos": -1,
-                    "entPhysicalMfgName": "CIENA",
-                    "ifIndex": null
-                },
-                {
-                    "entPhysicalIndex": 100004,
-                    "entPhysicalDescr": "FFFFFFFFFF qsfp28 transceiver manufactured 12/06/18 ",
-                    "entPhysicalClass": "sensor",
-                    "entPhysicalName": null,
-                    "entPhysicalHardwareRev": "",
-                    "entPhysicalFirmwareRev": null,
-                    "entPhysicalSoftwareRev": null,
-                    "entPhysicalAlias": null,
-                    "entPhysicalAssetID": null,
-                    "entPhysicalIsFRU": "true",
-                    "entPhysicalModelName": "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
-                    "entPhysicalVendorType": null,
-                    "entPhysicalSerialNum": "S1812345678",
-                    "entPhysicalContainedIn": 564,
-                    "entPhysicalParentRelPos": -1,
-                    "entPhysicalMfgName": "FFFFFFFFFF",
-                    "ifIndex": null
-                },
-                {
-                    "entPhysicalIndex": 100005,
-                    "entPhysicalDescr": "CIENA-INN qsfp28 transceiver manufactured 02/24/20 ",
-                    "entPhysicalClass": "sensor",
-                    "entPhysicalName": null,
-                    "entPhysicalHardwareRev": "",
-                    "entPhysicalFirmwareRev": null,
-                    "entPhysicalSoftwareRev": null,
-                    "entPhysicalAlias": null,
-                    "entPhysicalAssetID": null,
-                    "entPhysicalIsFRU": "true",
-                    "entPhysicalModelName": "XCVR-Q30V31",
-                    "entPhysicalVendorType": null,
-                    "entPhysicalSerialNum": "INKAC5123456",
-                    "entPhysicalContainedIn": 565,
-                    "entPhysicalParentRelPos": -1,
-                    "entPhysicalMfgName": "CIENA-INN",
-                    "ifIndex": null
-                },
-                {
-                    "entPhysicalIndex": 100006,
-                    "entPhysicalDescr": "CIENA-INN qsfp28 transceiver manufactured 02/24/20 ",
-                    "entPhysicalClass": "sensor",
-                    "entPhysicalName": null,
-                    "entPhysicalHardwareRev": "",
-                    "entPhysicalFirmwareRev": null,
-                    "entPhysicalSoftwareRev": null,
-                    "entPhysicalAlias": null,
-                    "entPhysicalAssetID": null,
-                    "entPhysicalIsFRU": "true",
-                    "entPhysicalModelName": "XCVR-Q30V31",
-                    "entPhysicalVendorType": null,
-                    "entPhysicalSerialNum": "INKAC5123456",
-                    "entPhysicalContainedIn": 566,
-                    "entPhysicalParentRelPos": -1,
-                    "entPhysicalMfgName": "CIENA-INN",
-                    "ifIndex": null
-                },
-                {
-                    "entPhysicalIndex": 100007,
-                    "entPhysicalDescr": "CIENA-INN qsfp28 transceiver manufactured 02/24/20 ",
-                    "entPhysicalClass": "sensor",
-                    "entPhysicalName": null,
-                    "entPhysicalHardwareRev": "",
-                    "entPhysicalFirmwareRev": null,
-                    "entPhysicalSoftwareRev": null,
-                    "entPhysicalAlias": null,
-                    "entPhysicalAssetID": null,
-                    "entPhysicalIsFRU": "true",
-                    "entPhysicalModelName": "XCVR-Q30V31",
-                    "entPhysicalVendorType": null,
-                    "entPhysicalSerialNum": "INKAC5123456",
-                    "entPhysicalContainedIn": 567,
-                    "entPhysicalParentRelPos": -1,
-                    "entPhysicalMfgName": "CIENA-INN",
-                    "ifIndex": null
-                },
-                {
-                    "entPhysicalIndex": 100065,
-                    "entPhysicalDescr": " qsfpPlus transceiver manufactured 18/10/20 ",
-                    "entPhysicalClass": "sensor",
-                    "entPhysicalName": null,
-                    "entPhysicalHardwareRev": "",
-                    "entPhysicalFirmwareRev": null,
-                    "entPhysicalSoftwareRev": null,
-                    "entPhysicalAlias": null,
-                    "entPhysicalAssetID": null,
-                    "entPhysicalIsFRU": "true",
-                    "entPhysicalModelName": "323637322D30325630322001",
-                    "entPhysicalVendorType": null,
-                    "entPhysicalSerialNum": "S1812345678",
-                    "entPhysicalContainedIn": 5665,
-                    "entPhysicalParentRelPos": -1,
-                    "entPhysicalMfgName": "",
-                    "ifIndex": null
-                },
-                {
-                    "entPhysicalIndex": 100067,
-                    "entPhysicalDescr": "CIENA qsfp28 transceiver manufactured 03/02/20 ",
-                    "entPhysicalClass": "sensor",
-                    "entPhysicalName": null,
-                    "entPhysicalHardwareRev": "",
-                    "entPhysicalFirmwareRev": null,
-                    "entPhysicalSoftwareRev": null,
-                    "entPhysicalAlias": null,
-                    "entPhysicalAssetID": null,
-                    "entPhysicalIsFRU": "true",
-                    "entPhysicalModelName": "160-9400-900",
-                    "entPhysicalVendorType": null,
-                    "entPhysicalSerialNum": "AVAGCN1234FG1234",
-                    "entPhysicalContainedIn": 5667,
-                    "entPhysicalParentRelPos": -1,
-                    "entPhysicalMfgName": "CIENA",
-                    "ifIndex": null
-                },
-                {
-                    "entPhysicalIndex": 100068,
-                    "entPhysicalDescr": "CIENA-INN qsfp28 transceiver manufactured 02/24/20 ",
-                    "entPhysicalClass": "sensor",
-                    "entPhysicalName": null,
-                    "entPhysicalHardwareRev": "",
-                    "entPhysicalFirmwareRev": null,
-                    "entPhysicalSoftwareRev": null,
-                    "entPhysicalAlias": null,
-                    "entPhysicalAssetID": null,
-                    "entPhysicalIsFRU": "true",
-                    "entPhysicalModelName": "XCVR-Q30V31",
-                    "entPhysicalVendorType": null,
-                    "entPhysicalSerialNum": "INKAC5123456",
-                    "entPhysicalContainedIn": 5668,
-                    "entPhysicalParentRelPos": -1,
-                    "entPhysicalMfgName": "CIENA-INN",
-                    "ifIndex": null
-                },
-                {
-                    "entPhysicalIndex": 100069,
-                    "entPhysicalDescr": "CIENA-INN qsfp28 transceiver manufactured 02/24/20 ",
-                    "entPhysicalClass": "sensor",
-                    "entPhysicalName": null,
-                    "entPhysicalHardwareRev": "",
-                    "entPhysicalFirmwareRev": null,
-                    "entPhysicalSoftwareRev": null,
-                    "entPhysicalAlias": null,
-                    "entPhysicalAssetID": null,
-                    "entPhysicalIsFRU": "true",
-                    "entPhysicalModelName": "XCVR-Q30V31",
-                    "entPhysicalVendorType": null,
-                    "entPhysicalSerialNum": "INKAC5123456",
-                    "entPhysicalContainedIn": 5669,
-                    "entPhysicalParentRelPos": -1,
-                    "entPhysicalMfgName": "CIENA-INN",
-                    "ifIndex": null
-                },
-                {
-                    "entPhysicalIndex": 100070,
-                    "entPhysicalDescr": "CIENA-INN qsfp28 transceiver manufactured 02/24/20 ",
-                    "entPhysicalClass": "sensor",
-                    "entPhysicalName": null,
-                    "entPhysicalHardwareRev": "",
-                    "entPhysicalFirmwareRev": null,
-                    "entPhysicalSoftwareRev": null,
-                    "entPhysicalAlias": null,
-                    "entPhysicalAssetID": null,
-                    "entPhysicalIsFRU": "true",
-                    "entPhysicalModelName": "XCVR-Q30V31",
-                    "entPhysicalVendorType": null,
-                    "entPhysicalSerialNum": "INKAC5123456",
-                    "entPhysicalContainedIn": 5670,
-                    "entPhysicalParentRelPos": -1,
-                    "entPhysicalMfgName": "CIENA-INN",
-                    "ifIndex": null
-                },
-                {
-                    "entPhysicalIndex": 100071,
-                    "entPhysicalDescr": "CIENA-INN qsfp28 transceiver manufactured 02/24/20 ",
-                    "entPhysicalClass": "sensor",
-                    "entPhysicalName": null,
-                    "entPhysicalHardwareRev": "",
-                    "entPhysicalFirmwareRev": null,
-                    "entPhysicalSoftwareRev": null,
-                    "entPhysicalAlias": null,
-                    "entPhysicalAssetID": null,
-                    "entPhysicalIsFRU": "true",
-                    "entPhysicalModelName": "XCVR-Q30V31",
-                    "entPhysicalVendorType": null,
-                    "entPhysicalSerialNum": "INKAC5123456",
-                    "entPhysicalContainedIn": 5671,
-                    "entPhysicalParentRelPos": -1,
-                    "entPhysicalMfgName": "CIENA-INN",
-                    "ifIndex": null
-                },
-                {
-                    "entPhysicalIndex": 100131,
-                    "entPhysicalDescr": "FFFFFFFFFF qsfp28 transceiver manufactured 12/06/18 ",
-                    "entPhysicalClass": "sensor",
-                    "entPhysicalName": null,
-                    "entPhysicalHardwareRev": "",
-                    "entPhysicalFirmwareRev": null,
-                    "entPhysicalSoftwareRev": null,
-                    "entPhysicalAlias": null,
-                    "entPhysicalAssetID": null,
-                    "entPhysicalIsFRU": "true",
-                    "entPhysicalModelName": "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
-                    "entPhysicalVendorType": null,
-                    "entPhysicalSerialNum": "S1812345678",
-                    "entPhysicalContainedIn": 56131,
-                    "entPhysicalParentRelPos": -1,
-                    "entPhysicalMfgName": "FFFFFFFFFF",
-                    "ifIndex": null
-                },
-                {
-                    "entPhysicalIndex": 100132,
-                    "entPhysicalDescr": "CIENA-INN qsfp28 transceiver manufactured 02/24/20 ",
-                    "entPhysicalClass": "sensor",
-                    "entPhysicalName": null,
-                    "entPhysicalHardwareRev": "",
-                    "entPhysicalFirmwareRev": null,
-                    "entPhysicalSoftwareRev": null,
-                    "entPhysicalAlias": null,
-                    "entPhysicalAssetID": null,
-                    "entPhysicalIsFRU": "true",
-                    "entPhysicalModelName": "XCVR-Q30V31",
-                    "entPhysicalVendorType": null,
-                    "entPhysicalSerialNum": "INKAC5123456",
-                    "entPhysicalContainedIn": 56132,
-                    "entPhysicalParentRelPos": -1,
-                    "entPhysicalMfgName": "CIENA-INN",
-                    "ifIndex": null
-                },
-                {
-                    "entPhysicalIndex": 100133,
-                    "entPhysicalDescr": "CIENA-INN qsfp28 transceiver manufactured 02/24/20 ",
-                    "entPhysicalClass": "sensor",
-                    "entPhysicalName": null,
-                    "entPhysicalHardwareRev": "",
-                    "entPhysicalFirmwareRev": null,
-                    "entPhysicalSoftwareRev": null,
-                    "entPhysicalAlias": null,
-                    "entPhysicalAssetID": null,
-                    "entPhysicalIsFRU": "true",
-                    "entPhysicalModelName": "XCVR-Q30V31",
-                    "entPhysicalVendorType": null,
-                    "entPhysicalSerialNum": "INKAC5123456",
-                    "entPhysicalContainedIn": 56133,
-                    "entPhysicalParentRelPos": -1,
-                    "entPhysicalMfgName": "CIENA-INN",
-                    "ifIndex": null
-                },
-                {
-                    "entPhysicalIndex": 100134,
-                    "entPhysicalDescr": "CIENA-INN qsfp28 transceiver manufactured 02/24/20 ",
-                    "entPhysicalClass": "sensor",
-                    "entPhysicalName": null,
-                    "entPhysicalHardwareRev": "",
-                    "entPhysicalFirmwareRev": null,
-                    "entPhysicalSoftwareRev": null,
-                    "entPhysicalAlias": null,
-                    "entPhysicalAssetID": null,
-                    "entPhysicalIsFRU": "true",
-                    "entPhysicalModelName": "XCVR-Q30V31",
-                    "entPhysicalVendorType": null,
-                    "entPhysicalSerialNum": "INKAC5123456",
-                    "entPhysicalContainedIn": 56134,
-                    "entPhysicalParentRelPos": -1,
-                    "entPhysicalMfgName": "CIENA-INN",
-                    "ifIndex": null
-                },
-                {
-                    "entPhysicalIndex": 100135,
-                    "entPhysicalDescr": "CIENA-INN qsfp28 transceiver manufactured 02/24/20 ",
-                    "entPhysicalClass": "sensor",
-                    "entPhysicalName": null,
-                    "entPhysicalHardwareRev": "",
-                    "entPhysicalFirmwareRev": null,
-                    "entPhysicalSoftwareRev": null,
-                    "entPhysicalAlias": null,
-                    "entPhysicalAssetID": null,
-                    "entPhysicalIsFRU": "true",
-                    "entPhysicalModelName": "XCVR-Q30V31",
-                    "entPhysicalVendorType": null,
-                    "entPhysicalSerialNum": "INKAC5123456",
-                    "entPhysicalContainedIn": 56135,
-                    "entPhysicalParentRelPos": -1,
-                    "entPhysicalMfgName": "CIENA-INN",
-                    "ifIndex": null
-                },
-                {
-                    "entPhysicalIndex": 100193,
-                    "entPhysicalDescr": "FS 850 nm sfp transceiver manufactured 08/23/18 ",
-                    "entPhysicalClass": "sensor",
-                    "entPhysicalName": null,
-                    "entPhysicalHardwareRev": "000A",
-                    "entPhysicalFirmwareRev": null,
-                    "entPhysicalSoftwareRev": null,
-                    "entPhysicalAlias": null,
-                    "entPhysicalAssetID": null,
-                    "entPhysicalIsFRU": "true",
-                    "entPhysicalModelName": "SFP-10GSR-85",
-                    "entPhysicalVendorType": null,
-                    "entPhysicalSerialNum": "S1812345678",
-                    "entPhysicalContainedIn": 56193,
-                    "entPhysicalParentRelPos": -1,
-                    "entPhysicalMfgName": "FS",
-                    "ifIndex": null
-                },
-                {
-                    "entPhysicalIndex": 100195,
-                    "entPhysicalDescr": "FS 850 nm sfp transceiver manufactured 08/23/18 ",
-                    "entPhysicalClass": "sensor",
-                    "entPhysicalName": null,
-                    "entPhysicalHardwareRev": "000A",
-                    "entPhysicalFirmwareRev": null,
-                    "entPhysicalSoftwareRev": null,
-                    "entPhysicalAlias": null,
-                    "entPhysicalAssetID": null,
-                    "entPhysicalIsFRU": "true",
-                    "entPhysicalModelName": "SFP-10GSR-85",
-                    "entPhysicalVendorType": null,
-                    "entPhysicalSerialNum": "S1812345678",
-                    "entPhysicalContainedIn": 56195,
-                    "entPhysicalParentRelPos": -1,
-                    "entPhysicalMfgName": "FS",
-                    "ifIndex": null
-                },
-                {
-                    "entPhysicalIndex": 100196,
-                    "entPhysicalDescr": "FS 850 nm sfp transceiver manufactured 08/23/18 ",
-                    "entPhysicalClass": "sensor",
-                    "entPhysicalName": null,
-                    "entPhysicalHardwareRev": "000A",
-                    "entPhysicalFirmwareRev": null,
-                    "entPhysicalSoftwareRev": null,
-                    "entPhysicalAlias": null,
-                    "entPhysicalAssetID": null,
-                    "entPhysicalIsFRU": "true",
-                    "entPhysicalModelName": "SFP-10GSR-85",
-                    "entPhysicalVendorType": null,
-                    "entPhysicalSerialNum": "S1812345678",
-                    "entPhysicalContainedIn": 56196,
-                    "entPhysicalParentRelPos": -1,
-                    "entPhysicalMfgName": "FS",
-                    "ifIndex": null
-                },
-                {
-                    "entPhysicalIndex": 100197,
-                    "entPhysicalDescr": "CIENA-XGI 1550 nm sfp transceiver manufactured 07/02/19 ",
-                    "entPhysicalClass": "sensor",
-                    "entPhysicalName": null,
-                    "entPhysicalHardwareRev": "003",
-                    "entPhysicalFirmwareRev": null,
-                    "entPhysicalSoftwareRev": null,
-                    "entPhysicalAlias": null,
-                    "entPhysicalAssetID": null,
-                    "entPhysicalIsFRU": "true",
-                    "entPhysicalModelName": "XCVR-S40V55",
-                    "entPhysicalVendorType": null,
-                    "entPhysicalSerialNum": "191234567890",
-                    "entPhysicalContainedIn": 56197,
-                    "entPhysicalParentRelPos": -1,
-                    "entPhysicalMfgName": "CIENA-XGI",
-                    "ifIndex": null
-                },
-                {
-                    "entPhysicalIndex": 100198,
-                    "entPhysicalDescr": "CIENA-XGI 1550 nm sfp transceiver manufactured 07/02/19 ",
-                    "entPhysicalClass": "sensor",
-                    "entPhysicalName": null,
-                    "entPhysicalHardwareRev": "003",
-                    "entPhysicalFirmwareRev": null,
-                    "entPhysicalSoftwareRev": null,
-                    "entPhysicalAlias": null,
-                    "entPhysicalAssetID": null,
-                    "entPhysicalIsFRU": "true",
-                    "entPhysicalModelName": "XCVR-S40V55",
-                    "entPhysicalVendorType": null,
-                    "entPhysicalSerialNum": "191234567890",
-                    "entPhysicalContainedIn": 56198,
-                    "entPhysicalParentRelPos": -1,
-                    "entPhysicalMfgName": "CIENA-XGI",
-                    "ifIndex": null
-                },
-                {
-                    "entPhysicalIndex": 100211,
-                    "entPhysicalDescr": "FS 850 nm sfp transceiver manufactured 08/23/18 ",
-                    "entPhysicalClass": "sensor",
-                    "entPhysicalName": null,
-                    "entPhysicalHardwareRev": "000A",
-                    "entPhysicalFirmwareRev": null,
-                    "entPhysicalSoftwareRev": null,
-                    "entPhysicalAlias": null,
-                    "entPhysicalAssetID": null,
-                    "entPhysicalIsFRU": "true",
-                    "entPhysicalModelName": "SFP-10GSR-85",
-                    "entPhysicalVendorType": null,
-                    "entPhysicalSerialNum": "S1812345678",
-                    "entPhysicalContainedIn": 56211,
-                    "entPhysicalParentRelPos": -1,
-                    "entPhysicalMfgName": "FS",
-                    "ifIndex": null
-                },
-                {
-                    "entPhysicalIndex": 100212,
-                    "entPhysicalDescr": "FS 850 nm sfp transceiver manufactured 08/23/18 ",
-                    "entPhysicalClass": "sensor",
-                    "entPhysicalName": null,
-                    "entPhysicalHardwareRev": "000A",
-                    "entPhysicalFirmwareRev": null,
-                    "entPhysicalSoftwareRev": null,
-                    "entPhysicalAlias": null,
-                    "entPhysicalAssetID": null,
-                    "entPhysicalIsFRU": "true",
-                    "entPhysicalModelName": "SFP-10GSR-85",
-                    "entPhysicalVendorType": null,
-                    "entPhysicalSerialNum": "S1812345678",
-                    "entPhysicalContainedIn": 56212,
-                    "entPhysicalParentRelPos": -1,
-                    "entPhysicalMfgName": "FS",
-                    "ifIndex": null
+                    "ifIndex": 223
                 }
             ]
         },


### PR DESCRIPTION
The entity discovery fix from 9/29/24 generated an error when doing entity discovery against Ciena service delivery switch devices.  The issue was it tried to set entPhysicalIndex using the ifIndex as discovered via a walk of BRIDGE-MIB, which Ciena doesn't implement. This results in a null in entPHysicalIndex which causes an SQL error.

Changes:

 - Replace BRIDGE-MIB  with IF-MIB for gathering ifIndex value.
 -  Add a check for detecting if cienaCesEttpConfig exists on the device (not all platforms use it) and skipping if not present.
 - Updates the mib CIENA-CES-PORT-XCVR-MIB



DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
