### PR TITLE
Fixed port error red flag staying after error correction on FDB table and ARP table

### DIFF
--- a/app/Http/Controllers/Table/FdbTablesController.php
+++ b/app/Http/Controllers/Table/FdbTablesController.php
@@ -187,7 +187,7 @@ class FdbTablesController extends TableController
         if ($fdb_entry->port) {
             $item['interface'] = Blade::render('<x-port-link :port="$port">{{ $port->getShortLabel() }}</x-port-link>', ['port' => $fdb_entry->port]);
             $item['description'] = $fdb_entry->port->ifAlias;
-            if ($fdb_entry->port->ifInErrors > 0 || $fdb_entry->port->ifOutErrors > 0) {
+            if ($fdb_entry->port->ifInErrors_delta > 0 || $fdb_entry->port->ifOutErrors_delta > 0) {
                 $item['interface'] .= Blade::render(' <x-port-link :port="$port"><i class="fa fa-flag fa-lg" style="color:red" aria-hidden="true"></i></x-port-link>', ['port' => $fdb_entry->port]);
             }
             if ($this->getMacCount($fdb_entry->port) == 1) {

--- a/includes/html/table/arp-search.inc.php
+++ b/includes/html/table/arp-search.inc.php
@@ -56,7 +56,7 @@ if (isset($vars['searchPhrase']) && ! empty($vars['searchPhrase'])) {
 $pag = $query->paginate($rowCount);
 
 foreach ($pag->items() as $arp) {
-    if ($arp->port->ifInErrors > 0 || $arp->port->ifOutErrors > 0) {
+    if ($arp->port->ifInErrors_delta > 0 || $arp->port->ifOutErrors_delta > 0) {
         $error_img = generate_port_link($arp->port, "<i class='fa fa-flag fa-lg' style='color:red' aria-hidden='true'></i>", 'port_errors');
     } else {
         $error_img = '';


### PR DESCRIPTION
This PR fixes port error red flag behavior.

Before this fix, red flag on port was based on any error counted since device's power-on.
This behavior was inconsistent with /ports.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
