### PR TITLE
Testing fixes

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.1]
+        php: [8.3]
     steps:
       -
         name: Checkout Code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,12 +24,12 @@ jobs:
             skip-web-check: 1
             database: mariadb:10.5
           -
-            php-version: 8.1
+            php-version: 8.2
             name: Unit
             skip-web-check: 1
             database: mysql:8.0
           -
-            php-version: 8.1
+            php-version: 8.2
             name: Web
             skip-unit-check: 1
             database: mariadb:10.11

--- a/LibreNMS/Util/DynamicConfigItem.php
+++ b/LibreNMS/Util/DynamicConfigItem.php
@@ -25,7 +25,7 @@
 
 namespace LibreNMS\Util;
 
-use LibreNMS\Config;
+use App\Facades\LibrenmsConfig;
 use Validator;
 
 #[\AllowDynamicProperties]
@@ -50,7 +50,7 @@ class DynamicConfigItem implements \ArrayAccess
     public function __construct($name, $settings = [])
     {
         $this->name = $name;
-        $this->value = Config::get($this->name, $this->default);
+        $this->value = LibrenmsConfig::get($this->name, $this->default);
 
         foreach ($settings as $key => $value) {
             $this->$key = $value;

--- a/tests/Unit/ConfigItemTest.php
+++ b/tests/Unit/ConfigItemTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Unit;
 
+use LibreNMS\Tests\TestCase;
 use LibreNMS\Util\DynamicConfigItem;
-use PHPUnit\Framework\TestCase;
 
 class ConfigItemTest extends TestCase
 {


### PR DESCRIPTION
Attempt to call LibrenmsConfig directly in DynamicConfigItem test

I can't reproduce this issue locally.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
