### PR TITLE
Re-add ifIndex index to ports table 

### DIFF
--- a/database/migrations/2025_01_30_000121_add_ifindex_index_to_ports_table.php
+++ b/database/migrations/2025_01_30_000121_add_ifindex_index_to_ports_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('ports', function (Blueprint $table) {
+            $table->index(['device_id', 'ifIndex']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('ports', function (Blueprint $table) {
+            $table->dropIndex(['device_id', 'ifIndex']);
+        });
+    }
+};

--- a/misc/db_schema.yaml
+++ b/misc/db_schema.yaml
@@ -1639,6 +1639,7 @@ ports:
     PRIMARY: { Name: PRIMARY, Columns: [port_id], Unique: true, Type: BTREE }
     ports_ifalias_port_descr_descr_portname_index: { Name: ports_ifalias_port_descr_descr_portname_index, Columns: [ifAlias, port_descr_descr, portName], Unique: false, Type: BTREE }
     ports_ifdescr_ifname_index: { Name: ports_ifdescr_ifname_index, Columns: [ifDescr, ifName], Unique: false, Type: BTREE }
+    ports_device_id_ifindex_index: { Name: ports_device_id_ifindex_index, Columns: [device_id, ifIndex], Unique: false, Type: BTREE }
 ports_adsl:
   Columns:
     - { Field: port_id, Type: 'int unsigned', 'Null': false, Extra: '' }


### PR DESCRIPTION
It was removed when the unique constraint was used, but this also removed the index causing performance issues.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
