### PR TITLE
cast_number() => Number::cast()

### DIFF
--- a/LibreNMS/Device/Sensor.php
+++ b/LibreNMS/Device/Sensor.php
@@ -26,12 +26,14 @@
 namespace LibreNMS\Device;
 
 use App\Models\Eventlog;
+use Illuminate\Support\Facades\Log;
 use LibreNMS\Config;
 use LibreNMS\Enum\Severity;
 use LibreNMS\Interfaces\Discovery\DiscoveryModule;
 use LibreNMS\Interfaces\Polling\PollerModule;
 use LibreNMS\OS;
 use LibreNMS\RRD\RrdDefinition;
+use LibreNMS\Util\Number;
 use LibreNMS\Util\StringHelpers;
 
 class Sensor implements DiscoveryModule, PollerModule
@@ -136,7 +138,7 @@ class Sensor implements DiscoveryModule, PollerModule
             $this->valid = is_numeric($this->current);
         }
 
-        d_echo('Discovered ' . get_called_class() . ' ' . print_r($sensor, true));
+        Log::debug('Discovered ' . get_called_class() . ' ' . print_r($sensor, true));
     }
 
     /**
@@ -323,14 +325,14 @@ class Sensor implements DiscoveryModule, PollerModule
         // process data or run custom polling
         $typeInterface = static::getPollingInterface($type);
         if ($os instanceof $typeInterface) {
-            d_echo("Using OS polling for $type\n");
+            Log::debug("Using OS polling for $type\n");
             $function = static::getPollingMethod($type);
             $data = $os->$function($sensors);
         } else {
             $data = static::processSensorData($sensors, $prefetch);
         }
 
-        d_echo($data);
+        Log::debug($data);
 
         self::recordSensorData($os, $sensors, $data);
     }
@@ -357,7 +359,7 @@ class Sensor implements DiscoveryModule, PollerModule
         array_walk($snmp_data, function (&$oid) {
             preg_match('/-?\d+(\.\d+)?(e-?\d+)?/i', $oid, $matches);
             if (isset($matches[0])) {
-                $oid = cast_number($matches[0]);
+                $oid = Number::cast($matches[0]);
             } else {
                 $oid = trim('"', $oid); // allow string only values
             }
@@ -409,11 +411,11 @@ class Sensor implements DiscoveryModule, PollerModule
         }
 
         if ($divisor && $sensor_value !== 0) {
-            $sensor_value = (cast_number($sensor_value) / $divisor);
+            $sensor_value = (Number::cast($sensor_value) / $divisor);
         }
 
         if ($multiplier) {
-            $sensor_value = (cast_number($sensor_value) * $multiplier);
+            $sensor_value = (Number::cast($sensor_value) * $multiplier);
         }
 
         return $sensor_value;

--- a/LibreNMS/OS/Arubaos.php
+++ b/LibreNMS/OS/Arubaos.php
@@ -36,6 +36,7 @@ use LibreNMS\Interfaces\Discovery\Sensors\WirelessPowerDiscovery;
 use LibreNMS\Interfaces\Discovery\Sensors\WirelessUtilizationDiscovery;
 use LibreNMS\Interfaces\Polling\Sensors\WirelessFrequencyPolling;
 use LibreNMS\OS;
+use LibreNMS\Util\Number;
 use SnmpQuery;
 
 class Arubaos extends OS implements
@@ -162,7 +163,7 @@ class Arubaos extends OS implements
 
     protected function decodeChannel($channel)
     {
-        return cast_number($channel) & 255; // mask off the channel width information
+        return Number::cast($channel) & 255; // mask off the channel width information
     }
 
     private function discoverInstantRadio($type, $oid, $desc = 'Radio %s')

--- a/includes/discovery/sensors/state/equallogic.inc.php
+++ b/includes/discovery/sensors/state/equallogic.inc.php
@@ -11,10 +11,13 @@
  * the source code distribution for details.
  */
 
+use Illuminate\Support\Facades\Log;
+use LibreNMS\Util\Number;
+
 $oids = snmp_walk($device, 'eqlMemberHealthStatus', '-OQne', 'EQLMEMBER-MIB', 'equallogic');
 
