### PR TITLE
Mempool perc_warn, never update

### DIFF
--- a/LibreNMS/Modules/Mempools.php
+++ b/LibreNMS/Modules/Mempools.php
@@ -27,7 +27,7 @@ namespace LibreNMS\Modules;
 
 use App\Models\Device;
 use App\Models\Mempool;
-use App\Observers\MempoolObserver;
+use App\Observers\ModuleModelObserver;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Log;
 use LibreNMS\DB\SyncsModels;
@@ -77,7 +77,7 @@ class Mempools implements Module
         // check if linux or similar and calculate available ram
         $this->calculateAvailable($mempools);
 
-        MempoolObserver::observe(\App\Models\Mempool::class);
+        ModuleModelObserver::observe(\App\Models\Mempool::class);
         $this->syncModels($os->getDevice(), 'mempools', $mempools);
 
         Log::info('');

--- a/app/Observers/MempoolObserver.php
+++ b/app/Observers/MempoolObserver.php
@@ -25,23 +25,27 @@
 
 namespace App\Observers;
 
+use App\Models\Mempool;
 use Log;
 use Rrd;
 
-class MempoolObserver extends ModuleModelObserver
+class MempoolObserver
 {
-    /** @param \App\Models\Mempool $model  */
-    public function updated($model): void
+    public function updating(Mempool $mempool): void
     {
-        parent::updated($model);
+        // prevent update of mempool_perc_warn
+        $mempool->mempool_perc_warn = $mempool->getOriginal('mempool_perc_warn');
+    }
 
-        if ($model->isDirty('mempool_class')) {
-            Log::debug("Mempool class changed $model->mempool_descr ($model->mempool_id)");
+    public function updated(Mempool $mempool): void
+    {
+        if ($mempool->isDirty('mempool_class')) {
+            Log::debug("Mempool class changed $mempool->mempool_descr ($mempool->mempool_id)");
             $device = [
-                'device_id' => $model->device->device_id,
-                'hostname' => $model->device->hostname,
+                'device_id' => $mempool->device->device_id,
+                'hostname' => $mempool->device->hostname,
             ];
-            Rrd::renameFile($device, ['mempool', $model->mempool_type, $model->getOriginal('mempool_class'), $model->mempool_index], ['mempool', $model->mempool_type, $model->mempool_class, $model->mempool_index]);
+            Rrd::renameFile($device, ['mempool', $mempool->mempool_type, $mempool->getOriginal('mempool_class'), $mempool->mempool_index], ['mempool', $mempool->mempool_type, $mempool->mempool_class, $mempool->mempool_index]);
         }
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -144,6 +144,7 @@ class AppServiceProvider extends ServiceProvider
     private function bootObservers()
     {
         \App\Models\Device::observe(\App\Observers\DeviceObserver::class);
+        \App\Models\Mempool::observe(\App\Observers\MempoolObserver::class);
         \App\Models\Package::observe(\App\Observers\PackageObserver::class);
         \App\Models\Qos::observe(\App\Observers\QosObserver::class);
         \App\Models\Sensor::observe(\App\Observers\SensorObserver::class);


### PR DESCRIPTION
Never update perc_warn, allows the user to set their own values

fixes #17192

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
