### PR TITLE
Create pfsense.inc.php

### DIFF
--- a/includes/discovery/sensors/temperature/pfsense.inc.php
+++ b/includes/discovery/sensors/temperature/pfsense.inc.php
@@ -1,0 +1,12 @@
+<?php
+/*
+ * LibreNMS - pfSense CPU Temperature Sensor Discovery
+ * Adds support for CPU temperature monitoring via NET-SNMP extend OID
+ */
+if ($device['os'] === 'pfsense') {
+    $temp_oid = '.1.3.6.1.4.1.8072.1.3.2.3.1.2.7.99.112.117.84.101.109.112'; // NET-SNMP-EXTEND-MIB::nsExtendOutput1Line."cpuTemp"
+    $temp = snmp_get($device, $temp_oid, '-Oqv');
+    if (is_numeric($temp)) {
+        discover_sensor($valid['sensor'], 'temperature', $device, $temp_oid, 0, 'pfsense', 'CPU Temperature', 1, 1, null, null, null, null, $temp);
+    }
+}


### PR DESCRIPTION
This pull request adds CPU temperature sensor discovery for pfSense devices using the NET-SNMP extend OID .1.3.6.1.4.1.8072.1.3.2.3.1.2.7.99.112.117.84.101.109.112 (NET-SNMP-EXTEND-MIB::nsExtendOutput1Line."cpuTemp"). The implementation enhances pfSense support in LibreNMS.

Changes
Added includes/discovery/sensors/temperature/pfsense.inc.php to poll CPU temperature via SNMP.
Discovers a "CPU Temperature" sensor when a numeric value is returned.
Tested on pfSense 2.7.2-RELEASE (FreeBSD 14.0-CURRENT amd64) with a temperature of 31.5°C, successfully graphed.

Directions for PFSense to monitor CPU Temp.

install NET-SNMP 
pkg install -y pfSense-pkg-net-snmp

Turn off OLD SNMP

Go to Diagnostics/Command Prompt
touch /root/get_cpu_temp.sh && chmod +x /root/get_cpu_temp.sh

Go to Diagnostics/Edit File
edit /root/get_cpu_temp.sh - Paste two lines below
#!/bin/sh
/sbin/sysctl dev.cpu | /usr/bin/awk '/temperature/ {print $2}' | /usr/bin/sed 's/C//g' | awk '{s+=$1} END {print s/NR}'

Check by running from Diagnostics/Command Prompt: /root/get_cpu_temp.sh
Output should be: 72

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
