### PR TITLE
dont migrate views in 2021_02_09_122930_migrate_to_utf8mb4

### DIFF
--- a/database/migrations/2021_02_09_122930_migrate_to_utf8mb4.php
+++ b/database/migrations/2021_02_09_122930_migrate_to_utf8mb4.php
@@ -39,7 +39,7 @@ return new class extends Migration
         // Get the list of all tables
         $tableNames = DB::table('information_schema.tables')
             ->where('table_schema', $databaseName)
-            ->where('TABLE_TYPE', 'BASE TABLE')            
+            ->where('TABLE_TYPE', 'BASE TABLE')
             ->pluck('TABLE_NAME');
 
         // Iterate through the list and alter each table

--- a/database/migrations/2021_02_09_122930_migrate_to_utf8mb4.php
+++ b/database/migrations/2021_02_09_122930_migrate_to_utf8mb4.php
@@ -39,6 +39,7 @@ return new class extends Migration
         // Get the list of all tables
         $tableNames = DB::table('information_schema.tables')
             ->where('table_schema', $databaseName)
+            ->where('TABLE_TYPE', 'BASE TABLE')            
             ->pluck('TABLE_NAME');
 
         // Iterate through the list and alter each table


### PR DESCRIPTION
Please give a short description what your pull request is for

Migrated a system and had the database character set not set to utf8mb4.   Validate and and migrate picked it up and tried to run 2021_02_09_122930_migrate_to_utf8mb4 which failed on view view_port_mac_links

This should exclude views from this migration incase this impacts any other person in the future that does something not-so-clever

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
