### PR TITLE
Removed surplus sql_param entry causing graphs not to display on devices page

### DIFF
--- a/includes/html/pages/devices.inc.php
+++ b/includes/html/pages/devices.inc.php
@@ -184,7 +184,6 @@ if ($format == 'graph') {
         $where .= ' AND status= ?';
         $sql_param[] = $state;
         $where .= " AND disabled='0' AND `disable_notify`='0'";
-        $sql_param[] = '';
     }
     if (! empty($vars['disabled'])) {
         $where .= ' AND disabled= ?';


### PR DESCRIPTION
Bug, causes pages not to load when trying to view devices list with graphs.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
