### PR TITLE
Update Install-LibreNMS.md

### DIFF
--- a/doc/Installation/Install-LibreNMS.md
+++ b/doc/Installation/Install-LibreNMS.md
@@ -74,7 +74,7 @@ Connect to the server command line and follow the instructions below.
 === "Debian 12"
     === "NGINX"
         ```
-        apt install lsb-release ca-certificates wget acl curl fping git graphviz imagemagick mariadb-client mariadb-server mtr-tiny nginx-full nmap php-cli php-curl php-fpm php-gd php-gmp php-mbstring php-mysql php-snmp php-xml php-zip python3-dotenv python3-pymysql python3-redis python3-setuptools python3-systemd python3-pip rrdtool snmp snmpd unzip whois
+        apt install lsb-release ca-certificates wget acl curl composer fping git graphviz imagemagick mariadb-client mariadb-server mtr-tiny nginx-full nmap php-cli php-curl php-fpm php-gd php-gmp php-mbstring php-mysql php-snmp php-xml php-zip python3-dotenv python3-pymysql python3-redis python3-setuptools python3-systemd python3-pip rrdtool snmp snmpd unzip whois
         ```
 
 ## Add librenms user


### PR DESCRIPTION
Added composer to the list of packages to install for Debian 12 as it is required.

Following the instructions today for a Debian 12 installation on a fresh VM, I got to the point of trying to configure via the web interface and found it failing with "FastCGI sent in stderr: "PHP message: PHP Warning:  require(/opt/librenms/html/../vendor/autoload.php): Failed to open stream: No such file or directory in /opt/librenms/html/index.php on line 34; PHP message: PHP Fatal error:  Uncaught Error: Failed opening required '/opt/librenms/html/../vendor/autoload.php' (include_path='.:/usr/share/php') in /opt/librenms/html/index.php:34"

Wen I went to run composer to install the missing dependencies, I found my system did not have composer installed.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
