### PR TITLE
Increased z-index for navbar css to ensure it stays on top.

### DIFF
--- a/html/css/styles.css
+++ b/html/css/styles.css
@@ -1636,7 +1636,7 @@ tr.search:nth-child(odd) {
 nav.navbar-sticky-top {
   position: sticky;
   top: 0;
-  z-index: 100;
+  z-index: 1000;
   border-bottom-width: 2px;
   border-left-width: 0;
   border-top-width: 0;


### PR DESCRIPTION
Single line change increasing the z-index of the top navbar from 100 to 1000, this fixes the menu drawing under the leaflet map on my installations.

<img width="687" alt="Screenshot 2025-02-03 at 21 28 50" src="https://github.com/user-attachments/assets/cc0617dc-879e-47a2-8eff-dc6805a83927" />
<img width="493" alt="Screenshot 2025-02-03 at 21 25 23" src="https://github.com/user-attachments/assets/67ec42f1-9097-4c2a-bdf6-1a8ca86080b5" />

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
