### PR TITLE
Show unused cached snmp queries

### DIFF
--- a/LibreNMS/Data/Source/NetSnmpQuery.php
+++ b/LibreNMS/Data/Source/NetSnmpQuery.php
@@ -416,11 +416,18 @@ class NetSnmpQuery implements SnmpQueryInterface
             $key = $this->getCacheKey($command, $oids);
 
             if (Debug::isEnabled()) {
+                $cache_performance = Cache::driver($driver)->get('SnmpQuery_cache_performance', []);
+                $cache_performance[$key] ??= 0;
+
                 if (Cache::driver($driver)->has($key)) {
                     Log::debug("Cache hit for $command " . implode(',', $oids));
+                    $cache_performance[$key]++;
                 } else {
                     Log::debug("Cache miss for $command " . implode(',', $oids) . ', grabbing fresh data.');
                 }
+
+                // update cache performance
+                Cache::driver($driver)->put('SnmpQuery_cache_performance', $cache_performance);
             }
         }
 

--- a/app/Polling/Measure/MeasurementManager.php
+++ b/app/Polling/Measure/MeasurementManager.php
@@ -26,6 +26,7 @@
 namespace App\Polling\Measure;
 
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Cache;
 use Log;
 
 class MeasurementManager
@@ -118,6 +119,15 @@ class MeasurementManager
         app('Datastore')->getStats()->each(function (MeasurementCollection $stats, string $datastore) {
             $this->printSummary($datastore, $stats, self::DATASTORE_COLOR);
         });
+
+        $snmpquery_cache_performance = Cache::driver('array')->get('SnmpQuery_cache_performance');
+        if (! empty($snmpquery_cache_performance)) {
+            Log::info('SnmpQuery Cache Performance');
+            foreach ($snmpquery_cache_performance as $key => $hits) {
+                $vars = explode('|', $key);
+                Log::info(" $vars[4] cache hits: $hits" . ($hits ? '' : ' %RWaste of memory!%n'), ['color' => true]);
+            }
+        }
     }
 
     public function getCategory(string $category): MeasurementCollection


### PR DESCRIPTION
SnmpQuery only and only when debug is enabled

![image](https://github.com/user-attachments/assets/ae6bc3ea-0be3-42f3-9c10-2bc61903ebca)

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
