### PR TITLE
procuve: don't detect stack state if stacking is disabled

### DIFF
--- a/includes/definitions/discovery/procurve.yaml
+++ b/includes/definitions/discovery/procurve.yaml
@@ -108,6 +108,11 @@ modules:
                     num_oid: '.1.3.6.1.4.1.11.2.14.11.5.1.69.1.1.4.0'
                     descr: 'Stack Topology'
                     state_name: hpStackTopology
+                    skip_values:
+                        - 
+                          oid: hpStackOperStatus 
+                          op: '==' 
+                          value: 1 
                     states:
                         - { descr: unKnown, graph: 1, value: 0, generic: 0 }
                         - { descr: chain, graph: 1, value: 1, generic: 0 }


### PR DESCRIPTION
Since PR #16673 switches which are not in Stack State have a warning because of this new unKnown state. This PR tries to fix the combination if a switch is not in Stack mode.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
