### PR TITLE
Added time period names: threeday, tenday

### DIFF
--- a/app/ConfigRepository.php
+++ b/app/ConfigRepository.php
@@ -549,7 +549,9 @@ class ConfigRepository
         $this->set('time.twelvehour', $now - 43200); // time() - (12 * 60 * 60);
         $this->set('time.day', $now - 86400); // time() - (24 * 60 * 60);
         $this->set('time.twoday', $now - 172800); // time() - (2 * 24 * 60 * 60);
+        $this->set('time.threeday', $now - 259200); // time() - (3 * 24 * 60 * 60);
         $this->set('time.week', $now - 604800); // time() - (7 * 24 * 60 * 60);
+        $this->set('time.tenday', $now - 864000); // time() - (10 * 24 * 60 * 60);
         $this->set('time.twoweek', $now - 1209600); // time() - (2 * 7 * 24 * 60 * 60);
         $this->set('time.month', $now - 2678400); // time() - (31 * 24 * 60 * 60);
         $this->set('time.twomonth', $now - 5356800); // time() - (2 * 31 * 24 * 60 * 60);


### PR DESCRIPTION
This PR adds time period names: threeday, tenday.
This addition enables to make graphs on sequence of 24 hrs, 3 days, 10 days, 31 days: almost evenly multiplied by 3 on each step.

In addition to this modification, I add the following lines to my site specific config.php.
```
$config['graphs']['mini']['normal'] = array(
    'day' => '24 Hours',
    'threeday' => '3 Days',
    'tenday' => '10 Days',
    'month' => 'One Month'
);
```

This sequence fits to our 12/5 operating site;
On Mondays, threeday graph covers Friday traffic, and tenday graph covers previous week's morning traffic spike.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
