### PR TITLE
fix broken mac parsing on zyxel 1900 devices

### DIFF
--- a/includes/discovery/fdb-table/zynos.inc.php
+++ b/includes/discovery/fdb-table/zynos.inc.php
@@ -32,7 +32,7 @@ if (in_array(explode('-', $device['hardware'], 2)[0], ['GS1900'])) {
         // fix the Q-BRIDGE implementation
         $indexes = explode('.', $index);
         $vlan = $indexes[0]; //1st element
-        $mac_address = Mac::parse((string) array_map('dechex', array_splice($indexes, -6, 6)))->hex(); //last 6 elements
+        $mac_address = Mac::parse(implode( ":", array_map('dechex', array_splice($indexes, -6, 6))))->hex(); //last 6 elements
 
         $port = get_port_by_index_cache($device['device_id'], $port_data['Q-BRIDGE-MIB::dot1qTpFdbPort']);
         $port_id = $port && $port['port_id'] ? $port['port_id'] : 0;


### PR DESCRIPTION
@mpikzink 

after your commit 

https://github.com/librenms/librenms/commit/a20a1aade73157f4997088743dcffd866cfb0b8c#diff-61d493fd1304eaca2d40112eb35458a0e99060e10c133bfe05a6b625a345e709

my fdb table on a zyxel 1900 device was empty.

This commit fixed it for me.