### PR TITLE
Fix time intervals sometimes being wrong

### DIFF
--- a/LibreNMS/Util/Time.php
+++ b/LibreNMS/Util/Time.php
@@ -25,9 +25,8 @@
 
 namespace LibreNMS\Util;
 
-use Carbon\Carbon;
 use Carbon\CarbonInterface;
-use Carbon\CarbonInterval;
+use Illuminate\Support\Carbon;
 
 class Time
 {
@@ -62,23 +61,22 @@ class Time
             return '';
         }
 
-        $parts = $parts ?? ($short ? 3 : -1);
+        $parts = $parts ?? ($short ? 3 : 4);
 
         try {
             // handle negative seconds correctly
             if ($seconds < 0) {
-                return CarbonInterval::seconds($seconds)->invert()->cascade()->forHumans([
-                    'syntax' => CarbonInterface::DIFF_RELATIVE_TO_NOW,
-                    'parts' => $parts,
-                    'short' => $short,
-                ]);
+                return Carbon::now()->addSeconds($seconds)->diffForHumans(
+                    short: $short,
+                    parts: $parts,
+                );
             }
 
-            return CarbonInterval::seconds($seconds)->cascade()->forHumans([
-                'syntax' => CarbonInterface::DIFF_ABSOLUTE,
-                'parts' => $parts,
-                'short' => $short,
-            ]);
+            return Carbon::now()->subSeconds($seconds)->diffForHumans(
+                syntax: CarbonInterface::DIFF_ABSOLUTE,
+                short: $short,
+                parts: $parts,
+            );
         } catch (\Exception) {
             return '';
         }

--- a/LibreNMS/Util/Time.php
+++ b/LibreNMS/Util/Time.php
@@ -61,21 +61,11 @@ class Time
             return '';
         }
 
-        $parts = $parts ?? ($short ? 3 : 4);
-
         try {
-            // handle negative seconds correctly
-            if ($seconds < 0) {
-                return Carbon::now()->addSeconds($seconds)->diffForHumans(
-                    short: $short,
-                    parts: $parts,
-                );
-            }
-
-            return Carbon::now()->subSeconds($seconds)->diffForHumans(
-                syntax: CarbonInterface::DIFF_ABSOLUTE,
+            return Carbon::now()->subSeconds(abs($seconds))->diffForHumans(
+                syntax: $seconds < 0 ? CarbonInterface::DIFF_RELATIVE_TO_NOW : CarbonInterface::DIFF_ABSOLUTE,
                 short: $short,
-                parts: $parts,
+                parts: $parts ?? ($short ? 3 : 4),
             );
         } catch (\Exception) {
             return '';

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -29,7 +29,6 @@ use LibreNMS\Device\YamlDiscovery;
 use LibreNMS\Enum\IntegerType;
 use LibreNMS\Util\Number;
 use LibreNMS\Util\StringHelpers;
-use LibreNMS\Util\Time;
 
 class FunctionsTest extends TestCase
 {
@@ -96,25 +95,6 @@ class FunctionsTest extends TestCase
         $this->assertSame(10, YamlDiscovery::getValueFromData('oneoff', 3, $data, $pre_cache));
         $this->assertSame('Pickle', YamlDiscovery::getValueFromData('singletable', 11, $data, $pre_cache));
         $this->assertSame('BBQ', YamlDiscovery::getValueFromData('doubletable', 13, $data, $pre_cache));
-    }
-
-    public function testParseAtTime(): void
-    {
-        $this->assertEquals(time(), Time::parseAt('now'), 'now did not match');
-        $this->assertEquals(time() + 180, Time::parseAt('+3m'), '+3m did not match');
-        $this->assertEquals(time() + 7200, Time::parseAt('+2h'), '+2h did not match');
-        $this->assertEquals(time() + 172800, Time::parseAt('+2d'), '+2d did not match');
-        $this->assertEquals(time() + 63115200, Time::parseAt('+2y'), '+2y did not match');
-        $this->assertEquals(time() - 180, Time::parseAt('-3m'), '-3m did not match');
-        $this->assertEquals(time() - 7200, Time::parseAt('-2h'), '-2h did not match');
-        $this->assertEquals(time() - 172800, Time::parseAt('-2d'), '-2d did not match');
-        $this->assertEquals(time() - 63115200, Time::parseAt('-2y'), '-2y did not match');
-        $this->assertEquals(429929439, Time::parseAt('429929439'));
-        $this->assertEquals(212334234, Time::parseAt(212334234));
-        $this->assertEquals(time() - 43, Time::parseAt('-43'), '-43 did not match');
-        $this->assertEquals(0, Time::parseAt('invalid'));
-        $this->assertEquals(606614400, Time::parseAt('March 23 1989 UTC'));
-        $this->assertEquals(time() + 86400, Time::parseAt('+1 day'));
     }
 
     public function testNumberCast()

--- a/tests/Unit/TimeUtilityTest.php
+++ b/tests/Unit/TimeUtilityTest.php
@@ -43,4 +43,23 @@ class TimeUtilityTest extends TestCase
 
         $this->assertSame('4 years', Time::formatInterval(1461 * 24 * 60 * 60));
     }
+
+    public function testParseAtTime(): void
+    {
+        $this->assertEquals(time(), Time::parseAt('now'), 'now did not match');
+        $this->assertEquals(time() + 180, Time::parseAt('+3m'), '+3m did not match');
+        $this->assertEquals(time() + 7200, Time::parseAt('+2h'), '+2h did not match');
+        $this->assertEquals(time() + 172800, Time::parseAt('+2d'), '+2d did not match');
+        $this->assertEquals(time() + 63115200, Time::parseAt('+2y'), '+2y did not match');
+        $this->assertEquals(time() - 180, Time::parseAt('-3m'), '-3m did not match');
+        $this->assertEquals(time() - 7200, Time::parseAt('-2h'), '-2h did not match');
+        $this->assertEquals(time() - 172800, Time::parseAt('-2d'), '-2d did not match');
+        $this->assertEquals(time() - 63115200, Time::parseAt('-2y'), '-2y did not match');
+        $this->assertEquals(429929439, Time::parseAt('429929439'));
+        $this->assertEquals(212334234, Time::parseAt(212334234));
+        $this->assertEquals(time() - 43, Time::parseAt('-43'), '-43 did not match');
+        $this->assertEquals(0, Time::parseAt('invalid'));
+        $this->assertEquals(606614400, Time::parseAt('March 23 1989 UTC'));
+        $this->assertEquals(time() + 86400, Time::parseAt('+1 day'));
+    }
 }

