### PR TITLE
Non-Greedy version from hrSWInstalledName on junos

### DIFF
--- a/LibreNMS/OS/Junos.php
+++ b/LibreNMS/OS/Junos.php
@@ -59,7 +59,7 @@ class Junos extends \LibreNMS\OS implements SlaDiscovery, OSPolling, SlaPolling,
 
         preg_match('/Juniper Networks, Inc. (?<hardware>\S+) .* kernel JUNOS (?<version>[^, ]+)[, ]/', $device->sysDescr, $parsed);
         if (isset($data[2]['hrSWInstalledName'])) {
-            preg_match('/\[(.+)]/', $data[2]['hrSWInstalledName'], $parsedVersion);
+            preg_match('/\[(.+?)]/', $data[2]['hrSWInstalledName'], $parsedVersion);
         }
 
         $device->hardware = $data[0]['jnxBoxDescr'] ?? (isset($parsed['hardware']) ? 'Juniper ' . strtoupper($parsed['hardware']) : null);

--- a/LibreNMS/OS/Junos.php
+++ b/LibreNMS/OS/Junos.php
@@ -59,7 +59,7 @@ class Junos extends \LibreNMS\OS implements SlaDiscovery, OSPolling, SlaPolling,
 
         preg_match('/Juniper Networks, Inc. (?<hardware>\S+) .* kernel JUNOS (?<version>[^, ]+)[, ]/', $device->sysDescr, $parsed);
         if (isset($data[2]['hrSWInstalledName'])) {
-            preg_match('/\[(.+?)]/', $data[2]['hrSWInstalledName'], $parsedVersion);
+            preg_match('/^JUNOS.*\[(.+?)]/', $data[2]['hrSWInstalledName'], $parsedVersion);
         }
 
         $device->hardware = $data[0]['jnxBoxDescr'] ?? (isset($parsed['hardware']) ? 'Juniper ' . strtoupper($parsed['hardware']) : null);

--- a/tests/data/junos_qfx5100-vcs-14.1x53-d40.8-1.json
+++ b/tests/data/junos_qfx5100-vcs-14.1x53-d40.8-1.json
@@ -1,0 +1,23 @@
+{
+    "os": {
+        "discovery": {
+            "devices": [
+                {
+                    "sysName": "<private>",
+                    "sysObjectID": ".1.3.6.1.4.1.2636.1.1.1.4.82.4",
+                    "sysDescr": "Juniper Networks, Inc. qfx5100-24q-2p Ethernet Switch, kernel JUNOS 14.1X53-D40.8, Build date: 2016-11-09 02:23:05 UTC Copyright (c) 1996-2016 Juniper Networks, Inc.",
+                    "sysContact": "<private>",
+                    "version": "14.1X53-D40.8",
+                    "hardware": "Juniper Virtual Chassis Switch",
+                    "features": null,
+                    "location": "<private>",
+                    "os": "junos",
+                    "type": "network",
+                    "serial": "TB3714070326",
+                    "icon": "junos.png"
+                }
+            ]
+        },
+        "poller": "matches discovery"
+    }
+}

--- a/tests/data/junos_qfx5100-vcs-14.1x53-d40.8-2.json
+++ b/tests/data/junos_qfx5100-vcs-14.1x53-d40.8-2.json
@@ -1,0 +1,23 @@
+{
+    "os": {
+        "discovery": {
+            "devices": [
+                {
+                    "sysName": "<private>",
+                    "sysObjectID": ".1.3.6.1.4.1.2636.1.1.1.4.82.4",
+                    "sysDescr": "Juniper Networks, Inc. qfx5100-24q-2p Ethernet Switch, kernel JUNOS 14.1X53-D40.8, Build date: 2016-11-09 02:23:05 UTC Copyright (c) 1996-2016 Juniper Networks, Inc.",
+                    "sysContact": "<private>",
+                    "version": "14.1X53-D40.8",
+                    "hardware": "Juniper Virtual Chassis Switch",
+                    "features": null,
+                    "location": "<private>",
+                    "os": "junos",
+                    "type": "network",
+                    "serial": "VG3716220239",
+                    "icon": "junos.png"
+                }
+            ]
+        },
+        "poller": "matches discovery"
+    }
+}

--- a/tests/snmpsim/junos_qfx5100-vcs-14.1x53-d40.8-1.snmprec
+++ b/tests/snmpsim/junos_qfx5100-vcs-14.1x53-d40.8-1.snmprec
@@ -1,0 +1,8 @@
+1.3.6.1.2.1.1.1.0|4|Juniper Networks, Inc. qfx5100-24q-2p Ethernet Switch, kernel JUNOS 14.1X53-D40.8, Build date: 2016-11-09 02:23:05 UTC Copyright (c) 1996-2016 Juniper Networks, Inc.
+1.3.6.1.2.1.1.2.0|6|1.3.6.1.4.1.2636.1.1.1.4.82.4
+1.3.6.1.2.1.1.4.0|4|<private>
+1.3.6.1.2.1.1.5.0|4|<private>
+1.3.6.1.2.1.1.6.0|4|<private>
+1.3.6.1.2.1.25.6.3.1.2.2|4|junos-ez-stdlib [11.10.4_1.junos.i386]D40.8]
+1.3.6.1.4.1.2636.3.1.2.0|4|Juniper Virtual Chassis Switch
+1.3.6.1.4.1.2636.3.1.3.0|4|TB3714070326

