### PR TITLE
Add multi-select support to custom map editor

### DIFF
--- a/app/Http/Controllers/Maps/CustomMapController.php
+++ b/app/Http/Controllers/Maps/CustomMapController.php
@@ -156,7 +156,7 @@ class CustomMapController extends Controller
         $data['map_conf']['width'] = $map->width;
         $data['map_conf']['height'] = $map->height;
         // Override some settings for the editor
-        $data['map_conf']['interaction'] = ['dragNodes' => true, 'dragView' => false, 'zoomView' => false];
+        $data['map_conf']['interaction'] = ['dragNodes' => true, 'dragView' => false, 'zoomView' => false, 'multiselect' => true];
         $data['map_conf']['manipulation'] = ['enabled' => true, 'initiallyActive' => true];
         $data['map_conf']['physics'] = ['enabled' => false];
 

--- a/lang/en/map.php
+++ b/lang/en/map.php
@@ -46,6 +46,7 @@ return [
                 'selectall' => 'Select All',
                 'name' => 'Name',
                 'menu_group' => 'Menu Group',
+                'multiselect_info' => 'Either long-click or hold down ctrl to select multiple nodes',
                 'no_group' => 'No Group',
                 'width' => 'Width',
                 'height' => 'Height',

--- a/lang/en/map.php
+++ b/lang/en/map.php
@@ -43,6 +43,7 @@ return [
             ],
             'map' => [
                 'settings_title' => 'Map Settings',
+                'selectall' => 'Select All',
                 'name' => 'Name',
                 'menu_group' => 'Menu Group',
                 'no_group' => 'No Group',

--- a/resources/views/map/custom-edit.blade.php
+++ b/resources/views/map/custom-edit.blade.php
@@ -27,6 +27,7 @@
       </center>
     </div>
     <div class="col-md-5 text-right">
+      <button type=button value="mapselectall" id="map-selectallButton" class="btn btn-primary" onclick="network.selectNodes(network_nodes.getIds());">{{ __('map.custom.edit.map.selectall') }}</button>
       <button type=button value="maprender" id="map-renderButton" class="btn btn-primary" style="display: none" onclick="CreateNetwork();">{{ __('map.custom.edit.map.rerender') }}</button>
       <button type=button value="mapsave" id="map-saveDataButton" class="btn btn-primary" style="display: none" onclick="saveMapData();">{{ __('map.custom.edit.map.save') }}</button>
       <button type=button value="maplist" id="map-listButton" class="btn btn-primary" onclick="mapList();">{{ __('map.custom.edit.map.list') }}</button>
@@ -340,9 +341,6 @@
                 nodepos = network.getPositions(data.nodes);
                 $.each( nodepos, function( nodeid, node ) {
                     if ( nodeid.startsWith("legend_") ) {
-                        // Make sure the moved node is still on the map
-                        fixNodePos(nodeid, node);
-
                         // Get the current node config
                         cur_node = network_nodes.get(nodeid);
 
@@ -350,7 +348,19 @@
                         legend.x = legend.x + node.x - cur_node.x;
                         legend.y = legend.y + node.y - cur_node.y;
 
+                        // Make sure the top of the legend is still on the map
+                        fixNodePos("legend", legend);
+
                         redrawLegend();
+
+                        // Make sure the bottom of the legend is still on the map
+                        legendEndNode = network_nodes.get("legend_" + (legend.steps - 1))
+                        moveUp = legendEndNode.y - network_height + {{ $vmargin }};
+                        if (moveUp > 0) {
+                            legend.y -= moveUp;
+                            redrawLegend();
+                        }
+
                         return;
                     }
                     let move = fixNodePos(nodeid, node);
@@ -453,6 +463,9 @@
     }
 
     function redrawLegend() {
+        // Save list of selected nodes because we are going to remove and re-add the legend
+        selectedNodes = network.selectionHandler.getSelectedNodes();
+
         // Clear out the old legend
         old_nodes = network_nodes.get({filter: function(node) { return node.id.startsWith("legend_") }});
         old_nodes.forEach((node) => {
@@ -504,6 +517,9 @@
             }
             network_nodes.flush();
         }
+
+        // Re-select nodes
+        network.selectNodes(selectedNodes);
     }
 
     function editMapSuccess(data) {
@@ -531,6 +547,8 @@
     function editMapCancel() {
         mapSettingsReset();
         $('#mapModal').modal('hide');
+        $("#savemap-alert").attr("class", "col-sm-12");
+        $("#savemap-alert").text("");
     }
 
     function saveMapData() {

--- a/resources/views/map/custom-edit.blade.php
+++ b/resources/views/map/custom-edit.blade.php
@@ -27,7 +27,7 @@
       </center>
     </div>
     <div class="col-md-5 text-right">
-      <button type=button value="mapselectall" id="map-selectallButton" class="btn btn-primary" onclick="network.selectNodes(network_nodes.getIds());">{{ __('map.custom.edit.map.selectall') }}</button>
+      <button type=button value="mapselectall" id="map-selectallButton" class="btn btn-primary" onclick="network.selectNodes(network_nodes.getIds());" title="{{ __('map.custom.edit.map.multiselect_info') }}">{{ __('map.custom.edit.map.selectall') }}</button>
       <button type=button value="maprender" id="map-renderButton" class="btn btn-primary" style="display: none" onclick="CreateNetwork();">{{ __('map.custom.edit.map.rerender') }}</button>
       <button type=button value="mapsave" id="map-saveDataButton" class="btn btn-primary" style="display: none" onclick="saveMapData();">{{ __('map.custom.edit.map.save') }}</button>
       <button type=button value="maplist" id="map-listButton" class="btn btn-primary" onclick="mapList();">{{ __('map.custom.edit.map.list') }}</button>
@@ -339,8 +339,15 @@
             if(data.edges.length > 0 || data.nodes.length > 0) {
                 // Make sure a node is not dragged outside the canvas
                 nodepos = network.getPositions(data.nodes);
+                legendMoved = false;
                 $.each( nodepos, function( nodeid, node ) {
                     if ( nodeid.startsWith("legend_") ) {
+                        // Only move the legend once
+                        if (legendMoved) {
+                            continue;
+                        }
+                        legendMoved = true;
+
                         // Get the current node config
                         cur_node = network_nodes.get(nodeid);
 
@@ -361,7 +368,7 @@
                             redrawLegend();
                         }
 
-                        return;
+                        continue;
                     }
                     let move = fixNodePos(nodeid, node);
                     if ( move ) {
@@ -464,7 +471,7 @@
 
     function redrawLegend() {
         // Save list of selected nodes because we are going to remove and re-add the legend
-        selectedNodes = network.selectionHandler.getSelectedNodes();
+        selectedNodes = network.selectionHandler.getSelectedNodes().map((n) => {return n.id});
 
         // Clear out the old legend
         old_nodes = network_nodes.get({filter: function(node) { return node.id.startsWith("legend_") }});
@@ -518,8 +525,10 @@
             network_nodes.flush();
         }
 
-        // Re-select nodes
-        network.selectNodes(selectedNodes);
+        // Re-select nodes if multiple nodes are selected
+        if (selectedNodes.length > 1) {
+            network.selectNodes(selectedNodes);
+        }
     }
 
     function editMapSuccess(data) {

--- a/resources/views/map/custom-edit.blade.php
+++ b/resources/views/map/custom-edit.blade.php
@@ -344,7 +344,7 @@
                     if ( nodeid.startsWith("legend_") ) {
                         // Only move the legend once
                         if (legendMoved) {
-                            continue;
+                            return;
                         }
                         legendMoved = true;
 
@@ -368,7 +368,7 @@
                             redrawLegend();
                         }
 
-                        continue;
+                        return;
                     }
                     let move = fixNodePos(nodeid, node);
                     if ( move ) {

--- a/resources/views/map/custom-map-modal.blade.php
+++ b/resources/views/map/custom-map-modal.blade.php
@@ -132,6 +132,25 @@
             height = height + "px";
         }
 
+        if (width.endsWith("px") && height.endsWith("px")) {
+            widthInt = parseInt(width);
+            heightInt = parseInt(height);
+
+            var nodeError = false;
+            network_nodes.forEach((node) => {
+                if (node.x > widthInt - {{ $hmargin }} || node.y > heightInt - {{ $vmargin }}) {
+                    nodeError = true;
+                }
+            });
+            if (nodeError) {
+                let alert_content = $("#savemap-alert");
+                alert_content.text('Please move nodes inside the new area before shrinking the map');
+                alert_content.attr("class", "col-sm-12 alert alert-danger");
+                $("#map-saveButton").removeAttr('disabled');
+                return;
+            }
+        }
+
         @if(isset($map_id))
             var url = '{{ route('maps.custom.update', ['map' => $map_id]) }}';
             var method = 'PUT';

--- a/resources/views/map/custom-map-modal.blade.php
+++ b/resources/views/map/custom-map-modal.blade.php
@@ -138,7 +138,7 @@
 
             var nodeError = false;
             network_nodes.forEach((node) => {
-                if (node.x > widthInt - {{ $hmargin }} || node.y > heightInt - {{ $vmargin }}) {
+                if (node.x > widthInt - {{ isset($hmargin) ? $hmargin : 10 }} || node.y > heightInt - {{ isset($vmargin) ? $vmargin : 10 }}) {
                     nodeError = true;
                 }
             });


### PR DESCRIPTION
 - Multi-select has been enabled in edit mode (items can be multi-selected by long press or holding ctrl)
 - A select all button has been added to the top-right
 - Legend has been prevented from moving outside the map canvas
 - Checks have been put in place when shrinking a map to make sure all nodes still fit on the canvas

This PR aims to make it easier to resize or shift an entire map within the canvas.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