-d_echo('Health oids:');
-d_echo($oids . "\n");
+Log::debug('Health oids:');
+Log::debug($oids . "\n");
 
 /*
 eqlMemberHealthStatus
@@ -54,7 +57,7 @@ if (! empty($oids)) {
             [$oid,$current] = explode(' = ', $data, 2);
             $split_oid = explode('.', $oid);
             $num_index = $split_oid[count($split_oid) - 1];
-            $index = (int) cast_number($num_index);
+            $index = (int) Number::cast($num_index);
             $low_limit = 0.5;
             $high_limit = 2.5;
             discover_sensor(null, 'state', $device, $oid, $index, $state_name, $descr, 1, 1, $low_limit, $low_limit, $high_limit, $high_limit, $current, 'snmp', $index);
@@ -65,8 +68,8 @@ if (! empty($oids)) {
 
 $oids1 = snmp_walk($device, 'eqlMemberHealthDetailsPowerSupplyName', '-OQn', 'EQLMEMBER-MIB', 'equallogic');
 
-d_echo('PowerSupplyName oids:');
-d_echo($oids1 . "\n");
+Log::debug('PowerSupplyName oids:');
+Log::debug($oids1 . "\n");
 
 /*
     .1.3.6.1.4.1.12740.2.1.8.1.2.1.329840783.1 = Power Cooling Module 0
@@ -98,12 +101,12 @@ if (! empty($oids1)) {
             [$oid,$descr] = explode(' = ', $data, 2);
             $split_oid = explode('.', $oid);
             $num_index = $split_oid[count($split_oid) - 1];
-            $index = (int) cast_number($num_index);
+            $index = (int) Number::cast($num_index);
             $member_id = $split_oid[count($split_oid) - 2];
             $num_index = $member_id . '.' . $num_index;
             $oid = $base_oid . $num_index;
             $extra = snmp_get_multi($device, $oid, '-OQne', 'EQLMEMBER-MIB', 'equallogic');
-            d_echo($extra);
+            Log::debug($extra);
             if (! empty($extra)) {
                 [$foid,$pstatus] = explode(' = ', $extra, 2);
                 $index = (100 + $index);
@@ -118,8 +121,8 @@ if (! empty($oids1)) {
 
 $oids_disks = snmp_walk($device, 'eqlDiskSerialNumber', '-OQn', 'EQLDISK-MIB', 'equallogic');
 
-d_echo('Disk Serials oids:' . PHP_EOL);
-d_echo($oids_disks . "\n");
+Log::debug('Disk Serials oids:' . PHP_EOL);
+Log::debug($oids_disks . "\n");
 
 $disks_base_oid = '.1.3.6.1.4.1.12740.3.1.1.1.8.1.'; // eqlDiskStatus
 
@@ -147,7 +150,7 @@ if (! empty($oids_disks)) {
             $num_index = $member_id . '.' . $disk_index;
             $oid = $disks_base_oid . $num_index;
             $extra = snmp_get($device, $oid, '-OQne', 'EQLDISK-MIB', 'equallogic');
-            d_echo($extra);
+            Log::debug($extra);
             if (! empty($extra)) {
                 [$foid,$pstatus] = explode(' = ', $extra, 2);
                 $index = 'eqlDiskStatus.' . $disk_index;

--- a/includes/discovery/sensors/temperature/boss.inc.php
+++ b/includes/discovery/sensors/temperature/boss.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Util\Number;
+
 $temps = snmp_walk($device, '.1.3.6.1.4.1.45.1.6.3.7.1.1.5.5', '-Osqn');
 if (empty($temps)) {
     return;
@@ -11,6 +13,6 @@ foreach (explode("\n", $temps) as $i => $t) {
     $val = $t[1];
     // Sensors are reported as 2 * value
     $divisor = 2;
-    $val = (cast_number($val) / $divisor);
+    $val = (Number::cast($val) / $divisor);
     discover_sensor(null, 'temperature', $device, $oid, zeropad($i + 1), 'avaya-ers', 'Unit ' . ($i + 1) . ' temperature', $divisor, 1, null, null, null, null, $val);
 }

--- a/includes/discovery/storage/eql-storage.inc.php
+++ b/includes/discovery/storage/eql-storage.inc.php
@@ -12,6 +12,8 @@
  * the source code distribution for details.
  */
 
