### PR TITLE
Add a new edge option to select the position of the edge text

### DIFF
--- a/app/Http/Controllers/Maps/CustomMapController.php
+++ b/app/Http/Controllers/Maps/CustomMapController.php
@@ -209,6 +209,7 @@ class CustomMapController extends Controller
                 'color' => Config::get('custom_map.edge_font_color', '#343434'),
                 'size' => Config::get('custom_map.edge_font_size', 12),
                 'face' => Config::get('custom_map.edge_font_face', 'arial'),
+                'align' => Config::get('custom_map.edge_font_align', 'horizontal'),
             ],
             'label' => true,
         ];

--- a/app/Http/Controllers/Maps/CustomMapDataController.php
+++ b/app/Http/Controllers/Maps/CustomMapDataController.php
@@ -69,6 +69,7 @@ class CustomMapDataController extends Controller
                 'text_face' => $edge->text_face,
                 'text_size' => $edge->text_size,
                 'text_colour' => $edge->text_colour,
+                'text_align' => $edge->text_align,
                 'mid_x' => $edge->mid_x,
                 'mid_y' => $edge->mid_y,
             ];
@@ -304,6 +305,7 @@ class CustomMapDataController extends Controller
                 $dbedge->text_face = $edge['text_face'];
                 $dbedge->text_size = $edge['text_size'];
                 $dbedge->text_colour = $edge['text_colour'];
+                $dbedge->text_align = $edge['text_align'];
                 $dbedge->mid_x = intval($edge['mid_x']);
                 $dbedge->mid_y = intval($edge['mid_y']);
 

--- a/database/migrations/2024_11_07_110342_custommap_edge_add_text_align.php
+++ b/database/migrations/2024_11_07_110342_custommap_edge_add_text_align.php
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('custom_map_edges', function (Blueprint $table) {
-            $table->text('text_align')->after('text_colour')->default('horizontal');
+            $table->string('text_align', 16)->after('text_colour')->default('horizontal');
         });
     }
 

--- a/database/migrations/2024_11_07_110342_custommap_edge_add_text_align.php
+++ b/database/migrations/2024_11_07_110342_custommap_edge_add_text_align.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('custom_map_edges', function (Blueprint $table) {
+            $table->text('text_align')->after('text_colour')->default('horizontal');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('custom_map_edges', function (Blueprint $table) {
+            $table->dropColumn(['text_align']);
+        });
+    }
+};

--- a/lang/en/map.php
+++ b/lang/en/map.php
@@ -161,6 +161,13 @@ return [
                 ],
                 'show_usage_percent' => 'Show percent usage',
                 'show_usage_bps' => 'Show bps usage',
+                'text_align' => 'Text Alignment',
+                'align_options' => [
+                    'horizontal' => 'Horizontal',
+                    'top' => 'Top',
+                    'middle' => 'Middle',
+                    'bottom' => 'Bottom',
+                ],
                 'label' => 'Label',
                 'recenter' => 'Recenter Line',
             ],

--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -1049,6 +1049,19 @@
                 "value": "map"
             }
         },
