### PR TITLE
Fix Stack Topology alert Update procurve.yaml

### DIFF
--- a/includes/definitions/discovery/procurve.yaml
+++ b/includes/definitions/discovery/procurve.yaml
@@ -109,7 +109,7 @@ modules:
                     descr: 'Stack Topology'
                     state_name: hpStackTopology
                     states:
-                        - { descr: unKnown, graph: 1, value: 0, generic: 1 }
+                        - { descr: unKnown, graph: 1, value: 0, generic: 0 }
                         - { descr: chain, graph: 1, value: 1, generic: 0 }
                         - { descr: ring, graph: 1, value: 2, generic: 0 }
                         - { descr: mesh, graph: 1, value: 3, generic: 0 }


### PR DESCRIPTION
Stack topology will alert on the unknown state. This is not necessary for unstacked switches.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
