### PR TITLE
Fix an issue with the menu when there is only one group of custom maps

### DIFF
--- a/resources/views/layouts/menu.blade.php
+++ b/resources/views/layouts/menu.blade.php
@@ -244,7 +244,7 @@
                                     <ul class="dropdown-menu scrollable-menu">
                                 @endif
                                         @foreach($custommaps as $map_group => $group_maps)
-                                            @if($map_group)
+                                            @if($map_group && $custommaps->count() > 1)
                                             <li class="dropdown-submenu">
                                             <a><i class="fa fa-map-marked fa-fw fa-lg"aria-hidden="true"></i> {{ $map_group  }}
                                             </a>
@@ -255,7 +255,7 @@
                                                     {{ ucfirst($map->name) }}
                                                 </a></li>
                                             @endforeach
-                                        @if($map_group)</ul></li>@endif
+                                            @if($map_group && $custommaps->count() > 1)</ul></li>@endif
                                         @endforeach
                                 @if($custommaps->count() == 1)
                                     </ul>


### PR DESCRIPTION
I found an error when there is only a single group of custom maps, but the group has a name.  This PR makes the menu work again.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
