### PR TITLE
Resolved issue with interfacepicker using large interface lists

### DIFF
--- a/includes/html/javascript-interfacepicker.inc.php
+++ b/includes/html/javascript-interfacepicker.inc.php
@@ -21,10 +21,21 @@ function getInterfaceList(sel)
         }
 }
 
-function createInterfaces(index)
-{
-        var obj = document.getElementById('port_id');
-        eval(ajax[index].response);     // Executing the response from Ajax as Javascript code
-}
+function createInterfaces(index) {
+    const obj = document.getElementById('port_id');
 
+    // Assuming ajax[index].response contains JavaScript-like code as a string
+    const lines = ajax[index].response.split(';'); // Split into individual lines of code
+
+    lines.forEach(line => {
+        if (line.trim()) { // Skip empty lines
+            const match = line.match(/new Option\(['"](.*?)['"],['"](.*?)['"]\)/);
+            if (match) {
+                const label = match[1];
+                const value = match[2];
+                obj.options[obj.options.length] = new Option(label, value);
+            }
+        }
+    });
+}
 </script>


### PR DESCRIPTION
Please give a short description what your pull request is for

Using the traffic billed ports interface dropdown list generator under Traffic Bills, if the list of returned interfaces is too long the createInterfaces function seems to fail and return no interfaces from the supplied java code. As eval() is not recommended I have updated the code to resolve both the original issue and the use of eval().

Original failing code:
`function createInterfaces(index)
{
        var obj = document.getElementById('port_id');
        eval(ajax[index].response);     // Executing the response from Ajax as Javascript code
}` 

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
