### PR TITLE
Allow ifIndex swaps during port discovery

### DIFF
--- a/database/migrations/2025_01_28_135558_ports_drop_unique_ifindex.php
+++ b/database/migrations/2025_01_28_135558_ports_drop_unique_ifindex.php
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('ports', function (Blueprint $table) {
-            $table->dropUnique(['device_id', 'ifIndex']); 
+            $table->dropUnique(['device_id', 'ifIndex']);
         });
     }
 

--- a/database/migrations/2025_01_28_135558_ports_drop_unique_ifindex.php
+++ b/database/migrations/2025_01_28_135558_ports_drop_unique_ifindex.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('ports', function (Blueprint $table) {
+            $table->dropUnique(['device_id', 'ifIndex']); 
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('ports', function (Blueprint $table) {
+            $table->unique(['device_id', 'ifIndex']);
+        });
+    }
+};

--- a/includes/discovery/ports.inc.php
+++ b/includes/discovery/ports.inc.php
@@ -2,7 +2,6 @@
 
 // Build SNMP Cache Array
 use App\Models\PortGroup;
-use Illuminate\Support\Facades\DB;
 use LibreNMS\Config;
 use LibreNMS\Enum\PortAssociationMode;
 use LibreNMS\Util\StringHelpers;
@@ -123,64 +122,6 @@ if ($device['os'] == 'ekinops') {
 }
 
 $default_port_group = Config::get('default_port_group');
