### PR TITLE
Dark mode for the new Sensor graphs addition 

### DIFF
--- a/includes/html/graphs/sensor/generic.inc.php
+++ b/includes/html/graphs/sensor/generic.inc.php
@@ -2,6 +2,7 @@
 
 use LibreNMS\Data\Store\Rrd;
 use LibreNMS\Util\Number;
+use LibreNMS\Config;
 
 $sensor_descr_fixed = Rrd::fixedSafeDescr($sensor->sensor_descr, 25);
 $sensor_color = (Config::get('applied_site_style') == 'dark') ? '#f2f2f2' : '#272b30';

--- a/includes/html/graphs/sensor/generic.inc.php
+++ b/includes/html/graphs/sensor/generic.inc.php
@@ -4,7 +4,6 @@ use LibreNMS\Config;
 use LibreNMS\Data\Store\Rrd;
 use LibreNMS\Util\Number;
 
-
 $sensor_descr_fixed = Rrd::fixedSafeDescr($sensor->sensor_descr, 25);
 $sensor_color = (Config::get('applied_site_style') == 'dark') ? '#f2f2f2' : '#272b30';
 $background_color = (Config::get('applied_site_style') == 'dark') ? '#272b30' : '#ffffff';

--- a/includes/html/graphs/sensor/generic.inc.php
+++ b/includes/html/graphs/sensor/generic.inc.php
@@ -1,8 +1,9 @@
 <?php
 
+use LibreNMS\Config;
 use LibreNMS\Data\Store\Rrd;
 use LibreNMS\Util\Number;
-use LibreNMS\Config;
+
 
 $sensor_descr_fixed = Rrd::fixedSafeDescr($sensor->sensor_descr, 25);
 $sensor_color = (Config::get('applied_site_style') == 'dark') ? '#f2f2f2' : '#272b30';


### PR DESCRIPTION
adding what seems like a missing "use" in order for the system to determine if the graphs should be light or dark mode
this is an addition to #16985 made by @mpikzink 
i could not get the new graphs to show as intended and the proposed change fixed that issue

![darkmode](https://github.com/user-attachments/assets/3d019aad-4edd-4b5a-b25b-d5075c101a90)


Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
