### PR TITLE
Fix for Navbar overlapping page content when it overflows

### DIFF
--- a/html/css/styles.css
+++ b/html/css/styles.css
@@ -1637,7 +1637,11 @@ nav.navbar-sticky-top {
   position: sticky;
   top: 0;
   z-index: 100;
-  border-width: 2px;
+  border-bottom-width: 2px;
+  border-left-width: 0;
+  border-top-width: 0;
+  border-right-width: 0;
+  border-radius: 0;
 }
 
 .navbar-brand {

--- a/html/css/styles.css
+++ b/html/css/styles.css
@@ -3,7 +3,7 @@ body {
   margin: 0px;
   padding: 0px;
   padding-bottom: 50px;
-  padding-top: 50px;
+  padding-top: 0px;
   background: rgb(255,255,255); /* Old browsers */
   color: #555;
   font-size: 10pt;
@@ -1631,6 +1631,13 @@ tr.search:nth-child(odd) {
 
 .navbar-debug {
   min-height: 25px;
+}
+
+nav.navbar-sticky-top {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  border-width: 2px;
 }
 
 .navbar-brand {

--- a/resources/views/layouts/librenmsv1.blade.php
+++ b/resources/views/layouts/librenmsv1.blade.php
@@ -42,7 +42,7 @@
     <link href="{{ asset('css/query-builder.default.min.css') }}" rel="stylesheet">
     <link href="{{ asset('css/app.css') }}" rel="stylesheet">
     <link href="{{ asset('css/bootstrap.min.css') }}" rel="stylesheet">
-    <link href="{{ asset(LibreNMS\Config::get('stylesheet', 'css/styles.css')) }}?ver=13062024" rel="stylesheet">
+    <link href="{{ asset(LibreNMS\Config::get('stylesheet', 'css/styles.css')) }}?ver=27112024" rel="stylesheet">
     <link href="{{ asset('css/' . LibreNMS\Config::get('applied_site_style', 'light') . '.css?ver=632417643') }}" rel="stylesheet">
     @foreach(LibreNMS\Config::get('webui.custom_css', []) as $custom_css)
         <link href="{{ $custom_css }}" rel="stylesheet">

--- a/resources/views/layouts/librenmsv1.blade.php
+++ b/resources/views/layouts/librenmsv1.blade.php
@@ -112,8 +112,6 @@
     @include('layouts.menu')
 @endif
 
-<br />
-
 @yield('content')
 
 @yield('scripts')

--- a/resources/views/layouts/menu.blade.php
+++ b/resources/views/layouts/menu.blade.php
@@ -1,4 +1,4 @@
-<nav class="navbar navbar-default {{ $navbar }} navbar-fixed-top" role="navigation">
+<nav class="navbar navbar-default {{ $navbar }} navbar-sticky-top" role="navigation">
     <div class="container-fluid">
         <div class="navbar-header">
             <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navHeaderCollapse">


### PR DESCRIPTION
I have noticed that when the menu buttons at the top of the page on the navbar overflow to a new line the navbar overlaps the top of the content underneath. It looks to be caused by the navbar having the navbar-fixed-top class which sets it position to fixed. The only difference I noticed with removing the navbar-fixed-top class was the navbar being offset from the top. I have removed the offset and everything looked good. I also removed a br tag that was adding too much of a gap between the navbar and content.

fixes #16719

I am not sure what the original intent was of doing it this way so if someone knows why that might help me find what these changes might break. So far I have navigated to most pages I visit frequently and everything looks good.

This is a picture of the changes. Usually the dashboard edit options would be slightly obscured. It was a lot worse on other pages but this is a production server I am testing on so  I don't really want to show other pages.
![1732231202_grim](https://github.com/user-attachments/assets/5f75e5ec-a92d-488d-b4c8-1d156235d82a)


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
