### PR TITLE
Skip JunOS transceiver current sensor when value < 5μA

### DIFF
--- a/includes/definitions/discovery/junos.yaml
+++ b/includes/definitions/discovery/junos.yaml
@@ -241,7 +241,7 @@ modules:
                     num_oid: '.1.3.6.1.4.1.2636.3.60.1.1.1.1.6.{{ $index }}'
                     descr: '{{ $ifDescr }} Tx Current'
                     divisor: 1000000
-                    skip_values: 0
+                    skip_value_lt: 5
                     low_limit: JUNIPER-DOM-MIB::jnxDomCurrentTxLaserBiasCurrentLowAlarmThreshold
                     low_warn_limit: JUNIPER-DOM-MIB::jnxDomCurrentTxLaserBiasCurrentLowWarningThreshold
                     high_limit: JUNIPER-DOM-MIB::jnxDomCurrentTxLaserBiasCurrentHighAlarmThreshold

--- a/tests/data/junos_mx5t-isis.json
+++ b/tests/data/junos_mx5t-isis.json
@@ -12211,5 +12211,131 @@
                 }
             ]
         }
+    },
+    "ports-stack": {
+        "discovery": {
+            "ports_stack": [
+                {
+                    "high_ifIndex": 516,
+                    "low_ifIndex": 577,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 517,
+                    "low_ifIndex": 578,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 518,
+                    "low_ifIndex": 579,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 519,
+                    "low_ifIndex": 580,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 520,
+                    "low_ifIndex": 581,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 521,
+                    "low_ifIndex": 582,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 522,
+                    "low_ifIndex": 583,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 523,
+                    "low_ifIndex": 584,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 524,
+                    "low_ifIndex": 585,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 525,
+                    "low_ifIndex": 588,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 526,
+                    "low_ifIndex": 617,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 527,
+                    "low_ifIndex": 589,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 528,
+                    "low_ifIndex": 590,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 529,
+                    "low_ifIndex": 591,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 530,
+                    "low_ifIndex": 592,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 531,
+                    "low_ifIndex": 593,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 532,
+                    "low_ifIndex": 594,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 533,
+                    "low_ifIndex": 595,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 534,
+                    "low_ifIndex": 596,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 535,
+                    "low_ifIndex": 616,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 541,
+                    "low_ifIndex": 559,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 556,
+                    "low_ifIndex": 572,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 557,
+                    "low_ifIndex": 573,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 558,
+                    "low_ifIndex": 576,
+                    "ifStackStatus": "active"
+                }
+            ]
+        }
     }
 }

--- a/tests/data/junos_qfx5100.json
+++ b/tests/data/junos_qfx5100.json
@@ -11320,5 +11320,101 @@
                 }
             ]
         }
+    },
+    "ports-stack": {
+        "discovery": {
+            "ports_stack": [
+                {
+                    "high_ifIndex": 6,
+                    "low_ifIndex": 22,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 17,
+                    "low_ifIndex": 18,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 37,
+                    "low_ifIndex": 220,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 116,
+                    "low_ifIndex": 118,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 503,
+                    "low_ifIndex": 515,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 504,
+                    "low_ifIndex": 505,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 508,
+                    "low_ifIndex": 510,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 509,
+                    "low_ifIndex": 511,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 512,
+                    "low_ifIndex": 532,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 513,
+                    "low_ifIndex": 514,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 516,
+                    "low_ifIndex": 517,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 518,
+                    "low_ifIndex": 519,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 520,
+                    "low_ifIndex": 528,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 522,
+                    "low_ifIndex": 523,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 524,
+                    "low_ifIndex": 525,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 526,
+                    "low_ifIndex": 527,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 529,
+                    "low_ifIndex": 533,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 530,
+                    "low_ifIndex": 531,
+                    "ifStackStatus": "active"
+                }
+            ]
+        }
     }
 }

--- a/tests/data/junos_rpm.json
+++ b/tests/data/junos_rpm.json
@@ -13414,5 +13414,116 @@
                 }
             ]
         }
+    },
+    "ports-stack": {
+        "discovery": {
+            "ports_stack": [
+                {
+                    "high_ifIndex": 3,
+                    "low_ifIndex": 15,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 6,
+                    "low_ifIndex": 16,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 6,
+                    "low_ifIndex": 21,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 6,
+                    "low_ifIndex": 22,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 6,
+                    "low_ifIndex": 248,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 504,
+                    "low_ifIndex": 505,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 504,
+                    "low_ifIndex": 508,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 504,
+                    "low_ifIndex": 510,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 504,
+                    "low_ifIndex": 511,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 504,
+                    "low_ifIndex": 512,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 509,
+                    "low_ifIndex": 513,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 509,
+                    "low_ifIndex": 514,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 509,
+                    "low_ifIndex": 515,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 509,
+                    "low_ifIndex": 516,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 509,
+                    "low_ifIndex": 517,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 518,
+                    "low_ifIndex": 520,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 519,
+                    "low_ifIndex": 525,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 526,
+                    "low_ifIndex": 529,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 527,
+                    "low_ifIndex": 530,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 538,
+                    "low_ifIndex": 539,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 538,
+                    "low_ifIndex": 545,
+                    "ifStackStatus": "active"
+                }
+            ]
+        }
     }
 }

--- a/tests/data/junos_vmx.json
+++ b/tests/data/junos_vmx.json
@@ -13205,5 +13205,81 @@
                 }
             ]
         }
+    },
+    "ports-stack": {
+        "discovery": {
+            "ports_stack": [
+                {
+                    "high_ifIndex": 1,
+                    "low_ifIndex": 13,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 23,
+                    "low_ifIndex": 24,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 512,
+                    "low_ifIndex": 536,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 512,
+                    "low_ifIndex": 537,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 513,
+                    "low_ifIndex": 514,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 519,
+                    "low_ifIndex": 520,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 521,
+                    "low_ifIndex": 524,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 521,
+                    "low_ifIndex": 525,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 522,
+                    "low_ifIndex": 523,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 526,
+                    "low_ifIndex": 538,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 527,
+                    "low_ifIndex": 539,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 528,
+                    "low_ifIndex": 540,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 529,
+                    "low_ifIndex": 541,
+                    "ifStackStatus": "active"
+                },
+                {
+                    "high_ifIndex": 530,
+                    "low_ifIndex": 544,
+                    "ifStackStatus": "active"
+                }
+            ]
+        }
     }
 }


### PR DESCRIPTION
If accepted, this PR will result in transceiver laser bias sensors for JunOS devices being skipped if they report a current value less than 5μA.

At present, low sensor threshold alerts are generated if the current reported is not exactly zero. Because of the precision of their sensors, some transceivers report an extremely small current of 2 micro Amps when the laser is shutdown which generates false alerts. 

```
JUNIPER-DOM-MIB::jnxDomCurrentTxLaserBiasCurrent.548 = INTEGER: 2 0.001 mA
JUNIPER-DOM-MIB::jnxDomCurrentTxLaserOutputPower.548 = INTEGER: 0 0.01 dbm
IF-MIB::ifAdminStatus.548 = INTEGER: down(2)
IF-MIB::ifOperStatus.548 = INTEGER: down(2)
```

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
