### PR TITLE
use raw string for Python regex

### DIFF
--- a/LibreNMS/wrapper.py
+++ b/LibreNMS/wrapper.py
@@ -286,7 +286,7 @@ def poll_worker(
                     executable, wrappers[wrapper_type]["option"], device_id
                 )
                 if modules is not None and len(str(modules).strip()):
-                    module_str = re.sub("\s", "", str(modules).strip())
+                    module_str = re.sub(r"\s", "", str(modules).strip())
                     command = command + " -m {}".format(module_str)
 
                 # enable debug output otherwise, set -q for lnms commands


### PR DESCRIPTION
wrapper.py has an escape sequence \r in a regular expression. Python 3.12 makes it a syntax warning to use invalid escape sequences in a string where those escape sequences are interpreted (i.e. not a raw string). Python falls back to including the escape sequence directly, but if e.g. an actual escape sequence for \r would be added in a future Python version, there would be a problem. Simply convert to a raw string to avoid this issue.

Fixes this warning at runtime with 3.12+ (which is expected to become an error sometime in a future version).

```
/var/www/librenms/LibreNMS/wrapper.py:289: SyntaxWarning: invalid escape sequence '\s'
  module_str = re.sub("\s", "", str(modules).strip())
```

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
