### PR TITLE
Add screenshot mode option to custom map widget

### DIFF
--- a/app/Http/Controllers/Widgets/CustomMapController.php
+++ b/app/Http/Controllers/Widgets/CustomMapController.php
@@ -35,6 +35,7 @@ class CustomMapController extends WidgetController
     protected $defaults = [
         'title' => null,
         'custom_map' => null,
+        'screenshot' => false,
     ];
 
     public function __construct()

--- a/resources/views/widgets/custom-map.blade.php
+++ b/resources/views/widgets/custom-map.blade.php
@@ -48,7 +48,7 @@
             .done(function( data ) {
                 // Add/update nodes
                 $.each( data.nodes, function( nodeid, node) {
-                    var node_cfg = custommap.getNodeCfg(nodeid, node, false, custom_image_base);
+                    var node_cfg = custommap.getNodeCfg(nodeid, node, Boolean({{$screenshot}}), custom_image_base);
                     if(node.device_id) {
                         node_device_map[nodeid] = {device_id: node.device_id, device_name: node.device_name};
                     } else if(node.linked_map_name) {
@@ -58,7 +58,7 @@
                 });
 
                 $.each( data.edges, function( edgeid, edge) {
-                    var mid = custommap.getEdgeMidCfg(edgeid, edge, false);
+                    var mid = custommap.getEdgeMidCfg(edgeid, edge, Boolean({{$screenshot}}));
                     var edge1 = custommap.getEdgeCfg(edgeid, edge, "from", reverse_arrows);
                     var edge2 = custommap.getEdgeCfg(edgeid, edge, "to", reverse_arrows);
 

--- a/resources/views/widgets/settings/custom-map.blade.php
+++ b/resources/views/widgets/settings/custom-map.blade.php
@@ -13,10 +13,21 @@
             @endif
         </select>
     </div>
+    <div class="form-group">
+        <label for="screenshot-{{ $id }}" class="control-label">{{ __('Screenshot Mode') }}</label>
+        <input type="checkbox" class="form-control" name="screenshot" id="screenshot-{{ $id }}" value=0 data-size="normal" @if($screenshot) checked @endif>
+    </div>
 @endsection
 
 @section('javascript')
     <script type="text/javascript">
         init_select2('#custom_map-{{ $id }}', 'custom-map', {});
+
+        $('#screenshot-{{ $id }}')
+            .bootstrapSwitch('offColor','danger')
+            .on('switchChange.bootstrapSwitch', function (e, data) {
+                let thisval = $(this).is(':checked') ? "1": "0";
+                $('#screenshot-{{ $id }}').val(thisval);
+            });
     </script>
 @endsection


### PR DESCRIPTION
Add a new option to the custom map widget settings to enable screenshot mode, which hides the labels

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
