### PR TITLE
Fix for saveMapSettings() when creating a new map

### DIFF
--- a/resources/views/map/custom-map-modal.blade.php
+++ b/resources/views/map/custom-map-modal.blade.php
@@ -132,26 +132,26 @@
             height = height + "px";
         }
 
-        if (width.endsWith("px") && height.endsWith("px")) {
-            widthInt = parseInt(width);
-            heightInt = parseInt(height);
-
-            var nodeError = false;
-            network_nodes.forEach((node) => {
-                if (node.x > widthInt - {{ isset($hmargin) ? $hmargin : 10 }} || node.y > heightInt - {{ isset($vmargin) ? $vmargin : 10 }}) {
-                    nodeError = true;
-                }
-            });
-            if (nodeError) {
-                let alert_content = $("#savemap-alert");
-                alert_content.text('Please move nodes inside the new area before shrinking the map');
-                alert_content.attr("class", "col-sm-12 alert alert-danger");
-                $("#map-saveButton").removeAttr('disabled');
-                return;
-            }
-        }
-
         @if(isset($map_id))
+            if (width.endsWith("px") && height.endsWith("px")) {
+                widthInt = parseInt(width);
+                heightInt = parseInt(height);
+
+                var nodeError = false;
+                network_nodes.forEach((node) => {
+                    if (node.x > widthInt - {{ isset($hmargin) ? $hmargin : 10 }} || node.y > heightInt - {{ isset($vmargin) ? $vmargin : 10 }}) {
+                        nodeError = true;
+                    }
+                });
+                if (nodeError) {
+                    let alert_content = $("#savemap-alert");
+                    alert_content.text('Please move nodes inside the new area before shrinking the map');
+                    alert_content.attr("class", "col-sm-12 alert alert-danger");
+                    $("#map-saveButton").removeAttr('disabled');
+                    return;
+                }
+            }
+
             var url = '{{ route('maps.custom.update', ['map' => $map_id]) }}';
             var method = 'PUT';
         @else


### PR DESCRIPTION
I discovered a bug in a recent commit that prevents custom maps from being created.  This resolves the issue.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
