### PR TITLE
Remove error_handling(0) calls in auth code

### DIFF
--- a/app/Providers/LegacyUserProvider.php
+++ b/app/Providers/LegacyUserProvider.php
@@ -57,9 +57,7 @@ class LegacyUserProvider implements UserProvider
      */
     public function retrieveByLegacyId($identifier)
     {
-        error_reporting(0);
         $legacy_user = LegacyAuth::get()->getUser($identifier);
-        error_reporting(-1);
 
         return $this->retrieveByCredentials(['username' => $legacy_user['username'] ?? null]);
     }
@@ -116,8 +114,6 @@ class LegacyUserProvider implements UserProvider
      */
     public function validateCredentials(Authenticatable $user, array $credentials)
     {
-        error_reporting(0);
-
         $authorizer = LegacyAuth::get();
 
         try {
@@ -141,8 +137,6 @@ class LegacyUserProvider implements UserProvider
             $username = $username ?? Session::get('username', $credentials['username']);
 
             DB::table('authlog')->insert(['user' => $username, 'address' => Request::ip(), 'result' => $auth_message]);
-        } finally {
-            error_reporting(-1);
         }
 
         return false;
@@ -156,8 +150,6 @@ class LegacyUserProvider implements UserProvider
      */
     public function retrieveByCredentials(array $credentials)
     {
-        error_reporting(0);
-
         $auth = LegacyAuth::get();
         $type = LegacyAuth::getType();
 
@@ -170,18 +162,12 @@ class LegacyUserProvider implements UserProvider
         $auth_id = $auth->getUserid($username);
         $new_user = $auth->getUser($auth_id);
 
-        error_reporting(-1);
-
         if (empty($new_user)) {
             // some legacy auth create users in the authenticate method, if it doesn't exist yet, lets try authenticate (Laravel calls retrieveByCredentials first)
             try {
-                error_reporting(0);
-
                 $auth->authenticate($credentials);
                 $auth_id = $auth->getUserid($username);
                 $new_user = $auth->getUser($auth_id);
-
-                error_reporting(-1);
             } catch (AuthenticationException $ae) {
                 toast()->error($ae->getMessage());
             }


### PR DESCRIPTION
Legacy authenticators should be clean by now thanks to phpstan


#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
