### PR TITLE
Fix comment syntax in rrdcached.service

### DIFF
--- a/dist/rrdcached/rrdcached.service
+++ b/dist/rrdcached/rrdcached.service
@@ -7,17 +7,17 @@ Documentation=https://docs.librenms.org/Extensions/RRDCached/ man:rrdcached(1)
 Type=forking
 PIDFile=/run/rrdcached.pid
 ExecStart=/usr/bin/rrdcached \
-    -w 1800 \ # Write to disk every 1800 seconds
-    -z 1800 \ # Delay updates by 1800 seconds
-    -f 3600 \ # Flush updates every 3600 seconds
-    -s librenms \ # Run socket librenms user
-    -U librenms \ # Run as user librenms
-    -G librenms \ # Run as group librenms
-    -B -R -j /var/tmp \ # Use /var/tmp for journal files
-    -l unix:/run/rrdcached.sock \ # Listen on UNIX socket
-    -t 4    \ # Use 4 threads
-    -F      \ # Force daemon mode
-    -b /opt/librenms/rrd/ # Base directory for RRD files
+    -w 1800 \ # Write to disk every 1800 seconds \
+    -z 1800 \ # Delay updates by 1800 seconds \
+    -f 3600 \ # Flush updates every 3600 seconds \
+    -s librenms \ # Run socket librenms user \
+    -U librenms \ # Run as user librenms \
+    -G librenms \ # Run as group librenms \
+    -B -R -j /var/tmp \ # Use /var/tmp for journal files \
+    -l unix:/run/rrdcached.sock \ # Listen on UNIX socket \
+    -t 4    \ # Use 4 threads \
+    -F      \ # Force daemon mode \
+    -b /opt/librenms/rrd/ \ # Base directory for RRD files 
 Restart=always
 RestartSec=10
 


### PR DESCRIPTION
This PR fixes an issue with the systemd unit file for rrdcached.service to make sure the comments are not improperly parsed allowing the service to work again.

Should address https://github.com/librenms/librenms/issues/17045

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [X] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