-
-// If we are not using ifIndex as the port association, handle tricky changes here to avoid unique key constraint violations
-if ($port_association_mode != 'ifIndex') {
-    // Get ifIndex -> port map
-    $ports_ifindex = $ports_mapped['maps']['ifIndex'];
-    $ifindex_conflicts = [];
-
-    // Go through each SNMP entry and figure out if the index has changed
-    foreach ($port_stats as $ifIndex => $snmp_data) {
-        // We only need to consider results that have an entry in the database
-        if (array_key_exists($ifIndex, $ports_ifindex)) {
-            $snmp_data['ifIndex'] = $ifIndex; // Store ifIndex in port entry
-            $snmp_data['ifAlias'] = StringHelpers::inferEncoding($snmp_data['ifAlias'] ?? null);
-
-            $port_id = get_port_id($ports_mapped, $snmp_data, $port_association_mode);
-
-            if (! $port_id) {
-                // If the SNMP to port_id lookup fails, we need to be aware of conflicts later
-                $ifindex_conflicts[$ifIndex] = $ports_ifindex[$ifIndex];
-            } elseif ($ports_ifindex[$ifIndex] != $port_id) {
-                // The SNMP data found an existing port that is different from the DB row with the same ifIndex
-                d_echo("port_id has changed for interface with index $ifIndex\n");
-
-                // Fetch the data of the keys we want to swap
-                $old_ifIndex = $ports_db[$port_id]['ifIndex'];
-                $conflicting_port_id = $ports_ifindex[$ifIndex];
-
-                // Use a transaction to swap the indexes.  We use null ifIndex temporarily to avoid duplicate key constraints
-                DB::transaction(function () use ($port_id, $ifIndex, $conflicting_port_id, $old_ifIndex) {
-                    DB::update('UPDATE ports SET ifIndex=NULL WHERE port_id=:port_id', ['port_id' => $conflicting_port_id]);
-                    DB::update('UPDATE ports SET ifIndex=:ifIndex WHERE port_id=:port_id', ['ifIndex' => $ifIndex, 'port_id' => $port_id]);
-                    DB::update('UPDATE ports SET ifIndex=:ifIndex WHERE port_id=:port_id', ['ifIndex' => $old_ifIndex, 'port_id' => $conflicting_port_id]);
-                });
-
-                // Update the maps for both ports
-                $ports_db[$conflicting_port_id]['ifIndex'] = $old_ifIndex;
-                $ports_ifindex[$old_ifIndex] = $conflicting_port_id;
-                $ports_db[$port_id]['ifIndex'] = $ifIndex;
-                $ports_ifindex[$ifIndex] = $port_id;
-            } elseif (array_key_exists($ifIndex, $ifindex_conflicts)) {
-                // We can just update this record because there is no conflict on the ifIndex, and another port wants to use the existing ifIndex
-                DB::update('UPDATE ports SET ifIndex=:ifIndex WHERE port_id=:port_id', ['ifIndex' => $ifIndex, 'port_id' => $port_id]);
-
-                // Update the maps
-                $ports_db[$port_id]['ifIndex'] = $ifIndex;
-                $ports_ifindex[$ifIndex] = $port_id;
-
-                // This is no longer a conflict
-                unset($ifindex_conflicts[$ifIndex]);
-            }
-        }
-    }
-
-    // Go through remaining conflicts and delete any rows marked as deleted
-    foreach ($ifindex_conflicts as $ifIndex => $port_id) {
-        DB::update('DELETE FROM ports WHERE deleted=1 AND port_id=:port_id', ['port_id' => $port_id]);
-    }
-}
 
 // New interface detection
 foreach ($port_stats as $ifIndex => $snmp_data) {

--- a/includes/discovery/ports.inc.php
+++ b/includes/discovery/ports.inc.php
@@ -142,10 +142,9 @@ if ($port_association_mode != 'ifIndex') {
             if (! $port_id) {
                 // If the SNMP to port_id lookup fails, we need to be aware of conflicts later
                 $ifindex_conflicts[$ifIndex] = $ports_ifindex[$ifIndex];
-            } elseif (array_key_exists($ifIndex, $ports_ifindex) && $ports_ifindex[$ifIndex] != $port_id) {
-                // The SNMP data found an existing port that is different from the DB
+            } elseif ($ports_ifindex[$ifIndex] != $port_id) {
+                // The SNMP data found an existing port that is different from the DB row with the same ifIndex
                 d_echo("port_id has changed for interface with index $ifIndex\n");
-                print_r($ports_ifindex);
 
                 // Fetch the data of the keys we want to swap
                 $old_ifIndex = $ports_db[$port_id]['ifIndex'];

--- a/includes/discovery/ports.inc.php
+++ b/includes/discovery/ports.inc.php
@@ -139,7 +139,7 @@ if ($port_association_mode != 'ifIndex') {
 
             $port_id = get_port_id($ports_mapped, $snmp_data, $port_association_mode);
 
-            if (!$port_id) {
+            if (! $port_id) {
                 // If the SNMP to port_id lookup fails, we need to be aware of conflicts later
                 $ifindex_conflicts[$ifIndex] = $ports_ifindex[$ifIndex];
             } elseif (array_key_exists($ifIndex, $ports_ifindex) && $ports_ifindex[$ifIndex] != $port_id) {

--- a/misc/db_schema.yaml
+++ b/misc/db_schema.yaml
@@ -1637,7 +1637,6 @@ ports:
     - { Field: poll_period, Type: 'int unsigned', 'Null': true, Extra: '' }
   Indexes:
     PRIMARY: { Name: PRIMARY, Columns: [port_id], Unique: true, Type: BTREE }
-    ports_device_id_ifindex_unique: { Name: ports_device_id_ifindex_unique, Columns: [device_id, ifIndex], Unique: true, Type: BTREE }
     ports_ifalias_port_descr_descr_portname_index: { Name: ports_ifalias_port_descr_descr_portname_index, Columns: [ifAlias, port_descr_descr, portName], Unique: false, Type: BTREE }
     ports_ifdescr_ifname_index: { Name: ports_ifdescr_ifname_index, Columns: [ifDescr, ifName], Unique: false, Type: BTREE }
 ports_adsl:


### PR DESCRIPTION
Add some code on the port discovery module to swap the ifIndex entries of ports

I have noticed that if the SNMP ifIndex for 2 interfaces swap places, and LibreNMS is not using ifIndex for mapping interfaces to ports, the poller can get stuck being unable to update these ports because both ports get a unique constraint violation.  This PR adds some code into the discovery module that will do one of 2 things to fix this:
 - It will swap the ifIndex IDs of the 2 ports within a transaction if both ports are detected in the DB
 - It will immediately update the ifIndex of a port if a new port will need the ifIndex
 - It will delete any ports with the deleted flag if a new port will need the ifIndex

There are probably some conditions that will take 2 discovery cycles to resolve (if a port has not been detected as deleted yet), but the main goal is still to try and preserve the port_id, so it is better to take 2 cycles to re-use a ifIndex than to delete a port that has just had its ifIndex changed.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
