### PR TITLE
Fix status option name in world map widget

### DIFF
--- a/resources/views/widgets/worldmap.blade.php
+++ b/resources/views/widgets/worldmap.blade.php
@@ -13,7 +13,7 @@
                 type: "POST",
                 url: '{{ route('maps.getdevices') }}',
                 dataType: "json",
-                data: { location_valid: 1, disabled: 0, disabled_alerts: 0, status: status, group: device_group },
+                data: { location_valid: 1, disabled: 0, disabled_alerts: 0, statuses: status, group: device_group },
                 success: function (data) {
                     var redMarker = L.AwesomeMarkers.icon({
                         icon: 'server',


### PR DESCRIPTION
 - Use the correct option name (statuses vs status) in the world map widget when fetching devices to show

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
