### PR TITLE
Aruba refactor some wireless code

### DIFF
--- a/LibreNMS/Data/Source/SnmpResponse.php
+++ b/LibreNMS/Data/Source/SnmpResponse.php
@@ -201,7 +201,7 @@ class SnmpResponse
     public function groupByIndex(int $index_count = 1, array &$array = []): array
     {
         foreach ($this->values() as $oid => $value) {
-            $parts = $this->getOidParts($oid);
+            $parts = $this->getOidParts(ltrim($oid, '.')); // trim leftmost . so negative counts work as expected
             $suffix = array_slice($parts, -$index_count);
             $index = implode('.', $suffix);
 

--- a/LibreNMS/Data/Source/SnmpResponse.php
+++ b/LibreNMS/Data/Source/SnmpResponse.php
@@ -193,6 +193,28 @@ class SnmpResponse
         return $output;
     }
 
+    /**
+     * Group values by index as specified by $index_count
+     * Useful when dealing with numeric oids
+     * (By default this counts from right to left, using a negative index count will count from left to right)
+     */
+    public function groupByIndex(int $index_count = 1, array &$array = []): array
+    {
+        foreach ($this->values() as $oid => $value) {
+            $parts = $this->getOidParts($oid);
+            $suffix = array_slice($parts, -$index_count);
+            $index = implode('.', $suffix);
+
+            $array[$index][$oid] = $value;
+        }
+
+        return $array;
+    }
+
+    /**
+     * Separate the index from the OID name
+     * Insert into array as index => oidName
+     */
     public function valuesByIndex(array &$array = []): array
     {
         foreach ($this->values() as $oid => $value) {

--- a/LibreNMS/OS/Arubaos.php
+++ b/LibreNMS/OS/Arubaos.php
@@ -36,6 +36,7 @@ use LibreNMS\Interfaces\Discovery\Sensors\WirelessPowerDiscovery;
 use LibreNMS\Interfaces\Discovery\Sensors\WirelessUtilizationDiscovery;
 use LibreNMS\Interfaces\Polling\Sensors\WirelessFrequencyPolling;
 use LibreNMS\OS;
+use SnmpQuery;
 
 class Arubaos extends OS implements
     OsDiscovery,
@@ -50,7 +51,7 @@ class Arubaos extends OS implements
     public function discoverOS(Device $device): void
     {
         parent::discoverOS($device); // yaml
-        $aruba_info = \SnmpQuery::get([
+        $aruba_info = SnmpQuery::get([
             'WLSX-SWITCH-MIB::wlsxSwitchRole.0',
             'WLSX-SWITCH-MIB::wlsxSwitchMasterIp.0',
             'WLSX-SWITCH-MIB::wlsxSwitchLicenseSerialNumber.0',
@@ -166,7 +167,7 @@ class Arubaos extends OS implements
 
     private function discoverInstantRadio($type, $oid, $desc = 'Radio %s')
     {
-        $data = snmpwalk_cache_numerical_oid($this->getDeviceArray(), $oid, [], 'AI-AP-MIB');
+        $data = SnmpQuery::numeric()->walk("AI-AP-MIB::$oid")->groupByIndex(1); // group by radio index
 
         $sensors = [];
         foreach ($data as $index => $entry) {

--- a/includes/polling/aruba-controller.inc.php
+++ b/includes/polling/aruba-controller.inc.php
@@ -8,8 +8,6 @@ use LibreNMS\Util\Mac;
 if ($device['type'] == 'wireless' && $device['os'] == 'arubaos') {
     // get data about the controller
     $aruba_stats = SnmpQuery::get([
-//        'WLSX-SWITCH-MIB::wlsxSwitchRole.0',
-//        'WLSX-SWITCH-MIB::wlsxSwitchMasterIp.0',
         'WLSX-SWITCH-MIB::wlsxSwitchTotalNumAccessPoints.0',
         'WLSX-SWITCH-MIB::wlsxSwitchTotalNumStationsAssociated.0',
     ])->values();

--- a/includes/snmp.inc.php
+++ b/includes/snmp.inc.php
@@ -428,27 +428,6 @@ function snmpwalk_cache_oid($device, $oid, $array = [], $mib = null, $mibdir = n
     return $array;
 }//end snmpwalk_cache_oid()
 
-function snmpwalk_cache_numerical_oid($device, $oid, $array = [], $mib = null, $mibdir = null, $snmpflags = '-OQUsn')
-{
-    $data = snmp_walk($device, $oid, $snmpflags, $mib, $mibdir);
-
-    if (empty($data)) {
-        return $array;
-    }
-
-    foreach (explode("\n", $data) as $entry) {
-        [$oid,$value] = explode('=', $entry, 2);
-        $oid = trim($oid);
-        $value = trim($value);
-        [$index] = explode('.', strrev($oid), 2);
-        if (! strstr($value, 'at this OID') && isset($oid) && isset($index)) {
-            $array[$index][$oid] = $value;
-        }
-    }
-
-    return $array;
-}//end snmpwalk_cache_oid()
-
 function snmpwalk_cache_long_oid($device, $oid, $noid, $array = [], $mib = null, $mibdir = null, $snmpflags = '-OQnU')
 {
     $data = snmp_walk($device, $oid, $snmpflags, $mib, $mibdir);

--- a/tests/Unit/SnmpResponseTest.php
+++ b/tests/Unit/SnmpResponseTest.php
@@ -127,6 +127,26 @@ class SnmpResponseTest extends TestCase
         ], $response->valuesByIndex($existing));
     }
 
+    public function testGroupByIndex(): void
+    {
+        $response = new SnmpResponse(".1.3.6.1.2.1.2.2.1.10.1 = 495813425\n.1.3.6.1.2.1.2.2.1.10.2 = 3495809228\n");
+        $this->assertTrue($response->isValid());
+        $this->assertEquals([1 => ['.1.3.6.1.2.1.2.2.1.10.1' => 495813425], 2 => ['.1.3.6.1.2.1.2.2.1.10.2' => 3495809228]], $response->groupByIndex());
+        $this->assertEquals(['1.10.1' => ['.1.3.6.1.2.1.2.2.1.10.1' => 495813425], '1.10.2' => ['.1.3.6.1.2.1.2.2.1.10.2' => 3495809228]], $response->groupByIndex(3));
+        $this->assertEquals(['6.1.2.1.2.2.1.10.1' => ['.1.3.6.1.2.1.2.2.1.10.1' => 495813425], '6.1.2.1.2.2.1.10.2' => ['.1.3.6.1.2.1.2.2.1.10.2' => 3495809228]], $response->groupByIndex(-2));
+
+        $response = new SnmpResponse(".1.3.6.1.2.1.2.2.1.10.1 = 495813425\n.1.3.6.1.2.1.2.2.1.11.1 = 3495809228\n");
+        $this->assertEquals([1 => ['.1.3.6.1.2.1.2.2.1.10.1' => 495813425, '.1.3.6.1.2.1.2.2.1.11.1' => 3495809228]], $response->groupByIndex());
+        $this->assertEquals(['10.1' => ['.1.3.6.1.2.1.2.2.1.10.1' => 495813425], '11.1' => ['.1.3.6.1.2.1.2.2.1.11.1' => 3495809228]], $response->groupByIndex(2));
+        $this->assertEquals(['1.2.2.1.10.1' => ['.1.3.6.1.2.1.2.2.1.10.1' => 495813425], '1.2.2.1.11.1' => ['.1.3.6.1.2.1.2.2.1.11.1' => 3495809228]], $response->groupByIndex(-5));
+
+        $response = new SnmpResponse("SOME-MIB::oid.1.1.0 = 14\nSOME-MIB::oid.1.2.0 = 42\n");
+        $this->assertTrue($response->isValid());
+        $this->assertEquals([0 => ['SOME-MIB::oid.1.1.0' => '14', 'SOME-MIB::oid.1.2.0' => '42']], $response->groupByIndex());
+        $this->assertEquals(['1.0' => ['SOME-MIB::oid.1.1.0' => '14'], '2.0' => ['SOME-MIB::oid.1.2.0' => '42']], $response->groupByIndex(2));
+        $this->assertEquals(['1.1.0' => ['SOME-MIB::oid.1.1.0' => '14'], '1.2.0' => ['SOME-MIB::oid.1.2.0' => '42']], $response->groupByIndex(-1));
+    }
+
     public function testMultiLine(): void
     {
         $response = new SnmpResponse("SNMPv2-MIB::sysDescr.1 = \"something\n on two lines\"\n");


### PR DESCRIPTION
Don't use snmpwalk_cache_numerical_oid
Remove legacy db queries in aruba-controller
Add groupByIndex to SnmpResponse to ease working with numeric oids.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