--- a/tests/snmpsim/junos_qfx5100-vcs-14.1x53-d40.8-2.snmprec
+++ b/tests/snmpsim/junos_qfx5100-vcs-14.1x53-d40.8-2.snmprec
@@ -1,0 +1,8 @@
+1.3.6.1.2.1.1.1.0|4|Juniper Networks, Inc. qfx5100-24q-2p Ethernet Switch, kernel JUNOS 14.1X53-D40.8, Build date: 2016-11-09 02:23:05 UTC Copyright (c) 1996-2016 Juniper Networks, Inc.
+1.3.6.1.2.1.1.2.0|6|1.3.6.1.4.1.2636.1.1.1.4.82.4
+1.3.6.1.2.1.1.4.0|4|<private>
+1.3.6.1.2.1.1.5.0|4|<private>
+1.3.6.1.2.1.1.6.0|4|<private>
+1.3.6.1.2.1.25.6.3.1.2.2|4|JUNOS Base OS boot [14.1X53-D40.8]X53-D40.8]
+1.3.6.1.4.1.2636.3.1.2.0|4|Juniper Virtual Chassis Switch
+1.3.6.1.4.1.2636.3.1.3.0|4|VG3716220239


### PR DESCRIPTION
Please give a short description what your pull request is for

With the following versions I have noted the extracted version is incorrect

11.10.4_1.junos.i386]D40.8
14.1X53-D40.8]X53-D40.8

This can be seen due to the return of bad data from device

```
~$ snmpget -M +./mibs:./mibs/junos -v2c -c <readacted> DUT \
  JUNIPER-MIB::jnxBoxDescr.0 \
  JUNIPER-MIB::jnxBoxSerialNo.0 \
  JUNIPER-VIRTUALCHASSIS-MIB::jnxVirtualChassisMemberSWVersion.0 \
  HOST-RESOURCES-MIB::hrSWInstalledName.2
JUNIPER-MIB::jnxBoxDescr.0 = STRING: Juniper Virtual Chassis Switch
JUNIPER-MIB::jnxBoxSerialNo.0 = STRING: VG3716220239
JUNIPER-VIRTUALCHASSIS-MIB::jnxVirtualChassisMemberSWVersion.0 = No Such Instance currently exists at this OID
HOST-RESOURCES-MIB::hrSWInstalledName.2 = STRING: "JUNOS Base OS boot [14.1X53-D40.8]X53-D40.8]"
```

Also using a specific index of hrSWInstalledName is probably not the best idea as there are other packages, and non JUNOS packages can have versions that are not the base software version.

We could pull the whole set of installed software and try to come up with some 'Base OS' package we use .. but this seems overtly complex given the match from sysDesr seems to be correct in this particular instance 

```
snmpget -M +./mibs:./mibs/junos -v2c -c <redacted> DUT2 \
  JUNIPER-MIB::jnxBoxDescr.0 \
  JUNIPER-MIB::jnxBoxSerialNo.0 \
  JUNIPER-VIRTUALCHASSIS-MIB::jnxVirtualChassisMemberSWVersion.0 \
  HOST-RESOURCES-MIB::hrSWInstalledName.2
JUNIPER-MIB::jnxBoxDescr.0 = STRING: Juniper Virtual Chassis Switch
JUNIPER-MIB::jnxBoxSerialNo.0 = STRING: TB3714070326
JUNIPER-VIRTUALCHASSIS-MIB::jnxVirtualChassisMemberSWVersion.0 = No Such Instance currently exists at this OID
HOST-RESOURCES-MIB::hrSWInstalledName.2 = STRING: "junos-ez-stdlib [11.10.4_1.junos.i386]D40.8]"
```


Switching from a greedy to a non-greedy match resolves this as per test here, and if we add JUNOS we ensure we don't match non-JUNOS packages ...

```
#!/usr/bin/env php
<?php
$testString = 'JUNOS Base OS boot [14.1X53-D40.8]X53-D40.8]';

echo "Test string: $testString\n\n";

// Greedy regex pattern: matches from the first [ to the last ]
$greedyPattern = '/^JUNOS.*\[(.+)]/';
if (preg_match($greedyPattern, $testString, $matches)) {
    echo "Greedy match: " . $matches[1] . "\n";
} else {
    echo "No greedy match found.\n";
}

// Non-greedy regex pattern: matches minimally between [ and ]
$nonGreedyPattern = '/^JUNOS.*\[(.+?)\]/';
if (preg_match($nonGreedyPattern, $testString, $matches)) {
    echo "Non-greedy match: " . $matches[1] . "\n";
} else {
    echo "No non-greedy match found.\n";
}
```

```
./test
Test string: JUNOS Base OS boot [14.1X53-D40.8]X53-D40.8]

Greedy match: 14.1X53-D40.8]X53-D40.8
Non-greedy match: 14.1X53-D40.8
```

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
