### PR TITLE
Feat/enable disabling of alert transporting

### DIFF
--- a/app/Models/Device.php
+++ b/app/Models/Device.php
@@ -47,6 +47,7 @@ class Device extends BaseModel
         'community',
         'cryptoalgo',
         'cryptopass',
+        'disable_alert_transport',
         'disable_notify',
         'disabled',
         'features',

--- a/database/migrations/2025_04_17_181001_add_disable_alert_transport_to_devices_table.php
+++ b/database/migrations/2025_04_17_181001_add_disable_alert_transport_to_devices_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('devices', function (Blueprint $table) {
+            $table->boolean('disable_alert_transport')->default(false);
+            //
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('devices', function (Blueprint $table) {
+            $table->dropColumn('disable_alert_transport');
+        });
+    }
+};

--- a/includes/html/pages/device/edit/device.inc.php
+++ b/includes/html/pages/device/edit/device.inc.php
@@ -193,7 +193,7 @@ $disable_notify = get_dev_attrib($device, 'disable_notify');
     <div class="form-group" title="To set coordinates, include [latitude,longitude]">
         <div class="col-sm-2"></div>
         <div class="col-sm-6">
-          <input id="sysLocation" name="sysLocation" class="form-control"
+            <input id="sysLocation" name="sysLocation" class="form-control"
                 <?php
                 if (! $device_model->override_sysLocation) {
                     echo ' disabled="1"';
@@ -202,29 +202,28 @@ $disable_notify = get_dev_attrib($device, 'disable_notify');
         </div>
     </div>
     <div class="form-group">
-      <label for="override_sysContact" class="col-sm-2 control-label">Override sysContact</label>
-      <div class="col-sm-6">
+        <label for="override_sysContact" class="col-sm-2 control-label">Override sysContact</label>
+        <div class="col-sm-6">
         <input onChange="edit.sysContact.disabled=!edit.override_sysContact.checked" type="checkbox" id="override_sysContact" name="override_sysContact" data-size="small"
-    <?php
-    if ($override_sysContact_bool) {
-        echo ' checked="1"';
-    }
-    ?>
-   />
+            <?php
+            if ($override_sysContact_bool) {
+                echo ' checked="1"';
+            }
+            ?> />
       </div>
     </div>
     <div class="form-group">
-      <div class="col-sm-2">
-      </div>
-      <div class="col-sm-6">
-        <input id="sysContact" class="form-control" name="sysContact" size="32"
-    <?php
-    if (! $override_sysContact_bool) {
-        echo ' disabled="1"';
-    }
-    ?>
-    value="<?php echo htmlentities($override_sysContact_string); ?>" />
-      </div>
+        <div class="col-sm-2"></div>
+        <div class="col-sm-6">
+            <input id="sysContact" class="form-control" name="sysContact" size="32"
+                <?php
+                if (! $override_sysContact_bool) {
+                echo ' disabled="1"';
+                }
+                ?>
+                value="<?php echo htmlentities($override_sysContact_string); ?>"
+                />
+        </div>
     </div>
     <div class="form-group">
         <label for="parent_id" class="col-sm-2 control-label">This device depends on</label>
@@ -253,55 +252,54 @@ $disable_notify = get_dev_attrib($device, 'disable_notify');
             </select>
         </div>
     </div>
-<?php
-if (\LibreNMS\Config::get('distributed_poller') === true) {
-                    ?>
-   <div class="form-group">
-       <label for="poller_group" class="col-sm-2 control-label">Poller Group</label>
-       <div class="col-sm-6">
-           <select name="poller_group" id="poller_group" class="form-control input-sm">
-           <option value="0">General<?=\LibreNMS\Config::get('distributed_poller_group') == 0 ? ' (default Poller)' : ''?></option>
     <?php
-    foreach (dbFetchRows('SELECT `id`,`group_name` FROM `poller_groups` ORDER BY `group_name`') as $group) {
-        echo '<option value="' . $group['id'] . '"' .
-        ($device_model->poller_group == $group['id'] ? ' selected' : '') . '>' . $group['group_name'];
-        echo \LibreNMS\Config::get('distributed_poller_group') == $group['id'] ? ' (default Poller)' : '';
-        echo '</option>';
-    } ?>
+    if (\LibreNMS\Config::get('distributed_poller') === true) {
+    ?>
+    <div class="form-group">
+        <label for="poller_group" class="col-sm-2 control-label">Poller Group</label>
+        <div class="col-sm-6">
+            <select name="poller_group" id="poller_group" class="form-control input-sm">
+            <option value="0">General<?=\LibreNMS\Config::get('distributed_poller_group') == 0 ? ' (default Poller)' : ''?></option>
+            <?php
+            foreach (dbFetchRows('SELECT `id`,`group_name` FROM `poller_groups` ORDER BY `group_name`') as $group) {
+                echo '<option value="' . $group['id'] . '"' .
+                ($device_model->poller_group == $group['id'] ? ' selected' : '') . '>' . $group['group_name'];
+                echo \LibreNMS\Config::get('distributed_poller_group') == $group['id'] ? ' (default Poller)' : '';
+                echo '</option>';
+            } ?>
            </select>
-       </div>
-   </div>
+        </div>
+    </div>
     <?php
-                }//endif
-?>
+    }  # endif
+    ?>
     <div class="form-group">
         <label for="disabled" class="col-sm-2 control-label">Disable polling and alerting</label>
         <div class="col-sm-6">
-          <input name="disabled" type="checkbox" id="disabled" value="1" data-size="small"
-                <?php
-                if ($device_model->disabled) {
-                    echo 'checked=checked';
-                }
-                ?> />
+            <input name="disabled" type="checkbox" id="disabled" value="1" data-size="small"
+            <?php
+            if ($device_model->disabled) {
+                echo 'checked=checked';
+            }
+            ?> />
         </div>
     </div>
     <div class="form-group">
-      <label for="maintenance" class="col-sm-2 control-label"></label>
-      <div class="col-sm-6">
-      <button type="button" id="maintenance" data-device_id="<?php echo $device['device_id']; ?>" <?php echo \LibreNMS\Alert\AlertUtil::isMaintenance($device['device_id']) ? 'disabled class="btn btn-warning"' : 'class="btn btn-success"'?> name="maintenance"><i class="fa fa-wrench"></i> Maintenance Mode</button>
-      </div>
+        <label for="maintenance" class="col-sm-2 control-label"></label>
+        <div class="col-sm-6">
+            <button type="button" id="maintenance" data-device_id="<?php echo $device['device_id']; ?>" <?php echo \LibreNMS\Alert\AlertUtil::isMaintenance($device['device_id']) ? 'disabled class="btn btn-warning"' : 'class="btn btn-success"'?> name="maintenance"><i class="fa fa-wrench"></i> Maintenance Mode</button>
+        </div>
     </div>
-
     <div class="form-group">
-      <label for="disable_notify" class="col-sm-2 control-label">Disable alerting</label>
-      <div class="col-sm-6">
-        <input id="disable_notify" type="checkbox" name="disable_notify" data-size="small"
-                <?php
-                if ($device_model->disable_notify) {
-                    echo 'checked=checked';
-                }
-                ?> />
-      </div>
+        <label for="disable_notify" class="col-sm-2 control-label">Disable alerting</label>
+            <div class="col-sm-6">
+                <input id="disable_notify" type="checkbox" name="disable_notify" data-size="small"
+                    <?php
+                    if ($device_model->disable_notify) {
+                        echo 'checked=checked';
+                    }
+                    ?> />
+        </div>
     </div>
     <div class="form-group">
         <label for="disable_alert_transport" class="col-sm-2 control-label"
@@ -323,7 +321,7 @@ if they are enabled at the corresponding alert rule.">Disable alert transports</
 However, ignore tag can be read in alert rules.
 If `devices.ignore = 0` or `macros.device = 1` condition is is set and ignore alert tag is on, the alert rule won't match.">Ignore alert tag</label>
         <div class="col-sm-6">
-           <input name="ignore" type="checkbox" id="ignore" value="1" data-size="small"
+            <input name="ignore" type="checkbox" id="ignore" value="1" data-size="small"
                 <?php
                 if ($device_model->ignore) {
                     echo 'checked=checked';
@@ -334,7 +332,7 @@ If `devices.ignore = 0` or `macros.device = 1` condition is is set and ignore al
     <div class="form-group">
         <label for="ignore_status" class="col-sm-2 control-label" title="Tag device to ignore Status. It will always be shown as online.">Ignore Device Status</label>
         <div class="col-sm-6">
-           <input name="ignore_status" type="checkbox" id="ignore_status" value="1" data-size="small"
+            <input name="ignore_status" type="checkbox" id="ignore_status" value="1" data-size="small"
                 <?php
                 if ($device_model->ignore_status) {
                     echo 'checked=checked';

--- a/includes/html/pages/device/edit/device.inc.php
+++ b/includes/html/pages/device/edit/device.inc.php
@@ -35,6 +35,7 @@ if (! empty($_POST['editing'])) {
         $device_model->ignore_status = (int) isset($_POST['ignore_status']);
         $device_model->disabled = (int) isset($_POST['disabled']);
         $device_model->disable_notify = (int) isset($_POST['disable_notify']);
+        $device_model->disable_alert_transport = (int) isset($_POST['disable_alert_transport']);
         $device_model->type = $_POST['type'];
         $device_model->overwrite_ip = $_POST['overwrite_ip'];
 
@@ -301,6 +302,21 @@ if (\LibreNMS\Config::get('distributed_poller') === true) {
                 }
                 ?> />
       </div>
+    </div>
+    <div class="form-group">
+        <label for="disable_alert_transport" class="col-sm-2 control-label"
+            title="Tag device to not send any alert messages via configured transports as long as
+this switch is enabled.
+After turning off, an erroneous device may trigger recovery alert messages
+if they are enabled at the corresponding alert rule.">Disable alert transports</label>
+        <div class="col-sm-6">
+            <input id="disable_alert_transport" type="checkbox" name="disable_alert_transport" data-size="small"
+                <?php
+                if ($device_model->disable_alert_transport) {
+                    echo 'checked=checked';
+                }
+                ?> />
+        </div>
     </div>
     <div class="form-group">
         <label for="ignore" class="col-sm-2 control-label" title="Tag device to ignore alerts. Alert checks will still run.

--- a/misc/db_schema.yaml
+++ b/misc/db_schema.yaml
@@ -647,6 +647,7 @@ devices:
     - { Field: max_depth, Type: int, 'Null': false, Extra: '', Default: '0' }
     - { Field: disable_notify, Type: tinyint, 'Null': false, Extra: '', Default: '0' }
     - { Field: ignore_status, Type: tinyint, 'Null': false, Extra: '', Default: '0' }
+    - { Field: disable_alert_transport, Type: tinyint, 'Null': false, Extra: '', Default: '0' }
   Indexes:
     PRIMARY: { Name: PRIMARY, Columns: [device_id], Unique: true, Type: BTREE }
     devices_hostname_sysname_display_index: { Name: devices_hostname_sysname_display_index, Columns: [hostname, sysName, display], Unique: false, Type: BTREE }


### PR DESCRIPTION
Often enough, a device is affected by some kind of maintenance(*) and will therefore probably go offline one or a few times, but is not down all the time. We want to log all these errors including the recovery, but any alerting messages via mail, chat etc. would be no help at all.

Another scenario is simply: You do not want transports for a very specific device but somehow can’t exclude it from an alert rule (because the include mechanism is already used or whatever). Or you simply don’t want to duplicate dozens of rules …

Thus we need a mechanism to only suppress alert transports for a single device. This PR introduces a switch similar to the ones for "Disable Alerting" etc. It prevents any alert transport but still allows for recovery alert message *after* the alert transport disabling has been turned off again.


**Screenshots:**

![Screenshot 1](https://github.com/user-attachments/assets/c6d5ad8c-1b80-416d-b8ac-91218f12e86e)
![Screenshot 2](https://github.com/user-attachments/assets/e9741949-165a-4509-a739-25921e720fe3)


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
