### PR TITLE
Bugfix for Sensor Graphs

### DIFF
--- a/includes/html/graphs/sensor/generic.inc.php
+++ b/includes/html/graphs/sensor/generic.inc.php
@@ -33,9 +33,9 @@ if ($sensor->hasThresholds()) {
 // defined, so it's forced to +-1% of the min/max.
 if ($sensor->doesntHaveThresholds()) {
     $rrd_options .= ' CDEF:canvas_max=sensor_max,1.01,*';
-    $rrd_options .= ' LINE0:canvas_max#000000ff::dashes'; // Hidden for scale only
+    $rrd_options .= ' LINE1:canvas_max#000000ff::dashes'; // Hidden for scale only
     $rrd_options .= ' CDEF:canvas_min=sensor_min,0.99,*';
-    $rrd_options .= ' LINE0:canvas_min#000000ff::dashes'; // Hidden for scale only
+    $rrd_options .= ' LINE1:canvas_min#000000ff::dashes'; // Hidden for scale only
 }
 
 $rrd_options .= ' COMMENT:"\n"';


### PR DESCRIPTION
Some users encounter issues when using RRDtool. They receive the following error message:

"BAD line width: 0"

This error occurs when an attempt is made to draw a line with a width of 0. If the line width is set to 0, RRDtool in versions before 1.7.2. interprets this as an invalid input and returns the error,  I haven't seen this in my test with 1.7.2 

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
