### PR TITLE
updating minor help popup text grammatical error

### DIFF
--- a/lang/en/poller.php
+++ b/lang/en/poller.php
@@ -89,7 +89,7 @@ return [
             ],
             'watchdog_enabled' => [
                 'description' => 'Watchdog Enabled',
-                'help' => 'Watchdog monitors the log file and restarts the service it it has not been updated',
+                'help' => 'Watchdog monitors the log file and restarts the service if it has not been updated',
             ],
             'watchdog_log' => [
                 'description' => 'Log File to Watch',

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -1677,7 +1677,7 @@ return [
         ],
         'service_watchdog_enabled' => [
             'description' => 'Watchdog Enabled',
-            'help' => 'Watchdog monitors the log file and restarts the service it it has not been updated. Sets the default value for all nodes.',
+            'help' => 'Watchdog monitors the log file and restarts the service if it has not been updated. Sets the default value for all nodes.',
         ],
         'service_watchdog_log' => [
             'description' => 'Log File to Watch',

--- a/lang/it/poller.php
+++ b/lang/it/poller.php
@@ -89,7 +89,7 @@ return [
             ],
             'watchdog_enabled' => [
                 'description' => 'Watchdog Enabled',
-                'help' => 'Watchdog monitors the log file and restarts the service it it has not been updated',
+                'help' => 'Watchdog monitors the log file and restarts the service if it has not been updated',
             ],
             'watchdog_log' => [
                 'description' => 'Log File to Watch',

--- a/lang/it/settings.php
+++ b/lang/it/settings.php
@@ -1309,7 +1309,7 @@ return [
         ],
         'service_watchdog_enabled' => [
             'description' => 'Watchdog Enabled',
-            'help' => 'Watchdog monitors the log file and restarts the service it it has not been updated. Sets the default value for all nodes.',
+            'help' => 'Watchdog monitors the log file and restarts the service if it has not been updated. Sets the default value for all nodes.',
         ],
         'service_watchdog_log' => [
             'description' => 'Log File to Watch',

--- a/lang/zh-TW/poller.php
+++ b/lang/zh-TW/poller.php
@@ -89,7 +89,7 @@ return [
             ],
             'watchdog_enabled' => [
                 'description' => '啟用看門狗',
-                'help' => 'Watchdog monitors the log file and restarts the service it it has not been updated',
+                'help' => 'Watchdog monitors the log file and restarts the service if it has not been updated',
             ],
             'watchdog_log' => [
                 'description' => '看門狗記錄檔',


### PR DESCRIPTION
A minor text fix on the pop help shown on the poller settings page.

For example:
![image](https://github.com/user-attachments/assets/956d4144-05f5-4ca9-9a80-edcd3059b90f)

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [Y] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [Y] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [N/A] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
