### PR TITLE
Fix a bug in the custom map viewer if the device image is invalid

### DIFF
--- a/resources/views/map/custom-js.blade.php
+++ b/resources/views/map/custom-js.blade.php
@@ -132,7 +132,7 @@
                 } else if (node.device_image) {
                     node_cfg.image = {unselected: node.device_image};
                 } else {
-                    // Default to box if we do not get a valid image from the database 
+                    // Default to box if we do not get a valid image from the database
                     node.style = 'box';
                     node_cfg.shape = 'box';
                     node_cfg.image = undefined;
@@ -153,7 +153,7 @@
                 arrows = {to: {enabled: true, scaleFactor: 0.6}, from: {enabled: false}};
             }
 
-            var edge_cfg = {id: edgeid + "_" + fromto, to: edgeid + "_mid", arrows: arrows, font: {face: edge.text_face, size: edge.text_size, color: edge.text_colour, background: "#FFFFFF", align: edge.text_align || "horizontal"}, smooth: {type: edge.style}, , arrowStrikethrough: false};
+            var edge_cfg = {id: edgeid + "_" + fromto, to: edgeid + "_mid", arrows: arrows, font: {face: edge.text_face, size: edge.text_size, color: edge.text_colour, background: "#FFFFFF", align: edge.text_align || "horizontal"}, smooth: {type: edge.style}, arrowStrikethrough: false};
             if (fromto == "from") {
                 edge_cfg.from = edge.custom_map_node1_id;
                 var port_pct = Boolean(reverse_arrows) ? edge.port_topct : edge.port_frompct;

--- a/resources/views/map/custom-js.blade.php
+++ b/resources/views/map/custom-js.blade.php
@@ -132,10 +132,10 @@
                 } else if (node.device_image) {
                     node_cfg.image = {unselected: node.device_image};
                 } else {
-                    // If we do not get a valid image from the database, use defaults
-                    node_cfg.shape = newnodeconf.shape;
-                    node_cfg.icon = newnodeconf.icon;
-                    node_cfg.image = newnodeconf.image || undefined;
+                    // Default to box if we do not get a valid image from the database 
+                    node.style = 'box';
+                    node_cfg.shape = 'box';
+                    node_cfg.image = undefined;
                 }
             } else {
                 node_cfg.image = undefined;


### PR DESCRIPTION
I believe this is a fix for the issue reported here:
https://community.librenms.org/t/map-erorr-loading-data/26298/7

The problematic code was copied from the editor, where newnodeconf exists.  This makes the editor use a valid style if the device image becomes invalid.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
