### PR TITLE
Change access_points->interference from tinyint to int fixes 'Numeric value out of range' for ArubaOS8 Wireless Controllers

### DIFF
--- a/database/migrations/2025_02_12_174229_change_access_points_interference_tinyint_to_smallint.php
+++ b/database/migrations/2025_02_12_174229_change_access_points_interference_tinyint_to_smallint.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('access_points', function (Blueprint $table) {
+            $table->smallInteger('interference')->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('access_points', function (Blueprint $table) {
+            $table->tinyInteger('interference')->change();
+        });
+    }
+};

--- a/database/migrations/2025_02_12_174229_change_access_points_interference_tinyint_to_smallint.php
+++ b/database/migrations/2025_02_12_174229_change_access_points_interference_tinyint_to_smallint.php
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('access_points', function (Blueprint $table) {
-            $table->smallInteger('interference')->change();
+            $table->unsignedSmallInteger('interference')->change();
         });
     }
 
@@ -22,7 +22,7 @@ return new class extends Migration
     public function down(): void
     {
         Schema::table('access_points', function (Blueprint $table) {
-            $table->tinyInteger('interference')->change();
+            $table->unsignedTinyInteger('interference')->change();
         });
     }
 };

--- a/database/migrations/2025_02_12_174229_change_access_points_interference_tinyint_to_smallint.php
+++ b/database/migrations/2025_02_12_174229_change_access_points_interference_tinyint_to_smallint.php
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('access_points', function (Blueprint $table) {
-            $table->unsignedSmallInteger('interference')->change();
+            $table->unsignedInteger('interference')->change();
         });
     }
 

--- a/database/schema/mysql-schema.sql
+++ b/database/schema/mysql-schema.sql
@@ -45,7 +45,7 @@ CREATE TABLE `access_points` (
   `nummonclients` smallint(6) NOT NULL DEFAULT 0,
   `numactbssid` tinyint(4) NOT NULL DEFAULT 0,
   `nummonbssid` tinyint(4) NOT NULL DEFAULT 0,
-  `interference` tinyint(3) unsigned NOT NULL,
+  `interference` smallint(6) unsigned NOT NULL,
   PRIMARY KEY (`accesspoint_id`),
   KEY `name` (`name`,`radio_number`),
   KEY `access_points_deleted_index` (`deleted`)

--- a/database/schema/mysql-schema.sql
+++ b/database/schema/mysql-schema.sql
@@ -45,7 +45,7 @@ CREATE TABLE `access_points` (
   `nummonclients` smallint(6) NOT NULL DEFAULT 0,
   `numactbssid` tinyint(4) NOT NULL DEFAULT 0,
   `nummonbssid` tinyint(4) NOT NULL DEFAULT 0,
-  `interference` smallint(6) unsigned NOT NULL,
+  `interference` tinyint(3) unsigned NOT NULL,
   PRIMARY KEY (`accesspoint_id`),
   KEY `name` (`name`,`radio_number`),
   KEY `access_points_deleted_index` (`deleted`)

--- a/misc/db_schema.yaml
+++ b/misc/db_schema.yaml
@@ -29,7 +29,7 @@ access_points:
     - { Field: nummonclients, Type: smallint, 'Null': false, Extra: '', Default: '0' }
     - { Field: numactbssid, Type: tinyint, 'Null': false, Extra: '', Default: '0' }
     - { Field: nummonbssid, Type: int, 'Null': false, Extra: '', Default: '0' }
-    - { Field: interference, Type: 'smallint unsigned', 'Null': false, Extra: '' }
+    - { Field: interference, Type: 'int unsigned', 'Null': false, Extra: '' }
   Indexes:
     PRIMARY: { Name: PRIMARY, Columns: [accesspoint_id], Unique: true, Type: BTREE }
     access_points_deleted_index: { Name: access_points_deleted_index, Columns: [deleted], Unique: false, Type: BTREE }

--- a/misc/db_schema.yaml
+++ b/misc/db_schema.yaml
@@ -29,7 +29,7 @@ access_points:
     - { Field: nummonclients, Type: smallint, 'Null': false, Extra: '', Default: '0' }
     - { Field: numactbssid, Type: tinyint, 'Null': false, Extra: '', Default: '0' }
     - { Field: nummonbssid, Type: int, 'Null': false, Extra: '', Default: '0' }
-    - { Field: interference, Type: 'tinyint unsigned', 'Null': false, Extra: '' }
+    - { Field: interference, Type: 'smallint unsigned', 'Null': false, Extra: '' }
   Indexes:
     PRIMARY: { Name: PRIMARY, Columns: [accesspoint_id], Unique: true, Type: BTREE }
     access_points_deleted_index: { Name: access_points_deleted_index, Columns: [deleted], Unique: false, Type: BTREE }


### PR DESCRIPTION
The column 'interference tinyint(3)' is not enough for aruba wireless controllers. Changed it to smallint(6) fixes the issue.

Also updated misc/db_schema.yaml to reflect the changes.

I've read the guidelines but couldn't find a lot of info regarding database migrations but I think I did it the right way :)

``
[2025-02-12T17:51:10][ERROR] SQLSTATE[22003]: Numeric value out of range: 1264 Out of range value for column 'interference' at row 1 (Connection: mysql, SQL: insert into `access_points` (`name`, `radio_number`, `type`, `mac_addr`, `channel`, `txpow`, `radioutil`, `numasoclients`, `nummonclients`, `numactbssid`, `nummonbssid`, `interference`, `device_id`) values (name, 2, dot11g, xx:xx:xx:xx:xx:xx, 1, 12, 16, 0, 25, 3, 253, 602, 12)) {"exception":"[object] (Illuminate\\Database\\QueryException(code: 22003): SQLSTATE[22003]: Numeric value out of range: 1264 Out of range value for column 'interference' at row 1 (Connection: mysql, SQL: insert into `access_points` (`name`, `radio_number`, `type`, `mac_addr`, `channel`, `txpow`, `radioutil`, `numasoclients`, `nummonclients`, `numactbssid`, `nummonbssid`, `interference`, `device_id`) values (name, 2, dot11g, xx:xx:xx:xx:xx:xx, 1, 12, 16, 0, 25, 3, 253, 602, 12)) at /opt/librenms/vendor/laravel/framework/src/Illuminate/Database/Connection.php:829)
[previous exception] [object] (PDOException(code: 22003): SQLSTATE[22003]: Numeric value out of range: 1264 Out of range value for column 'interference' at row 1 at /opt/librenms/vendor/laravel/framework/src/Illuminate/Database/MySqlConnection.php:45)"}
[2025-02-12T17:51:10][ALERT] INFO: device:poll x.x.x.x (13) polled in 7.677s
[2025-02-12T17:51:10][ERROR] %rError polling aruba-controller module for x.x.x.x.%n PDOException: SQLSTATE[22003]: Numeric value out of range: 1264 Out of range value for column 'interference' at row 1 in /opt/librenms/vendor/laravel/framework/src/Illuminate/Database/MySqlConnection.php:45
``


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
