### PR TITLE
app Sneck: now includes a easy means to view per check info as well as support debug only items

### DIFF
--- a/doc/Extensions/Applications/Sneck.md
+++ b/doc/Extensions/Applications/Sneck.md
@@ -94,11 +94,10 @@ at [MetaCPAN](https://metacpan.org/dist/Monitoring-Sneck-Boop_Snoot) and
     */5 * * * * /usr/bin/env PATH=/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin /usr/local/bin/sneck -u 2> /dev/null > /dev/null
     ```
 
-4. Set it up in the snmpd config and restart snmpd. The `-c` flag will
-   tell read it to read from cache instead of rerunning the checks.
+4. Set it up in the snmpd config and restart snmpd.
 
     ```bash
-    extend sneck /usr/bin/env PATH=/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin /usr/local/bin/sneck -c
+    extend sneck /bin/cat /var/cache/sneck.cache.snmp
     ```
 
 5. In LibreNMS, enable the application for the server in question or wait for auto discovery to find it.

--- a/doc/Extensions/Applications/Sneck.md
+++ b/doc/Extensions/Applications/Sneck.md
@@ -94,7 +94,8 @@ at [MetaCPAN](https://metacpan.org/dist/Monitoring-Sneck-Boop_Snoot) and
     */5 * * * * /usr/bin/env PATH=/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin /usr/local/bin/sneck -u 2> /dev/null > /dev/null
     ```
 
-4. Set it up in the snmpd config and restart snmpd.
+4. Set it up in the snmpd config and restart snmpd. If calling `sneck -c` instead or catting the non-snmp cache file, there is the possibility
+   of snmpd mangling the return. To avoid this cat the snmp cache file as below or call `sneck -c -b`.
 
     ```bash
     extend sneck /bin/cat /var/cache/sneck.cache.snmp

--- a/includes/html/pages/device/apps/sneck.inc.php
+++ b/includes/html/pages/device/apps/sneck.inc.php
@@ -7,46 +7,120 @@ $link_array = [
     'app' => 'sneck',
 ];
 
-$link_array = [
-    'page' => 'device',
-    'device' => $device['device_id'],
-    'tab' => 'apps',
-    'app' => 'sneck',
-];
+$sneck_data = $app->app_id;
+if (isset($sneck_data)) {
+    $checks = $app->data['data']['checks'] ?? [];
+    $checks_list = array_keys($checks);
+    $debugs = $app->data['data']['debugs'] ?? [];
+    $debugs_list = array_keys($debugs);
+    if (isset($checks_list[0]) || isset($debugs_list[0])) {
+        print_optionbar_start();
+        echo generate_link('Overview', $link_array) . "<br>\n";
+        if (isset($checks_list[0])) {
+            echo 'Check Info: ';
+            foreach ($checks_list as $index => $check) {
+                $label = $vars['sneck_check'] == $check
+                    ? '<span class="pagemenu-selected">' . htmlspecialchars($check) . '</span>'
+                    : htmlspecialchars($check);
 
-$graphs = [
-    'sneck_results' => 'Results',
-    'sneck_time' => 'Time Difference',
-];
+                echo generate_link($label, $link_array, ['sneck_check' => $check]) . "\n";
 
-foreach ($graphs as $key => $text) {
-    $graph_type = $key;
-    $graph_array['height'] = '100';
-    $graph_array['width'] = '215';
-    $graph_array['to'] = \LibreNMS\Config::get('time.now');
-    $graph_array['id'] = $app->app_id;
-    $graph_array['type'] = 'application_' . $key;
+                if ($index < (count($checks_list) - 1)) {
+                    echo ', ';
+                } else {
+                    echo "<br>\n";
+                }
+            }
+        }
+        if (isset($debugs_list[0])) {
+            echo 'Debug Info: ';
+            foreach ($debugs_list as $index => $debug) {
+                $label = $vars['sneck_debug'] == $debug
+                    ? '<span class="pagemenu-selected">' . htmlspecialchars($debug) . '</span>'
+                    : htmlspecialchars($debug);
 
-    echo '<div class="panel panel-default">
+                echo generate_link($label, $link_array, ['sneck_debug' => $debug]) . "\n";
+
+                if ($index < (count($debugs_list) - 1)) {
+                    echo ', ';
+                } else {
+                    echo "<br>\n";
+                }
+            }
+        }
+        print_optionbar_end();
+    }
+}
+
+if ((isset($vars['sneck_check']) && isset($app->data['data']['checks'][$vars['sneck_check']])) || (isset($vars['sneck_debug']) && isset($app->data['data']['debugs'][$vars['sneck_debug']]))) {
+    $type='checks';
+    $type_name='';
+    if (isset($vars['sneck_debug'])) {
+        $type='debugs';
+        $type_name = $vars['sneck_debug'];
+    } else {
+        $type_name = $vars['sneck_check'];
+    }
+    print_optionbar_start();
+    // is the template used
+    if (isset($app->data['data'][$type][$type_name]['check'])) {
+        echo '<b>Check:</b> ' . htmlspecialchars($app->data['data'][$type][$type_name]['check']) . "<br>\n";
+    }
+    // what was ran post templating
+    if (isset($app->data['data'][$type][$type_name]['ran'])) {
+        echo '<b>Ran:</b> ' . htmlspecialchars($app->data['data'][$type][$type_name]['ran']) . "<br>\n";
+    }
+    // exit code
+    if (isset($app->data['data'][$type][$type_name]['exit'])) {
+        echo '<b>Exit:</b> ' . htmlspecialchars($app->data['data'][$type][$type_name]['exit']) . "<br>\n";
+    }
+    // error non-standard exit info
+    if (isset($app->data['data'][$type][$type_name]['error'])) {
+        echo '<b>Error:</b> ' . htmlspecialchars($app->data['data'][$type][$type_name]['error']) . "<br>\n";
+    }
+    // output
+    if (isset($app->data['data'][$type][$type_name]['output'])) {
+        echo "<b>Output...</b><br>\n<pre>";
+        echo htmlspecialchars($app->data['data'][$type][$type_name]['output']) . "\n";
+        echo "</pre><br>\n";
+    }
+    echo "<b>Raw JSON:</b><br>\n";
+    echo "<pre>\n" . htmlspecialchars(json_encode($app->data['data'][$type][$type_name], JSON_PRETTY_PRINT)) . "</pre>\n";
+    print_optionbar_end();
+} else {
+    $graphs = [
+        'sneck_results' => 'Results',
+        'sneck_time' => 'Time Difference',
+    ];
+
+    foreach ($graphs as $key => $text) {
+        $graph_type = $key;
+        $graph_array['height'] = '100';
+        $graph_array['width'] = '215';
+        $graph_array['to'] = \LibreNMS\Config::get('time.now');
+        $graph_array['id'] = $app->app_id;
+        $graph_array['type'] = 'application_' . $key;
+
+        echo '<div class="panel panel-default">
     <div class="panel-heading">
         <h3 class="panel-title">' . $text . '</h3>
     </div>
     <div class="panel-body">
     <div class="row">';
-    include 'includes/html/print-graphrow.inc.php';
-    echo '</div>';
-    echo '</div>';
-    echo '</div>';
-}
+        include 'includes/html/print-graphrow.inc.php';
+        echo '</div>';
+        echo '</div>';
+        echo '</div>';
+    }
 
-// print any alerts if found
-$sneck_data = $app->app_id;
-if (isset($sneck_data)) {
-    print_optionbar_start();
-    echo 'Last Return...<br>';
-    echo "<b>Alert(s):</b><br>\n";
-    echo str_replace("\n", "<br>\n", htmlspecialchars($app->data['data']['alertString'])) . "<br><br>\n";
-    echo "<b>Raw JSON:</b><br>\n";
-    echo "<pre>\n" . htmlspecialchars(json_encode($app->data, JSON_PRETTY_PRINT)) . "</pre>\n";
-    print_optionbar_end();
+    // print returned all info from sneck with alert info broken out
+    if (isset($sneck_data)) {
+        print_optionbar_start();
+        echo 'Last Return...<br>';
+        echo "<b>Alert(s):</b><br>\n";
+        echo str_replace("\n", "<br>\n", htmlspecialchars($app->data['data']['alertString'])) . "<br><br>\n";
+        echo "<b>Raw JSON:</b><br>\n";
+        echo "<pre>\n" . htmlspecialchars(json_encode($app->data, JSON_PRETTY_PRINT)) . "</pre>\n";
+        print_optionbar_end();
+    }
 }

--- a/includes/html/pages/device/apps/sneck.inc.php
+++ b/includes/html/pages/device/apps/sneck.inc.php
@@ -53,10 +53,10 @@ if (isset($sneck_data)) {
 }
 
 if ((isset($vars['sneck_check']) && isset($app->data['data']['checks'][$vars['sneck_check']])) || (isset($vars['sneck_debug']) && isset($app->data['data']['debugs'][$vars['sneck_debug']]))) {
-    $type='checks';
-    $type_name='';
+    $type = 'checks';
+    $type_name = '';
     if (isset($vars['sneck_debug'])) {
-        $type='debugs';
+        $type = 'debugs';
         $type_name = $vars['sneck_debug'];
     } else {
         $type_name = $vars['sneck_check'];

--- a/includes/polling/applications/sneck.inc.php
+++ b/includes/polling/applications/sneck.inc.php
@@ -46,7 +46,7 @@ if (isset($json_return['data']) and isset($json_return['data']['checks'])) {
 
 $new_debugs = [];
 if (isset($json_return['data']) and isset($json_return['data']['debugs'])) {
-    $new_debugs = array_keys($json_return['data']['checks']);
+    $new_debugs = array_keys($json_return['data']['debugs']);
 }
 
 $rrd_name = ['app', $name, $app->app_id];

--- a/includes/polling/applications/sneck.inc.php
+++ b/includes/polling/applications/sneck.inc.php
@@ -97,7 +97,7 @@ $added_checks = array_values(array_diff($new_checks, $old_checks));
 $added_debugs = array_values(array_diff($new_debugs, $old_debugs));
 
 //check for removed checks/debugs
-$removed_debugs = array_values(array_diff($old_checks, $new_checks));
+$removed_checks = array_values(array_diff($old_checks, $new_checks));
 $removed_debugs = array_values(array_diff($old_debugs, $new_debugs));
 
 // if we have any check changes, log it

--- a/includes/polling/applications/sneck.inc.php
+++ b/includes/polling/applications/sneck.inc.php
@@ -16,6 +16,13 @@ if (isset($app->data['data']) && isset($app->data['data']['checks'])) {
     $old_checks_data = $app->data['data']['checks'];
 }
 
+$old_debugs = [];
+$old_debugs_data = [];
+if (isset($app->data['data']) && isset($app->data['data']['debugs'])) {
+    $old_checks = array_keys($app->data['data']['debugs']);
+    $old_checks_data = $app->data['data']['debugs'];
+}
+
 if (Config::has('apps.sneck.polling_time_diff')) {
     $compute_time_diff = Config::get('apps.sneck.polling_time_diff');
 } else {
@@ -37,6 +44,11 @@ $app->data = $json_return;
 $new_checks = [];
 if (isset($json_return['data']) and isset($json_return['data']['checks'])) {
     $new_checks = array_keys($json_return['data']['checks']);
+}
+
+$new_debugs = [];
+if (isset($json_return['data']) and isset($json_return['data']['debugs'])) {
+    $new_debugs = array_keys($json_return['data']['checks']);
 }
 
 $rrd_name = ['app', $name, $app->app_id];
@@ -82,17 +94,27 @@ if (abs($time_to_polling) > 540) {
     $json_return['data']['alert'] = 1;
 }
 
-//check for added checks
+//check for added checks/debugs
 $added_checks = array_values(array_diff($new_checks, $old_checks));
+$added_debugs = array_values(array_diff($new_debugs, $old_debugs));
 
-//check for removed checks
-$removed_checks = array_values(array_diff($old_checks, $new_checks));
+//check for removed checks/debugs
+$removed_debugs = array_values(array_diff($old_checks, $new_checks));
+$removed_debugs = array_values(array_diff($old_debugs, $new_debugs));
 
 // if we have any check changes, log it
 if (count($added_checks) > 0 || count($removed_checks) > 0) {
     $log_message = 'Sneck Check Change:';
     $log_message .= count($added_checks) > 0 ? ' Added ' . json_encode($added_checks) : '';
     $log_message .= count($removed_checks) > 0 ? ' Removed ' . json_encode($added_checks) : '';
+    Eventlog::log($log_message, $device['device_id'], 'application');
+}
+
+// if we have any debug changes, log it
+if (count($added_debugs) > 0 || count($removed_debugs) > 0) {
+    $log_message = 'Sneck Debugs Change:';
+    $log_message .= count($added_debugs) > 0 ? ' Added ' . json_encode($added_debugs) : '';
+    $log_message .= count($removed_debugs) > 0 ? ' Removed ' . json_encode($added_debugs) : '';
     Eventlog::log($log_message, $device['device_id'], 'application');
 }
 

--- a/includes/polling/applications/sneck.inc.php
+++ b/includes/polling/applications/sneck.inc.php
@@ -17,10 +17,8 @@ if (isset($app->data['data']) && isset($app->data['data']['checks'])) {
 }
 
 $old_debugs = [];
-$old_debugs_data = [];
 if (isset($app->data['data']) && isset($app->data['data']['debugs'])) {
-    $old_checks = array_keys($app->data['data']['debugs']);
-    $old_checks_data = $app->data['data']['debugs'];
+    $old_debugs = array_keys($app->data['data']['debugs']);
 }
 
 if (Config::has('apps.sneck.polling_time_diff')) {


### PR DESCRIPTION
`.data.debugs` is basically a mirror of `.data.checks`, but it does not count towards any of the counts and not tracked in regards to stats.

Basically a handy means to include additional information for what ever along with the returned checks.

Monitoring::Sneck 1.0.0 has no changes to the returned data outside of that and since  the stored stats data and data written to RRD remains the same no need to add a new test for this version of it.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
