### PR TITLE
Correct discovery for Panduit G5 series PDUs

### DIFF
--- a/includes/definitions/hpe-mapdu.yaml
+++ b/includes/definitions/hpe-mapdu.yaml
@@ -17,3 +17,5 @@ discovery:
         sysDescr:
             - P9S18A
             - Outlet Metered, Outlet Switched
+        sysObjectID_except:
+            - .1.3.6.1.4.1.19536 # Panduit

--- a/mibs/panduit/PANDUIT-MIB
+++ b/mibs/panduit/PANDUIT-MIB
@@ -1,5 +1,5 @@
 -- ****************************************************************************
---   Copyright(C) 2019 Panduit 
+--   Copyright(C) 2023 Panduit
 --   G5 PDU SNMP MIB DEFINITIONS
 -- ****************************************************************************
 
@@ -7,22 +7,21 @@
 PANDUIT-MIB DEFINITIONS ::= BEGIN
 
 IMPORTS
-    enterprises   FROM RFC1155-SMI
-    Counter       FROM RFC1155-SMI
-    DisplayString FROM RFC1213-MIB
-    ifIndex       FROM RFC1213-MIB
-    ifDescr       FROM RFC1213-MIB
-    sysName       FROM RFC1213-MIB
+    enterprises   FROM SNMPv2-SMI
+    DisplayString FROM SNMPv2-TC
+    IpAddress     FROM SNMPv2-SMI
+    Integer32     FROM SNMPv2-SMI
     sysDescr      FROM RFC1213-MIB
-    sysContact    FROM RFC1213-MIB
-    sysLocation   FROM RFC1213-MIB  
+    OBJECT-GROUP  FROM SNMPv2-CONF
     OBJECT-TYPE   FROM RFC-1212
-    NOTIFICATION-TYPE     FROM RFC-1215;
+    NOTIFICATION-GROUP    FROM SNMPv2-CONF
+    MODULE-COMPLIANCE     FROM SNMPv2-CONF
+    NOTIFICATION-TYPE     FROM SNMPv2-SMI
+    MODULE-IDENTITY       FROM SNMPv2-SMI;
 
-panduit                  OBJECT IDENTIFIER 	::= { enterprises 19536 }
 
 g5 MODULE-IDENTITY
-       LAST-UPDATED "201902021200Z"  -- 2 February 2019
+       LAST-UPDATED "202307241200Z"  -- 24 July 2023
        ORGANIZATION "Panduit"
        CONTACT-INFO "Panduit
 
@@ -33,22 +32,66 @@ g5 MODULE-IDENTITY
 
         Tel:        +1 708 532-1800/888-506-5400
 
-        E-mail:     techsupport@panduit.com"
+        E-mail:     systemsupport@panduit.com"
        DESCRIPTION
                "SmartZone G5 iPDU"
-       REVISION "201902021200Z"  -- 12 February 2019 
+
+       REVISION "202307241200Z"  -- 24 July 2023
+       DESCRIPTION 
+                "SNMPv3 Traps support for Ipv6 address"
+
+       REVISION "202306271200Z"  -- 27 June 2023
+       DESCRIPTION 
+                "Updated pdug5GroupCurrentThStatus to include CB_off status"
+
+       REVISION "202303131200Z"  -- 13 March 2023
+       DESCRIPTION
+                "Added 2 New OIDs to support Beacon control"
+
+       REVISION "202302131200Z"  -- 13 Feb 2023
+       DESCRIPTION
+                "Updated to fix description, misspellings and punctuation"
+
+       REVISION "202212151200Z"  -- 15 Dec 2022
+       DESCRIPTION
+                "Updated pdug5OutletType to include COMBO outlet type"
+
+       REVISION "202210171200Z"  -- 17 Oct 2022 
+       DESCRIPTION 
+                "Added new OID pdug5HWVersion" 
+
+       REVISION "202207121200Z"  -- 12 Jul 2022
+       DESCRIPTION
+                "Updated access type for group threshold OIDs and display string size limit for sensors"
+				
+       REVISION "202202041200Z"  -- 04 Feb 2022
+       DESCRIPTION
+                "Added Support for RCM Self-Test"
+
+       REVISION "202102021200Z"  -- 02 Feb 2021
+       DESCRIPTION
+                "Added Support for RCM"
+
+       REVISION "202006301200Z"  -- 30 June 2020
+       DESCRIPTION
+                "Added Support for Power Share and Enhanced access control support"
+
+       REVISION "202003301200Z"  -- 30 March 2020
+       DESCRIPTION
+                "Added new access hub OIDs and corrected the scale for temperature and humidity sensor"
+       REVISION "201902121200Z"  -- 12 February 2019
        DESCRIPTION
                 "Fix the index and access hub and added the Energy Thresholds"
        REVISION "201801121200Z"  -- 12 January 2018
        DESCRIPTION
                 "First Major Release"
-        ::= { panduit 10 }
+       ::= { panduit 10 }
 
 --
 -- pdug5 Monitored Managed PDU object identifiers
 --
-pdug5                     OBJECT IDENTIFIER       ::= {g5 1}  
-
+panduit                   OBJECT IDENTIFIER       ::= { enterprises 19536 }
+pdug5                     OBJECT IDENTIFIER       ::= { g5 1 }
 pdug5Ident                OBJECT IDENTIFIER       ::= { pdug5 1 }
 pdug5Input                OBJECT IDENTIFIER       ::= { pdug5 2 }
 pdug5Group                OBJECT IDENTIFIER       ::= { pdug5 3 }
@@ -56,1355 +99,1790 @@ pdug5Environment          OBJECT IDENTIFIER       ::= { pdug5 4 }
 pdug5Outlet               OBJECT IDENTIFIER       ::= { pdug5 5 }
 pdug5Traps                OBJECT IDENTIFIER       ::= { pdug5 6 }
 pdug5TrapInfo             OBJECT IDENTIFIER       ::= { pdug5 7 }
-
+pdug5Conformance          OBJECT IDENTIFIER       ::= { pdug5 8 }
 -- ====================================================================================
 -- ====================================================================================
 --             pdug5 - monitored and managed PDU line
 --             pdug5  (Panduit PDU) - Metered PDU - Switched PDU - Metered+Switched PDU
 -- ====================================================================================
---  
+--
 --  g5                        OBJECT IDENTIFIER       ::= { panduit 10}
---  pdug5                     OBJECT IDENTIFIER       ::= { g5 1}  
+--  pdug5                     OBJECT IDENTIFIER       ::= { g5 1}
 --  pdug5Ident                OBJECT IDENTIFIER       ::= { pdug5 1 }
 --  PDU identification group
 --  OID= .1.3.6.1.4.1.19536.10.1.1
 
 pdug5NumberPDU OBJECT-TYPE
-    SYNTAX INTEGER (1..4)
-    ACCESS read-only
-    STATUS mandatory
+    SYNTAX Integer32 (1..4)
+    MAX-ACCESS read-only
+    STATUS current
     DESCRIPTION
-	"The number of PDUs detected (in its daisy chain)."
+        "The number of PDUs detected (in its daisy chain)."
     ::= { pdug5Ident 1 }
-    
+
 -- ======= pdug5 Identification ===========
 
 pdug5IdentTable OBJECT-TYPE
-    SYNTAX SEQUENCE OF pdug5IdentEntry
-    ACCESS not-accessible
-    STATUS mandatory
-    DESCRIPTION "Aggregate Object with number of entries equal to pdug5NumberPDU ."
+    SYNTAX SEQUENCE OF Pdug5IdentEntry
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+        "Aggregate Object with number of entries equal to pdug5NumberPDU ."
     ::= { pdug5Ident 2 }
 
 pdug5IdentEntry OBJECT-TYPE
-    SYNTAX pdug5IdentEntry
-    ACCESS not-accessible
-    STATUS mandatory
-    DESCRIPTION "The Identity table entry containing the name, model, manufacturer, 
-                 firmware version, part number, etc."
+    SYNTAX Pdug5IdentEntry
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+        "The Identity table entry containing the name, model, manufacturer,
+         firmware version, part number, etc."
     INDEX { pdug5IdentIndex }
     ::= { pdug5IdentTable 1 }
 
