### PR TITLE
adding ieee754_to_decimal function in common.php

### DIFF
--- a/includes/common.php
+++ b/includes/common.php
@@ -816,11 +816,11 @@ function get_vm_parent_id($device)
 /**
  * Converts ieee754 32-bit floating point decimal represenation to decimal
  */
-function ieee754_to_decimal($value) 
+function ieee754_to_decimal($value)
 {
     $hex = dechex($value);
     $binary = str_pad(base_convert($hex, 16, 2), 32, '0', STR_PAD_LEFT);
-    $sign = (int)$binary[0];
+    $sign = (int) $binary[0];
     $exponent = bindec(substr($binary, 1, 8)) - 127;
     $mantissa = substr($binary, 9);
     $mantissa_value = 1;

--- a/includes/common.php
+++ b/includes/common.php
@@ -814,6 +814,27 @@ function get_vm_parent_id($device)
 }
 
 /**
+ * Converts ieee754 32-bit floating point decimal represenation to decimal
+ */
+function ieee754_to_decimal($value) 
+{
+    $hex = dechex($value);
+    $binary = str_pad(base_convert($hex, 16, 2), 32, '0', STR_PAD_LEFT);
+    $sign = (int)$binary[0];
+    $exponent = bindec(substr($binary, 1, 8)) - 127;
+    $mantissa = substr($binary, 9);
+    $mantissa_value = 1;
+    for ($i = 0; $i < strlen($mantissa); $i++) {
+        if ($mantissa[$i] == '1') {
+            $mantissa_value += pow(2, -($i + 1));
+        }
+    }
+    $value = pow(-1, $sign) * $mantissa_value * pow(2, $exponent);
+
+    return $value;
+}
+
+/**
  * Index an array by a column
  *
  * @param  array  $array


### PR DESCRIPTION
adding ieee754_to_decimal function in common.php to allow conversion of 32-bit floating point decimal representation to decimal. This will be used in a ber sensor in timos.yaml (different PR).

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
