### PR TITLE
add in application info fetching for alert templating

### DIFF
--- a/LibreNMS/Alert/RunAlerts.php
+++ b/LibreNMS/Alert/RunAlerts.php
@@ -34,6 +34,7 @@ namespace LibreNMS\Alert;
 use App\Facades\DeviceCache;
 use App\Facades\Rrd;
 use App\Models\AlertTransport;
+use App\Models\Application;
 use App\Models\Eventlog;
 use LibreNMS\Config;
 use LibreNMS\Enum\AlertState;
@@ -130,6 +131,16 @@ class RunAlerts
             }
         }
         $extra = $alert['details'];
+
+        // finds all applications for the device and includes those
+        $applications = Application::where('device_id', $device->device_id)->get();
+        if (count($applications) > 0) {
+            $obj['applications'] = [];
+            // change it into a hash for usability purposes
+            foreach ($applications as $application) {
+                $obj['applications'][$application['app_type']] = $application;
+            }
+        }
 
         $tpl = new Template;
         $template = $tpl->getTemplate($obj);


### PR DESCRIPTION
Can now add in app data info into alert templates.

Below is a example showing the alert string value for Sneck. 'data' is there twice given how the whole JSON return is stored by the app.

```
Alert String: {{ $alert->applications['sneck']['data']['data']['alertString'] }}
```

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
