### PR TITLE
Expose discovery protocol settings to webui

### DIFF
--- a/doc/Extensions/Auto-Discovery.md
+++ b/doc/Extensions/Auto-Discovery.md
@@ -12,26 +12,27 @@ default and within 5 minutes for new devices).
 Please note that you need at least ONE device added before
 auto-discovery will work.
 
-The first thing to do though is add the required configuration options to `config.php`.
+The first thing to do though is add the required configuration options.
 
 ## SNMP Details
 
 To add devices automatically we need to know your snmp details,
 examples of SNMP v1, v2c and v3 are below:
 
-```php
-// v1 or v2c
-$config['snmp']['community'][] = "my_custom_community";
-$config['snmp']['community'][] = "another_community";
+!!! setting "poller/snmp"
+    ```bash
+    lnms config:set snmp.community.+ my_custom_community
+    lnms config:set snmp.community.+ another_community
 
-// v3
-$config['snmp']['v3'][0]['authlevel'] = 'authPriv';
-$config['snmp']['v3'][0]['authname'] = 'my_username';
-$config['snmp']['v3'][0]['authpass'] = 'my_password';
-$config['snmp']['v3'][0]['authalgo'] = 'SHA';
-$config['snmp']['v3'][0]['cryptopass'] = 'my_crypto';
-$config['snmp']['v3'][0]['cryptoalgo'] = 'AES';
-```
+    lnms config:set snmp.v3.+ '{
+        "authlevel": "authPriv",
+        "authname": "my_username",
+        "authpass": "my_password",
+        "authalgo": "SHA",
+        "cryptopass": "my_crypto",
+        "cryptoalgo": "AES"
+    }'
+    ```
 
 These details will be attempted when adding devices, you can specify
 any mixture of these.
@@ -114,9 +115,12 @@ within the Modules section.
 
 ### XDP
 
-Enabled by default.
+Enabled by default. Can be disabled with:
 
-`$config['autodiscovery']['xdp'] = false;` to disable.
+!!! setting "discovery/autodiscovery"
+    ```bash
+    lnms config:set autodiscovery.xdp false
+    ```
 
 This includes FDP, CDP and LLDP support based on the device type.
 
@@ -125,47 +129,50 @@ However, LibreNMS will only try to add the new devices discovered with LLDP/xDP 
 
 Devices may be excluded from xdp discovery by sysName and sysDescr.
 
-```php
-//Exclude devices by name
-$config['autodiscovery']['xdp_exclude']['sysname_regexp'][] = '/host1/';
-$config['autodiscovery']['xdp_exclude']['sysname_regexp'][] = '/^dev/';
+!!! setting "discovery/autodiscovery"
+    ```bash
+    lnms config:set autodiscovery.xdp_exclude.sysname_regexp.+ '/host1/'
+    lnms config:set autodiscovery.xdp_exclude.sysname_regexp.+ '/^dev/'
+    
+    lnms config:set autodiscovery.xdp_exclude.sysdescr_regexp.+ '/-K9W8/'
+    lnms config:set autodiscovery.xdp_exclude.sysdescr_regexp.+ '/Vendor X/'
+    ```
 
-//Exclude devices by description
-$config['autodiscovery']['xdp_exclude']['sysdesc_regexp'][] = '/Vendor X/';
-$config['autodiscovery']['xdp_exclude']['sysdesc_regexp'][] = '/Vendor Y/';
-```
+Devices may be excluded from cdp discovery by platform. (CDP only)
 
-Devices may be excluded from cdp discovery by platform.
-
-```php
-//Exclude devices by platform(Cisco only)
-$config['autodiscovery']['cdp_exclude']['platform_regexp'][] = '/WS-C3750G/';
-```
-
-These devices are excluded by default:
-
-```php
-$config['autodiscovery']['xdp_exclude']['sysdesc_regexp'][] = '/-K9W8/'; // Cisco Lightweight Access Point
-$config['autodiscovery']['cdp_exclude']['platform_regexp'][] = '/^Cisco IP Phone/'; //Cisco IP Phone
-```
+!!! setting "discovery/autodiscovery"
+    ```bash
+    lnms config:set autodiscovery.cdp_exclude.platform_regexp.+ '/WS-C3750G/'
+    lnms config:set autodiscovery.cdp_exclude.platform_regexp.+ '/^Cisco IP Phone/'
+    ```
 
 ### OSPF
 
 Enabled by default.
 
