### PR TITLE
Expose os_text as a report field

### DIFF
--- a/app/Console/Commands/ReportDevices.php
+++ b/app/Console/Commands/ReportDevices.php
@@ -6,6 +6,7 @@ use App\Console\DynamicInputOption;
 use App\Console\LnmsCommand;
 use App\Console\SyntheticDeviceField;
 use App\Models\Device;
+use LibreNMS\Config;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Schema;
@@ -108,6 +109,7 @@ class ReportDevices extends LnmsCommand
         return [
             'displayName' => new SyntheticDeviceField('displayName', ['hostname', 'sysName', 'ip', 'display'], fn (Device $device) => $device->displayName(), headerName: 'display name'),
             'location' => new SyntheticDeviceField('location', ['location_id'], fn (Device $device) => $device->location->location, fn (Builder $q) => $q->with('location')),
+            'os_text' => new SyntheticDeviceField('os_text', ['os'], fn (Device $device) => Config::getOsSetting($device->os, 'text'), headerName: 'os text'),
         ];
     }
 

--- a/app/Console/Commands/ReportDevices.php
+++ b/app/Console/Commands/ReportDevices.php
@@ -6,10 +6,10 @@ use App\Console\DynamicInputOption;
 use App\Console\LnmsCommand;
 use App\Console\SyntheticDeviceField;
 use App\Models\Device;
-use LibreNMS\Config;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Schema;
+use LibreNMS\Config;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 


### PR DESCRIPTION
This is the pretty version of the OS name that's included in the OS YAML defintions.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
