### PR TITLE
Fix InvalidIpException due to stripping (issue #16992)

### DIFF
--- a/LibreNMS/Util/IP.php
+++ b/LibreNMS/Util/IP.php
@@ -44,6 +44,14 @@ abstract class IP
      */
     public static function fromHexString($hex, $ignore_errors = false)
     {
+        // If IP addresses happen to contain only readable ascii, the snmp
+        // tools might represent them by a regular string.
+        // E.g. '!"#$' == 33.34.35.36 or 'ABCD' == 65.66.67.68
+        $len = strlen($hex);
+        if ($len == 4 || $len == 16) {
+            $hex = StringHelpers::asciiToHex($hex);
+        }
+
         $hex = str_replace([' ', '"'], '', $hex);
 
         try {
@@ -53,12 +61,6 @@ abstract class IP
         }
 
         $hex = str_replace([':', '.'], '', $hex);
-
-        // check if hex was incorrectly converted to ascii
-        $len = strlen($hex);
-        if (($len == 4 || $len == 16) && preg_match('/[^0-9a-fA-F]/', $hex)) {
-            $hex = StringHelpers::asciiToHex($hex);
-        }
 
         try {
             if (strlen($hex) == 8) {


### PR DESCRIPTION
Provides a possible fix to #16992. By wrapping SnmpQuery, we get proper values for all IP addresses and won't need to throw InvalidIpExceptions.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
