### PR TITLE
Fixed: failed with 415 with content type not supported issue

### DIFF
--- a/LibreNMS/Alert/Transport/Linemessagingapi.php
+++ b/LibreNMS/Alert/Transport/Linemessagingapi.php
@@ -38,7 +38,7 @@ class Linemessagingapi extends Transport
 
         $res = Http::client()
         ->withToken($this->config['line-messaging-token'])
-        ->asForm()
+        ->asJson()
         ->post($apiURL, $data);
 
         if ($res->successful()) {


### PR DESCRIPTION
Using the LINE Message API to send a message will result in an error message:

```
Test to linemessagingapi failedTransport delivery failed with 415 for : {"message":"The content type, 'application/x-www-form-urlencoded', is not supported"}
```

This PR fixes this type discrepancy.

Fixes: #16745

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