+        "custom_map.edge_font_align": {
+            "default": "horizontal",
+            "type": "select",
+            "options": {
+                "horizontal": "Horizontal",
+                "top": "top",
+                "middle": "Middle",
+                "bottom": "Bottom"
+            },
+            "group": "webui",
+            "section": "custom-map",
+            "order": 54
+        },
         "custom_map.edge_font_color": {
             "default": "#343434",
             "type": "color",

--- a/misc/db_schema.yaml
+++ b/misc/db_schema.yaml
@@ -569,6 +569,7 @@ custom_map_edges:
     - { Field: text_face, Type: varchar(50), 'Null': false, Extra: '' }
     - { Field: text_size, Type: int, 'Null': false, Extra: '' }
     - { Field: text_colour, Type: varchar(10), 'Null': false, Extra: '' }
+    - { Field: text_align, Type: text, 'Null': false, Extra: '', Default: 'horizontal' }
     - { Field: mid_x, Type: int, 'Null': false, Extra: '' }
     - { Field: mid_y, Type: int, 'Null': false, Extra: '' }
     - { Field: created_at, Type: timestamp, 'Null': true, Extra: '' }

--- a/misc/db_schema.yaml
+++ b/misc/db_schema.yaml
@@ -569,7 +569,7 @@ custom_map_edges:
     - { Field: text_face, Type: varchar(50), 'Null': false, Extra: '' }
     - { Field: text_size, Type: int, 'Null': false, Extra: '' }
     - { Field: text_colour, Type: varchar(10), 'Null': false, Extra: '' }
-    - { Field: text_align, Type: varchar(255), 'Null': false, Extra: '', Default: 'horizontal' }
+    - { Field: text_align, Type: text, 'Null': false, Extra: '', Default: horizontal }
     - { Field: mid_x, Type: int, 'Null': false, Extra: '' }
     - { Field: mid_y, Type: int, 'Null': false, Extra: '' }
     - { Field: created_at, Type: timestamp, 'Null': true, Extra: '' }

--- a/misc/db_schema.yaml
+++ b/misc/db_schema.yaml
@@ -569,7 +569,7 @@ custom_map_edges:
     - { Field: text_face, Type: varchar(50), 'Null': false, Extra: '' }
     - { Field: text_size, Type: int, 'Null': false, Extra: '' }
     - { Field: text_colour, Type: varchar(10), 'Null': false, Extra: '' }
-    - { Field: text_align, Type: text, 'Null': false, Extra: '', Default: 'horizontal' }
+    - { Field: text_align, Type: varchar(255), 'Null': false, Extra: '', Default: 'horizontal' }
     - { Field: mid_x, Type: int, 'Null': false, Extra: '' }
     - { Field: mid_y, Type: int, 'Null': false, Extra: '' }
     - { Field: created_at, Type: timestamp, 'Null': true, Extra: '' }

--- a/misc/db_schema.yaml
+++ b/misc/db_schema.yaml
@@ -569,7 +569,7 @@ custom_map_edges:
     - { Field: text_face, Type: varchar(50), 'Null': false, Extra: '' }
     - { Field: text_size, Type: int, 'Null': false, Extra: '' }
     - { Field: text_colour, Type: varchar(10), 'Null': false, Extra: '' }
-    - { Field: text_align, Type: text, 'Null': false, Extra: '', Default: horizontal }
+    - { Field: text_align, Type: varchar(16), 'Null': false, Extra: '', Default: horizontal }
     - { Field: mid_x, Type: int, 'Null': false, Extra: '' }
     - { Field: mid_y, Type: int, 'Null': false, Extra: '' }
     - { Field: created_at, Type: timestamp, 'Null': true, Extra: '' }

--- a/resources/views/map/custom-edge-modal.blade.php
+++ b/resources/views/map/custom-edge-modal.blade.php
@@ -109,6 +109,17 @@
                                     <button type=button class="btn btn-primary" value="reset" id="edgecolourtextreset" onclick="$('#edgetextcolour').val(newedgeconf.font.color); $(this).attr('disabled','disabled');">{{ __('Reset') }}</button>
                                 </div>
                             </div>
+                            <div class="form-group row">
+                                <label for="edgetextalign" class="col-sm-3 control-label">{{ __('map.custom.edit.edge.text_align') }}</label>
+                                <div class="col-sm-9">
+                                    <select id="edgetextalign" class="form-control input-sm">
+                                        <option value="horizontal">{{ __('map.custom.edit.edge.align_options.horizontal') }}</option>
+                                        <option value="top">{{ __('map.custom.edit.edge.align_options.top') }}</option>
+                                        <option value="middle">{{ __('map.custom.edit.edge.align_options.middle') }}</option>
+                                        <option value="bottom">{{ __('map.custom.edit.edge.align_options.bottom') }}</option>
+                                    </select>
+                                </div>
+                            </div>
                             <div class="form-group row existing-edge" id="edgeRecenterRow">
                                 <label for="edgerecenter" class="col-sm-3 control-label">{{ __('map.custom.edit.edge.recenter') }}</label>
                                 <div class="col-sm-9">
@@ -182,6 +193,7 @@
         edgedata.edge1.font.face = edgedata.edge2.font.face = $("#edgetextface").val();
         edgedata.edge1.font.size = edgedata.edge2.font.size = $("#edgetextsize").val();
         edgedata.edge1.font.color = edgedata.edge2.font.color = $("#edgetextcolour").val();
+        edgedata.edge1.font.align = edgedata.edge2.font.align = $("#edgetextalign").val();
         edgedata.edge1.label = edgedata.edge2.label = edgeLabel($("#edgetextshow").prop('checked'), $("#edgebpsshow").prop('checked'), null);
         edgedata.edge1.width = edgedata.edge2.width = parseFloat($("#edgefixedwidth").val()) || null;
         edgedata.edge1.title = edgedata.edge2.title = $("#port_id").val();
@@ -247,6 +259,7 @@
         $("#edgetextface").val(newedgeconf.font.face);
         $("#edgetextsize").val(newedgeconf.font.size);
         $("#edgetextcolour").val(newedgeconf.font.color);
+        $("#edgetextalign").val(newedgeconf.font.align || "horizontal");
         $("#edgetextshow").bootstrapSwitch('state', (newedgeconf.label.includes('xx%') || newedgeconf.label.includes('true')));
         $("#edgebpsshow").bootstrapSwitch('state', (newedgeconf.label.includes('bps')));
         $('#edgecolourtextreset').attr('disabled', 'disabled');
@@ -291,6 +304,7 @@
         $("#edgetextface").val(edgedata.edge1.font.face);
         $("#edgetextsize").val(edgedata.edge1.font.size);
         $("#edgetextcolour").val(edgedata.edge1.font.color);
+        $("#edgetextalign").val(edgedata.edge1.font.align || "horizontal");
         $("#edgetextshow").bootstrapSwitch('state', (edgedata.edge1.label != null && edgedata.edge1.label.includes('xx%')));
         $("#edgebpsshow").bootstrapSwitch('state', (edgedata.edge1.label != null && edgedata.edge1.label.includes('bps')));
         $("#edgelabel").val('label' in edgedata.mid ? edgedata.mid.label : '');
@@ -342,6 +356,7 @@
         newedgeconf.font.face = $("#edgetextface").val();
         newedgeconf.font.size = $("#edgetextsize").val();
         newedgeconf.font.color = $("#edgetextcolour").val();
+        newedgeconf.font.align = $("#edgetextalign").val();
         newedgeconf.label = edgeLabel($("#edgetextshow").prop('checked'), $("#edgebpsshow").prop('checked'), '');
         newedgeconf.width = parseFloat($("#edgefixedwidth").val()) || null;
         $("#map-saveDataButton").show();

--- a/resources/views/map/custom-edit.blade.php
+++ b/resources/views/map/custom-edit.blade.php
@@ -545,7 +545,7 @@
                 edgeid = node.id.split("_")[0];
                 edge1 = network_edges.get(edgeid + "_from");
                 edge2 = network_edges.get(edgeid + "_to");
-                edges[edgeid] = {id: edgeid, text_colour: edge1.font.color, text_size: edge1.font.size, text_face: edge1.font.face, from: edge1.from, to: edge2.from, showpct: (edge1.label != null && edge1.label.includes("xx%")), showbps: (edge1.label != null && edge1.label.includes("bps")), label: (node.label || ''), fixed_width: (edge1.width || null), port_id: edge1.title, style: edge1.smooth.type, mid_x: node.x, mid_y: node.y, reverse: (edgeid in edge_port_map ? edge_port_map[edgeid].reverse : false)};
+                edges[edgeid] = {id: edgeid, text_colour: edge1.font.color, text_size: edge1.font.size, text_face: edge1.font.face, text_align: edge1.font.align, from: edge1.from, to: edge2.from, showpct: (edge1.label != null && edge1.label.includes("xx%")), showbps: (edge1.label != null && edge1.label.includes("bps")), label: (node.label || ''), fixed_width: (edge1.width || null), port_id: edge1.title, style: edge1.smooth.type, mid_x: node.x, mid_y: node.y, reverse: (edgeid in edge_port_map ? edge_port_map[edgeid].reverse : false)};
             } else {
                 if(node.icon.code) {
                     node.icon = node.icon.code.charCodeAt(0).toString(16);
@@ -743,8 +743,8 @@
                         arrows = {to: {enabled: true, scaleFactor: 0.6}, from: {enabled: false}};
                     }
 
-                    var edge1 = {id: edgeid + "_from", from: edge.custom_map_node1_id, to: edgeid + "_mid", arrows: arrows, font: {face: edge.text_face, size: edge.text_size, color: edge.text_colour}, smooth: {type: edge.style}};
-                    var edge2 = {id: edgeid + "_to", from: edge.custom_map_node2_id, to: edgeid + "_mid", arrows: arrows, font: {face: edge.text_face, size: edge.text_size, color: edge.text_colour}, smooth: {type: edge.style}};
+                    var edge1 = {id: edgeid + "_from", from: edge.custom_map_node1_id, to: edgeid + "_mid", arrows: arrows, font: {face: edge.text_face, size: edge.text_size, color: edge.text_colour, align: edge.text_align}, smooth: {type: edge.style}};
+                    var edge2 = {id: edgeid + "_to", from: edge.custom_map_node2_id, to: edgeid + "_mid", arrows: arrows, font: {face: edge.text_face, size: edge.text_size, color: edge.text_colour, align: edge.text_align}, smooth: {type: edge.style}};
                     if(edge.fixed_width) {
                         edge1.width = edge2.width = parseFloat(edge.fixed_width) || null;
                     }

--- a/resources/views/map/custom-js.blade.php
+++ b/resources/views/map/custom-js.blade.php
@@ -151,7 +151,7 @@
                 arrows = {to: {enabled: true, scaleFactor: 0.6}, from: {enabled: false}};
             }
 
-            var edge_cfg = {id: edgeid + "_" + fromto, to: edgeid + "_mid", arrows: arrows, font: {face: edge.text_face, size: edge.text_size, color: edge.text_colour, background: "#FFFFFF"}, smooth: {type: edge.style}};
+            var edge_cfg = {id: edgeid + "_" + fromto, to: edgeid + "_mid", arrows: arrows, font: {face: edge.text_face, size: edge.text_size, color: edge.text_colour, background: "#FFFFFF", align: edge.text_align || "horizontal"}, smooth: {type: edge.style}};
             if (fromto == "from") {
                 edge_cfg.from = edge.custom_map_node1_id;
                 var port_pct = Boolean(reverse_arrows) ? edge.port_topct : edge.port_frompct;


### PR DESCRIPTION
Add a new edge option to select the position and alignment of edge text.  You can see this on the screenshot below where the text on the top row follows the lines on the bottom top and middle, while the text on the bottom link uses the default horizontal alignment.

![image](https://github.com/user-attachments/assets/d3398ece-5f8e-43be-a291-625fc9470f54)

I have come across some rendering issues when using the non-default options, but these are vis.js bugs, and users can select the horizontal option if they come across a bug.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
