### PR TITLE
IPSEC tunnels Exception on empty IP addr

### DIFF
--- a/includes/polling/cipsec-tunnels.inc.php
+++ b/includes/polling/cipsec-tunnels.inc.php
@@ -26,8 +26,8 @@ if ($device['os_group'] == 'cisco') {
             $tunnel_full = array_merge($tunnel, $ike_array[$tunnel['cipSecTunIkeTunnelIndex']]);
         } else {
             $tunnel_full = $tunnel;
-            $tunnel_full['cikeTunLocalValue'] = (string) IP::fromHexString($tunnel_full['cipSecTunLocalAddr']);
-            $tunnel_full['cikeTunLocalName'] = (string) IP::fromHexString($tunnel_full['cipSecTunLocalAddr']);
+            $tunnel_full['cikeTunLocalValue'] = (string) IP::fromHexString($tunnel_full['cipSecTunLocalAddr'], true) ?? '';
+            $tunnel_full['cikeTunLocalName'] = (string) IP::fromHexString($tunnel_full['cipSecTunLocalAddr'], true) ?? '';
         }
 
         d_echo($tunnel_full);


### PR DESCRIPTION
Error polling cipsec-tunnels module for 10.8.9.38. LibreNMS\Exceptions\InvalidIpException: Could not parse into IP:  in /opt/librenms/LibreNMS/Util/IP.php:78
Stack trace:
#0 /opt/librenms/includes/polling/cipsec-tunnels.inc.php(31): LibreNMS\Util\IP::fromHexString('')
#1 /opt/librenms/LibreNMS/Modules/LegacyModule.php(115): include('/opt/librenms/i...')
#2 /opt/librenms/app/Jobs/PollDevice.php(139): LibreNMS\Modules\LegacyModule->poll(Object(LibreNMS\OS\Asa), Object(LibreNMS\Data\Store\Datastore))
#3 /opt/librenms/app/Jobs/PollDevice.php(63): App\Jobs\PollDevice->pollModules()
#4 /opt/librenms/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(36): App\Jobs\PollDevice->handle()
#5 /opt/librenms/vendor/laravel/framework/src/Illuminate/Container/Util.php(41): Illuminate\Container\BoundMethod::Illuminate\Container\{closure}()
#6 /opt/librenms/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(93): Illuminate\Container\Util::unwrapIfClosure(Object(Closure))
#7 /opt/librenms/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(35): Illuminate\Container\BoundMethod::callBoundMethod(Object(Illuminate\Foundation\Application), Array, Object(Closure))
#8 /opt/librenms/vendor/laravel/framework/src/Illuminate/Container/Container.php(662): Illuminate\Container\BoundMethod::call(Object(Illuminate\Foundation\Application), Array, Array, NULL)
#9 /opt/librenms/vendor/laravel/framework/src/Illuminate/Bus/Dispatcher.php(128): Illuminate\Container\Container->call(Array)
#10 /opt/librenms/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(144): Illuminate\Bus\Dispatcher->Illuminate\Bus\{closure}(Object(App\Jobs\PollDevice))
#11 /opt/librenms/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(119): Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}(Object(App\Jobs\PollDevice))
#12 /opt/librenms/vendor/laravel/framework/src/Illuminate/Bus/Dispatcher.php(132): Illuminate\Pipeline\Pipeline->then(Object(Closure))
#13 /opt/librenms/vendor/laravel/framework/src/Illuminate/Queue/CallQueuedHandler.php(123): Illuminate\Bus\Dispatcher->dispatchNow(Object(App\Jobs\PollDevice), false)
#14 /opt/librenms/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(144): Illuminate\Queue\CallQueuedHandler->Illuminate\Queue\{closure}(Object(App\Jobs\PollDevice))
#15 /opt/librenms/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(119): Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}(Object(App\Jobs\PollDevice))
#16 /opt/librenms/vendor/laravel/framework/src/Illuminate/Queue/CallQueuedHandler.php(122): Illuminate\Pipeline\Pipeline->then(Object(Closure))
#17 /opt/librenms/vendor/laravel/framework/src/Illuminate/Queue/CallQueuedHandler.php(70): Illuminate\Queue\CallQueuedHandler->dispatchThroughMiddleware(Object(Illuminate\Queue\Jobs\SyncJob), Object(App\Jobs\PollDevice))
#18 /opt/librenms/vendor/laravel/framework/src/Illuminate/Queue/Jobs/Job.php(102): Illuminate\Queue\CallQueuedHandler->call(Object(Illuminate\Queue\Jobs\SyncJob), Array)
#19 /opt/librenms/vendor/laravel/framework/src/Illuminate/Queue/SyncQueue.php(43): Illuminate\Queue\Jobs\Job->fire()
#20 /opt/librenms/vendor/laravel/framework/src/Illuminate/Bus/Dispatcher.php(254): Illuminate\Queue\SyncQueue->push(Object(App\Jobs\PollDevice))
#21 /opt/librenms/vendor/laravel/framework/src/Illuminate/Bus/Dispatcher.php(230): Illuminate\Bus\Dispatcher->pushCommandToQueue(Object(Illuminate\Queue\SyncQueue), Object(App\Jobs\PollDevice))
#22 /opt/librenms/vendor/laravel/framework/src/Illuminate/Bus/Dispatcher.php(95): Illuminate\Bus\Dispatcher->dispatchToQueue(Object(App\Jobs\PollDevice))
#23 /opt/librenms/vendor/laravel/framework/src/Illuminate/Foundation/Bus/Dispatchable.php(76): Illuminate\Bus\Dispatcher->dispatchSync(Object(App\Jobs\PollDevice))
#24 /opt/librenms/app/Console/Commands/DevicePoll.php(79): App\Jobs\PollDevice::dispatchSync(591, Array)
#25 /opt/librenms/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(36): App\Console\Commands\DevicePoll->handle(Object(App\Polling\Measure\MeasurementManager))
#26 /opt/librenms/vendor/laravel/framework/src/Illuminate/Container/Util.php(41): Illuminate\Container\BoundMethod::Illuminate\Container\{closure}()
#27 /opt/librenms/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(93): Illuminate\Container\Util::unwrapIfClosure(Object(Closure))
#28 /opt/librenms/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(35): Illuminate\Container\BoundMethod::callBoundMethod(Object(Illuminate\Foundation\Application), Array, Object(Closure))
#29 /opt/librenms/vendor/laravel/framework/src/Illuminate/Container/Container.php(662): Illuminate\Container\BoundMethod::call(Object(Illuminate\Foundation\Application), Array, Array, NULL)
#30 /opt/librenms/vendor/laravel/framework/src/Illuminate/Console/Command.php(211): Illuminate\Container\Container->call(Array)
#31 /opt/librenms/vendor/symfony/console/Command/Command.php(326): Illuminate\Console\Command->execute(Object(Symfony\Component\Console\Input\ArgvInput), Object(Illuminate\Console\OutputStyle))
#32 /opt/librenms/vendor/laravel/framework/src/Illuminate/Console/Command.php(180): Symfony\Component\Console\Command\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Illuminate\Console\OutputStyle))
#33 /opt/librenms/vendor/symfony/console/Application.php(1096): Illuminate\Console\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#34 /opt/librenms/vendor/symfony/console/Application.php(324): Symfony\Component\Console\Application->doRunCommand(Object(App\Console\Commands\DevicePoll), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#35 /opt/librenms/vendor/symfony/console/Application.php(175): Symfony\Component\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#36 /opt/librenms/vendor/laravel/framework/src/Illuminate/Foundation/Console/Kernel.php(201): Symfony\Component\Console\Application->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#37 /opt/librenms/app/Console/Kernel.php(66): Illuminate\Foundation\Console\Kernel->handle(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#38 /opt/librenms/lnms(38): App\Console\Kernel->handle(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#39 {main}  
Could not parse into IP:  {"exception":"[object] (LibreNMS\\Exceptions\\InvalidIpException(code: 0): Could not parse into IP:  at /opt/librenms/LibreNMS/Util/IP.php:78)"} 

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
