### PR TITLE
Ciena SAOS Port State SNMP Traps

### DIFF
--- a/LibreNMS/Snmptrap/Handlers/CienaCesPortNotificationPortDown.php
+++ b/LibreNMS/Snmptrap/Handlers/CienaCesPortNotificationPortDown.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * CienaCesPortNotificationPortDown.php
  *

--- a/LibreNMS/Snmptrap/Handlers/CienaCesPortNotificationPortDown.php
+++ b/LibreNMS/Snmptrap/Handlers/CienaCesPortNotificationPortDown.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * CienaCesPortNotificationPortDown.php
+ *
+ * -Description-
+ *
+ * Handles Ciena port down traps.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * @link       https://www.librenms.org
+ *
+ * @copyright  2024 KanREN Inc
+ * @author     Heath Barnhart <hbarnhart@kanren.net>
+ */
+
+namespace LibreNMS\Snmptrap\Handlers;
+
+use App\Models\Device;
+use LibreNMS\Enum\Severity;
+use LibreNMS\Interfaces\SnmptrapHandler;
+use LibreNMS\Snmptrap\Trap;
+
+class CienaCesPortNotificationPortDown implements SnmptrapHandler
+{
+    /**
+     * Handle snmptrap.
+     * Data is pre-parsed and delivered as a Trap.
+     *
+     * @param  Device  $device
+     * @param  Trap  $trap
+     * @return void
+     */
+    public function handle(Device $device, Trap $trap)
+    {
+        $chassis = CienaCesPortNotificationUtils::getCienaChassis($trap);
+        $shelf = CienaCesPortNotificationUtils::getCienaShelf($trap);
+        $slot = CienaCesPortNotificationUtils::getCienaSlot($trap);
+        $port = CienaCesPortNotificationUtils::getCienaPort($trap);
+        $trap->log("Port down on Chassis: $chassis Shelf: $shelf Slot: $slot Port: $port", Severity::Error);
+
+        $librePort = $device->ports()->where('ifIndex', $port)->first();
+        $librePort->ifOperStatus = 'down';
+        $librePort->save();
+    }
+}

--- a/LibreNMS/Snmptrap/Handlers/CienaCesPortNotificationPortUp.php
+++ b/LibreNMS/Snmptrap/Handlers/CienaCesPortNotificationPortUp.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * CienaCesPortNotificationPortUp.php
+ *
+ * -Description-
+ *
+ * Handles Ciena port up traps.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * @link       https://www.librenms.org
+ *
+ * @copyright  2024 KanREN Inc
+ * @author     Heath Barnhart <hbarnhart@kanren.net>
+ */
+
+namespace LibreNMS\Snmptrap\Handlers;
+
+use App\Models\Device;
+use LibreNMS\Enum\Severity;
+use LibreNMS\Interfaces\SnmptrapHandler;
+use LibreNMS\Snmptrap\Trap;
+
+class CienaCesPortNotificationPortUp implements SnmptrapHandler
+{
+    /**
+     * Handle snmptrap.
+     * Data is pre-parsed and delivered as a Trap.
+     *
+     * @param  Device  $device
+     * @param  Trap  $trap
+     * @return void
+     */
+    public function handle(Device $device, Trap $trap)
+    {
+        $chassis = CienaCesPortNotificationUtils::getCienaChassis($trap);
+        $shelf = CienaCesPortNotificationUtils::getCienaShelf($trap);
+        $slot = CienaCesPortNotificationUtils::getCienaSlot($trap);
+        $port = CienaCesPortNotificationUtils::getCienaPort($trap);
+        $trap->log("Port up on Chassis: $chassis Shelf: $shelf Slot: $slot Port: $port", Severity::Ok);
+
+        $librePort = $device->ports()->where('ifIndex', $port)->first();
+        $librePort->ifOperStatus = 'up';
+        $librePort->save();
+    }
+}

--- a/LibreNMS/Snmptrap/Handlers/CienaCesPortNotificationPortUp.php
+++ b/LibreNMS/Snmptrap/Handlers/CienaCesPortNotificationPortUp.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * CienaCesPortNotificationPortUp.php
  *

--- a/LibreNMS/Snmptrap/Handlers/CienaCesPortNotificationUtils.php
+++ b/LibreNMS/Snmptrap/Handlers/CienaCesPortNotificationUtils.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * ApcTrapUtil.php
  *

