### PR TITLE
Convert device actions to a table instead of a bootstrap grid

### DIFF
--- a/resources/views/device/action-icon.blade.php
+++ b/resources/views/device/action-icon.blade.php
@@ -1,5 +1,5 @@
-<div class="col-xs-1">
+<td style="padding: 2px;">
     <a href="{{ $href }}" @if($external ?? true)target="_blank" rel="noopener" @endif title="{{ $title }}">
-        <i class="fa fa-lg icon-theme {{ $icon ?? 'fa-external-link' }}"></i>
+        &nbsp;<i class="fa fa-lg icon-theme {{ $icon ?? 'fa-external-link' }}"></i>
     </a>
-</div>
+</td>

--- a/resources/views/device/actions.blade.php
+++ b/resources/views/device/actions.blade.php
@@ -1,9 +1,9 @@
-<div class="container-fluid" style="padding-left: 0; padding-right: 0;">
+<table>
     @foreach($actions as $row)
-        <div>
+        <tr>
             @foreach($row as $action)
                 @include('device.action-icon', $action)
             @endforeach
-        </div>
+        </tr>
     @endforeach
-</div>
+</table>


### PR DESCRIPTION
The icons on the actions table on my system was displaying with both rows overlapping (see below).  I tried to add a nbsp; but this resulted in the icons being displayed outside their parent div.  Converting to a table results in the correct display (also see below):

Before:
![image](https://github.com/user-attachments/assets/4ef49995-07ac-4edf-a77d-d4f0107dc529)

After:
![image](https://github.com/user-attachments/assets/6600802f-bbac-4c4c-962e-cf1c01bfd009)


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
