### PR TITLE
Fix incorrect usage of array_slice

### DIFF
--- a/LibreNMS/Device/YamlDiscovery.php
+++ b/LibreNMS/Device/YamlDiscovery.php
@@ -276,7 +276,7 @@ class YamlDiscovery
 
             // if subindex is a range, get them all, otherwise just get the first
             $index = isset($matches[3])
-                ? implode('.', array_slice($sub_indexes, (int) $matches[2], (int) $matches[3]))
+                ? implode('.', array_slice($sub_indexes, (int) $matches[2], (int) ($matches[3] - $matches[2] + 1)))
                 : $sub_indexes[(int) $matches[2]];
         }
 

--- a/includes/definitions/discovery/aruba-instant.yaml
+++ b/includes/definitions/discovery/aruba-instant.yaml
@@ -37,7 +37,7 @@ modules:
                     oid: aiRadioStatus
                     num_oid: '.1.3.6.1.4.1.14823.2.3.3.1.2.2.1.20.{{ $index }}'
                     snmp_flags: '-OteQUsb'
-                    descr: '{{ $aiAPName:0-6 }} ({{ $aiAPSerialNum:0-6 }}) Radio {{ $subindex6 }}'
+                    descr: '{{ $aiAPName:0-5 }} ({{ $aiAPSerialNum:0-5 }}) Radio {{ $subindex6 }}'
                     group: 'Cluster Radios'
                     state_name: aiRadioStatus
                     states:


### PR DESCRIPTION
The current usage was to treat the parameters as start/end - however the documenation states they are start/length
https://www.php.net/manual/en/function.array-slice.php

This meant that e.g. when 0-1 is specified, instead of selecting subindex 0 and 1, one value is selected starting at subindex0.

To calculate the correct length, we substract the low index from the high, and add one to adjust between offsets and lengths.

I've only found the syntax in use here: https://github.com/librenms/librenms/blob/master/includes/definitions/discovery/aruba-instant.yaml#L40

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
