### PR TITLE
Convert device neighbour blade to use components for device and port map pop-ups

### DIFF
--- a/app/Http/Controllers/Device/Tabs/NeighboursController.php
+++ b/app/Http/Controllers/Device/Tabs/NeighboursController.php
@@ -58,8 +58,6 @@ class NeighboursController implements DeviceTab
     {
         $selection = Url::parseOptions('selection', 'list');
 
-        $links = [];
-
         $devices[$device->device_id] = [
             'url' => Url::deviceLink($device, null, [], 0, 0, 0, 1),
             'hw' => $device->hardware,
@@ -69,34 +67,24 @@ class NeighboursController implements DeviceTab
         if ($selection == 'list') {
             $linksQuery = $device->links()->with('port', 'remoteDevice', 'remotePort');
 
-            foreach ($linksQuery->get()->sortBy('port.ifName') as $link) {
-                $links[] = [
-                    'local_url' => Url::portLink($link->port, null, null, true, false),
-                    'ldev_id' => $device->device_id,
-                    'local_portname' => $link->port->ifAlias,
-                    'rport_url' => $link->remotePort ? Url::portLink($link->remotePort, null, null, true, false) : '',
-                    'rdev_url' => $link->remoteDevice ? Url::deviceLink($link->remoteDevice, null, [], 0, 0, 0, 1) : null,
-                    'rdev_name' => $link->remoteDevice ? $link->remoteDevice->shortDisplayName() : $link->remote_hostname,
-                    'rdev_info' => $link->remoteDevice ? $link->remoteDevice->hardware : $link->remote_platform,
-                    'rport_name' => $link->remotePort ? $link->remotePort->ifAlias : $link->remote_port,
-                    'protocol' => strtoupper($link->protocol),
-                ];
-            }
+            $links = $linksQuery->get()->sortBy('port.ifName');
+        } else {
+            $links = [];
         }
 
         return [
             'selections' => [
                 'list' => [
                     'text' => 'List',
-                    'link' => Url::deviceUrl($device, ['tab' => 'neighbours', 'selection' => 'list']),
+                    'link' => route('device', ['device' => $device, 'tab' => 'neighbours', 'vars' => 'selection=list']),
                 ],
                 'map' => [
                     'text' => 'Map',
-                    'link' => Url::deviceUrl($device, ['tab' => 'neighbours', 'selection' => 'map']),
+                    'link' => route('device', ['device' => $device, 'tab' => 'neighbours', 'vars' => 'selection=map']),
                 ],
             ],
             'selection' => $selection,
-            'device_id' => $device->device_id,
+            'device' => $device,
             'links' => $links,
             'link_types' => Config::get('network_map_items', ['xdp', 'mac']),
             'visoptions' => Config::get('network_map_vis_options'),

--- a/resources/views/device/tabs/neighbours.blade.php
+++ b/resources/views/device/tabs/neighbours.blade.php
@@ -14,21 +14,32 @@
         </thead>
         <tbody>
 @foreach($data['links'] as $link)
-@if($link['rdev_url'])
             <tr>
-                <td>{!! $link['local_url'] !!}<br />{{ $link['local_portname'] }}</td>
-                <td>{!! $link['rdev_url'] !!}<br />{{ $link['rdev_info'] }}</td>
-                <td>{!! $link['rport_url'] !!}<br />{{ $link['rport_name'] }}</td>
-                <td>{{ $link['protocol'] }}</td>
+                <td>
+                @if($link->port)
+                    <x-port-link :port="$link->port" />
+                    <br />{{$link->port->ifAlias}}
+                @endif
+                <td>
+                @if($link->remoteDevice)
+                    <x-device-link :device="$link->remoteDevice" />
+                    <br />{{$link->remoteDevice->hardware}}
+                @else
+                    {{$link->remote_hostname}}
+                    <br />{{$link->remote_platform}}
+                @endif
+                </td>
+                <td>
+                @if($link->remotePort)
+                    <x-port-link :port="$link->remotePort" />
+                    <br />{{$link->remotePort->ifAlias}}
+                @else
+                    {{$link->remote_port}}
+                @endif
+                </td>
+                </td>
+                <td>{{ strtoupper($link->protocol) }}</td>
             </tr>
-@else
-            <tr>
-                <td>{!! $link['local_url'] !!}<br />{{ $link['local_portname'] }}</td>
-                <td>{{ $link['rdev_name'] }}<br />{{ $link['rdev_info'] }}</td>
-                <td>{{ $link['rport_name'] }}</td>
-                <td>{{ $link['protocol'] }}</td>
-            </tr>
-@endif
 @endforeach
         </tbody>
     </table>
@@ -40,7 +51,7 @@
 var network_nodes = new vis.DataSet({queue: {delay: 100}});
 var network_edges = new vis.DataSet({queue: {delay: 100}});
 
-$.post( '{{ route('maps.getdevicelinks') }}', {device: {{$data['device_id']}}, link_types: @json($data['link_types'])})
+$.post( '{{ route('maps.getdevicelinks') }}', {device: {{$device->device_id}}, link_types: @json($data['link_types'])})
     .done(function( data ) {
         var devices = [];
         $.each(data, function( link_id, link ) {


### PR DESCRIPTION
Convert device neighbour blade to use components for device and port map pop-ups instead of the old URL helper

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