--- a/LibreNMS/Snmptrap/Handlers/CienaCesPortNotificationUtils.php
+++ b/LibreNMS/Snmptrap/Handlers/CienaCesPortNotificationUtils.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * ApcTrapUtil.php
+ *
+ * -Description-
+ *
+ * Common utility class for handling Ciena CES Notification Traps.
+ * Traps from the CienaCESPortXcvr MIB carry the same set of OIDs.
+ * This utility class cuts down on code reuse.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * @link       https://www.librenms.org
+ *
+ * @copyright  2024 KanREN, Inc.
+ * @author     Heath Barnhart <hbarnhart@kanren.net>
+ */
+
+namespace LibreNMS\Snmptrap\Handlers;
+
+use LibreNMS\Snmptrap\Trap;
+
+class CienaCesPortNotificationUtils
+{
+    /**
+     * Get Ciena Chassis ID
+     *
+     * @param  Trap  $trap
+     * @return string
+     */
+    public static function getCienaChassis($trap)
+    {
+        if (str_starts_with($trap->getOidData($trap->findOid('SNMPv2-MIB::snmpTrapOID.0')), 'CIENA-CES-PORT-MIB')) {
+            return $trap->getOidData($trap->findOid('CIENA-CES-PORT-MIB::cienaCesChPortPgIdMappingChassisIndex'));
+        } else {
+            return $trap->getOidData($trap->findOid('CIENA-CES-PORT-XCVR-MIB::cienaCesPortXcvrNotifChassisIndex'));
+        }
+    }
+
+    /**
+     * Get Ciena Shelf ID
+     *
+     * @param  Trap  $trap
+     * @return string
+     */
+    public static function getCienaShelf($trap)
+    {
+        if (str_starts_with($trap->getOidData($trap->findOid('SNMPv2-MIB::snmpTrapOID.0')), 'CIENA-CES-PORT-MIB')) {
+            return $trap->getOidData($trap->findOid('CIENA-CES-PORT-MIB::cienaCesPortPgIdMappingShelfIndex'));
+        } else {
+            return $trap->getOidData($trap->findOid('CIENA-CES-PORT-XCVR-MIB::cienaCesPortXcvrNotifShelfIndex'));
+        }
+    }
+
+    /**
+     * Get Ciena Slot ID
+     *
+     * @param  Trap  $trap
+     * @return string
+     */
+    public static function getCienaSlot($trap)
+    {
+        if (str_starts_with($trap->getOidData($trap->findOid('SNMPv2-MIB::snmpTrapOID.0')), 'CIENA-CES-PORT-MIB')) {
+            return $trap->getOidData($trap->findOid('CIENA-CES-PORT-MIB::cienaCesChPortPgIdMappingNotifSlotIndex'));
+        } else {
+            return $trap->getOidData($trap->findOid('CIENA-CES-PORT-XCVR-MIB::cienaCesPortXcvrNotifSlotIndex'));
+        }
+    }
+
+    /**
+     * Get Ciena Port ID
+     *
+     * @param  Trap  $trap
+     * @return string
+     */
+    public static function getCienaPort($trap)
+    {
+        if (str_starts_with($trap->getOidData($trap->findOid('SNMPv2-MIB::snmpTrapOID.0')), 'CIENA-CES-PORT-MIB')) {
+            return $trap->getOidData($trap->findOid('CIENA-CES-PORT-MIB::cienaCesPortPgIdMappingNotifPortNumber'));
+        } else {
+            return $trap->getOidData($trap->findOid('CIENA-CES-PORT-XCVR-MIB::cienaCesPortXcvrNotifPortNumber'));
+        }
+    }
+}