-pdug5IdentEntry ::= SEQUENCE {
-      	pdug5IdentIndex         		INTEGER,
-      	pdug5Name               		DisplayString,
-      	pdug5Model              		DisplayString,
-      	pdug5Manufacturer       		DisplayString,
-      	pdug5FirmwareVersion    		DisplayString,
-		pdug5FirmwareVersionTimeStamp  	DisplayString,
-      	pdug5PartNumber         		DisplayString,
-      	pdug5SerialNumber       		DisplayString,
-      	pdug5Status             		INTEGER,
-      	pdug5Controllable       		INTEGER,
-      	pdug5InputPhaseCount			INTEGER,
-		pdug5GroupCount					INTEGER,
-        pdug5OutletCount	 			INTEGER,
-		pdug5MACAddress					DisplayString,
-		pdug5IPv4Address				DisplayString,
-		pdug5IPv6Address				DisplayString    
+Pdug5IdentEntry ::= SEQUENCE {
+        pdug5IdentIndex                         INTEGER,
+        pdug5Name                               DisplayString,
+        pdug5Model                              DisplayString,
+        pdug5Manufacturer                       DisplayString,
+        pdug5FirmwareVersion                    DisplayString,
+        pdug5FirmwareVersionTimeStamp           DisplayString,
+        pdug5PartNumber                         DisplayString,
+        pdug5SerialNumber                       DisplayString,
+        pdug5Status                             INTEGER,
+        pdug5Controllable                       INTEGER,
+        pdug5InputPhaseCount                    INTEGER,
+        pdug5GroupCount                         INTEGER,
+        pdug5OutletCount                        INTEGER,
+        pdug5MACAddress                         DisplayString,
+        pdug5IPv4Address                        IpAddress,
+        pdug5IPv6Address                        DisplayString,
+        pdug5HWVersion                          DisplayString
     }
 
 pdug5IdentIndex OBJECT-TYPE
-    SYNTAX INTEGER	(1..4)
-    ACCESS read-only
-    STATUS mandatory
+    SYNTAX Integer32 (1..6)
+    MAX-ACCESS not-accessible
+    STATUS current
     DESCRIPTION
-	"Index for the pdug5IdentEntry table."
+        "Index for the pdug5IdentEntry table."
     ::= { pdug5IdentEntry 1 }
 
 pdug5Name OBJECT-TYPE
     SYNTAX DisplayString (SIZE (0..63))
-    ACCESS read-write
-    STATUS mandatory
+    MAX-ACCESS read-write
+    STATUS current
     DESCRIPTION
-	"The string identify the device in daisy chain. Example PDU A."
+        "The string identify the device in daisy chain. Example PDU A."
     ::= { pdug5IdentEntry 2 }
 
 pdug5Model OBJECT-TYPE
     SYNTAX DisplayString (SIZE (0..63))
-    ACCESS read-only
-    STATUS mandatory
+    MAX-ACCESS read-only
+    STATUS current
     DESCRIPTION
-	"The Device Model."
+        "The Device Model."
     ::= { pdug5IdentEntry 3 }
 
 pdug5Manufacturer OBJECT-TYPE
     SYNTAX DisplayString (SIZE (0..63))
-    ACCESS read-only
-    STATUS mandatory
+    MAX-ACCESS read-only
+    STATUS current
     DESCRIPTION
-	"The Device Manufacturer Name."
+        "The Device Manufacturer Name."
     ::= { pdug5IdentEntry 4 }
 
 pdug5FirmwareVersion OBJECT-TYPE
     SYNTAX DisplayString (SIZE (0..63))
-    ACCESS read-only
-    STATUS mandatory
+    MAX-ACCESS read-only
+    STATUS current
     DESCRIPTION
-	"The firmware revision level of the device."
+        "The firmware revision level of the device."
     ::= { pdug5IdentEntry 5 }
 
-pdug5FirmwareVersionTimeStamp  OBJECT-TYPE
-	SYNTAX 	DisplayString
-	ACCESS  read-only
-	STATUS 	mandatory
-	DESCRIPTION 
-	   "Timestamp of when the PDU firmware was last updated"
-	::= { pdug5IdentEntry 6 }
+pdug5FirmwareVersionTimeStamp OBJECT-TYPE
+    SYNTAX DisplayString
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+       "Timestamp of when the PDU firmware was last updated"
+    ::= { pdug5IdentEntry 6 }
 
 pdug5PartNumber OBJECT-TYPE
     SYNTAX DisplayString (SIZE (0..63))
-    ACCESS read-only
-    STATUS mandatory
+    MAX-ACCESS read-only
+    STATUS current
     DESCRIPTION
-	"The device part number. Example P36E09M."
+        "The device part number. Example P36E09M."
     ::= { pdug5IdentEntry 7 }
 
 pdug5SerialNumber OBJECT-TYPE
     SYNTAX DisplayString (SIZE (0..63))
-    ACCESS read-only
-    STATUS mandatory
+    MAX-ACCESS read-only
+    STATUS current
     DESCRIPTION
-	"The device serial number, 10-digit."
+        "The device serial number, 10-digit."
     ::= { pdug5IdentEntry 8 }
 
 pdug5Status OBJECT-TYPE
-    SYNTAX  INTEGER
-    {
-      other(1),    
-      ok(2),
-      degraded(3),
-      failed(4)
-    }
-    ACCESS	read-only
-    STATUS	mandatory
+    SYNTAX INTEGER
+        {
+            other(1),
+            ok(2),
+            degraded(3),
+            failed(4)
+        }
+    MAX-ACCESS read-only
+    STATUS current
     DESCRIPTION
-    "The overall status of the device.  A value of OK(2) indicates the device is operating normally.
-    A value of degraded(3) indicates the device is operating with warning indicators.  A value of
-    failed(4) indicates the device is operating with critical indicators."
+        "The overall status of the device.  A value of OK(2) indicates the device is operating normally.
+         A value of degraded(3) indicates the device is operating with warning indicators.  A value of
+         failed(4) indicates the device is operating with critical indicators."
     ::= { pdug5IdentEntry 9 }
 
 pdug5Controllable OBJECT-TYPE
-    SYNTAX  INTEGER 
-    {
-      yes(1),
-      no(2)
-    }
-    ACCESS  read-only
-    STATUS  mandatory
+    SYNTAX INTEGER
+        {
+            yes(1),
+            no(2)
+        }
+    MAX-ACCESS read-only
+    STATUS current
     DESCRIPTION
-           "This object indicates whether or not the device is controllable."
+       "This object indicates whether or not the device is controllable."
     ::= { pdug5IdentEntry 10 }
 
-pdug5InputPhaseCount  OBJECT-TYPE
-    SYNTAX     INTEGER (1..3)
-    ACCESS     read-only
-    STATUS     mandatory
-    DESCRIPTION 
-     	"The number of input phase on this pdu 1 or 3."
+pdug5InputPhaseCount OBJECT-TYPE
+    SYNTAX Integer32 (1..3)
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "The number of input phase on this pdu 1 or 3."
     ::= { pdug5IdentEntry 11 }
 
-pdug5GroupCount  OBJECT-TYPE
-    SYNTAX     INTEGER (0..12)
-    ACCESS     read-only
-    STATUS     mandatory
-    DESCRIPTION 
-	"The number of groups (breakers) on this pdu."
+pdug5GroupCount OBJECT-TYPE
+    SYNTAX Integer32 (0..12)
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "The number of groups (breakers) on this pdu."
     ::= { pdug5IdentEntry 12 }
 
-pdug5OutletCount  OBJECT-TYPE
-    SYNTAX     INTEGER (1..48)
-    ACCESS     read-only
-    STATUS     mandatory
+pdug5OutletCount OBJECT-TYPE
+    SYNTAX Integer32 (1..48)
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "The number of outlets in this PDU."
+     ::= { pdug5IdentEntry 13 }
+
+pdug5MACAddress OBJECT-TYPE
+    SYNTAX DisplayString
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "The assigned MAC address for this PDU."
+    ::= { pdug5IdentEntry 14 }
+
+pdug5IPv4Address OBJECT-TYPE
+    SYNTAX IpAddress
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "The current IPv4 Address.
+         A value of 0.0.0.0 indicates an error or an unset option."
+    ::= { pdug5IdentEntry 15 }
+
+pdug5IPv6Address OBJECT-TYPE
+    SYNTAX DisplayString
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "The current IPv6 Address.
+         A value of 0.0.0.0.0.0 indicates an error or an unset option."
+    ::= { pdug5IdentEntry 16 }
+
+pdug5HWVersion OBJECT-TYPE 
+    SYNTAX DisplayString 
+    MAX-ACCESS read-only 
+    STATUS current 
     DESCRIPTION 
-	"The number of outlets in this PDU."
-         ::= { pdug5IdentEntry 13 }
-
-pdug5MACAddress	OBJECT-TYPE
-	SYNTAX		DisplayString
-	ACCESS		read-only
-	STATUS		mandatory
-	DESCRIPTION
-		"The assigned MAC address for this PDU."
-	::={ pdug5IdentEntry 14 }
-
-pdug5IPv4Address  OBJECT-TYPE
-	SYNTAX		IpAddress
-	ACCESS		read-only
-	STATUS 		mandatory
-	DESCRIPTION
-		"The current IPv4 Address. 
-		A value of 0.0.0.0 indicates an error or an unset option."
-	::={ pdug5IdentEntry 15 }
-
-pdug5IPv6Address  OBJECT-TYPE
-	SYNTAX		DisplayString
-	ACCESS   	read-only
-	STATUS		mandatory
-	DESCRIPTION
-		"The current IPv6 Address.
-		A vale of 0.0.0.0.0.0 indicates an error or an unset option."
-	::={ pdug5IdentEntry 16 }
-
--- ============ pdug5 Configuration ======= 
+        "The current Hardware Version. 
+         1.0  - G5 (STM) No Powershare, 
+         1.5  - G5 (STM) with Powershare,
+         2.0  - G6 Processor" 
+    ::= { pdug5IdentEntry 17 } 
+ 
+-- ============ pdug5 Configuration =======
 
 pdug5ConfigTable OBJECT-TYPE
-    SYNTAX SEQUENCE OF pdug5ConfigEntry
-    ACCESS not-accessible
-    STATUS mandatory
-    DESCRIPTION "Aggregate Object with number of entries equal to pdug5NumberPDU."
+    SYNTAX SEQUENCE OF Pdug5ConfigEntry
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+        "Aggregate Object with number of entries equal to pdug5NumberPDU."
     ::= { pdug5Ident 3 }
-	
-pdug5ConfigEntry	OBJECT-TYPE
-	SYNTAX pdug5ConfigEntry
-	ACCESS not-accessible
-	STATUS mandatory
-	DESCRIPTION	
-		"Read Configuration data from the PDU being queried."
-	INDEX {pdug5ConfigIndex}
-	::=	{pdug5ConfigTable 1}
-	
-pdug5ConfigEntry	::= SEQUENCE{
-		pdug5ConfigIndex				INTEGER,
-		pdug5ConfigSsh				INTEGER,
-		pdug5ConfigFtps				INTEGER,
-		pdug5ConfigHttp				INTEGER,
-		pdug5ConfigHttps				INTEGER,
-		pdug5ConfigIPv4IPv6Switch		INTEGER,
-		pdug5ConfigRedfishAPI			INTEGER,
-		pdug5ConfigOledDispalyOrientation	INTEGER,
-		pdug5ConfigEnergyReset			INTEGER,
-		pdug5ConfigNetworkManagementCardReset	INTEGER,
-		pdug5ConfigDaisyChainStatus		INTEGER
-		}
 
-pdug5ConfigIndex	OBJECT-TYPE
-		SYNTAX  INTEGER (1..4)
-		ACCESS  not-accessible
-		STATUS  mandatory
-		DESCRIPTION
-			"The index of PDU configuration entry."
-		::={pdug5ConfigEntry 1}
+pdug5ConfigEntry OBJECT-TYPE
+    SYNTAX Pdug5ConfigEntry
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+        "Read Configuration data from the PDU being queried."
+    INDEX {pdug5ConfigIndex}
+    ::= {pdug5ConfigTable 1}
 
-pdug5ConfigSsh	OBJECT-TYPE
-		SYNTAX	INTEGER{
-			off(0),
-			on(1)
-		}
-		ACCESS  read-write
-		STATUS	mandatory
-		DESCRIPTION
-			"Setting this OID to off(0) will disable the SSH conneciton.
-			 Setting this OID to on(1) will enable the SSH connection. iNC reboot will be required for the settings to take effect."
-		::={pdug5ConfigEntry 2}
-		
-pdug5ConfigFtps	OBJECT-TYPE
-		SYNTAX	INTEGER{
-			off(0),
-			on(1)
-		}
-		ACCESS	read-write
-		STATUS	mandatory
-		DESCRIPTION
-			"Setting this OID to off(0) will disable the FTPS connection.
-			 Setting this OID to on(1) will enable the FTPS connection. iNC reboot will be required for the settings to take effect"
-		::={pdug5ConfigEntry 3}
-		
-pdug5ConfigHttp	OBJECT-TYPE
-		SYNTAX	INTEGER{
-			off(0),
-			on(1)
-		}
-		ACCESS	read-write
-		STATUS	mandatory
-		DESCRIPTION
-			"Setting this OID to off(0) will disable the HTTP connection.
-			 Setting this OID to on(1) will enable the HTTP connection.iNC reboot will be required for the settings to take effect"
-		::={pdug5ConfigEntry 4}
+Pdug5ConfigEntry ::= SEQUENCE{
+        pdug5ConfigIndex                        INTEGER,
+        pdug5ConfigSsh                          INTEGER,
+        pdug5ConfigFtps                         INTEGER,
+        pdug5ConfigHttp                         INTEGER,
+        pdug5ConfigHttps                        INTEGER,
+        pdug5ConfigIPv4IPv6Switch               INTEGER,
+        pdug5ConfigRedfishAPI                   INTEGER,
+        pdug5ConfigOledDispalyOrientation       INTEGER,
+        pdug5ConfigEnergyReset                  INTEGER,
+        pdug5ConfigNetworkManagementCardReset   INTEGER,
+        pdug5ConfigDaisyChainStatus             INTEGER
+    }
 
-pdug5ConfigHttps	OBJECT-TYPE
-		SYNTAX	INTEGER{
-			off(0),
-			on(1)
-		}
-		ACCESS	read-write
-		STATUS	mandatory
-		DESCRIPTION
-			"Setting this OID to off(0) will disable the HTTPS connection.
-			 Setting this OID to on(1) will enable the HTTPS connection.iNC reboot will be required for the settings to take effect"
-		::={pdug5ConfigEntry 5}
+pdug5ConfigIndex OBJECT-TYPE
+    SYNTAX Integer32 (1..4)
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+        "The index of PDU configuration entry."
+    ::= {pdug5ConfigEntry 1}
 
-pdug5ConfigIPv4IPv6Switch	OBJECT-TYPE
-		SYNTAX	INTEGER{
-			iPv4(1),
-			iPv6(2),
-			iPv4IPv6(3)
-		}
-		ACCESS read-write
-		STATUS	mandatory
-		DESCRIPTION
-			"Setting this OID to IPv4(1) will enable the IPv4 configuration.
-			 Setting this OID to IPv6(2) will enable the IPv6 configuration.
-			 Setting this OID to IPv4&IPv6(3) will enable both IPv4 and IPv6 configuration.iNC reboot will be required for the settings to take effect"
-		::={pdug5ConfigEntry 6}		
-		
+pdug5ConfigSsh OBJECT-TYPE
+    SYNTAX INTEGER
+        {
+            off(0),
+            on(1)
+        }
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Setting this OID to off(0) will disable the SSH connection.
+         Setting this OID to on(1) will enable the SSH connection. iNC reboot will be required for the settings to take effect."
+    ::= {pdug5ConfigEntry 2}
+
+pdug5ConfigFtps OBJECT-TYPE
+    SYNTAX INTEGER
+        {
+            off(0),
+            on(1)
+        }
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Setting this OID to off(0) will disable the FTPS connection.
+         Setting this OID to on(1) will enable the FTPS connection. iNC reboot will be required for the settings to take effect"
+    ::= {pdug5ConfigEntry 3}
+
+pdug5ConfigHttp OBJECT-TYPE
+    SYNTAX INTEGER
+        {
+            off(0),
+            on(1)
+        }
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Setting this OID to off(0) will disable the HTTP connection.
+         Setting this OID to on(1) will enable the HTTP connection.iNC reboot will be required for the settings to take effect"
+    ::= {pdug5ConfigEntry 4}
+
+pdug5ConfigHttps OBJECT-TYPE
+    SYNTAX INTEGER
+        {
+            off(0),
+            on(1)
+        }
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Setting this OID to off(0) will disable the HTTPS connection.
+         Setting this OID to on(1) will enable the HTTPS connection.iNC reboot will be required for the settings to take effect"
+    ::= {pdug5ConfigEntry 5}
+
+pdug5ConfigIPv4IPv6Switch OBJECT-TYPE
+    SYNTAX INTEGER
+        {
+            iPv4(1),
+            iPv6(2),
+            iPv4IPv6(3)
+        }
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Setting this OID to IPv4(1) will enable the IPv4 configuration.
+         Setting this OID to IPv6(2) will enable the IPv6 configuration.
+         Setting this OID to IPv4&IPv6(3) will enable both IPv4 and IPv6 configuration.iNC reboot will be required for the settings to take effect"
+    ::= {pdug5ConfigEntry 6}
+
 pdug5ConfigRedfishAPI OBJECT-TYPE
-		SYNTAX  INTEGER{
-			off(0),
-			on(1)
-		}
-		ACCESS read-write
-		STATUS	mandatory
-		DESCRIPTION
-			"Setting this OID to off(0) will disable the Redfish API.
-			 Setting this OID to on(1) will enable the Redfish API.iNC reboot will be required for the settings to take effect"
-		::={pdug5ConfigEntry 7}
-		
-pdug5ConfigOledDispalyOrientation	OBJECT-TYPE
-		SYNTAX INTEGER{
-			displayNormal(1),
-			displayReverse(2)
-		}
-		ACCESS read-write
-		STATUS  mandatory
-		DESCRIPTION
-			"Indicates the intended physical orientation of OLED display.
-			 displayNormal(1) indicates normal orientation.
-			 displayReverse(2) indicates upside down orientation."
-		::={pdug5ConfigEntry 8}
-		
-pdug5ConfigEnergyReset	OBJECT-TYPE
-		SYNTAX INTEGER{
-			noOperation(1),
-			reset(2),
-			notSupported(3)
-		}
-		ACCESS read-write
-		STATUS	mandatory
-		DESCRIPTION
-			"Setting this OID to reset(2) will cause the device energy meter value 
-			 to be reset to zero. Getting this OID in models that support this feature
-			 will do nothing and return the noOperation(1) value. Models that do not
-			 supported this feature will respond to this OID with a value of notSupported(3).
-			 Attempts to set this OID in these models will fail."
-		::={pdug5ConfigEntry 9}
-		
-pdug5ConfigNetworkManagementCardReset  OBJECT-TYPE
-		SYNTAX INTEGER{
-			noOperation(0),
-			reset(1)
-		}
-		ACCESS read-write
-		STATUS mandatory
-		DESCRIPTION
-			"Getting this OID will return noOperation(0).
-			 Getting this OID to reset(1) will reset iNC."
-		::={pdug5ConfigEntry 10} 
-		
-pdug5ConfigDaisyChainStatus	OBJECT-TYPE 
-		SYNTAX INTEGER{
-			daisychain(0),
+    SYNTAX INTEGER
+        {
+            off(0),
+            on(1)
+        }
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Setting this OID to off(0) will disable the Redfish API.
+         Setting this OID to on(1) will enable the Redfish API.iNC reboot will be required for the settings to take effect"
+    ::= {pdug5ConfigEntry 7}
+
+pdug5ConfigOledDispalyOrientation OBJECT-TYPE
+    SYNTAX INTEGER
+        {
+            displayNormal(1),
+            displayReverse(2)
+        }
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Indicates the intended physical orientation of OLED display.
+         displayNormal(1) indicates normal orientation.
+         displayReverse(2) indicates upside down orientation."
+    ::= {pdug5ConfigEntry 8}
+
+pdug5ConfigEnergyReset OBJECT-TYPE
+    SYNTAX INTEGER
+        {
+            noOperation(1),
+            reset(2),
+            notSupported(3)
+        }
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Setting this OID to reset(2) will cause the device energy meter value
+         to be reset to zero. Getting this OID in models that support this feature
+         will do nothing and return the noOperation(1) value. Models that do not
+         supported this feature will respond to this OID with a value of notSupported(3).
+         Attempts to set this OID in these models will fail."
+    ::= {pdug5ConfigEntry 9}
+
+pdug5ConfigNetworkManagementCardReset OBJECT-TYPE
+    SYNTAX INTEGER
+        {
+            noOperation(0),
+            reset(1)
+        }
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Getting this OID will return noOperation(0).
+         Getting this OID to reset(1) will reset iNC."
+    ::= {pdug5ConfigEntry 10}
+
+pdug5ConfigDaisyChainStatus OBJECT-TYPE
+    SYNTAX INTEGER
+        {
+            daisychain(0),
             rna(1)
-		}
-		ACCESS read-write
-		STATUS mandatory
-		DESCRIPTION
-			"Setting this OID will change daisychain mode. 0:QNA,1:DNA."
-		::={pdug5ConfigEntry 11}
-		
+        }
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Setting this OID will change daisychain mode. 0:QNA,1:DNA."
+    ::= {pdug5ConfigEntry 11}
+
+-- ========== Powershare Status ===========
+pdug5PowershareTable OBJECT-TYPE
+    SYNTAX SEQUENCE OF Pdug5PowershareEntry
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+        "Aggregate Object with number of entries equal to number of PDUs and Power share "
+    ::= { pdug5Ident 4 }
+
+pdug5PowershareEntry OBJECT-TYPE
+    SYNTAX Pdug5PowershareEntry
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+        "The Power share entry containing the available, input, output etc."
+    INDEX {pdug5PowershareIndex}
+    ::= {pdug5PowershareTable 1}
+
+Pdug5PowershareEntry ::= SEQUENCE{
+        pdug5PowershareIndex                    INTEGER,
+        pdug5PowershareFunctionStatus           INTEGER,
+        pdug5PowershareFunctionUpstreamStatus   INTEGER,
+        pdug5PowershareOutput                   INTEGER,
+        pdug5PowershareInput                    INTEGER,
+        pdug5PowershareOptMode                  INTEGER,
+        pdug5PowershareFunc                     INTEGER
+    }
+
+pdug5PowershareIndex OBJECT-TYPE
+    SYNTAX Integer32 (1..4)
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+        "The index of the PDU Power share table entry"
+    ::= { pdug5PowershareEntry 1 }
+
+pdug5PowershareFunctionStatus OBJECT-TYPE
+    SYNTAX INTEGER
+        {
+            notAvailable(0),
+            available(1)
+        }
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Power share function status on PDU. "
+    ::= { pdug5PowershareEntry 2 }
+
+pdug5PowershareFunctionUpstreamStatus OBJECT-TYPE
+    SYNTAX INTEGER
+        {
+            notAvailable(0),
+            available(1)
+        }
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Power share function status on upstream PDU "
+    ::= { pdug5PowershareEntry 3 }
+
+pdug5PowershareOutput OBJECT-TYPE
+    SYNTAX INTEGER
+        {
+            off(0),
+            on(1)
+        }
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Power share output status. "
+    ::= { pdug5PowershareEntry 4 }
+
+pdug5PowershareInput OBJECT-TYPE
+    SYNTAX INTEGER
+        {
+            off(0),
+            on(1)
+        }
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Power share input status. "
+    ::= { pdug5PowershareEntry 5 }
+
+pdug5PowershareOptMode OBJECT-TYPE
+    SYNTAX INTEGER
+        {
+            powerByPowershare(0),
+            powerByMains(1)
+        }
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Power share operation status of PDU. 0 meaning pdu is using powershare to power the NMC, 1 meaning pdu is using mains power to power the NMC"
+    ::= { pdug5PowershareEntry 6 }
+
+pdug5PowershareFunc OBJECT-TYPE
+    SYNTAX INTEGER
+        {
+            disablePowershare(0),
+            enablePowershare(1)
+        }
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Enable/Disable Powershare function of PDU. Set 1 to enable powershare. Set 0 to disable powershare"
+    ::= { pdug5PowershareEntry 7 }
+
 -- ====================================================================================--
 --  g5                        OBJECT IDENTIFIER       ::= { panduit 10}
 --  pdug5                     OBJECT IDENTIFIER       ::= { g5 1}
 --  pdug5Ident                OBJECT IDENTIFIER       ::= { pdug5 2 }
 --  PDU input group
 --  OID= .1.3.6.1.4.1.19536.10.1.2
-   
-pdug5InputTable  OBJECT-TYPE
-	SYNTAX SEQUENCE OF pdug5InputEntry
-	ACCESS     not-accessible
-	STATUS     mandatory
-	DESCRIPTION 
-		"Aggregate Object with number of entries equal to pdug5NumberPDU ."
-	::= { pdug5Input 1 }
 
-pdug5InputEntry  OBJECT-TYPE
-	SYNTAX 	pdug5InputEntry
-	ACCESS     not-accessible
-	STATUS     mandatory
-	DESCRIPTION 
-		"The ident table entry containing the VA, Watts, WH, etc."
-	INDEX { pdug5IdentIndex }
-	::= { pdug5InputTable 1 }
+pdug5InputTable OBJECT-TYPE
+    SYNTAX SEQUENCE OF Pdug5InputEntry
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+        "Aggregate Object with number of entries equal to pdug5NumberPDU ."
+    ::= { pdug5Input 1 }
 
-pdug5InputEntry ::= SEQUENCE {
-	pdug5InputType			INTEGER,
-	pdug5InputFrequency		INTEGER,
-	pdug5InputFrequencyStatus	INTEGER,
-	pdug5InputPowerVA		INTEGER,
-	pdug5InputPowerWatts		INTEGER,
-	pdug5InputTotalEnergy		INTEGER,
-	pdug5InputPowerWattHourTimer	DisplayString,
-	pdug5InputResettableEnergy	INTEGER,
-	pdug5InputPowerFactor		INTEGER,
-	pdug5InputPowerVAR		INTEGER,
-	pdug5InputTotalCurrent		INTEGER
+pdug5InputEntry OBJECT-TYPE
+    SYNTAX Pdug5InputEntry
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+        "The ident table entry containing the VA, Watts, WH, etc."
+    INDEX { pdug5IdentIndex }
+    ::= { pdug5InputTable 1 }
+
+Pdug5InputEntry ::= SEQUENCE {
+        pdug5InputType                  INTEGER,
+        pdug5InputFrequency             INTEGER,
+        pdug5InputFrequencyStatus       INTEGER,
+        pdug5InputPowerVA               INTEGER,
+        pdug5InputPowerWatts            INTEGER,
+        pdug5InputTotalEnergy           INTEGER,
+        pdug5InputPowerWattHourTimer    DisplayString,
+        pdug5InputResettableEnergy      INTEGER,
+        pdug5InputPowerFactor           INTEGER,
+        pdug5InputPowerVAR              INTEGER,
+        pdug5InputTotalCurrent          INTEGER
         }
 
-pdug5InputType  OBJECT-TYPE
-	SYNTAX     INTEGER {
-		singlePhase (1),
-		splitPhase (2),
-		threePhaseDelta (3),
-		threePhaseWye (4)
-	}
-	ACCESS     read-only
-	STATUS     mandatory
-	DESCRIPTION 
-		"Type of input - single phase, split phase, three phase delta, or three
-				phase wye."
-	::= { pdug5InputEntry 1 }
+pdug5InputType OBJECT-TYPE
+    SYNTAX INTEGER
+        {
+            singlePhase (1),
+            splitPhase (2),
+            threePhaseDelta (3),
+            threePhaseWye (4)
+        }
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Type of input - single phase, split phase, three phase delta, or three
+         phase wye."
+    ::= { pdug5InputEntry 1 }
 
-pdug5InputFrequency  OBJECT-TYPE
-	SYNTAX     INTEGER (0..2147483647) -- UNITS RMS 0.001 Hz
-	ACCESS     read-only
-	STATUS     mandatory
-	DESCRIPTION 
-		"The measured input frequency from the PDU meters in tenths of Hz."
-	::= { pdug5InputEntry 2 }
+pdug5InputFrequency OBJECT-TYPE
+    SYNTAX Integer32 (0..2147483647) -- UNITS RMS 0.001 Hz
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "The measured input frequency from the PDU meters in tenths of Hz."
+    ::= { pdug5InputEntry 2 }
 
-pdug5InputFrequencyStatus  OBJECT-TYPE
-	SYNTAX     INTEGER {
-		good (1),
-		outOfRange (2)
-	}
-	ACCESS     read-only
-	STATUS     mandatory
-	DESCRIPTION 
-		"Status of the measured input frequency relative to the nominal frequency and the admitted tolerance."
-	::= { pdug5InputEntry 3 }
+pdug5InputFrequencyStatus OBJECT-TYPE
+    SYNTAX INTEGER
+       {
+           good (1),
+           outOfRange (2)
+        }
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Status of the measured input frequency relative to the nominal frequency and the admitted tolerance."
+    ::= { pdug5InputEntry 3 }
 
-pdug5InputPowerVA  OBJECT-TYPE
-	SYNTAX     INTEGER	-- Units in VA
-	ACCESS     read-only
-	STATUS     mandatory
-	DESCRIPTION 
-		"A total input VA of all phases.  Units are VA.  A negative value indicates
-		          that this object is not available."
-	::= { pdug5InputEntry 4 }
+pdug5InputPowerVA OBJECT-TYPE
+    SYNTAX Integer32 -- Units in VA
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "A total input VA of all phases.  Units are VA.  A negative value indicates
+         that this object is not available."
+    ::= { pdug5InputEntry 4 }
 
-pdug5InputPowerWatts  OBJECT-TYPE
-	SYNTAX     INTEGER	-- Units in Watts
-	ACCESS     read-only
-	STATUS     mandatory
-	DESCRIPTION 
-		"A total input Watts of all phases.  Units are Watts.  A negative value indicates
-		          that this object is not available."
-	::= { pdug5InputEntry 5 }
+pdug5InputPowerWatts OBJECT-TYPE
+    SYNTAX Integer32 -- Units in Watts
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "A total input Watts of all phases.  Units are Watts.  A negative value indicates
+         that this object is not available."
+    ::= { pdug5InputEntry 5 }
 
-pdug5InputTotalEnergy  OBJECT-TYPE
-	SYNTAX     INTEGER	-- Units in KWh
-	ACCESS     read-only
-	STATUS     mandatory
-	DESCRIPTION 
-		"A total input Watt-Hour value for all phases.  Units are KWh. This value is accumulated since PDU in service.   
-                 A negative value indicates that this object is not available."
-	::= { pdug5InputEntry 6 }
+pdug5InputTotalEnergy OBJECT-TYPE
+    SYNTAX Integer32 -- Units in KWh
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "A total input Watt-Hour value for all phases.  Units are KWh. This value is accumulated since PDU in service.
+         A negative value indicates that this object is not available."
+    ::= { pdug5InputEntry 6 }
 
-pdug5InputPowerWattHourTimer  OBJECT-TYPE
-	SYNTAX     DisplayString (SIZE (0..22))  -- display Date Time Since Last Reset
-	ACCESS     read-only
-	STATUS     mandatory
-	DESCRIPTION 
-		"A Timestamp of when the Total Input WH was last reset."
-	::= { pdug5InputEntry 7 }
+pdug5InputPowerWattHourTimer OBJECT-TYPE
+    SYNTAX DisplayString (SIZE (0..22))  -- display Date Time Since Last Reset
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "A Timestamp of when the Total Input WH was last reset."
+    ::= { pdug5InputEntry 7 }
 
-pdug5InputResettableEnergy  OBJECT-TYPE
-	SYNTAX     INTEGER	-- Units in Wh
-	ACCESS     read-only
-	STATUS     mandatory
-	DESCRIPTION 
-		"A total input Watt-Hour value for all phases.  Units are Wh. This value can be reset to 0 
-                using GUI. In that case, the pdug5InputPowerWattHourTimer will be reset as well  
-                A negative value indicates that this object is not available."
-	::= { pdug5InputEntry 8 }
+pdug5InputResettableEnergy OBJECT-TYPE
+    SYNTAX Integer32 -- Units in Wh
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "A total input Watt-Hour value for all phases.  Units are Wh. This value can be reset to 0
+         using GUI. In that case, the pdug5InputPowerWattHourTimer will be reset as well
+         A negative value indicates that this object is not available."
+    ::= { pdug5InputEntry 8 }
 
-pdug5InputPowerFactor  OBJECT-TYPE
-	SYNTAX     INTEGER	-- units 0.01
-	ACCESS     read-only
-	STATUS     mandatory
-	DESCRIPTION 
-		"An input PF value.  Units are in thousandths, for example a power factor
-		 of 0.95 would be returned as 95, and 0.92 would be returned as 92.  
-                 A negative value indicates that this object is not available."
-	::= { pdug5InputEntry 9 }
+pdug5InputPowerFactor OBJECT-TYPE
+    SYNTAX Integer32 -- Units 0.01
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "An input PF value.  Units are in hundredths, for example a power factor
+         of 0.95 would be returned as 95, and 0.92 would be returned as 92.
+         A negative value indicates that this object is not available."
+    ::= { pdug5InputEntry 9 }
 
-pdug5InputPowerVAR  OBJECT-TYPE
-	SYNTAX     INTEGER	-- Units in VAR
-	ACCESS     read-only
-	STATUS     mandatory
-	DESCRIPTION 
-		"An input VAR value.  Units are VAR.  A negative value indicates
-		 that this object is not available."
-	::= { pdug5InputEntry 10 }
+pdug5InputPowerVAR OBJECT-TYPE
+    SYNTAX Integer32 -- Units in VAR
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "An input VAR value.  Units are VAR.  A negative value indicates
+         that this object is not available."
+    ::= { pdug5InputEntry 10 }
 
-pdug5InputTotalCurrent  OBJECT-TYPE
-	SYNTAX     INTEGER	-- Units are 0.01 A
-	ACCESS     read-only
-	STATUS     mandatory
-	DESCRIPTION 
-		"All phases total current value.  Units are 0.01 amps. 
-		For 3 phase, mathematically add totally 3 phase current together."
-	::= { pdug5InputEntry 11 }
+pdug5InputTotalCurrent OBJECT-TYPE
+    SYNTAX Integer32 -- Units are 0.01 A
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "All phases total current value.  Units are 0.01 amps.
+        For 3 phase, mathematically add totally 3 phase current together."
+    ::= { pdug5InputEntry 11 }
 
 -- ==========Input per Phase =============
-
 pdug5InputPhaseTable OBJECT-TYPE
-    SYNTAX SEQUENCE OF pdug5InputPhaseEntry
-    ACCESS not-accessible
-    STATUS mandatory
+    SYNTAX SEQUENCE OF Pdug5InputPhaseEntry
+    MAX-ACCESS not-accessible
+    STATUS current
     DESCRIPTION
-           "Aggregate Object with number of entries equal to number of PDUs (pdug5NumberPDU) and
-            number of input phase (pdug5InputPhaseCount)."
+       "Aggregate Object with number of entries equal to number of PDUs (pdug5NumberPDU) and
+        number of input phase (pdug5InputPhaseCount)."
     ::= {pdug5Input 2}
 
 pdug5InputPhaseEntry OBJECT-TYPE
-    SYNTAX pdug5InputPhaseEntry
-    ACCESS not-accessible
-    STATUS mandatory
-    DESCRIPTION 
-           "The input table entry containing the voltage, current, frequency, power for each phase.
-            Entries are given with number of pdu and number of input phase 1, 2, or 3."
+    SYNTAX Pdug5InputPhaseEntry
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+       "The input table entry containing the voltage, current, frequency, power for each phase.
+        Entries are given with number of pdu and number of input phase 1, 2, or 3."
     INDEX { pdug5IdentIndex, pdug5InputPhaseIndex }
     ::= { pdug5InputPhaseTable 1 }
 
-pdug5InputPhaseEntry ::= SEQUENCE {
-      pdug5InputPhaseIndex      			INTEGER,
-      pdug5InputPhaseVoltageMeasType  		INTEGER,
-      pdug5InputPhaseVoltage    			INTEGER,
-      pdug5InputPhaseVoltageThStatus  		INTEGER,
-      pdug5InputPhaseVoltageThLowerWarning  	INTEGER,
-      pdug5InputPhaseVoltageThLowerCritical  	INTEGER,
-      pdug5InputPhaseVoltageThUpperWarning  	INTEGER,
-      pdug5InputPhaseVoltageThUpperCritical  	INTEGER,
-      pdug5InputPhaseCurrentMeasType		INTEGER,
-      pdug5InputPhaseCurrentRating		INTEGER,
-      pdug5InputPhaseCurrent    			INTEGER,
-      pdug5InputPhaseCurrentThStatus		INTEGER,
-      pdug5InputPhaseCurrentThLowerWarning	INTEGER,
-      pdug5InputPhaseCurrentThLowerCritical	INTEGER,
-      pdug5InputPhaseCurrentThUpperWarning	INTEGER,
-      pdug5InputPhaseCurrentThUpperCritical	INTEGER,
-      pdug5InputPhaseCurrentPercentLoad		INTEGER,
-      pdug5InputPhasePowerMeasType		INTEGER,
-      pdug5InputPhasePowerVA			INTEGER,
-      pdug5InputPhasePowerWatts 			INTEGER,
-      pdug5InputPhasePowerWattHour		INTEGER,
-      pdug5InputPhasePowerWattHourTimer		DisplayString,
-      pdug5InputPhasePowerFactor			INTEGER,
-      pdug5InputPhasePowerVAR			INTEGER,
-      pdug5InputPhaseVoltageThResetThld  	INTEGER,
-      pdug5InputPhaseVoltageThChangeDelay  	INTEGER,
-      pdug5InputPhaseVoltageThCtrl			INTEGER,
-      pdug5InputPhaseCurrentThResetThld  	INTEGER,
-      pdug5InputPhaseCurrentThChangeDelay  	INTEGER,
-      pdug5InputPhaseCurrentThCtrl			INTEGER,
-      pdug5InputPowerThresholdThLowerWarning  	INTEGER,
-      pdug5InputPowerThresholdThLowerCritical  	INTEGER,
-      pdug5InputPowerThresholdThUpperWarning  	INTEGER,
-      pdug5InputPowerThresholdThUpperCritical  	INTEGER,
-      pdug5InputPowerThresholdThResetThld  	INTEGER,
-      pdug5InputPowerThresholdThChangeDelay  	INTEGER,
-      pdug5InputPowerThresholdThCtrl			INTEGER,
-	  pdug5InputEnergyThresholdThUpperWarning  	INTEGER,
-      pdug5InputEnergyThresholdThUpperCritical  	INTEGER,
-      pdug5InputEnergyThresholdThResetThld  	INTEGER,
-      pdug5InputEnergyThresholdThChangeDelay  	INTEGER,
-      pdug5InputEnergyThresholdThCtrl			INTEGER
+Pdug5InputPhaseEntry ::= SEQUENCE {
+      pdug5InputPhaseIndex                      INTEGER,
+      pdug5InputPhaseVoltageMeasType            INTEGER,
+      pdug5InputPhaseVoltage                    Integer32,
+      pdug5InputPhaseVoltageThStatus            INTEGER,
+      pdug5InputPhaseVoltageThLowerWarning      Integer32,
+      pdug5InputPhaseVoltageThLowerCritical     Integer32,
+      pdug5InputPhaseVoltageThUpperWarning      Integer32,
+      pdug5InputPhaseVoltageThUpperCritical     Integer32,
+      pdug5InputPhaseCurrentMeasType            INTEGER,
+      pdug5InputPhaseCurrentRating              Integer32,
+      pdug5InputPhaseCurrent                    Integer32,
+      pdug5InputPhaseCurrentThStatus            INTEGER,
+      pdug5InputPhaseCurrentThLowerWarning      Integer32,
+      pdug5InputPhaseCurrentThLowerCritical     Integer32,
+      pdug5InputPhaseCurrentThUpperWarning      Integer32,
+      pdug5InputPhaseCurrentThUpperCritical     Integer32,
+      pdug5InputPhaseCurrentPercentLoad         Integer32,
+      pdug5InputPhasePowerMeasType              INTEGER,
+      pdug5InputPhasePowerVA                    Integer32,
+      pdug5InputPhasePowerWatts                 Integer32,
+      pdug5InputPhasePowerWattHour              Integer32,
+      pdug5InputPhasePowerWattHourTimer         DisplayString,
+      pdug5InputPhasePowerFactor                Integer32,
+      pdug5InputPhasePowerVAR                   Integer32,
+      pdug5InputPhaseVoltageThResetThld         Integer32,
+      pdug5InputPhaseVoltageThChangeDelay       Integer32,
+      pdug5InputPhaseVoltageThCtrl              Integer32,
+      pdug5InputPhaseCurrentThResetThld         Integer32,
+      pdug5InputPhaseCurrentThChangeDelay       Integer32,
+      pdug5InputPhaseCurrentThCtrl              Integer32,
+      pdug5InputPowerThresholdThLowerWarning    Integer32,
+      pdug5InputPowerThresholdThLowerCritical   Integer32,
+      pdug5InputPowerThresholdThUpperWarning    Integer32,
+      pdug5InputPowerThresholdThUpperCritical   Integer32,
+      pdug5InputPowerThresholdThResetThld       Integer32,
+      pdug5InputPowerThresholdThChangeDelay     Integer32,
+      pdug5InputPowerThresholdThCtrl            Integer32,
+      pdug5InputEnergyThresholdThUpperWarning   Integer32,
+      pdug5InputEnergyThresholdThUpperCritical  Integer32,
+      pdug5InputEnergyThresholdThResetThld      Integer32,
+      pdug5InputEnergyThresholdThChangeDelay    Integer32,
+      pdug5InputEnergyThresholdThCtrl           Integer32,
+      pdug5InputPhasePowerThStatus              Integer32
     }
 
 pdug5InputPhaseIndex OBJECT-TYPE
-    SYNTAX INTEGER	(1..3)
-    ACCESS read-only
-    STATUS mandatory
+    SYNTAX Integer32      (1..3)
+    MAX-ACCESS not-accessible
+    STATUS current
     DESCRIPTION
-	"Index for the pdug5InputEntry table."
+        "Index for the pdug5InputEntry table."
     ::= { pdug5InputPhaseEntry 1}
 
-pdug5InputPhaseVoltageMeasType  OBJECT-TYPE
-	SYNTAX     INTEGER {
-		singlePhase (1),
-		phase1toN (2),
-		phase2toN (3),
-		phase3toN (4),
-		phase1to2 (5),
-		phase2to3 (6),
-		phase3to1 (7)
-	}
-	ACCESS  read-only
-	STATUS  mandatory
-	DESCRIPTION 
-		"Value indicates what input voltage is being measured in this table row - single phase
-		voltage, phase 1 to neutral, phase 2 to neutral, phase 3 to neutral, phase 1 to phase 2,
-		phase 2 to phase 3, or phase 3 to phase 1."
-	::= { pdug5InputPhaseEntry 2 }
+pdug5InputPhaseVoltageMeasType OBJECT-TYPE
+    SYNTAX INTEGER
+        {
+            singlePhase (1),
+            phase1toN (2),
+            phase2toN (3),
+            phase3toN (4),
+            phase1to2 (5),
+            phase2to3 (6),
+            phase3to1 (7)
+        }
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Value indicates what input voltage is being measured in this table row - single phase
+         voltage, phase 1 to neutral, phase 2 to neutral, phase 3 to neutral, phase 1 to phase 2,
+         phase 2 to phase 3, or phase 3 to phase 1."
+    ::= { pdug5InputPhaseEntry 2 }
 
 pdug5InputPhaseVoltage OBJECT-TYPE
-    SYNTAX   INTEGER    -- UNITS RMS 0.1 V
-    ACCESS   read-only
-    STATUS   mandatory
+    SYNTAX Integer32 -- UNITS RMS 0.1 V
+    MAX-ACCESS read-only
+    STATUS current
     DESCRIPTION
-	"An input voltage measurement value.  Values is in 0.1 V."
+        "An input voltage measurement value.  Values is in 0.1 V."
     ::= {pdug5InputPhaseEntry 3}
 
-pdug5InputPhaseVoltageThStatus  OBJECT-TYPE
-	SYNTAX     INTEGER {
-		good (1),
-		lowWarning (2),
-		lowCritical (3),
-		highWarning (4),
-		highCritical (5)
-	}
-	ACCESS  read-only
-	STATUS  mandatory
-	DESCRIPTION 
-		"Status of the measured input voltage relative to the configured thresholds."
-	::= { pdug5InputPhaseEntry 4 }
+pdug5InputPhaseVoltageThStatus OBJECT-TYPE
+    SYNTAX INTEGER
+        {
+            good (1),
+            lowWarning (2),
+            lowCritical (3),
+            highWarning (4),
+            highCritical (5)
+        }
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Status of the measured input voltage relative to the configured thresholds."
+    ::= { pdug5InputPhaseEntry 4 }
 
-pdug5InputPhaseVoltageThLowerWarning  OBJECT-TYPE
-	SYNTAX   INTEGER (-1..500000)	-- Units in 0.1 V
-	ACCESS   read-write
-	STATUS   mandatory
-	DESCRIPTION 
-		"Lower warning threshold.  Units are 0.1 volts.  A negative value indicates
-		          that this object is not available."
-	::= { pdug5InputPhaseEntry 5 }
+pdug5InputPhaseVoltageThLowerWarning OBJECT-TYPE
+    SYNTAX Integer32 (-1..500000) -- Units in 0.1 V
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Lower warning threshold.  Units are 0.1 volts.  A negative value indicates
+         that this object is not available."
+    ::= { pdug5InputPhaseEntry 5 }
 
-pdug5InputPhaseVoltageThLowerCritical  OBJECT-TYPE
-	SYNTAX   INTEGER (-1..500000)	-- Units in 0.1 V
-	ACCESS   read-write
-	STATUS   mandatory
-	DESCRIPTION 
-		"Lower critical threshold.  Units are 0.1 volts.  A negative value indicates
-		          that this object is not available."
-	::= { pdug5InputPhaseEntry 6 }
+pdug5InputPhaseVoltageThLowerCritical OBJECT-TYPE
+    SYNTAX Integer32 (-1..500000) -- Units in 0.1 V
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Lower critical threshold.  Units are 0.1 volts.  A negative value indicates
+         that this object is not available."
+    ::= { pdug5InputPhaseEntry 6 }
 
-pdug5InputPhaseVoltageThUpperWarning  OBJECT-TYPE
-	SYNTAX   INTEGER (-1..500000)	-- Units in 0.1 V
-	ACCESS   read-write
-	STATUS   mandatory
-	DESCRIPTION 
-		"Upper warning threshold.  Units are 0.1 volts.  A negative value indicates
-		          that this object is not available."
-	::= { pdug5InputPhaseEntry 7 }
+pdug5InputPhaseVoltageThUpperWarning OBJECT-TYPE
+    SYNTAX Integer32 (-1..500000) -- Units in 0.1 V
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Upper warning threshold.  Units are 0.1 volts.  A negative value indicates
+         that this object is not available."
+    ::= { pdug5InputPhaseEntry 7 }
 
-pdug5InputPhaseVoltageThUpperCritical  OBJECT-TYPE
-	SYNTAX   INTEGER (-1..500000)	-- Units in 0.1 V
-	ACCESS   read-write
-	STATUS   mandatory
-	DESCRIPTION 
-		"Upper critical threshold.  Units are 0.1 volts.  A negative value indicates
-		          that this object is not available."
-	::= { pdug5InputPhaseEntry 8 }
+pdug5InputPhaseVoltageThUpperCritical OBJECT-TYPE
+    SYNTAX Integer32 (-1..500000) -- Units in 0.1 V
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Upper critical threshold.  Units are 0.1 volts.  A negative value indicates
+         that this object is not available."
+    ::= { pdug5InputPhaseEntry 8 }
 
-pdug5InputPhaseCurrentMeasType  OBJECT-TYPE
-	SYNTAX     INTEGER {
-		singlePhase (1),
-		neutral (2),
-		phase1 (3),
-		phase2 (4),
-		phase3 (5)
-	}
-	ACCESS  read-only
-	STATUS  mandatory
-	DESCRIPTION 
-		"Which input wire is being measured in this table row - single phase, neutral, phase 1,
-		phase 2, or phase 3."
-	::= { pdug5InputPhaseEntry 9 }
+pdug5InputPhaseCurrentMeasType OBJECT-TYPE
+    SYNTAX INTEGER
+        {
+            singlePhase (1),
+            neutral (2),
+            phase1 (3),
+            phase2 (4),
+            phase3 (5)
+        }
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Which input wire is being measured in this table row - single phase, neutral, phase 1,
+         phase 2, or phase 3."
+    ::= { pdug5InputPhaseEntry 9 }
 
-pdug5InputPhaseCurrentRating  OBJECT-TYPE
-	SYNTAX   INTEGER		-- Units in 0.01 A
-	ACCESS   read-only
-	STATUS   mandatory
-	DESCRIPTION 
-		"Rated current capacity of the input.  A negative value indicates that
-		the hardware current capacity is unknown.  Units are 0.01 amps."
-	::= { pdug5InputPhaseEntry 10 }
+pdug5InputPhaseCurrentRating OBJECT-TYPE
+    SYNTAX Integer32 -- Units in 0.01 A
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Rated current capacity of the input.  A negative value indicates that
+         the hardware current capacity is unknown.  Units are 0.01 amps."
+    ::= { pdug5InputPhaseEntry 10 }
 
-pdug5InputPhaseCurrent  OBJECT-TYPE
-	SYNTAX   INTEGER		-- Units in 0.01 A
-	ACCESS   read-only
-	STATUS   mandatory
-	DESCRIPTION 
-		"An input current measurement value.  Units are 0.01 amps."
-	::= { pdug5InputPhaseEntry 11 }
+pdug5InputPhaseCurrent OBJECT-TYPE
+    SYNTAX Integer32 -- Units in 0.01 A
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+                "An input current measurement value.  Units are 0.01 amps."
+    ::= { pdug5InputPhaseEntry 11 }
 
-pdug5InputPhaseCurrentThStatus  OBJECT-TYPE
-	SYNTAX     INTEGER {
-		good (1),
-		lowWarning (2),
-		lowCritical (3),
-		highWarning (4),
-		highCritical (5)
-	}
-	ACCESS  read-only
-	STATUS  mandatory
-	DESCRIPTION 
-		"Status of the measured input current relative to the configured thresholds."
-	::= { pdug5InputPhaseEntry 12 }
+pdug5InputPhaseCurrentThStatus OBJECT-TYPE
+    SYNTAX INTEGER
+        {
+            good (1),
+            lowWarning (2),
+            lowCritical (3),
+            highWarning (4),
+            highCritical (5)
+        }
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Status of the measured input current relative to the configured thresholds."
+    ::= { pdug5InputPhaseEntry 12 }
 
-pdug5InputPhaseCurrentThLowerWarning  OBJECT-TYPE
-	SYNTAX    INTEGER (-1..100000)		-- Units in 0.01 A
-	ACCESS    read-write
-	STATUS    mandatory
-	DESCRIPTION 
-		"Lower warning threshold.  Units are 0.01 amps.  A negative value indicates
-		          that this object is not available."
-	::= { pdug5InputPhaseEntry 13 }
+pdug5InputPhaseCurrentThLowerWarning OBJECT-TYPE
+    SYNTAX Integer32 (-1..100000) -- Units in 0.01 A
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Lower warning threshold.  Units are 0.01 amps.  A negative value indicates
+         that this object is not available."
+    ::= { pdug5InputPhaseEntry 13 }
 
-pdug5InputPhaseCurrentThLowerCritical  OBJECT-TYPE
-	SYNTAX    INTEGER (-1..100000)		-- Units in 0.01 A
-	ACCESS    read-write
-	STATUS    mandatory
-	DESCRIPTION 
-		"Lower critical threshold.  Units are 0.01 amps.  A negative value indicates
-		          that this object is not available."
-	::= { pdug5InputPhaseEntry 14 }
+pdug5InputPhaseCurrentThLowerCritical OBJECT-TYPE
+    SYNTAX Integer32 (-1..100000) -- Units in 0.01 A
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Lower critical threshold.  Units are 0.01 amps.  A negative value indicates
+         that this object is not available."
+    ::= { pdug5InputPhaseEntry 14 }
 
-pdug5InputPhaseCurrentThUpperWarning  OBJECT-TYPE
-	SYNTAX   INTEGER (-1..100000)		-- Units in 0.01 A
-	ACCESS   read-write
-	STATUS   mandatory
-	DESCRIPTION 
-		"Upper warning threshold.  Units are 0.01 amps.  A negative value indicates
-		          that this object is not available."
-	::= { pdug5InputPhaseEntry 15 }
+pdug5InputPhaseCurrentThUpperWarning OBJECT-TYPE
+    SYNTAX Integer32 (-1..100000) -- Units in 0.01 A
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Upper warning threshold.  Units are 0.01 amps.  A negative value indicates
+         that this object is not available."
+    ::= { pdug5InputPhaseEntry 15 }
 
-pdug5InputPhaseCurrentThUpperCritical  OBJECT-TYPE
-	SYNTAX   INTEGER (-1..100000)		-- Units in 0.01 A
-	ACCESS   read-write
-	STATUS   mandatory
-	DESCRIPTION 
-		"Upper critical threshold.  Units are 0.01 amps.  A negative value indicates
-		          that this object is not available."
-	::= { pdug5InputPhaseEntry 16 }
+pdug5InputPhaseCurrentThUpperCritical OBJECT-TYPE
+    SYNTAX Integer32 (-1..100000) -- Units in 0.01 A
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Upper critical threshold.  Units are 0.01 amps.  A negative value indicates
+         that this object is not available."
+    ::= { pdug5InputPhaseEntry 16 }
 
-pdug5InputPhaseCurrentPercentLoad  OBJECT-TYPE
-	SYNTAX     INTEGER
-	ACCESS     read-write
-	STATUS     mandatory
-	DESCRIPTION 
-		"Current percent load, based on the rated current capacity.  Units are
-                  percentage, for example 80% will be returned as 80.  A negative
-                  value indicates that this object is not available."
-	::= { pdug5InputPhaseEntry 17 }
+pdug5InputPhaseCurrentPercentLoad OBJECT-TYPE
+    SYNTAX Integer32
+  	MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Current percent load, based on the rated current capacity.  Units are
+         percentage, for example 80% will be returned as 80.  A negative
+         value indicates that this object is not available."
+    ::= { pdug5InputPhaseEntry 17 }
 
-pdug5InputPhasePowerMeasType  OBJECT-TYPE
-	SYNTAX     INTEGER {
-		singlePhase (1),
-		neutral (2),
-		phase1 (3),
-		phase2 (4),
-		phase3 (5)
-	 }
-	ACCESS  read-only
-	STATUS  mandatory
-	DESCRIPTION 
-		"Which input wire is being measured in this table row - single phase, neutral, phase 1,
-		phase 2, or phase 3."
-	::= { pdug5InputPhaseEntry 18 }
+pdug5InputPhasePowerMeasType OBJECT-TYPE
+    SYNTAX INTEGER
+        {
+            singlePhase (1),
+            neutral (2),
+            phase1 (3),
+            phase2 (4),
+            phase3 (5)
+         }
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Which input wire is being measured in this table row - single phase, neutral, phase 1,
+         phase 2, or phase 3."
+    ::= { pdug5InputPhaseEntry 18 }
 
-pdug5InputPhasePowerVA  OBJECT-TYPE
-	SYNTAX    INTEGER
-	ACCESS    read-only
-	STATUS    mandatory
-	DESCRIPTION 
-		"An input VA value.  Units are VA.  A negative value indicates
-		          that this object is not available."
-	::= { pdug5InputPhaseEntry 19 }
+pdug5InputPhasePowerVA OBJECT-TYPE
+    SYNTAX Integer32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "An input VA value.  Units are VA.  A negative value indicates
+         that this object is not available."
+    ::= { pdug5InputPhaseEntry 19 }
 
-pdug5InputPhasePowerWatts  OBJECT-TYPE
-	SYNTAX    INTEGER
-	ACCESS    read-only
-	STATUS    mandatory
-	DESCRIPTION 
-		"An input Watts value.  Units are Watts.  A negative value indicates
-		          that this object is not available."
-	::= { pdug5InputPhaseEntry 20 }
+pdug5InputPhasePowerWatts OBJECT-TYPE
+    SYNTAX Integer32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "An input Watts value.  Units are Watts.  A negative value indicates
+         that this object is not available."
+    ::= { pdug5InputPhaseEntry 20 }
 
-pdug5InputPhasePowerWattHour  OBJECT-TYPE
-	SYNTAX     INTEGER 
-	ACCESS     read-only
-	STATUS     mandatory
-	DESCRIPTION 
-		"A Watt-Hour value for each Input phase.  Units are WH. This value can be reset to 0 
-                 using GUI. In that case, the pdug5InputPhasePowerWattHourTimer will be reset as well    
-                 A negative value indicates that this object is not available."
-	::= { pdug5InputPhaseEntry 21 }
+pdug5InputPhasePowerWattHour OBJECT-TYPE
+    SYNTAX Integer32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "A Watt-Hour value for each Input phase.  Units are WH. This value can be reset to 0
+         using GUI. In that case, the pdug5InputPhasePowerWattHourTimer will be reset as well
+         A negative value indicates that this object is not available."
+    ::= { pdug5InputPhaseEntry 21 }
 
-pdug5InputPhasePowerWattHourTimer  OBJECT-TYPE
-	SYNTAX    DisplayString (SIZE (0..22))  -- display Date Time
-	ACCESS    read-only
-	STATUS    mandatory
-	DESCRIPTION 
-		"Timestamp of when input Watt-hours (inputWh) was last reset."
-	::= { pdug5InputPhaseEntry 22 }
+pdug5InputPhasePowerWattHourTimer OBJECT-TYPE
+    SYNTAX DisplayString (SIZE (0..22))  -- display Date Time
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Timestamp of when input Watt-hours (inputWh) was last reset."
+    ::= { pdug5InputPhaseEntry 22 }
 
-pdug5InputPhasePowerFactor  OBJECT-TYPE
-	SYNTAX    INTEGER		-- units 0.01
-	ACCESS    read-only
-	STATUS    mandatory
-	DESCRIPTION 
-		"An input PF value.  Units are in thousandths, for example a power factor
-                 of 0.95 would be returned as 95, and 0.92 would be returned 
-		 as 92.  A negative value indicates that this object is not available."
-	::= { pdug5InputPhaseEntry 23 }
+pdug5InputPhasePowerFactor OBJECT-TYPE
+    SYNTAX Integer32 -- Units 0.01
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "An input PF value.  Units are in hundredths, for example a power factor
+         of 0.95 would be returned as 95, and 0.92 would be returned
+         as 92.  A negative value indicates that this object is not available."
+    ::= { pdug5InputPhaseEntry 23 }
 
-pdug5InputPhasePowerVAR  OBJECT-TYPE
-	SYNTAX    INTEGER
-	ACCESS    read-only
-	STATUS    mandatory
-	DESCRIPTION 
-		"An input VAR value.  Units are VAR.  A negative value indicates
-		          that this object is not available."
-	::= { pdug5InputPhaseEntry 24 }
-	
--- 1.3.6.1.4.1.19536.10.1.2.2.1.25
+pdug5InputPhasePowerVAR OBJECT-TYPE
+    SYNTAX Integer32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "An input VAR value.  Units are VAR.  A negative value indicates
+         that this object is not available."
+    ::= { pdug5InputPhaseEntry 24 }
+
 pdug5InputPhaseVoltageThResetThld OBJECT-TYPE
-	SYNTAX INTEGER
-	ACCESS read-write
-	STATUS mandatory
-	DESCRIPTION
-    "Input phase voltage alarm reset threshold.  Units are 0.1 volts.  
-              A negative value indicates that this object is not available."
-	DEFVAL { 0 }
-	::= { pdug5InputPhaseEntry 25 }
-	
--- 1.3.6.1.4.1.19536.10.1.2.2.1.26
+    SYNTAX Integer32
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "The Reset threshold is the number of volts the reading needs to fall below
+         the threshold setting for the condition to be cleared. Units are 0.1 volts."
+    DEFVAL { 0 }
+    ::= { pdug5InputPhaseEntry 25 }
+
 pdug5InputPhaseVoltageThChangeDelay OBJECT-TYPE
-	SYNTAX INTEGER
-	ACCESS read-write
-	STATUS mandatory
-	DESCRIPTION
-		"Input phase voltage alarm change delay.  Units are 0.1 volts.  
-              A negative value indicates that this object is not available."
-	DEFVAL { 0 }
-	::= { pdug5InputPhaseEntry 26 }
-	
--- 1.3.6.1.4.1.19536.10.1.2.2.1.27
+    SYNTAX Integer32 (0..100)
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "The number of consecutive sample that the condition is present before
+         an alarm is raised."
+    DEFVAL { 0 }
+    ::= { pdug5InputPhaseEntry 26 }
+
 pdug5InputPhaseVoltageThCtrl OBJECT-TYPE
-	SYNTAX INTEGER
-	ACCESS read-write
-	STATUS mandatory
-	DESCRIPTION
-		"Input phase voltage alarm threshold control:
-		bit 0:  up critical alarm control bit,    0 -  enable, 1 -  disable
-		bit 1:  up warning alarm control bit,  0 -  enable, 1 -  disable
-		bit 2:  low warning alarm control bit, 0 -  enable, 1 -  disable
-		bit 3:  low critical alarm control bit,   0 -  enable, 1 -  disable"
-	DEFVAL { 0 }
-	::= { pdug5InputPhaseEntry 27 }
+    SYNTAX Integer32
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Input phase voltage alarm threshold control:
+         bit 0:  up critical alarm control bit,    0 -  enable, 1 -  disable
+         bit 1:  up warning alarm control bit,  0 -  enable, 1 -  disable
+         bit 2:  low warning alarm control bit, 0 -  enable, 1 -  disable
+         bit 3:  low critical alarm control bit,   0 -  enable, 1 -  disable"
+    DEFVAL { 0 }
+    ::= { pdug5InputPhaseEntry 27 }
 
--- 1.3.6.1.4.1.19536.10.1.2.2.1.28
-pdug5InputPhaseCurrentThResetThld  OBJECT-TYPE
-	SYNTAX   INTEGER (-1..100000)		-- Units in 0.01 A
-	ACCESS   read-write
-	STATUS   mandatory
-	DESCRIPTION 
-		"Input phase current alarm reset threshold.  Units are 0.01 amps.  
-              A negative value indicates that this object is not available."
-	::= { pdug5InputPhaseEntry 28 }
-	
--- 1.3.6.1.4.1.19536.10.1.2.2.1.29
-pdug5InputPhaseCurrentThChangeDelay  OBJECT-TYPE
-	SYNTAX   INTEGER (-1..100000)		-- Units in 0.01 A
-	ACCESS   read-write
-	STATUS   mandatory
-	DESCRIPTION 
-		"Input phase current alarm change delay.  Units are 0.01 amps.  
-              A negative value indicates that this object is not available."
-	::= { pdug5InputPhaseEntry 29 }
-	
--- 1.3.6.1.4.1.19536.10.1.2.2.1.30
+pdug5InputPhaseCurrentThResetThld OBJECT-TYPE
+    SYNTAX Integer32 
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "The Reset threshold is the number of amps the reading needs to fall below
+         the threshold setting for the condition to be cleared. Units are 0.01 amps."
+    ::= { pdug5InputPhaseEntry 28 }
+
+pdug5InputPhaseCurrentThChangeDelay OBJECT-TYPE
+    SYNTAX Integer32 (0..100)
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "The number of consecutive sample that the condition is present before
+         an alarm is raised."
+    ::= { pdug5InputPhaseEntry 29 }
+
 pdug5InputPhaseCurrentThCtrl OBJECT-TYPE
-	SYNTAX INTEGER
-	ACCESS read-write
-	STATUS mandatory
-	DESCRIPTION
-		"Input phase current alarm threshold control:
-		bit 0:  up critical alarm control bit,    0 -  enable, 1 -  disable
-		bit 1:  up warning alarm control bit,  0 -  enable, 1 -  disable
-		bit 2:  low warning alarm control bit, 0 -  enable, 1 -  disable
-		bit 3:  low critical alarm control bit,   0 -  enable, 1 -  disable"
-	DEFVAL { 0 }
-	::= { pdug5InputPhaseEntry 30 }
+    SYNTAX Integer32
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Input phase current alarm threshold control:
+         bit 0:  up critical alarm control bit,    0 -  enable, 1 -  disable
+         bit 1:  up warning alarm control bit,  0 -  enable, 1 -  disable
+         bit 2:  low warning alarm control bit, 0 -  enable, 1 -  disable
+         bit 3:  low critical alarm control bit,   0 -  enable, 1 -  disable"
+    DEFVAL { 0 }
+    ::= { pdug5InputPhaseEntry 30 }
 
-pdug5InputPowerThresholdThLowerWarning  OBJECT-TYPE
-	SYNTAX   INTEGER (-1..500000)	-- Units in  W
-	ACCESS   read-write
-	STATUS   mandatory
-	DESCRIPTION 
-		"Lower warning Power threshold.  Units are in Watts.  A negative value indicates
-		          that this object is not available."
-	::= { pdug5InputPhaseEntry 31 }
+pdug5InputPowerThresholdThLowerWarning OBJECT-TYPE
+    SYNTAX Integer32 (-1..500000) -- Units in  W
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Lower warning Power threshold.  Units are in Watts.  A negative value indicates
+         that this object is not available."
+    ::= { pdug5InputPhaseEntry 31 }
 
-pdug5InputPowerThresholdThLowerCritical  OBJECT-TYPE
-	SYNTAX   INTEGER (-1..500000)	-- Units in W
-	ACCESS   read-write
-	STATUS   mandatory
-	DESCRIPTION 
-		"Lower critical Power threshold.  Units are in Watts.  A negative value indicates
-		          that this object is not available."
-	::= { pdug5InputPhaseEntry 32 }
+pdug5InputPowerThresholdThLowerCritical OBJECT-TYPE
+    SYNTAX Integer32 (-1..500000) -- Units in W
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Lower critical Power threshold.  Units are in Watts.  A negative value indicates
+         that this object is not available."
+    ::= { pdug5InputPhaseEntry 32 }
 
-pdug5InputPowerThresholdThUpperWarning  OBJECT-TYPE
-	SYNTAX   INTEGER (-1..500000)	-- Units in W
-	ACCESS   read-write
-	STATUS   mandatory
-	DESCRIPTION 
-		"Upper warning Power threshold.  Units are in Watts.  A negative value indicates
-		          that this object is not available."
-	::= { pdug5InputPhaseEntry 33 }
+pdug5InputPowerThresholdThUpperWarning OBJECT-TYPE
+    SYNTAX Integer32 (-1..500000) -- Units in W
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Upper warning Power threshold.  Units are in Watts.  A negative value indicates
+         that this object is not available."
+    ::= { pdug5InputPhaseEntry 33 }
 
-pdug5InputPowerThresholdThUpperCritical  OBJECT-TYPE
-	SYNTAX   INTEGER (-1..500000)	-- Units in W
-	ACCESS   read-write
-	STATUS   mandatory
-	DESCRIPTION 
-		"Upper critical Power threshold.  Units are in Watts.  A negative value indicates
-		          that this object is not available."
-	::= { pdug5InputPhaseEntry 34 }
+pdug5InputPowerThresholdThUpperCritical OBJECT-TYPE
+    SYNTAX Integer32 (-1..500000) -- Units in W
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Upper critical Power threshold.  Units are in Watts.  A negative value indicates
+         that this object is not available."
+    ::= { pdug5InputPhaseEntry 34 }
 
-pdug5InputPowerThresholdThResetThld  OBJECT-TYPE
-	SYNTAX   INTEGER (-1..100000)		-- Units in W
-	ACCESS   read-write
-	STATUS   mandatory
-	DESCRIPTION 
-		"Power alarm reset threshold.  Units are in Watts.  
-              A negative value indicates that this object is not available."
-	::= { pdug5InputPhaseEntry 35 }
-	
-pdug5InputPowerThresholdThChangeDelay  OBJECT-TYPE
-	SYNTAX   INTEGER (-1..100000)		-- Units in W
-	ACCESS   read-write
-	STATUS   mandatory
-	DESCRIPTION 
-		"Power alarm change delay.  Units are in Watts.  
-              A negative value indicates that this object is not available."
-	::= { pdug5InputPhaseEntry 36 }
-	
+pdug5InputPowerThresholdThResetThld OBJECT-TYPE
+    SYNTAX Integer32
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "The Reset threshold is the number of watts the reading needs to fall below
+         the threshold setting for the condition to be cleared. Units are watts."
+    ::= { pdug5InputPhaseEntry 35 }
+
+pdug5InputPowerThresholdThChangeDelay OBJECT-TYPE
+    SYNTAX Integer32 (0..100)
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "The number of consecutive sample that the condition is present before
+         an alarm is raised."
+    ::= { pdug5InputPhaseEntry 36 }
+
 pdug5InputPowerThresholdThCtrl OBJECT-TYPE
-	SYNTAX INTEGER
-	ACCESS read-write
-	STATUS mandatory
-	DESCRIPTION
-		"Power alarm threshold control:
-		bit 0:  up critical alarm control bit,    0 -  enable, 1 -  disable
-		bit 1:  up warning alarm control bit,  0 -  enable, 1 -  disable
-		bit 2:  low warning alarm control bit, 0 -  enable, 1 -  disable
-		bit 3:  low critical alarm control bit,   0 -  enable, 1 -  disable"
-	DEFVAL { 0 }
-	::= { pdug5InputPhaseEntry 37 }
-	
-pdug5InputEnergyThresholdThUpperWarning  OBJECT-TYPE
-	SYNTAX   INTEGER (-1..500000)	-- Units in W
-	ACCESS   read-write
-	STATUS   mandatory
-	DESCRIPTION 
-		"Upper warning Energy threshold.  Units are in Watts.  A negative value indicates
-		          that this object is not available."
-	::= { pdug5InputPhaseEntry 38 }
+    SYNTAX Integer32
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Power alarm threshold control:
+         bit 0:  up critical alarm control bit,    0 -  enable, 1 -  disable
+         bit 1:  up warning alarm control bit,  0 -  enable, 1 -  disable
+         bit 2:  low warning alarm control bit, 0 -  enable, 1 -  disable
+         bit 3:  low critical alarm control bit,   0 -  enable, 1 -  disable"
+    DEFVAL { 0 }
+    ::= { pdug5InputPhaseEntry 37 }
 
-pdug5InputEnergyThresholdThUpperCritical  OBJECT-TYPE
-	SYNTAX   INTEGER (-1..500000)	-- Units in W
-	ACCESS   read-write
-	STATUS   mandatory
-	DESCRIPTION 
-		"Upper critical Energy threshold.  Units are in Watts.  A negative value indicates
-		          that this object is not available."
-	::= { pdug5InputPhaseEntry 39 }
+pdug5InputEnergyThresholdThUpperWarning OBJECT-TYPE
+    SYNTAX Integer32 (-1..500000) -- Units in W
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Upper warning Energy threshold.  Units are in Watts.  A negative value indicates
+         that this object is not available."
+    ::= { pdug5InputPhaseEntry 38 }
 
-pdug5InputEnergyThresholdThResetThld  OBJECT-TYPE
-	SYNTAX   INTEGER (-1..100000)		-- Units in W
-	ACCESS   read-write
-	STATUS   mandatory
-	DESCRIPTION 
-		"Energy alarm reset threshold.  Units are in Watts.  
-              A negative value indicates that this object is not available."
-	::= { pdug5InputPhaseEntry 40 }
-	
-pdug5InputEnergyThresholdThChangeDelay  OBJECT-TYPE
-	SYNTAX   INTEGER (-1..100000)		-- Units in W
-	ACCESS   read-write
-	STATUS   mandatory
-	DESCRIPTION 
-		"Energy alarm change delay.  Units are in Watts.  
-              A negative value indicates that this object is not available."
-	::= { pdug5InputPhaseEntry 41 }
-	
+pdug5InputEnergyThresholdThUpperCritical OBJECT-TYPE
+    SYNTAX Integer32 (-1..500000) -- Units in W
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Upper critical Energy threshold.  Units are in Watts.  A negative value indicates
+         that this object is not available."
+    ::= { pdug5InputPhaseEntry 39 }
+
+pdug5InputEnergyThresholdThResetThld OBJECT-TYPE
+    SYNTAX Integer32
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "The Reset threshold is the number of watts the reading needs to fall below
+         the threshold setting for the condition to be cleared. Units are watts."
+    ::= { pdug5InputPhaseEntry 40 }
+
+pdug5InputEnergyThresholdThChangeDelay OBJECT-TYPE
+    SYNTAX Integer32 (0..100)
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "The number of consecutive sample that the condition is present before
+         an alarm is raised."
+    ::= { pdug5InputPhaseEntry 41 }
+
 pdug5InputEnergyThresholdThCtrl OBJECT-TYPE
-	SYNTAX INTEGER
-	ACCESS read-write
-	STATUS mandatory
-	DESCRIPTION
-		"Energy alarm threshold control:
-		bit 0:  up critical alarm control bit,    0 -  enable, 1 -  disable
-		bit 1:  up warning alarm control bit,  0 -  enable, 1 -  disable
-		bit 2:  low warning alarm control bit, 0 -  enable, 1 -  disable
-		bit 3:  low critical alarm control bit,   0 -  enable, 1 -  disable"
-	DEFVAL { 0 }
-	::= { pdug5InputPhaseEntry 42 }
+    SYNTAX Integer32
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Energy alarm threshold control:
+         bit 0:  up critical alarm control bit,    0 -  enable, 1 -  disable
+         bit 1:  up warning alarm control bit,  0 -  enable, 1 -  disable
+         bit 2:  low warning alarm control bit, 0 -  enable, 1 -  disable
+         bit 3:  low critical alarm control bit,   0 -  enable, 1 -  disable"
+    DEFVAL { 0 }
+    ::= { pdug5InputPhaseEntry 42 }
+
+pdug5InputPhasePowerThStatus OBJECT-TYPE
+    SYNTAX INTEGER
+       {
+            good (1),
+            lowWarning (2),
+            lowCritical (3),
+            highWarning (4),
+            highCritical (5)
+       }
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Status of the measured input current relative to the configured thresholds."
+    ::= { pdug5InputPhaseEntry 43 }
+
+-- ========== Input RCM =============
+pdug5InputRcmTable OBJECT-TYPE
+    SYNTAX SEQUENCE OF Pdug5InputRcmEntry
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+        "Aggregate Object with number of entries equal to number of PDUs (pdug5NumberPDU) and
+         number of RCM modules per PDU."
+    ::= {pdug5Input 3}
+
+pdug5InputRcmEntry OBJECT-TYPE
+    SYNTAX Pdug5InputRcmEntry
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+        "The ident table entry containing the RCM Module status, RCM current, RCM module threshold settings, etc."
+    INDEX { pdug5IdentIndex }
+    ::= { pdug5InputRcmTable 1 }
+
+Pdug5InputRcmEntry ::= SEQUENCE {
+        pdug5InputRcmEnabled                INTEGER,
+        pdug5InputRcmModStatus              INTEGER,
+        pdug5InputRcmThUpperWarning         Integer32,
+        pdug5InputRcmThUpperCritical        Integer32,
+        pdug5InputRcmThResetThld            Integer32,
+        pdug5InputRcmThChangeDelay          Integer32,
+        pdug5InputRcmThCtrl                 Integer32,
+        pdug5InputRcmThStatus               INTEGER,
+        pdug5InputRcmCurrent                Integer32
+        }
+
+pdug5InputRcmEnabled OBJECT-TYPE
+    SYNTAX INTEGER
+        {
+            featureNotAvailable(-1),
+            off(0),
+            on(1)
+        }
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "RCM configuration value
+         off(0) if the PDU doesn't have RCM,
+         on(1) if the PDU has RCM."
+    ::= { pdug5InputRcmEntry 1 }
+
+pdug5InputRcmModStatus OBJECT-TYPE
+    SYNTAX INTEGER
+        {
+	    featureNotAvailable(-1),
+            ok(2),
+            degraded(3),
+            failed(4)
+        }
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "RCM module status
+         ok(2) if the PDU can communicate with the RCM module,
+         failed(4) if the PDU cannot communicate with the RCM module,
+         degraded(3) if the PDU can communicate with the RCM module and the last self-test failed."
+    ::= { pdug5InputRcmEntry 2 }
+
+pdug5InputRcmThUpperWarning OBJECT-TYPE
+    SYNTAX Integer32 (15..300) -- Units in 0.01 A
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "RCM Current Upper warning threshold. Units are 0.01 amps.
+         A negative value indicates that this object is not available."
+    ::= { pdug5InputRcmEntry 3 }
+
+pdug5InputRcmThUpperCritical OBJECT-TYPE
+    SYNTAX Integer32 (15..300) -- Units in 0.01 A
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "RCM Current Upper critical threshold. Units are 0.01 amps.
+         A negative value indicates that this object is not available."
+    ::= { pdug5InputRcmEntry 4 }
+
+pdug5InputRcmThResetThld OBJECT-TYPE
+    SYNTAX Integer32 (0..16) -- Units in 0.01 A
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "The Reset threshold is the number of amps the reading needs to fall below
+         the threshold setting for the condition to be cleared. Units are 0.01 amps."
+    ::= { pdug5InputRcmEntry 5 }
+
+pdug5InputRcmThChangeDelay OBJECT-TYPE
+    SYNTAX Integer32 (0..100)
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "The number of consecutive sample that the condition is present before
+         an alarm is raised."
+    ::= { pdug5InputRcmEntry 6 }
+
+pdug5InputRcmThCtrl OBJECT-TYPE
+    SYNTAX Integer32
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Rcm current alarm threshold control:
+         bit 0:  up critical alarm control bit,    0 -  enable, 1 -  disable
+         bit 1:  up warning alarm control bit,  0 -  enable, 1 -  disable."
+    DEFVAL { 0 }
+    ::= { pdug5InputRcmEntry 7 }
+
+pdug5InputRcmThStatus OBJECT-TYPE
+    SYNTAX INTEGER
+        {
+	    featureNotAvailable(-1),
+            good (1),
+            highWarning (4),
+            highCritical (5)
+        }
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Status of the measured Rcm current relative to the configured thresholds."
+    ::= { pdug5InputRcmEntry 8 }
+
+pdug5InputRcmCurrent OBJECT-TYPE
+    SYNTAX Integer32 -- Units 0.01
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Rcm module current reading. Units are milliAmps."
+    ::= { pdug5InputRcmEntry 9 }
+
+
+-- ========== Input RCM Self Test=============
+pdug5InputRcmSelfTestTable OBJECT-TYPE
+    SYNTAX SEQUENCE OF Pdug5InputRcmSelfTestEntry
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+       "Aggregate Object with number of entries equal to number of PDUs (pdug5NumberPDU) and
+        number of Rcm modules per PDU."
+    ::= {pdug5Input 4}
+
+pdug5InputRcmSelfTestEntry OBJECT-TYPE
+    SYNTAX Pdug5InputRcmSelfTestEntry
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+        "The ident table entry containing the Rcm Module Self Test Enable, Schedule, LastRunTime,LastRunStatus etc."
+    INDEX { pdug5IdentIndex }
+    ::= { pdug5InputRcmSelfTestTable 1 }
+
+Pdug5InputRcmSelfTestEntry ::= SEQUENCE {
+        pdug5InputRcmSelfTestEnable                 INTEGER,
+        pdug5InputRcmSelfTestFreq                   INTEGER,
+    pdug5InputRcmSelfTestHour                   INTEGER,
+    pdug5InputRcmSelfTestMinute                   INTEGER,
+    pdug5InputRcmSelfTestDay                       INTEGER,
+    pdug5InputRcmSelfTestMonth                   INTEGER,
+        pdug5InputRcmSelfTestNextRunTime              DisplayString,
+        pdug5InputRcmSelfTestLastRunTime             DisplayString,
+        pdug5InputRcmSelfTestLastRunStatus          INTEGER
+        }
+
+pdug5InputRcmSelfTestEnable OBJECT-TYPE
+    SYNTAX INTEGER
+        {
+            featureNotAvailable(-1),
+            disable(0),
+            enable(1)
+        }
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Rcm Self Test configuration value
+             Disable(0) if the self test is disabled on the PDU,
+             Enable(1) if self test is enabled on the PDU ."
+    ::= { pdug5InputRcmSelfTestEntry 1 }
+
+pdug5InputRcmSelfTestFreq OBJECT-TYPE
+    SYNTAX INTEGER
+        {
+            featureNotAvailable(-1),
+            daily(1),
+            weekly(2),
+            monthly(3),
+            yearly(4)
+        }
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Rcm module self test run frequency , the time for the test is set from Pdug5RcmSelfTestNextRunTime, the self test will be repeated based on the setting as Daily(1),Weekly(2),First Day Of Month(3),Yearly(4)"
+    ::= { pdug5InputRcmSelfTestEntry 2 }
+
+pdug5InputRcmSelfTestHour OBJECT-TYPE
+    SYNTAX Integer32 (-1..23)
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Rcm module self test schedule hour setting,-1 means feature not available "
+    ::= { pdug5InputRcmSelfTestEntry 3 }
+
+pdug5InputRcmSelfTestMinute OBJECT-TYPE
+    SYNTAX Integer32 (-1..59)
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Rcm module self test schedule minute setting,-1 means feature not available "
+    ::= { pdug5InputRcmSelfTestEntry 4 }
+
+pdug5InputRcmSelfTestDay OBJECT-TYPE
+    SYNTAX INTEGER
+         {
+            featureNotAvailable(-1),
+            sunday(0),
+            monday(1),
+            tuesday(2),
+            wednesday(3),
+            thursday(4),
+            friday(5),
+            saturday(6)
+        }
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Rcm module self test schedule day setting,-1 means feature not available "
+    ::= { pdug5InputRcmSelfTestEntry 5 }
+
+pdug5InputRcmSelfTestMonth OBJECT-TYPE
+    SYNTAX INTEGER
+         {
+            featureNotAvailable(-1),
+            january(0),
+            february(1),
+            march(2),
+            april(3),
+            may(4),
+            june(5),
+            july(6),
+            august(7),
+            september(8),
+            october(9),
+            november(10),
+            december(11)
+        }
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Rcm module self test schedule month setting,-1 means feature not available "
+    ::= { pdug5InputRcmSelfTestEntry 6}
+
+pdug5InputRcmSelfTestNextRunTime OBJECT-TYPE
+    SYNTAX DisplayString
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "next run date and Time for self test."
+    ::= { pdug5InputRcmSelfTestEntry 7 }
+
+pdug5InputRcmSelfTestLastRunTime OBJECT-TYPE
+    SYNTAX DisplayString
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Date and Time when the self test run previously"
+    ::= { pdug5InputRcmSelfTestEntry 8 }
+
+pdug5InputRcmSelfTestLastRunStatus OBJECT-TYPE
+    SYNTAX INTEGER
+        {
+                  featureNotAvailable(-1),
+            passed(1),
+            failed(2),
+            pending(3)
+        }
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Status of the lastest self test run"
+    ::= { pdug5InputRcmSelfTestEntry 9 }
 
 -- ====================================================================================
 --  g5                        OBJECT IDENTIFIER       ::= { panduit 10}
 --  pdug5                     OBJECT IDENTIFIER       ::= { g5 1}
 --  pdug5Group                OBJECT IDENTIFIER       ::= { pdug5 3 }
---  pdug5 Output groups of outlets 
+--  pdug5 Output groups of outlets
 --  OID= .1.3.6.1.4.1.19536.10.1.3
 
 pdug5GroupTable OBJECT-TYPE
-    SYNTAX SEQUENCE OF pdug5GroupEntry
-    ACCESS not-accessible
-    STATUS mandatory
-    DESCRIPTION "Aggregate Object with number of entries equal to number of PDUs
-                 and number of breakers (pdug5GroupCount)."
+    SYNTAX SEQUENCE OF Pdug5GroupEntry
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+        "Aggregate Object with number of entries equal to number of PDUs
+         and number of breakers (pdug5GroupCount)."
     ::= { pdug5Group 1 }
 
 pdug5GroupEntry OBJECT-TYPE
-    SYNTAX pdug5GroupEntry
-    ACCESS not-accessible
-    STATUS mandatory
-    DESCRIPTION 
-           "The input table entry containing the name, voltages, currents, power, etc."
+    SYNTAX Pdug5GroupEntry
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+       "The input table entry containing the name, voltages, currents, power, etc."
     INDEX { pdug5IdentIndex, pdug5GroupIndex }
     ::= { pdug5GroupTable 1 }
 
-pdug5GroupEntry ::= SEQUENCE {
-      pdug5GroupIndex         		INTEGER,
-      pdug5GroupName	     		DisplayString,
-      pdug5GroupType          		INTEGER,
-      pdug5GroupVoltageMeasType		INTEGER,
-      pdug5GroupVoltage          	INTEGER,
-      pdug5GroupVoltageThStatus		INTEGER,
-      pdug5GroupVoltageThLowerWarning	INTEGER,
-      pdug5GroupVoltageThLowerCritical	INTEGER,
-      pdug5GroupVoltageThUpperWarning	INTEGER,
-      pdug5GroupVoltageThUpperCritical	INTEGER,
-      pdug5groupCurrentRating		INTEGER,
-      pdug5GroupCurrent			INTEGER,
-      pdug5GroupCurrentThStatus		INTEGER,
-      pdug5GroupCurrentThLowerWarning	INTEGER,
-      pdug5GroupCurrentThLowerCritical	INTEGER,
-      pdug5GroupCurrentThUpperWarning	INTEGER,
-      pdug5GroupCurrentThUpperCritical	INTEGER,
-      pdug5GroupCurrentPercentLoad	INTEGER,
-      pdug5GroupPowerVA			INTEGER,
-      pdug5GroupPowerWatts		INTEGER,
-      pdug5GroupPowerWattHour		INTEGER,
-      pdug5GroupPowerWattHourTimer	DisplayString,
-      pdug5GroupPowerFactor		INTEGER,
-      pdug5GroupPowerVAR			INTEGER,
-      pdug5GroupOutletCount	 	INTEGER,
-      pdug5GroupBreakerStatus    	INTEGER,
-      pdug5GroupVoltageThCtrl    	INTEGER,
-      pdug5GroupCurrentThCtrl    	INTEGER
+Pdug5GroupEntry ::= SEQUENCE {
+      pdug5GroupIndex                   Integer32,
+      pdug5GroupName                    DisplayString,
+      pdug5GroupType                    INTEGER,
+      pdug5GroupVoltageMeasType         INTEGER,
+      pdug5GroupVoltage                 Integer32,
+      pdug5GroupVoltageThStatus         INTEGER,
+      pdug5GroupVoltageThLowerWarning   Integer32,
+      pdug5GroupVoltageThLowerCritical  Integer32,
+      pdug5GroupVoltageThUpperWarning   Integer32,
+      pdug5GroupVoltageThUpperCritical  Integer32,
+      pdug5groupCurrentRating           Integer32,
+      pdug5GroupCurrent                 Integer32,
+      pdug5GroupCurrentThStatus         INTEGER,
+      pdug5GroupCurrentThLowerWarning   Integer32,
+      pdug5GroupCurrentThLowerCritical  Integer32,
+      pdug5GroupCurrentThUpperWarning   Integer32,
+      pdug5GroupCurrentThUpperCritical  Integer32,
+      pdug5GroupCurrentPercentLoad      Integer32,
+      pdug5GroupPowerVA                 Integer32,
+      pdug5GroupPowerWatts              Integer32,
+      pdug5GroupPowerWattHour           Integer32,
+      pdug5GroupPowerWattHourTimer      DisplayString,
+      pdug5GroupPowerFactor             Integer32,
+      pdug5GroupPowerVAR                Integer32,
+      pdug5GroupOutletCount             Integer32,
+      pdug5GroupBreakerStatus           INTEGER,
+      pdug5GroupVoltageThCtrl           Integer32,
+      pdug5GroupCurrentThCtrl           Integer32
     }
 
 pdug5GroupIndex OBJECT-TYPE
-    SYNTAX INTEGER	(0..12)
-    ACCESS read-only
-    STATUS mandatory
+    SYNTAX Integer32      (0..12)
+    MAX-ACCESS not-accessible
+    STATUS current
     DESCRIPTION
-	"Index for the pdug5GroupEntry table."
+        "Index for the pdug5GroupEntry table."
     ::= { pdug5GroupEntry 1 }
 
-pdug5GroupName  OBJECT-TYPE
-	SYNTAX    DisplayString (SIZE(1..31))
-	ACCESS    read-write
-	STATUS    mandatory
-	DESCRIPTION 
-		"A descriptive name for the group."
-	::= { pdug5GroupEntry 2 }
+pdug5GroupName OBJECT-TYPE
+    SYNTAX DisplayString (SIZE(1..31))
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "A descriptive name for the group."
+    ::= { pdug5GroupEntry 2 }
 
-pdug5GroupType  OBJECT-TYPE
-	SYNTAX     INTEGER {
-		breaker1pole (2),
-		breaker2pole (3),
-		breaker3pole (4),
-		outletSection (5)
-	}
-	ACCESS  read-only
-	STATUS  mandatory
-	DESCRIPTION 
-		"The type of the group. (5) has no breaker"
-	::= { pdug5GroupEntry 3 }
+pdug5GroupType OBJECT-TYPE
+    SYNTAX INTEGER
+        {
+            breaker1pole (2),
+            breaker2pole (3),
+            breaker3pole (4),
+            outletSection (5)
+        }
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "The type of the group. (5) has no breaker"
+    ::= { pdug5GroupEntry 3 }
 
-pdug5GroupVoltageMeasType  OBJECT-TYPE
-	SYNTAX     INTEGER {
-		singlePhase (1),
-		phase1toN (2),
-		phase2toN (3),
-		phase3toN (4),
-		phase1to2 (5),
-		phase2to3 (6),
-		phase3to1 (7)
-	}
-	ACCESS     read-only
-	STATUS     mandatory
-	DESCRIPTION 
-		"Value indicates what input voltage is being measured in this table row - single phase
-		voltage, phase 1 to neutral, phase 2 to neutral, phase 3 to neutral, phase 1 to phase 2,
-		phase 2 to phase 3, or phase 3 to phase 1."
-	::= { pdug5GroupEntry 4 }
+pdug5GroupVoltageMeasType OBJECT-TYPE
+    SYNTAX INTEGER
+        {
+            singlePhase (1),
+            phase1toN (2),
+            phase2toN (3),
+            phase3toN (4),
+            phase1to2 (5),
+            phase2to3 (6),
+            phase3to1 (7)
+        }
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Value indicates what input voltage is being measured in this table row - single phase
+         voltage, phase 1 to neutral, phase 2 to neutral, phase 3 to neutral, phase 1 to phase 2,
+         phase 2 to phase 3, or phase 3 to phase 1."
+    ::= { pdug5GroupEntry 4 }
 
-pdug5GroupVoltage  OBJECT-TYPE
-	SYNTAX    INTEGER	-- Units 0.1 V
-	ACCESS    read-only
-	STATUS    mandatory
-	DESCRIPTION 
-		"Units are 0.1 volts."
-	::= { pdug5GroupEntry 5 }
+pdug5GroupVoltage OBJECT-TYPE
+    SYNTAX Integer32 -- Units 0.1 V
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Units are 0.1 volts."
+    ::= { pdug5GroupEntry 5 }
 
-pdug5GroupVoltageThStatus  OBJECT-TYPE
-	SYNTAX     INTEGER {
-		good (1),
-		lowWarning (2),
-		lowCritical (3),
-		highWarning (4),
-		highCritical (5)
-	}
-	ACCESS   read-only
-	STATUS   mandatory
-	DESCRIPTION 
-		"Status of the measured group voltage relative to the configured thresholds."
-	::= { pdug5GroupEntry 6 }
+pdug5GroupVoltageThStatus OBJECT-TYPE
+    SYNTAX INTEGER
+        {
+            good (1),
+            lowWarning (2),
+            lowCritical (3),
+            highWarning (4),
+            highCritical (5)
+        }
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Status of the measured group voltage relative to the configured thresholds."
+    ::= { pdug5GroupEntry 6 }
 
-pdug5GroupVoltageThLowerWarning  OBJECT-TYPE
-	SYNTAX     INTEGER (-1..500000)		-- Units 0.1 V
-	ACCESS    read-write
-	STATUS    mandatory
-	DESCRIPTION 
-		"Lower warning threshold.  Units are 0.1 volts.  A negative value indicates
-		          that this object is not available."
-	::= { pdug5GroupEntry 7 }
+pdug5GroupVoltageThLowerWarning OBJECT-TYPE
+    SYNTAX Integer32 (-1..500000) -- Units 0.1 V
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Lower warning threshold.  Units are 0.1 volts.  A negative value indicates
+         that this object is not available."
+    ::= { pdug5GroupEntry 7 }
 
-pdug5GroupVoltageThLowerCritical  OBJECT-TYPE
-	SYNTAX    INTEGER (-1..500000)		-- Units 0.1 V
-	ACCESS    read-write
-	STATUS    mandatory
-	DESCRIPTION 
-		"Lower critical threshold.  Units are 0.1 volts.  A negative value indicates
-		          that this object is not available."
-	::= { pdug5GroupEntry 8 }
+pdug5GroupVoltageThLowerCritical OBJECT-TYPE
+    SYNTAX Integer32 (-1..500000) -- Units 0.1 V
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Lower critical threshold.  Units are 0.1 volts.  A negative value indicates
+         that this object is not available."
+    ::= { pdug5GroupEntry 8 }
 
-pdug5GroupVoltageThUpperWarning  OBJECT-TYPE
-	SYNTAX    INTEGER (-1..500000)		-- Units 0.1 V
-	ACCESS    read-write
-	STATUS    mandatory
-	DESCRIPTION 
-		"Upper warning threshold.  Units are 0.1 volts.  A negative value indicates
-		          that this object is not available."
-	::= { pdug5GroupEntry 9 }
+pdug5GroupVoltageThUpperWarning OBJECT-TYPE
+    SYNTAX Integer32 (-1..500000) -- Units 0.1 V
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Upper warning threshold.  Units are 0.1 volts.  A negative value indicates
+         that this object is not available."
+    ::= { pdug5GroupEntry 9 }
 
-pdug5GroupVoltageThUpperCritical  OBJECT-TYPE
-	SYNTAX    INTEGER (-1..500000)		-- Units 0.1 V
-	ACCESS    read-write
-	STATUS    mandatory
-	DESCRIPTION 
-		"Upper critical threshold.  Units are 0.1 volts.  A negative value indicates
-		          that this object is not available."
-	::= { pdug5GroupEntry 10 }
+pdug5GroupVoltageThUpperCritical OBJECT-TYPE
+    SYNTAX Integer32 (-1..500000) -- Units 0.1 V
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Upper critical threshold.  Units are 0.1 volts.  A negative value indicates
+         that this object is not available."
+    ::= { pdug5GroupEntry 10 }
 
-pdug5groupCurrentRating  OBJECT-TYPE
-	SYNTAX    INTEGER	-- Units 0.01 A
-	ACCESS    read-only
-	STATUS    mandatory
-	DESCRIPTION 
-		"Rated current capacity of the group.  Units are 0.01 amps.  A negative 
-		      value indicates that the hardware current capacity is unknown (it
-		      will always be unknown for custom groups)."
-	::= { pdug5GroupEntry 11 }
+pdug5groupCurrentRating OBJECT-TYPE
+    SYNTAX Integer32 -- Units 0.01 A
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Rated current capacity of the group.  Units are 0.01 amps.  A negative
+         value indicates that the hardware current capacity is unknown (it
+         will always be unknown for custom groups)."
+    ::= { pdug5GroupEntry 11 }
 
-pdug5GroupCurrent  OBJECT-TYPE
-	SYNTAX    INTEGER	-- Units 0.01 A
-	ACCESS    read-only
-	STATUS    mandatory
-	DESCRIPTION 
-		"A group current measurement value.  Units are 0.01 amps."
-	::= { pdug5GroupEntry 12 }
+pdug5GroupCurrent OBJECT-TYPE
+    SYNTAX Integer32 -- Units 0.01 A
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "A group current measurement value.  Units are 0.01 amps."
+    ::= { pdug5GroupEntry 12 }
 
-pdug5GroupCurrentThStatus  OBJECT-TYPE
-	SYNTAX     INTEGER {
-		good (1),
-		lowWarning (2),
-		lowCritical (3),
-		highWarning (4),
-		highCritical (5)
-	}
-	ACCESS  read-only
-	STATUS  mandatory
-	DESCRIPTION 
-		"Status of the measured group current relative to the configured thresholds."
-	::= { pdug5GroupEntry 13 }
+pdug5GroupCurrentThStatus OBJECT-TYPE
+    SYNTAX INTEGER
+        {
+            good (1),
+            lowWarning (2),
+            lowCritical (3),
+            highWarning (4),
+            highCritical (5),
+            cbOff (6)
+        }
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Status of the measured group current relative to the configured thresholds."
+    ::= { pdug5GroupEntry 13 }
 
-pdug5GroupCurrentThLowerWarning  OBJECT-TYPE
-	SYNTAX    INTEGER (-1..100000)		-- Units 0.01 A
-	ACCESS    read-write
-	STATUS    mandatory
-	DESCRIPTION 
-		"Lower warning threshold.  Units are 0.01 amps.  A negative value indicates
-		          that this object is not available."
-	::= { pdug5GroupEntry 14 }
+pdug5GroupCurrentThLowerWarning OBJECT-TYPE
+    SYNTAX Integer32 (-1..100000) -- Units 0.01 A
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Lower warning threshold.  Units are 0.01 amps.  A negative value indicates
+         that this object is not available."
+    ::= { pdug5GroupEntry 14 }
 
-pdug5GroupCurrentThLowerCritical  OBJECT-TYPE
-	SYNTAX     INTEGER (-1..100000)		-- Units 0.01 A
-	ACCESS     read-write
-	STATUS     mandatory
-	DESCRIPTION 
-		"Lower critical threshold.  Units are 0.01 amps.  A negative value indicates
-		          that this object is not available."
-	::= { pdug5GroupEntry 15 }
+pdug5GroupCurrentThLowerCritical OBJECT-TYPE
+    SYNTAX Integer32 (-1..100000) -- Units 0.01 A
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Lower critical threshold.  Units are 0.01 amps.  A negative value indicates
+         that this object is not available."
+    ::= { pdug5GroupEntry 15 }
 
-pdug5GroupCurrentThUpperWarning  OBJECT-TYPE
-	SYNTAX     INTEGER (-1..100000)		-- Units 0.01 A
-	ACCESS     read-write
-	STATUS     mandatory
-	DESCRIPTION 
-		"Upper warning threshold.  Units are 0.01 amps.  A negative value indicates
-		          that this object is not available."
-	::= { pdug5GroupEntry 16 }
+pdug5GroupCurrentThUpperWarning OBJECT-TYPE
+    SYNTAX Integer32 (-1..100000) -- Units 0.01 A
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Upper warning threshold.  Units are 0.01 amps.  A negative value indicates
+         that this object is not available."
+    ::= { pdug5GroupEntry 16 }
 
-pdug5GroupCurrentThUpperCritical  OBJECT-TYPE
-	SYNTAX     INTEGER (-1..100000)		-- Units 0.01 A
-	ACCESS     read-write
-	STATUS     mandatory
-	DESCRIPTION 
-		"Upper critical threshold.  Units are 0.01 amps.  A negative value indicates
-		          that this object is not available."
-	::= { pdug5GroupEntry 17 }
+pdug5GroupCurrentThUpperCritical OBJECT-TYPE
+    SYNTAX Integer32 (-1..100000) -- Units 0.01 A
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Upper critical threshold.  Units are 0.01 amps.  A negative value indicates
+         that this object is not available."
+    ::= { pdug5GroupEntry 17 }
 
 
-pdug5GroupCurrentPercentLoad  OBJECT-TYPE
-	SYNTAX     INTEGER
-	ACCESS     read-only
-	STATUS     mandatory
-	DESCRIPTION 
-		"Current percent load, based on the rated current capacity.  Units are
-                  percentage, for example 80% will be returned as 80.  A negative
-                  value indicates that this object is not available."
-	::= { pdug5GroupEntry 18 }
+pdug5GroupCurrentPercentLoad OBJECT-TYPE
+    SYNTAX Integer32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Current percent load, based on the rated current capacity.  Units are
+         percentage, for example 80% will be returned as 80.  A negative
+         value indicates that this object is not available."
+    ::= { pdug5GroupEntry 18 }
 
-pdug5GroupPowerVA  OBJECT-TYPE
-	SYNTAX     INTEGER  	-- units in VA
-	ACCESS     read-only
-	STATUS     mandatory
-	DESCRIPTION 
-		"A group VA value.  Units are VA.  A negative value indicates
-		          that this object is not available."
-	::= { pdug5GroupEntry 19 }
+pdug5GroupPowerVA OBJECT-TYPE
+    SYNTAX Integer32 -- Units in VA
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "A group VA value.  Units are VA.  A negative value indicates
+         that this object is not available."
+    ::= { pdug5GroupEntry 19 }
 
-pdug5GroupPowerWatts  OBJECT-TYPE
-	SYNTAX     INTEGER	-- units in Watt
-	ACCESS     read-only
-	STATUS     mandatory
-	DESCRIPTION 
-		"A group power value.  Units are Watts.  A negative value indicates
-		          that this object is not available."
-	::= { pdug5GroupEntry 20 }
+pdug5GroupPowerWatts OBJECT-TYPE
+    SYNTAX Integer32 -- Units in Watt
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "A group power value.  Units are Watts.  A negative value indicates
+         that this object is not available."
+    ::= { pdug5GroupEntry 20 }
 
-pdug5GroupPowerWattHour  OBJECT-TYPE
-	SYNTAX     INTEGER 	-- Units in Watt-Hour
-	ACCESS     read-only
-	STATUS     mandatory
-	DESCRIPTION 
-		"A Watt-Hour value for each section.  Units are WH. This value can be reset to 0 
-                 using GUI. In that case, the pdug5GroupPowerWattHourTimer will be reset as well.    
-                 A negative value indicates that this object is not available."
-	::= { pdug5GroupEntry 21 }
+pdug5GroupPowerWattHour OBJECT-TYPE
+    SYNTAX Integer32 -- Units in Watt-Hour
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "A Watt-Hour value for each section.  Units are WH. This value can be reset to 0
+         using GUI. In that case, the pdug5GroupPowerWattHourTimer will be reset as well.
+         A negative value indicates that this object is not available."
+    ::= { pdug5GroupEntry 21 }
 
-pdug5GroupPowerWattHourTimer  OBJECT-TYPE
-	SYNTAX     DisplayString (SIZE (0..22))	-- display Date and Time
-	ACCESS     read-only
-	STATUS     mandatory
-	DESCRIPTION 
-		"Timestamp of when group Watt-hours (groupWh) was last reset."
-	::= { pdug5GroupEntry 22 }
+pdug5GroupPowerWattHourTimer OBJECT-TYPE
+    SYNTAX DisplayString (SIZE (0..22)) -- display Date and Time
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Timestamp of when group Watt-hours (groupWh) was last reset."
+    ::= { pdug5GroupEntry 22 }
 
-pdug5GroupPowerFactor  OBJECT-TYPE
-	SYNTAX     INTEGER	-- Value is in 0.01							
-	ACCESS     read-only
-	STATUS     mandatory
-	DESCRIPTION 
-		"A group PF value.  Units are in thousandths, for example a power factor
-                  of 0.95 would be returned as 95, and 0.92 would be returned as 92.  
-                 A negative value indicates that this object is not available."
-	::= { pdug5GroupEntry 23 }
+pdug5GroupPowerFactor OBJECT-TYPE
+    SYNTAX Integer32      -- Value is in 0.01
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "A group PF value.  Units are in hundredths, for example a power factor
+         of 0.95 would be returned as 95, and 0.92 would be returned as 92.
+         A negative value indicates that this object is not available."
+    ::= { pdug5GroupEntry 23 }
 
-pdug5GroupPowerVAR  OBJECT-TYPE
-	SYNTAX     INTEGER		-- Units in VAR
-	ACCESS     read-only
-	STATUS     mandatory
-	DESCRIPTION 
-		"A group VAR value.  Units are VAR.  A negative value indicates
-		          that this object is not available."
-	::= { pdug5GroupEntry 24 }
+pdug5GroupPowerVAR OBJECT-TYPE
+    SYNTAX Integer32 -- Units in VAR
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "A group VAR value.  Units are VAR.  A negative value indicates
+         that this object is not available."
+    ::= { pdug5GroupEntry 24 }
 
-pdug5GroupOutletCount  OBJECT-TYPE
-    	SYNTAX     INTEGER (0..48)
-    	ACCESS     read-only
-    	STATUS     mandatory
-    	DESCRIPTION 
-		"The number of outlets in each group (breaker)."
-         ::= { pdug5GroupEntry 25 }
+pdug5GroupOutletCount OBJECT-TYPE
+    SYNTAX Integer32 (0..48)
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "The number of outlets in each group (breaker)."
+    ::= { pdug5GroupEntry 25 }
 
-pdug5GroupBreakerStatus  OBJECT-TYPE
-	SYNTAX     INTEGER {
-		notApplicable (1),
-		breakerOn (2),
-		breakerOff (3)
-	}
-	ACCESS 	   read-only
-	STATUS     mandatory
-	DESCRIPTION 
-		"Only applicable to groups with breaker.  Indicates whether a breaker is turned
-		      off or on."
-	::= { pdug5GroupEntry 26 }
-	
--- 1.3.6.1.4.1.19536.10.1.3.1.1.27
+pdug5GroupBreakerStatus OBJECT-TYPE
+    SYNTAX INTEGER
+        {
+            notApplicable (1),
+            breakerOn (2),
+            breakerOff (3)
+        }
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Only applicable to groups with breaker.  Indicates whether a breaker is turned
+         off or on."
+    ::= { pdug5GroupEntry 26 }
+
 pdug5GroupVoltageThCtrl OBJECT-TYPE
-	SYNTAX INTEGER
-	ACCESS read-write
-	STATUS mandatory
-	DESCRIPTION
-		"Circuit Breaker voltage alarm threshold control:
-		bit 0:  up critical alarm control bit,    0 -  enable, 1 -  disable
-		bit 1:  up warning alarm control bit,  0 -  enable, 1 -  disable
-		bit 2:  low warning alarm control bit, 0 -  enable, 1 -  disable
-		bit 3:  low critical alarm control bit,   0 -  enable, 1 -  disable"
-	DEFVAL { 0 }
-	::= { pdug5GroupEntry 27 }
+    SYNTAX Integer32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Circuit Breaker voltage alarm threshold control:
+         bit 0:  up critical alarm control bit,    0 -  enable, 1 -  disable
+         bit 1:  up warning alarm control bit,  0 -  enable, 1 -  disable
+         bit 2:  low warning alarm control bit, 0 -  enable, 1 -  disable
+         bit 3:  low critical alarm control bit,   0 -  enable, 1 -  disable"
+    DEFVAL { 0 }
+    ::= { pdug5GroupEntry 27 }
 
--- 1.3.6.1.4.1.19536.10.1.3.1.1.28
 pdug5GroupCurrentThCtrl OBJECT-TYPE
-	SYNTAX INTEGER
-	ACCESS read-write
-	STATUS mandatory
-	DESCRIPTION
-		"Circuit Breaker current alarm threshold control:
-		bit 0:  up critical alarm control bit,    0 -  enable, 1 -  disable
-		bit 1:  up warning alarm control bit,  0 -  enable, 1 -  disable
-		bit 2:  low warning alarm control bit, 0 -  enable, 1 -  disable
-		bit 3:  low critical alarm control bit,   0 -  enable, 1 -  disable"
-	::= { pdug5GroupEntry 28 }
+    SYNTAX Integer32
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Circuit Breaker current alarm threshold control:
+         bit 0:  up critical alarm control bit,    0 -  enable, 1 -  disable
+         bit 1:  up warning alarm control bit,  0 -  enable, 1 -  disable
+         bit 2:  low warning alarm control bit, 0 -  enable, 1 -  disable
+         bit 3:  low critical alarm control bit,   0 -  enable, 1 -  disable"
+    ::= { pdug5GroupEntry 28 }
 
 -- ====================================================================================
 --  g5                        OBJECT IDENTIFIER       ::= { panduit 10}
@@ -1414,1394 +1892,1509 @@ pdug5GroupCurrentThCtrl OBJECT-TYPE
 --  PDU identification group
 --  OID= .1.3.6.1.4.1.19536.10.1.4
 
-pdug5EnvProbeTable  OBJECT-TYPE
-	SYNTAX 	SEQUENCE OF pdug5EnvProbeEntry
-	ACCESS 	not-accessible
-	STATUS  mandatory
-	DESCRIPTION 
-		"A list of environment probe (1 per PDU) for temperature, humidity, and contacts.  
-                 The number of entries is given by number of PDUs in daisy chain."
-	::= { pdug5Environment 1 }
+pdug5EnvProbeTable OBJECT-TYPE
+    SYNTAX SEQUENCE OF Pdug5EnvProbeEntry
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+        "A list of environment probe (1 per PDU) for temperature, humidity, and contacts.
+         The number of entries is given by number of PDUs in daisy chain."
+    ::= { pdug5Environment 1 }
 
-pdug5EnvProbeEntry  OBJECT-TYPE
-	SYNTAX 	pdug5EnvProbeEntry
-	ACCESS  not-accessible
-	STATUS  mandatory
-	DESCRIPTION 
-		"Aggregate entries equal to number of PDUs."
-	INDEX { pdug5IdentIndex }
-	::= { pdug5EnvProbeTable 1 }
+pdug5EnvProbeEntry OBJECT-TYPE
+    SYNTAX Pdug5EnvProbeEntry
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+        "Aggregate entries equal to number of PDUs."
+    INDEX { pdug5IdentIndex }
+    ::= { pdug5EnvProbeTable 1 }
 
-pdug5EnvProbeEntry ::= SEQUENCE {
-	pdug5TemperatureScale		INTEGER,
-	pdug5TemperatureCount		INTEGER,
-	pdug5HumidityCount		INTEGER,
-	pdug5DoorCount		INTEGER,
-    pdug5DryCount       INTEGER,
-    pdug5SpotCount       INTEGER,
-    pdug5RopeCount       INTEGER,
-    pdug5HidCount       INTEGER
-}
+Pdug5EnvProbeEntry ::= SEQUENCE {
+        pdug5TemperatureScale   INTEGER,
+        pdug5TemperatureCount   Integer32,
+        pdug5HumidityCount      Integer32,
+        pdug5DoorCount          Integer32,
+        pdug5DryCount           Integer32,
+        pdug5SpotCount          Integer32,
+        pdug5RopeCount          Integer32,
+        pdug5HidCount           Integer32
+    }
 
-pdug5TemperatureScale  OBJECT-TYPE
-	SYNTAX  INTEGER {
-		celsius (1),
-		fahrenheit (2)
-	}
-	ACCESS  read-write
-	STATUS  mandatory
-	DESCRIPTION 
-		"Scale used to return temperature objects."
-	::= { pdug5EnvProbeEntry 1 }
+pdug5TemperatureScale OBJECT-TYPE
+    SYNTAX INTEGER
+        {
+            celsius (1),
+            fahrenheit (2)
+        }
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Scale used to return temperature objects."
+    ::= { pdug5EnvProbeEntry 1 }
 
-pdug5TemperatureCount  OBJECT-TYPE
-	SYNTAX  INTEGER
-	ACCESS 	read-only
-	STATUS  mandatory
-	DESCRIPTION 
-		"The number of temperature measurements.The MAX is 6 (1 per probe)."
-	::= { pdug5EnvProbeEntry 2  }
+pdug5TemperatureCount OBJECT-TYPE
+    SYNTAX Integer32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "The number of temperature measurements.The MAX is 6 (1 per probe)."
+    ::= { pdug5EnvProbeEntry 2  }
 
-pdug5HumidityCount  OBJECT-TYPE
-	SYNTAX  INTEGER
-	ACCESS  read-only
-	STATUS  mandatory
-	DESCRIPTION 
-		"The number of humidity measurements.The MAX is 6(1 per probe)."
-	::= { pdug5EnvProbeEntry 3 }
+pdug5HumidityCount OBJECT-TYPE
+    SYNTAX Integer32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "The number of humidity measurements.The MAX is 6(1 per probe)."
+    ::= { pdug5EnvProbeEntry 3 }
 
-pdug5DoorCount  OBJECT-TYPE
-	SYNTAX   INTEGER
-	ACCESS 	 read-only
-	STATUS   mandatory
-	DESCRIPTION 
-		"The number of door sensors.The MAX is 6(1 per probe)."
-	::= { pdug5EnvProbeEntry 4 }
-	
+pdug5DoorCount OBJECT-TYPE
+    SYNTAX Integer32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "The number of door sensors.The MAX is 6(1 per probe)."
+    ::= { pdug5EnvProbeEntry 4 }
+
 pdug5DryCount OBJECT-TYPE
-	SYNTAX INTEGER
-	ACCESS read-only
-	STATUS mandatory
-	DESCRIPTION
-		"The number of dry sensors.The MAX is 2(1 per probe)."
-	::= { pdug5EnvProbeEntry 5 }
+    SYNTAX Integer32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "The number of dry sensors.The MAX is 2(1 per probe)."
+    ::= { pdug5EnvProbeEntry 5 }
 
 pdug5SpotCount OBJECT-TYPE
-	SYNTAX INTEGER
-	ACCESS read-only
-	STATUS mandatory
-	DESCRIPTION
-		"The number of spot sensors.The MAX is 2(1 per probe)."
-	::= { pdug5EnvProbeEntry 6 }
+    SYNTAX Integer32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "The number of spot sensors.The MAX is 2(1 per probe)."
+    ::= { pdug5EnvProbeEntry 6 }
 
 pdug5RopeCount OBJECT-TYPE
-	SYNTAX INTEGER
-	ACCESS read-only
-	STATUS mandatory
-	DESCRIPTION
-		"The number of rope sensors.The MAX is 2(1 per probe)."
-	::= { pdug5EnvProbeEntry 7 }
+    SYNTAX Integer32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "The number of rope sensors.The MAX is 2(1 per probe)."
+    ::= { pdug5EnvProbeEntry 7 }
 
 pdug5HidCount OBJECT-TYPE
-	SYNTAX INTEGER
-	ACCESS read-only
-	STATUS mandatory
-	DESCRIPTION
-		"The number of hid sensors. The MAX is 2(1 per probe)."
-	::= { pdug5EnvProbeEntry 10 }
+    SYNTAX Integer32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "The number of hid sensors. The MAX is 2(1 per probe)."
+    ::= { pdug5EnvProbeEntry 10 }
 
 -- ========Temperature Measurements ============
 
-pdug5TemperatureTable  OBJECT-TYPE
-	SYNTAX 	SEQUENCE OF pdug5TemperatureEntry
-	ACCESS 	not-accessible
-	STATUS  mandatory
-	DESCRIPTION 
-		"A list of temperature probe measurements.  The number of entries are
-		 given by number of pdu and pdug5TemperatureCount."
-	::= { pdug5Environment 2 }
+pdug5TemperatureTable OBJECT-TYPE
+    SYNTAX SEQUENCE OF Pdug5TemperatureEntry
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+        "A list of temperature probe measurements.  The number of entries are
+         given by number of pdu and pdug5TemperatureCount."
+    ::= { pdug5Environment 2 }
 
-pdug5TemperatureEntry  OBJECT-TYPE
-	SYNTAX 	pdug5TemperatureEntry
-	ACCESS  not-accessible
-	STATUS  mandatory
-	DESCRIPTION 
-		"An entry for a temperature measurement."
-	INDEX { pdug5IdentIndex, pdug5TemperatureIndex }
-	::= { pdug5TemperatureTable 1 }
+pdug5TemperatureEntry OBJECT-TYPE
+    SYNTAX Pdug5TemperatureEntry
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+        "An entry for a temperature measurement."
+    INDEX { pdug5IdentIndex, pdug5TemperatureIndex }
+    ::= { pdug5TemperatureTable 1 }
 
-pdug5TemperatureEntry ::= SEQUENCE {
-	pdug5TemperatureIndex		INTEGER,
-	pdug5TemperatureName		DisplayString,
-	pdug5TemperatureProbeStatus	INTEGER,
-	pdug5TemperatureValue		INTEGER,
-	pdug5TemperatureThStatus		INTEGER,
-	pdug5TemperatureThLowerWarning	INTEGER,
-	pdug5TemperatureThLowerCritical	INTEGER,
-	pdug5TemperatureThUpperWarning	INTEGER,
-	pdug5TemperatureThUpperCritical	INTEGER,
-	pdug5TemperatureThCtrl	INTEGER	
+Pdug5TemperatureEntry ::= SEQUENCE {
+        pdug5TemperatureIndex           Integer32,
+        pdug5TemperatureName            DisplayString,
+        pdug5TemperatureProbeStatus     INTEGER,
+        pdug5TemperatureValue           Integer32,
+        pdug5TemperatureThStatus        INTEGER,
+        pdug5TemperatureThLowerWarning  Integer32,
+        pdug5TemperatureThLowerCritical Integer32,
+        pdug5TemperatureThUpperWarning  Integer32,
+        pdug5TemperatureThUpperCritical Integer32,
+        pdug5TemperatureThCtrl          Integer32
 }
 
-pdug5TemperatureIndex  OBJECT-TYPE
-	SYNTAX   INTEGER (1..6)
-	ACCESS   read-only
-	STATUS   mandatory
-	DESCRIPTION 
-		"A unique value for each temperature probe measurement.  Its value
-		      ranges from 1 to temperatureCount."
-	::= { pdug5TemperatureEntry 1 }
+pdug5TemperatureIndex OBJECT-TYPE
+    SYNTAX Integer32 (1..6)
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+        "A unique value for each temperature probe measurement.  Its value
+         ranges from 1 to temperatureCount."
+    ::= { pdug5TemperatureEntry 1 }
 
-pdug5TemperatureName  OBJECT-TYPE
-	SYNTAX   DisplayString (SIZE(1..31))
-	ACCESS   read-write
-	STATUS   mandatory
-	DESCRIPTION 
-		"A descriptive name for the temperature probe."
-	::= { pdug5TemperatureEntry 2 }
+pdug5TemperatureName OBJECT-TYPE
+    SYNTAX DisplayString (SIZE(1..15))
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "A descriptive name for the temperature probe."
+    ::= { pdug5TemperatureEntry 2 }
 
-pdug5TemperatureProbeStatus  OBJECT-TYPE
-	SYNTAX     INTEGER {
-		disconnected (1),
-		connected (2),
-		bad (3)
-	}
-	ACCESS  read-only
-	STATUS  mandatory
-	DESCRIPTION 
-		"Indicates whether a probe is connected or not."
-	::= { pdug5TemperatureEntry 3 }
+pdug5TemperatureProbeStatus OBJECT-TYPE
+    SYNTAX INTEGER
+        {
+            disconnected (1),
+            connected (2),
+            bad (3)
+        }
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Indicates whether a probe is connected or not."
+    ::= { pdug5TemperatureEntry 3 }
 
-pdug5TemperatureValue  OBJECT-TYPE
-	SYNTAX    INTEGER  --0.1 Fahrenheit or Celsius
-	ACCESS    read-only
-	STATUS    mandatory
-	DESCRIPTION 
-		"Units are degree(either Fahrenheit or Celsius)."
-	::= { pdug5TemperatureEntry 4 }
+pdug5TemperatureValue OBJECT-TYPE
+    SYNTAX Integer32  -- Fahrenheit or Celsius
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Units are degree(either Fahrenheit or Celsius)."
+    ::= { pdug5TemperatureEntry 4 }
 
 
-pdug5TemperatureThStatus  OBJECT-TYPE
-	SYNTAX     INTEGER {
-		good (1),
-		lowWarning (2),
-		lowCritical (3),
-		highWarning (4),
-		highCritical (5)
-	}
-	ACCESS  read-only
-	STATUS  mandatory
-	DESCRIPTION 
-		"Status of the measured temperature relative to the configured thresholds."
-	::= { pdug5TemperatureEntry 5 }
+pdug5TemperatureThStatus OBJECT-TYPE
+    SYNTAX INTEGER
+        {
+            good (1),
+            lowWarning (2),
+            lowCritical (3),
+            highWarning (4),
+            highCritical (5)
+        }
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Status of the measured temperature relative to the configured thresholds."
+    ::= { pdug5TemperatureEntry 5 }
 
-pdug5TemperatureThLowerWarning  OBJECT-TYPE
-	SYNTAX   INTEGER (-1..150000)
-	ACCESS   read-write
-	STATUS   mandatory
-	DESCRIPTION 
-		"Lower warning threshold.  Units are degrees.  A negative value
-                  indicates that this object is not available."
-	::= { pdug5TemperatureEntry 6 }
+pdug5TemperatureThLowerWarning OBJECT-TYPE
+    SYNTAX Integer32 (-1..150000)
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Lower warning threshold.  Units are degrees.  A negative value
+         indicates that this object is not available."
+    ::= { pdug5TemperatureEntry 6 }
 
-pdug5TemperatureThLowerCritical  OBJECT-TYPE
-	SYNTAX    INTEGER (-1..150000)
-	ACCESS    read-write
-	STATUS    mandatory
-	DESCRIPTION 
-		"Lower critical threshold.  Units are degrees.  A negative value
-		          indicates that this object is not available."
-	::= { pdug5TemperatureEntry 7 }
+pdug5TemperatureThLowerCritical OBJECT-TYPE
+    SYNTAX Integer32 (-1..150000)
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Lower critical threshold.  Units are degrees.  A negative value
+         indicates that this object is not available."
+    ::= { pdug5TemperatureEntry 7 }
 
-pdug5TemperatureThUpperWarning  OBJECT-TYPE
-	SYNTAX    INTEGER (-1..150000)
-	ACCESS    read-write
-	STATUS    mandatory
-	DESCRIPTION 
-		"Upper warning threshold.  Units are degrees.  A negative value
-                  indicates that this object is not available."
-	::= { pdug5TemperatureEntry 8 }
+pdug5TemperatureThUpperWarning OBJECT-TYPE
+    SYNTAX Integer32 (-1..150000)
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Upper warning threshold.  Units are degrees.  A negative value
+         indicates that this object is not available."
+    ::= { pdug5TemperatureEntry 8 }
 
-pdug5TemperatureThUpperCritical  OBJECT-TYPE
-	SYNTAX    INTEGER (-1..150000)
-	ACCESS    read-write
-	STATUS    mandatory
-	DESCRIPTION 
-		"Upper critical threshold.  Units are degrees. A negative value
-                  indicates that this object is not available."
-	::= { pdug5TemperatureEntry 9 }
-	
--- 1.3.6.1.4.1.19536.10.1.4.2.1.10
+pdug5TemperatureThUpperCritical OBJECT-TYPE
+    SYNTAX Integer32 (-1..150000)
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Upper critical threshold.  Units are degrees. A negative value
+         indicates that this object is not available."
+    ::= { pdug5TemperatureEntry 9 }
+
 pdug5TemperatureThCtrl OBJECT-TYPE
-	SYNTAX INTEGER
-	ACCESS read-write
-	STATUS mandatory
-	DESCRIPTION
-		"Temperature alarm threshold control:
-		bit 0:  up critical alarm control bit,    0 -  enable, 1 -  disable
-		bit 1:  up warning alarm control bit,  0 -  enable, 1 -  disable
-		bit 2:  low warning alarm control bit, 0 -  enable, 1 -  disable
-		bit 3:  low critical alarm control bit,   0 -  enable, 1 -  disable"
-	DEFVAL { 0 }
-	::= { pdug5TemperatureEntry 10 }
+    SYNTAX Integer32
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Temperature alarm threshold control:
+         bit 0:  up critical alarm control bit,    0 -  enable, 1 -  disable
+         bit 1:  up warning alarm control bit,  0 -  enable, 1 -  disable
+         bit 2:  low warning alarm control bit, 0 -  enable, 1 -  disable
+         bit 3:  low critical alarm control bit,   0 -  enable, 1 -  disable"
+    DEFVAL { 0 }
+    ::= { pdug5TemperatureEntry 10 }
 
 -- ==========Humidity Measurements ==========
 
-pdug5HumidityTable  OBJECT-TYPE
-	SYNTAX   SEQUENCE OF pdug5HumidityEntry
-	ACCESS   not-accessible
-	STATUS   mandatory
-	DESCRIPTION 
-		"A list of humidity probe measurements.  The number of entries are
-		 given by number of pdu and pdug5HumidityCount."
-	::= { pdug5Environment 3 }
+pdug5HumidityTable OBJECT-TYPE
+    SYNTAX SEQUENCE OF Pdug5HumidityEntry
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+        "A list of humidity probe measurements.  The number of entries are
+         given by number of pdu and pdug5HumidityCount."
+    ::= { pdug5Environment 3 }
 
-pdug5HumidityEntry  OBJECT-TYPE
-	SYNTAX 	pdug5HumidityEntry
-	ACCESS  not-accessible
-	STATUS  mandatory
-	DESCRIPTION 
-		"An entry for a humidity measurement."
-	INDEX { pdug5IdentIndex, pdug5HumidityIndex }
-	::= { pdug5HumidityTable 1 }
+pdug5HumidityEntry OBJECT-TYPE
+    SYNTAX Pdug5HumidityEntry
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+        "An entry for a humidity measurement."
+    INDEX { pdug5IdentIndex, pdug5HumidityIndex }
+    ::= { pdug5HumidityTable 1 }
 
-pdug5HumidityEntry ::= SEQUENCE {
-	pdug5HumidityIndex		INTEGER,
-	pdug5HumidityName		DisplayString,
-	pdug5HumidityProbeStatus		INTEGER,
-	pdug5HumidityValue		INTEGER,
-	pdug5HumidityThStatus		INTEGER,
-	pdug5HumidityThLowerWarning	INTEGER,
-	pdug5HumidityThLowerCritical	INTEGER,
-	pdug5HumidityThUpperWarning	INTEGER,
-	pdug5HumidityThUpperCritical	INTEGER,
-	pdug5HumidityThCtrl	INTEGER
-}
+Pdug5HumidityEntry ::= SEQUENCE {
+        pdug5HumidityIndex              Integer32,
+        pdug5HumidityName               DisplayString,
+        pdug5HumidityProbeStatus        INTEGER,
+        pdug5HumidityValue              Integer32,
+        pdug5HumidityThStatus           INTEGER,
+        pdug5HumidityThLowerWarning     Integer32,
+        pdug5HumidityThLowerCritical    Integer32,
+        pdug5HumidityThUpperWarning     Integer32,
+        pdug5HumidityThUpperCritical    Integer32,
+        pdug5HumidityThCtrl             Integer32
+    }
 
-pdug5HumidityIndex  OBJECT-TYPE
-	SYNTAX     INTEGER (1..6)
-	ACCESS     read-only
-	STATUS     mandatory
-	DESCRIPTION 
-		"A unique value for each humidity probe measurement.  Its value
-		 ranges from 1 to pdug5HumidityCount per PDU."
-	::= { pdug5HumidityEntry 1 }
+pdug5HumidityIndex OBJECT-TYPE
+    SYNTAX Integer32 (1..6)
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+        "A unique value for each humidity probe measurement.  Its value
+         ranges from 1 to pdug5HumidityCount per PDU."
+    ::= { pdug5HumidityEntry 1 }
 
-pdug5HumidityName  OBJECT-TYPE
-	SYNTAX   DisplayString (SIZE(1..31))
-	ACCESS   read-write
-	STATUS   mandatory
-	DESCRIPTION 
-		"A descriptive name for the humidity probe."
-	::= { pdug5HumidityEntry 2 }
+pdug5HumidityName OBJECT-TYPE
+    SYNTAX DisplayString (SIZE(1..15))
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+            "A descriptive name for the humidity probe."
+    ::= { pdug5HumidityEntry 2 }
 
-pdug5HumidityProbeStatus  OBJECT-TYPE
-	SYNTAX  INTEGER {
-		disconnected (1),
-		connected (2),
-		bad (3)
-	}
-	ACCESS  read-only
-	STATUS  mandatory
-	DESCRIPTION 
-		"Indicates whether a probe is connected or not."
-	::= { pdug5HumidityEntry 3 }
+pdug5HumidityProbeStatus OBJECT-TYPE
+    SYNTAX INTEGER
+        {
+            disconnected (1),
+            connected (2),
+            bad (3)
+        }
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Indicates whether a probe is connected or not."
+    ::= { pdug5HumidityEntry 3 }
 
-pdug5HumidityValue  OBJECT-TYPE
-	SYNTAX    INTEGER
-	ACCESS    read-only
-	STATUS    mandatory
-	DESCRIPTION 
-		"Units are %RH."
-	::= { pdug5HumidityEntry 4 }
+pdug5HumidityValue OBJECT-TYPE
+    SYNTAX Integer32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Units are %RH."
+    ::= { pdug5HumidityEntry 4 }
 
-pdug5HumidityThStatus  OBJECT-TYPE
-	SYNTAX  INTEGER {
-		good (1),
-		lowWarning (2),
-		lowCritical (3),
-		highWarning (4),
-		highCritical (5)
-	}
-	ACCESS  read-only
-	STATUS  mandatory
-	DESCRIPTION 
-		"Status of the measured humidity relative to the configured thresholds."
-	::= { pdug5HumidityEntry 5 }
+pdug5HumidityThStatus OBJECT-TYPE
+    SYNTAX INTEGER
+        {
+            good (1),
+            lowWarning (2),
+            lowCritical (3),
+            highWarning (4),
+            highCritical (5)
+        }
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Status of the measured humidity relative to the configured thresholds."
+    ::= { pdug5HumidityEntry 5 }
 
-pdug5HumidityThLowerWarning  OBJECT-TYPE
-	SYNTAX    INTEGER (-1..1000)
-	ACCESS    read-write
-	STATUS    mandatory
-	DESCRIPTION 
-		"Lower warning threshold.  Units are %RH.  A negative value
-                  indicates that this object is not available."
-	::= { pdug5HumidityEntry 6 }
+pdug5HumidityThLowerWarning OBJECT-TYPE
+    SYNTAX Integer32 (-1..1000)
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Lower warning threshold.  Units are %RH.  A negative value
+         indicates that this object is not available."
+    ::= { pdug5HumidityEntry 6 }
 
-pdug5HumidityThLowerCritical  OBJECT-TYPE
-	SYNTAX    INTEGER (-1..1000)
-	ACCESS    read-write
-	STATUS    mandatory
-	DESCRIPTION 
-		"Lower critical threshold.  Units are %RH.  A negative value
-                  indicates that this object is not available."
-	::= { pdug5HumidityEntry 7 }
+pdug5HumidityThLowerCritical OBJECT-TYPE
+    SYNTAX Integer32 (-1..1000)
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Lower critical threshold.  Units are %RH.  A negative value
+         indicates that this object is not available."
+    ::= { pdug5HumidityEntry 7 }
 
-pdug5HumidityThUpperWarning  OBJECT-TYPE
-	SYNTAX   INTEGER (-1..1000)
-	ACCESS   read-write
-	STATUS   mandatory
-	DESCRIPTION 
-		"Upper warning threshold.  Units are %RH.  A negative value
-                  indicates that this object is not available."
-	::= { pdug5HumidityEntry 8 }
+pdug5HumidityThUpperWarning OBJECT-TYPE
+    SYNTAX Integer32 (-1..1000)
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Upper warning threshold.  Units are %RH.  A negative value
+         indicates that this object is not available."
+    ::= { pdug5HumidityEntry 8 }
 
-pdug5HumidityThUpperCritical  OBJECT-TYPE
-	SYNTAX   INTEGER (-1..1000)
-	ACCESS   read-write
-	STATUS   mandatory
-	DESCRIPTION 
-		"Upper critical threshold.  Units are %RH.  A negative value
-                  indicates that this object is not available."
-	::= { pdug5HumidityEntry 9 }
+pdug5HumidityThUpperCritical OBJECT-TYPE
+    SYNTAX Integer32 (-1..1000)
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Upper critical threshold.  Units are %RH.  A negative value
+         indicates that this object is not available."
+    ::= { pdug5HumidityEntry 9 }
 
--- 1.3.6.1.4.1.19536.10.1.4.3.1.10
 pdug5HumidityThCtrl OBJECT-TYPE
-	SYNTAX INTEGER
-	ACCESS read-write
-	STATUS mandatory
-	DESCRIPTION
-		"Humidity alarm threshold control:
-		bit 0:  up critical alarm control bit,    0 -  enable, 1 -  disable
-		bit 1:  up warning alarm control bit,  0 -  enable, 1 -  disable
-		bit 2:  low warning alarm control bit, 0 -  enable, 1 -  disable
-		bit 3:  low critical alarm control bit,   0 -  enable, 1 -  disable"
-	DEFVAL { 0 }
-	::= { pdug5HumidityEntry 10 }
+    SYNTAX Integer32
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Humidity alarm threshold control:
+         bit 0:  up critical alarm control bit,    0 -  enable, 1 -  disable
+         bit 1:  up warning alarm control bit,  0 -  enable, 1 -  disable
+         bit 2:  low warning alarm control bit, 0 -  enable, 1 -  disable
+         bit 3:  low critical alarm control bit,   0 -  enable, 1 -  disable"
+    DEFVAL { 0 }
+    ::= { pdug5HumidityEntry 10 }
 
 -- ======Door sensor Status==========
+pdug5DoorTable OBJECT-TYPE
+    SYNTAX SEQUENCE OF Pdug5DoorEntry
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+        "A list of door sensors.  The number of entries are
+         given by number of PDU and pdug5DoorCount."
+    ::= { pdug5Environment 4 }
 
-pdug5DoorTable  OBJECT-TYPE
-	SYNTAX  SEQUENCE OF pdug5DoorEntry
-	ACCESS  not-accessible
-	STATUS  mandatory
-	DESCRIPTION 
-		"A list of door sensors.  The number of entries are
-		 given by number of PDU and pdug5DoorCount."
-	::= { pdug5Environment 4 }
+pdug5DoorEntry OBJECT-TYPE
+    SYNTAX Pdug5DoorEntry
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+        "An entry for a door sensor"
+    INDEX { pdug5IdentIndex, pdug5DoorIndex }
+    ::= { pdug5DoorTable 1 }
 
-pdug5DoorEntry  OBJECT-TYPE
-	SYNTAX 	 pdug5DoorEntry
-	ACCESS   not-accessible
-	STATUS   mandatory
-	DESCRIPTION 
-		"An entry for a door sensor"
-	INDEX { pdug5IdentIndex, pdug5DoorIndex }
-	::= { pdug5DoorTable 1 }
+Pdug5DoorEntry ::= SEQUENCE
+    {
+        pdug5DoorIndex       Integer32,
+        pdug5DoorName        DisplayString,
+        pdug5DoorProbeStatus INTEGER,
+        pdug5DoorState       INTEGER
+    }
 
-pdug5DoorEntry ::= SEQUENCE {
-	pdug5DoorIndex	INTEGER,
-	pdug5DoorName		DisplayString,
-	pdug5DoorProbeStatus	INTEGER,
-	pdug5DoorState	INTEGER
-}
+pdug5DoorIndex OBJECT-TYPE
+    SYNTAX Integer32 (1..2)
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+        "A unique value for each door sensor.  Its value ranges from 1 to
+         doorCount."
+    ::= { pdug5DoorEntry 1 }
 
-pdug5DoorIndex  OBJECT-TYPE
-	SYNTAX   INTEGER (1..2)
-	ACCESS   read-only
-	STATUS   mandatory
-	DESCRIPTION 
-		"A unique value for each door sensor.  Its value ranges from 1 to
-		      doorCount."
-	::= { pdug5DoorEntry 1 }
+pdug5DoorName OBJECT-TYPE
+    SYNTAX DisplayString (SIZE(1..15))
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "A descriptive name for the door sensor."
+    ::= { pdug5DoorEntry 2 }
 
-pdug5DoorName  OBJECT-TYPE
-	SYNTAX    DisplayString (SIZE(1..31))
-	ACCESS    read-write
-	STATUS    mandatory
-	DESCRIPTION 
-		"A descriptive name for the door sensor."
-	::= { pdug5DoorEntry 2 }
+pdug5DoorProbeStatus OBJECT-TYPE
+    SYNTAX INTEGER
+        {
+            disconnected (1),
+            connected (2),
+            bad (3)
+        }
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Indicates whether a probe is connected or not.
+         Will not be returned  if the door sensor is internal to the ePDU,
+         in that case only doorState should be read."
+    ::= { pdug5DoorEntry 3 }
 
-pdug5DoorProbeStatus  OBJECT-TYPE
-	SYNTAX  INTEGER {
-		disconnected (1),
-		connected (2),
-		bad (3)
-	}
-	ACCESS  read-only
-	STATUS  mandatory
-	DESCRIPTION 
-		"Indicates whether a probe is connected or not.
-		Will not be returned  if the door sensor is internal to the ePDU,
-		in that case only doorState should be read."
-	::= { pdug5DoorEntry 3 }
+pdug5DoorState OBJECT-TYPE
+    SYNTAX INTEGER
+        {
+            doorOpen (1),
+            doorClosed (2),
+            badDoorSensor (3)
+        }
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "The state of the door sensor."
+    ::= { pdug5DoorEntry 4 }
 
-pdug5DoorState  OBJECT-TYPE
-	SYNTAX  INTEGER {
-		doorOpen (1),
-		doorClosed (2),
-		BaddoorSensor (3)
-	}
-	ACCESS  read-only
-	STATUS  mandatory
-	DESCRIPTION 
-		"The state of the door sensor."
-	::= { pdug5DoorEntry 4 }
 
-		
 --     ======Dry Sensor Status==========
-		-- 1.3.6.1.4.1.19536.10.1.4.5
-		pdug5DryTable OBJECT-TYPE
-			SYNTAX SEQUENCE OF pdug5DryEntry
-			ACCESS not-accessible
-			STATUS mandatory
-			DESCRIPTION
-				"A list of dry sensors.  The number of entries are
-				given by number of pdu and pdug5DryCount."
-			::= { pdug5Environment 5 }
+pdug5DryTable OBJECT-TYPE
+    SYNTAX SEQUENCE OF Pdug5DryEntry
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+        "A list of dry sensors.  The number of entries are
+         given by number of pdu and pdug5DryCount."
+    ::= { pdug5Environment 5 }
 
-		
+pdug5DryEntry OBJECT-TYPE
+    SYNTAX Pdug5DryEntry
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+        "An entry for a contact sensor"
+    INDEX { pdug5IdentIndex, pdug5DryIndex }
+    ::= { pdug5DryTable 1 }
 
-		-- 1.3.6.1.4.1.19536.10.1.4.5.1
-		pdug5DryEntry OBJECT-TYPE
-			SYNTAX pdug5DryEntry
-			ACCESS not-accessible
-			STATUS mandatory
-			DESCRIPTION
-				"An entry for a contact sensor"
-			INDEX { pdug5IdentIndex, pdug5DryIndex }
-			::= { pdug5DryTable 1 }
-
-		
-		pdug5DryEntry ::=
-			SEQUENCE { 
-				pdug5DryIndex
-					INTEGER,
-				pdug5DryName
-					DisplayString,
-				pdug5DryProbeStatus
-					INTEGER,
-				pdug5DryState
-					INTEGER
-			 }
+Pdug5DryEntry ::= SEQUENCE
+    {
+        pdug5DryIndex          Integer32,
+        pdug5DryName           DisplayString,
+        pdug5DryProbeStatus    INTEGER,
+        pdug5DryState          INTEGER
+    }
 
 
-		-- 1.3.6.1.4.1.19536.10.1.4.5.1.1
-		pdug5DryIndex OBJECT-TYPE
-			SYNTAX INTEGER (1..2)
-			ACCESS read-only
-			STATUS mandatory
-			DESCRIPTION
-				"A unique value for each dry sensor.  Its value ranges from 1 to
-				dryCount."
-			::= { pdug5DryEntry 1 }
+pdug5DryIndex OBJECT-TYPE
+    SYNTAX Integer32 (1..2)
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+        "A unique value for each dry sensor.  Its value ranges from 1 to
+        dryCount."
+    ::= { pdug5DryEntry 1 }
 
-		
+pdug5DryName OBJECT-TYPE
+SYNTAX DisplayString (SIZE (1..15))
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "A descriptive name for the dry sensor."
+    ::= { pdug5DryEntry 2 }
 
-		-- 1.3.6.1.4.1.19536.10.1.4.5.1.2
-		pdug5DryName OBJECT-TYPE
-			SYNTAX DisplayString (SIZE (1..31))
-			ACCESS read-write
-			STATUS mandatory
-			DESCRIPTION
-				"A descriptive name for the dry sensor."
-			::= { pdug5DryEntry 2 }
+pdug5DryProbeStatus OBJECT-TYPE
+    SYNTAX INTEGER
+        {
+            disconnected(1),
+            connected(2),
+            bad(3)
+        }
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Indicates whether a probe is connected or not."
+    ::= { pdug5DryEntry 3 }
 
-		
+pdug5DryState OBJECT-TYPE
+    SYNTAX INTEGER
+        {
+            good(1),
+            alarmed(2)
+        }
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "The state of the dry sensor."
+    ::= { pdug5DryEntry 4 }
 
-		-- 1.3.6.1.4.1.19536.10.1.4.5.1.3
-		pdug5DryProbeStatus OBJECT-TYPE
-			SYNTAX INTEGER
-				{
-				disconnected(1),
-				connected(2),
-				bad(3)
-				}
-			ACCESS read-only
-			STATUS mandatory
-			DESCRIPTION
-				"Indicates whether a probe is connected or not."
-			::= { pdug5DryEntry 3 }
-
-		
-
-		-- 1.3.6.1.4.1.19536.10.1.4.5.1.4
-		pdug5DryState OBJECT-TYPE
-			SYNTAX INTEGER
-				{
-				good(1),
-				alarmed(2)
-				}
-			ACCESS read-only
-			STATUS mandatory
-			DESCRIPTION
-				"The state of the dry sensor."
-			::= { pdug5DryEntry 4 }
-
-		
 --     ====== Water Spot Sensor Status==========
+pdug5SpotTable OBJECT-TYPE
+    SYNTAX SEQUENCE OF Pdug5SpotEntry
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+        "A list of contact sensors.  The number of entries are
+         given by number of pdu and pdug5SpotCount."
+    ::= { pdug5Environment 6 }
 
-		-- 1.3.6.1.4.1.19536.10.1.4.6
-		pdug5SpotTable OBJECT-TYPE
-			SYNTAX SEQUENCE OF pdug5SpotEntry
-			ACCESS not-accessible
-			STATUS mandatory
-			DESCRIPTION
-				"A list of contact sensors.  The number of entries are
-				given by number of pdu and pdug5SpotCount."
-			::= { pdug5Environment 6 }
+pdug5SpotEntry OBJECT-TYPE
+    SYNTAX Pdug5SpotEntry
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+        "An entry for a contact sensor"
+    INDEX { pdug5IdentIndex, pdug5SpotIndex }
+    ::= { pdug5SpotTable 1 }
 
-		
+Pdug5SpotEntry ::= SEQUENCE
+    {
+        pdug5SpotIndex         Integer32,
+        pdug5SpotName          DisplayString,
+        pdug5SpotProbeStatus   INTEGER,
+        pdug5SpotState         INTEGER
+    }
 
-		-- 1.3.6.1.4.1.19536.10.1.4.6.1
-		pdug5SpotEntry OBJECT-TYPE
-			SYNTAX pdug5SpotEntry
-			ACCESS not-accessible
-			STATUS mandatory
-			DESCRIPTION
-				"An entry for a contact sensor"
-			INDEX { pdug5IdentIndex, pdug5SpotIndex }
-			::= { pdug5SpotTable 1 }
+pdug5SpotIndex OBJECT-TYPE
+    SYNTAX Integer32 (1..3)
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+        "A unique value for each spot sensor.  Its value ranges from 1 to
+         spotCount."
+    ::= { pdug5SpotEntry 1 }
 
-		
-		pdug5SpotEntry ::=
-			SEQUENCE { 
-				pdug5SpotIndex
-					INTEGER,
-				pdug5SpotName
-					DisplayString,
-				pdug5SpotProbeStatus
-					INTEGER,
-				pdug5SpotState
-					INTEGER
-			 }
+pdug5SpotName OBJECT-TYPE
+    SYNTAX DisplayString (SIZE (1..15))
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "A descriptive name for the spot sensor."
+    ::= { pdug5SpotEntry 2 }
 
+pdug5SpotProbeStatus OBJECT-TYPE
+    SYNTAX INTEGER
+        {
+            disconnected(1),
+            connected(2),
+            bad(3)
+        }
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Indicates whether a probe is connected or not."
+    ::= { pdug5SpotEntry 3 }
 
-		-- 1.3.6.1.4.1.19536.10.1.4.6.1.1
-		pdug5SpotIndex OBJECT-TYPE
-			SYNTAX INTEGER (1..3)
-			ACCESS read-only
-			STATUS mandatory
-			DESCRIPTION
-				"A unique value for each spot sensor.  Its value ranges from 1 to
-				spotCount."
-			::= { pdug5SpotEntry 1 }
+pdug5SpotState OBJECT-TYPE
+    SYNTAX INTEGER
+        {
+            noleak(1),
+            leak(2)
+        }
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "The state of the spot sensor."
+    ::= { pdug5SpotEntry 4 }
 
-		
-
-		-- 1.3.6.1.4.1.19536.10.1.4.6.1.2
-		pdug5SpotName OBJECT-TYPE
-			SYNTAX DisplayString (SIZE (1..31))
-			ACCESS read-write
-			STATUS mandatory
-			DESCRIPTION
-				"A descriptive name for the spot sensor."
-			::= { pdug5SpotEntry 2 }
-
-		
-		-- 1.3.6.1.4.1.19536.10.1.4.6.1.3
-		pdug5SpotProbeStatus OBJECT-TYPE
-			SYNTAX INTEGER
-				{
-				disconnected(1),
-				connected(2),
-				bad(3)
-				}
-			ACCESS read-only
-			STATUS mandatory
-			DESCRIPTION
-				"Indicates whether a probe is connected or not."
-			::= { pdug5SpotEntry 3 }
-
-		
-		-- 1.3.6.1.4.1.19536.10.1.4.6.1.4
-		pdug5SpotState OBJECT-TYPE
-			SYNTAX INTEGER
-				{
-				noleak(1),
-				leak(2)
-				}
-			ACCESS read-only
-			STATUS mandatory
-			DESCRIPTION
-				"The state of the spot sensor."
-			::= { pdug5SpotEntry 4 }
-
-		
 --     ======Water Rope Sensor Status==========
-		-- 1.3.6.1.4.1.19536.10.1.4.7
-		pdug5RopeTable OBJECT-TYPE
-			SYNTAX SEQUENCE OF pdug5RopeEntry
-			ACCESS not-accessible
-			STATUS mandatory
-			DESCRIPTION
-				"A list of rope sensors.  The number of entries are
-				given by number of pdu and pdug5RopeCount."
-			::= { pdug5Environment 7 }
+pdug5RopeTable OBJECT-TYPE
+    SYNTAX SEQUENCE OF Pdug5RopeEntry
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+        "A list of rope sensors.  The number of entries are
+         given by number of pdu and pdug5RopeCount."
+    ::= { pdug5Environment 7 }
 
-		
-		-- 1.3.6.1.4.1.19536.10.1.4.7.1
-		pdug5RopeEntry OBJECT-TYPE
-			SYNTAX pdug5RopeEntry
-			ACCESS not-accessible
-			STATUS mandatory
-			DESCRIPTION
-				"An entry for a contact sensor"
-			INDEX { pdug5IdentIndex, pdug5RopeIndex }
-			::= { pdug5RopeTable 1 }
+pdug5RopeEntry OBJECT-TYPE
+    SYNTAX Pdug5RopeEntry
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+        "An entry for a contact sensor"
+    INDEX { pdug5IdentIndex, pdug5RopeIndex }
+    ::= { pdug5RopeTable 1 }
 
-		
-		pdug5RopeEntry ::=
-			SEQUENCE { 
-				pdug5RopeIndex
-					INTEGER,
-				pdug5RopeName
-					DisplayString,
-				pdug5RopeProbeStatus
-					INTEGER,
-				pdug5RopeState
-					INTEGER
-			 }
+Pdug5RopeEntry ::= SEQUENCE
+    {
+        pdug5RopeIndex         Integer32,
+        pdug5RopeName          DisplayString,
+        pdug5RopeProbeStatus   INTEGER,
+        pdug5RopeState         INTEGER
+    }
 
-		-- 1.3.6.1.4.1.19536.10.1.4.7.1.1
-		pdug5RopeIndex OBJECT-TYPE
-			SYNTAX INTEGER (1..3)
-			ACCESS read-only
-			STATUS mandatory
-			DESCRIPTION
-				"A unique value for each rope sensor.  Its value ranges from 1 to
-				ropeCount."
-			::= { pdug5RopeEntry 1 }
+pdug5RopeIndex OBJECT-TYPE
+    SYNTAX Integer32 (1..3)
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+        "A unique value for each rope sensor.  Its value ranges from 1 to
+         ropeCount."
+    ::= { pdug5RopeEntry 1 }
 
-		
-		-- 1.3.6.1.4.1.19536.10.1.4.7.1.2
-		pdug5RopeName OBJECT-TYPE
-			SYNTAX DisplayString (SIZE (1..31))
-			ACCESS read-write
-			STATUS mandatory
-			DESCRIPTION
-				"A descriptive name for the rope sensor."
-			::= { pdug5RopeEntry 2 }
+pdug5RopeName OBJECT-TYPE
+    SYNTAX DisplayString (SIZE (1..15))
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "A descriptive name for the rope sensor."
+    ::= { pdug5RopeEntry 2 }
 
-		
-		-- 1.3.6.1.4.1.19536.10.1.4.7.1.3
-		pdug5RopeProbeStatus OBJECT-TYPE
-			SYNTAX INTEGER
-				{
-				disconnected(1),
-				connected(2),
-				bad(3)
-				}
-			ACCESS read-only
-			STATUS mandatory
-			DESCRIPTION
-				"Indicates whether a probe is connected or not."
-			::= { pdug5RopeEntry 3 }
+pdug5RopeProbeStatus OBJECT-TYPE
+    SYNTAX INTEGER
+        {
+            disconnected(1),
+            connected(2),
+            bad(3)
+        }
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Indicates whether a probe is connected or not."
+    ::= { pdug5RopeEntry 3 }
 
-		
-		-- 1.3.6.1.4.1.19536.10.1.4.7.1.4
-		pdug5RopeState OBJECT-TYPE
-			SYNTAX INTEGER
-				{
-				noleak(1),
-				leak(2)
-				}
-			ACCESS read-only
-			STATUS mandatory
-			DESCRIPTION
-				"The state of the rope sensor."
-			::= { pdug5RopeEntry 4 }
-		
-		-- 1.3.6.1.4.1.19536.10.1.4.10
-		pdug5EnvHID OBJECT IDENTIFIER ::= { pdug5Environment 10 }
+pdug5RopeState OBJECT-TYPE
+    SYNTAX INTEGER
+        {
+            noleak(1),
+            leak(2)
+        }
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "The state of the rope sensor."
+    ::= { pdug5RopeEntry 4 }
 
-		
+
+--     ======Hid Table  ==========
+pdug5EnvHID OBJECT IDENTIFIER ::= { pdug5Environment 10 }
+
+
 --     ======Hid Sensor Status==========
-		-- 1.3.6.1.4.1.19536.10.1.4.10.1
-		pdug5EnvHidTable OBJECT-TYPE
-			SYNTAX SEQUENCE OF pdug5EnvHidEntry
-			ACCESS not-accessible
-			STATUS mandatory
-			DESCRIPTION
-				"A list of contact sensors.  The number of entries are
-				given by number of pdu and pdug5HidCount."
-			::= { pdug5EnvHID 1 }
+pdug5EnvHidTable OBJECT-TYPE
+    SYNTAX SEQUENCE OF Pdug5EnvHidEntry
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+        "A list of contact sensors.  The number of entries are
+         given by number of pdu and pdug5HidCount."
+    ::= { pdug5EnvHID 1 }
 
-		
-		-- 1.3.6.1.4.1.19536.10.1.4.10.1.1
-		pdug5EnvHidEntry OBJECT-TYPE
-			SYNTAX pdug5EnvHidEntry
-			ACCESS not-accessible
-			STATUS mandatory
-			DESCRIPTION
-				"An entry for a contact sensor"
-			INDEX { pdug5IdentIndex, pdug5HIDIndex }
-			::= { pdug5EnvHidTable 1 }
+pdug5EnvHidEntry OBJECT-TYPE
+    SYNTAX Pdug5EnvHidEntry
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+        "An entry for a contact sensor"
+    INDEX { pdug5IdentIndex, pdug5HIDIndex }
+    ::= { pdug5EnvHidTable 1 }
 
-		
-		pdug5EnvHidEntry ::=
-			SEQUENCE { 
-				pdug5HIDIndex
-					INTEGER,
-				pdug5HidAisle
-					INTEGER,
-				pdug5HidHandleOperation		
-					INTEGER	
-			 }
+Pdug5EnvHidEntry ::= SEQUENCE
+    {
+        pdug5HIDIndex              Integer32,
+        pdug5HidAisle              INTEGER,
+        pdug5HidHandleOperation    INTEGER,
+        pduHIDVer                  DisplayString,
+        pdug5MechanicalLock        INTEGER,
+        pduHIDSerial               DisplayString,
+        pduHIDHwVer                DisplayString,
+        pdug5HIDAutoLockTime       Integer32,
+        pdug5HIDDoorOpenTime       Integer32,
+        pdug5HIDMaxDoorOpenTime    Integer32,
+        pdug5HIDUserPinLength      Integer32,
+        pdug5HIDUserPinMode        INTEGER,
+        pdug5HIDAisleControl       INTEGER,
+        pdug5HIDBeaconFuncControl  INTEGER,
+        pdug5HidBeaconColorControl INTEGER
+     }
 
-		-- 1.3.6.1.4.1.19536.10.1.4.10.1.1.1
-		pdug5HIDIndex OBJECT-TYPE
-			SYNTAX INTEGER (1..2)
-			ACCESS read-only
-			STATUS mandatory
-			DESCRIPTION
-				"The index of the PDU HID table entry"
-			::= { pdug5EnvHidEntry 1 }
+pdug5HIDIndex OBJECT-TYPE
+    SYNTAX Integer32 (1..2)
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+        "The index of the PDU HID table entry"
+    ::= { pdug5EnvHidEntry 1 }
 
-		
+pdug5HidAisle OBJECT-TYPE
+    SYNTAX INTEGER
+        {
+            cold(1),
+            hot(2)
+        }
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Aisle of HID handle. "
+    ::= { pdug5EnvHidEntry 2 }
+
+pdug5HidHandleOperation OBJECT-TYPE
+    SYNTAX INTEGER
+        {
+            unlock(1),
+            lock(2)
+        }
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "HID handle control operations "
+    ::= { pdug5EnvHidEntry 3 }
+
+pduHIDVer OBJECT-TYPE
+    SYNTAX DisplayString (SIZE (0..63))
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "The firmware revision level of the HID"
+    ::= { pdug5EnvHidEntry 4 }
+
+pdug5MechanicalLock OBJECT-TYPE
+    SYNTAX INTEGER
+        {
+            unlock(1),
+            lock(2)
+        }
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "HID Mechanical operations "
+    ::= { pdug5EnvHidEntry 5 }
+
+pduHIDSerial OBJECT-TYPE
+    SYNTAX DisplayString (SIZE (0..63))
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "The Serial Number of the HID"
+    ::= { pdug5EnvHidEntry 6 }
+
+pduHIDHwVer OBJECT-TYPE
+    SYNTAX DisplayString (SIZE (0..63))
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "The hardware revision level of the HID"
+    ::= { pdug5EnvHidEntry 7 }
+
+pdug5HIDAutoLockTime OBJECT-TYPE
+SYNTAX Integer32
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "HID Electronic Latch Autolock Time in seconds, Value ranges (0-999) "
+::= { pdug5EnvHidEntry 8 }
+
+pdug5HIDDoorOpenTime OBJECT-TYPE
+    SYNTAX Integer32
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "HID Door Open Time in seconds, Value ranges (0-999)"
+        ::= { pdug5EnvHidEntry 9 }
+
+pdug5HIDMaxDoorOpenTime OBJECT-TYPE
+    SYNTAX Integer32
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "HID Max Door Open Time in seconds, Value ranges (0-32400),
+         critical alarm will be raised if door is left open past this time"
+    ::= { pdug5EnvHidEntry 10 }
+
+pdug5HIDUserPinLength OBJECT-TYPE
+    SYNTAX Integer32
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Rack Access User minimum PIN Length, value ranges(0-16)"
+    ::= { pdug5EnvHidEntry 11 }
+
+pdug5HIDUserPinMode OBJECT-TYPE
+    SYNTAX INTEGER
+        {
+            visible(1),
+            hidden (2)
+        }
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Rack Access User PIN mode setting"
+    ::= { pdug5EnvHidEntry 12 }
+
+pdug5HIDAisleControl OBJECT-TYPE
+    SYNTAX INTEGER
+        {
+            combined (1),
+            standalone(2)
+        }
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Rack Access Aisle Control setting,
+         when set to standalone each aisle will controlled separately,
+         when set to combined opposite aisle can be controlled with authenticated control action on either aisle"
+    ::= { pdug5EnvHidEntry 13 }
+
+pdug5HIDBeaconFuncControl  OBJECT-TYPE
+	SYNTAX INTEGER
+        {
+            locate (0),
+            standby (1)
+        }
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Beacon Function Control"
+    ::= { pdug5EnvHidEntry 14 }
 	
-		-- 1.3.6.1.4.1.19536.10.1.4.10.1.1.2
-		pdug5HidAisle OBJECT-TYPE
-			SYNTAX INTEGER
-				{
-				COLD(1),
-				HOT(2)
-				}
-			ACCESS read-only
-			STATUS mandatory
-			DESCRIPTION
-				"Aisle of HID handle. "
-			::= { pdug5EnvHidEntry 2 }		
-		-- 1.3.6.1.4.1.19536.10.1.4.10.1.1.3
-		pdug5HidHandleOperation OBJECT-TYPE
-			SYNTAX INTEGER
-				{
-				unlock(1),
-				lock(2)
-				}
-			ACCESS read-write
-			STATUS mandatory
-			DESCRIPTION
-				"HID handle control opterations "
-			::= { pdug5EnvHidEntry 3 }	
-		-- 1.3.6.1.4.1.19536.10.1.4.10.1.1.4
-		pduHIDVer OBJECT-TYPE
-			SYNTAX DisplayString (SIZE (0..63))
-			ACCESS read-only
-			STATUS mandatory
-			DESCRIPTION
-				"The firmware revision level of the HID"
-			::= { pdug5EnvHidEntry 4 }
-		-- 1.3.6.1.4.1.19536.10.1.4.10.1.1.5
-		pdug5MechanicalLock OBJECT-TYPE
-			SYNTAX INTEGER
-				{
-				unlock(1),
-				lock(2)
-				}
-			ACCESS read-only
-			STATUS mandatory
-			DESCRIPTION
-				"HID Mechanical opterations "
-			::= { pdug5EnvHidEntry 5 }		
+pdug5HidBeaconColorControl  OBJECT-TYPE
+    SYNTAX INTEGER
+        {
+            red(0),
+            green(1),
+            blue(2),
+            yellow(3),
+            magenta(4),
+            aqua(5),
+            white(6),
+            beaconoff(7)
+        }
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Beacon Color Control"
+    ::= { pdug5EnvHidEntry 15 }
+
 --     ======Hid hid control table==========
-		-- 1.3.6.1.4.1.19536.10.1.4.10.2
-		pdug5EnvHidControlTable OBJECT-TYPE
-			SYNTAX SEQUENCE OF pdug5EnvHidControlEntry
-			ACCESS not-accessible
-			STATUS mandatory
-			DESCRIPTION
-				"A list of smartcard.  The number of entries are
-				given by number of pdu and pdug5HidCount."
-			::= { pdug5EnvHID 2 }
+pdug5EnvHidControlTable OBJECT-TYPE
+    SYNTAX SEQUENCE OF Pdug5EnvHidControlEntry
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+        "A list of smartcard.  The number of entries are
+         given by number of pdu and pdug5HidCount."
+    ::= { pdug5EnvHID 2 }
 
-		
-		-- 1.3.6.1.4.1.19536.10.1.4.10.2.1
-		pdug5EnvHidControlEntry OBJECT-TYPE
-			SYNTAX pdug5EnvHidControlEntry
-			ACCESS not-accessible
-			STATUS mandatory
-			DESCRIPTION
-				"The smartcard table entry containing the usrname, cardid, cardaisle etc."
-			INDEX { pdug5IdentIndex, pdug5HidControlIndex }
-			::= { pdug5EnvHidControlTable 1 }
+pdug5EnvHidControlEntry OBJECT-TYPE
+    SYNTAX Pdug5EnvHidControlEntry
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+        "The smart card table entry containing the username, cardid, cardaisle etc."
+    INDEX { pdug5IdentIndex, pdug5HidControlIndex }
+    ::= { pdug5EnvHidControlTable 1 }
 
-		
-		pdug5EnvHidControlEntry ::=
-			SEQUENCE { 
-				pdug5HidControlIndex			INTEGER,
-				pdug5HidControlUserName			DisplayString,
-				pdug5HidControlCardID			INTEGER,
-				pdug5HidControlTimestamp		DisplayString,
-				pdug5HidControlCardAisle		INTEGER
-			 }
-		-- 1.3.6.1.4.1.19536.10.1.4.10.2.1.1
-		pdug5HidControlIndex OBJECT-TYPE
-			SYNTAX INTEGER (1..2)
-			ACCESS read-only
-			STATUS mandatory
-			DESCRIPTION
-				"The index of the PDU smartcard table entry"
-			::= { pdug5EnvHidControlEntry 1 }			 
-		-- 1.3.6.1.4.1.19536.10.1.4.10.2.1.2
-		pdug5HidControlUserName OBJECT-TYPE
-			SYNTAX DisplayString
-			ACCESS read-write
-			STATUS mandatory
-			DESCRIPTION
-				"User name of smartcard"
-			::= { pdug5EnvHidControlEntry 2 }	
-			
-		-- 1.3.6.1.4.19536.10.1.4.10.2.1.3
-		pdug5HidControlCardID OBJECT-TYPE
-			SYNTAX INTEGER
-			ACCESS read-write
-			STATUS mandatory
-			DESCRIPTION
-				"HID smartcard ID."
-			::= { pdug5EnvHidControlEntry 3 }	
-		
-		-- 1.3.6.1.4.19536.10.1.4.10.2.1.4
-		pdug5HidControlTimestamp OBJECT-TYPE
-			SYNTAX DisplayString
-			ACCESS read-write
-			STATUS mandatory
-			DESCRIPTION
-				"Indicates the date and time of accessing"
-			::= { pdug5EnvHidControlEntry 4 }
+Pdug5EnvHidControlEntry ::= SEQUENCE
+    {
+        pdug5HidControlIndex                    Integer32,
+        pdug5HidControlUserName                 DisplayString,
+        pdug5HidControlCardID                   Integer32,
+        pdug5HidControlTimestamp                DisplayString,
+        pdug5HidControlCardAisle                INTEGER,
+        pdug5HidControlStartTime                DisplayString,
+        pdug5HidControlExpireTime               DisplayString,
+        pdug5HidControlTempUser                 INTEGER,
+        pdug5HidControlPin                      DisplayString,
+        pdug5HidControlCardIdStr                DisplayString
+    }
 
-		
-		-- 1.3.6.1.4.19536.10.1.4.10.2.1.5
-		pdug5HidControlCardAisle OBJECT-TYPE
-			SYNTAX INTEGER
-				{
-				COLD(1),
-				HOT(2)
-				}
-			ACCESS read-write
-			STATUS mandatory
-			DESCRIPTION
-				"Aisle of authorized card. "
-			::= { pdug5EnvHidControlEntry 5 }				
-		
+pdug5HidControlIndex OBJECT-TYPE
+    SYNTAX Integer32 (1..200)
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+        "The index of the PDU smartcard table entry"
+    ::= { pdug5EnvHidControlEntry 1 }
+
+pdug5HidControlUserName OBJECT-TYPE
+    SYNTAX DisplayString
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "User name of smartcard.
+         Use #delete# to delete the HID user"
+    ::= { pdug5EnvHidControlEntry 2 }
+
+-- pdug5HidControlCardID reads 0 in 1.5 series PDUs
+-- keeping the OID for backward compatibility
+pdug5HidControlCardID OBJECT-TYPE
+    SYNTAX Integer32
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "HID smartcard ID."
+    ::= { pdug5EnvHidControlEntry 3 }
+
+pdug5HidControlTimestamp OBJECT-TYPE
+    SYNTAX DisplayString
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Indicates the date and time of accessing"
+    ::= { pdug5EnvHidControlEntry 4 }
+
+pdug5HidControlCardAisle OBJECT-TYPE
+    SYNTAX INTEGER
+        {
+            cold(1),
+            hot(2),
+            both(3)
+        }
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Aisle of authorized card"
+    ::= { pdug5EnvHidControlEntry 5 }
+
+pdug5HidControlStartTime OBJECT-TYPE
+    SYNTAX DisplayString
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Indicates the start date and time Rack access user is given access"
+    ::= { pdug5EnvHidControlEntry 6 }
+
+pdug5HidControlExpireTime OBJECT-TYPE
+    SYNTAX DisplayString
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Indicates the date and time when the access of user card will expire, To set expire time first set user as temporary user"
+    ::= { pdug5EnvHidControlEntry 7 }
+
+pdug5HidControlTempUser OBJECT-TYPE
+    SYNTAX INTEGER
+        {
+            no(1),
+            yes(2)
+        }
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Indicates if the card user has temporary access"
+    ::= { pdug5EnvHidControlEntry 8 }
+
+pdug5HidControlPin OBJECT-TYPE
+    SYNTAX DisplayString
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Rack access control entry keypad PIN"
+    ::= { pdug5EnvHidControlEntry 9 }
+
+pdug5HidControlCardIdStr OBJECT-TYPE
+    SYNTAX DisplayString
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Smartrack Access Card ID String"
+    ::= { pdug5EnvHidControlEntry 10 }
+
 -- ====================================================================================
 --  g5                        OBJECT IDENTIFIER       ::= { panduit 10}
 --  pdug5                     OBJECT IDENTIFIER       ::= { g5 1}
 --  pdug5Outlet               OBJECT IDENTIFIER       ::= { pdug5 5 }
 --  OID= .1.3.6.1.4.1.19536.10.1.5
 
-pdug5OutletTable  OBJECT-TYPE
-	SYNTAX SEQUENCE OF pdug5OutletEntry
-	ACCESS     not-accessible
-	STATUS     mandatory
-	DESCRIPTION 
-		"Aggregate Object with number of entries equal to Number of PDU (pdug5IdentIndex)
-                 and Number of outlet per PDU (pdug5OutletIndex)."
-	::= { pdug5Outlet 1 }
+pdug5OutletTable OBJECT-TYPE
+    SYNTAX SEQUENCE OF Pdug5OutletEntry
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+        "Aggregate Object with number of entries equal to Number of PDU (pdug5IdentIndex)
+         and Number of outlet per PDU (pdug5OutletIndex)."
+    ::= { pdug5Outlet 1 }
 
-pdug5OutletEntry  OBJECT-TYPE
-	SYNTAX 	pdug5OutletEntry
-	ACCESS     not-accessible
-	STATUS     mandatory
-	DESCRIPTION 
-		"The Outlet table entry containing the type, voltage, current etc."
-  INDEX { pdug5IdentIndex, pdug5OutletIndex }
-	::= { pdug5OutletTable 1 }
+pdug5OutletEntry OBJECT-TYPE
+    SYNTAX Pdug5OutletEntry
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+        "The Outlet table entry containing the type, voltage, current etc."
+    INDEX { pdug5IdentIndex, pdug5OutletIndex }
+    ::= { pdug5OutletTable 1 }
 
-pdug5OutletEntry ::= SEQUENCE {
-	pdug5OutletIndex				INTEGER,
-	pdug5OutletName				DisplayString,
-	pdug5OutletType				INTEGER,
-	pdug5OutletCurrentRating			INTEGER,
-	pdug5OutletCurrent			INTEGER,
-	pdug5OutletActivePowerThStatus		INTEGER,
-	pdug5OutletActivePowerThLowerWarning	INTEGER,
-	pdug5OutletActivePowerThLowerCritical	INTEGER,
-	pdug5OutletActivePowerThUpperWarning	INTEGER,
-	pdug5OutletActivePowerThUpperCritical	INTEGER,
-	pdug5OutletCurrentPercentLoad		INTEGER,
-	pdug5OutletVA				INTEGER,
-	pdug5OutletWatts				INTEGER,
-	pdug5OutletWh				INTEGER,
-	pdug5OutletWhTimer			DisplayString,
-	pdug5OutletPowerFactor			INTEGER,
-	pdug5OutletVAR				INTEGER,
-	pdug5OutletBranch           INTEGER,
-	pdug5OutletActivePowerThResetThld	INTEGER,
-	pdug5OutletActivePowerThChangeDelay	INTEGER,
-	pdug5OutletActivePowerThCtrl           INTEGER
-}
+Pdug5OutletEntry ::= SEQUENCE {
+        pdug5OutletIndex                        Integer32,
+        pdug5OutletName                         DisplayString,
+        pdug5OutletType                         INTEGER,
+        pdug5OutletCurrentRating                Integer32,
+        pdug5OutletCurrent                      Integer32,
+        pdug5OutletActivePowerThStatus          INTEGER,
+        pdug5OutletActivePowerThLowerWarning    Integer32,
+        pdug5OutletActivePowerThLowerCritical   Integer32,
+        pdug5OutletActivePowerThUpperWarning    Integer32,
+        pdug5OutletActivePowerThUpperCritical   Integer32,
+        pdug5OutletCurrentPercentLoad           Integer32,
+        pdug5OutletVA                           Integer32,
+        pdug5OutletWatts                        Integer32,
+        pdug5OutletWh                           Integer32,
+        pdug5OutletWhTimer                      DisplayString,
+        pdug5OutletPowerFactor                  Integer32,
+        pdug5OutletVAR                          Integer32,
+        pdug5OutletBranch                       Integer32,
+        pdug5OutletActivePowerThResetThld       Integer32,
+        pdug5OutletActivePowerThChangeDelay     Integer32,
+        pdug5OutletActivePowerThCtrl            Integer32
+    }
 
 pdug5OutletIndex OBJECT-TYPE
-    	SYNTAX INTEGER	(0..48)
-    	ACCESS read-only
-    	STATUS mandatory
-    	DESCRIPTION
-		"Index for each outlet, value from 1 to the number of outlets per PDU."
-    	::= { pdug5OutletEntry 1 }
+    SYNTAX Integer32  (0..48)
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+        "Index for each outlet, value from 1 to the number of outlets per PDU."
+    ::= { pdug5OutletEntry 1 }
 
-pdug5OutletName  OBJECT-TYPE
-	SYNTAX   DisplayString (SIZE(1..31))
-	ACCESS   read-write
-	STATUS   mandatory
-	DESCRIPTION 
-		"A descriptive name for the outlet."
-	::= { pdug5OutletEntry 2 }
+pdug5OutletName OBJECT-TYPE
+    SYNTAX DisplayString (SIZE(1..31))
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "A descriptive name for the outlet."
+    ::= { pdug5OutletEntry 2 }
 
-pdug5OutletType  OBJECT-TYPE
-	SYNTAX  INTEGER {
-		iecC13 (1),
-		iecC19 (2),
-		i5-20R (3),
-		uk (10),
-		french (11),
-		schuko (12),
-		nema515 (20),
-		nema51520 (21),
-		nema520 (22),
-		nemaL520 (23),
-		nemaL530 (24),
-		nema615 (25),
-		nema620 (26),
-		nemaL620 (27),
-		nemaL630 (28),
-		nemaL715 (29),
-		rf203p277 (30)
-	}
-	ACCESS     read-only
-	STATUS     mandatory
-	DESCRIPTION 
-		"Type of this outlet - C13, C19 ,5-20R."
-	::= { pdug5OutletEntry 3 }
+pdug5OutletType OBJECT-TYPE
+    SYNTAX INTEGER
+        {
+            iecC13 (1),
+            iecC19 (2),
+            nema5-20R (3),
+            iecC13iecC15combo (4),
+            iecC13iecC15iec19combo (5),
+            uk (10),
+            french (11),
+            schuko (12),
+            nema515 (20),
+            nema51520 (21),
+            nema520 (22),
+            nemaL520 (23),
+            nemaL530 (24),
+            nema615 (25),
+            nema620 (26),
+            nemaL620 (27),
+            nemaL630 (28),
+            nemaL715 (29),
+            rf203p277 (30)
+        }
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Type of this outlet - C13, C19, 5-20R, iecC13/C15 COMBO, iecC13/C15/C19 COMBO..."
+    ::= { pdug5OutletEntry 3 }
 
-pdug5OutletCurrentRating  OBJECT-TYPE
-	SYNTAX    INTEGER	-- Units 0.01 A
-	ACCESS    read-only
-	STATUS    mandatory
-	DESCRIPTION 
-		"Rated current capacity of this outlet.  Units are 0.01 amps.  A negative 
-		 value indicates that the hardware current capacity is unknown."
-	::= { pdug5OutletEntry 4 }
+pdug5OutletCurrentRating OBJECT-TYPE
+    SYNTAX Integer32 -- Units 0.01 A
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Rated current capacity of this outlet.  Units are 0.01 amps.  A negative
+         value indicates that the hardware current capacity is unknown."
+    ::= { pdug5OutletEntry 4 }
 
-pdug5OutletCurrent  OBJECT-TYPE
-	SYNTAX    INTEGER	-- Units 0.01 A
-	ACCESS    read-only
-	STATUS    mandatory
-	DESCRIPTION 
-		"A outlet current measurement value.  Units are 0.01 amps."
-	::= { pdug5OutletEntry 5 }
+pdug5OutletCurrent OBJECT-TYPE
+    SYNTAX Integer32 -- Units 0.01 A
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "A outlet current measurement value.  Units are 0.01 amps."
+    ::= { pdug5OutletEntry 5 }
 
-pdug5OutletActivePowerThStatus  OBJECT-TYPE
-	SYNTAX     INTEGER {
-		good (1),
-		lowWarning (2),
-		lowCritical (3),
-		highWarning (4),
-		highCritical (5)
-	}
-	ACCESS  read-only
-	STATUS  mandatory
-	DESCRIPTION 
-		"Status of the measured outlet active power relative to the configured thresholds."
-	::= { pdug5OutletEntry 6 }
+pdug5OutletActivePowerThStatus OBJECT-TYPE
+    SYNTAX INTEGER
+        {
+            good (1),
+            lowWarning (2),
+            lowCritical (3),
+            highWarning (4),
+            highCritical (5)
+        }
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Status of the measured outlet active power relative to the configured thresholds."
+    ::= { pdug5OutletEntry 6 }
 
-pdug5OutletActivePowerThLowerWarning  OBJECT-TYPE
-	SYNTAX    INTEGER (-1..10000)		
-	ACCESS    read-write
-	STATUS    mandatory
-	DESCRIPTION 
-		"Lower warning threshold.  Units are Watts(W).  A negative value indicates
-		          that this object is not available."
-	::= { pdug5OutletEntry 7 }
+pdug5OutletActivePowerThLowerWarning OBJECT-TYPE
+    SYNTAX Integer32 (-1..10000)
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Lower warning threshold.  Units are Watts(W).  A negative value indicates
+         that this object is not available."
+    ::= { pdug5OutletEntry 7 }
 
-pdug5OutletActivePowerThLowerCritical  OBJECT-TYPE
-	SYNTAX     INTEGER (-1..10000)		
-	ACCESS     read-write
-	STATUS     mandatory
-	DESCRIPTION 
-		"Lower critical threshold.  Units are Watts(W).  A negative value indicates
-		          that this object is not available."
-	::= { pdug5OutletEntry 8 }
+pdug5OutletActivePowerThLowerCritical OBJECT-TYPE
+    SYNTAX Integer32 (-1..10000)
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Lower critical threshold.  Units are Watts(W).  A negative value indicates
+         that this object is not available."
+    ::= { pdug5OutletEntry 8 }
 
-pdug5OutletActivePowerThUpperWarning  OBJECT-TYPE
-	SYNTAX     INTEGER (-1..10000)		
-	ACCESS     read-write
-	STATUS     mandatory
-	DESCRIPTION 
-		"Upper warning threshold.  Units are Watts(W).  A negative value indicates
-		          that this object is not available."
-	::= { pdug5OutletEntry 9 }
+pdug5OutletActivePowerThUpperWarning OBJECT-TYPE
+    SYNTAX Integer32 (-1..10000)
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Upper warning threshold.  Units are Watts(W).  A negative value indicates
+         that this object is not available."
+    ::= { pdug5OutletEntry 9 }
 
-pdug5OutletActivePowerThUpperCritical  OBJECT-TYPE
-	SYNTAX     INTEGER (-1..10000)		
-	ACCESS     read-write
-	STATUS     mandatory
-	DESCRIPTION 
-		"Upper critical threshold.  Units are Watts(W).  A negative value indicates
-		          that this object is not available."
-	::= { pdug5OutletEntry 10 }
+pdug5OutletActivePowerThUpperCritical OBJECT-TYPE
+    SYNTAX Integer32 (-1..10000)
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Upper critical threshold.  Units are Watts(W).  A negative value indicates
+         that this object is not available."
+    ::= { pdug5OutletEntry 10 }
 
+pdug5OutletCurrentPercentLoad OBJECT-TYPE
+    SYNTAX Integer32 -- Unit in percentage
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Current percent load, based on the rated current capacity.  Units are
+         percentage, for example 80% will be returned as 80.  A negative
+         value indicates that this object is not available."
+    ::= { pdug5OutletEntry 11 }
 
-pdug5OutletCurrentPercentLoad  OBJECT-TYPE
-	SYNTAX     INTEGER		-- unit in percentage
-	ACCESS     read-only
-	STATUS     mandatory
-	DESCRIPTION 
-		"Current percent load, based on the rated current capacity.  Units are
-                  percentage, for example 80% will be returned as 80.  A negative
-                  value indicates that this object is not available."
-	::= { pdug5OutletEntry 11 }
+pdug5OutletVA OBJECT-TYPE
+    SYNTAX Integer32 -- Units in VA
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "A outlet VA value.  Units are VA.  A negative value indicates
+         that this object is not available."
+    ::= { pdug5OutletEntry 12 }
 
-pdug5OutletVA  OBJECT-TYPE
-	SYNTAX     INTEGER  	-- units in VA
-	ACCESS     read-only
-	STATUS     mandatory
-	DESCRIPTION 
-		"A outlet VA value.  Units are VA.  A negative value indicates
-		          that this object is not available."
-	::= { pdug5OutletEntry 12 }
+pdug5OutletWatts OBJECT-TYPE
+    SYNTAX Integer32 -- Units in Watt
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "A outlet Watts value.  Units are Watts.  A negative value indicates
+         that this object is not available."
+    ::= { pdug5OutletEntry 13 }
 
-pdug5OutletWatts  OBJECT-TYPE
-	SYNTAX     INTEGER	-- units in Watt
-	ACCESS     read-only
-	STATUS     mandatory
-	DESCRIPTION 
-		"A outlet Watts value.  Units are Watts.  A negative value indicates
-		          that this object is not available."
-	::= { pdug5OutletEntry 13 }
+pdug5OutletWh OBJECT-TYPE
+    SYNTAX Integer32 -- Units in Watt-Hour
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "A Watt-Hour value for each outlet.  Units are WH.
+         This object is writable so that it can be reset to 0.  When it is
+         written to, the pdug5OutletWhTimer will be reset updated as well
+         A negative value indicates that this object is not available."
+    ::= { pdug5OutletEntry 14 }
 
-pdug5OutletWh  OBJECT-TYPE
-	SYNTAX     INTEGER 	-- Units in Watt-Hour
-	ACCESS     read-only
-	STATUS     mandatory
-	DESCRIPTION 
-		"A Watt-Hour value for each outlet.  Units are WH.
-This object is writable so that it can be reset to 0.  When it is
-		written to, the pdug5OutletWhTimer will be reset updated as well    
-      A negative value indicates that this object is not available."
-	::= { pdug5OutletEntry 14 }
+pdug5OutletWhTimer OBJECT-TYPE
+    SYNTAX DisplayString (SIZE (0..22)) -- display Date and Time
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Timestamp (date and time) of outlet Watt-hours was last reset."
+    ::= { pdug5OutletEntry 15 }
 
-pdug5OutletWhTimer  OBJECT-TYPE
-	SYNTAX     DisplayString (SIZE (0..22))	-- display Date and Time
-	ACCESS     read-only
-	STATUS     mandatory
-	DESCRIPTION 
-		"Timestamp (date and time) of outlet Watt-hours was last reset."
-	::= { pdug5OutletEntry 15 }
+pdug5OutletPowerFactor OBJECT-TYPE
+    SYNTAX Integer32 -- Units are in 0.01
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "An outlet PF value.  Units are in hundredths, for example a power factor
+         of 0.95 would be returned as 95, and 0.92 would be returned
+         as 92.  A negative value indicates that this object is not available."
+    ::= { pdug5OutletEntry 16 }
 
-pdug5OutletPowerFactor  OBJECT-TYPE
-	SYNTAX     INTEGER		-- units are in 0.01
-	ACCESS     read-only
-	STATUS     mandatory
-	DESCRIPTION 
-		"An outlet PF value.  Units are in thousandths, for example a power factor
-                  of 0.95 would be returned as 95, and 0.92 would be returned 
-		          as 92.  A negative value indicates that this object is not available."
-	::= { pdug5OutletEntry 16 }
+pdug5OutletVAR OBJECT-TYPE
+    SYNTAX Integer32 -- Units in VAR
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "An outlet VAR value.  Units are VAR.  A negative value indicates
+         that this object is not available."
+    ::= { pdug5OutletEntry 17 }
 
-pdug5OutletVAR  OBJECT-TYPE
-	SYNTAX     INTEGER		-- Units in VAR
-	ACCESS     read-only
-	STATUS     mandatory
-	DESCRIPTION 
-		"An outlet VAR value.  Units are VAR.  A negative value indicates
-		          that this object is not available."
-	::= { pdug5OutletEntry 17 }
+pdug5OutletBranch OBJECT-TYPE
+    SYNTAX Integer32 -- Units in VAR
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "The branch number outlet located."
+    ::= { pdug5OutletEntry 18 }
 
-pdug5OutletBranch  OBJECT-TYPE
-	SYNTAX     INTEGER		-- Units in VAR
-	ACCESS     read-only
-	STATUS     mandatory
-	DESCRIPTION 
-		"The branch number outlet located."
-	::= { pdug5OutletEntry 18 }
+pdug5OutletActivePowerThResetThld OBJECT-TYPE
+    SYNTAX Integer32 (-1..10000)
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "The Reset threshold is the number of watss the reading needs to fall below
+         the threshold setting for the condition to be cleared. Units are watts."
+    ::= { pdug5OutletEntry 19 }
 
--- 1.3.6.1.4.1.19536.10.1.5.1.1.19
-pdug5OutletActivePowerThResetThld  OBJECT-TYPE
-	SYNTAX     INTEGER (-1..10000)		
-	ACCESS     read-write
-	STATUS     mandatory
-	DESCRIPTION 
-		"Outlet Active Power alarm reset threshold.  Units are Watts(W).  
-              A negative value indicates that this object is not available."
-	::= { pdug5OutletEntry 19 }
+pdug5OutletActivePowerThChangeDelay OBJECT-TYPE
+    SYNTAX Integer32 (0..100)
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "The number of consecutive sample that the condition is present before
+         an alarm is raised."
+    ::= { pdug5OutletEntry 20 }
 
--- 1.3.6.1.4.1.19536.10.1.5.1.1.20
-pdug5OutletActivePowerThChangeDelay  OBJECT-TYPE
-	SYNTAX     INTEGER (-1..10000)		
-	ACCESS     read-write
-	STATUS     mandatory
-	DESCRIPTION 
-		"Outlet Active Power generates alarm every outlet alarm times.   
-              A negative value indicates that this object is not available."
-	::= { pdug5OutletEntry 20 }
-	
 -- 1.3.6.1.4.1.19536.10.1.5.1.1.21
 pdug5OutletActivePowerThCtrl OBJECT-TYPE
-	SYNTAX INTEGER
-	ACCESS read-write
-	STATUS mandatory
-	DESCRIPTION
-		"Outlet Active Power alarm threshold control:
-		bit 0:  up critical alarm control bit,    0 -  enable, 1 -  disable
-		bit 1:  up warning alarm control bit,  0 -  enable, 1 -  disable
-		bit 2:  low warning alarm control bit, 0 -  enable, 1 -  disable
-		bit 3:  low critical alarm control bit,   0 -  enable, 1 -  disable"
-	DEFVAL { 0 }
-	::= { pdug5OutletEntry 21 }
+    SYNTAX Integer32
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Outlet Active Power alarm threshold control:
+         bit 0:  up critical alarm control bit,    0 -  enable, 1 -  disable
+         bit 1:  up warning alarm control bit,  0 -  enable, 1 -  disable
+         bit 2:  low warning alarm control bit, 0 -  enable, 1 -  disable
+         bit 3:  low critical alarm control bit,   0 -  enable, 1 -  disable"
+    DEFVAL { 0 }
+    ::= { pdug5OutletEntry 21 }
 
 -- ====================== PDU Outlet Control=====================
 
-pdug5OutletControlTable  OBJECT-TYPE
-	SYNTAX SEQUENCE OF pdug5OutletControlEntry
-	ACCESS     not-accessible
-	STATUS     mandatory
-	DESCRIPTION 
-		"Aggregate Object with number of entries equal to Number of PDU (pdug5IdentIndex) 
-                 and Number of outlets per PDU (pdug5OutletIndex)."
-	::= { pdug5Outlet 2 }
+pdug5OutletControlTable OBJECT-TYPE
+    SYNTAX SEQUENCE OF Pdug5OutletControlEntry
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+        "Aggregate Object with number of entries equal to Number of PDU (pdug5IdentIndex)
+         and Number of outlets per PDU (pdug5OutletIndex)."
+    ::= { pdug5Outlet 2 }
 
-pdug5OutletControlEntry  OBJECT-TYPE
-	SYNTAX 	pdug5OutletControlEntry
-	ACCESS     not-accessible
-	STATUS     mandatory
-	DESCRIPTION 
-		"The Outlet table entry containing the type, voltage, current etc."
-  INDEX { pdug5IdentIndex, pdug5OutletIndex }
-	::= { pdug5OutletControlTable 1 }
+pdug5OutletControlEntry OBJECT-TYPE
+    SYNTAX Pdug5OutletControlEntry
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+        "The Outlet table entry containing the type, voltage, current etc."
+    INDEX { pdug5IdentIndex, pdug5OutletIndex }
+    ::= { pdug5OutletControlTable 1 }
 
-pdug5OutletControlEntry ::= SEQUENCE {
-
-	pdug5OutletControlStatus			INTEGER,
-	pdug5OutletControlOffCmd			INTEGER,
-	pdug5OutletControlOnCmd			INTEGER,
-	pdug5OutletControlRebootCmd		INTEGER,
-	pdug5OutletControlPowerOnState		INTEGER,
-	pdug5OutletControlSequenceDelay		INTEGER,
-	pdug5OutletControlRebootOffTime		INTEGER,
-	pdug5OutletControlSwitchable		INTEGER,
-	pdug5OutletControlShutoffDelay		INTEGER,
-	pdug5OutletControlCommand			INTEGER
+Pdug5OutletControlEntry ::= SEQUENCE {
+        pdug5OutletControlStatus                INTEGER,
+        pdug5OutletControlOffCmd                Integer32,
+        pdug5OutletControlOnCmd                 Integer32,
+        pdug5OutletControlRebootCmd             Integer32,
+        pdug5OutletControlPowerOnState          INTEGER,
+        pdug5OutletControlSequenceDelay         Integer32,
+        pdug5OutletControlRebootOffTime         Integer32,
+        pdug5OutletControlSwitchable            INTEGER,
+        pdug5OutletControlShutoffDelay          Integer32,
+        pdug5OutletControlCommand               INTEGER
 }
 
-pdug5OutletControlStatus  OBJECT-TYPE
-    	SYNTAX 		INTEGER	{
-			off (1),
-			on (2),
-			pendingOff (3),
-			pendingOn (4)
-			}
-    	ACCESS 		read-only
-    	STATUS 		mandatory
-    	DESCRIPTION
-		"current state of a control outlet."
-    	::= { pdug5OutletControlEntry 1 }
+pdug5OutletControlStatus OBJECT-TYPE
+    SYNTAX INTEGER
+        {
+            off (1),
+            on (2),
+            pendingOff (3),
+            pendingOn (4)
+        }
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "current state of a control outlet."
+    ::= { pdug5OutletControlEntry 1 }
 
-pdug5OutletControlOffCmd  OBJECT-TYPE
-    	SYNTAX 		 INTEGER (-1..99999)		
-    	ACCESS 		 read-write
-    	STATUS 		 mandatory
-    	DESCRIPTION
-		"When write, once issued, the outlet will turn Off immediately.
-                 0-n: Time in seconds until the outlet command is issued
-                 -1: Cancel a pending outlet Off command
-		 When read, returns -1 if no command is pending, or the current downcount in 
-                 seconds of a pending command."
-    	::= { pdug5OutletControlEntry 2 }
+pdug5OutletControlOffCmd OBJECT-TYPE
+    SYNTAX Integer32 (-1..99999)
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "When write, once issued, the outlet will turn Off immediately.
+         0-n: Time in seconds until the outlet command is issued
+         -1: Cancel a pending outlet Off command
+         When read, returns -1 if no command is pending, or the current downcount in
+         seconds of a pending command."
+    ::= { pdug5OutletControlEntry 2 }
 
-pdug5OutletControlOnCmd  OBJECT-TYPE
-    	SYNTAX 		INTEGER (-1..99999)		
-    	ACCESS 		read-write
-    	STATUS 		mandatory
-    	DESCRIPTION
-		"When write, once issued, the outlet will turn On immediately.
-                 0-n: Time in seconds until the outlet command is issued
-                 -1: Cancel a pending outlet On command
-		 When read, returns -1 if no command is pending, or the current downcount in 
-                 seconds of a pending command."
-    	::= { pdug5OutletControlEntry 3 }
+pdug5OutletControlOnCmd OBJECT-TYPE
+    SYNTAX Integer32 (-1..99999)
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "When write, once issued, the outlet will turn On immediately.
+         0-n: Time in seconds until the outlet command is issued
+         -1: Cancel a pending outlet On command
+         When read, returns -1 if no command is pending, or the current downcount in
+         seconds of a pending command."
+    ::= { pdug5OutletControlEntry 3 }
 
-pdug5OutletControlRebootCmd  OBJECT-TYPE
-    	SYNTAX 		    INTEGER (-1..99999)		
-    	ACCESS 		    read-write
-    	STATUS 		    mandatory
-    	DESCRIPTION
-		"When write, for outlets that are On prior to this Reboot command, they will 
-                 switch Off immediately when the command is issued, remain Off for 
-                 outletControlRebootOffTime seconds, and then turn back On.
-		 For outlets that are Off prior to the Reboot command, they will turn On after 
-                 a delay of outletControlRebootOffTime seconds from when the command is issued.
-		 0-n : Time in seconds until the Reboot command is issued
-		 -1 : Cancel a pending outlet Reboot command 
-		
-		When read, returns -1 if no command is pending, or the current downcount in 
-                seconds of a pending command."
-    	::= { pdug5OutletControlEntry 4 }
+pdug5OutletControlRebootCmd OBJECT-TYPE
+    SYNTAX Integer32 (-1..99999)
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "When write, for outlets that are On prior to this Reboot command, they will
+         switch Off immediately when the command is issued, remain Off for
+         outletControlRebootOffTime seconds, and then turn back On.
+         For outlets that are Off prior to the Reboot command, they will turn On after
+         a delay of outletControlRebootOffTime seconds from when the command is issued.
+         0-n : Time in seconds until the Reboot command is issued
+         -1 : Cancel a pending outlet Reboot command
 
-pdug5OutletControlPowerOnState  OBJECT-TYPE
-    	SYNTAX 		    INTEGER {
-		            off (1),
-		            on (2),
-		            lastState (3)
-                            }	
-    	ACCESS 		    read-write
-    	STATUS 		    mandatory
-    	DESCRIPTION
-		"Determines the outlet state when power is applied to the unit.
-		1 : not restart at device startup
-		2 : should sequence back ON in line with outletControlSequenceTime
-		3 : should take the state the outlet had when power was lost.
-		If the state was ON, should sequence back ON in line with outletControlSequenceTime."
-    	::= { pdug5OutletControlEntry 5 }
+        When read, returns -1 if no command is pending, or the current downcount in
+        seconds of a pending command."
+    ::= { pdug5OutletControlEntry 4 }
 
-pdug5OutletControlSequenceDelay  OBJECT-TYPE
-    	SYNTAX 		        INTEGER (-1..7200)		
-    	ACCESS 		        read-write
-    	STATUS 		        mandatory
-    	DESCRIPTION
-		"Time delay in seconds from when a Global Sequence On command is issued to
-		when the command is executed on this outlet.  This delay is also used as a power-on
-		delay. Set to -1 to exclude this outlet from Global Sequence On commands."
-    	::= { pdug5OutletControlEntry 6 }
+pdug5OutletControlPowerOnState OBJECT-TYPE
+    SYNTAX INTEGER
+        {
+            off (1),
+            on (2),
+            lastState (3)
+        }
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Determines the outlet state when power is applied to the unit.
+         1 : not restart at device startup
+         2 : should sequence back ON in line with outletControlSequenceTime
+         3 : should take the state the outlet had when power was lost.
+         If the state was ON, should sequence back ON in line with outletControlSequenceTime."
+    ::= { pdug5OutletControlEntry 5 }
 
-pdug5OutletControlRebootOffTime  OBJECT-TYPE
-    	SYNTAX 		        INTEGER (-1..7200)		
-    	ACCESS 		        read-write
-    	STATUS 		        mandatory
-    	DESCRIPTION
-		"Time delay in seconds that the outlet should remain in the Off state when executing a Reboot command."
-    	::= { pdug5OutletControlEntry 7 }
+pdug5OutletControlSequenceDelay OBJECT-TYPE
+    SYNTAX Integer32 (-1..7200)
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Time delay in seconds from when a Global Sequence On command is issued to when
+         the command is executed on this outlet.  This delay is also used as a power-on delay."
+    ::= { pdug5OutletControlEntry 6 }
 
-pdug5OutletControlSwitchable  OBJECT-TYPE
-    	SYNTAX 		    INTEGER {
-		            switchable (1),
-		            notSwitchable (2)
-                            }	
-    	ACCESS 		    read-write
-    	STATUS 		    mandatory
-    	DESCRIPTION
-		"Determines the outlet capability to be controlled On/Off from the communication channels.
-		1 : control On/Off enabled
-		2 : control On/Off disabled."
-    	::= { pdug5OutletControlEntry 8 }
+pdug5OutletControlRebootOffTime OBJECT-TYPE
+    SYNTAX Integer32 (5..60)
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Time delay in seconds that the outlet should remain in the Off state when executing a Reboot command."
+    ::= { pdug5OutletControlEntry 7 }
 
-pdug5OutletControlShutoffDelay  OBJECT-TYPE
-    	SYNTAX 		        INTEGER (-1..7200)		
-    	ACCESS 		        read-write
-    	STATUS 		        mandatory
-    	DESCRIPTION
-		"Time delay in seconds that could be taken in account before shutting of the outlet.
-    An application which need to shutoff properly an outlet will read this parameter first
-    then write it to the command pdug5OutletControlOffCmd."
-    	::= { pdug5OutletControlEntry 9 }
+pdug5OutletControlSwitchable OBJECT-TYPE
+    SYNTAX INTEGER
+        {
+            switchable (1),
+            notSwitchable (2)
+        }
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Determines the outlet capability to be controlled On/Off from the communication channels.
+         1 : control On/Off enabled
+         2 : control On/Off disabled."
+    ::= { pdug5OutletControlEntry 8 }
 
-		
-pdug5OutletControlCommand  OBJECT-TYPE
-	SYNTAX 	INTEGER {
-		immediateOff (1),
-		immediateOn (2),
-		delayedOff (3),
-		delayedOn (4),
-		immediateReboot (5),
-		delayedReboot (6),
-		outletUnknown (7)
-		}
-	MAX-ACCESS  	read-write
-	STATUS 	current
-	DESCRIPTION 
-		"Getting this variable will return the outlet state.
-            If the outlet is on, the immediateOn (2) 
-            value will be returned. If the outlet is off, 
-            the immediateOff (1) value will be returned. 
-            If the state of the outlet cannot be determined, the 
-            outletUnknown (7) value will be returned. If the 
-            outletUnknown condition should occur, all devices 
-            powered by the PDU should be shut down. The PDU's 
-            power should then be cycled to clear this condition. 
-            Setting this variable to immediateOn (2) will immediately 
-            turn the outlet on. Setting this variable to 
-            immediateOff (1) will immediately turn the outlet off. 
-            Setting this variable to immediateReboot (5) 
-            will cause the Switched PDU to perform an immediateOff 
-            command, wait the pdug5OutletControlRebootOffTime
-            OID time, and then perform an immediateOn command.
-            Setting this variable to delayedOn (4) will turn the 
-            outlet on after the pdug5OutletControlSequenceDelay
-            OID time has elapsed. Setting this variable to 
-            delayedOff (3) will turn the outlet off after the 
-            pdug5OutletControlShutoffDelay OID time has elapsed. 
-            Setting this variable to delayedReboot  (6) will cause 
-            the Switched PDU to perform a delayedOff command, wait 
-            the pdug5OutletControlRebootOffTime OID time, and 
-            then perform a delayedOn command."
-	::= { pdug5OutletControlEntry 10 }
-	
+pdug5OutletControlShutoffDelay OBJECT-TYPE
+    SYNTAX Integer32 (-1..7200)
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Time delay in seconds that could be taken in account before shutting of the outlet.
+         An application which need to shutoff properly an outlet will read this parameter first
+         then write it to the command pdug5OutletControlOffCmd."
+    ::= { pdug5OutletControlEntry 9 }
+
+pdug5OutletControlCommand OBJECT-TYPE
+    SYNTAX INTEGER
+        {
+            immediateOff (1),
+            immediateOn (2),
+            delayedOff (3),
+            delayedOn (4),
+            immediateReboot (5),
+            delayedReboot (6),
+            outletUnknown (7)
+        }
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Getting this variable will return the outlet state.
+         If the outlet is on, the immediateOn (2)
+         value will be returned. If the outlet is off,
+         the immediateOff (1) value will be returned.
+         If the state of the outlet cannot be determined, the
+         outletUnknown (7) value will be returned. If the
+         outletUnknown condition should occur, all devices
+         powered by the PDU should be shut down. The PDU's
+         power should then be cycled to clear this condition.
+         Setting this variable to immediateOn (2) will immediately
+         turn the outlet on. Setting this variable to
+         immediateOff (1) will immediately turn the outlet off.
+         Setting this variable to immediateReboot (5)
+         will cause the Switched PDU to perform an immediateOff
+         command, wait the pdug5OutletControlRebootOffTime
+         OID time, and then perform an immediateOn command.
+         Setting this variable to delayedOn (4) will turn the
+         outlet on after the pdug5OutletControlSequenceDelay
+         OID time has elapsed. Setting this variable to
+         delayedOff (3) will turn the outlet off after the
+         pdug5OutletControlShutoffDelay OID time has elapsed.
+         Setting this variable to delayedReboot  (6) will cause
+         the Switched PDU to perform a delayedOff command, wait
+         the pdug5OutletControlRebootOffTime OID time, and
+         then perform a delayedOn command."
+    ::= { pdug5OutletControlEntry 10 }
+
 -- ====================================================================================
 --  g5                        OBJECT IDENTIFIER       ::= { panduit 10}
---  pdug5                     OBJECT IDENTIFIER       ::= { g5 1}  
+--  pdug5                     OBJECT IDENTIFIER       ::= { g5 1}
 --  pdug5Traps                OBJECT IDENTIFIER       ::= { pdug5 6 }
 --  PDU identification group
 --  OID= .1.3.6.1.4.1.19536.10.1.6
 
-trapCritical NOTIFICATION-TYPE
-	OBJECTS  {
-	             trapCode, 
-	             trapDescription, 
-	             sysDescr, 
-	             pdug5IPv4Address}
-        STATUS      current
-	DESCRIPTION
+trapCritical NOTIFICATION-TYPE OBJECTS
+    {
+        trapCode,
+        trapDescription,
+        sysDescr,
+        pdug5IPv4Address,
+        pdug5IPv6Address
+    }
+    STATUS current
+    DESCRIPTION
         "A critical alarm has occurred."
-        ::= {pdug5Traps 1}
+    ::= {pdug5Traps 1}
 
-trapWarning NOTIFICATION-TYPE
-	OBJECTS  { 
-	             trapCode, 
-	             trapDescription, 
-	             sysDescr, 
-	             pdug5IPv4Address }
-        STATUS      current
-	DESCRIPTION
+trapWarning NOTIFICATION-TYPE OBJECTS
+    {
+        trapCode,
+        trapDescription,
+        sysDescr,
+        pdug5IPv4Address,
+        pdug5IPv6Address
+    }
+    STATUS current
+    DESCRIPTION
         "A warning alarm has occurred."
-        ::= {pdug5Traps 2}
+    ::= {pdug5Traps 2}
 
-trapInformation NOTIFICATION-TYPE
-	OBJECTS  {
-	             trapCode, 
-	             trapDescription, 
-	             sysDescr, 
-	             pdug5IPv4Address }
-        STATUS      current
-	DESCRIPTION
+trapInformation NOTIFICATION-TYPE OBJECTS
+    {
+        trapCode,
+        trapDescription,
+        sysDescr,
+        pdug5IPv4Address,
+        pdug5IPv6Address
+    }
+    STATUS current
+    DESCRIPTION
         "An informational alarm has occurred."
-        ::= {pdug5Traps 3}
+    ::= {pdug5Traps 3}
 
-trapCleared NOTIFICATION-TYPE
-	OBJECTS  {
-	             trapCode, 
-	             trapDescription, 
-	             sysDescr, 
-	             pdug5IPv4Address }
-        STATUS      current
-	DESCRIPTION
+trapCleared NOTIFICATION-TYPE OBJECTS
+    {
+        trapCode,
+        trapDescription,
+        sysDescr,
+        pdug5IPv4Address,
+        pdug5IPv6Address
+    }
+    STATUS current
+    DESCRIPTION
         "An alarm has cleared."
-        ::= {pdug5Traps 4}
+    ::= {pdug5Traps 4}
 
-trapTest NOTIFICATION-TYPE
-        OBJECTS  {
-                     trapCode,
-		             trapDescription,
-                     sysDescr, 
-                     pdug5IPv4Address } 
-        STATUS      current
-        DESCRIPTION
-        "Test trap sent to a trap receiver to check proper reception of traps" 
-        ::= {pdug5Traps 5}
+trapTest NOTIFICATION-TYPE OBJECTS
+    {
+        trapCode,
+        trapDescription,
+        sysDescr,
+        pdug5IPv4Address,
+        pdug5IPv6Address
+    }
+    STATUS current
+    DESCRIPTION
+        "Test trap sent to a trap receiver to check proper reception of traps"
+    ::= {pdug5Traps 5}
 
--- ====================================================================================  
+-- ====================================================================================
 --  g5                        OBJECT IDENTIFIER       ::= { panduit 10}
---  pdug5                     OBJECT IDENTIFIER       ::= { g5 1}  
+--  pdug5                     OBJECT IDENTIFIER       ::= { g5 1}
 --  pdug5TrapInfo             OBJECT IDENTIFIER       ::= { pdug5 7 }
 --  PDU identification group
 --  OID= .1.3.6.1.4.1.19536.10.1.7
@@ -2809,18 +3402,326 @@ trapTest NOTIFICATION-TYPE
 pdug5TrapInfoEntry OBJECT IDENTIFIER ::= { pdug5TrapInfo 1 }
 
 trapCode OBJECT-TYPE
-	SYNTAX INTEGER
-	ACCESS not-accessible
-	STATUS mandatory
-	DESCRIPTION
-		"A number identifying the event for the trap that was sent."
+    SYNTAX Integer32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "A number identifying the event for the trap that was sent."
     ::= { pdug5TrapInfoEntry 1 }
 
 trapDescription OBJECT-TYPE
-	SYNTAX DisplayString (SIZE (0..255))
-	ACCESS not-accessible
-	STATUS mandatory
-	DESCRIPTION
-		"A string identifying the event for that last trap that was sent."
+    SYNTAX DisplayString (SIZE (0..255))
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "A string identifying the event for that last trap that was sent."
     ::= { pdug5TrapInfoEntry 2 }
-END
+
+--
+-- Conformance
+--
+pdug5Compliances   OBJECT IDENTIFIER ::= { pdug5Conformance 1 }
+pdug5Groups        OBJECT IDENTIFIER ::= { pdug5Conformance 2 }
+
+pdug5FullCompliance MODULE-COMPLIANCE
+    STATUS current
+    DESCRIPTION "Compliance statement"
+    MODULE
+        MANDATORY-GROUPS {
+            pdug5IdentGroup,
+            pdug5InputGroup,
+            pdug5GroupGroup,
+            pdug5EnvironmentGroup,
+            pdug5OutletGroup,
+            pdug5TrapGroup,
+            pdug5TrapInfoGroup}
+    ::= { pdug5Compliances 1 }
+
+pdug5IdentGroup OBJECT-GROUP
+    OBJECTS {
+            pdug5NumberPDU,
+            pdug5Name,
+            pdug5Model,
+            pdug5Manufacturer,
+            pdug5FirmwareVersion,
+            pdug5FirmwareVersionTimeStamp,
+            pdug5PartNumber,
+            pdug5SerialNumber,
+            pdug5Status,
+            pdug5Controllable,
+            pdug5InputPhaseCount,
+            pdug5GroupCount,
+            pdug5OutletCount,
+            pdug5MACAddress,
+            pdug5IPv4Address,
+            pdug5IPv6Address,
+            pdug5HWVersion,
+            pdug5ConfigSsh,
+            pdug5ConfigFtps,
+            pdug5ConfigHttp,
+            pdug5ConfigHttps,
+            pdug5ConfigIPv4IPv6Switch,
+            pdug5ConfigRedfishAPI,
+            pdug5ConfigOledDispalyOrientation,
+            pdug5ConfigEnergyReset,
+            pdug5ConfigNetworkManagementCardReset,
+            pdug5ConfigDaisyChainStatus,
+            pdug5PowershareFunctionStatus,
+            pdug5PowershareFunctionUpstreamStatus,
+            pdug5PowershareOutput,
+            pdug5PowershareInput,
+            pdug5PowershareOptMode,
+            pdug5PowershareFunc}
+    STATUS current
+    DESCRIPTION
+        "the pdug5Identity defines objects which aid PDU system level
+        configuration"
+    ::= { pdug5Groups 1 }
+
+
+pdug5InputGroup OBJECT-GROUP
+    OBJECTS {
+            pdug5InputType,
+            pdug5InputFrequency,
+            pdug5InputFrequencyStatus,
+            pdug5InputPowerVA,
+            pdug5InputPowerWatts,
+            pdug5InputTotalEnergy,
+            pdug5InputPowerWattHourTimer,
+            pdug5InputResettableEnergy,
+            pdug5InputPowerFactor,
+            pdug5InputPowerVAR,
+            pdug5InputTotalCurrent,
+            pdug5InputPhaseVoltageMeasType,
+            pdug5InputPhaseVoltage,
+            pdug5InputPhaseVoltageThStatus,
+            pdug5InputPhaseVoltageThLowerWarning,
+            pdug5InputPhaseVoltageThLowerCritical,
+            pdug5InputPhaseVoltageThUpperWarning,
+            pdug5InputPhaseVoltageThUpperCritical,
+            pdug5InputPhaseCurrentMeasType,
+            pdug5InputPhaseCurrentRating,
+            pdug5InputPhaseCurrent,
+            pdug5InputPhaseCurrentThStatus,
+            pdug5InputPhaseCurrentThLowerWarning,
+            pdug5InputPhaseCurrentThLowerCritical,
+            pdug5InputPhaseCurrentThUpperWarning,
+            pdug5InputPhaseCurrentThUpperCritical,
+            pdug5InputPhaseCurrentPercentLoad,
+            pdug5InputPhasePowerMeasType,
+            pdug5InputPhasePowerVA,
+            pdug5InputPhasePowerWatts,
+            pdug5InputPhasePowerWattHour,
+            pdug5InputPhasePowerWattHourTimer,
+            pdug5InputPhasePowerFactor,
+            pdug5InputPhasePowerVAR,
+            pdug5InputPhaseVoltageThResetThld,
+            pdug5InputPhaseVoltageThChangeDelay,
+            pdug5InputPhaseVoltageThCtrl,
+            pdug5InputPhaseCurrentThResetThld,
+            pdug5InputPhaseCurrentThChangeDelay,
+            pdug5InputPhaseCurrentThCtrl,
+            pdug5InputPowerThresholdThLowerWarning,
+            pdug5InputPowerThresholdThLowerCritical,
+            pdug5InputPowerThresholdThUpperWarning,
+            pdug5InputPowerThresholdThUpperCritical,
+            pdug5InputPowerThresholdThResetThld,
+            pdug5InputPowerThresholdThChangeDelay,
+            pdug5InputPowerThresholdThCtrl,
+            pdug5InputEnergyThresholdThUpperWarning,
+            pdug5InputEnergyThresholdThUpperCritical,
+            pdug5InputEnergyThresholdThResetThld,
+            pdug5InputEnergyThresholdThChangeDelay,
+            pdug5InputEnergyThresholdThCtrl,
+            pdug5InputPhasePowerThStatus,
+            pdug5InputRcmEnabled,
+            pdug5InputRcmModStatus,
+            pdug5InputRcmThUpperWarning,
+            pdug5InputRcmThUpperCritical,
+            pdug5InputRcmThResetThld,
+            pdug5InputRcmThChangeDelay,
+            pdug5InputRcmThCtrl,
+            pdug5InputRcmThStatus,
+            pdug5InputRcmCurrent,
+	    pdug5InputRcmSelfTestEnable,
+	    pdug5InputRcmSelfTestFreq,
+	    pdug5InputRcmSelfTestHour,
+	    pdug5InputRcmSelfTestMinute,
+	    pdug5InputRcmSelfTestDay,
+	    pdug5InputRcmSelfTestMonth,
+	    pdug5InputRcmSelfTestNextRunTime,
+	    pdug5InputRcmSelfTestLastRunTime,
+	    pdug5InputRcmSelfTestLastRunStatus}
+    STATUS current
+    DESCRIPTION
+        "the pdug5InputGroup defines objects which aid Input level
+        configuration and monitoring"
+    ::= { pdug5Groups 2 }
+ 
+ 
+pdug5GroupGroup OBJECT-GROUP 
+    OBJECTS { 
+            pdug5GroupName, 
+            pdug5GroupType, 
+            pdug5GroupVoltageMeasType, 
+            pdug5GroupVoltage, 
+            pdug5GroupVoltageThStatus, 
+            pdug5GroupVoltageThLowerWarning, 
+            pdug5GroupVoltageThLowerCritical, 
+            pdug5GroupVoltageThUpperWarning, 
+            pdug5GroupVoltageThUpperCritical, 
+            pdug5groupCurrentRating, 
+            pdug5GroupCurrent, 
+            pdug5GroupCurrentThStatus, 
+            pdug5GroupCurrentThLowerWarning, 
+            pdug5GroupCurrentThLowerCritical, 
+            pdug5GroupCurrentThUpperWarning, 
+            pdug5GroupCurrentThUpperCritical, 
+            pdug5GroupCurrentPercentLoad, 
+            pdug5GroupPowerVA, 
+            pdug5GroupPowerWatts, 
+            pdug5GroupPowerWattHour, 
+            pdug5GroupPowerWattHourTimer, 
+            pdug5GroupPowerFactor, 
+            pdug5GroupPowerVAR, 
+            pdug5GroupOutletCount, 
+            pdug5GroupBreakerStatus, 
+            pdug5GroupVoltageThCtrl, 
+            pdug5GroupCurrentThCtrl} 
+    STATUS current 
+    DESCRIPTION 
+        "the pdug5GroupGroup defines objects which aid Breaker level 
+        configuration and monitoring" 
+    ::= { pdug5Groups 3 } 
+ 
+pdug5EnvironmentGroup OBJECT-GROUP 
+    OBJECTS { 
+            pdug5TemperatureScale, 
+            pdug5TemperatureCount, 
+            pdug5HumidityCount, 
+            pdug5DoorCount, 
+            pdug5DryCount, 
+            pdug5SpotCount, 
+            pdug5RopeCount, 
+            pdug5HidCount, 
+            pdug5TemperatureName, 
+            pdug5TemperatureProbeStatus, 
+            pdug5TemperatureValue, 
+            pdug5TemperatureThStatus, 
+            pdug5TemperatureThLowerWarning, 
+            pdug5TemperatureThLowerCritical, 
+            pdug5TemperatureThUpperWarning, 
+            pdug5TemperatureThUpperCritical, 
+            pdug5TemperatureThCtrl, 
+            pdug5HumidityName, 
+            pdug5HumidityProbeStatus, 
+            pdug5HumidityValue, 
+            pdug5HumidityThStatus, 
+            pdug5HumidityThLowerWarning, 
+            pdug5HumidityThLowerCritical, 
+            pdug5HumidityThUpperWarning, 
+            pdug5HumidityThUpperCritical, 
+            pdug5HumidityThCtrl, 
+            pdug5DoorName, 
+            pdug5DoorProbeStatus, 
+            pdug5DoorState, 
+            pdug5DryName, 
+            pdug5DryProbeStatus, 
+            pdug5DryState, 
+            pdug5SpotName, 
+            pdug5SpotProbeStatus, 
+            pdug5SpotState, 
+            pdug5RopeName, 
+            pdug5RopeProbeStatus, 
+            pdug5RopeState, 
+            pdug5HidAisle, 
+            pdug5HidHandleOperation, 
+            pduHIDVer, 
+            pdug5MechanicalLock, 
+            pduHIDSerial, 
+            pduHIDHwVer, 
+            pdug5HIDAutoLockTime, 
+            pdug5HIDDoorOpenTime, 
+            pdug5HIDMaxDoorOpenTime, 
+            pdug5HIDUserPinLength, 
+            pdug5HIDUserPinMode, 
+            pdug5HIDAisleControl,
+            pdug5HIDBeaconFuncControl,
+            pdug5HidBeaconColorControl,			
+            pdug5HidControlUserName, 
+            pdug5HidControlCardID, 
+            pdug5HidControlTimestamp, 
+            pdug5HidControlCardAisle, 
+            pdug5HidControlStartTime, 
+            pdug5HidControlExpireTime, 
+            pdug5HidControlTempUser, 
+            pdug5HidControlPin, 
+            pdug5HidControlCardIdStr} 
+    STATUS current 
+    DESCRIPTION 
+        "the pdug5Environmental defines objects which aid Environmental level 
+        configuration and monitoring" 
+    ::= { pdug5Groups 4 } 
+ 
+ 
+pdug5OutletGroup OBJECT-GROUP 
+    OBJECTS { 
+            pdug5OutletName, 
+            pdug5OutletType, 
+            pdug5OutletCurrentRating, 
+            pdug5OutletCurrent, 
+            pdug5OutletActivePowerThStatus, 
+            pdug5OutletActivePowerThLowerWarning, 
+            pdug5OutletActivePowerThLowerCritical, 
+            pdug5OutletActivePowerThUpperWarning, 
+            pdug5OutletActivePowerThUpperCritical, 
+            pdug5OutletCurrentPercentLoad, 
+            pdug5OutletVA, 
+            pdug5OutletWatts, 
+            pdug5OutletWh, 
+            pdug5OutletWhTimer, 
+            pdug5OutletPowerFactor, 
+            pdug5OutletVAR, 
+            pdug5OutletBranch, 
+            pdug5OutletActivePowerThResetThld, 
+            pdug5OutletActivePowerThChangeDelay, 
+            pdug5OutletActivePowerThCtrl, 
+            pdug5OutletControlStatus, 
+            pdug5OutletControlOffCmd, 
+            pdug5OutletControlOnCmd, 
+            pdug5OutletControlRebootCmd, 
+            pdug5OutletControlPowerOnState, 
+            pdug5OutletControlSequenceDelay, 
+            pdug5OutletControlRebootOffTime, 
+            pdug5OutletControlSwitchable, 
+            pdug5OutletControlShutoffDelay, 
+            pdug5OutletControlCommand} 
+    STATUS current 
+    DESCRIPTION 
+        "the pdug5OutletGroup defines objects which aid Outlet level 
+        configuration and monitoring" 
+    ::= { pdug5Groups 5 } 
+ 
+pdug5TrapGroup NOTIFICATION-GROUP 
+    NOTIFICATIONS { 
+            trapCritical, 
+            trapWarning, 
+            trapInformation, 
+            trapCleared, 
+            trapTest} 
+    STATUS current 
+    DESCRIPTION 
+        "the pdug5TrapGroup defines Traps." 
+    ::= { pdug5Groups 6 } 
+ 
+ 
+pdug5TrapInfoGroup OBJECT-GROUP 
+    OBJECTS { 
+            trapCode, 
+            trapDescription} 
+    STATUS current 
+    DESCRIPTION 
+        "the pdug5TrapInfoGroup defines Traps Information." 
+    ::= { pdug5Groups 7 } 
+ 
+END 

--- a/tests/data/panduit_g5-p32g13m.json
+++ b/tests/data/panduit_g5-p32g13m.json
@@ -1,0 +1,23 @@
+{
+    "os": {
+        "discovery": {
+            "devices": [
+                {
+                    "sysName": null,
+                    "sysObjectID": ".1.3.6.1.4.1.19536.10.1",
+                    "sysDescr": "SN:Outlet Metered, Outlet Switched PN:Device Model:P32G13M Rating:200-240V, 32A, 7.4kVA, 50/60Hz",
+                    "sysContact": null,
+                    "version": null,
+                    "hardware": null,
+                    "features": null,
+                    "location": null,
+                    "os": "panduit",
+                    "type": "power",
+                    "serial": null,
+                    "icon": "panduit.png"
+                }
+            ]
+        },
+        "poller": "matches discovery"
+    }
+}

--- a/tests/snmpsim/panduit_g5-p32g13m.snmprec
+++ b/tests/snmpsim/panduit_g5-p32g13m.snmprec
@@ -1,0 +1,2 @@
+1.3.6.1.2.1.1.1.0|4| SN:Outlet Metered, Outlet Switched PN:Device Model:P32G13M Rating:200-240V, 32A, 7.4kVA, 50/60Hz
+1.3.6.1.2.1.1.2.0|6|1.3.6.1.4.1.19536.10.1


### PR DESCRIPTION
Panduit G5 series PDUs are currently being discovered as OS `hpe-mapdu`rather than `panduit` resulting in no sensors etc.

They have the following sysobjectID /sysDescr:

```
.*.*.0 = .*.4.1.19536.10.1
.*.*.0 =  SN:Outlet Metered, Outlet Switched PN:Device Model:P32G13M Rating:200-240V, 32A, 7.4kVA, 50/60Hz
```
At present, discovery appears to match any device which includes the string `Outlet Metered, Outlet Switched` in its sysDescr as an HPE: https://github.com/librenms/librenms/blob/95eb9a705126611aa1a2c7f3b7396bc38becb082/includes/definitions/hpe-mapdu.yaml#L19

This logic is incorrect (the HPE PDUs probably share that string as they are rebadged Panduit devices). 

One option would be to remove the sysDescr match and I believe the HPE PDU snmprec below in the tests directory would still be discovered correctly via a sysobjectID match:
https://github.com/librenms/librenms/blob/95eb9a705126611aa1a2c7f3b7396bc38becb082/tests/snmpsim/hpe-mapdu_pdu3.snmprec#L2
I have not found any other snmprec file with that sysDescr string.

Another less intrusive fix could be to exclude any Panduit sysObjectID from matching. This pull request does that but I am happy to change it if necessary. 

This pull request also includes the latest PANDUIT-MIB bundled with the 3.3.6 firmware from
https://www.panduit.com/en/support/download-center/power-distribution-units.html
for updated trap handling.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
