### PR TITLE
Exclude irrelevant server state from Panorama servers

### DIFF
--- a/includes/definitions/discovery/panos.yaml
+++ b/includes/definitions/discovery/panos.yaml
@@ -87,6 +87,11 @@ modules:
                     states:
                         - { value: 0, generic: 1, graph: 1, descr: Not-Connected }
                         - { value: 1, generic: 0, graph: 1, descr: Connected }
+                    skip_values:
+                        -
+                          device: hardware
+                          op: '='
+                          value: 'Panorama'
                 -
                     oid: panMgmtPanorama2Connected
                     num_oid: '.1.3.6.1.4.1.25461.2.1.2.4.2.{{ $index }}'
@@ -96,6 +101,11 @@ modules:
                     states:
                         - { value: 0, generic: 1, graph: 1, descr: Not-Connected }
                         - { value: 1, generic: 0, graph: 1, descr: Connected }
+                    skip_values:
+                        -
+                          device: hardware
+                          op: '='
+                          value: 'Panorama'
         count:
             data:
                 -


### PR DESCRIPTION
My former addition https://github.com/librenms/librenms/pull/17119 lazily adds panorama connection status for panos - including panorama servers, which is irrelevant if the device is itself a Panorama server.

This skips state display if the device is a Panorama server.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
