### PR TITLE
Stop STP page from doing lookups on blanks

### DIFF
--- a/app/Http/Controllers/Table/PortStpController.php
+++ b/app/Http/Controllers/Table/PortStpController.php
@@ -88,8 +88,8 @@ class PortStpController extends TableController
         $drMac = Mac::parse($stpPort->designatedRoot);
         $dbMac = Mac::parse($stpPort->designatedBridge);
 
-        $dr = DeviceCache::get(Stp::where('bridgeAddress', $stpPort->designatedRoot)->value('device_id'));
-        $db = DeviceCache::get(Stp::where('bridgeAddress', $stpPort->designatedBridge)->value('device_id'));
+        $dr = DeviceCache::get(Stp::where('bridgeAddress', $stpPort->designatedRoot)->whereNot('bridgeAddress', '000000000000')->value('device_id'));
+        $db = DeviceCache::get(Stp::where('bridgeAddress', $stpPort->designatedBridge)->whereNot('bridgeAddress', '')->value('device_id'));
 
         return [
             'port_id' => Blade::render('<x-port-link :port="$port">{{ $port->getShortLabel() }}</x-port-link><br /> {{ $port->getDescription() }}', ['port' => $stpPort->port]),

--- a/resources/views/device/tabs/stp.blade.php
+++ b/resources/views/device/tabs/stp.blade.php
@@ -42,7 +42,7 @@
                     <td>{{ trans('stp.designated_root') }}</td>
                     <td>
                         {{ \LibreNMS\Util\Mac::parse($instance['designatedRoot'])->readable() }}
-                        @if($url = \LibreNMS\Util\Url::deviceLink(\App\Facades\DeviceCache::get(\App\Models\Stp::where('bridgeAddress', $instance['designatedRoot'])->value('device_id'))))
+                        @if($url = \LibreNMS\Util\Url::deviceLink(\App\Facades\DeviceCache::get(\App\Models\Stp::where('bridgeAddress', $instance['designatedRoot'])->whereNot('bridgeAddress', '')->value('device_id'))))
                             ({!! $url !!})
                         @elseif($drVendor = \LibreNMS\Util\Mac::parse($instance['designatedRoot'])->vendor())
                             ({{ $drVendor }})


### PR DESCRIPTION
We noticed that the STP page was giving links to invalid devices in the "Designated root" and "Designated port" fields.  This was happening when the relevant field for the bridge or bridge port was all zeroes or blank.  I also found multiple records in our stp table where the bridgeAddress column was either blank or all zeroes, which explains the issue.

This PR fixes the issue by filtering out any blank or all zero records from the stp table when doing the lookup.  I can't think of any scenario where these records would be valid.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
