### PR TITLE
The unbound app creates RRD's incorrectly, with 'DERIVE'. 

### DIFF
--- a/includes/polling/applications/unbound.inc.php
+++ b/includes/polling/applications/unbound.inc.php
@@ -21,24 +21,24 @@ foreach ($lines as $line) {
 }
 //Unbound Queries
 $rrd_def = RrdDefinition::make()
-    ->addDataset('type0', 'DERIVE', 0, 125000000000)
-    ->addDataset('A', 'DERIVE', 0, 125000000000)
-    ->addDataset('NS', 'DERIVE', 0, 125000000000)
-    ->addDataset('CNAME', 'DERIVE', 0, 125000000000)
-    ->addDataset('SOA', 'DERIVE', 0, 125000000000)
-    ->addDataset('NULL', 'DERIVE', 0, 125000000000)
-    ->addDataset('WKS', 'DERIVE', 0, 125000000000)
-    ->addDataset('PTR', 'DERIVE', 0, 125000000000)
-    ->addDataset('MX', 'DERIVE', 0, 125000000000)
-    ->addDataset('TXT', 'DERIVE', 0, 125000000000)
-    ->addDataset('AAAA', 'DERIVE', 0, 125000000000)
-    ->addDataset('SRV', 'DERIVE', 0, 125000000000)
-    ->addDataset('NAPTR', 'DERIVE', 0, 125000000000)
-    ->addDataset('DS', 'DERIVE', 0, 125000000000)
-    ->addDataset('DNSKEY', 'DERIVE', 0, 125000000000)
-    ->addDataset('SPF', 'DERIVE', 0, 125000000000)
-    ->addDataset('ANY', 'DERIVE', 0, 125000000000)
-    ->addDataset('other', 'DERIVE', 0, 125000000000);
+    ->addDataset('type0', 'GAUGE', 0, 125000000000)
+    ->addDataset('A', 'GAUGE', 0, 125000000000)
+    ->addDataset('NS', 'GAUGE', 0, 125000000000)
+    ->addDataset('CNAME', 'GAUGE', 0, 125000000000)
+    ->addDataset('SOA', 'GAUGE', 0, 125000000000)
+    ->addDataset('NULL', 'GAUGE', 0, 125000000000)
+    ->addDataset('WKS', 'GAUGE', 0, 125000000000)
+    ->addDataset('PTR', 'GAUGE', 0, 125000000000)
+    ->addDataset('MX', 'GAUGE', 0, 125000000000)
+    ->addDataset('TXT', 'GAUGE', 0, 125000000000)
+    ->addDataset('AAAA', 'GAUGE', 0, 125000000000)
+    ->addDataset('SRV', 'GAUGE', 0, 125000000000)
+    ->addDataset('NAPTR', 'GAUGE', 0, 125000000000)
+    ->addDataset('DS', 'GAUGE', 0, 125000000000)
+    ->addDataset('DNSKEY', 'GAUGE', 0, 125000000000)
+    ->addDataset('SPF', 'GAUGE', 0, 125000000000)
+    ->addDataset('ANY', 'GAUGE', 0, 125000000000)
+    ->addDataset('other', 'GAUGE', 0, 125000000000);
 $fields = [
     'type0' => $unbound['num.query.type.type0'],
     'A' => $unbound['num.query.type.a'],
@@ -70,9 +70,9 @@ $tags = [
 data_update($device, 'app', $tags, $fields);
 //Unbound Cache
 $rrd_def = RrdDefinition::make()
-    ->addDataset('queries', 'DERIVE', 0, 125000000000)
-    ->addDataset('hits', 'DERIVE', 0, 125000000000)
-    ->addDataset('misses', 'DERIVE', 0, 125000000000);
+    ->addDataset('queries', 'GAUGE', 0, 125000000000)
+    ->addDataset('hits', 'GAUGE', 0, 125000000000)
+    ->addDataset('misses', 'GAUGE', 0, 125000000000);
 $fields = [
     'queries' => $unbound['total.num.queries'],
     'hits' => $unbound['total.num.cachehits'],
@@ -89,10 +89,10 @@ $tags = [
 data_update($device, 'app', $tags, $fields);
 //Unbound Operations - Total opcodes and three valuable return codes
 $rrd_def = RrdDefinition::make()
-    ->addDataset('opcodeQuery', 'DERIVE', 0, 125000000000)
-    ->addDataset('rcodeNOERROR', 'DERIVE', 0, 125000000000)
-    ->addDataset('rcodeNXDOMAIN', 'DERIVE', 0, 125000000000)
-    ->addDataset('rcodeNodata', 'DERIVE', 0, 125000000000);
+    ->addDataset('opcodeQuery', 'GAUGE', 0, 125000000000)
+    ->addDataset('rcodeNOERROR', 'GAUGE', 0, 125000000000)
+    ->addDataset('rcodeNXDOMAIN', 'GAUGE', 0, 125000000000)
+    ->addDataset('rcodeNodata', 'GAUGE', 0, 125000000000);
 $fields = [
     'opcodeQuery' => $unbound['num.query.opcode.query'],
     'rcodeNOERROR' => $unbound['num.answer.rcode.noerror'],
@@ -111,9 +111,9 @@ data_update($device, 'app', $tags, $fields);
 
 //Unbound requestlist
 $rrd_def = RrdDefinition::make()
-    ->addDataset('max', 'DERIVE', 0, 125000000000)
-    ->addDataset('overwritten', 'DERIVE', 0, 125000000000)
-    ->addDataset('exceeded', 'DERIVE', 0, 125000000000);
+    ->addDataset('max', 'GAUGE', 0, 125000000000)
+    ->addDataset('overwritten', 'GAUGE', 0, 125000000000)
+    ->addDataset('exceeded', 'GAUGE', 0, 125000000000);
 $fields = [
     'max' => $unbound['total.requestlist.max'],
     'overwritten' => $unbound['total.requestlist.overwritten'],


### PR DESCRIPTION
Please give a short description what your pull request is for:

The unbound app creates RRD's incorrectly, with 'DERIVE'.  However, the unbound-script at the unbound server runs `unbound-control stats`, which resets the internal counters. So DERIVE is incorrect here, and we should use GAUGE.

Please note that this requires deletion of the existing RRD's.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.


Screenshot of graphs on a non-fixed device:
![image](https://github.com/user-attachments/assets/b2d4db84-0620-49c8-b8b5-a6df707b84be)

Screenshot of graphs on a similar, fixed device:
![image](https://github.com/user-attachments/assets/670b6880-c8dd-4f36-9dae-df107582ff7b)
