### PR TITLE
Map graph refresh

### DIFF
--- a/resources/views/components/refresh-timer.blade.php
+++ b/resources/views/components/refresh-timer.blade.php
@@ -2,6 +2,7 @@
 <script>
     var no_refresh = false;
     var Countdown = {
+        refreshNum: 0,
         sec: {{ max($refresh, 30) }},
 
         Start: function () {
@@ -28,6 +29,7 @@
         },
         Reset: function () {
             this.sec = {{ max($refresh, 30) }};
+            this.refreshNum++;
         },
     };
 

--- a/resources/views/map/custom-view.blade.php
+++ b/resources/views/map/custom-view.blade.php
@@ -156,11 +156,33 @@
                    window.location.href = 'device/device=' + edge_port_map[edge_id].device_id + '/tab=port/port=' + edge_port_map[edge_id].port_id + '/';
                 }
             });
+
+            network.on('showPopup', function (itemId) {
+                let item = null;
+                if(isNaN(itemId)) {
+                    // Edges and special nodes are non-numeric
+                    item = network_edges.get(itemId);
+                } else {
+                    // Nodes are normally numeric
+                    item = network_nodes.get(itemId);
+                }
+                if (item && item.title) {
+                    for (let img of item.title.getElementsByClassName('graph-image')) {
+                        if(img.src.includes('&refreshnum=')) {
+                            let regex = /&refreshnum=\d+/;
+                            img.src = img.src.replace(regex, "&refreshnum=" + Countdown.refreshNum.toString());
+                        } else {
+                            img.src += "&refreshnum=" + Countdown.refreshNum.toString();
+                        }
+                    }
+                }
+            });
         }
     }
 
     $(document).ready(function () {
         Countdown = {
+            refreshNum: 0,
             sec: {{$page_refresh}},
 
             Start: function () {
@@ -170,6 +192,7 @@
                     if (cur.sec <= 0) {
                         refreshMap();
                         cur.sec = {{$page_refresh}};
+                        cur.refreshNum++;
                     }
                 }, 1000);
             },

--- a/resources/views/map/device-dependency.blade.php
+++ b/resources/views/map/device-dependency.blade.php
@@ -212,6 +212,26 @@
                             window.location.href = "device/device="+properties.nodes+"/"
                         }
                     });
+                    network.on('showPopup', function (itemId) {
+                        let item = null;
+                        if(itemId.includes('.')) {
+                            // Edges have a .
+                            item = network_edges.get(itemId);
+                        } else {
+                            // Nodes are numeric
+                            item = network_nodes.get(itemId);
+                        }
+                        if (item && item.title) {
+                            for (let img of item.title.getElementsByClassName('graph-image')) {
+                                if(img.src.includes('&refreshnum=')) {
+                                    let regex = /&refreshnum=\d+/;
+                                    img.src = img.src.replace(regex, "&refreshnum=" + Countdown.refreshNum.toString());
+                                } else {
+                                    img.src += "&refreshnum=" + Countdown.refreshNum.toString();
+                                }
+                            }
+                        }
+                    });
                 } else {
                     // Remove any nodes that have disappeared
                     $.each( network_nodes.getIds(), function( dev_idx, device_id ) {

--- a/resources/views/map/netmap.blade.php
+++ b/resources/views/map/netmap.blade.php
@@ -237,6 +237,26 @@
                     window.location.href = "device/device="+properties.nodes+"/"
                 }
             });
+            network.on('showPopup', function (itemId) {
+                let item = null;
+                if(itemId.includes('.')) {
+                    // Edges have a .
+                    item = network_edges.get(itemId);
+                } else {
+                    // Nodes are numeric
+                    item = network_nodes.get(itemId);
+                }
+                if (item && item.title) {
+                    for (let img of item.title.getElementsByClassName('graph-image')) {
+                        if(img.src.includes('&refreshnum=')) {
+                            let regex = /&refreshnum=\d+/;
+                            img.src = img.src.replace(regex, "&refreshnum=" + Countdown.refreshNum.toString());
+                        } else {
+                            img.src += "&refreshnum=" + Countdown.refreshNum.toString();
+                        }
+                    }
+                }
+            });
         }
     }
 


### PR DESCRIPTION
I noticed that the pop-ups on various maps (custom, network and dependency) didn't update without a page refresh.  This PR adds a URL parameter to all the graph images in the pop-ups that updates with each timer refresh, resulting in the browser fetching new images.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
