### PR TITLE
Updated Custom map list to sub menu

### DIFF
--- a/resources/views/layouts/menu.blade.php
+++ b/resources/views/layouts/menu.blade.php
@@ -239,8 +239,10 @@
 
                         @if($custommaps->isNotEmpty())
                             <li role="presentation" class="divider"></li>
+                                @if($custommaps->count() == 1)
                                 <li class="dropdown-submenu"><a><i class="fa fa-th fa-fw fa-lg" aria-hidden="true"></i> {{__('Custom Maps') }}</a>
                                     <ul class="dropdown-menu scrollable-menu">
+                                @endif
                                         @foreach($custommaps as $map_group => $group_maps)
                                             @if($map_group)
                                             <li class="dropdown-submenu">
@@ -255,8 +257,10 @@
                                             @endforeach
                                         @if($map_group)</ul></li>@endif
                                         @endforeach
+                                @if($custommaps->count() == 1)
                                     </ul>
                                 </li>
+                                @endif
                         @endif
                         @admin
                         <li role="presentation" class="divider"></li>

--- a/resources/views/layouts/menu.blade.php
+++ b/resources/views/layouts/menu.blade.php
@@ -239,20 +239,24 @@
 
                         @if($custommaps->isNotEmpty())
                             <li role="presentation" class="divider"></li>
-                                    @foreach($custommaps as $map_group => $group_maps)
-                                        @if($map_group)
-                                        <li class="dropdown-submenu">
-                                        <a><i class="fa fa-map-marked fa-fw fa-lg"aria-hidden="true"></i> {{ $map_group  }}
-                                        </a>
-                                            <ul class="dropdown-menu scrollable-menu">
-                                        @endif
-                                        @foreach($group_maps as $map)
-                                        <li><a href="{{ route('maps.custom.show', ['map' => $map->custom_map_id]) }}"><i class="fa fa-map-marked fa-fw fa-lg" aria-hidden="true"></i>
-                                                {{ ucfirst($map->name) }}
-                                            </a></li>
-                                        @endforeach
+                                <li class="dropdown-submenu"><a><i class="fa fa-th fa-fw fa-lg" aria-hidden="true"></i> {{__('Custom Maps') }}</a>
+                                    <ul class="dropdown-menu scrollable-menu">
+                                        @foreach($custommaps as $map_group => $group_maps)
+                                            @if($map_group)
+                                            <li class="dropdown-submenu">
+                                            <a><i class="fa fa-map-marked fa-fw fa-lg"aria-hidden="true"></i> {{ $map_group  }}
+                                            </a>
+                                                <ul class="dropdown-menu scrollable-menu">
+                                            @endif
+                                            @foreach($group_maps as $map)
+                                            <li><a href="{{ route('maps.custom.show', ['map' => $map->custom_map_id]) }}"><i class="fa fa-map-marked fa-fw fa-lg" aria-hidden="true"></i>
+                                                    {{ ucfirst($map->name) }}
+                                                </a></li>
+                                            @endforeach
                                         @if($map_group)</ul></li>@endif
-                                    @endforeach
+                                        @endforeach
+                                    </ul>
+                                </li>
                         @endif
                         @admin
                         <li role="presentation" class="divider"></li>


### PR DESCRIPTION
When you have a large number of maps with no grouping going on the menu overflows. Moved to a sub-menu one no groups exist (count of 1 as if you create one group then it's in essence no group and a group = 2.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
