### PR TITLE
Added ZenDuty Transport

### DIFF
--- a/LibreNMS/Alert/Transport/ZenDuty.php
+++ b/LibreNMS/Alert/Transport/ZenDuty.php
@@ -43,10 +43,30 @@ class ZenDuty extends Transport
             $alert_type = $alert_data['severity'];
         }
         // Set the standard data ZD expects to see
+        $msg = (json_decode($alert_data['msg'], true)) ? json_decode($alert_data['msg'], true) : $alert_data['msg'];
         $data = [
             'message' => $alert_data['title'],
             'alert_type' => $alert_type,
             'entity_id' => $alert_data['alert_id'],
+            'payload' => [
+                'hostname' => $alert_data['hostname'],
+                'sysName' => $alert_data['sysName'],
+                'id' => $alert_data['id'],
+                'uid' => $alert_data['uid'],
+                'sysDescr' => $alert_data['sysDescr'],
+                'os' => $alert_data['os'],
+                'type' => $alert_type,
+                'ip' => $alert_data['ip'],
+                'hardware' => $alert_data['hardware'],
+                'version' => $alert_data['version'],
+                'uptime' => $alert_data['uptime'],
+                'uptime_short' => $alert_data['uptime_short'],
+                'timestamp' => $alert_data['timestamp'],
+                'description' => $alert_data['description'],
+                'title' => $alert_data['title'],
+                'msg' => $msg,
+                'state' => $alert_data['state'],
+            ],
             'urls' => [
                 [
                     'link_url' => route('device', ['device' => $alert_data['device_id']]),
@@ -55,6 +75,14 @@ class ZenDuty extends Transport
             ],
         ];
 
+        if (isset($this->config['sla_id'])) {
+            $data['sla'] = $this->config['sla_id'];
+        }
+
+        if (isset($this->config['escalation_policy_id'])) {
+            $data['escalation_policy'] = $this->config['escalation_policy_id'];
+        }
+
         $tmp_msg = json_decode($alert_data['msg'], true);
         if (isset($tmp_msg['message']) && isset($tmp_msg['summary'])) {
             $data = array_merge($data, $tmp_msg);
@@ -62,6 +90,7 @@ class ZenDuty extends Transport
             $data['summary'] = $alert_data['msg'];
         }
 
+        var_dump($data);
         $client = Http::client();
 
         $res = $client->withHeaders(
@@ -85,6 +114,18 @@ class ZenDuty extends Transport
                     'title' => 'ZenDuty WebHook',
                     'name' => 'zenduty-url',
                     'descr' => 'ZenDuty WebHook',
+                    'type' => 'text',
+                ],
+                [
+                    'title' => 'SLA ID',
+                    'name' => 'sla_id',
+                    'descr' => 'Unique ID of the SLA',
+                    'type' => 'text',
+                ],
+                [
+                    'title' => 'Escalation Policy ID',
+                    'name' => 'escalation_policy_id',
+                    'descr' => 'Unique ID of the Escalation Policy',
                     'type' => 'text',
                 ],
             ],

--- a/LibreNMS/Alert/Transport/ZenDuty.php
+++ b/LibreNMS/Alert/Transport/ZenDuty.php
@@ -90,7 +90,6 @@ class ZenDuty extends Transport
             $data['summary'] = $alert_data['msg'];
         }
 
-        var_dump($data);
         $client = Http::client();
 
         $res = $client->withHeaders(

--- a/LibreNMS/Alert/Transport/ZenDuty.php
+++ b/LibreNMS/Alert/Transport/ZenDuty.php
@@ -52,7 +52,7 @@ class ZenDuty extends Transport
                     'link_url' => route('device', ['device' => $alert_data['device_id']]),
                     'link_text' => $alert_data['hostname'],
                 ],
-            ]
+            ],
         ];
 
         $tmp_msg = json_decode($alert_data['msg'], true);

