### PR TITLE
Allow underscores in hostnames

### DIFF
--- a/LibreNMS/Util/Validate.php
+++ b/LibreNMS/Util/Validate.php
@@ -47,7 +47,7 @@ class Validate
         // maximum length is 253 characters, maximum segment size is 63
 
         return
-            preg_match("/^([a-z\d](-*[a-z\d])*)(\.([a-z\d](-*[a-z\d])*))*\.?$/i", $hostname) //valid chars check
+            preg_match("/^([a-z\d](-*[a-z\d_])*)(\.([a-z\d](-*[a-z\d_])*))*\.?$/i", $hostname) //valid chars check
             && preg_match('/^.{1,253}$/', $hostname) //overall length check
             && preg_match("/^[^\.]{1,63}(\.[^\.]{1,63})*\.?$/", $hostname);
     }

--- a/tests/CommonFunctionsTest.php
+++ b/tests/CommonFunctionsTest.php
@@ -127,7 +127,7 @@ class CommonFunctionsTest extends TestCase
         $this->assertTrue(Validate::hostname('www.averylargedomainthatdoesnotreallyexist.com'), 'www.averylargedomainthatdoesnotreallyexist.com');
         $this->assertTrue(Validate::hostname('cont-ains.h-yph-en-s.com'), 'cont-ains.h-yph-en-s.com');
         $this->assertTrue(Validate::hostname('cisco-3750x'), 'cisco-3750x');
-        $this->assertFalse(Validate::hostname('cisco_3750x'), 'cisco_3750x');
+        $this->assertTrue(Validate::hostname('cisco_3750x'), 'cisco_3750x');
         $this->assertFalse(Validate::hostname('goo gle.com'), 'goo gle.com');
         $this->assertFalse(Validate::hostname('google..com'), 'google..com');
         $this->assertFalse(Validate::hostname('google.com '), 'google.com ');


### PR DESCRIPTION
Feels like we should allow underscores, they are used in hostnames more generally and has been reported as a regression in #16577


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
