### PR TITLE
Fix alert history table verbose detail display

### DIFF
--- a/includes/html/common/alert-log.inc.php
+++ b/includes/html/common/alert-log.inc.php
@@ -172,7 +172,7 @@ $common_output[] = '<div class="form-group"> \
             $(target).collapse(\'toggle\');
             $(this).toggleClass(\'fa-plus fa-minus\');
         });
-        grid.find(".command-alert-details").on("click", function(e) {
+        grid.find(".verbose-alert-details").on("click", function(e) {
             e.preventDefault();
             var alert_log_id = $(this).data(\'alert_log_id\');
             $(\'#alert_log_id\').val(alert_log_id);
@@ -180,6 +180,9 @@ $common_output[] = '<div class="form-group"> \
         });
         grid.find(".incident").each(function () {
             $(this).parent().addClass(\'col-lg-4 col-md-4 col-sm-4 col-xs-4\');
+            if ($(this).parent().parent().find(".alert-status").hasClass(\'label-danger\')){
+                $(this).parent().parent().find(".verbose-alert-details").fadeIn(0);
+            }
             $(this).parent().parent().on("mouseenter", function () {
                 $(this).find(".incident-toggle").fadeIn(200);
                 if ($(this).find(".alert-status").hasClass(\'label-danger\')){

--- a/includes/html/table/alertlog.inc.php
+++ b/includes/html/table/alertlog.inc.php
@@ -130,7 +130,7 @@ foreach (dbFetchRows($sql, $param) as $alertlog) {
         'id' => $rulei++,
         'time_logged' => $alertlog['humandate'],
         'details' => '<a class="fa fa-plus incident-toggle" style="display:none" data-toggle="collapse" data-target="#incident' . $rulei . '" data-parent="#alerts"></a>',
-        'verbose_details' => "<button type='button' class='btn btn-alert-details command-alert-details' style='display:none' aria-label='Details' id='alert-details' data-alert_log_id='{$alert_log_id}'><i class='fa-solid fa-circle-info'></i></button>",
+        'verbose_details' => "<button type='button' class='btn btn-alert-details verbose-alert-details' style='display:none' aria-label='Details' id='alert-details' data-alert_log_id='{$alert_log_id}'><i class='fa-solid fa-circle-info'></i></button>",
         'hostname' => '<div class="incident">' . generate_device_link($dev) . '<div id="incident' . $rulei . '" class="collapse">' . $fault_detail . '</div></div>',
         'alert' => htmlspecialchars($alertlog['alert']),
         'status' => "<i class='alert-status " . $status . "' title='" . ($alert_state ? 'active' : 'recovered') . "'></i>",


### PR DESCRIPTION
Discord discussion pointed out the inconsistencies and fancy fadein/out confusion of the icon in the details column in the alerts history table.  It never shows for restore, and is hidden until mousein otherwise.

This change nukes the fancy so it behaves like the Details column on the main Notifications table and always displays.

Maybe not the ideal way to do it, and maybe the fade things were planned for something else?

![image](https://github.com/user-attachments/assets/35a68d2d-45cd-4a0f-b5ed-2e44bbdf2413)

Couple of style fixes (sql line and some comment) came for free from local lnms dev:check

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
