### PR TITLE
Bugfix for setting dependency map selected border width

### DIFF
--- a/resources/views/map/device-dependency.blade.php
+++ b/resources/views/map/device-dependency.blade.php
@@ -148,7 +148,7 @@
                         this_dev.color.background = '#D2E5FF';
                     }
                     // Set the highlighted style
-                    this_dev.borderWidthSelected = ;node_highlight_style.borderWidth;
+                    this_dev.borderWidthSelected = node_highlight_style.borderWidth;
                     this_dev.color.highlight = {};
                     this_dev.color.highlight.background = this_dev.color.background;
                     this_dev.color.highlight.border = node_highlight_style.color.border;


### PR DESCRIPTION
Fix a bug so the dependency map correctly sets the border width of selected items.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
