### PR TITLE
stat graph update: adds max and min information for hourly, weekly, and monthly

### DIFF
--- a/includes/html/graphs/generic_stats.inc.php
+++ b/includes/html/graphs/generic_stats.inc.php
@@ -172,8 +172,8 @@ if ($height > 25) {
     }
     if ($munge) {
         $rrd_options .= ' CDEF:dsm01h=dsm01hds,' . $munge_opts;
-        $rrd_options .= ' CDEF:dsm01h=dsm01hminds,' . $munge_opts;
-        $rrd_options .= ' CDEF:dsm01h=dsm01hmaxds,' . $munge_opts;
+        $rrd_options .= ' CDEF:dsm01hmin=dsm01hminds,' . $munge_opts;
+        $rrd_options .= ' CDEF:dsm01hmax=dsm01hmaxds,' . $munge_opts;
     }
     $rrd_options .= ' VDEF:' . $id . '50th=' . $id . ',50,PERCENTNAN';
     $rrd_options .= ' VDEF:' . $id . '25th=' . $id . ',25,PERCENTNAN';

--- a/includes/html/graphs/generic_stats.inc.php
+++ b/includes/html/graphs/generic_stats.inc.php
@@ -15,10 +15,6 @@
 
 require 'includes/html/graphs/common.inc.php';
 