--- a/LibreNMS/Alert/Transport/ZenDuty.php
+++ b/LibreNMS/Alert/Transport/ZenDuty.php
@@ -1,0 +1,96 @@
+<?php
+/* Copyright (C) 2014 Daniel Preussker <f0o@devilcode.org>, Tyler Christiansen <code@tylerc.me>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>. */
+
+/*
+ * API Transport
+ * @author Neil Lathwood, Configuration Services <neil@configuration.co.uk>
+ * @license GPL
+ * @package LibreNMS
+ * @subpackage Alerts
+ */
+
+namespace LibreNMS\Alert\Transport;
+
+use LibreNMS\Alert\Transport;
+use LibreNMS\Exceptions\AlertTransportDeliveryException;
+use LibreNMS\Util\Http;
+
+class ZenDuty extends Transport
+{
+    protected string $name = 'ZenDuty';
+
+    public function deliverAlert(array $alert_data): bool
+    {
+        $url = $this->config['zenduty-url'];
+        // If the alert has recovered set to resolved
+        if ($alert_data['state'] == 0) {
+            $alert_type = 'resolved';
+        } elseif ($alert_data['state'] == 2) {
+            $alert_type = 'acknowledged';
+        } else {
+            $alert_type = $alert_data['severity'];
+        }
+        // Set the standard data ZD expects to see
+        $data = [
+            'message' => $alert_data['title'],
+            'alert_type' => $alert_type,
+            'entity_id' => $alert_data['alert_id'],
+            'urls' => [
+                [
+                    'link_url' => route('device', ['device' => $alert_data['device_id']]),
+                    'link_text' => $alert_data['hostname'],
+                ],
+            ]
+        ];
+
+        $tmp_msg = json_decode($alert_data['msg'], true);
+        if (isset($tmp_msg['message']) && isset($tmp_msg['summary'])) {
+            $data = array_merge($data, $tmp_msg);
+        } else {
+            $data['summary'] = $alert_data['msg'];
+        }
+
+        $client = Http::client();
+
+        $res = $client->withHeaders(
+            [
+                'Content-Type' => 'application/json',
+            ]
+        )->acceptJson()->post($url, $data);
+
+        if ($res->successful()) {
+            return true;
+        }
+
+        throw new AlertTransportDeliveryException($alert_data, $res->status(), $res->body(), $data['message'], $data);
+    }
+
+    public static function configTemplate(): array
+    {
+        return [
+            'config' => [
+                [
+                    'title' => 'ZenDuty WebHook',
+                    'name' => 'zenduty-url',
+                    'descr' => 'ZenDuty WebHook',
+                    'type' => 'text',
+                ],
+            ],
+            'validation' => [
+                'zenduty-url' => 'required|url',
+            ],
+        ];
+    }
+}

--- a/doc/Alerting/Transports.md
+++ b/doc/Alerting/Transports.md
@@ -1147,15 +1147,19 @@ They can be in international dialling format only.
 
 ## Zenduty
 
