### PR TITLE
Adding support for new Meraki CW

### DIFF
--- a/includes/definitions/merakicw.yaml
+++ b/includes/definitions/merakicw.yaml
@@ -1,0 +1,12 @@
+os: merakimr
+text: 'Meraki AP'
+type: wireless
+icon: meraki
+ifname: true
+over:
+    - { graph: device_bits, text: 'Device Traffic' }
+bad_uptime: true
+discovery:
+    -
+        sysDescr_regex:
+            - '/^=?Meraki CW/'


### PR DESCRIPTION
Support the latest Meraki CW APs so they are not detected as generic device.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
