### PR TITLE
Fix wlanAPChInterferenceIndex formula. Fixes Numeric value out of range: 1264 Out of range value for column 'interference'

### DIFF
--- a/includes/polling/aruba-controller.inc.php
+++ b/includes/polling/aruba-controller.inc.php
@@ -48,7 +48,7 @@ if ($device['type'] == 'wireless' && $device['os'] == 'arubaos') {
                 'nummonclients' => $data['WLSX-WLAN-MIB::wlanAPRadioNumMonitoredClients'] ?? null,
                 'numactbssid' => $data['WLSX-WLAN-MIB::wlanAPRadioNumActiveBSSIDs'] ?? null,
                 'nummonbssid' => $data['WLSX-WLAN-MIB::wlanAPRadioNumMonitoredBSSIDs'] ?? null,
-                'interference' => $data['WLSX-WLAN-MIB::wlanAPChInterferenceIndex'] ?? null,
+                'interference' => (($data['WLSX-WLAN-MIB::wlanAPChInterferenceIndex'] / 60000) * 100) ?? null,
             ]);
 
             Log::debug(<<<DEBUG


### PR DESCRIPTION
I get quite a lot of `Numeric value out of range: 1264 Out of range value for column 'interference'` errors. It seems the data from wlanAPChInterferenceIndex  is not a percentage which is expected by librenms for access_points->interference.

I've used the Aruba mobilitycontroller to figure out how the values are used. The webui uses 0-60000 for a piechart which uses data from execUiQuery.xml.

execUiQuery.xml contains xml data with channel/radio performance info
`
          <value>162,673,525,58640</value>
          <value>673/60000</value>
          <value>162/60000</value>
          <value>525/60000</value>
          <value>58640/60000</value>
`
These data's match the ui's piechart for tx, rx, interference and unused. With some manual comparisons in the webif the values of interference seems to checkout with the percentages in the piecharts.

a reference was found in dashboard.min.js
'channel_interference': genRatio(60000),

The error that appear in the poller log.

`[2025-02-12T17:51:10][ERROR] SQLSTATE[22003]: Numeric value out of range: 1264 Out of range value for column 'interference' at row 1 (Connection: mysql, SQL: insert into `access_points` (`name`, `radio_number`, `type`, `mac_addr`, `channel`, `txpow`, `radioutil`, `numasoclients`, `nummonclients`, `numactbssid`, `nummonbssid`, `interference`, `device_id`) values (name, 2, dot11g, xx:xx:xx:xx:xx:xx, 1, 12, 16, 0, 25, 3, 253, 602, 12)) {"exception":"[object] (Illuminate\\Database\\QueryException(code: 22003): SQLSTATE[22003]: Numeric value out of range: 1264 Out of range value for column 'interference' at row 1 (Connection: mysql, SQL: insert into `access_points` (`name`, `radio_number`, `type`, `mac_addr`, `channel`, `txpow`, `radioutil`, `numasoclients`, `nummonclients`, `numactbssid`, `nummonbssid`, `interference`, `device_id`) values (name, 2, dot11g, xx:xx:xx:xx:xx:xx, 1, 12, 16, 0, 25, 3, 253, 602, 12)) at /opt/librenms/vendor/laravel/framework/src/Illuminate/Database/Connection.php:829) [previous exception] [object] (PDOException(code: 22003): SQLSTATE[22003]: Numeric value out of range: 1264 Out of range value for column 'interference' at row 1 at /opt/librenms/vendor/laravel/framework/src/Illuminate/Database/MySqlConnection.php:45)"} [2025-02-12T17:51:10][ALERT] INFO: device:poll x.x.x.x (13) polled in 7.677s [2025-02-12T17:51:10][ERROR] %rError polling aruba-controller module for x.x.x.x.%n PDOException: SQLSTATE[22003]: Numeric value out of range: 1264 Out of range value for column 'interference' at row 1 in /opt/librenms/vendor/laravel/framework/src/Illuminate/Database/MySqlConnection.php:45`

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
