### PR TITLE
bug - Fix for device--print-alert-rules.php

### DIFF
--- a/includes/html/print-alert-rules.php
+++ b/includes/html/print-alert-rules.php
@@ -85,6 +85,7 @@ require_once 'includes/html/modal/edit_alert_transport.inc.php';
 
 echo '<form method="post" action="" id="result_form">';
 echo csrf_field();
+
 if (isset($_POST['results_amount']) && $_POST['results_amount'] > 0) {
     $results = $_POST['results'];
 } else {
@@ -132,13 +133,16 @@ if (isset($device['device_id']) && $device['device_id'] > 0) {
     $device_rules = 'SELECT ar2.* FROM alert_rules AS ar2 WHERE ar2.id IN (SELECT adm2.rule_id FROM alert_device_map AS adm2 WHERE adm2.device_id=?)';
     $param[] = $device['device_id'];
 
-    $device_group_rules = 'SELECT ar3.* FROM alert_rules AS ar3 WHERE ar3.id IN (SELECT agm3.rule_id FROM alert_group_map AS agm3 LEFT JOIN device_group_device AS dgd3 ON agm3.group_id=dgd3.device_group_id WHERE dgd3.device_id=?)';
+    $device_group_rules = 'SELECT ar3.* FROM alert_rules AS ar3 WHERE ar3.invert_map AND ar3.id NOT IN (SELECT agm3.rule_id FROM alert_group_map AS agm3  LEFT JOIN device_group_device AS dgd3 ON agm3.group_id=dgd3.device_group_id WHERE dgd3.device_id=?)';
+    $param[] = $device['device_id'];
+
+    $device_group_rules_invert = 'SELECT ar3.* FROM alert_rules AS ar3 WHERE NOT ar3.invert_map AND ar3.id IN (SELECT agm3.rule_id FROM alert_group_map AS agm3 LEFT JOIN device_group_device AS dgd3 ON agm3.group_id=dgd3.device_group_id WHERE dgd3.device_id=?)';
     $param[] = $device['device_id'];
 
     $device_location_rules = 'SELECT ar4.* FROM alert_rules AS ar4 WHERE ar4.id IN (SELECT alm4.rule_id FROM alert_location_map AS alm4 LEFT JOIN devices AS d4 ON alm4.location_id=d4.location_id WHERE d4.device_id=?)';
     $param[] = $device['device_id'];
 
-    $full_query = '(' . $global_rules . ') UNION DISTINCT (' . $device_rules . ') UNION DISTINCT (' . $device_group_rules . ') UNION DISTINCT (' . $device_location_rules . ')';
+    $full_query = '(' . $global_rules . ') UNION DISTINCT (' . $device_rules . ') UNION DISTINCT (' . $device_group_rules . ') UNION DISTINCT (' . $device_group_rules_invert . ') UNION DISTINCT (' . $device_location_rules . ')';
 } else {
     // no device selected
     $full_query = 'SELECT alert_rules.* FROM alert_rules';

--- a/includes/html/print-alert-rules.php
+++ b/includes/html/print-alert-rules.php
@@ -85,7 +85,6 @@ require_once 'includes/html/modal/edit_alert_transport.inc.php';
 
 echo '<form method="post" action="" id="result_form">';
 echo csrf_field();
-
 if (isset($_POST['results_amount']) && $_POST['results_amount'] > 0) {
     $results = $_POST['results'];
 } else {


### PR DESCRIPTION
fixes #17484

Here is a proposal to handle both cases with invert_map and groups:
- device is in group AND invert_map is not set
- device is not in group AND invert_map is set


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
