### PR TITLE
Remove ospfv3_ports.ospfv3IfInstId and display area ID using dot notation

### DIFF
--- a/LibreNMS/Modules/Ospfv3.php
+++ b/LibreNMS/Modules/Ospfv3.php
@@ -157,6 +157,8 @@ class Ospfv3 implements Module
                     $ospf_port['ospfv3AreaScopeLsaCksumSum'] ??= 0;
                     $ospf_port['ospfv3IfIndex'] ??= 0;
 
+                    unset($ospf_port['ospfv3IfInstId']);
+
                     return Ospfv3Port::updateOrCreate([
                         'device_id' => $os->getDeviceId(),
                         'ospfv3_instance_id' => $ospf_instance_id,

--- a/LibreNMS/Modules/Ospfv3.php
+++ b/LibreNMS/Modules/Ospfv3.php
@@ -129,7 +129,7 @@ class Ospfv3 implements Module
                 ->mapTable(function ($ospf_area, $ospf_area_id) use ($context_name, $os) {
                     return Ospfv3Area::updateOrCreate([
                         'device_id' => $os->getDeviceId(),
-                        'ospfv3AreaId' => is_int($ospf_area_id) ? long2ip($ospf_area_id) : $ospf_area_id,
+                        'ospfv3AreaId' => $ospf_area_id,
                         'context_name' => $context_name,
                     ], $ospf_area);
                 });

--- a/LibreNMS/Modules/Ospfv3.php
+++ b/LibreNMS/Modules/Ospfv3.php
@@ -129,7 +129,7 @@ class Ospfv3 implements Module
                 ->mapTable(function ($ospf_area, $ospf_area_id) use ($context_name, $os) {
                     return Ospfv3Area::updateOrCreate([
                         'device_id' => $os->getDeviceId(),
-                        'ospfv3AreaId' => $ospf_area_id,
+                        'ospfv3AreaId' => is_int($ospf_area_id) ? long2ip($ospf_area_id) : $ospf_area_id,
                         'context_name' => $context_name,
                     ], $ospf_area);
                 });

--- a/app/Models/Ospfv3Port.php
+++ b/app/Models/Ospfv3Port.php
@@ -40,7 +40,6 @@ class Ospfv3Port extends PortRelatedModel
         'ospfv3_port_id',
         'context_name',
         'ospfv3IfIndex',
-        'ospfv3IfInstId',
         'ospfv3IfAreaId',
         'ospfv3IfType',
         'ospfv3IfAdminStatus',

--- a/database/migrations/2025_03_11_031114_add_ospfv3ifinstid_default.php
+++ b/database/migrations/2025_03_11_031114_add_ospfv3ifinstid_default.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
@@ -13,7 +14,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('ospfv3_ports', function (Blueprint $table) {
-            $table->integer('ospfv3IfInstId')->default(1)->change();
+            $table->dropColumn('ospfv3IfInstId');
         });
     }
 
@@ -25,7 +26,7 @@ return new class extends Migration
     public function down(): void
     {
         Schema::table('ospfv3_ports', function (Blueprint $table) {
-            $table->integer('ospfv3IfInstId')->default(null)->change();
+            $table->integer('ospfv3IfInstId');
         });
     }
 };

--- a/database/migrations/2025_03_11_031114_add_ospfv3ifinstid_default.php
+++ b/database/migrations/2025_03_11_031114_add_ospfv3ifinstid_default.php
@@ -13,7 +13,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('ospfv3_ports', function (Blueprint $table) {
-            $table->integer('ospfv3IfInstId')->default(1);
+            $table->integer('ospfv3IfInstId')->default(1)->change();
         });
     }
 
@@ -25,7 +25,7 @@ return new class extends Migration
     public function down(): void
     {
         Schema::table('ospfv3_ports', function (Blueprint $table) {
-            $table->integer('ospfv3IfInstId')->default(null);
+            $table->integer('ospfv3IfInstId')->default(null)->change();
         });
     }
 };

