### PR TITLE
Changing chromatic dispersion sensor measurement unit to ps/nm

### DIFF
--- a/lang/de/sensors.php
+++ b/lang/de/sensors.php
@@ -32,7 +32,7 @@ return [
     'chromatic_dispersion' => [
         'short' => 'Chromatische Dispersion',
         'long' => 'Chromatische Dispersion',
-        'unit' => 'ps/nm/km',
+        'unit' => 'ps/nm',
         'unit_long' => 'Picosekunden pro Nanometer per Kilometer',
     ],
     'cooling' => [

--- a/lang/en/sensors.php
+++ b/lang/en/sensors.php
@@ -33,7 +33,7 @@ return [
     'chromatic_dispersion' => [
         'short' => 'Chromatic Dispersion',
         'long' => 'Chromatic Dispersion',
-        'unit' => 'ps/nm/km',
+        'unit' => 'ps/nm',
         'unit_long' => 'Picoseconds per Nanometer per Kilometer',
     ],
     'cooling' => [

--- a/lang/fr/sensors.php
+++ b/lang/fr/sensors.php
@@ -32,7 +32,7 @@ return [
     'chromatic_dispersion' => [
         'short' => 'Dispersion chromatique',
         'long' => 'Dispersion chromatique',
-        'unit' => 'ps/nm/km',
+        'unit' => 'ps/nm',
         'unit_long' => 'Picosecondes par nanomètre par kilomètre',
     ],
     'cooling' => [

--- a/lang/it/sensors.php
+++ b/lang/it/sensors.php
@@ -33,7 +33,7 @@ return [
     'chromatic_dispersion' => [
         'short' => 'Chromatic Dispersion',
         'long' => 'Chromatic Dispersion',
-        'unit' => 'ps/nm/km',
+        'unit' => 'ps/nm',
         'unit_long' => 'Picoseconds per Nanometer per Kilometer',
     ],
     'cooling' => [

--- a/lang/pt-BR/sensors.php
+++ b/lang/pt-BR/sensors.php
@@ -33,7 +33,7 @@ return [
     'chromatic_dispersion' => [
         'short' => 'Dispersão Cromática',
         'long' => 'Dispersão Cromática',
-        'unit' => 'ps/nm/km',
+        'unit' => 'ps/nm',
         'unit_long' => 'Picosegundos por Nanômetro por Quilômetro',
     ],
     'cooling' => [

--- a/lang/sr/sensors.php
+++ b/lang/sr/sensors.php
@@ -32,7 +32,7 @@ return [
     'chromatic_dispersion' => [
         'short' => 'Hromatična disperzija',
         'long' => 'Hromatična disperzija',
-        'unit' => 'ps/nm/km',
+        'unit' => 'ps/nm',
         'unit_long' => 'Picosekundi po nanometru po kilometru',
     ],
     'cooling' => [

--- a/lang/uk/sensors.php
+++ b/lang/uk/sensors.php
@@ -33,7 +33,7 @@ return [
     'chromatic_dispersion' => [
         'short' => 'Хроматична дисперсія',
         'long' => 'Хроматична дисперсія',
-        'unit' => 'ps/nm/km',
+        'unit' => 'ps/nm',
         'unit_long' => 'Пікосекунди на нанометри на кілометри',
     ],
     'cooling' => [

--- a/lang/zh-CN/sensors.php
+++ b/lang/zh-CN/sensors.php
@@ -33,7 +33,7 @@ return [
     'chromatic_dispersion' => [
         'short' => '色散',
         'long' => '色散',
-        'unit' => 'ps/nm/km',
+        'unit' => 'ps/nm',
         'unit_long' => '皮秒/纳米/千米',
     ],
     'cooling' => [

--- a/lang/zh-TW/sensors.php
+++ b/lang/zh-TW/sensors.php
@@ -32,7 +32,7 @@ return [
     'chromatic_dispersion' => [
         'short' => '色散',
         'long' => '色散',
-        'unit' => 'ps/nm/km',
+        'unit' => 'ps/nm',
         'unit_long' => 'Picoseconds per Nanometer per Kilometer',
     ],
     'cooling' => [


### PR DESCRIPTION
Changing chromatic dispersion sensor measurement unit from ps/nm/km to ps/nm to better reflect values polled from devices.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