--- a/config/snmptraps.php
+++ b/config/snmptraps.php
@@ -32,6 +32,8 @@ return [
         'BRIDGE-MIB::newRoot' => LibreNMS\Snmptrap\Handlers\BridgeNewRoot::class,
         'BRIDGE-MIB::topologyChange' => LibreNMS\Snmptrap\Handlers\BridgeTopologyChanged::class,
         'CIENA-CES-AAA-MIB::cienaCesAAAUserAuthenticationEvent' => LibreNMS\Snmptrap\Handlers\CienaCesAAAUserAuthenticationEvent::class,
+        'CIENA-CES-PORT-MIB::cienaCesPortNotificationPortDown' => \LibreNMS\Snmptrap\Handlers\CienaCesPortNotificationPortDown::class,
+        'CIENA-CES-PORT-MIB::cienaCesPortNotificationPortUp' => \LibreNMS\Snmptrap\Handlers\CienaCesPortNotificationPortUp::class,
         'CISCO-PORT-SECURITY-MIB::cpsSecureMacAddrViolation' => LibreNMS\Snmptrap\Handlers\CiscoMacViolation::class,
         'CISCO-ERR-DISABLE-MIB::cErrDisableInterfaceEventRev1' => LibreNMS\Snmptrap\Handlers\CiscoErrDisableInterfaceEvent::class,
         'CISCO-IETF-DHCP-SERVER-MIB::cDhcpv4ServerStartTime' => LibreNMS\Snmptrap\Handlers\CiscoDHCPServerStart::class,

--- a/tests/Feature/SnmpTraps/CienaCesPortNotificationTrapTest.php
+++ b/tests/Feature/SnmpTraps/CienaCesPortNotificationTrapTest.php
@@ -46,22 +46,22 @@ class CienaCesPortNotificationTrapTest extends SnmpTrapTestCase
         $port = Port::factory()->make(['ifAdminStatus' => 'up', 'ifOperStatus' => 'up']); /** @var Port $port */
         $device->ports()->save($port);
 
-        $this->assertTrapLogsMessage("<UNKNOWN>
-        UDP: [$device->ip]:57123->[192.168.4.4]:162
-        DISMAN-EVENT-MIB::sysUpTimeInstance 2:15:07:12.87
-        SNMPv2-MIB::snmpTrapOID.0 CIENA-CES-PORT-MIB::cienaCesPortNotificationPortDown
-        CIENA-GLOBAL-MIB::cienaGlobalSeverity warning
-        CIENA-CES-PORT-MIB::cienaCesChPortPgIdMappingChassisIndex 1 
-        CIENA-CES-PORT-MIB::cienaCesPortPgIdMappingShelfIndex 1
-        CIENA-CES-PORT-MIB::cienaCesChPortPgIdMappingNotifSlotIndex 1
-        CIENA-CES-PORT-MIB::cienaCesPortPgIdMappingNotifPortNumber $port->ifIndex 
-        CIENA-CES-PORT-MIB::cienaCesLogicalPortConfigPortAdminState enabled 
-        CIENA-CES-PORT-MIB::cienaCesLogicalPortConfigPortOperState disabled
-        CIENA-CES-PORT-MIB::cienaCesLogicalPortConfigPortName $port->ifName
-        CIENA-CES-PORT-MIB::cienaCesLogicalPortConfigPortDesc $port->ifDescr",
+        $this->assertTrapLogsMessage("$device->hostname
+UDP: [$device->ip]:57123->[192.168.4.4]:162
+DISMAN-EVENT-MIB::sysUpTimeInstance 2:15:07:12.87
+SNMPv2-MIB::snmpTrapOID.0 CIENA-CES-PORT-MIB::cienaCesPortNotificationPortDown
+CIENA-GLOBAL-MIB::cienaGlobalSeverity warning
+CIENA-CES-PORT-MIB::cienaCesChPortPgIdMappingChassisIndex 1 
+CIENA-CES-PORT-MIB::cienaCesPortPgIdMappingShelfIndex 1
+CIENA-CES-PORT-MIB::cienaCesChPortPgIdMappingNotifSlotIndex 1
+CIENA-CES-PORT-MIB::cienaCesPortPgIdMappingNotifPortNumber $port->ifIndex 
+CIENA-CES-PORT-MIB::cienaCesLogicalPortConfigPortAdminState enabled 
+CIENA-CES-PORT-MIB::cienaCesLogicalPortConfigPortOperState disabled
+CIENA-CES-PORT-MIB::cienaCesLogicalPortConfigPortName $port->ifName
+CIENA-CES-PORT-MIB::cienaCesLogicalPortConfigPortDesc $port->ifDescr",
         "Port down on Chassis: 1 Shelf: 1 Slot: 1 Port: $port->ifIndex",
         'Could not handle CienaCesPortDownNotification',
-        [Severity::Error, 'interface', $port->port_id],
+        [Severity::Error],
         );
 
         $port = $port->fresh(); // refresh from database
@@ -74,23 +74,23 @@ class CienaCesPortNotificationTrapTest extends SnmpTrapTestCase
         $port = Port::factory()->make(['ifAdminStatus' => 'up', 'ifOperStatus' => 'up']); /** @var Port $port */
         $device->ports()->save($port);
 
-        $this->assertTrapLogsMessage("<UNKNOWN>
-        UDP: [$device->ip]:57123->[192.168.4.4]:162
-        DISMAN-EVENT-MIB::sysUpTimeInstance 2:15:07:12.87
-        SNMPv2-MIB::snmpTrapOID.0 CIENA-CES-PORT-MIB::cienaCesPortNotificationPortUp
-        CIENA-GLOBAL-MIB::cienaGlobalSeverity warning
-        CIENA-CES-PORT-MIB::cienaCesChPortPgIdMappingChassisIndex 1
-        CIENA-CES-PORT-MIB::cienaCesPortPgIdMappingShelfIndex 1
-        CIENA-CES-PORT-MIB::cienaCesChPortPgIdMappingNotifSlotIndex 1
-        CIENA-CES-PORT-MIB::cienaCesPortPgIdMappingNotifPortNumber $port->ifIndex
-        CIENA-CES-PORT-MIB::cienaCesLogicalPortConfigPortAdminState enabled
-        CIENA-CES-PORT-MIB::cienaCesLogicalPortConfigPortOperState enabled
-        CIENA-CES-PORT-MIB::cienaCesLogicalPortConfigPortName $port->ifName
-        CIENA-CES-PORT-MIB::cienaCesLogicalPortConfigPortType 1
-        CIENA-CES-PORT-MIB::cienaCesLogicalPortConfigPortDesc $port->ifDescr",
+        $this->assertTrapLogsMessage("$device->hostname
+UDP: [$device->ip]:57123->[192.168.4.4]:162
+DISMAN-EVENT-MIB::sysUpTimeInstance 2:15:07:12.87
+SNMPv2-MIB::snmpTrapOID.0 CIENA-CES-PORT-MIB::cienaCesPortNotificationPortUp
+CIENA-GLOBAL-MIB::cienaGlobalSeverity warning
+CIENA-CES-PORT-MIB::cienaCesChPortPgIdMappingChassisIndex 1
+CIENA-CES-PORT-MIB::cienaCesPortPgIdMappingShelfIndex 1
+CIENA-CES-PORT-MIB::cienaCesChPortPgIdMappingNotifSlotIndex 1
+CIENA-CES-PORT-MIB::cienaCesPortPgIdMappingNotifPortNumber $port->ifIndex
+CIENA-CES-PORT-MIB::cienaCesLogicalPortConfigPortAdminState enabled
+CIENA-CES-PORT-MIB::cienaCesLogicalPortConfigPortOperState enabled
+CIENA-CES-PORT-MIB::cienaCesLogicalPortConfigPortName $port->ifName
+CIENA-CES-PORT-MIB::cienaCesLogicalPortConfigPortType 1
+CIENA-CES-PORT-MIB::cienaCesLogicalPortConfigPortDesc $port->ifDescr",
         "Port up on Chassis: 1 Shelf: 1 Slot: 1 Port: $port->ifIndex",
         'Could not handle CienaCesPortUpNotification',
-        [Severity::Ok, 'interface', $port->port_id],
+        [Severity::Ok],
         );
 
         $port = $port->fresh(); // refresh from database

--- a/tests/Feature/SnmpTraps/CienaCesPortNotificationTrapTest.php
+++ b/tests/Feature/SnmpTraps/CienaCesPortNotificationTrapTest.php
@@ -6,7 +6,7 @@
  * -Description-
  *
  * Test port up and down via Ciena's proprietary snmptraps.
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -59,10 +59,10 @@ CIENA-CES-PORT-MIB::cienaCesLogicalPortConfigPortAdminState enabled
 CIENA-CES-PORT-MIB::cienaCesLogicalPortConfigPortOperState disable
 CIENA-CES-PORT-MIB::cienaCesLogicalPortConfigPortName $port->ifName
 CIENA-CES-PORT-MIB::cienaCesLogicalPortConfigPortDesc $port->ifDescr",
-        "Port down on Chassis: 1 Shelf: 1 Slot: 1 Port: $port->ifIndex",
-        'Could not handle CienaCesPortDownNotification',
-        [Severity::Error],
-        $device,
+            "Port down on Chassis: 1 Shelf: 1 Slot: 1 Port: $port->ifIndex",
+            'Could not handle CienaCesPortDownNotification',
+            [Severity::Error],
+            $device,
         );
 
         $port = $port->fresh(); // refresh from database
@@ -89,10 +89,10 @@ CIENA-CES-PORT-MIB::cienaCesLogicalPortConfigPortOperState enabled
 CIENA-CES-PORT-MIB::cienaCesLogicalPortConfigPortName $port->ifName
 CIENA-CES-PORT-MIB::cienaCesLogicalPortConfigPortType 1
 CIENA-CES-PORT-MIB::cienaCesLogicalPortConfigPortDesc $port->ifDescr",
-        "Port up on Chassis: 1 Shelf: 1 Slot: 1 Port: $port->ifIndex",
-        'Could not handle CienaCesPortUpNotification',
-        [Severity::Ok],
-        $device,
+            "Port up on Chassis: 1 Shelf: 1 Slot: 1 Port: $port->ifIndex",
+            'Could not handle CienaCesPortUpNotification',
+            [Severity::Ok],
+            $device,
         );
 
         $port = $port->fresh(); // refresh from database

--- a/tests/Feature/SnmpTraps/CienaCesPortNotificationTrapTest.php
+++ b/tests/Feature/SnmpTraps/CienaCesPortNotificationTrapTest.php
@@ -36,6 +36,9 @@ use LibreNMS\Tests\Traits\RequiresDatabase;
 
 class CienaCesPortNotificationTrapTest extends SnmpTrapTestCase
 {
+    use RequiresDatabase;
+    use DatabaseTransactions;
+
     public function testCienaCesPortDownNotification()
     {
         // make a device and associate a port with it
@@ -43,7 +46,7 @@ class CienaCesPortNotificationTrapTest extends SnmpTrapTestCase
         $port = Port::factory()->make(['ifAdminStatus' => 'up', 'ifOperStatus' => 'up']); /** @var Port $port */
         $device->ports()->save($port);
 
-        $this->assertTrapLogsMessage(<<<'TRAP'
+        $this->assertTrapLogsMessage("<UNKNOWN>
         UDP: [$device->ip]:57123->[192.168.4.4]:162
         DISMAN-EVENT-MIB::sysUpTimeInstance 2:15:07:12.87
         SNMPv2-MIB::snmpTrapOID.0 CIENA-CES-PORT-MIB::cienaCesPortNotificationPortDown
@@ -55,9 +58,8 @@ class CienaCesPortNotificationTrapTest extends SnmpTrapTestCase
         CIENA-CES-PORT-MIB::cienaCesLogicalPortConfigPortAdminState enabled 
         CIENA-CES-PORT-MIB::cienaCesLogicalPortConfigPortOperState disabled
         CIENA-CES-PORT-MIB::cienaCesLogicalPortConfigPortName $port->ifName
-        CIENA-CES-PORT-MIB::cienaCesLogicalPortConfigPortDesc $port->ifDescr
-        TRAP,
-        "Port down on Chassis: 1 Shelf: 1 Slot: 1 Port:$port->ifIndex",
+        CIENA-CES-PORT-MIB::cienaCesLogicalPortConfigPortDesc $port->ifDescr",
+        "Port down on Chassis: 1 Shelf: 1 Slot: 1 Port: $port->ifIndex",
         'Could not handle CienaCesPortDownNotification',
         [Severity::Error, 'interface', $port->port_id],
         );
@@ -72,7 +74,7 @@ class CienaCesPortNotificationTrapTest extends SnmpTrapTestCase
         $port = Port::factory()->make(['ifAdminStatus' => 'up', 'ifOperStatus' => 'up']); /** @var Port $port */
         $device->ports()->save($port);
 
-        $this->assertTrapLogsMessage(<<<'TRAP'
+        $this->assertTrapLogsMessage("<UNKNOWN>
         UDP: [$device->ip]:57123->[192.168.4.4]:162
         DISMAN-EVENT-MIB::sysUpTimeInstance 2:15:07:12.87
         SNMPv2-MIB::snmpTrapOID.0 CIENA-CES-PORT-MIB::cienaCesPortNotificationPortUp
@@ -85,8 +87,7 @@ class CienaCesPortNotificationTrapTest extends SnmpTrapTestCase
         CIENA-CES-PORT-MIB::cienaCesLogicalPortConfigPortOperState enabled
         CIENA-CES-PORT-MIB::cienaCesLogicalPortConfigPortName $port->ifName
         CIENA-CES-PORT-MIB::cienaCesLogicalPortConfigPortType 1
-        CIENA-CES-PORT-MIB::cienaCesLogicalPortConfigPortDesc $port->ifDescr"
-        TRAP,
+        CIENA-CES-PORT-MIB::cienaCesLogicalPortConfigPortDesc $port->ifDescr",
         "Port up on Chassis: 1 Shelf: 1 Slot: 1 Port: $port->ifIndex",
         'Could not handle CienaCesPortUpNotification',
         [Severity::Ok, 'interface', $port->port_id],

--- a/tests/Feature/SnmpTraps/CienaCesPortNotificationTrapTest.php
+++ b/tests/Feature/SnmpTraps/CienaCesPortNotificationTrapTest.php
@@ -62,6 +62,7 @@ CIENA-CES-PORT-MIB::cienaCesLogicalPortConfigPortDesc $port->ifDescr",
         "Port down on Chassis: 1 Shelf: 1 Slot: 1 Port: $port->ifIndex",
         'Could not handle CienaCesPortDownNotification',
         [Severity::Error],
+        $device,
         );
 
         $port = $port->fresh(); // refresh from database
@@ -91,6 +92,7 @@ CIENA-CES-PORT-MIB::cienaCesLogicalPortConfigPortDesc $port->ifDescr",
         "Port up on Chassis: 1 Shelf: 1 Slot: 1 Port: $port->ifIndex",
         'Could not handle CienaCesPortUpNotification',
         [Severity::Ok],
+        $device,
         );
 
         $port = $port->fresh(); // refresh from database

--- a/tests/Feature/SnmpTraps/CienaCesPortNotificationTrapTest.php
+++ b/tests/Feature/SnmpTraps/CienaCesPortNotificationTrapTest.php
@@ -43,7 +43,7 @@ class CienaCesPortNotificationTrapTest extends SnmpTrapTestCase
         $port = Port::factory()->make(['ifAdminStatus' => 'up', 'ifOperStatus' => 'up']); /** @var Port $port */
         $device->ports()->save($port);
 
-        $this->assertTrapLogsMessage("<UNKNOWN>
+        $this->assertTrapLogsMessage(<<<'TRAP'
         UDP: [$device->ip]:57123->[192.168.4.4]:162
         DISMAN-EVENT-MIB::sysUpTimeInstance 2:15:07:12.87
         SNMPv2-MIB::snmpTrapOID.0 CIENA-CES-PORT-MIB::cienaCesPortNotificationPortDown
@@ -55,15 +55,12 @@ class CienaCesPortNotificationTrapTest extends SnmpTrapTestCase
         CIENA-CES-PORT-MIB::cienaCesLogicalPortConfigPortAdminState enabled 
         CIENA-CES-PORT-MIB::cienaCesLogicalPortConfigPortOperState disabled
         CIENA-CES-PORT-MIB::cienaCesLogicalPortConfigPortName $port->ifName
-        CIENA-CES-PORT-MIB::cienaCesLogicalPortConfigPortDesc $port->ifDescr",
-        [
-            "Port down on Chassis: 1 Shelf: 1 Slot: 1 Port:$port->ifIndex"
-        ],
+        CIENA-CES-PORT-MIB::cienaCesLogicalPortConfigPortDesc $port->ifDescr
+        TRAP,
+        "Port down on Chassis: 1 Shelf: 1 Slot: 1 Port:$port->ifIndex",
         'Could not handle CienaCesPortDownNotification',
-        [
-            [Severity::Error, 'interface', $port->port_id]
-        ],
-        $device);
+        [Severity::Error, 'interface', $port->port_id],
+        );
 
         $port = $port->fresh(); // refresh from database
         $this->assertEquals($port->ifOperStatus, 'down');
@@ -75,7 +72,7 @@ class CienaCesPortNotificationTrapTest extends SnmpTrapTestCase
         $port = Port::factory()->make(['ifAdminStatus' => 'up', 'ifOperStatus' => 'up']); /** @var Port $port */
         $device->ports()->save($port);
 
-        $this->assertTrapLogsMessage("<UNKNOWN>
+        $this->assertTrapLogsMessage(<<<'TRAP'
         UDP: [$device->ip]:57123->[192.168.4.4]:162
         DISMAN-EVENT-MIB::sysUpTimeInstance 2:15:07:12.87
         SNMPv2-MIB::snmpTrapOID.0 CIENA-CES-PORT-MIB::cienaCesPortNotificationPortUp
@@ -88,15 +85,12 @@ class CienaCesPortNotificationTrapTest extends SnmpTrapTestCase
         CIENA-CES-PORT-MIB::cienaCesLogicalPortConfigPortOperState enabled
         CIENA-CES-PORT-MIB::cienaCesLogicalPortConfigPortName $port->ifName
         CIENA-CES-PORT-MIB::cienaCesLogicalPortConfigPortType 1
-        CIENA-CES-PORT-MIB::cienaCesLogicalPortConfigPortDesc $port->ifDescr",
-        [
-            "Port up on Chassis: 1 Shelf: 1 Slot: 1 Port: $port->ifIndex"
-        ],
+        CIENA-CES-PORT-MIB::cienaCesLogicalPortConfigPortDesc $port->ifDescr"
+        TRAP,
+        "Port up on Chassis: 1 Shelf: 1 Slot: 1 Port: $port->ifIndex",
         'Could not handle CienaCesPortUpNotification',
-        [
-            [Severity::Ok, 'interface', $port->port_id]
-        ],
-        $device);
+        [Severity::Ok, 'interface', $port->port_id],
+        );
 
         $port = $port->fresh(); // refresh from database
         $this->assertEquals($port->ifOperStatus, 'up');

--- a/tests/Feature/SnmpTraps/CienaCesPortNotificationTrapTest.php
+++ b/tests/Feature/SnmpTraps/CienaCesPortNotificationTrapTest.php
@@ -1,0 +1,104 @@
+<?php
+
+/**
+ * CienaCesPortNotificationTrapTest.php
+ *
+ * -Description-
+ *
+ * Test port up and down via Ciena's proprietary snmptraps.
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * @link       https://www.librenms.org
+ *
+ * @copyright  2025 Heath Barnhart
+ * @author     Heath Barnhart <hbarnhart@kanren.net>
+ */
+
+namespace LibreNMS\Tests\Feature\SnmpTraps;
+
+use App\Models\Device;
+use App\Models\Port;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use LibreNMS\Enum\Severity;
+use LibreNMS\Tests\Traits\RequiresDatabase;
+
+class CienaCesPortNotificationTrapTest extends SnmpTrapTestCase
+{
+    public function testCienaCesPortDownNotification()
+    {
+        // make a device and associate a port with it
+        $device = Device::factory()->create(); /** @var Device $device */
+        $port = Port::factory()->make(['ifAdminStatus' => 'up', 'ifOperStatus' => 'up']); /** @var Port $port */
+        $device->ports()->save($port);
+
+        $this->assertTrapLogsMessage("<UNKNOWN>
+        UDP: [$device->ip]:57123->[192.168.4.4]:162
+        DISMAN-EVENT-MIB::sysUpTimeInstance 2:15:07:12.87
+        SNMPv2-MIB::snmpTrapOID.0 CIENA-CES-PORT-MIB::cienaCesPortNotificationPortDown
+        CIENA-GLOBAL-MIB::cienaGlobalSeverity warning
+        CIENA-CES-PORT-MIB::cienaCesChPortPgIdMappingChassisIndex 1 
+        CIENA-CES-PORT-MIB::cienaCesPortPgIdMappingShelfIndex 1
+        CIENA-CES-PORT-MIB::cienaCesChPortPgIdMappingNotifSlotIndex 1
+        CIENA-CES-PORT-MIB::cienaCesPortPgIdMappingNotifPortNumber $port->ifIndex 
+        CIENA-CES-PORT-MIB::cienaCesLogicalPortConfigPortAdminState enabled 
+        CIENA-CES-PORT-MIB::cienaCesLogicalPortConfigPortOperState disabled
+        CIENA-CES-PORT-MIB::cienaCesLogicalPortConfigPortName $port->ifName
+        CIENA-CES-PORT-MIB::cienaCesLogicalPortConfigPortDesc $port->ifDescr",
+        [
+            "Port down on Chassis: 1 Shelf: 1 Slot: 1 Port:$port->ifIndex"
+        ],
+        'Could not handle CienaCesPortDownNotification',
+        [
+            [Severity::Error, 'interface', $port->port_id]
+        ],
+        $device);
+
+        $port = $port->fresh(); // refresh from database
+        $this->assertEquals($port->ifOperStatus, 'down');
+    }
+    public function testCienaCesPortUpNotification()
+    {
+        // make a device and associate a port with it
+        $device = Device::factory()->create(); /** @var Device $device */
+        $port = Port::factory()->make(['ifAdminStatus' => 'up', 'ifOperStatus' => 'up']); /** @var Port $port */
+        $device->ports()->save($port);
+
+        $this->assertTrapLogsMessage("<UNKNOWN>
+        UDP: [$device->ip]:57123->[192.168.4.4]:162
+        DISMAN-EVENT-MIB::sysUpTimeInstance 2:15:07:12.87
+        SNMPv2-MIB::snmpTrapOID.0 CIENA-CES-PORT-MIB::cienaCesPortNotificationPortUp
+        CIENA-GLOBAL-MIB::cienaGlobalSeverity warning
+        CIENA-CES-PORT-MIB::cienaCesChPortPgIdMappingChassisIndex 1
+        CIENA-CES-PORT-MIB::cienaCesPortPgIdMappingShelfIndex 1
+        CIENA-CES-PORT-MIB::cienaCesChPortPgIdMappingNotifSlotIndex 1
+        CIENA-CES-PORT-MIB::cienaCesPortPgIdMappingNotifPortNumber $port->ifIndex
+        CIENA-CES-PORT-MIB::cienaCesLogicalPortConfigPortAdminState enabled
+        CIENA-CES-PORT-MIB::cienaCesLogicalPortConfigPortOperState enabled
+        CIENA-CES-PORT-MIB::cienaCesLogicalPortConfigPortName $port->ifName
+        CIENA-CES-PORT-MIB::cienaCesLogicalPortConfigPortType 1
+        CIENA-CES-PORT-MIB::cienaCesLogicalPortConfigPortDesc $port->ifDescr",
+        [
+            "Port up on Chassis: 1 Shelf: 1 Slot: 1 Port: $port->ifIndex"
+        ],
+        'Could not handle CienaCesPortUpNotification',
+        [
+            [Severity::Ok, 'interface', $port->port_id]
+        ],
+        $device);
+
+        $port = $port->fresh(); // refresh from database
+        $this->assertEquals($port->ifOperStatus, 'up');
+    }
+}

--- a/tests/Feature/SnmpTraps/CienaCesPortNotificationTrapTest.php
+++ b/tests/Feature/SnmpTraps/CienaCesPortNotificationTrapTest.php
@@ -68,6 +68,7 @@ CIENA-CES-PORT-MIB::cienaCesLogicalPortConfigPortDesc $port->ifDescr",
         $port = $port->fresh(); // refresh from database
         $this->assertEquals($port->ifOperStatus, 'down');
     }
+
     public function testCienaCesPortUpNotification()
     {
         // make a device and associate a port with it
@@ -98,4 +99,5 @@ CIENA-CES-PORT-MIB::cienaCesLogicalPortConfigPortDesc $port->ifDescr",
         $port = $port->fresh(); // refresh from database
         $this->assertEquals($port->ifOperStatus, 'up');
     }
+
 }

--- a/tests/Feature/SnmpTraps/CienaCesPortNotificationTrapTest.php
+++ b/tests/Feature/SnmpTraps/CienaCesPortNotificationTrapTest.php
@@ -99,5 +99,4 @@ CIENA-CES-PORT-MIB::cienaCesLogicalPortConfigPortDesc $port->ifDescr",
         $port = $port->fresh(); // refresh from database
         $this->assertEquals($port->ifOperStatus, 'up');
     }
-
 }

