### PR TITLE
Use ifIndex for TPLINK LLDP neighbour lookup first

### DIFF
--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -215,8 +215,10 @@ if (($device['os'] == 'routeros') && version_compare($device['version'], '7.7', 
                 continue;
             }
 
-            $local_port_id = get_port_by_ifIndex($device['device_id'], $IndexId);
-            if (! $local_port_id) {
+            $interface = get_port_by_ifIndex($device['device_id'], $IndexId);
+            if ($interface && $interface['port_id']) {
+                $local_port_id = $interface['port_id'];
+            } else {
                 $local_ifName = $lldp['lldpNeighborPortId'][$IndexId][1];
                 $local_port_id = find_port_id('gigabitEthernet ' . $local_ifName, null, $device['device_id']);
             }

--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -215,8 +215,11 @@ if (($device['os'] == 'routeros') && version_compare($device['version'], '7.7', 
                 continue;
             }
 
-            $local_ifName = $lldp['lldpNeighborPortId'][$IndexId][1];
-            $local_port_id = find_port_id('gigabitEthernet ' . $local_ifName, null, $device['device_id']);
+            $local_port_id = get_port_by_ifIndex($device['device_id'], $IndexId);
+            if (! $local_port_id) {
+                $local_ifName = $lldp['lldpNeighborPortId'][$IndexId][1];
+                $local_port_id = find_port_id('gigabitEthernet ' . $local_ifName, null, $device['device_id']);
+            }
 
             $remote_device_id = find_device_id($lldp['lldpNeighborDeviceName'][$IndexId][1]);
             $remote_device_name = $lldp['lldpNeighborDeviceName'][$IndexId][1];

--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -488,7 +488,7 @@ if (Config::get('autodiscovery.ospf') === true) {
 
 d_echo($link_exists);
 
-$sql = 'SELECT * FROM `links` AS L, `ports` AS I WHERE L.local_port_id = I.port_id AND I.device_id = ?';
+$sql = 'SELECT * FROM `links` AS L LEFT JOIN `ports` AS I ON L.local_port_id = I.port_id WHERE L.local_device_id = ?';
 foreach (dbFetchRows($sql, [$device['device_id']]) as $test) {
     $local_port_id = $test['local_port_id'];
     $remote_hostname = $test['remote_hostname'];


### PR DESCRIPTION
TPLink LLDP neighbours have been reports not working for a user here: https://github.com/librenms/librenms/issues/16639

This PR uses the ifindex lookup first, which should be more reliable than the interface name lookup that was implemented.  This code will still fall back to the original lookup method if the ifindex lookup fails.

I also discovered that the SQL query that cleaned up discovered links didn't handle null local ports either.  The clean-up SQL query was changed to an outer join to resolve this.
 
DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
