### PR TITLE
Updated some defaults for ospfv3 and dropped unused column

### DIFF
--- a/LibreNMS/Modules/Ospfv3.php
+++ b/LibreNMS/Modules/Ospfv3.php
@@ -127,6 +127,7 @@ class Ospfv3 implements Module
                 ->hideMib()->enumStrings()
                 ->walk('OSPFV3-MIB::ospfv3AreaTable')
                 ->mapTable(function ($ospf_area, $ospfv3AreaId) use ($context_name, $os) {
+                    $ospf_area['ospfv3AreaScopeLsaCksumSum'] ??= 0;
                     return Ospfv3Area::updateOrCreate([
                         'device_id' => $os->getDeviceId(),
                         'ospfv3AreaId' => $ospfv3AreaId,
@@ -152,9 +153,8 @@ class Ospfv3 implements Module
                     // find port_id
                     $ospf_port['port_id'] = (int) PortCache::getIdFromIfIndex($ospfv3IfIndex, $os->getDeviceId());
                     $ospf_port['ospfv3_instance_id'] = $ospfv3IfInstId;
-                    $ospf_port['ospfv3IfDesignatedRouter'] = long2ip($ospf_port['ospfv3IfDesignatedRouter']);
-                    $ospf_port['ospfv3IfBackupDesignatedRouter'] = long2ip($ospf_port['ospfv3IfBackupDesignatedRouter']);
-                    $ospf_port['ospfv3AreaScopeLsaCksumSum'] ??= 0;
+                    $ospf_port['ospfv3IfDesignatedRouter'] = long2ip($ospf_port['ospfv3IfDesignatedRouter'] ?? 0);
+                    $ospf_port['ospfv3IfBackupDesignatedRouter'] = long2ip($ospf_port['ospfv3IfBackupDesignatedRouter'] ?? 0);
                     $ospf_port['ospfv3IfIndex'] ??= 0;
 
                     unset($ospf_port['ospfv3IfInstId']);
@@ -189,6 +189,7 @@ class Ospfv3 implements Module
                     $ospf_nbr['port_id'] = PortCache::getIdFromIp($ospf_nbr['ospfv3NbrAddress'], $context_name); // search all devices
                     $ospf_nbr['ospfv3_instance_id'] = $ospfv3NbrIfInstId;
                     $ospf_nbr['ospfv3NbrRtrId'] = long2ip($ospfv3NbrRtrId);
+                    $ospf_nbr['ospfv3NbrHelloSuppressed'] = $ospf_nbr['ospfv3NbrHelloSuppressed'] ?? '';
 
                     return Ospfv3Nbr::updateOrCreate([
                         'device_id' => $os->getDeviceId(),

--- a/app/Models/Ospfv3Nbr.php
+++ b/app/Models/Ospfv3Nbr.php
@@ -40,7 +40,6 @@ class Ospfv3Nbr extends DeviceRelatedModel
         'context_name',
         'ospfv3NbrIfId',
         'ospfv3NbrAddress',
-        'ospfv3NbrIfInstId',
         'ospfv3NbrAddressType',
         'ospfv3NbrRtrId',
         'ospfv3NbrOptions',

--- a/database/migrations/2025_03_23_225730_drop_ospfv3_nbr_if_inst_id.php
+++ b/database/migrations/2025_03_23_225730_drop_ospfv3_nbr_if_inst_id.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('ospfv3_nbrs', function (Blueprint $table) {
+            $table->dropColumn('ospfv3NbrIfInstId');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('ospfv3_nbrs', function (Blueprint $table) {
+            $table->integer('ospfv3NbrIfInstId')->after('ospfv3NbrIfIndex');
+        });
+    }
+};

--- a/doc/API/Routing.md
+++ b/doc/API/Routing.md
@@ -472,6 +472,7 @@ Output:
         {
             "device_id": "1",
             "port_id": "0",
+            "ospfv3_instance_id": "0",
             "ospfv3_nbr_id": "2",
             "ospfv3NbrIfId: "1147535360",
             "ospfv3NbrIfInstId": "0",

--- a/tests/data/fortigate_60fospfv3.json
+++ b/tests/data/fortigate_60fospfv3.json
@@ -7492,7 +7492,7 @@
                     "ospfIfMetricValue": 0,
                     "ospfIfMetricStatus": "notInService",
                     "context_name": "",
-                    "ifIndex": null
+                    "ifIndex": 2
                 },
                 {
                     "ospf_port_id": "10.0.11.99.0",
@@ -7522,7 +7522,7 @@
                     "ospfIfMetricValue": 0,
                     "ospfIfMetricStatus": "notInService",
                     "context_name": "",
-                    "ifIndex": null
+                    "ifIndex": 17
                 },
                 {
                     "ospf_port_id": "10.0.21.101.0",
@@ -7552,7 +7552,7 @@
                     "ospfIfMetricValue": 0,
                     "ospfIfMetricStatus": "notInService",
                     "context_name": "",
-                    "ifIndex": null
+                    "ifIndex": 18
                 },
                 {
                     "ospf_port_id": "10.0.21.17.0",
@@ -7582,7 +7582,7 @@
                     "ospfIfMetricValue": 0,
                     "ospfIfMetricStatus": "notInService",
                     "context_name": "",
-                    "ifIndex": null
+                    "ifIndex": 31
                 },
                 {
                     "ospf_port_id": "10.150.1.254.0",
@@ -7612,7 +7612,7 @@
                     "ospfIfMetricValue": 0,
                     "ospfIfMetricStatus": "notInService",
                     "context_name": "",
-                    "ifIndex": null
+                    "ifIndex": 25
                 },
                 {
                     "ospf_port_id": "10.150.12.254.0",
@@ -7642,7 +7642,7 @@
                     "ospfIfMetricValue": 0,
                     "ospfIfMetricStatus": "notInService",
                     "context_name": "",
-                    "ifIndex": null
+                    "ifIndex": 26
                 },
                 {
                     "ospf_port_id": "10.150.13.254.0",
@@ -7672,7 +7672,7 @@
                     "ospfIfMetricValue": 0,
                     "ospfIfMetricStatus": "notInService",
                     "context_name": "",
-                    "ifIndex": null
+                    "ifIndex": 28
                 },
                 {
                     "ospf_port_id": "10.150.14.254.0",
@@ -7702,7 +7702,7 @@
                     "ospfIfMetricValue": 0,
                     "ospfIfMetricStatus": "notInService",
                     "context_name": "",
-                    "ifIndex": null
+                    "ifIndex": 27
                 },
                 {
                     "ospf_port_id": "10.150.2.254.0",
@@ -7732,7 +7732,7 @@
                     "ospfIfMetricValue": 0,
                     "ospfIfMetricStatus": "notInService",
                     "context_name": "",
-                    "ifIndex": null
+                    "ifIndex": 29
                 },
                 {
                     "ospf_port_id": "10.150.3.254.0",
@@ -7762,7 +7762,7 @@
                     "ospfIfMetricValue": 0,
                     "ospfIfMetricStatus": "notInService",
                     "context_name": "",
-                    "ifIndex": null
+                    "ifIndex": 20
                 },
                 {
                     "ospf_port_id": "10.150.4.254.0",
@@ -7792,7 +7792,7 @@
                     "ospfIfMetricValue": 0,
                     "ospfIfMetricStatus": "notInService",
                     "context_name": "",
-                    "ifIndex": null
+                    "ifIndex": 22
                 },
                 {
                     "ospf_port_id": "10.150.5.254.0",
@@ -7822,7 +7822,7 @@
                     "ospfIfMetricValue": 0,
                     "ospfIfMetricStatus": "notInService",
                     "context_name": "",
-                    "ifIndex": null
+                    "ifIndex": 19
                 },
                 {
                     "ospf_port_id": "10.150.6.254.0",
@@ -7852,7 +7852,7 @@
                     "ospfIfMetricValue": 0,
                     "ospfIfMetricStatus": "notInService",
                     "context_name": "",
-                    "ifIndex": null
+                    "ifIndex": 23
                 },
                 {
                     "ospf_port_id": "10.150.7.254.0",
@@ -7882,7 +7882,7 @@
                     "ospfIfMetricValue": 0,
                     "ospfIfMetricStatus": "notInService",
                     "context_name": "",
-                    "ifIndex": null
+                    "ifIndex": 24
                 },
                 {
                     "ospf_port_id": "10.150.8.254.0",
@@ -7912,7 +7912,7 @@
                     "ospfIfMetricValue": 0,
                     "ospfIfMetricStatus": "notInService",
                     "context_name": "",
-                    "ifIndex": null
+                    "ifIndex": 21
                 },
                 {
                     "ospf_port_id": "10.150.9.254.0",
@@ -7942,7 +7942,7 @@
                     "ospfIfMetricValue": 0,
                     "ospfIfMetricStatus": "notInService",
                     "context_name": "",
-                    "ifIndex": null
+                    "ifIndex": 30
                 }
             ],
             "ospf_instances": [
@@ -8065,6 +8065,7 @@
                     "ospfv3_instance_id": 0,
                     "ospfv3_nbr_id": "2",
                     "ospfv3NbrIfId": 1147535360,
+                    "ospfv3NbrIfIndex": 0,
                     "ospfv3NbrIfInstId": 0,
                     "ospfv3NbrAddressType": "ipv6",
                     "ospfv3NbrAddress": "fe80::1d7:101:98cf:af80",


### PR DESCRIPTION
`ospfv3AreaScopeLsaCksumSum` was in the wrong table for updateOrCreate.

Added some defaults as I'm seeing issues with arista_eos not supplying all the data in the snmp output (I can't provide test data as it's not mine).

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