-`$config['autodiscovery']['ospf'] = false;` to disable.
+!!! setting "discovery/autodiscovery"
+    ```bash
+    lnms config:set autodiscovery.ospf false
+    ```
 
 ### OSPFv3
 
 Enabled by default.
 
-`$config['autodiscovery']['ospfv3'] = false;` to disable.
+!!! setting "discovery/autodiscovery"
+    ```bash
+    lnms config:set autodiscovery.ospfv3 false
+    ```
+
 
 ### BGP
 
 Enabled by default.
 
-`$config['autodiscovery']['bgp'] = false;` to disable.
+!!! setting "discovery/autodiscovery"
+    ```bash
+    lnms config:set autodiscovery.bgp false
+    ```
 
 This module is invoked from bgp-peers discovery module.
 
@@ -209,4 +216,10 @@ optional arguments:
 
 Newly discovered devices will be added to the `default_poller_group`, this value defaults to 0 if unset.
 
-When using distributed polling, this value can be changed locally by setting `$config['default_poller_group']` in config.php or globally by using `lnms config:set`.
+When using distributed polling, this value can be changed locally by setting `default_poller_group`
+
+!!! setting "poller/distributed"
+    ```bash
+    lnms config:set default_poller_group 3
+    ```
+

--- a/doc/Extensions/Auto-Discovery.md
+++ b/doc/Extensions/Auto-Discovery.md
@@ -218,6 +218,13 @@ Newly discovered devices will be added to the `default_poller_group`, this value
 
 When using distributed polling, this value can be changed locally by setting `default_poller_group`
 
