### PR TITLE
Fix ospfv3 page when port is missing

### DIFF
--- a/includes/html/pages/device/routing/ospfv3.inc.php
+++ b/includes/html/pages/device/routing/ospfv3.inc.php
@@ -111,7 +111,7 @@ foreach ($instances as $instance) {
         echo '
                   <tbody>
                     <tr>
-                      <td>' . Blade::render('<x-port-link :port="$port"/>', ['port' => $ospfPort->port]) . '</td>
+                      <td>' .  ($ospfPort->port ? Blade::render('<x-port-link :port="$port"/>', ['port' => $ospfPort->port]) : '') . '</td>
                       <td>' . $ospfPort->ospfv3IfType . '</td>
                       <td>' . $ospfPort->ospfv3IfState . '</td>
                       <td>' . $ospfPort->ospfv3IfMetricValue . '</td>


### PR DESCRIPTION
Seems to be on Juniper, probably an issue with their polling.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
