### PR TITLE
Add Custom Linux Sensors

### DIFF
--- a/doc/Extensions/Applications.md
+++ b/doc/Extensions/Applications.md
@@ -631,6 +631,82 @@ The application should be auto-discovered as described at the top of
 the page. If it is not, please follow the steps set out under `SNMP
 Extend` heading top of page.
 
+## Add Custom Linux Sensors
+Custom SNMP Extension: Adding Unsupported Sensors and states
+
+You can extend SNMP to LNMS custom sensors using your own scripts.
+This guide will walk you through the process of creating, configuring,
+and using a custom SNMP extension.
+
+1. Create Your Custom Script
+
+Write a script in your preferred programming language (e.g., Python, Bash)
+to fetch sensor data. Save the script in a directory like /etc/snmp/.
+
+The script should output sensor data in the following format:
+
+[unique_name1],[sensor_type],[description1],[low_limit],[low_warn_limit],[high_warn_limit],[high_limit],[group];
+[current_value1]
+[unique_name2],[sensor_type],[description2],[low_limit],[low_warn_limit],[high_warn_limit],[high_limit];
+[current_value2]
+
+    unique_name: A unique identifier for the sensor.
+    sensor_type: The type of the sensor (e.g., signal, count, temperature).
+    description: A human-readable description of the sensor.
+    low_limit: Minimum acceptable value (leave blank if not applicable).
+    low_warn_limit: Value triggering a low warning (leave blank if not applicable).
+    high_warn_limit: Value triggering a high warning (leave blank if not applicable).
+    high_limit: Maximum acceptable value (leave blank if not applicable).
+    group: Groups Sensors in the device overview.
+    current_value: The current reading from the sensor.
+
+2. Example Script
+
+Here’s an example script (/etc/snmp/smsmonitor) to monitor SMS-related metrics that you get an idea:
+```
+#!/bin/bash
+# Custom SNMP script for SMS monitoring
+
+echo "isms1_signal,signal,SMS Signal,,,,;"
+echo "-51"
+echo "isms1_sms_sent,count,SMS Sent,,,,;"
+echo "1342"
+echo "isms1_sms_received,count,SMS Received,,,,;"
+echo "0"
+echo "isms1_sms_failed,count,SMS Failed,,,,;"
+echo "0"
+```
+3. Make the Script Executable
+
+Set execute permissions for your script:
+```
+chmod +x /etc/snmp/smsmonitor
+```
+
+4. Update SNMP Configuration
+
+Edit the snmpd.conf file (commonly located at `/etc/snmp/snmpd.conf`) to include the custom script:
+```
+extend custom /etc/snmp/smsmonitor
+```
+
+The extend directive tells SNMP to execute your script and make its output available via SNMP.
+
+5. Restart SNMP Service
+```
+sudo systemctl restart snmpd
+```
+This output can be parsed and integrated into your system for alerts and analytics.
+
+Tips for a Robust Implementation
+- Error Handling: Ensure your script handles errors gracefully and outputs meaningful logs for debugging.
+- Script Efficiency: Optimize the script to minimize execution time and system resource usage.
+- Testing: Test the script manually to verify correct output before integrating it with SNMP.
+- Documentation: Comment your script for maintainability and include descriptions for each metric.
+
+With this approach, you can easily monitor custom metrics and expand your SNMP capabilities.
+
+
 ## Docker Stats
 
 It gathers metrics about the docker containers, including:

--- a/doc/Extensions/Applications.md
+++ b/doc/Extensions/Applications.md
@@ -665,16 +665,16 @@ The script should output sensor data in the following format:
 Here’s an example script (/etc/snmp/smsmonitor) to monitor SMS-related metrics that you get an idea:
 ```
 #!/bin/bash
-# Custom SNMP script for SMS monitoring
+read -e -a status <<<  $( grep -E "^GSM1:" /run/smstools/smsd_stats/status)
 
-echo "isms1_signal,signal,SMS Signal,,,,;"
-echo "-51"
-echo "isms1_sms_sent,count,SMS Sent,,,,;"
-echo "1342"
-echo "isms1_sms_received,count,SMS Received,,,,;"
-echo "0"
-echo "isms1_sms_failed,count,SMS Failed,,,,;"
-echo "0"
+echo "isms1_signal,signal,Signal,,,,;"
+echo "${status[8]}"
+echo "isms1_sms_sent,count,Sent,,,,,SMS;"
+echo "${status[4]:0:-1}"
+echo "isms1_sms_received,count,Received,,,,,SMS;"
+echo "${status[6]:0:-1}"
+echo "isms1_sms_failed,count,Failed,,,,,SMS;"
+echo "${status[5]:0:-1}"
 ```
 3. Make the Script Executable
 

--- a/doc/Extensions/Applications.md
+++ b/doc/Extensions/Applications.md
@@ -632,7 +632,7 @@ the page. If it is not, please follow the steps set out under `SNMP
 Extend` heading top of page.
 
 ## Add Custom Linux Sensors
-Custom SNMP Extension: Adding Unsupported Sensors and states
+Adding unsupported sensors and states as extend SNMP attribute.
 
 You can extend SNMP to LNMS custom sensors using your own scripts.
 This guide will walk you through the process of creating, configuring,

