### PR TITLE
Clarify the naming convention for seeder keys.

### DIFF
--- a/doc/Support/Configuration.md
+++ b/doc/Support/Configuration.md
@@ -140,6 +140,11 @@ snmp.community:
 snmp.max_repeaters: 30
 ```
 
+**CAUTION**: The above example uses the correct, flattened notation whereas you might be tempted to create a
+block for `snmp` with sub-keys `community` and `max_repeaters`.  Do **NOT** do this as the whole `snmp`
+block will be overwritten, replaced with only those two sub-keys.  The config keys in your `seeders` file
+should follow the exact name you see in **Global Settings**.
+
 ## Directories
 
 ```bash

--- a/doc/Support/Configuration.md
+++ b/doc/Support/Configuration.md
@@ -143,7 +143,7 @@ snmp.max_repeaters: 30
 **CAUTION**: The above example uses the correct, flattened notation whereas you might be tempted to create a
 block for `snmp` with sub-keys `community` and `max_repeaters`.  Do **NOT** do this as the whole `snmp`
 block will be overwritten, replaced with only those two sub-keys.  The config keys in your `seeders` file
-should follow the exact name you see in **Global Settings**.
+must match those specified in `misc/config_definitions.json`.
 
 ## Directories
 


### PR DESCRIPTION
The example is correct, but one might be tempted to follow an expanded naming (i.e., specify blocks rather than dotted key notation).  This can cause unexpected behaviors.

Please give a short description what your pull request is for

I debated about raising this PR.  But this bit me hard.  I had a seeders file with this:

```yaml
os:
  routeros:
    poller_modules:
      netstats: false
```

In recent versions of LibreNMS, this broke polling -- ENTIRELY.  I wanted to prevent others from being as dumb as me, so I added a fine point to the docs.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
