### PR TITLE
Validation: Ignore composer files when plugin is installed

### DIFF
--- a/LibreNMS/Validations/User.php
+++ b/LibreNMS/Validations/User.php
@@ -103,6 +103,8 @@ class User extends BaseValidation
                         "$dir/storage/framework/sessions/",
                         "$dir/storage/framework/views/",
                         "$dir/storage/debugbar/",
+                        "$dir/composer.json",  // files are restored before update and modified when plugins are installed
+                        "$dir/composer.lock",
                         "$dir/.pki/", // ignore files/folders created by setting the librenms home directory to the install directory
                     ];
 

--- a/LibreNMS/Validations/User.php
+++ b/LibreNMS/Validations/User.php
@@ -103,10 +103,13 @@ class User extends BaseValidation
                         "$dir/storage/framework/sessions/",
                         "$dir/storage/framework/views/",
                         "$dir/storage/debugbar/",
-                        "$dir/composer.json",  // files are restored before update and modified when plugins are installed
-                        "$dir/composer.lock",
                         "$dir/.pki/", // ignore files/folders created by setting the librenms home directory to the install directory
                     ];
+
+                    // files are restored before update and modified when plugins are installed
+                    if (file_exists("$dir/composer.plugins.json")) {
+                        array_push($ignore_files, "$dir/composer.json", "$dir/composer.lock");
+                    }
 
                     $files = array_filter(explode(PHP_EOL, $find_result), function ($file) use ($ignore_files) {
                         if (Str::startsWith($file, $ignore_files)) {


### PR DESCRIPTION
Installing a plugin modifies composer.json and composer.lock, but the changes are reverted run updates are ran by daily.sh

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