--- a/includes/discovery/sensors.inc.php
+++ b/includes/discovery/sensors.inc.php
@@ -25,6 +25,7 @@ if ($device['os'] == 'openbsd') {
 
 if ($device['os'] == 'linux') {
     include 'includes/discovery/sensors/rpigpiomonitor.inc.php';
+    include 'includes/discovery/sensors/custom.inc.php';
 }
 
 if (isset($device['hardware']) && strstr($device['hardware'], 'Dell')) {

--- a/includes/discovery/sensors/custom.inc.php
+++ b/includes/discovery/sensors/custom.inc.php
@@ -51,7 +51,7 @@ if (! empty($gpio_mon_data)) {
                 create_state_index($sensor_data['name'], $sensor_data['state_data']);
             }
 
-            discover_sensor(null, $sensor_data['type'], $device, $sensor_data['oid'], $sensor_id, $sensor_data['name'], $sensor_data['descr'], 1, 1, $sensor_data['low_limit'], $sensor_data['low_warn_limit'], $sensor_data['warn_limit'], $sensor_data['high_limit'], $sensor_data['value'],null,null,null,null,$sensor_data['group']);
+            discover_sensor(null, $sensor_data['type'], $device, $sensor_data['oid'], $sensor_id, $sensor_data['name'], $sensor_data['descr'], 1, 1, $sensor_data['low_limit'], $sensor_data['low_warn_limit'], $sensor_data['warn_limit'], $sensor_data['high_limit'], $sensor_data['value'],'snmp',null,null,null,$sensor_data['group']);
 
             if (isset($sensor_data['state_data'])) {
                 create_sensor_to_state_index($device, $sensor_data['name'], $sensor_id);

--- a/includes/discovery/sensors/custom.inc.php
+++ b/includes/discovery/sensors/custom.inc.php
@@ -1,0 +1,63 @@
+<?php
+$gpio_mon_data = snmpwalk_cache_oid($device, 'nsExtendOutLine."custom"', [], 'NET-SNMP-EXTEND-MIB', null, '-OteQUsb');
+
+if (! empty($gpio_mon_data)) {
+    $sensor_index = 0;
+    $sensors = [];
+
+    foreach ($gpio_mon_data as $index => $entry) {
+        if (Str::contains($entry['nsExtendOutLine'], ';')) {
+            $splitted_data_array = explode(';', $entry['nsExtendOutLine']);
+            $sensor_data = [];
+            foreach ($splitted_data_array as $splitted_data_index => $splitted_data) {
+                $sensor_data_parts = explode(',', $splitted_data);
+
+                if ($splitted_data_index == 0) {
+                    if (isset($sensor_data_parts[0]) && isset($sensor_data_parts[1]) && isset($sensor_data_parts[2])) {
+                        $sensor_data['name'] = $sensor_data_parts[0];
+                        $sensor_data['type'] = $sensor_data_parts[1];
+                        $sensor_data['descr'] = $sensor_data_parts[2];
+                        $sensor_data['low_limit'] = $sensor_data_parts[3];
+                        $sensor_data['low_warn_limit'] = $sensor_data_parts[4];
+                        $sensor_data['warn_limit'] = $sensor_data_parts[5];
+                        $sensor_data['high_limit'] = $sensor_data_parts[6];
+                        $sensor_data['group'] = $sensor_data_parts[7];
+                    }
+                } else {
+                    if (isset($sensor_data_parts[0]) && isset($sensor_data_parts[1]) && isset($sensor_data_parts[2])) {
+                        if (! isset($sensor_data['state_data'])) {
+                            $sensor_data['state_data'] = [];
+                        }
+
+                        $state_data['value'] = intval($sensor_data_parts[0]);
+                        $state_data['generic'] = intval($sensor_data_parts[1]);
+                        $state_data['graph'] = 1;
+                        $state_data['descr'] = $sensor_data_parts[2];
+                        array_push($sensor_data['state_data'], $state_data);
+                    }
+                }
+                $sensors[$sensor_index] = $sensor_data;
+            }
+        } else {
+            $sensors[$sensor_index]['value'] = intval($entry['nsExtendOutLine']);
+            $sensors[$sensor_index]['oid'] = '.1.3.6.1.4.1.8072.1.3.2.4.1.2.' . $index;
+            $sensor_index++;
+        }
+    }
+
+    foreach ($sensors as $sensor_id => $sensor_data) {
+        if (isset($sensor_data['name']) && isset($sensor_data['type']) && isset($sensor_data['descr'])) {
+            if (isset($sensor_data['state_data'])) {
+                create_state_index($sensor_data['name'], $sensor_data['state_data']);
+            }
+
+            discover_sensor(null, $sensor_data['type'], $device, $sensor_data['oid'], $sensor_id, $sensor_data['name'], $sensor_data['descr'], 1, 1, $sensor_data['low_limit'], $sensor_data['low_warn_limit'], $sensor_data['warn_limit'], $sensor_data['high_limit'], $sensor_data['value'],null,null,null,null,$sensor_data['group']);
+
+            if (isset($sensor_data['state_data'])) {
+                create_sensor_to_state_index($device, $sensor_data['name'], $sensor_id);
+            }
+        } else {
+            echo "[custom] An error occurred while reading a sensor! Please run your custom script on the target device to verify the configuration.\n";
+        }
+    }
+}


### PR DESCRIPTION
Adding unsupported sensors and states as extend SNMP attribute.

You can extend SNMP to LNMS custom sensors using your own scripts.
This guide will walk you through the process of creating, configuring,
and using a custom SNMP extension.

![Screenshot from 2024-11-29 21-51-48](https://github.com/user-attachments/assets/365c640e-48a5-4fb9-88aa-4173c302d35d)

**This function is inspired by #12749, but should be kept more general for users. THANKS for your PR**

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