+To set per-poller, set this in each poller's config.php file:
+```php
+$config['default_poller_group'] = 3;
+```
+
+Set globally
+
 !!! setting "poller/distributed"
     ```bash
     lnms config:set default_poller_group 3

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -41,9 +41,9 @@ return [
             'general' => ['name' => 'General Discovery Settings'],
             'route' => ['name' => 'Routes Discovery Module'],
             'discovery_modules' => ['name' => 'Discovery Modules'],
+            'autodiscovery' => ['name' => 'Network Discovery'],
             'ports' => ['name' => 'Ports Module'],
             'storage' => ['name' => 'Storage Module'],
-            'networks' => ['name' => 'Networks'],
         ],
         'external' => [
             'binaries' => ['name' => 'Binary Locations'],
@@ -1490,9 +1490,41 @@ return [
             'help' => 'Networks from which devices will be discovered automatically.',
         ],
         'autodiscovery' => [
+            'bgp' => [
+                'description' => 'Enable BGP neighbor discovery',
+                'help' => 'Add links and neighbors based on BGP peers',
+            ],
+            'cdp_exclude' => [
+                'platform_regexp' => [
+                    'description' => 'CDP exclude platform regex',
+                    'help' => 'Prevent devices from being added by CDP if sysName matches regular expression',
+                ],
+            ],
             'nets-exclude' => [
                 'description' => 'Networks/IPs to be ignored',
                 'help' => 'Networks/IPs which will not be discovered automatically. Excludes also IPs from Autodiscovery Networks',
+            ],
+            'ospf' => [
+                'description' => 'Enable OSPF neighbor discovery',
+                'help' => 'Add links and neighbors based on OSPF peers',
+            ],
+            'ospfv3' => [
+                'description' => 'Enable OSPFv3 neighbor discovery',
+                'help' => 'Add links and neighbors based on OSPFv3 peers',
+            ],
+            'xdp' => [
+                'description' => 'Enable xDP discovery protocols',
+                'help' => 'Use LLDP, CDP, etc protocols to discover network topology and neighbors and add them to LibreNMS',
+            ],
+            'xdp_exclude' => [
+                'sysname_regexp' => [
+                    'description' => 'xDP exclude sysName regex',
+                    'help' => 'Prevent devices from being added if sysName matches regular expression',
+                ],
+                'sysdesc_regexp' => [
+                    'description' => 'xDP exclude sysDescr regex',
+                    'help' => 'Prevent devices from being added if sysDescr matches regular expression',
+                ],
             ],
         ],
         'radius' => [

--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -834,17 +834,24 @@
         },
         "autodiscovery.bgp": {
             "default": true,
+            "group": "discovery",
+            "section": "autodiscovery",
+            "order": 12,
             "type": "boolean"
         },
         "autodiscovery.cdp_exclude.platform_regexp": {
             "type": "array",
-            "default": [
-                "/^Cisco IP Phone/"
-            ]
+            "default": [],
+            "group": "discovery",
+            "section": "autodiscovery",
+            "order": 7,
+            "validate": {
+                "value.*": "is_regex"
+            }
         },
         "autodiscovery.nets-exclude": {
             "group": "discovery",
-            "section": "networks",
+            "section": "autodiscovery",
             "order": 2,
             "type": "array",
             "default": [
@@ -856,26 +863,45 @@
             ]
         },
         "autodiscovery.ospf": {
+            "type": "boolean",
             "default": true,
-            "type": "boolean"
+            "group": "discovery",
+            "section": "autodiscovery",
+            "order": 13
         },
         "autodiscovery.ospfv3": {
             "default": true,
-            "type": "boolean"
-        },
-        "autodiscovery.snmpscan": {
-            "default": true,
-            "type": "boolean"
+            "type": "boolean",
+            "group": "discovery",
+            "section": "autodiscovery",
+            "order": 14
         },
         "autodiscovery.xdp": {
             "default": true,
-            "type": "boolean"
+            "type": "boolean",
+            "group": "discovery",
+            "section": "autodiscovery",
+            "order": 4
         },
         "autodiscovery.xdp_exclude.sysdesc_regexp": {
             "type": "array",
-            "default": [
-                "/-K9W8/"
-            ]
+            "default": [],
+            "group": "discovery",
+            "section": "autodiscovery",
+            "order": 6,
+            "validate": {
+                "value.*": "is_regex"
+            }
+        },
+        "autodiscovery.xdp_exclude.sysname_regexp": {
+            "type": "array",
+            "default": [],
+            "group": "discovery",
+            "section": "autodiscovery",
+            "order": 5,
+            "validate": {
+                "value.*": "is_regex"
+            }
         },
         "bad_entity_sensor_regex": {
             "default": null,
@@ -892,7 +918,7 @@
             "type": "array",
             "group": "discovery",
             "section": "ports",
-            "order": 0,
+            "order": 1,
             "default": [
                 "voip-null",
                 "virtual-",
@@ -922,7 +948,7 @@
             "type": "array",
             "group": "discovery",
             "section": "ports",
-            "order": 1,
+            "order": 2,
             "default": [
                 "/^ng[0-9]+$/",
                 "/^sl[0-9]/"
@@ -1278,7 +1304,7 @@
             "default": 0,
             "type": "select-dynamic",
             "group": "discovery",
-            "section": "networks",
+            "section": "ports",
             "order": 0,
             "options": {
                 "target": "port-group"
@@ -4764,7 +4790,7 @@
             "type": "array",
             "default": [],
             "group": "discovery",
-            "section": "networks",
+            "section": "autodiscovery",
             "order": 1
         },
         "network_map_dependencymap_vis_options": {


### PR DESCRIPTION
adds autodiscovery.xdp_exclude.sysname_regexp
fixes: #17471

![image](https://github.com/user-attachments/assets/338ec6ea-b2d4-49b4-8e7e-7eca6d06c435)


#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
