### PR TITLE
CIMC C220 M6 Model / Serial / Version Fix

### DIFF
--- a/includes/definitions/discovery/cimc.yaml
+++ b/includes/definitions/discovery/cimc.yaml
@@ -1,9 +1,13 @@
 mib: CISCO-UNIFIED-COMPUTING-COMPUTE-MIB:CISCO-UNIFIED-COMPUTING-PROCESSOR-MIB:CISCO-UNIFIED-COMPUTING-MEMORY-MIB:CISCO-UNIFIED-COMPUTING-STORAGE-MIB:CISCO-UNIFIED-COMPUTING-EQUIPMENT-MIB
 modules:
     os:
-        sysDescr_regex: '/Firmware Version (?<version>[^\s]+)/'
-        hardware: CISCO-UNIFIED-COMPUTING-COMPUTE-MIB::cucsComputeBoardModel.1
-        serial: CISCO-UNIFIED-COMPUTING-COMPUTE-MIB::cucsComputeBoardSerial.1
+        sysDescr_regex: '/Firmware Version (?<version>[^\s]+\))/'
+        hardware: 
+            - CISCO-UNIFIED-COMPUTING-COMPUTE-MIB::cucsComputeBoardModel.1
+            - CISCO-UNIFIED-COMPUTING-COMPUTE-MIB::cucsComputeBoardModel.0
+        serial: 
+            - CISCO-UNIFIED-COMPUTING-COMPUTE-MIB::cucsComputeBoardSerial.1
+            - CISCO-UNIFIED-COMPUTING-COMPUTE-MIB::cucsComputeBoardSerial.0
     sensors:
         current:
             data:

--- a/tests/data/cimc_1.json
+++ b/tests/data/cimc_1.json
@@ -1,0 +1,23 @@
+{
+    "os": {
+        "discovery": {
+            "devices": [
+                {
+                    "sysName": "<private>",
+                    "sysObjectID": ".1.3.6.1.4.1.9.1.3100",
+                    "sysDescr": "Cisco Integrated Management Controller(Cisco IMC) BE6K-M6-K9, Firmware Version 4.3(4.240152), Copyright (c) 2008-2024, Cisco Systems, Inc.",
+                    "sysContact": "<private>",
+                    "version": "4.3(4.240152)",
+                    "hardware": "UCSC-C220-M6S",
+                    "features": null,
+                    "location": "<private>",
+                    "os": "cimc",
+                    "type": "server",
+                    "serial": "WMP2224X0KR",
+                    "icon": "cisco.svg"
+                }
+            ]
+        },
+        "poller": "matches discovery"
+    }
+}

--- a/tests/snmpsim/cimc_1.snmprec
+++ b/tests/snmpsim/cimc_1.snmprec
@@ -1,0 +1,7 @@
+1.3.6.1.2.1.1.1.0|4|Cisco Integrated Management Controller(Cisco IMC) BE6K-M6-K9, Firmware Version 4.3(4.240152), Copyright (c) 2008-2024, Cisco Systems, Inc.
+1.3.6.1.2.1.1.2.0|6|1.3.6.1.4.1.9.1.3100
+1.3.6.1.2.1.1.4.0|4|<private>
+1.3.6.1.2.1.1.5.0|4|<private>
+1.3.6.1.2.1.1.6.0|4|<private>
+1.3.6.1.4.1.9.9.719.1.9.6.1.6.0|4|UCSC-C220-M6S
+1.3.6.1.4.1.9.9.719.1.9.6.1.14.0|4|WMP2224X0KR


### PR DESCRIPTION
C220 m6 servers have model and serial information at a different index. Also version regex was allowing a comma in some cases. This PR fixes all of that.

Before
![Before](https://github.com/user-attachments/assets/17528c97-16fe-4de4-a57c-d3d2d1ade7ee)

After
![After](https://github.com/user-attachments/assets/fe4b3d5a-b075-47dc-a91d-2c9bba4ef131)


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [X] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