--- a/tests/Feature/SnmpTraps/CienaCesPortNotificationTrapTest.php
+++ b/tests/Feature/SnmpTraps/CienaCesPortNotificationTrapTest.php
@@ -51,12 +51,12 @@ UDP: [$device->ip]:57123->[192.168.4.4]:162
 DISMAN-EVENT-MIB::sysUpTimeInstance 2:15:07:12.87
 SNMPv2-MIB::snmpTrapOID.0 CIENA-CES-PORT-MIB::cienaCesPortNotificationPortDown
 CIENA-GLOBAL-MIB::cienaGlobalSeverity warning
-CIENA-CES-PORT-MIB::cienaCesChPortPgIdMappingChassisIndex 1 
+CIENA-CES-PORT-MIB::cienaCesChPortPgIdMappingChassisIndex 1
 CIENA-CES-PORT-MIB::cienaCesPortPgIdMappingShelfIndex 1
 CIENA-CES-PORT-MIB::cienaCesChPortPgIdMappingNotifSlotIndex 1
-CIENA-CES-PORT-MIB::cienaCesPortPgIdMappingNotifPortNumber $port->ifIndex 
-CIENA-CES-PORT-MIB::cienaCesLogicalPortConfigPortAdminState enabled 
-CIENA-CES-PORT-MIB::cienaCesLogicalPortConfigPortOperState disabled
+CIENA-CES-PORT-MIB::cienaCesPortPgIdMappingNotifPortNumber $port->ifIndex
+CIENA-CES-PORT-MIB::cienaCesLogicalPortConfigPortAdminState enabled
+CIENA-CES-PORT-MIB::cienaCesLogicalPortConfigPortOperState disable
 CIENA-CES-PORT-MIB::cienaCesLogicalPortConfigPortName $port->ifName
 CIENA-CES-PORT-MIB::cienaCesLogicalPortConfigPortDesc $port->ifDescr",
         "Port down on Chassis: 1 Shelf: 1 Slot: 1 Port: $port->ifIndex",


### PR DESCRIPTION
Ciena uses proprietary traps for interface up and down. This change has the SNMP Handlers that generate log messages and updates the operational state of the interface in the database. This will allow for a faster detection of interface outages with Ciena SAOS devices.

Included a unit test.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
