### PR TITLE
WIP - Added the option to override the device type on each discovery condition

### DIFF
--- a/LibreNMS/Modules/Core.php
+++ b/LibreNMS/Modules/Core.php
@@ -143,12 +143,9 @@ class Core implements Module
     private static function setOS(Device $device, string $os_name, array $os_def): void
     {
         $device->os = $os_name;
+
         if (! $device->getAttrib('override_device_type')) {
-            if (array_key_exists('type', $os_def)) {
-                $device->type = $os_def['type'];
-            } else {
-                $device->type = Config::get("os.$device->os.type");
-            }
+            $device->type = $os_def['type'] ?? Config::get("os.$device->os.type");
         }
     }
 

--- a/LibreNMS/Modules/Core.php
+++ b/LibreNMS/Modules/Core.php
@@ -210,7 +210,6 @@ class Core implements Module
         }
 
         self::setOS($device, 'generic', []);
-
     }
 
     /**

--- a/LibreNMS/Modules/Core.php
+++ b/LibreNMS/Modules/Core.php
@@ -151,7 +151,6 @@ class Core implements Module
             }
         }
 
-        return;
     }
 
     /**
@@ -195,6 +194,7 @@ class Core implements Module
                 foreach ($def['discovery'] as $item) {
                     if (self::checkDiscovery($device, $item, $def['mib_dir'] ?? null)) {
                         self::setOS($device, $os, $item);
+
                         return;
                     }
                 }
@@ -207,13 +207,14 @@ class Core implements Module
             foreach ($os_defs[$os]['discovery'] as $item) {
                 if (self::checkDiscovery($device, $item, $os_defs[$os]['mib_dir'] ?? null)) {
                     self::setOS($device, $os, $item);
+
                     return;
                 }
             }
         }
 
         self::setOS($device, 'generic', []);
-        return;
+
     }
 
     /**

--- a/LibreNMS/Modules/Core.php
+++ b/LibreNMS/Modules/Core.php
@@ -210,7 +210,7 @@ class Core implements Module
         }
 
         self::setOS($device, 'generic', []);
-        return;
+
     }
 
     /**

--- a/LibreNMS/Modules/Core.php
+++ b/LibreNMS/Modules/Core.php
@@ -156,9 +156,9 @@ class Core implements Module
     /**
      * Detect the os of the given device.
      *
-     * @param  Device  $device  device to check
+     * @param  Device  $device  device to check and update
      * @param  bool  $fetch  fetch sysDescr and sysObjectID fresh from the device
-     * @return string the name of the os
+     * @return void
      *
      * @throws \Exception
      */

--- a/LibreNMS/Modules/Core.php
+++ b/LibreNMS/Modules/Core.php
@@ -150,7 +150,6 @@ class Core implements Module
                 $device->type = Config::get("os.$device->os.type");
             }
         }
