### PR TITLE
Log a message when an alert is unack'd too

### DIFF
--- a/app/Http/Controllers/AlertController.php
+++ b/app/Http/Controllers/AlertController.php
@@ -41,7 +41,7 @@ class AlertController extends Controller
 
         if ($alert->save()) {
             $rule_name = $alert->rule->name;
-            $act = strtolower($state_description) . "nowledged";
+            $act = strtolower($state_description) . 'nowledged';
             Eventlog::log("$username {$act} alert $rule_name note: $ack_msg", $alert->device_id, 'alert', Severity::Info, $alert->id);
 
             return response()->json([

--- a/app/Http/Controllers/AlertController.php
+++ b/app/Http/Controllers/AlertController.php
@@ -40,10 +40,9 @@ class AlertController extends Controller
         $alert->note = trim($alert->note . PHP_EOL . "$timestamp - $state_description ($username) " . $ack_msg);
 
         if ($alert->save()) {
-            if (in_array($state, [2, 22])) {
-                $rule_name = $alert->rule->name;
-                Eventlog::log("$username acknowledged alert $rule_name note: $ack_msg", $alert->device_id, 'alert', Severity::Info, $alert->id);
-            }
+            $rule_name = $alert->rule->name;
+            $act = strtolower($state_description) . "nowledged";
+            Eventlog::log("$username {$act} alert $rule_name note: $ack_msg", $alert->device_id, 'alert', Severity::Info, $alert->id);
 
             return response()->json([
                 'message' => "Alert {$state_description}nowledged.",


### PR DESCRIPTION
I have no idea why the condition here was:

```
in_array($state, [2, 22]))
```

I can't find any reference to state 22 anywhere else, so hopefully whatever it references is gone.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
