### PR TITLE
Enable config caching

### DIFF
--- a/app/Console/Commands/ClearConfigCommand.php
+++ b/app/Console/Commands/ClearConfigCommand.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Console\LnmsCommand;
+use App\Facades\LibrenmsConfig;
+use Illuminate\Foundation\Console\ConfigClearCommand;
+use Symfony\Component\Console\Input\ArrayInput;
+
+class ClearConfigCommand extends LnmsCommand
+{
+    protected $name = 'config:clear';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle(ConfigClearCommand $configClearCommand)
+    {
+        $configClearCommand->setLaravel($this->laravel);
+        $configClearCommand->run(new ArrayInput([]), $this->output);
+
+        LibrenmsConfig::invalidateCache();
+    }
+}

--- a/app/Console/Commands/DevicePoll.php
+++ b/app/Console/Commands/DevicePoll.php
@@ -4,6 +4,7 @@ namespace App\Console\Commands;
 
 use App\Console\LnmsCommand;
 use App\Events\DevicePolled;
+use App\Facades\LibrenmsConfig;
 use App\Jobs\PollDevice;
 use App\Models\Device;
 use App\Polling\Measure\MeasurementManager;
@@ -56,6 +57,8 @@ class DevicePoll extends LnmsCommand
             if ($this->getOutput()->isVerbose()) {
                 Log::debug(Version::get()->header());
                 \LibreNMS\Util\OS::updateCache(true); // Force update of OS Cache
+                LibrenmsConfig::invalidateCache();
+                LibrenmsConfig::reload();
             }
 
             $module_overrides = Module::parseUserOverrides(explode(',', $this->option('modules') ?? ''));

--- a/app/Facades/LibrenmsConfig.php
+++ b/app/Facades/LibrenmsConfig.php
@@ -27,6 +27,7 @@ namespace App\Facades;
 
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Facade;
+use Illuminate\Support\Facades\Log;
 
 class LibrenmsConfig extends Facade
 {
@@ -39,5 +40,13 @@ class LibrenmsConfig extends Facade
     {
         App::forgetInstance('librenms-config'); // clear singleton
         self::clearResolvedInstances(); // clear facade resolved instances cache
+    }
+
+    public static function invalidateAndReload(): void
+    {
+        self::invalidateCache();
+        self::reload();
+
+        Log::info('LibreNMS config cache cleared and config reloaded.');
     }
 }

--- a/config/librenms.php
+++ b/config/librenms.php
@@ -61,5 +61,5 @@
      | Amount of seconds to allow the config to be cached.  0 means no cache.
      */
 
-     'config_cache_ttl' => env('CONFIG_CACHE_TTL', 0),
+     'config_cache_ttl' => env('CONFIG_CACHE_TTL', 300),
  ];

--- a/discovery.php
+++ b/discovery.php
@@ -70,8 +70,7 @@ if (Debug::set(isset($options['d']), false) || isset($options['v'])) {
     echo "DEBUG!\n";
     Debug::setVerbose(isset($options['v']));
     \LibreNMS\Util\OS::updateCache(true); // Force update of OS Cache
-    LibrenmsConfig::invalidateCache();
-    LibrenmsConfig::reload();
+    LibrenmsConfig::invalidateAndReload();
 }
 
 if (! $where) {

--- a/discovery.php
+++ b/discovery.php
@@ -70,6 +70,8 @@ if (Debug::set(isset($options['d']), false) || isset($options['v'])) {
     echo "DEBUG!\n";
     Debug::setVerbose(isset($options['v']));
     \LibreNMS\Util\OS::updateCache(true); // Force update of OS Cache
+    LibrenmsConfig::invalidateCache();
+    LibrenmsConfig::reload();
 }
 
 if (! $where) {

--- a/lang/en/commands.php
+++ b/lang/en/commands.php
@@ -1,6 +1,9 @@
 <?php
 
 return [
+    'config:clear' => [
+        'description' => 'Clear config cache.  This will allow any changes that have been made since the last full config load to be reflected in the current config.',
+    ],
     'config:get' => [
         'description' => 'Get configuration value',
         'arguments' => [

--- a/scripts/collect-snmp-data.php
+++ b/scripts/collect-snmp-data.php
@@ -127,8 +127,7 @@ try {
 
     echo 'Capturing Data: ';
     \LibreNMS\Util\OS::updateCache(true); // Force update of OS Cache
-    LibrenmsConfig::invalidateCache();
-    LibrenmsConfig::reload();
+    LibrenmsConfig::invalidateAndReload();
     $capture->captureFromDevice($device['device_id'], $prefer_new_snmprec, $full);
     echo "\nVerify these file(s) do not contain any private data before sharing!\n";
 } catch (InvalidModuleException $e) {

--- a/scripts/collect-snmp-data.php
+++ b/scripts/collect-snmp-data.php
@@ -127,6 +127,8 @@ try {
 
     echo 'Capturing Data: ';
     \LibreNMS\Util\OS::updateCache(true); // Force update of OS Cache
+    LibrenmsConfig::invalidateCache();
+    LibrenmsConfig::reload();
     $capture->captureFromDevice($device['device_id'], $prefer_new_snmprec, $full);
     echo "\nVerify these file(s) do not contain any private data before sharing!\n";
 } catch (InvalidModuleException $e) {

--- a/scripts/save-test-data.php
+++ b/scripts/save-test-data.php
@@ -144,6 +144,8 @@ try {
         echo PHP_EOL;
 
         \LibreNMS\Util\OS::updateCache(true); // Force update of OS Cache
+        LibrenmsConfig::invalidateCache();
+        LibrenmsConfig::reload();
         $tester = new ModuleTestHelper($modules, $target_os, $target_variant);
         if (! $no_save && ! empty($output_file)) {
             $tester->setJsonSavePath($output_file);

--- a/scripts/save-test-data.php
+++ b/scripts/save-test-data.php
@@ -144,8 +144,7 @@ try {
         echo PHP_EOL;
 
         \LibreNMS\Util\OS::updateCache(true); // Force update of OS Cache
-        LibrenmsConfig::invalidateCache();
-        LibrenmsConfig::reload();
+        LibrenmsConfig::invalidateAndReload();
         $tester = new ModuleTestHelper($modules, $target_os, $target_variant);
         if (! $no_save && ! empty($output_file)) {
             $tester->setJsonSavePath($output_file);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -84,7 +84,6 @@ if (getenv('DBTEST')) {
 }
 
 \LibreNMS\Util\OS::updateCache(true); // Force update of OS Cache
-LibrenmsConfig::invalidateCache();
-LibrenmsConfig::reload();
+LibrenmsConfig::invalidateAndReload();
 
 app()->terminate(); // destroy the bootstrap Laravel application

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -84,5 +84,7 @@ if (getenv('DBTEST')) {
 }
 
 \LibreNMS\Util\OS::updateCache(true); // Force update of OS Cache
+LibrenmsConfig::invalidateCache();
+LibrenmsConfig::reload();
 
 app()->terminate(); // destroy the bootstrap Laravel application


### PR DESCRIPTION
default 5 minutes (when testing set CONFIG_CACHE_TTL higher so issues are obvious)
lnms config:clear now clears both Laravel and LibreNMS config caches.  LibreNMS config cache will automatically regenerate on next application load.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
