### PR TITLE
Disable QoS discovery by default

### DIFF
--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -1550,7 +1550,7 @@
             "order": 260,
             "group": "discovery",
             "section": "discovery_modules",
-            "default": true,
+            "default": false,
             "type": "boolean"
         },
         "discovery_modules.route": {


### PR DESCRIPTION
I saw some reports of the QoS module consuming large amounts of disk space.  The old CBQoS module was disabled by default, so this PR restores the original default behaviour for QoS in LibreNMS.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
