### PR TITLE
rename Jira Service Managment transport (#16195)

### DIFF
--- a/LibreNMS/Alert/Transport/Jsm.php
+++ b/LibreNMS/Alert/Transport/Jsm.php
@@ -6,7 +6,7 @@ use LibreNMS\Alert\Transport;
 use LibreNMS\Exceptions\AlertTransportDeliveryException;
 use LibreNMS\Util\Http;
 
-class Jiraservicemanagement extends Transport
+class Jsm extends Transport
 {
     protected string $name = 'Jira Service Management';
 


### PR DESCRIPTION
Changes the Jira Service Management transport to fix #16195, where the name jiraservicemanagement is too long for the transport_type field in the database.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [X] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
