### PR TITLE
Add Device page default to preferred SNMP settings

### DIFF
--- a/includes/html/pages/addhost.inc.php
+++ b/includes/html/pages/addhost.inc.php
@@ -149,7 +149,7 @@ $pagetitle[] = 'Add host';
             <select name="snmpver" id="snmpver" class="form-control input-sm" onChange="changeForm();">
                 <?php
                 $snmpver_list = [ "v1", "v2c", "v3" ];
-                $snmpver_pref = Config::get('snmp.version.0');
+                $snmpver_pref = Config::get('snmp.version.0', 'v2c');
                 foreach ($snmpver_list as $snmpver_item) {
                     $selected = '';
                     $snmpver_item == $snmpver_pref ? $selected = 'selected' : '';
@@ -159,12 +159,13 @@ $pagetitle[] = 'Add host';
 	    </select>
           </div>
           <div class="col-sm-3">
-            <input type="text" name="port" placeholder="port" class="form-control input-sm" value="<?php echo Config::get('snmp.port') ?>">
+            <input type="text" name="port" placeholder="port" class="form-control input-sm" value="<?php echo Config::get('snmp.port', 161) ?>">
           </div>
           <div class="col-sm-3">
             <select name="transport" id="transport" class="form-control input-sm">
 <?php
-foreach (Config::get('snmp.transports') as $transport) {
+var_dump(Config::get('snmp.transports', ['udp']));
+foreach (Config::get('snmp.transports', 'udp') as $transport) {
     $selected = '';
     Config::get('snmp.transports')[0] == $transport ? $selected = 'selected' : ''; 
     echo "<option value='" . $transport . $selected . "'>" . $transport . '</option>';
@@ -217,7 +218,7 @@ foreach (PortAssociationMode::getModes() as $mode) {
               <select name="authlevel" id="authlevel" class="form-control input-sm">
                   <?php
                   $authlevel_list = [ "noAuthNoPriv", "authNoPriv", "authPriv" ];
-                  $authlevel_pref = Config::get('snmp.v3.0.authlevel');
+                  $authlevel_pref = Config::get('snmp.v3.0.authlevel', 'noAuthNoPriv');
                   foreach ($authlevel_list as $authlevel_item) {
                       $selected = '';
                       $authlevel_item == $authlevel_pref ? $selected = 'selected' : '';

--- a/includes/html/pages/addhost.inc.php
+++ b/includes/html/pages/addhost.inc.php
@@ -147,19 +147,27 @@ $pagetitle[] = 'Add host';
           <label for="snmpver" class="col-sm-3 control-label">SNMP Version</label>
           <div class="col-sm-3">
             <select name="snmpver" id="snmpver" class="form-control input-sm" onChange="changeForm();">
-              <option value="v1">v1</option>
-              <option value="v2c" <?php echo (Config::get('snmp.version')[0] == 'v2c' ? 'selected' : '') ?> >v2c</option>
-              <option value="v3" <?php echo (Config::get('snmp.version')[0] == 'v3' ? 'selected' : '') ?> >v3</option>
-            </select>
+                <?php
+                $snmpver_list = [ "v1", "v2c", "v3" ];
+                $snmpver_pref = Config::get('snmp.version.0');
+                foreach ($snmpver_list as $snmpver_item) {
+                    $selected = '';
+                    $snmpver_item == $snmpver_pref ? $selected = 'selected' : '';
+                    echo "<option value=\"" . $snmpver_item ."\"" . $selected . ">" . $snmpver_item. "</option>";
+                }
+                ?>
+	    </select>
           </div>
           <div class="col-sm-3">
-            <input type="text" name="port" placeholder="port" class="form-control input-sm">
+            <input type="text" name="port" placeholder="port" class="form-control input-sm" value="<?php echo Config::get('snmp.port') ?>">
           </div>
           <div class="col-sm-3">
             <select name="transport" id="transport" class="form-control input-sm">
 <?php
 foreach (Config::get('snmp.transports') as $transport) {
-    echo "<option value='" . $transport . "'>" . $transport . '</option>';
+    $selected = '';
+    Config::get('snmp.transports')[0] == $transport ? $selected = 'selected' : ''; 
+    echo "<option value='" . $transport . $selected . "'>" . $transport . '</option>';
 }
 ?>
             </select>
@@ -193,7 +201,7 @@ foreach (PortAssociationMode::getModes() as $mode) {
           <div class="form-group">
             <label for="community" class="col-sm-3 control-label">Community</label>
             <div class="col-sm-9">
-              <input type="text" name="community" id="community" placeholder="Community" class="form-control input-sm">
+              <input type="text" name="community" id="community" placeholder="Community" class="form-control input-sm" value="<?php echo Config::get('snmp.community.0') ?>">
             </div>
           </div>
         </div>
@@ -207,22 +215,28 @@ foreach (PortAssociationMode::getModes() as $mode) {
             <label for="authlevel" class="col-sm-3 control-label">Auth Level</label>
             <div class="col-sm-3">
               <select name="authlevel" id="authlevel" class="form-control input-sm">
-                <option value="noAuthNoPriv" selected>noAuthNoPriv</option>
-                <option value="authNoPriv">authNoPriv</option>
-                <option value="authPriv">authPriv</option>
+                  <?php
+                  $authlevel_list = [ "noAuthNoPriv", "authNoPriv", "authPriv" ];
+                  $authlevel_pref = Config::get('snmp.v3.0.authlevel');
+                  foreach ($authlevel_list as $authlevel_item) {
+                      $selected = '';
+                      $authlevel_item == $authlevel_pref ? $selected = 'selected' : '';
+                      echo "<option value=\"" . $authlevel_item. "\" " . $selected . ">" . $authlevel_item. "</option>";
+                  }
+                  ?>
               </select>
             </div>
           </div>
           <div class="form-group">
             <label for="authname" class="col-sm-3 control-label">Auth User Name</label>
             <div class="col-sm-9">
-              <input type="text" name="authname" id="authname" class="form-control input-sm" autocomplete="off">
+              <input type="text" name="authname" id="authname" class="form-control input-sm" autocomplete="off" value="<?php echo Config::get('snmp.v3.0.authname') ?>">
             </div>
           </div>
           <div class="form-group">
             <label for="authpass" class="col-sm-3 control-label">Auth Password</label>
             <div class="col-sm-9">
-              <input type="text" name="authpass" id="authpass" placeholder="AuthPass" class="form-control input-sm" autocomplete="off">
+              <input type="text" name="authpass" id="authpass" placeholder="AuthPass" class="form-control input-sm" autocomplete="off" value="<?php echo Config::get('snmp.v3.0.authpass') ?>">
             </div>
           </div>
           <div class="form-group">
@@ -230,8 +244,11 @@ foreach (PortAssociationMode::getModes() as $mode) {
             <div class="col-sm-9">
               <select name="authalgo" id="authalgo" class="form-control input-sm">
                   <?php
+                  $algo_pref = Config::get('snmp.v3.0.authalgo');
                   foreach (\LibreNMS\SNMPCapabilities::authAlgorithms() as $algo => $enabled) {
-                      echo "<option value=\"$algo\"" . ($enabled ?: ' disabled') . ">$algo</option>";
+                      $selected = '';
+                      $algo == $algo_pref ? $selected = 'selected' : '';
+                      echo "<option value=\"$algo\"" . ($enabled ? '' : ' disabled') . " " . $selected . ">$algo</option>";
                   }
                   ?>
               </select>
@@ -243,7 +260,7 @@ foreach (PortAssociationMode::getModes() as $mode) {
           <div class="form-group">
             <label for="cryptopass" class="col-sm-3 control-label">Crypto Password</label>
             <div class="col-sm-9">
-              <input type="text" name="cryptopass" id="cryptopass" placeholder="Crypto Password" class="form-control input-sm" autocomplete="off">
+              <input type="text" name="cryptopass" id="cryptopass" placeholder="Crypto Password" class="form-control input-sm" autocomplete="off" value="<?php echo Config::get('snmp.v3.0.cryptopass') ?>">
             </div>
           </div>
           <div class="form-group">
@@ -251,8 +268,11 @@ foreach (PortAssociationMode::getModes() as $mode) {
             <div class="col-sm-9">
               <select name="cryptoalgo" id="cryptoalgo" class="form-control input-sm">
                   <?php
+                  $algo_pref = Config::get('snmp.v3.0.cryptoalgo');
                   foreach (\LibreNMS\SNMPCapabilities::cryptoAlgoritms() as $algo => $enabled) {
-                      echo "<option value=\"$algo\"" . ($enabled ?: ' disabled') . ">$algo</option>";
+                      $selected = '';
+                      $algo == $algo_pref ? $selected = 'selected' : '';
+                      echo "<option value=\"$algo\"" . ($enabled ? '' : ' disabled') . " ". $selected . ">$algo</option>";
                   }
                   ?>
               </select>

--- a/includes/html/pages/addhost.inc.php
+++ b/includes/html/pages/addhost.inc.php
@@ -148,8 +148,8 @@ $pagetitle[] = 'Add host';
           <div class="col-sm-3">
             <select name="snmpver" id="snmpver" class="form-control input-sm" onChange="changeForm();">
               <option value="v1">v1</option>
-              <option value="v2c" selected>v2c</option>
-              <option value="v3">v3</option>
+              <option value="v2c" <?php echo (Config::get('snmp.version')[0] == 'v2c' ? 'selected' : '') ?> >v2c</option>
+              <option value="v3" <?php echo (Config::get('snmp.version')[0] == 'v3' ? 'selected' : '') ?> >v3</option>
             </select>
           </div>
           <div class="col-sm-3">
@@ -365,6 +365,8 @@ if (Config::get('distributed_poller') === true) {
 
     $("[name='snmp']").bootstrapSwitch('offColor','danger');
     $("[name='force_add']").bootstrapSwitch();
+
+    $(document).ready(function loadPage() { changeForm(); });
 <?php
 if (! $snmp_enabled) {
     echo '  $("[name=\'snmp\']").trigger(\'click\');';


### PR DESCRIPTION
https://github.com/librenms/librenms/issues/17111

Set the default on the Add Device (addhost) page to the global preferred SNMP version.

As suggested, have then pulled in the preferences from global config options under Poller -> SNMP, taking the first array result and pre-populating.

eg this:

![image](https://github.com/user-attachments/assets/a44c5563-ae00-400f-bd37-6bfe51530b0c)

![image](https://github.com/user-attachments/assets/16dfd7dc-814b-4e7b-aa27-ce2e8d39aa04)

Produces this when adding a device on first page load:

![image](https://github.com/user-attachments/assets/b503c991-ab14-4007-9d73-54cdd15ac469)


Have tested device creations across v2 and the 3 x v3 auth options and checks out my side - it's the next best thing to letting lnms device:add attempt them all for you.




DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
