### PR TITLE
lnms dev:check modules only

### DIFF
--- a/LibreNMS/Util/CiHelper.php
+++ b/LibreNMS/Util/CiHelper.php
@@ -203,7 +203,7 @@ class CiHelper
             array_push($phpunit_cmd, '--group', 'docs');
         } elseif ($this->flags['unit_svg']) {
             $phpunit_cmd[] = 'tests/SVGTest.php';
-        } elseif ($this->flags['unit_modules']) {
+        } elseif ($this->flags['unit_modules'] || $this->flags['os-modules-only']) {
             $phpunit_cmd[] = 'tests/OSModulesTest.php';
         }
 

--- a/app/Console/Commands/DevCheckCommand.php
+++ b/app/Console/Commands/DevCheckCommand.php
@@ -96,10 +96,13 @@ class DevCheckCommand extends LnmsCommand
                 'lint_enable' => false,
                 'unit_enable' => true,
                 'web_enable' => false,
-                'os-modules-only' => $this->option('os-modules-only'),
             ]);
             $this->helper->setOS(explode(',', $os));
         }
+
+        $this->helper->setFlags([
+            'os-modules-only' => $this->option('os-modules-only'),
+        ]);
 
         if ($modules = $this->option('module')) {
             $this->helper->setFlags(['style_enable' => false, 'lint_enable' => false, 'unit_enable' => true, 'web_enable' => false]);

--- a/doc/Developing/os/Test-Units.md
+++ b/doc/Developing/os/Test-Units.md
@@ -64,9 +64,16 @@ tests: `lnms dev:check unit --db --snmpsim`
 
 `lnms dev:check unit -o osname`
 
+### Test an OS, but only discovery and polling modules (exluding OS detection)
+`lnms dev:check unit --os osname --os-modules-only`
+
+
 ### Specific Module
 
 `lnms dev:check unit -m modulename`
+
+### Test all modules for all os and stop on failure
+`lnms dev:check unit --db -snmpsim --os-modules-only -f`
 
 ## Using snmpsim for testing
 
@@ -82,6 +89,17 @@ the community and 127.1.6.1:1161 as the host.
 ```bash
 snmpget -v 2c -c ios_c3560e 127.1.6.1:1161 sysDescr.0
 ```
+
+## Simulate specific device from test data
+
+Add/update a device called "snmpsim" to your install and set to use a specific snmprec file
+
+```bash
+lnms dev:simulate ios_2960x
+```
+
+You can then run `./discovery.php -h snmpsim -d -v` and `lnms device:poll snmpsim -vvv`
+to discover and poll the simulated device.
 
 ## Snmprec format
 


### PR DESCRIPTION
`lnms dev:check unit --db -snmpsim --os-modules-only -f`  check only modules, skip os detection checks

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
