### PR TITLE
Add a GLPI Alert Transport

### DIFF
--- a/LibreNMS/Alert/Transport/Glpi.php
+++ b/LibreNMS/Alert/Transport/Glpi.php
@@ -1,0 +1,251 @@
+<?php
+/* Copyright (C) 2025 Raphaël Aubry <aubryr@asperience.fr>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>. */
+
+/**
+ * IRC Transport
+ *
+ * @author Raphaël Aubry <aubryr@asperience.fr>
+ * @copyright 2025 ASPerience
+ * @license GPL
+ */
+
+namespace LibreNMS\Alert\Transport;
+
+use LibreNMS\Alert\Transport;
+use LibreNMS\Exceptions\AlertTransportDeliveryException;
+use LibreNMS\Util\Http;
+
+class Glpi extends Transport
+{
+    protected string $name = 'GLPI';
+
+    public function deliverAlert(array $alert_data): bool
+    {
+        // Connect to the API with app/user tokens
+        $headers = [
+            "Content-Type" => "application/json",
+            "App-Token" => $this->config["app-token"]
+        ];
+
+        $data = [
+            "user_token" => $this->config["user-token"]
+        ];
+
+        $res = Http::client()
+            ->withHeaders($headers)
+            ->get($this->config["api-url"] . "/initSession", $data);
+
+        if (!$res->successful()) {
+            throw new AlertTransportDeliveryException($alert_data, $res->status(), $res->body(), 
+                                                      $alert_data['msg'], $data);
+        }
+
+        $headers["Session-Token"] = json_decode($res->body(), true)["session_token"];
+
+        // Change the active profile to the admin one
+        $profile = null;
+        $profiles = Http::client()
+            ->withHeaders($headers)
+            ->get($this->config["api-url"] . "/getMyProfiles");
+        
+        foreach ($profiles['myprofiles'] as $profile) {
+            if (str_contains($profile['name'], "super-admin")) {
+                $profile = $profile['id'];
+                break;
+            }
+        }
+
+        if ($profile != null) {
+            $data = [
+                'profiles_id' => $profile
+            ];
+
+            $res = Http::client()
+                ->withHeaders($headers)
+                ->post($this->config["api-url"] . "/changeActiveProfile/", $data);
+
+            $res = Http::client()
+                ->withHeaders($headers)
+                ->post($this->config["api-url"] . "/changeActiveEntities/");
+        }
+
+        // Retrieve the ticket for the alert (by title)
+        $ticketURL = $this->config["api-url"] . "/Ticket";
+        $searchURL = $this->config["api-url"].
+            "/search/Ticket?".
+            "forcedisplay[0]=2&".
+            "criteria[0][field]=1&".
+            "criteria[0][searchtype]=contains&".
+            "criteria[0][value]=^[LibreNMS: " . $alert_data['sysName'] . "] " . $alert_data["name"] . "$&".
+            "criteria[1][link]=AND&".
+            "criteria[1][field]=12&".
+            "criteria[1][searchtype]=equals&".
+            "criteria[1][value]=notclosed";
+
+        $res = Http::client()
+            ->withHeaders($headers)
+            ->get($searchURL);
+
+        if (!array_key_exists("data", $res->json())) {
+            // No ticket for the alert found, create a new one
+
+            // Retrieve the device in GLPI
+            $deviceSearchURL = $this->config["api-url"].
+                "/search/Computer?".
+                "forcedisplay[0]=2&".
+                "forcedisplay[1]=80&".
+                "criteria[0][field]=1&".
+                "criteria[0][searchtype]=contains&".
+                "criteria[0][value]=^" . $alert_data["sysName"] . "$";
+            
+            $res = Http::client()
+                ->withHeaders($headers)
+                ->get($deviceSearchURL);
+
+            $deviceID = $res->json()["data"][0]["2"] ?? null;
+            
+            // Retrieve the entity in GLPI
+            $entityName = $res->json()["data"][0]["80"] ?? null;
+            $entityID = null;
+            if ($entityName != null) {
+                $entitySearchURL = $this->config["api-url"].
+                    "/search/Entity?".
+                    "forcedisplay[0]=2&".
+                    "criteria[0][field]=1&".
+                    "criteria[0][searchtype]=contains&".
+                    "criteria[0][value]=^" . $entityName . "$";
+
+                $res = Http::client()
+                    ->withHeaders($headers)
+                    ->get($entitySearchURL);
+
+                $entityID = $res->json()["data"][0]["2"] ?? null;
+            }
+
+            // Retrieve the user logged in
+            $res = Http::client()
+                ->withHeaders($headers)
+                ->get($this->config["api-url"] . "/getFullSession");
+
+            $userID = $res->json()["session"]["glpiID"];
+
+            // Create the ticket
+            $data = [
+                "input" => [
+                    "name" => "[LibreNMS: " . $alert_data['sysName'] . "] " . $alert_data["name"],
+                    "content" => $alert_data["msg"],
+                    "_users_id_requester" => $userID
+                ]
+            ];
+
+            if ($entityID != null) {
+                $data["input"]["entities_id"] = $entityID;
+            }
+            
+            $res = Http::client()
+                ->withHeaders($headers)
+                ->post($ticketURL, $data);
+
+            // Associate GLPI device to the ticket
+            if ($res->successful() && $deviceID != null) {
+                $ticketID = $res->json()["id"];
+                
+                $data = [
+                    "input" => [
+                        "items_id" => $deviceID,
+                        "itemtype" => "Computer",
+                        "tickets_id" => $ticketID
+                    ]
+                ];
+
+                $res = Http::client()
+                    ->withHeaders($headers)
+                    ->post($this->config["api-url"] . "/Item_Ticket", $data);
+            }
+
+        } else {
+            // Update the status if resolved
+            $ticketID = $res->json()["data"][0]["2"];
+            $res = Http::client()
+                ->withHeaders($headers)
+                ->get($this->config["api-url"] . "/Ticket/$ticketID");
+
+            if ($res->json()["status"] == 5) {
+                $data = [
+                    "input" => [
+                        "status" => 2
+                    ]
+                ];
+
+                $res = Http::client()
+                    ->withHeaders($headers)
+                    ->patch($this->config["api-url"] . "/Ticket/$ticketID", $data);
+            }
+            
+            // Add followup to ticket
+            $data = [
+                "input" => [
+                    "content" => $alert_data["msg"],
+                    "itemtype" => "Ticket",
+                    "items_id" => $ticketID
+                ]
+            ];
+
+            $followupURL = $this->config["api-url"] . "/ITILFollowup";
+
+            $res = Http::client()
+                ->withHeaders($headers)
+                ->post($followupURL, $data);
+        }
+
+        if ($res->successful()) {
+            return true;
+        }
+
+        throw new AlertTransportDeliveryException($alert_data, $res->status(), $res->body(), 
+                                                  $alert_data['msg'], $data);
+    }
+
+    public static function configTemplate(): array
+    {
+        return [
+            'config' => [
+                [
+                    'title' => 'GLPI API URL',
+                    'name' => 'api-url',
+                    'descr' => 'API URL of GLPI (typically ending in apirest.php)',
+                    'type' => 'text',
+                ],
+                [
+                    'title' => 'User Token',
+                    'name' => 'user-token',
+                    'descr' => 'GLPI user token for API access (to generate: User preferences > API)',
+                    'type' => 'text',
+                ],
+                [
+                    'title' => 'App Token',
+                    'name' => 'app-token',
+                    'descr' => 'App token for API access (to generate: Configuration > General > API)',
+                    'type' => 'text',
+                ],
+            ],
+            'validation' => [
+                'api-url' => 'required|url',
+                'user-token' => 'required|string',
+                'app-token' => 'required|string',
+            ],
+        ];
+    }
+}

