### PR TITLE
Fixed non-numerical hddtemp sensors in unix-agent

### DIFF
--- a/includes/polling/unix-agent/hddtemp.inc.php
+++ b/includes/polling/unix-agent/hddtemp.inc.php
@@ -11,12 +11,14 @@ if (isset($agent_data['hddtemp']) && $agent_data['hddtemp'] != '|') {
         [$blockdevice,$descr,$temperature,$unit] = explode('|', $disk, 4);
         $diskcount++;
         $temperature = trim(str_replace('C', '', $temperature));
-        discover_sensor(null, 'temperature', $device, '', $diskcount, 'hddtemp', "$blockdevice: $descr", '1', '1', null, null, null, null, $temperature, 'agent');
-        dbUpdate(['sensor_current' => $temperature], 'sensors', '`sensor_index` = ? AND `sensor_class` = ? AND `poller_type` = ? AND `device_id` = ?', [$diskcount, 'temperature', 'agent', $device['device_id']]);
-        $tmp_agent_sensors = dbFetchRow("SELECT * FROM `sensors` WHERE `sensor_index` = ? AND `device_id` = ? AND `sensor_class` = 'temperature' AND `poller_type` = 'agent' AND `sensor_deleted` = 0 LIMIT 1", [$diskcount, $device['device_id']]);
-        $tmp_agent_sensors['new_value'] = $temperature;
-        $agent_sensors[] = $tmp_agent_sensors;
-        unset($tmp_agent_sensors);
+        if (is_numeric($temperature)) {
+            discover_sensor(null, 'temperature', $device, '', $diskcount, 'hddtemp', "$blockdevice: $descr", '1', '1', null, null, null, null, $temperature, 'agent');
+            dbUpdate(['sensor_current' => $temperature], 'sensors', '`sensor_index` = ? AND `sensor_class` = ? AND `poller_type` = ? AND `device_id` = ?', [$diskcount, 'temperature', 'agent', $device['device_id']]);
+            $tmp_agent_sensors = dbFetchRow("SELECT * FROM `sensors` WHERE `sensor_index` = ? AND `device_id` = ? AND `sensor_class` = 'temperature' AND `poller_type` = 'agent' AND `sensor_deleted` = 0 LIMIT 1", [$diskcount, $device['device_id']]);
+            $tmp_agent_sensors['new_value'] = $temperature;
+            $agent_sensors[] = $tmp_agent_sensors;
+            unset($tmp_agent_sensors);
+        }
     }
 
     echo "\n";


### PR DESCRIPTION
```
<<<hddtemp>>>
||||

0
0
0
0
```

Whilst this might be an issue on the client device, we should skip over non numerical values.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
