### PR TITLE
Correct accidental addition of $agent_raw variable in unix-agent.inc.php

### DIFF
--- a/includes/polling/unix-agent.inc.php
+++ b/includes/polling/unix-agent.inc.php
@@ -45,8 +45,6 @@ if ($device['os_group'] == 'unix' || $device['os'] == 'windows') {
     $agent_end = microtime(true);
     $agent_time = round(($agent_end - $agent_start) * 1000);
 
-    $agent_raw = "<<<app-proxmox>>>\nblah";
-
     if (! empty($agent_raw)) {
         echo 'execution time: ' . $agent_time . 'ms';
 


### PR DESCRIPTION
This commit corrects an issue introduced in https://github.com/librenms/librenms/pull/17040 where `$agent_raw` is hard coded, leading to a situation where proxmox is the only monitored application, if using the LibreNMS agent.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
