### PR TITLE
Add note about F5 devices requiring max repeaters set to 5

### DIFF
--- a/doc/Support/Performance.md
+++ b/doc/Support/Performance.md
@@ -65,7 +65,10 @@ hostname and community string:
 /opt/librenms/mibs -m IF-MIB IfEntry`
 
 > NOTE: Do not go blindly setting this value as you can impact polling
-> negatively.
+> negatively. Some devices might require a lower value for Max Repeaters. 
+> For instance, F5 devices may experience issues such as tooBig errors 
+> during polling, and may need the Max Repeaters value set to 5 to prevent
+> these errors.
 
 ## SNMP Max OIDs
 


### PR DESCRIPTION
Add note about F5 devices requiring max repeaters set to 5.  Without that setting, only 10 virtual servers were discovered.  After changing it to 5, it found all of them. 

I expect this would impact most F5 users, which is one of the most popular load-balancers.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
