### PR TITLE
Graph has trouble detecting the range if the sensor is constant

### DIFF
--- a/app/Models/Sensor.php
+++ b/app/Models/Sensor.php
@@ -171,6 +171,18 @@ class Sensor extends DeviceRelatedModel implements Keyable
         return Severity::Ok;
     }
 
+    public function hasTresholds(): bool
+    {
+        return $this->sensor_limit_low !== null
+            || $this->sensor_limit_low_warn !== null
+            || $this->sensor_limit_warn !== null
+            || $this->sensor_limit !== null;
+    }
+
+    public function doesntHaveTresholds(): bool
+    {
+        return ! $this->hasTresholds();
+    }
     // ---- Define Relationships ----
 
     public function events(): MorphMany

--- a/includes/html/graphs/sensor/generic.inc.php
+++ b/includes/html/graphs/sensor/generic.inc.php
@@ -19,11 +19,27 @@ $rrd_options .= ' DEF:sensor_max=' . $rrd_filename . ':sensor:MAX';
 $rrd_options .= ' DEF:sensor_min=' . $rrd_filename . ':sensor:MIN';
 $rrd_options .= ' AREA:sensor_max' . $variance_color;
 $rrd_options .= ' AREA:sensor_min' . $background_color;
-$rrd_options .= ' COMMENT:"Alert thresholds\:"';
-$rrd_options .= ($sensor->sensor_limit_low) ? '  LINE1.5:' . $sensor->sensor_limit_low . '#00008b:"low = ' . Number::formatSi($sensor->sensor_limit_low, 2, 3, $sensor->unit()) . '":dashes' : '';
-$rrd_options .= ($sensor->sensor_limit_low_warn) ? ' LINE1.5:' . $sensor->sensor_limit_low_warn . '#005bdf:"low_warn = ' . Number::formatSi($sensor->sensor_limit_low_warn, 2, 3, $sensor->unit()) . '":dashes' : '';
-$rrd_options .= ($sensor->sensor_limit_warn) ? (' LINE1.5:' . $sensor->sensor_limit_warn . '#ffa420:"high_warn = ' . Number::formatSi($sensor->sensor_limit_warn, 2, 3, $sensor->unit()) . '":dashes') : '';
-$rrd_options .= ($sensor->sensor_limit) ? (' LINE1.5:' . $sensor->sensor_limit . '#ff0000:"high = ' . Number::formatSi($sensor->sensor_limit, 2, 3, $sensor->unit()) . '":dashes') : '';
+
+if($sensor->hasTresholds())
+{
+    $rrd_options .= ' COMMENT:"Alert thresholds\:"';
+    $rrd_options .= ($sensor->sensor_limit_low) ? '  LINE1.5:' . $sensor->sensor_limit_low . '#00008b:"low = ' . Number::formatSi($sensor->sensor_limit_low, 2, 3, $sensor->unit()) . '":dashes' : '';
+    $rrd_options .= ($sensor->sensor_limit_low_warn) ? ' LINE1.5:' . $sensor->sensor_limit_low_warn . '#005bdf:"low_warn = ' . Number::formatSi($sensor->sensor_limit_low_warn, 2, 3, $sensor->unit()) . '":dashes' : '';
+    $rrd_options .= ($sensor->sensor_limit_warn) ? (' LINE1.5:' . $sensor->sensor_limit_warn . '#ffa420:"high_warn = ' . Number::formatSi($sensor->sensor_limit_warn, 2, 3, $sensor->unit()) . '":dashes') : '';
+    $rrd_options .= ($sensor->sensor_limit) ? (' LINE1.5:' . $sensor->sensor_limit . '#ff0000:"high = ' . Number::formatSi($sensor->sensor_limit, 2, 3, $sensor->unit()) . '":dashes') : '';
+}
+
+// Workaround because rrdtool has trouble detecting the
+// range if the sensor is constant and no thresholds are
+// defined, so it's forced to +-1% of the min/max.
+if($sensor->doesntHaveTresholds())
+{
+    $rrd_options .= ' CDEF:canvas_max=sensor_max,1.01,*';
+    $rrd_options .= ' LINE0:canvas_max#000000ff::dashes'; // Hidden for scale only
+    $rrd_options .= ' CDEF:canvas_min=sensor_min,0.99,*';
+    $rrd_options .= ' LINE0:canvas_min#000000ff::dashes'; // Hidden for scale only
+}
+
 $rrd_options .= ' COMMENT:"\n"';
 $rrd_options .= ' COMMENT:"' . Rrd::fixedSafeDescr('', 25) . '       Now        Avg       Min       Max\n"';
 $rrd_options .= ' LINE2:sensor' . $sensor_color . ':"' . $sensor_descr_fixed . '"';

--- a/includes/html/graphs/sensor/generic.inc.php
+++ b/includes/html/graphs/sensor/generic.inc.php
@@ -20,8 +20,7 @@ $rrd_options .= ' DEF:sensor_min=' . $rrd_filename . ':sensor:MIN';
 $rrd_options .= ' AREA:sensor_max' . $variance_color;
 $rrd_options .= ' AREA:sensor_min' . $background_color;
 
-if($sensor->hasTresholds())
-{
+if ($sensor->hasTresholds()) {
     $rrd_options .= ' COMMENT:"Alert thresholds\:"';
     $rrd_options .= ($sensor->sensor_limit_low) ? '  LINE1.5:' . $sensor->sensor_limit_low . '#00008b:"low = ' . Number::formatSi($sensor->sensor_limit_low, 2, 3, $sensor->unit()) . '":dashes' : '';
     $rrd_options .= ($sensor->sensor_limit_low_warn) ? ' LINE1.5:' . $sensor->sensor_limit_low_warn . '#005bdf:"low_warn = ' . Number::formatSi($sensor->sensor_limit_low_warn, 2, 3, $sensor->unit()) . '":dashes' : '';
@@ -32,8 +31,7 @@ if($sensor->hasTresholds())
 // Workaround because rrdtool has trouble detecting the
 // range if the sensor is constant and no thresholds are
 // defined, so it's forced to +-1% of the min/max.
-if($sensor->doesntHaveTresholds())
-{
+if ($sensor->doesntHaveTresholds()) {
     $rrd_options .= ' CDEF:canvas_max=sensor_max,1.01,*';
     $rrd_options .= ' LINE0:canvas_max#000000ff::dashes'; // Hidden for scale only
     $rrd_options .= ' CDEF:canvas_min=sensor_min,0.99,*';


### PR DESCRIPTION
This is a workaround, as rrdtool has difficulties recognising the range when the sensor is constant and no thresholds are defined. It defines invisible lines at +-1% of min/max to define a fallback scale for constant graphs.

Fixes part of #17027


Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