-if (! isset($graph_stat_cf)) {
-    $graph_stat_cf = \LibreNMS\Config::get('graph_stat_cf', 'AVERAGE');
-}
-
 $stacked = generate_stacked_graphs();
 
 if (! isset($munge)) {
@@ -134,12 +130,18 @@ $descr = \LibreNMS\Data\Store\Rrd::fixedSafeDescr($descr, $descr_len);
 if ($height > 25) {
     if (! $no_hourly) {
         $descr_1h = \LibreNMS\Data\Store\Rrd::fixedSafeDescr('1 hour avg', $descr_len);
+        $descr_1h_min = \LibreNMS\Data\Store\Rrd::fixedSafeDescr('1 hour min', $descr_len);
+        $descr_1h_max = \LibreNMS\Data\Store\Rrd::fixedSafeDescr('1 hour max', $descr_len);
     }
     if (! $no_daily) {
         $descr_1d = \LibreNMS\Data\Store\Rrd::fixedSafeDescr('1 day avg', $descr_len);
+        $descr_1d_min = \LibreNMS\Data\Store\Rrd::fixedSafeDescr('1 day min', $descr_len);
+        $descr_1d_max = \LibreNMS\Data\Store\Rrd::fixedSafeDescr('1 day max', $descr_len);
     }
     if (! $no_weekly) {
         $descr_1w = \LibreNMS\Data\Store\Rrd::fixedSafeDescr('1 week avg', $descr_len);
+        $descr_1w_min = \LibreNMS\Data\Store\Rrd::fixedSafeDescr('1 week min', $descr_len);
+        $descr_1w_max = \LibreNMS\Data\Store\Rrd::fixedSafeDescr('1 week max', $descr_len);
     }
 }
 
@@ -148,7 +150,7 @@ if ($munge) {
     $id = 'dsm0';
 }
 
-$rrd_options .= ' DEF:ds0' . "=$filename:$ds:$graph_stat_cf";
+$rrd_options .= ' DEF:ds0' . "=$filename:$ds:AVERAGE";
 
 $munge_helper = '';
 if ($munge) {
@@ -164,10 +166,14 @@ $rrd_optionsb .= ' LINE1.25:' . $id . '#' . $colour . ":'$descr'";
 
 if ($height > 25) {
     if (! $no_hourly) {
-        $rrd_options .= ' DEF:' . $id . "1h$munge_helper=$filename:$ds:$graph_stat_cf:step=3600";
+        $rrd_options .= ' DEF:' . $id . "1h$munge_helper=$filename:$ds:AVERAGE:step=3600";
+        $rrd_options .= ' DEF:' . $id . "1hmin$munge_helper=$filename:$ds:MIN:step=3600";
+        $rrd_options .= ' DEF:' . $id . "1hmax$munge_helper=$filename:$ds:MAX:step=3600";
     }
     if ($munge) {
         $rrd_options .= ' CDEF:dsm01h=dsm01hds,' . $munge_opts;
+        $rrd_options .= ' CDEF:dsm01h=dsm01hminds,' . $munge_opts;
+        $rrd_options .= ' CDEF:dsm01h=dsm01hmaxds,' . $munge_opts;
     }
     $rrd_options .= ' VDEF:' . $id . '50th=' . $id . ',50,PERCENTNAN';
     $rrd_options .= ' VDEF:' . $id . '25th=' . $id . ',25,PERCENTNAN';
@@ -183,9 +189,13 @@ if ($height > 25) {
     // displays nan if less than 17 hours
     if (! $no_daily) {
         if ($time_diff >= 61200) {
-            $rrd_options .= ' DEF:' . $id . "1d$munge_helper=$filename:$ds:$graph_stat_cf:step=86400";
+            $rrd_options .= ' DEF:' . $id . "1d$munge_helper=$filename:$ds:AVERAGE:step=86400";
+            $rrd_options .= ' DEF:' . $id . "1dmin$munge_helper=$filename:$ds:MIN:step=86400";
+            $rrd_options .= ' DEF:' . $id . "1dmax$munge_helper=$filename:$ds:MAX:step=86400";
             if ($munge) {
                 $rrd_options .= ' CDEF:dsm01d=dsm01dds,' . $munge_opts;
+                $rrd_options .= ' CDEF:dsm01dmin=dsm01dminds,' . $munge_opts;
+                $rrd_options .= ' CDEF:dsm01dmax=dsm01dmaxds,' . $munge_opts;
             }
         }
     }
@@ -193,9 +203,13 @@ if ($height > 25) {
     // weekly breaks and causes issues if it is less than 8 days
     if (! $no_weekly) {
         if ($time_diff >= 691200) {
-            $rrd_options .= ' DEF:' . $id . "1w$munge_helper=$filename:$ds:$graph_stat_cf:step=604800";
+            $rrd_options .= ' DEF:' . $id . "1w$munge_helper=$filename:$ds:AVERAGE:step=604800";
+            $rrd_options .= ' DEF:' . $id . "1wmin$munge_helper=$filename:$ds:MIN:step=604800";
+            $rrd_options .= ' DEF:' . $id . "1wmax$munge_helper=$filename:$ds:MAX:step=604800";
             if ($munge) {
                 $rrd_options .= ' CDEF:dsm01w=dsm01wds,' . $munge_opts;
+                $rrd_options .= ' CDEF:dsm01wmin=dsm01dminds,' . $munge_opts;
+                $rrd_options .= ' CDEF:dsm01wmax=dsm01dmaxds,' . $munge_opts;
             }
         }
     }
@@ -204,24 +218,51 @@ if ($height > 25) {
     $rrd_optionsb .= ' GPRINT:' . $id . ':MAX:%5.' . $float_precision . 'lf%s' . $units . ' GPRINT:' . $id . ":AVERAGE:'%5." . $float_precision . "lf%s$units\\n'";
 
     if (! $no_hourly) {
+        # 1 hour avg
         $rrd_optionsb .= ' LINE1.25:' . $id . '1h#' . $colour1h . ":'$descr_1h'";
         $rrd_optionsb .= ' GPRINT:' . $id . '1h:LAST:%5.' . $float_precision . 'lf%s' . $units . ' GPRINT:' . $id . '1h:MIN:%5.' . $float_precision . 'lf%s' . $units;
         $rrd_optionsb .= ' GPRINT:' . $id . '1h:MAX:%5.' . $float_precision . 'lf%s' . $units . ' GPRINT:' . $id . "1h:AVERAGE:'%5." . $float_precision . "lf%s$units\\n'";
+        # 1 hour min
+        $rrd_optionsb .= ' COMMENT:"  '.$descr_1h_min.'"';
+        $rrd_optionsb .= ' GPRINT:' . $id . '1hmin:LAST:%5.' . $float_precision . 'lf%s' . $units . ' GPRINT:' . $id . '1hmin:MIN:%5.' . $float_precision . 'lf%s' . $units;
+        $rrd_optionsb .= ' GPRINT:' . $id . '1hmin:MAX:%5.' . $float_precision . 'lf%s' . $units . ' GPRINT:' . $id . "1hmin:AVERAGE:'%5." . $float_precision . "lf%s$units\\n'";
+        # 1 hour max
+        $rrd_optionsb .= ' COMMENT:"  '.$descr_1h_max.'"';
+        $rrd_optionsb .= ' GPRINT:' . $id . '1hmax:LAST:%5.' . $float_precision . 'lf%s' . $units . ' GPRINT:' . $id . '1hmax:MIN:%5.' . $float_precision . 'lf%s' . $units;
+        $rrd_optionsb .= ' GPRINT:' . $id . '1hmax:MAX:%5.' . $float_precision . 'lf%s' . $units . ' GPRINT:' . $id . "1hmax:AVERAGE:'%5." . $float_precision . "lf%s$units\\n'";
     }
 
     if (! $no_daily) {
         if ($time_diff >= 61200) {
+            # 1 hour average
             $rrd_optionsb .= ' LINE1.25:' . $id . '1d#' . $colour1d . ":'$descr_1d'";
             $rrd_optionsb .= ' GPRINT:' . $id . '1d:LAST:%5.' . $float_precision . 'lf%s' . $units . ' GPRINT:' . $id . '1d:MIN:%5.' . $float_precision . 'lf%s' . $units;
             $rrd_optionsb .= ' GPRINT:' . $id . '1d:MAX:%5.' . $float_precision . 'lf%s' . $units . ' GPRINT:' . $id . "1d:AVERAGE:'%5." . $float_precision . "lf%s$units\\n'";
+            # 1 hour min
+            $rrd_optionsb .= ' COMMENT:"  '.$descr_1d_min.'"';
+            $rrd_optionsb .= ' GPRINT:' . $id . '1dmin:LAST:%5.' . $float_precision . 'lf%s' . $units . ' GPRINT:' . $id . '1dmin:MIN:%5.' . $float_precision . 'lf%s' . $units;
+            $rrd_optionsb .= ' GPRINT:' . $id . '1dmin:MAX:%5.' . $float_precision . 'lf%s' . $units . ' GPRINT:' . $id . "1dmin:AVERAGE:'%5." . $float_precision . "lf%s$units\\n'";
+            # 1 hour max
+            $rrd_optionsb .= ' COMMENT:"  '.$descr_1d_max.'"';
+            $rrd_optionsb .= ' GPRINT:' . $id . '1dmax:LAST:%5.' . $float_precision . 'lf%s' . $units . ' GPRINT:' . $id . '1dmax:MIN:%5.' . $float_precision . 'lf%s' . $units;
+            $rrd_optionsb .= ' GPRINT:' . $id . '1dmax:MAX:%5.' . $float_precision . 'lf%s' . $units . ' GPRINT:' . $id . "1dmax:AVERAGE:'%5." . $float_precision . "lf%s$units\\n'";
         }
     }
 
     if (! $no_weekly) {
         if ($time_diff >= 691200) {
+            # 1 hour avg
             $rrd_optionsb .= ' LINE1.25:' . $id . '1w#' . $colour1w . ":'$descr_1w'";
             $rrd_optionsb .= ' GPRINT:' . $id . '1w:LAST:%5.' . $float_precision . 'lf%s' . $units . ' GPRINT:' . $id . '1w:MIN:%5.' . $float_precision . 'lf%s' . $units;
             $rrd_optionsb .= ' GPRINT:' . $id . '1w:MAX:%5.' . $float_precision . 'lf%s' . $units . ' GPRINT:' . $id . "1w:AVERAGE:'%5." . $float_precision . "lf%s$units\\n'";
+            # 1 hour min
+            $rrd_optionsb .= ' COMMENT:"  '.$descr_1w_min.'"';
+            $rrd_optionsb .= ' GPRINT:' . $id . '1wmin:LAST:%5.' . $float_precision . 'lf%s' . $units . ' GPRINT:' . $id . '1wmin:MIN:%5.' . $float_precision . 'lf%s' . $units;
+            $rrd_optionsb .= ' GPRINT:' . $id . '1wmin:MAX:%5.' . $float_precision . 'lf%s' . $units . ' GPRINT:' . $id . "1wmin:AVERAGE:'%5." . $float_precision . "lf%s$units\\n'";
+            # 1 hour max
+            $rrd_optionsb .= ' COMMENT:"  '.$descr_1w_max.'"';
+            $rrd_optionsb .= ' GPRINT:' . $id . '1wmax:LAST:%5.' . $float_precision . 'lf%s' . $units . ' GPRINT:' . $id . '1wmax:MIN:%5.' . $float_precision . 'lf%s' . $units;
+            $rrd_optionsb .= ' GPRINT:' . $id . '1wmax:MAX:%5.' . $float_precision . 'lf%s' . $units . ' GPRINT:' . $id . "1wmax:AVERAGE:'%5." . $float_precision . "lf%s$units\\n'";
         }
     }
 

--- a/includes/html/graphs/generic_stats.inc.php
+++ b/includes/html/graphs/generic_stats.inc.php
@@ -227,7 +227,7 @@ if ($height > 25) {
         $rrd_optionsb .= ' GPRINT:' . $id . '1hmin:LAST:%5.' . $float_precision . 'lf%s' . $units . ' GPRINT:' . $id . '1hmin:MIN:%5.' . $float_precision . 'lf%s' . $units;
         $rrd_optionsb .= ' GPRINT:' . $id . '1hmin:MAX:%5.' . $float_precision . 'lf%s' . $units . ' GPRINT:' . $id . "1hmin:AVERAGE:'%5." . $float_precision . "lf%s$units\\n'";
         // 1 hour max
-        $rrd_optionsb .= ' COMMENT:"  '.$descr_1h_max.'"';
+        $rrd_optionsb .= ' COMMENT:"  ' . $descr_1h_max.'"';
         $rrd_optionsb .= ' GPRINT:' . $id . '1hmax:LAST:%5.' . $float_precision . 'lf%s' . $units . ' GPRINT:' . $id . '1hmax:MIN:%5.' . $float_precision . 'lf%s' . $units;
         $rrd_optionsb .= ' GPRINT:' . $id . '1hmax:MAX:%5.' . $float_precision . 'lf%s' . $units . ' GPRINT:' . $id . "1hmax:AVERAGE:'%5." . $float_precision . "lf%s$units\\n'";
     }
@@ -239,11 +239,11 @@ if ($height > 25) {
             $rrd_optionsb .= ' GPRINT:' . $id . '1d:LAST:%5.' . $float_precision . 'lf%s' . $units . ' GPRINT:' . $id . '1d:MIN:%5.' . $float_precision . 'lf%s' . $units;
             $rrd_optionsb .= ' GPRINT:' . $id . '1d:MAX:%5.' . $float_precision . 'lf%s' . $units . ' GPRINT:' . $id . "1d:AVERAGE:'%5." . $float_precision . "lf%s$units\\n'";
             // 1 hour min
-            $rrd_optionsb .= ' COMMENT:"  '.$descr_1d_min.'"';
+            $rrd_optionsb .= ' COMMENT:"  ' . $descr_1d_min . '"';
             $rrd_optionsb .= ' GPRINT:' . $id . '1dmin:LAST:%5.' . $float_precision . 'lf%s' . $units . ' GPRINT:' . $id . '1dmin:MIN:%5.' . $float_precision . 'lf%s' . $units;
             $rrd_optionsb .= ' GPRINT:' . $id . '1dmin:MAX:%5.' . $float_precision . 'lf%s' . $units . ' GPRINT:' . $id . "1dmin:AVERAGE:'%5." . $float_precision . "lf%s$units\\n'";
             // 1 hour max
-            $rrd_optionsb .= ' COMMENT:"  '.$descr_1d_max.'"';
+            $rrd_optionsb .= ' COMMENT:"  ' . $descr_1d_max . '"';
             $rrd_optionsb .= ' GPRINT:' . $id . '1dmax:LAST:%5.' . $float_precision . 'lf%s' . $units . ' GPRINT:' . $id . '1dmax:MIN:%5.' . $float_precision . 'lf%s' . $units;
             $rrd_optionsb .= ' GPRINT:' . $id . '1dmax:MAX:%5.' . $float_precision . 'lf%s' . $units . ' GPRINT:' . $id . "1dmax:AVERAGE:'%5." . $float_precision . "lf%s$units\\n'";
         }
@@ -256,11 +256,11 @@ if ($height > 25) {
             $rrd_optionsb .= ' GPRINT:' . $id . '1w:LAST:%5.' . $float_precision . 'lf%s' . $units . ' GPRINT:' . $id . '1w:MIN:%5.' . $float_precision . 'lf%s' . $units;
             $rrd_optionsb .= ' GPRINT:' . $id . '1w:MAX:%5.' . $float_precision . 'lf%s' . $units . ' GPRINT:' . $id . "1w:AVERAGE:'%5." . $float_precision . "lf%s$units\\n'";
             // 1 hour min
-            $rrd_optionsb .= ' COMMENT:"  '.$descr_1w_min.'"';
+            $rrd_optionsb .= ' COMMENT:"  ' . $descr_1w_min . '"';
             $rrd_optionsb .= ' GPRINT:' . $id . '1wmin:LAST:%5.' . $float_precision . 'lf%s' . $units . ' GPRINT:' . $id . '1wmin:MIN:%5.' . $float_precision . 'lf%s' . $units;
             $rrd_optionsb .= ' GPRINT:' . $id . '1wmin:MAX:%5.' . $float_precision . 'lf%s' . $units . ' GPRINT:' . $id . "1wmin:AVERAGE:'%5." . $float_precision . "lf%s$units\\n'";
             // 1 hour max
-            $rrd_optionsb .= ' COMMENT:"  '.$descr_1w_max.'"';
+            $rrd_optionsb .= ' COMMENT:"  ' . $descr_1w_max . '"';
             $rrd_optionsb .= ' GPRINT:' . $id . '1wmax:LAST:%5.' . $float_precision . 'lf%s' . $units . ' GPRINT:' . $id . '1wmax:MIN:%5.' . $float_precision . 'lf%s' . $units;
             $rrd_optionsb .= ' GPRINT:' . $id . '1wmax:MAX:%5.' . $float_precision . 'lf%s' . $units . ' GPRINT:' . $id . "1wmax:AVERAGE:'%5." . $float_precision . "lf%s$units\\n'";
         }

--- a/includes/html/graphs/generic_stats.inc.php
+++ b/includes/html/graphs/generic_stats.inc.php
@@ -15,7 +15,9 @@
 
 require 'includes/html/graphs/common.inc.php';
 
-$graph_stat_cf = \LibreNMS\Config::get('graph_stat_cf', 'AVERAGE');
+if (! isset($graph_stat_cf)) {
+    $graph_stat_cf = \LibreNMS\Config::get('graph_stat_cf', 'AVERAGE');
+}
 
 $stacked = generate_stacked_graphs();
 

--- a/includes/html/graphs/generic_stats.inc.php
+++ b/includes/html/graphs/generic_stats.inc.php
@@ -223,11 +223,11 @@ if ($height > 25) {
         $rrd_optionsb .= ' GPRINT:' . $id . '1h:LAST:%5.' . $float_precision . 'lf%s' . $units . ' GPRINT:' . $id . '1h:MIN:%5.' . $float_precision . 'lf%s' . $units;
         $rrd_optionsb .= ' GPRINT:' . $id . '1h:MAX:%5.' . $float_precision . 'lf%s' . $units . ' GPRINT:' . $id . "1h:AVERAGE:'%5." . $float_precision . "lf%s$units\\n'";
         // 1 hour min
-        $rrd_optionsb .= ' COMMENT:"  '.$descr_1h_min.'"';
+        $rrd_optionsb .= ' COMMENT:"  ' . $descr_1h_min . '"';
         $rrd_optionsb .= ' GPRINT:' . $id . '1hmin:LAST:%5.' . $float_precision . 'lf%s' . $units . ' GPRINT:' . $id . '1hmin:MIN:%5.' . $float_precision . 'lf%s' . $units;
         $rrd_optionsb .= ' GPRINT:' . $id . '1hmin:MAX:%5.' . $float_precision . 'lf%s' . $units . ' GPRINT:' . $id . "1hmin:AVERAGE:'%5." . $float_precision . "lf%s$units\\n'";
         // 1 hour max
-        $rrd_optionsb .= ' COMMENT:"  ' . $descr_1h_max.'"';
+        $rrd_optionsb .= ' COMMENT:"  ' . $descr_1h_max . '"';
         $rrd_optionsb .= ' GPRINT:' . $id . '1hmax:LAST:%5.' . $float_precision . 'lf%s' . $units . ' GPRINT:' . $id . '1hmax:MIN:%5.' . $float_precision . 'lf%s' . $units;
         $rrd_optionsb .= ' GPRINT:' . $id . '1hmax:MAX:%5.' . $float_precision . 'lf%s' . $units . ' GPRINT:' . $id . "1hmax:AVERAGE:'%5." . $float_precision . "lf%s$units\\n'";
     }

--- a/includes/html/graphs/generic_stats.inc.php
+++ b/includes/html/graphs/generic_stats.inc.php
@@ -188,7 +188,7 @@ if ($height > 25) {
     }
     // displays nan if less than 17 hours
     if (! $no_daily) {
-        if ($time_diff >= 61200) {
+        if ($time_diff >= 129600) {
             $rrd_options .= ' DEF:' . $id . "1d$munge_helper=$filename:$ds:AVERAGE:step=86400";
             $rrd_options .= ' DEF:' . $id . "1dmin$munge_helper=$filename:$ds:MIN:step=86400";
             $rrd_options .= ' DEF:' . $id . "1dmax$munge_helper=$filename:$ds:MAX:step=86400";
@@ -233,7 +233,7 @@ if ($height > 25) {
     }
 
     if (! $no_daily) {
-        if ($time_diff >= 61200) {
+        if ($time_diff >= 129600) {
             # 1 hour average
             $rrd_optionsb .= ' LINE1.25:' . $id . '1d#' . $colour1d . ":'$descr_1d'";
             $rrd_optionsb .= ' GPRINT:' . $id . '1d:LAST:%5.' . $float_precision . 'lf%s' . $units . ' GPRINT:' . $id . '1d:MIN:%5.' . $float_precision . 'lf%s' . $units;

--- a/includes/html/graphs/generic_stats.inc.php
+++ b/includes/html/graphs/generic_stats.inc.php
@@ -218,15 +218,15 @@ if ($height > 25) {
     $rrd_optionsb .= ' GPRINT:' . $id . ':MAX:%5.' . $float_precision . 'lf%s' . $units . ' GPRINT:' . $id . ":AVERAGE:'%5." . $float_precision . "lf%s$units\\n'";
 
     if (! $no_hourly) {
-        # 1 hour avg
+        // 1 hour avg
         $rrd_optionsb .= ' LINE1.25:' . $id . '1h#' . $colour1h . ":'$descr_1h'";
         $rrd_optionsb .= ' GPRINT:' . $id . '1h:LAST:%5.' . $float_precision . 'lf%s' . $units . ' GPRINT:' . $id . '1h:MIN:%5.' . $float_precision . 'lf%s' . $units;
         $rrd_optionsb .= ' GPRINT:' . $id . '1h:MAX:%5.' . $float_precision . 'lf%s' . $units . ' GPRINT:' . $id . "1h:AVERAGE:'%5." . $float_precision . "lf%s$units\\n'";
-        # 1 hour min
+        // 1 hour min
         $rrd_optionsb .= ' COMMENT:"  '.$descr_1h_min.'"';
         $rrd_optionsb .= ' GPRINT:' . $id . '1hmin:LAST:%5.' . $float_precision . 'lf%s' . $units . ' GPRINT:' . $id . '1hmin:MIN:%5.' . $float_precision . 'lf%s' . $units;
         $rrd_optionsb .= ' GPRINT:' . $id . '1hmin:MAX:%5.' . $float_precision . 'lf%s' . $units . ' GPRINT:' . $id . "1hmin:AVERAGE:'%5." . $float_precision . "lf%s$units\\n'";
-        # 1 hour max
+        // 1 hour max
         $rrd_optionsb .= ' COMMENT:"  '.$descr_1h_max.'"';
         $rrd_optionsb .= ' GPRINT:' . $id . '1hmax:LAST:%5.' . $float_precision . 'lf%s' . $units . ' GPRINT:' . $id . '1hmax:MIN:%5.' . $float_precision . 'lf%s' . $units;
         $rrd_optionsb .= ' GPRINT:' . $id . '1hmax:MAX:%5.' . $float_precision . 'lf%s' . $units . ' GPRINT:' . $id . "1hmax:AVERAGE:'%5." . $float_precision . "lf%s$units\\n'";
@@ -234,15 +234,15 @@ if ($height > 25) {
 
     if (! $no_daily) {
         if ($time_diff >= 129600) {
-            # 1 hour average
+            // 1 hour average
             $rrd_optionsb .= ' LINE1.25:' . $id . '1d#' . $colour1d . ":'$descr_1d'";
             $rrd_optionsb .= ' GPRINT:' . $id . '1d:LAST:%5.' . $float_precision . 'lf%s' . $units . ' GPRINT:' . $id . '1d:MIN:%5.' . $float_precision . 'lf%s' . $units;
             $rrd_optionsb .= ' GPRINT:' . $id . '1d:MAX:%5.' . $float_precision . 'lf%s' . $units . ' GPRINT:' . $id . "1d:AVERAGE:'%5." . $float_precision . "lf%s$units\\n'";
-            # 1 hour min
+            // 1 hour min
             $rrd_optionsb .= ' COMMENT:"  '.$descr_1d_min.'"';
             $rrd_optionsb .= ' GPRINT:' . $id . '1dmin:LAST:%5.' . $float_precision . 'lf%s' . $units . ' GPRINT:' . $id . '1dmin:MIN:%5.' . $float_precision . 'lf%s' . $units;
             $rrd_optionsb .= ' GPRINT:' . $id . '1dmin:MAX:%5.' . $float_precision . 'lf%s' . $units . ' GPRINT:' . $id . "1dmin:AVERAGE:'%5." . $float_precision . "lf%s$units\\n'";
-            # 1 hour max
+            // 1 hour max
             $rrd_optionsb .= ' COMMENT:"  '.$descr_1d_max.'"';
             $rrd_optionsb .= ' GPRINT:' . $id . '1dmax:LAST:%5.' . $float_precision . 'lf%s' . $units . ' GPRINT:' . $id . '1dmax:MIN:%5.' . $float_precision . 'lf%s' . $units;
             $rrd_optionsb .= ' GPRINT:' . $id . '1dmax:MAX:%5.' . $float_precision . 'lf%s' . $units . ' GPRINT:' . $id . "1dmax:AVERAGE:'%5." . $float_precision . "lf%s$units\\n'";
@@ -251,15 +251,15 @@ if ($height > 25) {
 
     if (! $no_weekly) {
         if ($time_diff >= 691200) {
-            # 1 hour avg
+            // 1 hour avg
             $rrd_optionsb .= ' LINE1.25:' . $id . '1w#' . $colour1w . ":'$descr_1w'";
             $rrd_optionsb .= ' GPRINT:' . $id . '1w:LAST:%5.' . $float_precision . 'lf%s' . $units . ' GPRINT:' . $id . '1w:MIN:%5.' . $float_precision . 'lf%s' . $units;
             $rrd_optionsb .= ' GPRINT:' . $id . '1w:MAX:%5.' . $float_precision . 'lf%s' . $units . ' GPRINT:' . $id . "1w:AVERAGE:'%5." . $float_precision . "lf%s$units\\n'";
-            # 1 hour min
+            // 1 hour min
             $rrd_optionsb .= ' COMMENT:"  '.$descr_1w_min.'"';
             $rrd_optionsb .= ' GPRINT:' . $id . '1wmin:LAST:%5.' . $float_precision . 'lf%s' . $units . ' GPRINT:' . $id . '1wmin:MIN:%5.' . $float_precision . 'lf%s' . $units;
             $rrd_optionsb .= ' GPRINT:' . $id . '1wmin:MAX:%5.' . $float_precision . 'lf%s' . $units . ' GPRINT:' . $id . "1wmin:AVERAGE:'%5." . $float_precision . "lf%s$units\\n'";
-            # 1 hour max
+            // 1 hour max
             $rrd_optionsb .= ' COMMENT:"  '.$descr_1w_max.'"';
             $rrd_optionsb .= ' GPRINT:' . $id . '1wmax:LAST:%5.' . $float_precision . 'lf%s' . $units . ' GPRINT:' . $id . '1wmax:MIN:%5.' . $float_precision . 'lf%s' . $units;
             $rrd_optionsb .= ' GPRINT:' . $id . '1wmax:MAX:%5.' . $float_precision . 'lf%s' . $units . ' GPRINT:' . $id . "1wmax:AVERAGE:'%5." . $float_precision . "lf%s$units\\n'";

--- a/includes/html/graphs/generic_stats.inc.php
+++ b/includes/html/graphs/generic_stats.inc.php
@@ -15,6 +15,8 @@
 
 require 'includes/html/graphs/common.inc.php';
 
+$graph_stat_cf = \LibreNMS\Config::get('graph_stat_cf', 'AVERAGE');
+
 $stacked = generate_stacked_graphs();
 
 if (! isset($munge)) {
@@ -144,7 +146,7 @@ if ($munge) {
     $id = 'dsm0';
 }
 
-$rrd_options .= ' DEF:ds0' . "=$filename:$ds:AVERAGE";
+$rrd_options .= ' DEF:ds0' . "=$filename:$ds:$graph_stat_cf";
 
 $munge_helper = '';
 if ($munge) {
@@ -160,7 +162,7 @@ $rrd_optionsb .= ' LINE1.25:' . $id . '#' . $colour . ":'$descr'";
 
 if ($height > 25) {
     if (! $no_hourly) {
-        $rrd_options .= ' DEF:' . $id . "1h$munge_helper=$filename:$ds:AVERAGE:step=3600";
+        $rrd_options .= ' DEF:' . $id . "1h$munge_helper=$filename:$ds:$graph_stat_cf:step=3600";
     }
     if ($munge) {
         $rrd_options .= ' CDEF:dsm01h=dsm01hds,' . $munge_opts;
@@ -179,7 +181,7 @@ if ($height > 25) {
     // displays nan if less than 17 hours
     if (! $no_daily) {
         if ($time_diff >= 61200) {
-            $rrd_options .= ' DEF:' . $id . "1d$munge_helper=$filename:$ds:AVERAGE:step=86400";
+            $rrd_options .= ' DEF:' . $id . "1d$munge_helper=$filename:$ds:$graph_stat_cf:step=86400";
             if ($munge) {
                 $rrd_options .= ' CDEF:dsm01d=dsm01dds,' . $munge_opts;
             }
@@ -189,7 +191,7 @@ if ($height > 25) {
     // weekly breaks and causes issues if it is less than 8 days
     if (! $no_weekly) {
         if ($time_diff >= 691200) {
-            $rrd_options .= ' DEF:' . $id . "1w$munge_helper=$filename:$ds:AVERAGE:step=604800";
+            $rrd_options .= ' DEF:' . $id . "1w$munge_helper=$filename:$ds:$graph_stat_cf:step=604800";
             if ($munge) {
                 $rrd_options .= ' CDEF:dsm01w=dsm01wds,' . $munge_opts;
             }

--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -2148,6 +2148,18 @@
             "order": 7,
             "type": "boolean"
         },
+        "graph_stat_cf": {
+            "default": "AVERAGE",
+            "group": "webui",
+            "section": "graph",
+            "order": 8,
+            "type": "select",
+            "options": {
+                "AVERAGE": "AVERAGE",
+                "MIN": "MIN",
+                "MAX": "MAX"
+            }
+        },
         "graph_colours.blues": {
             "default": [
                 "A9A9F2",
@@ -2158,6 +2170,18 @@
                 "3D3D99"
             ],
             "type": "array"
+        },
+        "graph_stat_cf_app_logsize": {
+            "default": "AVERAGE",
+            "group": "webui",
+            "section": "graph",
+            "order": 9,
+            "type": "select",
+            "options": {
+                "AVERAGE": "AVERAGE",
+                "MIN": "MIN",
+                "MAX": "MAX"
+            }
         },
         "graph_colours.default": {
             "default": [

--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -2148,18 +2148,6 @@
             "order": 7,
             "type": "boolean"
         },
-        "graph_stat_cf": {
-            "default": "AVERAGE",
-            "group": "webui",
-            "section": "graph",
-            "order": 8,
-            "type": "select",
-            "options": {
-                "AVERAGE": "AVERAGE",
-                "MIN": "MIN",
-                "MAX": "MAX"
-            }
-        },
         "graph_colours.blues": {
             "default": [
                 "A9A9F2",
@@ -2170,18 +2158,6 @@
                 "3D3D99"
             ],
             "type": "array"
-        },
-        "graph_stat_cf_app_logsize": {
-            "default": "AVERAGE",
-            "group": "webui",
-            "section": "graph",
-            "order": 9,
-            "type": "select",
-            "options": {
-                "AVERAGE": "AVERAGE",
-                "MIN": "MIN",
-                "MAX": "MAX"
-            }
         },
         "graph_colours.default": {
             "default": [


### PR DESCRIPTION
Currently just displays the average min, avg, and max.

This adds...
- max min, max avg, max max
- min min, min avg, min max

old: https://i.imgur.com/hpeYTme.png
new: https://i.imgur.com/a5oXLWA.png

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
