### PR TITLE
fix: Minor typo in PHP-FPM poller log

### DIFF
--- a/includes/polling/applications/php-fpm.inc.php
+++ b/includes/polling/applications/php-fpm.inc.php
@@ -125,7 +125,7 @@ $removed_pools = array_diff($old_pools, $new_pools);
 
 // if we have any changes in pools, log it
 if (count($added_pools) > 0 || count($removed_pools) > 0) {
-    $log_message = 'Suricata Instance Change:';
+    $log_message = 'PHP-FPM Pool Change:';
     $log_message .= count($added_pools) > 0 ? ' Added ' . implode(',', $added_pools) : '';
     $log_message .= count($removed_pools) > 0 ? ' Removed ' . implode(',', $added_pools) : '';
     Eventlog::log($log_message, $device['device_id'], 'application');


### PR DESCRIPTION
Minor typo in PHP-FPM poller log (copy/paste error from Suricata poller)

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [X] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
