### PR TITLE
Update hiveos-wireless.yaml

### DIFF
--- a/includes/definitions/hiveos-wireless.yaml
+++ b/includes/definitions/hiveos-wireless.yaml
@@ -10,4 +10,4 @@ over:
 discovery:
     -
         sysDescr_regex:
-            - '/^(Hive)?AP[\w-]+(?:_n)?, HiveOS/'
+            - '/^(Hive)?AP[\w-]+(?:_n)?, (HiveOS|IQ Engine)/'


### PR DESCRIPTION
Adjusts the discovery string to match new "IQ Engine" OS tag as Hive OS is being rebranded to "IQ Engine" as part of the Extreme Networks integration.


Fix pulled from Discord, which linked to here:

https://community.librenms.org/t/please-upgrade-hiveos-discovery-to-support-ap305c-1-ap410c-1-etc/22967/8

https://discord.com/channels/327529583601647617/327529583601647617/1305928135698550834


Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
