### PR TITLE
Added new options to SMTP (via TLS) settings for certificate verification

### DIFF
--- a/LibreNMS/Util/Mail.php
+++ b/LibreNMS/Util/Mail.php
@@ -119,12 +119,12 @@ class Mail
                     $mail->Password = Config::get('email_smtp_password');
                     $mail->SMTPAutoTLS = Config::get('email_auto_tls');
                     $mail->SMTPDebug = 0;
-                    $mail->SMTPOptions = array(
-                        'ssl' => array(
-                            'verify_peer' => Config::get('email_smtp_verifypeer'),
-                            'allow_self_signed' => Config::get('email_smtp_allowselfsigned')
-                        )
-                    );
+                    $mail->SMTPOptions = [
+                        'ssl' => [
+                            'verify_peer' => Config::get('email_smtp_verifypeer', true),
+                            'allow_self_signed' => Config::get('email_smtp_allowselfsigned', false),
+                        ],
+                    ];
                     break;
                 default:
                     $mail->Mailer = 'mail';

--- a/LibreNMS/Util/Mail.php
+++ b/LibreNMS/Util/Mail.php
@@ -119,6 +119,12 @@ class Mail
                     $mail->Password = Config::get('email_smtp_password');
                     $mail->SMTPAutoTLS = Config::get('email_auto_tls');
                     $mail->SMTPDebug = 0;
+                    $mail->SMTPOptions = array(
+                        'ssl' => array(
+                            'verify_peer' => Config::get('email_smtp_verifypeer'),
+                            'allow_self_signed' => Config::get('email_smtp_allowselfsigned')
+                        )
+                    );
                     break;
                 default:
                     $mail->Mailer = 'mail';

--- a/doc/Support/Configuration.md
+++ b/doc/Support/Configuration.md
@@ -688,6 +688,12 @@ What type of mail transport to use for delivering emails. Valid
 options for `email_backend` are mail, sendmail or smtp. The varying
 options after that are to support the different transports.
 
+For security reasons, the SMTP server connection via TLS will try to verify the validity of the certificate. If for some reason you need to disable verification, you can use the email_smtp_verifypeer option (true by default) and email_smtp_allowselfsigned (false by default).
+```bash
+    lnms config:set email_smtp_verifypeer false
+    lnms config:set email_smtp_allowselfsigned true
+```
+
 ## Alerting
 
 Please refer to [Alerting](../Alerting/index.md)

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -754,6 +754,14 @@ return [
             'description' => 'Auto TLS support',
             'help' => 'Tries to use TLS before falling back to un-encrypted',
         ],
+        'email_smtp_verifypeer' => [
+            'description' => 'Verify peer certificate',
+            'help' => 'Do not verify peer certificate when connecting to SMTP server via TLS',
+        ],
+        'email_smtp_allowselfsigned' => [
+            'description' => 'Allow self-signed certificate',
+            'help' => 'Allow self-signed certificate when connecting to SMTP server via TLS',
+        ],
         'email_attach_graphs' => [
             'description' => 'Attach graph images',
             'help' => 'This will generate a graph when the alert is raised and attach it and embed it in the email.',

--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -1842,6 +1842,48 @@
                 "value": "smtp"
             }
         },
+        "email_smtp_verifypeer": {
+            "default": true,
+            "group": "alerting",
+            "section": "email",
+            "order": 11,
+            "type": "boolean",
+            "when": {
+                "and": [
+                    {
+                        "setting": "email_backend",
+                        "operator": "equals",
+                        "value": "smtp"
+                    },
+                    {
+                        "setting": "email_smtp_secure",
+                        "operator": "equals",
+                        "value": "tls"
+                    }
+                ]
+            }
+        },
+        "email_smtp_allowselfsigned": {
+            "default": false,
+            "group": "alerting",
+            "section": "email",
+            "order": 12,
+            "type": "boolean",
+            "when": {
+                "and": [
+                    {
+                        "setting": "email_backend",
+                        "operator": "equals",
+                        "value": "smtp"
+                    },
+                    {
+                        "setting": "email_smtp_secure",
+                        "operator": "equals",
+                        "value": "tls"
+                    }
+                ]
+            }
+        },
         "email_attach_graphs": {
             "default": true,
             "group": "alerting",


### PR DESCRIPTION
Added new options to SMTP (via TLS) settings for certificate verification
New options in mailer and graphical (Web) settings
As mentioned in:
https://community.librenms.org/t/new-config-option-check-certificate-for-smtp-server/26594

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
