### PR TITLE
Fix neighbours controller when local port is not known

### DIFF
--- a/app/Http/Controllers/Device/Tabs/NeighboursController.php
+++ b/app/Http/Controllers/Device/Tabs/NeighboursController.php
@@ -73,7 +73,7 @@ class NeighboursController implements DeviceTab
                 $links[] = [
                     'local_url' => Url::portLink($link->port, null, null, true, false),
                     'ldev_id' => $device->device_id,
-                    'local_portname' => $link->port->ifAlias,
+                    'local_portname' => $link->port ? $link->port->ifAlias : '',
                     'rport_url' => $link->remotePort ? Url::portLink($link->remotePort, null, null, true, false) : '',
                     'rdev_url' => $link->remoteDevice ? Url::deviceLink($link->remoteDevice, null, [], 0, 0, 0, 1) : null,
                     'rdev_name' => $link->remoteDevice ? $link->remoteDevice->shortDisplayName() : $link->remote_hostname,


### PR DESCRIPTION
Issue was reported here https://github.com/librenms/librenms/pull/16677/files but without a branch

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
