### PR TITLE
Remove non existing module from config-definition

### DIFF
--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -5344,13 +5344,6 @@
             "default": false,
             "type": "boolean"
         },
-        "poller_modules.wifi": {
-            "order": 430,
-            "group": "poller",
-            "section": "poller_modules",
-            "default": false,
-            "type": "boolean"
-        },
         "poller_modules.wireless": {
             "order": 440,
             "group": "poller",


### PR DESCRIPTION
module already removed (https://github.com/librenms/librenms/pull/15549) but forgotten from config_definition 

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
