### PR TITLE
Introducing LibreNMS Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Test Status](https://github.com/librenms/librenms/actions/workflows/test.yml/badge.svg?branch=master&event=push)](https://github.com/librenms/librenms/actions/workflows/test.yml?query=event%3Apush+branch%3Amaster) [![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20LibreNMS%20Guru-006BFF)](https://gurubase.io/g/librenms)
+[![Test Status](https://github.com/librenms/librenms/actions/workflows/test.yml/badge.svg?branch=master&event=push)](https://github.com/librenms/librenms/actions/workflows/test.yml?query=event%3Apush+branch%3Amaster)
 
 Introduction
 ------------
@@ -22,6 +22,7 @@ Documentation
 
 Documentation can be found in the [doc directory][5] or [docs.librenms.org][16], including instructions
 for installing and contributing.
+You can also [Ask LibreNMS Guru](https://gurubase.io/g/librenms), it is LibreNMS-focused AI to answer your questions.
 
 
 Participating

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Test Status](https://github.com/librenms/librenms/actions/workflows/test.yml/badge.svg?branch=master&event=push)](https://github.com/librenms/librenms/actions/workflows/test.yml?query=event%3Apush+branch%3Amaster)
+[![Test Status](https://github.com/librenms/librenms/actions/workflows/test.yml/badge.svg?branch=master&event=push)](https://github.com/librenms/librenms/actions/workflows/test.yml?query=event%3Apush+branch%3Amaster) [![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20LibreNMS%20Guru-006BFF)](https://gurubase.io/g/librenms)
 
 Introduction
 ------------


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [LibreNMS Guru](https://gurubase.io/g/librenms) to Gurubase. LibreNMS Guru uses the data from this repo and data from the [docs](https://docs.librenms.org/) to answer questions by leveraging the LLM.

In this PR, I showcased the "LibreNMS Guru", which highlights that LibreNMS now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable LibreNMS Guru in Gurubase, just let me know that's totally fine.
