### PR TITLE
Add new config option for dependency map vis options

### DIFF
--- a/app/Http/Controllers/Maps/DeviceDependencyController.php
+++ b/app/Http/Controllers/Maps/DeviceDependencyController.php
@@ -46,7 +46,7 @@ class DeviceDependencyController extends Controller
         $data = [
             'page_refresh' => Config::get('page_refresh', 300),
             'group_id' => $group_id,
-            'options' => Config::get('network_map_vis_options'),
+            'options' => Config::get('network_map_dependencymap_vis_options') ?? Config::get('network_map_vis_options'),
             'group_name' => $group_name,
         ];
 

--- a/doc/Extensions/VisJS-Config.md
+++ b/doc/Extensions/VisJS-Config.md
@@ -1,42 +1,103 @@
 # Vis JS Configuration
 
-The [Network Maps](Network-Map.md) and [Dependency Maps](Dependency-Map.md) all use a common configuration for
-the vis.js library, which affects the way the maps are rendered, as well
+The [Network Maps](Network-Map.md) and [Dependency Maps](Dependency-Map.md) have configuration options for
+the vis.js library, which affects the way the maps are rendered as well
 as the way that users can interact with the maps. This configuration can
 be adjusted by following the instructions below.
 
 [This link](https://visjs.github.io/vis-network/docs/network/) will
 show you all the options and explain what they do.
 
+The commands to run to use the defaults is as follows:
+
+```bash
+lnms config:set network_map_vis_options '{
+  layout:{
+      randomSeed:2
+  },
+  "edges": {
+    arrows: {
+          to: {enabled: true, scaleFactor:0.5},
+    },
+    "smooth": {
+        enabled: false
+    },
+    font: {
+        size: 14,
+        color: "red",
+        face: "sans",
+        background: "white",
+        strokeWidth:3,
+        align: "middle",
+        strokeWidth: 2
+    }
+  },
+  "physics": {
+     "barnesHut": {
+      "gravitationalConstant": -2000,
+      "centralGravity": 0.3,
+      "springLength": 200,
+      "springConstant": 0.04,
+      "damping": 0.09,
+      "avoidOverlap": 1
+    },
+     "forceAtlas2Based": {
+      "gravitationalConstant": -50,
+      "centralGravity": 0.01,
+      "springLength": 200,
+      "springConstant": 0.08,
+      "damping": 0.4,
+      "avoidOverlap": 1
+    },
+     "repulsion": {
+      "centralGravity": 0.2,
+      "springLength": 250,
+      "springConstant": 0.2,
+      "nodeDistance": 200,
+      "damping": 0.07
+    },
+     "hierarchicalRepulsion": {
+      "nodeDistance": 300,
+      "centralGravity": 0.2,
+      "springLength": 300,
+      "springConstant": 0.2,
+      "damping": 0.07
+    },
+  "maxVelocity": 50,
+  "minVelocity": 0.4,
+  "solver": "hierarchicalRepulsion",
+  "stabilization": {
+    "enabled": true,
+    "iterations": 1000,
+    "updateInterval": 100,
+    "onlyDynamicEdges": false,
+    "fit": true
+  },
+  "timestep": 0.4,
+ }
+}'
+```
+
+An example to override the device dependency map to use a heirarchical layout is below.
+Note that you can choose to enter the JSON config on one line if you want.
+
+```bash
+lnms config:set network_map_devicedependency_vis_options '{ layout:{ hierarchical: { enabled: true, direction: "LR", sortMethod: "directed", nodeSpacing: 50, treeSpacing: 50, levelSeparation: 300 } }, "edges": { arrows: { to: { enabled: true, scaleFactor:0.5 }, }, "smooth": { enabled: false }, font: { size: 14, color: "red", face: "sans", background: "white", strokeWidth:3, align: "middle", strokeWidth: 2 } }, "physics": {"enabled": false } }'
+```
+
+### Configurator Output
+
 You may also access the dynamic configuration interface [example
 here](https://visjs.github.io/vis-network/examples/network/other/configuration.html)
 from within LibreNMS by adding the following to config.php
 
-```php
-$config['network_map_vis_options'] = '{
-  "configure": { "enabled": true},
-}';
-```
-
-### Note
-
-You may want to disable the automatic page refresh while you're
-tweaking your configuration, as the refresh will reset the dynamic
-configuration UI to the values currently saved in config.php This can
-be done by clicking on the Settings Icon then Refresh Pause.
-
-### Configurator Output
-
 Once you've achieved your desired map appearance, click the generate
 options button at the bottom to be given the necessary parameters to
-add to your config.php file. You will need to paste the generated
-config into config.php the format will need to look something like
-this. Note that the configurator will output the config with `var options`
-you will need to strip them out and at the end of the config you need to
-add an `}';` see the example below.
+set in the lnms command. Note that the configurator will output the config
+with `const options` you will need to strip this out.
 
-```php
-$config['network_map_vis_options'] = '{
+```bash
+lnms config:set network_map_vis_options '{
   "nodes": {
     "color": {
       "background": "rgba(20,252,18,1)"
@@ -65,7 +126,7 @@ $config['network_map_vis_options'] = '{
     },
     "minVelocity": 0.75
   }
-}';
+}'
 ```
 
 ![Example Network Map](/img/networkmap.png)

--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -4632,6 +4632,10 @@
             "section": "networks",
             "order": 1
         },
+        "network_map_dependencymap_vis_options": {
+            "default": null,
+            "type": "text"
+        },
         "network_map_items": {
             "default": [
                 "xdp",


### PR DESCRIPTION
This allows the device dependency maps to have a different set of vis.js options than the network maps

In our environment, we want to use the hierarchical layout for the dependency maps, but this doesn't make sense for the network maps, which incidentally are much more fun as a dynamic moving blob of devices that you can throw around the screen as much as you desire.  This allows the 2 different types of maps to have different options, while still defaulting to the current behaviour.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
