### PR TITLE
Update ports controller to use ARP/MAC table lookup for IPv4 neighbours

### DIFF
--- a/app/Http/Controllers/Device/Tabs/PortsController.php
+++ b/app/Http/Controllers/Device/Tabs/PortsController.php
@@ -175,24 +175,22 @@ class PortsController implements DeviceTab
             }
         }
 
-        if ($this->detail) {
-            // IPv4 + IPv6 subnet if detailed
-            // fa-arrow-right green portlink on devicelink
-            if ($port->ipv4Networks->isNotEmpty()) {
-                $ids = $port->ipv4Networks->map(fn ($net) => $net->ipv4->pluck('port_id'))->flatten();
-                foreach ($ids as $port_id) {
-                    if ($port_id !== $port->port_id) {
-                        $this->addPortNeighbor($neighbors, 'ipv4_network', $port_id);
-                    }
+        // IPv4 + IPv6 subnet if detailed
+        // fa-arrow-right green portlink on devicelink
+        if ($port->macLinkedPorts->isNotEmpty()) {
+            $ids = $port->macLinkedPorts->pluck('port_id');
+            foreach ($ids as $port_id) {
+                if ($port_id !== $port->port_id) {
+                    $this->addPortNeighbor($neighbors, 'ipv4_network', $port_id);
                 }
             }
+        }
 
-            if ($port->ipv6Networks->isNotEmpty()) {
-                $ids = $port->ipv6Networks->map(fn ($net) => $net->ipv6->pluck('port_id'))->flatten();
-                foreach ($ids as $port_id) {
-                    if ($port_id !== $port->port_id) {
-                        $this->addPortNeighbor($neighbors, 'ipv6_network', $port_id);
-                    }
+        if ($port->ipv6Networks->isNotEmpty()) {
+            $ids = $port->ipv6Networks->map(fn ($net) => $net->ipv6->pluck('port_id'))->flatten();
+            foreach ($ids as $port_id) {
+                if ($port_id !== $port->port_id) {
+                    $this->addPortNeighbor($neighbors, 'ipv6_network', $port_id);
                 }
             }
         }


### PR DESCRIPTION
We have a lot of VRFs that share the same IPv4 address space.  As a result, the IPv4 network lookup code gives a large number of invalid neighbours.

This PR changes the port controller to use the ARP/MAC table relationship to resolve IPv4 neighbours, which results in more reliable link lookups between routers.  It may result in missing results if a device does not have ARP table information in NMS.  It will also have a reduced number of neighbours if a device does not have an ARP entry for some devices in the same subnet.

This shouldn't be needed for IPv6 since duplicate addresses shouldn't happen in IPv6 address space.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
