### PR TITLE
Fix header mode authentication in SSOAuthorizer

### DIFF
--- a/LibreNMS/Authentication/SSOAuthorizer.php
+++ b/LibreNMS/Authentication/SSOAuthorizer.php
@@ -71,7 +71,7 @@ class SSOAuthorizer extends MysqlAuthorizer
 
     public function getExternalUsername()
     {
-        return $this->authSSOGetAttr(Config::get('sso.user_attr'), '');
+        return $this->authSSOGetAttr(Config::get('sso.user_attr'));
     }
 
     /**

--- a/tests/AuthSSOTest.php
+++ b/tests/AuthSSOTest.php
@@ -91,8 +91,11 @@ class AuthSSOTest extends DBTestCase
 
         Config::set('sso.mode', 'header');
 
+        $user = Str::random();
+
         $_SERVER['REMOTE_ADDR'] = '::1';
-        $_SERVER['REMOTE_USER'] = Str::random();
+        $_SERVER['REMOTE_USER'] = $user;
+        $_SERVER['HTTP_REMOTE_USER'] = $user;
 
         $_SERVER['HTTP_MAIL'] = 'test@example.org';
         $_SERVER['HTTP_DISPLAYNAME'] = 'Test User';
@@ -102,6 +105,7 @@ class AuthSSOTest extends DBTestCase
     {
         $user = Str::random();
         $_SERVER['REMOTE_USER'] = $user;
+        $_SERVER['HTTP_REMOTE_USER'] = $user;
 
         return $user;
     }


### PR DESCRIPTION
When this function is called: authSSOGetAttr($attr, $prefix = 'HTTP_')
$prefix is alway set to '' due to this call: return $this->authSSOGetAttr(Config::get('sso.user_attr'), '');

This breaks the header matching from Nginx which is prefixed with HTTP_. This fix allows the default of $prefix = 'HTTP_' to be used.

This fixes Authelia using the following settings:
    "user_attr": "REMOTE_USER",
    "mode": "header",
    "group_strategy": "static",
    "static_level": 10

Tested with docker image librenms/librenms:25.2.0, using Librenms helm chart version 3.18.0.


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
