### PR TITLE
Fallback processor discovery for EdgeCOS

### DIFF
--- a/LibreNMS/OS/Edgecos.php
+++ b/LibreNMS/OS/Edgecos.php
@@ -117,7 +117,7 @@ class Edgecos extends OS implements MempoolsDiscovery, ProcessorDiscovery
             ];
         }
 
-        return [];
+        return parent::discoverProcessors();
     }
 
     /**


### PR DESCRIPTION
This will make sure there will be a fallback to the default processor discovery whenever a specific model isn't defined in the OS discovery.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