--- a/LibreNMS/Alert/Transport/Glpi.php
+++ b/LibreNMS/Alert/Transport/Glpi.php
@@ -120,7 +120,7 @@ class Glpi extends Transport
             $entityName = $res->json()['data'][0]['80'] ?? null;
             $entityID = null;
             if ($entityName != null) {
-                $entitySearchURL = $this->config['api-url'].
+                $entitySearchURL = $this->config['api-url'] .
                     '/search/Entity?' .
                     'forcedisplay[0]=2&' .
                     'criteria[0][field]=1&' .
@@ -174,7 +174,6 @@ class Glpi extends Transport
                     ->withHeaders($headers)
                     ->post($this->config['api-url'] . '/Item_Ticket', $data);
             }
-
         } else {
             // Update the status if resolved
             $ticketID = $res->json()['data'][0]['2'];

--- a/LibreNMS/Alert/Transport/Glpi.php
+++ b/LibreNMS/Alert/Transport/Glpi.php
@@ -176,7 +176,7 @@ class Glpi extends Transport
             }
         } else {
             $ticketID = $res->json()['data'][0]['2'];
-            
+
             // Update the status if resolved
             $ticketData = Http::client()
                 ->withHeaders($headers)

--- a/LibreNMS/Alert/Transport/Glpi.php
+++ b/LibreNMS/Alert/Transport/Glpi.php
@@ -1,4 +1,5 @@
 <?php
+
 /* Copyright (C) 2025 Raphaël Aubry <aubryr@asperience.fr>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/LibreNMS/Alert/Transport/Glpi.php
+++ b/LibreNMS/Alert/Transport/Glpi.php
@@ -48,7 +48,7 @@ class Glpi extends Transport
             ->get($this->config['api-url'] . '/initSession', $data);
 
         if (! $res->successful()) {
-            throw new AlertTransportDeliveryException($alert_data, $res->status(), $res->body(), 
+            throw new AlertTransportDeliveryException($alert_data, $res->status(), $res->body(),
                 $alert_data['msg'], $data);
         }
 
@@ -213,7 +213,7 @@ class Glpi extends Transport
             return true;
         }
 
-        throw new AlertTransportDeliveryException($alert_data, $res->status(), $res->body(), 
+        throw new AlertTransportDeliveryException($alert_data, $res->status(), $res->body(),
             $alert_data['msg'], $data);
     }
 

--- a/LibreNMS/Alert/Transport/Glpi.php
+++ b/LibreNMS/Alert/Transport/Glpi.php
@@ -175,23 +175,12 @@ class Glpi extends Transport
                     ->post($this->config['api-url'] . '/Item_Ticket', $data);
             }
         } else {
-            // Update the status if resolved
             $ticketID = $res->json()['data'][0]['2'];
-            $res = Http::client()
+            
+            // Update the status if resolved
+            $ticketData = Http::client()
                 ->withHeaders($headers)
-                ->get($this->config['api-url'] . '/Ticket/$ticketID');
-
-            if ($res->json()['status'] == 5) {
-                $data = [
-                    'input' => [
-                        'status' => 2,
-                    ],
-                ];
-
-                $res = Http::client()
-                    ->withHeaders($headers)
-                    ->patch($this->config['api-url'] . '/Ticket/$ticketID', $data);
-            }
+                ->get($this->config['api-url'] . '/Ticket/' . $ticketID);
 
             // Add followup to ticket
             $data = [
@@ -207,6 +196,23 @@ class Glpi extends Transport
             $res = Http::client()
                 ->withHeaders($headers)
                 ->post($followupURL, $data);
+
+            if ($ticketData->json()['status'] == 5) {
+                // Reopen the ticket if it was resolved or close it if the device recovered
+                $data = [
+                    'input' => [
+                        'status' => 2,
+                    ],
+                ];
+
+                if ($alert_data['state'] == 0) {
+                    $data['input']['status'] = 6;
+                }
+
+                $res = Http::client()
+                    ->withHeaders($headers)
+                    ->patch($this->config['api-url'] . '/Ticket/' . $ticketID, $data);
+            }
         }
 
         if ($res->successful()) {

--- a/LibreNMS/Alert/Transport/Glpi.php
+++ b/LibreNMS/Alert/Transport/Glpi.php
@@ -59,7 +59,7 @@ class Glpi extends Transport
         $profiles = Http::client()
             ->withHeaders($headers)
             ->get($this->config['api-url'] . '/getMyProfiles');
-        
+
         foreach ($profiles['myprofiles'] as $profile) {
             if (str_contains($profile['name'], 'super-admin')) {
                 $profile = $profile['id'];
@@ -84,14 +84,14 @@ class Glpi extends Transport
         // Retrieve the ticket for the alert (by title)
         $ticketURL = $this->config['api-url'] . '/Ticket';
         $searchURL = $this->config['api-url'] .
-            '/search/Ticket?'.
-            'forcedisplay[0]=2&'.
-            'criteria[0][field]=1&'.
-            'criteria[0][searchtype]=contains&'.
-            'criteria[0][value]=^[LibreNMS: ' . $alert_data['sysName'] . '] ' . $alert_data['name'] . '$&'.
-            'criteria[1][link]=AND&'.
-            'criteria[1][field]=12&'.
-            'criteria[1][searchtype]=equals&'.
+            '/search/Ticket?' .
+            'forcedisplay[0]=2&' .
+            'criteria[0][field]=1&' .
+            'criteria[0][searchtype]=contains&' .
+            'criteria[0][value]=^[LibreNMS: ' . $alert_data['sysName'] . '] ' . $alert_data['name'] . '$&' .
+            'criteria[1][link]=AND&' .
+            'criteria[1][field]=12&' .
+            'criteria[1][searchtype]=equals&' .
             'criteria[1][value]=notclosed';
 
         $res = Http::client()
@@ -103,11 +103,11 @@ class Glpi extends Transport
 
             // Retrieve the device in GLPI
             $deviceSearchURL = $this->config['api-url'] .
-                '/search/Computer?'.
-                'forcedisplay[0]=2&'.
-                'forcedisplay[1]=80&'.
-                'criteria[0][field]=1&'.
-                'criteria[0][searchtype]=contains&'.
+                '/search/Computer?' .
+                'forcedisplay[0]=2&' .
+                'forcedisplay[1]=80&' .
+                'criteria[0][field]=1&' .
+                'criteria[0][searchtype]=contains&' .
                 'criteria[0][value]=^' . $alert_data['sysName'] . '$';
 
             $res = Http::client()
@@ -121,10 +121,10 @@ class Glpi extends Transport
             $entityID = null;
             if ($entityName != null) {
                 $entitySearchURL = $this->config['api-url'].
-                    '/search/Entity?'.
-                    'forcedisplay[0]=2&'.
-                    'criteria[0][field]=1&'.
-                    'criteria[0][searchtype]=contains&'.
+                    '/search/Entity?' .
+                    'forcedisplay[0]=2&' .
+                    'criteria[0][field]=1&' .
+                    'criteria[0][searchtype]=contains&' .
                     'criteria[0][value]=^' . $entityName . '$';
 
                 $res = Http::client()
@@ -147,7 +147,7 @@ class Glpi extends Transport
                     'name' => '[LibreNMS: ' . $alert_data['sysName'] . '] ' . $alert_data['name'],
                     'content' => $alert_data['msg'],
                     '_users_id_requester' => $userID,
-                ]
+                ],
             ];
 
             if ($entityID != null) {
@@ -167,7 +167,7 @@ class Glpi extends Transport
                         'items_id' => $deviceID,
                         'itemtype' => 'Computer',
                         'tickets_id' => $ticketID,
-                    ]
+                    ],
                 ];
 
                 $res = Http::client()
@@ -186,7 +186,7 @@ class Glpi extends Transport
                 $data = [
                     'input' => [
                         'status' => 2,
-                    ]
+                    ],
                 ];
 
                 $res = Http::client()
@@ -200,7 +200,7 @@ class Glpi extends Transport
                     'content' => $alert_data['msg'],
                     'itemtype' => 'Ticket',
                     'items_id' => $ticketID,
-                ]
+                ],
             ];
 
             $followupURL = $this->config['api-url'] . '/ITILFollowup';

--- a/doc/Alerting/Transports/GLPI.md
+++ b/doc/Alerting/Transports/GLPI.md
@@ -1,0 +1,21 @@
+## GLPI
+
+The GLPI transport creates a ticket in GLPI whenever an alert is raised.
+
+ - For each alert type on a device, a ticket is created.
+ - If multiple alerts of the same type are raised, follow-ups are added to the existing ticket.
+ - If the existing ticket is closed, it will create another ticket.
+
+The user identified by the user token will be set as the creator and the requester of the ticket. If a device with the same name exists in GLPI, it will be linked to the ticket.
+
+To set it up:
+ - **User token**: Go to User preferences > API in GLPI.
+ - **App token**: Go to Configuration > General > API in GLPI.
+
+**Example:**
+
+| Config | Example |
+| ------ | ------- |
+| GLPI API URL | <http://localhost/glpi/apirest.php> |
+| User Token | A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8S9t0 |
+| App Token | Z9y8X7w6V5u4T3s2R1q0P9o8N7m6L5k4J3i2H1g |


### PR DESCRIPTION
Addition of a GLPI Alert Transport

A ticket will be created for each alert with the title "[LibreNMS: sysName] alert-name"
If the ticket already exists for the alert, it will add followups on the same ticket
The ticket will be linked to the device and its entity in GLPI by sysName

The required field for the transport are:
- The API URL
- The user token for the user that will connect to the api (the ticket will be shown as created by the user)
- The app token to connect to the API (Configuration > General > API in GLPI)

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