-
     }
 
     /**
@@ -214,7 +213,6 @@ class Core implements Module
         }
 
         self::setOS($device, 'generic', []);
-
     }
 
     /**

--- a/LibreNMS/Modules/Core.php
+++ b/LibreNMS/Modules/Core.php
@@ -210,6 +210,7 @@ class Core implements Module
         }
 
         self::setOS($device, 'generic', []);
+        return;
     }
 
     /**

--- a/app/Actions/Device/ValidateDeviceAndCreate.php
+++ b/app/Actions/Device/ValidateDeviceAndCreate.php
@@ -96,7 +96,7 @@ class ValidateDeviceAndCreate
                 $this->device->sysName = SnmpQuery::device($this->device)->get('SNMPv2-MIB::sysName.0')->value();
                 $this->exceptIfSysNameExists();
 
-                $this->device->os = Core::detectOS($this->device);
+                Core::detectOS($this->device);
             }
         }
 

--- a/doc/Developing/os/Initial-Detection.md
+++ b/doc/Developing/os/Initial-Detection.md
@@ -49,6 +49,33 @@ discovery:
         - op: <["=","!=","==","!==","<=",">=","<",">","starts","ends","contains","regex","not_starts","not_ends","not_contains","not_regex","in_array","not_in_array","exists"]>
         - value: <'string' | boolean>
 ```
+- `type` You can override the type of device within any discovery section.
+  In the example below, unifi devices will default to having a type of wireless,
+  but the unifi gateway routers in the second discovery section will have a type
+  of network.
+```
+os: unifi
+text: 'Ubiquiti UniFi'
+type: wireless
+
+.....
+discovery:
+    -
+        sysObjectID:
+            - .1.3.6.1.4.1.41112
+            - .1.3.6.1.4.1.8072.3.2.10
+        sysDescr_regex:
+            - '/^UAP/'
+            - '/^U6/'
+            - '/^U7/'
+            - '/^U-LTE/'
+    -
+        sysObjectID:
+            - .1.3.6.1.4.1.8072.3.2.10
+        sysDescr_regex:
+            - '/^Ubiquiti UniFi/'
+        type: network
+```
 - `_except` You can add this to any of the above to exclude that
   element. As an example:
 

--- a/includes/definitions/unifi.yaml
+++ b/includes/definitions/unifi.yaml
@@ -18,12 +18,6 @@ discovery:
             - '/^U7/'
             - '/^U-LTE/'
     -
-        sysObjectID:
-            - .1.3.6.1.4.1.8072.3.2.10
-        sysDescr_regex:
-            - '/^Ubiquiti UniFi/'
-        type: network
-    -
         sysObjectID: .1.3.6.1.4.1.10002.1
         sysDescr: Linux
         snmpwalk:

--- a/includes/definitions/unifi.yaml
+++ b/includes/definitions/unifi.yaml
@@ -18,6 +18,12 @@ discovery:
             - '/^U7/'
             - '/^U-LTE/'
     -
+        sysObjectID:
+            - .1.3.6.1.4.1.8072.3.2.10
+        sysDescr_regex:
+            - '/^Ubiquiti UniFi/'
+        type: network
+    -
         sysObjectID: .1.3.6.1.4.1.10002.1
         sysDescr: Linux
         snmpwalk:

--- a/misc/os_schema.json
+++ b/misc/os_schema.json
@@ -43,6 +43,9 @@
                     "snmpget": {"$ref": "#/definitions/snmpget"},
                     "snmpget_except": {"$ref": "#/definitions/snmpget"},
                     "snmpwalk": {"$ref": "#/definitions/snmpget"}
+                    "type": {
+                        "type": "string"
+                    },
                 },
                 "minProperties": 1,
                 "additionalProperties": false

--- a/misc/os_schema.json
+++ b/misc/os_schema.json
@@ -42,10 +42,10 @@
                     "sysDescr_regex_except": {"$ref": "#/definitions/regex_group"},
                     "snmpget": {"$ref": "#/definitions/snmpget"},
                     "snmpget_except": {"$ref": "#/definitions/snmpget"},
-                    "snmpwalk": {"$ref": "#/definitions/snmpget"}
+                    "snmpwalk": {"$ref": "#/definitions/snmpget"},
                     "type": {
                         "type": "string"
-                    },
+                    }
                 },
                 "minProperties": 1,
                 "additionalProperties": false

--- a/misc/os_schema.json
+++ b/misc/os_schema.json
@@ -42,10 +42,10 @@
                     "sysDescr_regex_except": {"$ref": "#/definitions/regex_group"},
                     "snmpget": {"$ref": "#/definitions/snmpget"},
                     "snmpget_except": {"$ref": "#/definitions/snmpget"},
-                    "snmpwalk": {"$ref": "#/definitions/snmpget"},
+                    "snmpwalk": {"$ref": "#/definitions/snmpget"}
                     "type": {
                         "type": "string"
-                    }
+                    },
                 },
                 "minProperties": 1,
                 "additionalProperties": false

--- a/tests/OSDiscoveryTest.php
+++ b/tests/OSDiscoveryTest.php
@@ -124,14 +124,15 @@ class OSDiscoveryTest extends TestCase
         Debug::set();
         Debug::setVerbose();
         ob_start();
-        $os = Core::detectOS($this->genDevice($community));
+        $device = $this->genDevice($community);
+        Core::detectOS($device);
         $output = ob_get_contents();
         ob_end_clean();
         Debug::set(false);
         Debug::setVerbose(false);
 
         $this->assertLessThan(10, microtime(true) - $start, "OS $expected_os took longer than 10s to detect");
-        $this->assertEquals($expected_os, $os, "Test file: $community.snmprec\n$output");
+        $this->assertEquals($expected_os, $device->os, "Test file: $community.snmprec\n$output");
     }
 
     /**


### PR DESCRIPTION
Allows the OS type to be overridden on a discovery condition, removing the assumption that all devices for a given OS are part of the same classification.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