--- a/tests/Unit/TimeUtilityTest.php
+++ b/tests/Unit/TimeUtilityTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tests\Unit;
+
+use Illuminate\Support\Carbon;
+use LibreNMS\Tests\TestCase;
+use LibreNMS\Util\Time;
+
+class TimeUtilityTest extends TestCase
+{
+    /**
+     * A basic unit test example.
+     */
+    public function testFormatInterval(): void
+    {
+        $this->assertSame('', Time::formatInterval(0));
+        $this->assertSame('', Time::formatInterval(null));
+        $this->assertSame('1 second', Time::formatInterval(1));
+        $this->assertSame('3s', Time::formatInterval(3, true));
+        $this->assertSame('1 minute', Time::formatInterval(60));
+        $this->assertSame('1 minute ago', Time::formatInterval(-60));
+        $this->assertSame('1m 1s', Time::formatInterval(61, true));
+        $this->assertSame('1 hour', Time::formatInterval(60*60));
+        $this->assertSame('1 day', Time::formatInterval(24*60*60));
+        $this->assertSame('2 weeks 3 days 24 minutes 16 seconds', Time::formatInterval(17*24*60*60+1456));
+        $this->assertSame('2 weeks 3 days', Time::formatInterval(17*24*60*60+1456, parts: 2));
+
+        // different months could change this
+        $this->travelTo(Carbon::createFromTimestamp(30042), function () {
+            $this->assertSame('1 month 1 week 2 days 24 minutes', Time::formatInterval(39*24*60*60+1456));
+            $this->assertSame('1mo 1w 2d 24m 16s', Time::formatInterval(39*24*60*60+1456, true, 5));
+        });
+
+        // calculate if there is a leap year (could freeze time, try this instead)
+        if (Carbon::createFromDate(Carbon::now()->year, 2, 28)->isPast()) {
+            $days = Carbon::now()->isLeapYear() ? 366 : 365;
+        } else {
+            $days = Carbon::now()->subYear()->isLeapYear() ? 366 : 365;
+        }
+
+        $this->assertSame('1 year', Time::formatInterval($days*24*60*60));
+        $this->assertSame('1 year ago', Time::formatInterval(-$days*24*60*60));
+
+        $this->assertSame('4 years', Time::formatInterval(1461*24*60*60));
+    }
+}

--- a/tests/data/iosxe_c9800.json
+++ b/tests/data/iosxe_c9800.json
@@ -7326,7 +7326,7 @@
                     "last_bytes_in": null,
                     "last_bytes_out": 4808025091058,
                     "bytes_in_rate": null,
-                    "bytes_out_rate": 2768,
+                    "bytes_out_rate": 2767,
                     "last_bytes_drop_in": null,
                     "last_bytes_drop_out": 0,
                     "bytes_drop_in_rate": null,


### PR DESCRIPTION
Add the context of now to the interval to get accurate diffs

fixes: #16690 #16987

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
