### PR TITLE
wrapper: No new devices should not trigger error log

### DIFF
--- a/LibreNMS/wrapper.py
+++ b/LibreNMS/wrapper.py
@@ -301,7 +301,7 @@ def poll_worker(
                     timeout=PER_DEVICE_TIMEOUT,
                     valid_exit_codes=VALID_EXIT_CODES,
                 )
-                if exit_code not in [0, 6]:
+                if exit_code not in VALID_EXIT_CODES:
                     logger.error(
                         "Thread {} exited with code {}".format(
                             threading.current_thread().name, exit_code


### PR DESCRIPTION
So wrapper threads return 0 in case of success, 5 in case of no new devices, and 6 in case of timeout.
For whatever reason, I didn't use dedicated `VALID_EXIT_CODES` variables to check if we needed an error log line back in 2021 when I did rewrite wrapper.py.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [X] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
