### PR TITLE
Fix brower push alert too large

### DIFF
--- a/app/Notifications/AlertNotification.php
+++ b/app/Notifications/AlertNotification.php
@@ -41,7 +41,7 @@ class AlertNotification extends Notification
         $this->message = (new WebPushMessage)
             ->title($title)
             ->icon(asset('/images/mstile-144x144.png'))
-            ->body($body)
+            ->body(substr($body, 0, 3500))
             ->action('Acknowledge', 'alert.acknowledge')
             ->action('View', 'alert.view')
             ->options(['TTL' => 2000])


### PR DESCRIPTION
Truncate to 3500 characters max.
Full max (including json) is 4078, 3500 leaves room for json changes.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
