### PR TITLE
Fix edge graph pop-up on edge maps

### DIFF
--- a/app/Http/Controllers/Maps/MapDataController.php
+++ b/app/Http/Controllers/Maps/MapDataController.php
@@ -713,7 +713,7 @@ class MapDataController extends Controller
                         'ldev' => $port->device_id,
                         'rdev' => $remote_port->device_id,
                         'ifnames' => $port->ifName . ' <> ' . $remote_port->ifName,
-                        'url' => \Blade::render('<x-port-link :port="$port" />', ['port' => $port]),
+                        'url' => \Blade::render('<x-port-link-map :port="$port" />', ['port' => $port]),
                         'style' => $link_style,
                     ];
                 }

--- a/resources/views/map/netmap.blade.php
+++ b/resources/views/map/netmap.blade.php
@@ -179,7 +179,8 @@
                     this_edge['from'] = link['ldev'];
                     this_edge['to'] = link['rdev'];
                     this_edge['label'] = link['ifnames'];
-                    this_edge['title'] = link['url'];
+                    this_edge['title'] = document.createElement("div");
+                    this_edge['title'].innerHTML = link['url'];
 
                     if (!network_edges.get(link_id)) {
                         network_edges.add([this_edge]);


### PR DESCRIPTION
The update to the new vis.js broke the map pop-up for edged on the network map.  This fixes the regression.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
