### PR TITLE
Correct STP Controller logic

### DIFF
--- a/app/Http/Controllers/Device/Tabs/StpController.php
+++ b/app/Http/Controllers/Device/Tabs/StpController.php
@@ -72,7 +72,7 @@ class StpController implements DeviceTab
             'vlan' => $active_vlan,
             'device_id' => $device->device_id,
             'stpInstances' => $stpInstances->filter(function ($instance) use ($active_vlan) {
-                return $active_vlan == 1 && $instance->vlan !== null || $instance->vlan == $active_vlan;
+                return $active_vlan == 1 && $instance->vlan == null || $instance->vlan == $active_vlan;
             }),
             'stpPorts' => $device->stpPorts()->where('vlan', $active_vlan)->when($active_vlan == 1, function ($query) {
                 return $query->orWhereNull('vlan');


### PR DESCRIPTION
The goal of this condition is to display the STP instance `null` in vlan column, when VLAN 1 is currently chosen. Logic was reversed until now. 

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
