### PR TITLE
Adds support for UniFi E7 device(s).

### DIFF
--- a/includes/definitions/unifi.yaml
+++ b/includes/definitions/unifi.yaml
@@ -17,6 +17,7 @@ discovery:
             - '/^U6/'
             - '/^U7/'
             - '/^U-LTE/'
+            - '/^E7/'
     -
         sysObjectID: .1.3.6.1.4.1.10002.1
         sysDescr: Linux


### PR DESCRIPTION
Adds unifi OS definition support for E7 model(s). Discovery changes beyond updating the regex in the definition YAML do not appear needed and no test data has been generated.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
