### PR TITLE
New Meraki APs

### DIFF
--- a/includes/definitions/merakimr.yaml
+++ b/includes/definitions/merakimr.yaml
@@ -10,3 +10,4 @@ discovery:
     -
         sysDescr_regex:
             - '/^=?Meraki MR/'
+            - '/^=?Meraki CW/'


### PR DESCRIPTION
Newest Meraki access points have been rebranded as Catalyst Wireless (CW) that does not fit the current regex discovery of AP
This will add new registry value of '/^=?Meraki CW/' to the current AP discovery process.


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