+use LibreNMS\Util\Number;
+
 if ($device['os'] == 'equallogic') {
     $eql_storage = snmpwalk_cache_oid($device, 'EqliscsiVolumeEntry', null, 'EQLVOLUME-MIB', 'equallogic');
 
@@ -28,7 +30,7 @@ if ($device['os'] == 'equallogic') {
             } else {
                 // Trying to search the last '.' and take something after it as index
                 $arrindex = explode('.', $index);
-                $newindex = (int) cast_number(end($arrindex));
+                $newindex = (int) Number::cast(end($arrindex));
                 if (is_int($newindex)) {
                     discover_storage($valid_storage, $device, $newindex, $fstype, 'eql-storage', $descr, $size, $units, $used);
                 }

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -68,18 +68,6 @@ if (! function_exists('array_pairs')) {
     }
 }
 
-/**
- * Cast string to int or float.
- * Returns 0 if string is not numeric
- *
- * @param  string  $number
- * @return float|int
- */
-function cast_number($number)
-{
-    return \LibreNMS\Util\Number::cast($number);
-}
-
 if (! function_exists('trans_fb')) {
     /**
      * Translate the given message with a fallback string if none exists.

--- a/includes/polling/ports/os/infinera-groove.inc.php
+++ b/includes/polling/ports/os/infinera-groove.inc.php
@@ -22,6 +22,9 @@
  * @copyright  2019 Nick Hilliard
  * @author     Nick Hilliard <nick@foobar.org>
  */
+
+use LibreNMS\Util\Number;
+
 echo 'Port types:';
 
 foreach (['eth100g', 'eth40g', 'eth10g', 'fc16g', 'fc8g'] as $infineratype) {
@@ -74,7 +77,7 @@ foreach (['eth100g', 'eth40g', 'eth10g', 'fc16g', 'fc8g'] as $infineratype) {
         }
 
         // convert to integer
-        $lindex = cast_number($lindex);
+        $lindex = Number::cast($lindex);
 
         $port_stats[$lindex]['ifName'] = $descr;
         $port_stats[$lindex]['ifDescr'] = $descr;

--- a/includes/polling/ports/port-etherlike.inc.php
+++ b/includes/polling/ports/port-etherlike.inc.php
@@ -1,6 +1,7 @@
 <?php
 
 use LibreNMS\RRD\RrdDefinition;
+use LibreNMS\Util\Number;
 
 if ($this_port['dot3StatsIndex'] and $port['ifType'] == 'ethernetCsmacd') {
     $etherlike_oids = [
@@ -28,7 +29,7 @@ if ($this_port['dot3StatsIndex'] and $port['ifType'] == 'ethernetCsmacd') {
         $oid_ds = str_replace('dot3Stats', '', $oid);
         $rrd_def->addDataset($oid_ds, 'COUNTER', null, 100000000000);
 
-        $data = cast_number($this_port[$oid]);
+        $data = Number::cast($this_port[$oid]);
         $fields[$oid] = $data;
     }
 

--- a/includes/polling/storage/eql-storage.inc.php
+++ b/includes/polling/storage/eql-storage.inc.php
@@ -12,14 +12,17 @@
  * the source code distribution for details.
  */
 
+use Illuminate\Support\Facades\Log;
+use LibreNMS\Util\Number;
+
 if (! isset($storage_cache1['eql-storage'])) {
     $storage_cache1['eql-storage'] = snmpwalk_cache_oid($device, 'EqliscsiVolumeEntry', null, 'EQLVOLUME-MIB', 'equallogic');
-    d_echo($storage_cache1);
+    Log::debug($storage_cache1);
 }
 
 if (! isset($storage_cache2['eql-storage'])) {
     $storage_cache2['eql-storage'] = snmpwalk_cache_oid($device, 'EqliscsiVolumeStatusEntry', null, 'EQLVOLUME-MIB', 'equallogic');
-    d_echo($storage_cache2);
+    Log::debug($storage_cache2);
 }
 
 $iind = 0;
@@ -34,13 +37,13 @@ foreach ($storage_cache1['eql-storage'] as $index => $ventry) {
         $iind = $index;
     } else {
         $arrindex = explode('.', $index);
-        $iind = (int) cast_number(end($arrindex));
+        $iind = (int) Number::cast(end($arrindex));
     }
     if (is_int($iind)) {
         $storage_cache10[$iind] = $ventry;
     }
 }
-d_echo($storage_cache10);
+Log::debug($storage_cache10);
 
 foreach ($storage_cache2['eql-storage'] as $index => $vsentry) {
     if (! array_key_exists('eqliscsiVolumeStatusAvailable', $vsentry)) {
@@ -50,13 +53,13 @@ foreach ($storage_cache2['eql-storage'] as $index => $vsentry) {
         $iind = $index;
     } else {
         $arrindex = explode('.', $index);
-        $iind = (int) cast_number(end($arrindex));
+        $iind = (int) Number::cast(end($arrindex));
     }
     if (is_int($iind)) {
         $storage_cache20[$iind] = $vsentry;
     }
 }
-d_echo($storage_cache20);
+Log::debug($storage_cache20);
 
 $entry1 = $storage_cache10[$storage['storage_index']];
 $entry2 = $storage_cache20[$storage['storage_index']];

--- a/includes/polling/unix-agent/packages.inc.php
+++ b/includes/polling/unix-agent/packages.inc.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Models\Package;
+use LibreNMS\Util\Number;
 
 $pkgs_id = [];
 $pkgs_db_id = [];
@@ -33,7 +34,7 @@ $managers = [
                 'arch' => $arch,
                 'version' => $version,
                 'build' => '',
-                'size' => cast_number($size) * 1024,
+                'size' => Number::cast($size) * 1024,
                 'status' => 1,
             ]);
         },


### PR DESCRIPTION
Simplify the helper functions by using Laravel's built-in functions. Refactor the code to reduce custom implementations and use native Laravel methods instead. This approach ensures cleaner and more maintainable code without the need for extra documentation.

- `cast_number()` => `Number::cast()`

With additional clean-up work in the files.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
