### PR TITLE
Fix Ciena-SAOS MIB Discovery

### DIFF
--- a/includes/definitions/ciena-saos.yaml
+++ b/includes/definitions/ciena-saos.yaml
@@ -7,9 +7,10 @@ over:
 discovery:
     - sysObjectID:
         - .1.3.6.1.4.1.562.68.11
+        - .1.3.6.1.4.1.1271.1
     - sysDescr_regex:
         - '/.*Version saos-.*/'
-mib_dir: nortel
+mib_dir: ciena
 group: ciena
 discovery_modules:
     processors: false


### PR DESCRIPTION
Change #16808 made the Ciena 3924 devices running SAOS change OS discovery. Before it was discovery as ciena-sds, now its discovering as ciena-saos. Looking at the yaml discovery for ciena-saos I noticed that mib_dir is pointing at nortel and not ciena. My change fixes that and also adds the sysObject ID for the Ciena 39xx line. I think the existing sysObjectID also points to Nortel devices, I'm not sure what the history is on that.

I have tested this in on my test server with Ciena 3924 devices and no problems have been discovered.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