-Leveraging LibreNMS<>Zenduty Integration, users can send new LibreNMS 
+Two options are available for ZenDuty support, the first, [native ZenDuty](#native-zenduty)
+is via the API Transport as detailed in official [ZenDuty integration documentation](https://docs.zenduty.com/docs/librenms).
+The other way is by utilising a [native LibreNMS transport](#native-librenms-transport).
+
+### Native ZenDuty
+Leveraging LibreNMS > Zenduty Integration, users can send new LibreNMS 
 alerts to the right team and notify them based on on-call schedules
 via email, SMS, Phone Calls, Slack, Microsoft Teams and mobile push
 notifications. Zenduty provides engineers with detailed context around 
 the LibreNMS alert along with playbooks and a complete incident command
 framework to triage, remediate and resolve incidents with speed.
 
-Create a [LibreNMS
-Integration](https://docs.zenduty.com/docs/librenms) from inside 
+Create a [LibreNMS Integration](https://docs.zenduty.com/docs/librenms) from inside 
 [Zenduty](https://www.zenduty.com), then copy the Webhook URL from Zenduty
 to LibreNMS.
 
@@ -1163,6 +1167,75 @@ For a detailed guide with screenshots, refer to the
 [LibreNMS documentation at Zenduty](https://docs.zenduty.com/docs/librenms).
 
 **Example:**
+
+| Config | Example |
+| ------ | ------- |
+| WebHook URL | <https://www.zenduty.com/api/integration/librenms/integration-key/> |
+
+### Native LibreNMS Transport
+This integration uses the [ZenDuty Webhooks](https://zenduty.com/docs/generic-integration/) 
+which allows you to use all available ZenDuty parameters such as URLs, SLA, 
+Escalation Policies, etc.
+
+Follow the instructions in the above link to obtain your Webhook URL and then paste that 
+into the `ZenDuty WebHook` field when setting up the LibreNMS transport.
+
+This transport will send over the following fields:
+
+`message` - The alert title
+`alert_type` - The severity of the alert rule, acknowledged or resolved depending on the state of the alert.
+`entity_id` - The alert ID
+`urls` - A link back to the device generating the alert.
+`summary` - The output of the template associated with the alert rule.
+
+To customise what is sent to ZenDuty and override or add additional fields, you can create 
+a custom template which outputs the correct information via JSON. As an example:
+
+```json
+{
+  "message": "{{ $alert->title }}",
+  "payload": {
+    "Device Type": "{{ $alert->type }}",
+    "Device OS": "{{ $alert->os }}"
+  },
+  "summary": "@foreach ($alert->faults as $key => $value) Key: {{ $key }} Value: {{ $value }} @endforeach",
+  "escalation_policy" : "272841e2-2cbf-40a8-9a9a-64227fd3d722"
+}
+```
+If you are using more than one transport for an alert rule and need to customise the output per 
+transport then you can do the following:
+
+```
+@if ($alert->transport == 'ZenDuty')
+{
+  {
+    "message": "{{ $alert->title }}",
+    "payload": {
+      "Device Type": "{{ $alert->type }}",
+      "Device OS": "{{ $alert->os }}"
+    },
+    "summary": "@foreach ($alert->faults as $key => $value) Key: {{ $key }} Value: {{ $value }} @endforeach",
+    "escalation_policy" : "272841e2-2cbf-40a8-9a9a-64227fd3d722"
+  }
+}
+@else
+{{ $alert->title }}
+Severity: {{ $alert->severity }}
+@if ($alert->state == 0) Time elapsed: {{ $alert->elapsed }} @endif
+Timestamp: {{ $alert->timestamp }}
+Unique-ID: {{ $alert->uid }}
+Rule: @if ($alert->name) {{ $alert->name }} @else {{ $alert->rule }} @endif
+@if ($alert->faults) Faults:
+@foreach ($alert->faults as $key => $value)
+  {{ $key }}: {{ $value['string'] }}
+@endforeach
+@endif
+Alert sent to:
+@foreach ($alert->contacts as $key => $value)
+  {{ $value }} <{{ $key }}>
+@endforeach
+@endif
+```
 
 | Config | Example |
 | ------ | ------- |

--- a/doc/Alerting/Transports.md
+++ b/doc/Alerting/Transports.md
@@ -1237,6 +1237,6 @@ Alert sent to:
 @endif
 ```
 
-| Config | Example |
-| ------ | ------- |
-| WebHook URL | <https://www.zenduty.com/api/integration/librenms/integration-key/> |
+| Config | Example                                                      |
+| ------ |--------------------------------------------------------------|
+| WebHook URL | <https://events.zenduty.com/integration/we8jv/generic/hash/> |

--- a/doc/Alerting/Transports.md
+++ b/doc/Alerting/Transports.md
@@ -1180,6 +1180,9 @@ Escalation Policies, etc.
 Follow the instructions in the above link to obtain your Webhook URL and then paste that 
 into the `ZenDuty WebHook` field when setting up the LibreNMS transport.
 
+You can also set the SLA ID and Escalation Policy ID from within the Transport configuration 
+which will be sent with all alerts.
+
 This transport will send over the following fields:
 
 `message` - The alert title
@@ -1193,13 +1196,23 @@ a custom template which outputs the correct information via JSON. As an example:
 
 ```json
 {
-  "message": "{{ $alert->title }}",
-  "payload": {
-    "Device Type": "{{ $alert->type }}",
-    "Device OS": "{{ $alert->os }}"
-  },
-  "summary": "@foreach ($alert->faults as $key => $value) Key: {{ $key }} Value: {{ $value }} @endforeach",
-  "escalation_policy" : "272841e2-2cbf-40a8-9a9a-64227fd3d722"
+    "message": "{{ $alert->title }}",
+    "payload": {
+        "sysName": "{{ $alert->sysName }}",
+        "Device Type": "{{ $alert->type }}"
+    },
+    "summary": "Severity: {{ $alert->severity }}\nTimestamp: {{ $alert->timestamp }}\nRule: {{ $alert->title }}\n @foreach ($alert->faults as $key => $value) {{ $key }}: {{ $value['string'] }}\n @endforeach",
+    "sla": "ccaf3fd6-db51-4f9f-818b-de42aee54f29",
+    "urls": [
+        {
+            "link_url": "{{ route('device', ['device' => $alert->device_id ?: 1]) }}",
+            "link_text": "{{ $alert->hostname }}"
+        },
+        {
+            "link_url": "{{ route('device', ['device' => $alert->device_id ?? 1, 'tab' => 'alerts']) }}",
+            "link_text": "{{ $alert->hostname }} - Alerts"
+        }
+    ]
 }
 ```
 If you are using more than one transport for an alert rule and need to customise the output per 
@@ -1208,15 +1221,23 @@ transport then you can do the following:
 ```
 @if ($alert->transport == 'ZenDuty')
 {
-  {
-    "message": "{{ $alert->title }}",
-    "payload": {
-      "Device Type": "{{ $alert->type }}",
-      "Device OS": "{{ $alert->os }}"
+  "message": "{{ $alert->title }}",
+  "payload": {
+    "sysName": "{{ $alert->sysName }}",
+    "Device Type": "{{ $alert->type }}"
+  },
+  "summary": "Severity: {{ $alert->severity }}\nTimestamp: {{ $alert->timestamp }}\nRule: {{ $alert->title }}\n @foreach ($alert->faults as $key => $value) {{ $key }}: {{ $value['string'] }}\n @endforeach",
+  "sla": "ccaf3fd6-db51-4f9f-818b-de42aee54f29",
+  "urls": [
+    {
+      "link_url": "{{ route('device', ['device' => $alert->device_id ?: 1]) }}",
+      "link_text": "{{ $alert->hostname }}"
     },
-    "summary": "@foreach ($alert->faults as $key => $value) Key: {{ $key }} Value: {{ $value }} @endforeach",
-    "escalation_policy" : "272841e2-2cbf-40a8-9a9a-64227fd3d722"
-  }
+    {
+      "link_url": "{{ route('device', ['device' => $alert->device_id ?? 1, 'tab' => 'alerts']) }}",
+      "link_text": "{{ $alert->hostname }} - Alerts"
+    }
+  ]
 }
 @else
 {{ $alert->title }}
@@ -1237,6 +1258,8 @@ Alert sent to:
 @endif
 ```
 
-| Config | Example                                                      |
-| ------ |--------------------------------------------------------------|
-| WebHook URL | <https://events.zenduty.com/integration/we8jv/generic/hash/> |
+| Config               | Example                                                      |
+|----------------------|--------------------------------------------------------------|
+| WebHook URL          | <https://events.zenduty.com/integration/we8jv/generic/hash/> |
+| SLA ID               | g27u4gr824r-dd32rf2wdedeas-3e2wd223d23                       |
+| Escalation Policy ID | KIJDi23rwnef23-dankjd323r-DSAD£2232fds                        |


### PR DESCRIPTION
ZenDesk docs get you to use the API Transport which is ok and you can populate the template with whatever you want, however you can't pass over additional information to their API this way.

This transport is easier to setup within LibreNMS but allows for complete flexibility when sending data to the ZenDuty API.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
