### PR TITLE
Update NeighboursController.php

### DIFF
--- a/app/Http/Controllers/Device/Tabs/NeighboursController.php
+++ b/app/Http/Controllers/Device/Tabs/NeighboursController.php
@@ -73,7 +73,7 @@ class NeighboursController implements DeviceTab
                 $links[] = [
                     'local_url' => Url::portLink($link->port, null, null, true, false),
                     'ldev_id' => $device->device_id,
-                    'local_portname' => $link->port->ifAlias,
+                    'local_portname' => $link->port ? $link->port->ifAlias : $link->port,
                     'rport_url' => $link->remotePort ? Url::portLink($link->remotePort, null, null, true, false) : '',
                     'rdev_url' => $link->remoteDevice ? Url::deviceLink($link->remoteDevice, null, [], 0, 0, 0, 1) : null,
                     'rdev_name' => $link->remoteDevice ? $link->remoteDevice->shortDisplayName() : $link->remote_hostname,


### PR DESCRIPTION
After updating to 24.10.0 (and it is the same on my current 24.10.1 - Wed Nov 06 2024 16:04:00 GMT+0100) LibreNMS stopped showing neighbours on Neighbours tab for TP-Link switches. Models not working are SG3452XP 2.20, SG3452X 1.20, TL-SG3452XP 1.0, SG3428X 1.30, SX3016F 1.20. The only model working is SG3452P 3.30. After clicking on the Neighbours tab it shows “Whoops, looks like something went wrong. Check your librenms.log.”. Then the message “Attempt to read property “ifAlias” on null {“userId”:1,“exception”:”[object] (ErrorException(code: 0): Attempt to read property "ifAlias" on null at /opt/librenms/app/Http/Controllers/Device/Tabs/NeighboursController.php:76)“}” is in the librenms.log.

Suggested change solves the issue.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
