### PR TITLE
Skip arp/nd on an interface when the interface is not found

### DIFF
--- a/includes/discovery/arp-table.inc.php
+++ b/includes/discovery/arp-table.inc.php
@@ -47,6 +47,12 @@ foreach (DeviceCache::getPrimary()->getVrfContexts() as $context_name) {
     $insert_data = [];
     foreach ($arp_data as $ifIndex => $data) {
         $interface = get_port_by_index_cache($device['device_id'], $ifIndex);
+
+        if (!$interface) {
+            d_echo("Skipping arp/nd on interface with index $ifIndex - interface not found (hint: was it filtered out with bad_if/bad_if_regexp/bad_iftype/bad_ifoperstatus?)");
+            continue;
+        }
+
         $port_id = $interface['port_id'];
 
         $port_arp = array_merge(

--- a/includes/discovery/arp-table.inc.php
+++ b/includes/discovery/arp-table.inc.php
@@ -48,7 +48,7 @@ foreach (DeviceCache::getPrimary()->getVrfContexts() as $context_name) {
     foreach ($arp_data as $ifIndex => $data) {
         $interface = get_port_by_index_cache($device['device_id'], $ifIndex);
 
-        if (!$interface) {
+        if (! $interface) {
             d_echo("Skipping arp/nd on interface with index $ifIndex - interface not found (hint: was it filtered out with bad_if/bad_if_regexp/bad_iftype/bad_ifoperstatus?)");
             continue;
         }


### PR DESCRIPTION
If an interface is filtered with the various _bad_ settings, it still shows up in a the arp module, and causes a null constraint exception when trying to add the arp entry into the database.

Happy to tweak the debug message.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
