### PR TITLE
LDAP fixes for newer PHP versions

### DIFF
--- a/LibreNMS/Authentication/ADAuthorizationAuthorizer.php
+++ b/LibreNMS/Authentication/ADAuthorizationAuthorizer.php
@@ -2,6 +2,7 @@
 
 namespace LibreNMS\Authentication;
 
+use LDAP\Connection;
 use LibreNMS\Config;
 use LibreNMS\Enum\LegacyAuthLevel;
 use LibreNMS\Exceptions\AuthenticationException;
@@ -168,7 +169,7 @@ class ADAuthorizationAuthorizer extends MysqlAuthorizer
         return $user_id;
     }
 
-    protected function getConnection()
+    protected function getConnection(): ?Connection
     {
         return $this->ldap_connection;
     }

--- a/LibreNMS/Authentication/ActiveDirectoryAuthorizer.php
+++ b/LibreNMS/Authentication/ActiveDirectoryAuthorizer.php
@@ -6,6 +6,7 @@
 
 namespace LibreNMS\Authentication;
 
+use LDAP\Connection;
 use LibreNMS\Config;
 use LibreNMS\Enum\LegacyAuthLevel;
 use LibreNMS\Exceptions\AuthenticationException;
@@ -17,7 +18,7 @@ class ActiveDirectoryAuthorizer extends AuthorizerBase
 
     protected static $CAN_UPDATE_PASSWORDS = false;
 
-    protected $ldap_connection;
+    protected Connection|null $ldap_connection;
     protected $is_bound = false; // this variable tracks if bind has been called so we don't call it multiple times
 
     public function authenticate($credentials)
@@ -253,7 +254,7 @@ class ActiveDirectoryAuthorizer extends AuthorizerBase
         ldap_set_option($this->ldap_connection, LDAP_OPT_NETWORK_TIMEOUT, -1); // restore timeout
     }
 
-    protected function getConnection()
+    protected function getConnection(): ?Connection
     {
         $this->init(); // make sure connected and bound
 

--- a/LibreNMS/Authentication/ActiveDirectoryCommon.php
+++ b/LibreNMS/Authentication/ActiveDirectoryCommon.php
@@ -25,6 +25,7 @@
 
 namespace LibreNMS\Authentication;
 
+use LDAP\Connection;
 use LibreNMS\Config;
 
 trait ActiveDirectoryCommon
@@ -219,5 +220,5 @@ trait ActiveDirectoryCommon
      *
      * @return resource
      */
-    abstract protected function getConnection();
+    abstract protected function getConnection(): ?Connection;
 }

--- a/LibreNMS/Authentication/LdapAuthorizationAuthorizer.php
+++ b/LibreNMS/Authentication/LdapAuthorizationAuthorizer.php
@@ -46,7 +46,14 @@ class LdapAuthorizationAuthorizer extends AuthorizerBase
         /**
          * Set up connection to LDAP server
          */
-        $this->ldap_connection = @ldap_connect(Config::get('auth_ldap_server'), Config::get('auth_ldap_port'));
+        $port = Config::get('auth_ldap_port');
+        $uri = Config::get('auth_ldap_server');
+        if ($port) {
+            $uri .= ":$port";
+        }
+
+        $this->ldap_connection = @ldap_connect($uri);
+
         if (! $this->ldap_connection) {
             throw new AuthenticationException('Fatal error while connecting to LDAP server, uri not valid: ' . Config::get('auth_ldap_server') . ':' . Config::get('auth_ldap_port'));
         }

--- a/LibreNMS/Authentication/LdapAuthorizer.php
+++ b/LibreNMS/Authentication/LdapAuthorizer.php
@@ -326,7 +326,13 @@ class LdapAuthorizer extends AuthorizerBase
             throw new LdapMissingException();
         }
 
-        $this->ldap_connection = @ldap_connect(Config::get('auth_ldap_server'), Config::get('auth_ldap_port', 389));
+        $port = Config::get('auth_ldap_port');
+        $uri = Config::get('auth_ldap_server');
+        if ($port) {
+            $uri .= ":$port";
+        }
+
+        $this->ldap_connection = @ldap_connect($uri);
 
         if (! $this->ldap_connection) {
             throw new AuthenticationException('Unable to connect to ldap server');

--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -686,7 +686,7 @@
             }
         },
         "auth_ldap_port": {
-            "default": 389,
+            "default": null,
             "group": "auth",
             "section": "ldap",
             "order": 1,


### PR DESCRIPTION
return types changed in PHP 8.1
ldap_connect port argument deprecated in 8.3


#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
