### PR TITLE
procurve: don't detect PoE Power if no Power is available

### DIFF
--- a/includes/definitions/discovery/procurve.yaml
+++ b/includes/definitions/discovery/procurve.yaml
@@ -58,6 +58,11 @@ modules:
                     value: hpicfPseUsedPower
                     num_oid: '.1.3.6.1.4.1.11.2.14.11.1.9.1.6.1.5.{{ $index }}'
                     index: 'hpicfPseAvailablePower.{{ $index }}'
+                    skip_values:
+                        - 
+                          oid: hpicfPseAvailablePower 
+                          op: '==' 
+                          value: 0                     
                     high_limit: hpicfPseAvailablePower
                     descr: 'PoE Power Used'
         state:


### PR DESCRIPTION
![Screenshot from 2024-11-12 16-42-49](https://github.com/user-attachments/assets/2d1f4187-daf1-47ea-ae48-956b4c2bfa57)

Since PR #16515  2920-48G switches (no PoE) have problems if no Power is available. This PR should get rid of it.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
