### PR TITLE
Fix 'page' selection for the ARP Search page. $page wasn't supplied to pagination.

### DIFF
--- a/includes/html/table/arp-search.inc.php
+++ b/includes/html/table/arp-search.inc.php
@@ -53,7 +53,7 @@ if (isset($vars['searchPhrase']) && ! empty($vars['searchPhrase'])) {
     }
 }
 
-$pag = $query->paginate($rowCount);
+$pag = $query->paginate($rowCount, page: $page);
 
 foreach ($pag->items() as $arp) {
     if ($arp->port->ifInErrors_delta > 0 || $arp->port->ifOutErrors_delta > 0) {


### PR DESCRIPTION
Changing a page on the ARP Tables page always results in the first 50/100/250 rows. It seems $page was not passed on to paginate()

This PR fixes that.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
