### PR TITLE
Truenas storage fix

### DIFF
--- a/includes/discovery/storage/freenas-dataset.inc.php
+++ b/includes/discovery/storage/freenas-dataset.inc.php
@@ -8,7 +8,7 @@ if ($device['os'] == 'truenas') {
 
     if (is_array($datasetTable_array)) {
         foreach ($datasetTable_array as $index => $dataset) {
-            if (isset($dataset['datasetDescr'])) {
+            if (isset($dataset['datasetAvailable'])) {
                 if (!in_array($dataset['datasetDescr'], $tmp_storage)) {
                     $dataset['datasetIndex'] = $index;
                     $dataset['datasetTotal'] = $dataset['datasetSize'] * $dataset['datasetAllocationUnits'];


### PR DESCRIPTION
We have just deployed a TrueNAS box, and we are getting errors because the poller module for freenas-dataset storage is returning a value greater than a 64 bit integer.  The root cause is that our TrueNAS box appears to be returning different data than expected for the table lookup.

This PR makes sure that the last entry exists in the returned data (datasetAvailable) instead of the first (datasetDescr) for discovery.  This can be seen as an improvement, since this datasetAvailable value is needed for the poller to work properly, and since this is the last value in the table it ensures the whole table has been read.  As a side-effect, it also stops discovery on my system since the last OID is missing from my data.

I get the following if I run a manual SNMP walk without the "-OQ" flag, indicating that my data is different.

.1.3.6.1.4.1.50536.1.2.1.1.1.1 = INTEGER: 1
.1.3.6.1.4.1.50536.1.2.1.1.1.2 = INTEGER: 2
.1.3.6.1.4.1.50536.1.2.1.1.2.1 = STRING: boot-pool
.1.3.6.1.4.1.50536.1.2.1.1.2.2 = STRING: tank
.1.3.6.1.4.1.50536.1.2.1.1.3.1 = Wrong Type (should be INTEGER): Counter64: 5712158720
.1.3.6.1.4.1.50536.1.2.1.1.3.2 = Wrong Type (should be INTEGER): Counter64: 1554936664320
.1.3.6.1.4.1.50536.1.2.1.1.4.1 = Wrong Type (should be INTEGER): Counter64: 439623131136
.1.3.6.1.4.1.50536.1.2.1.1.4.2 = Wrong Type (should be INTEGER): Counter64: 1657252117793024
.1.3.6.1.4.1.50536.1.2.1.1.5.1 = Wrong Type (should be INTEGER): Counter64: 98304
.1.3.6.1.4.1.50536.1.2.1.1.5.2 = Wrong Type (should be INTEGER): Counter64: 243360


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
