### PR TITLE
Add nbsp to fix display of cog icon in device toolbar

### DIFF
--- a/resources/views/device/index.blade.php
+++ b/resources/views/device/index.blade.php
@@ -25,7 +25,7 @@
                    @if(isset($primary_device_link['onclick']))onclick="{{ $primary_device_link['onclick'] }}" @endif
                    @if($primary_device_link['external'])target="_blank" rel="noopener" @endif
                    title="{{ $primary_device_link['title'] }}"
-                > <i class="fa {{ $primary_device_link['icon'] }} fa-lg icon-theme"></i>
+                >&nbsp;<i class="fa {{ $primary_device_link['icon'] }} fa-lg icon-theme"></i>
                 </a>
                 <div class="btn-group" role="group">
                     <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">


### PR DESCRIPTION
The cog button on the device menu was not the same size as the 3 dots next to it.  This adds a nbsp to the cog button to make it the same as the 3 dots, which fixes the UI so the buttons are the same height.

Before:
![image](https://github.com/user-attachments/assets/a071021e-3a2f-4931-9482-699be7f5cabb)

After:
![image](https://github.com/user-attachments/assets/55228e77-989c-4d9e-b2a2-bffdf4f66e8d)


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