--- a/database/migrations/2025_03_11_031114_add_ospfv3ifinstid_default.php
+++ b/database/migrations/2025_03_11_031114_add_ospfv3ifinstid_default.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up(): void
+    {
+        Schema::table('ospfv3_ports', function (Blueprint $table) {
+            $table->integer('ospfv3IfInstId')->default(1);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down(): void
+    {
+        Schema::table('ospfv3_ports', function (Blueprint $table) {
+            $table->integer('ospfv3IfInstId')->default(null);
+        });
+    }
+};

--- a/database/migrations/2025_03_11_031114_drop_ospfv3ifinstid.php
+++ b/database/migrations/2025_03_11_031114_drop_ospfv3ifinstid.php
@@ -26,7 +26,7 @@ return new class extends Migration
     public function down(): void
     {
         Schema::table('ospfv3_ports', function (Blueprint $table) {
-            $table->integer('ospfv3IfInstId');
+            $table->integer('ospfv3IfInstId')->after('ospfv3IfIndex');
         });
     }
 };

--- a/doc/API/Routing.md
+++ b/doc/API/Routing.md
@@ -513,7 +513,6 @@ Output:
           "port_id": 2838,
           "ospfv3_port_id": "2",
           "ospfv3IfIndex": "2",
-          "ospfv3IfInstId": "0",
           "ospfv3IfAreaId": "0",
           "ospfv3IfType": "broadcast",
           "ospfv3IfAdminStatus": "enabled",

--- a/includes/html/pages/device/routing/ospfv3.inc.php
+++ b/includes/html/pages/device/routing/ospfv3.inc.php
@@ -72,7 +72,7 @@ foreach ($instances as $instance) {
         echo '
                       <tbody>
                         <tr>
-                          <td>' . $area->ospfv3AreaId . '</td>
+                          <td>' . (filter_var($area->ospfv3AreaId, FILTER_VALIDATE_IP) ? $area->ospfv3AreaId : long2ip($area->ospfv3AreaId)) . '</td>
                           <td>' . $area_port_count . '(' . $area_port_count_enabled . ')</td>
                           <td><span class="label label-' . $status_color . '">' . $instance->ospfv3AdminStatus . '</span></td>
                         </tr>
@@ -110,8 +110,8 @@ foreach ($instances as $instance) {
                       <td>' . $ospfPort->ospfv3IfState . '</td>
                       <td>' . $ospfPort->ospfv3IfMetricValue . '</td>
                       <td><span class="label label-' . $port_status_color . '">' . $ospfPort->ospfv3IfAdminStatus . '</span></td>
-                      <td>' . $ospfPort->ospfv3IfAreaId . '</td>
-                    </tr>
+                      <td>' . (filter_var($ospfPort->ospfv3IfAreaId, FILTER_VALIDATE_IP) ? $ospfPort->ospfv3IfAreaId : long2ip($ospfPort->ospfv3IfAreaId)) . '</td>
+                      </tr>
                   </tbody>';
     }
     echo '

--- a/includes/html/pages/device/routing/ospfv3.inc.php
+++ b/includes/html/pages/device/routing/ospfv3.inc.php
@@ -111,7 +111,7 @@ foreach ($instances as $instance) {
                       <td>' . $ospfPort->ospfv3IfMetricValue . '</td>
                       <td><span class="label label-' . $port_status_color . '">' . $ospfPort->ospfv3IfAdminStatus . '</span></td>
                       <td>' . (filter_var($ospfPort->ospfv3IfAreaId, FILTER_VALIDATE_IP) ? $ospfPort->ospfv3IfAreaId : long2ip($ospfPort->ospfv3IfAreaId)) . '</td>
-                      </tr>
+                    </tr>
                   </tbody>';
     }
     echo '

--- a/misc/db_schema.yaml
+++ b/misc/db_schema.yaml
@@ -1511,7 +1511,6 @@ ospfv3_ports:
     - { Field: ospfv3_instance_id, Type: 'int unsigned', 'Null': false, Extra: '' }
     - { Field: ospfv3_port_id, Type: varchar(32), 'Null': false, Extra: '' }
     - { Field: ospfv3IfIndex, Type: 'int', 'Null': false, Extra: '' }
-    - { Field: ospfv3IfInstId, Type: int, 'Null': false, Extra: '', Default: '1' }
     - { Field: ospfv3IfAreaId, Type: varchar(32), 'Null': false, Extra: '' }
     - { Field: ospfv3IfType, Type: varchar(32), 'Null': true, Extra: '' }
     - { Field: ospfv3IfAdminStatus, Type: varchar(32), 'Null': true, Extra: '' }

--- a/misc/db_schema.yaml
+++ b/misc/db_schema.yaml
@@ -1511,7 +1511,7 @@ ospfv3_ports:
     - { Field: ospfv3_instance_id, Type: 'int unsigned', 'Null': false, Extra: '' }
     - { Field: ospfv3_port_id, Type: varchar(32), 'Null': false, Extra: '' }
     - { Field: ospfv3IfIndex, Type: 'int', 'Null': false, Extra: '' }
-    - { Field: ospfv3IfInstId, Type: int, 'Null': false, Extra: '' }
+    - { Field: ospfv3IfInstId, Type: int, 'Null': false, Extra: '', Default: '1' }
     - { Field: ospfv3IfAreaId, Type: varchar(32), 'Null': false, Extra: '' }
     - { Field: ospfv3IfType, Type: varchar(32), 'Null': true, Extra: '' }
     - { Field: ospfv3IfAdminStatus, Type: varchar(32), 'Null': true, Extra: '' }

--- a/tests/data/fortigate_60fospfv3.json
+++ b/tests/data/fortigate_60fospfv3.json
@@ -8007,7 +8007,6 @@
                     "ospfv3_instance_id": 0,
                     "ospfv3_port_id": "2",
                     "ospfv3IfIndex": 2,
-                    "ospfv3IfInstId": 0,
                     "ospfv3IfAreaId": "0",
                     "ospfv3IfType": "broadcast",
                     "ospfv3IfAdminStatus": "enabled",


### PR DESCRIPTION
I have a device that is not returning ospfv3IfInstId. This causes an exception.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
