### PR TITLE
Fixes the -h option when 'all' is used on rrdstep.php

### DIFF
--- a/scripts/rrdstep.php
+++ b/scripts/rrdstep.php
@@ -56,11 +56,14 @@ $icmp_step = Config::get('ping_rrd_step', $system_step);
 $system_heartbeat = Config::get('rrd.heartbeat', $system_step * 2);
 $rrdtool = Config::get('rrdtool', 'rrdtool');
 $tmp_path = Config::get('temp_dir', '/tmp');
+$rrd_dir = Config::get('rrd_dir', Config::get('install_dir') . '/rrd');
 
+$files = [];
 if ($hostname === 'all') {
-    $hostname = '*';
+    $files = glob(Str::finish($rrd_dir, '/') . '*/*.rrd');
+} else {
+    $files = glob(Rrd::dirFromHost($hostname) . '/*.rrd');
 }
-$files = glob(Rrd::dirFromHost($hostname) . '/*.rrd');
 
 $converted = 0;
 $skipped = 0;


### PR DESCRIPTION
I noticed that the rrdstep.php script was not working when the -h option was set to "all" this was due to some filtering in the function Rrd::dirFromHost that was replacing the '*' with a '_'. I modified the script to instead construct its own file path when -h is set to "all". It still has the same behavior when -h is set to something besides all.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
