### PR TITLE
ARP search trim MAC search phrase

### DIFF
--- a/includes/html/table/arp-search.inc.php
+++ b/includes/html/table/arp-search.inc.php
@@ -39,7 +39,7 @@ if (isset($vars['port_id']) && is_numeric($vars['port_id'])) {
 
 if (isset($vars['searchPhrase']) && ! empty($vars['searchPhrase'])) {
     $ip_search = '%' . trim($vars['searchPhrase']) . '%';
-    $mac_search = '%' . str_replace([':', ' ', '-', '.', '0x'], '', $vars['searchPhrase']) . '%';
+    $mac_search = '%' . str_replace([':', ' ', '-', '.', '0x'], '', trim($vars['searchPhrase'])) . '%';
 
     if (isset($vars['searchby']) && $vars['searchby'] == 'ip') {
         $query->where('ipv4_address', 'like', $ip_search);


### PR DESCRIPTION
For some reason IP search trimmed the search pharse, but MAC search did not. Fix that. 
Especially noticeable when pasting MACs.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
