### PR TITLE
Alter the custom map menu to allow it to scale to a larger number of maps and groups

### DIFF
--- a/app/Http/Controllers/Maps/CustomMapController.php
+++ b/app/Http/Controllers/Maps/CustomMapController.php
@@ -45,15 +45,9 @@ class CustomMapController extends Controller
         $this->authorizeResource(CustomMap::class, 'map');
     }
 
-    public function index(Request $request): View
+    public function index(): View
     {
-        $request->validate([
-            'list' => 'boolean',
-        ]);
-
-        $blade = $request->boolean('list') ? 'map.custom-list' : 'map.custom-manage';
-
-        return view($blade, [
+        return view('map.custom-manage', [
             'maps' => CustomMap::orderBy('name')->get(['custom_map_id', 'name', 'menu_group'])->groupBy('menu_group')->sortKeys(),
             'name' => 'New Map',
             'menu_group' => null,

--- a/app/Http/Controllers/Maps/CustomMapController.php
+++ b/app/Http/Controllers/Maps/CustomMapController.php
@@ -45,9 +45,15 @@ class CustomMapController extends Controller
         $this->authorizeResource(CustomMap::class, 'map');
     }
 
-    public function index(): View
+    public function index(Request $request): View
     {
-        return view('map.custom-manage', [
+        $request->validate([
+            'list' => 'boolean',
+        ]);
+
+        $blade = $request->boolean('list') ? 'map.custom-list' : 'map.custom-manage';
+
+        return view($blade, [
             'maps' => CustomMap::orderBy('name')->get(['custom_map_id', 'name', 'menu_group'])->groupBy('menu_group')->sortKeys(),
             'name' => 'New Map',
             'menu_group' => null,

--- a/app/Http/Controllers/Maps/CustomMapListController.php
+++ b/app/Http/Controllers/Maps/CustomMapListController.php
@@ -39,7 +39,7 @@ class CustomMapListController extends Controller
 
         return view('map.custom-list', [
             'maps' => CustomMap::hasAccess($request->user())->orderBy('name')->get(['custom_map_id', 'name', 'menu_group'])->groupBy('menu_group')->sortKeys(),
-            'group' => $group,
+            'open_group' => $group,
         ]);
     }
 }

--- a/app/Http/Controllers/Maps/CustomMapListController.php
+++ b/app/Http/Controllers/Maps/CustomMapListController.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * CustomMapListController.php
+ *
+ * Controller for listing custom maps
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * @link       https://www.librenms.org
+ *
+ * @copyright  2025 Steven Wilton
+ * @author     Steven Wilton <swilton@fluentit.au>
+ */
+
+namespace App\Http\Controllers\Maps;
+
+use App\Http\Controllers\Controller;
+use App\Models\CustomMap;
+use Illuminate\Contracts\View\View;
+use Illuminate\Http\Request;
+
+class CustomMapListController extends Controller
+{
+    public function index(Request $request, string $group = ''): View
+    {
+        return view('map.custom-list', [
+            'maps' => CustomMap::hasAccess($request->user())->orderBy('name')->get(['custom_map_id', 'name', 'menu_group'])->groupBy('menu_group')->sortKeys(),
+            'group' => $group,
+        ]);
+    }
+}

--- a/app/Http/Controllers/Maps/CustomMapListController.php
+++ b/app/Http/Controllers/Maps/CustomMapListController.php
@@ -33,8 +33,10 @@ use Illuminate\Http\Request;
 
 class CustomMapListController extends Controller
 {
-    public function index(Request $request, string $group = ''): View
+    public function index(Request $request): View
     {
+        $group = $request->input('group') ?? '';
+
         return view('map.custom-list', [
             'maps' => CustomMap::hasAccess($request->user())->orderBy('name')->get(['custom_map_id', 'name', 'menu_group'])->groupBy('menu_group')->sortKeys(),
             'group' => $group,

--- a/resources/views/components/accordion/index.blade.php
+++ b/resources/views/components/accordion/index.blade.php
@@ -1,0 +1,5 @@
+@props(['accordionId'])
+
+<div {{ $attributes->merge(['class' => 'accordion']) }} id="accordion{{$accordionId}}">
+    {{ $slot }}
+</div>

--- a/resources/views/components/accordion/index.blade.php
+++ b/resources/views/components/accordion/index.blade.php
@@ -1,5 +1,5 @@
 @props(['accordionId'])
 
-<div {{ $attributes->merge(['class' => 'accordion']) }} id="accordion{{$accordionId}}">
+<div id="accordion{{$accordionId}}">
     {{ $slot }}
 </div>

--- a/resources/views/components/accordion/item.blade.php
+++ b/resources/views/components/accordion/item.blade.php
@@ -1,21 +1,23 @@
 @aware(['accordionId'])
 @props(['id', 'title', 'open' => false])
 
-<div class="accordion-header">
-    <button class="accordion-toggle" type="button" data-toggle="collapse" data-target="#collapse{{$id}}" onClick="$('#accordionPM{{$id}}').toggleClass('fa-minus').toggleClass('fa-plus');">
-        @if($open)
-        <span id="accordionPM{{$id}}" class="fa fa-minus"></span>{!! $title !!}
-        @else
-        <span id="accordionPM{{$id}}" class="fa fa-plus"></span>{!! $title !!}
-        @endif
-    </button>
-</div>
+<div class="panel panel-default">
+    <div class="panel-heading accordion-header">
+        <button class="accordion-toggle" type="button" data-toggle="collapse" data-target="#collapse{{$id}}" onClick="$('#accordionPM{{$id}}').toggleClass('fa-minus').toggleClass('fa-plus');">
+            @if($open)
+            <span id="accordionPM{{$id}}" class="fa fa-minus"></span>{!! $title !!}
+            @else
+            <span id="accordionPM{{$id}}" class="fa fa-plus"></span>{!! $title !!}
+            @endif
+        </button>
+    </div>
 @if($open)
-<div class="accordion-body collapse in" id="collapse{{$id}}" aria-expanded="true">
-    {{ $slot }}
-</div>
+    <div class="panel-body accordion-body collapse in" id="collapse{{$id}}" aria-expanded="true">
+        {{ $slot }}
+    </div>
 @else
-<div class="accordion-body collapse" id="collapse{{$id}}">
-    {{ $slot }}
-</div>
+    <div class="panel-body accordion-body collapse" id="collapse{{$id}}">
+        {{ $slot }}
+    </div>
 @endif
+</div class="panel panel-default">

--- a/resources/views/components/accordion/item.blade.php
+++ b/resources/views/components/accordion/item.blade.php
@@ -1,0 +1,15 @@
+@aware(['accordionId'])
+@props(['id', 'title'])
+
+<div class="accordion-item">
+    <h3 class="accordion-header">
+        <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapse{{$id}}" aria-expanded="true" aria-controls="collapse{{$id}}">
+            {{ $title }}
+        </button>
+    </h3>
+    <div class="accordion-collapse collapse" id="collapse{{$id}}" data-bs-parent="#accordion{{$accordionId}}">
+        <div class="accordion-body">
+            {{ $slot }}
+        </div>
+    </div>
+</div>

--- a/resources/views/components/accordion/item.blade.php
+++ b/resources/views/components/accordion/item.blade.php
@@ -1,15 +1,21 @@
 @aware(['accordionId'])
-@props(['id', 'title'])
+@props(['id', 'title', 'open' => false])
 
-<div class="accordion-item">
-    <h3 class="accordion-header">
-        <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapse{{$id}}" aria-expanded="true" aria-controls="collapse{{$id}}">
-            {{ $title }}
-        </button>
-    </h3>
-    <div class="accordion-collapse collapse" id="collapse{{$id}}" data-bs-parent="#accordion{{$accordionId}}">
-        <div class="accordion-body">
-            {{ $slot }}
-        </div>
-    </div>
+<div class="accordion-header">
+    <button class="accordion-toggle" type="button" data-toggle="collapse" data-target="#collapse{{$id}}" onClick="$('#accordionPM{{$id}}').toggleClass('fa-minus').toggleClass('fa-plus');">
+        @if($open)
+        <span id="accordionPM{{$id}}" class="fa fa-minus"></span>{!! $title !!}
+        @else
+        <span id="accordionPM{{$id}}" class="fa fa-plus"></span>{!! $title !!}
+        @endif
+    </button>
 </div>
+@if($open)
+<div class="accordion-body collapse in" id="collapse{{$id}}" aria-expanded="true">
+    {{ $slot }}
+</div>
+@else
+<div class="accordion-body collapse" id="collapse{{$id}}">
+    {{ $slot }}
+</div>
+@endif

--- a/resources/views/layouts/menu.blade.php
+++ b/resources/views/layouts/menu.blade.php
@@ -234,28 +234,42 @@
 
                         @if($custommaps->isNotEmpty())
                             <li role="presentation" class="divider"></li>
-                                @if($custommaps->count() == 1)
-                                <li class="dropdown-submenu"><a><i class="fa fa-th fa-fw fa-lg" aria-hidden="true"></i> {{__('Custom Maps') }}</a>
-                                    <ul class="dropdown-menu scrollable-menu">
-                                @endif
-                                        @foreach($custommaps as $map_group => $group_maps)
-                                            @if($map_group && $custommaps->count() > 1)
-                                            <li class="dropdown-submenu">
-                                            <a><i class="fa fa-map-marked fa-fw fa-lg"aria-hidden="true"></i> {{ $map_group  }}
-                                            </a>
-                                                <ul class="dropdown-menu scrollable-menu">
-                                            @endif
-                                            @foreach($group_maps as $map)
-                                            <li><a href="{{ route('maps.custom.show', ['map' => $map->custom_map_id]) }}"><i class="fa fa-map-marked fa-fw fa-lg" aria-hidden="true"></i>
-                                                    {{ ucfirst($map->name) }}
-                                                </a></li>
-                                            @endforeach
-                                            @if($map_group && $custommaps->count() > 1)</ul></li>@endif
+                            @if($custommaps->count() == 1)
+                            <li class="dropdown-submenu"><a><i class="fa fa-th fa-fw fa-lg" aria-hidden="true"></i> {{__('Custom Maps') }}</a>
+                                <ul class="dropdown-menu scrollable-menu">
+                                    @foreach($custommaps as $map_group => $group_maps)
+                                        @foreach($group_maps as $map)
+                                        <li><a href="{{ route('maps.custom.show', ['map' => $map->custom_map_id]) }}"><i class="fa fa-map-marked fa-fw fa-lg" aria-hidden="true"></i>
+                                            {{ ucfirst($map->name) }}
+                                        </a></li>
                                         @endforeach
-                                @if($custommaps->count() == 1)
+                                    @endforeach
+                                </ul>
+                            </li>
+                            @elseif($custommaps->count() < 20)
+                                @foreach($custommaps as $map_group => $group_maps)
+                                <li class="dropdown-submenu">
+                                    <a><i class="fa fa-map-marked fa-fw fa-lg"aria-hidden="true"></i> {{ $map_group  }}</a>
+                                    <ul class="dropdown-menu scrollable-menu">
+                                    @foreach($group_maps as $map)
+                                    <li><a href="{{ route('maps.custom.show', ['map' => $map->custom_map_id]) }}"><i class="fa fa-map-marked fa-fw fa-lg" aria-hidden="true"></i>
+                                        {{ ucfirst($map->name) }}
+                                    </a></li>
+                                    @endforeach
                                     </ul>
                                 </li>
-                                @endif
+                                @endforeach
+                            @else
+                            <li class="dropdown-submenu"><a><i class="fa fa-th fa-fw fa-lg" aria-hidden="true"></i> {{__('Custom Maps') }}</a>
+                                <ul class="dropdown-menu scrollable-menu">
+                                    @foreach($custommaps as $map_group => $group_maps)
+                                        <li><a href="{{ route('maps.custom.list', ['group' => $map_group]) }}"><i class="fa fa-map-marked fa-fw fa-lg" aria-hidden="true"></i>
+                                            {{ ucfirst($map_group) }}
+                                        </a></li>
+                                    @endforeach
+                                </ul>
+                            </li>
+                            @endif
                         @endif
                         @admin
                         <li role="presentation" class="divider"></li>

--- a/resources/views/layouts/menu.blade.php
+++ b/resources/views/layouts/menu.blade.php
@@ -260,7 +260,7 @@
                                 </li>
                                 @endforeach
                             @else
-                            <li class="dropdown-submenu"><a><i class="fa fa-th fa-fw fa-lg" aria-hidden="true"></i> {{__('Custom Maps') }}</a>
+                            <li class="dropdown-submenu"><a href="{{ route('maps.custom.list') }}"><i class="fa fa-th fa-fw fa-lg" aria-hidden="true"></i> {{__('Custom Maps') }}</a>
                                 <ul class="dropdown-menu scrollable-menu">
                                     @foreach($custommaps as $map_group => $group_maps)
                                         <li><a href="{{ route('maps.custom.list', ['group' => $map_group]) }}"><i class="fa fa-map-marked fa-fw fa-lg" aria-hidden="true"></i>

--- a/resources/views/map/custom-list.blade.php
+++ b/resources/views/map/custom-list.blade.php
@@ -21,7 +21,7 @@
                         <div class="tw:flex tw:justify-between tw:p-3 tw:items-center tw:hover:bg-gray-100 tw:dark:hover:bg-gray-600">
                             <div>
                                 <i class="fa fa-map-marked fa-fw fa-lg" aria-hidden="true"></i>
-                                <a href="{{ route('maps.custom.show', $map->custom_map_id) }}">{{ $map->name }}</a>
+                                <a href="{{ route('maps.custom.show', $map->custom_map_id) }}">{!! $map->name !!}</a>
                             </div>
                         </div>
                     </div>

--- a/resources/views/map/custom-list.blade.php
+++ b/resources/views/map/custom-list.blade.php
@@ -1,0 +1,34 @@
+@extends('layouts.librenmsv1')
+
+@section('title', __('Custom Maps'))
+
+@section('content')
+<div class="tw:px-3 tw:sm:px-6 tw:mx-auto">
+    <x-panel id="manage-custom-maps" body-class="tw:pb-0!" class="tw:mx-auto tw:max-w-(--breakpoint-lg)">
+        <x-slot name="title">
+            <div class="tw:flex tw:justify-between tw:items-center">
+                <div>
+                    {{ __('Custom Maps') }}
+                </div>
+            </div>
+        </x-slot>
+
+        <x-accordion accordionId="CustomMapGroups">
+            @foreach($maps as $group_name => $group)
+                <x-accordion.item title="{{$group_name ?? 'Custom Maps'}}" id="{{uniqid()}}">
+                @foreach($group as $map)
+                    <div id="map-{{ $map->custom_map_id }}" class="tw:even:bg-gray-50 tw:dark:even:bg-zinc-900">
+                        <div class="tw:flex tw:justify-between tw:p-3 tw:items-center tw:hover:bg-gray-100 tw:dark:hover:bg-gray-600">
+                            <div>
+                                <i class="fa fa-map-marked fa-fw fa-lg" aria-hidden="true"></i>
+                                <a href="{{ route('maps.custom.show', $map->custom_map_id) }}">{{ $map->name }}</a>
+                            </div>
+                        </div>
+                    </div>
+                @endforeach
+                </x-accordion.item>
+            @endforeach
+        </x-accordion>
+    </x-panel>
+</div>
+@endsection

--- a/resources/views/map/custom-list.blade.php
+++ b/resources/views/map/custom-list.blade.php
@@ -15,7 +15,7 @@
 
         <x-accordion accordionId="CustomMapGroups">
             @foreach($maps as $group_name => $group)
-                <x-accordion.item title="{{$group_name ?? 'Custom Maps'}}" id="{{uniqid()}}" open="{{($open_group == $group_name) || (count($maps) == 1)}}">
+                <x-accordion.item title="{{$group_name ?: 'Ungrouped'}}" id="{{uniqid()}}" open="{{($open_group == $group_name) || (count($maps) == 1)}}">
                 @foreach($group as $map)
                     <div id="map-{{ $map->custom_map_id }}" class="tw:even:bg-gray-50 tw:dark:even:bg-zinc-900">
                         <div class="tw:flex tw:justify-between tw:p-3 tw:items-center tw:hover:bg-gray-100 tw:dark:hover:bg-gray-600">

--- a/resources/views/map/custom-list.blade.php
+++ b/resources/views/map/custom-list.blade.php
@@ -15,7 +15,7 @@
 
         <x-accordion accordionId="CustomMapGroups">
             @foreach($maps as $group_name => $group)
-                <x-accordion.item title="{{$group_name ?? 'Custom Maps'}}" id="{{uniqid()}}">
+                <x-accordion.item title="{{$group_name ?? 'Custom Maps'}}" id="{{uniqid()}}" open="{{($open_group == $group_name) || (count($maps) == 1)}}">
                 @foreach($group as $map)
                     <div id="map-{{ $map->custom_map_id }}" class="tw:even:bg-gray-50 tw:dark:even:bg-zinc-900">
                         <div class="tw:flex tw:justify-between tw:p-3 tw:items-center tw:hover:bg-gray-100 tw:dark:hover:bg-gray-600">

--- a/resources/views/map/custom-list.blade.php
+++ b/resources/views/map/custom-list.blade.php
@@ -32,3 +32,14 @@
     </x-panel>
 </div>
 @endsection
+
+@section('scripts')
+<script type="text/javascript">
+    $(document).ready(async function () {
+        scrollTo = document.getElementById("accordionCustomMapGroups").querySelector("div.accordion-header span.fa-minus");
+        if(scrollTo != null) {
+            scrollTo.scrollIntoView({block: "center"})
+        };
+    });
+</script>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -132,7 +132,7 @@ Route::middleware(['auth'])->group(function () {
         Route::post('custom/{map}/background', [CustomMapBackgroundController::class, 'save'])->name('maps.custom.background.save');
         Route::get('custom/{map}/data', [CustomMapDataController::class, 'get'])->name('maps.custom.data');
         Route::post('custom/{map}/data', [CustomMapDataController::class, 'save'])->name('maps.custom.data.save');
-        Route::get('customlist/{group?}', [CustomMapListController::class, 'index'])->name('maps.custom.list');
+        Route::get('customlist', [CustomMapListController::class, 'index'])->name('maps.custom.list');
         Route::get('devicedependency', [DeviceDependencyController::class, 'dependencyMap']);
         Route::post('getdevices', [Maps\MapDataController::class, 'getDevices'])->name('maps.getdevices');
         Route::post('getdevicelinks', [Maps\MapDataController::class, 'getDeviceLinks'])->name('maps.getdevicelinks');

--- a/routes/web.php
+++ b/routes/web.php
@@ -19,6 +19,7 @@ use App\Http\Controllers\Maps;
 use App\Http\Controllers\Maps\CustomMapBackgroundController;
 use App\Http\Controllers\Maps\CustomMapController;
 use App\Http\Controllers\Maps\CustomMapDataController;
+use App\Http\Controllers\Maps\CustomMapListController;
 use App\Http\Controllers\Maps\CustomMapNodeImageController;
 use App\Http\Controllers\Maps\DeviceDependencyController;
 use App\Http\Controllers\NacController;
@@ -131,6 +132,7 @@ Route::middleware(['auth'])->group(function () {
         Route::post('custom/{map}/background', [CustomMapBackgroundController::class, 'save'])->name('maps.custom.background.save');
         Route::get('custom/{map}/data', [CustomMapDataController::class, 'get'])->name('maps.custom.data');
         Route::post('custom/{map}/data', [CustomMapDataController::class, 'save'])->name('maps.custom.data.save');
+        Route::get('customlist/{group?}', [CustomMapListController::class, 'index'])->name('maps.custom.list');
         Route::get('devicedependency', [DeviceDependencyController::class, 'dependencyMap']);
         Route::post('getdevices', [Maps\MapDataController::class, 'getDevices'])->name('maps.getdevices');
         Route::post('getdevicelinks', [Maps\MapDataController::class, 'getDeviceLinks'])->name('maps.getdevicelinks');


### PR DESCRIPTION
The map menu does not scale when the number of custom map groups grows too large.  The issue is that the "Maps" menu cannot be made to scroll because it has sub-menus (scrollable menus are incompatible with sub-menus).

The plan is to do the following:
 - When the number of custom map groups grows beyond 20, change the "Maps" menu to have a single "Custom Maps" entry with the custom maps in the sub-menu.  (This is instead of having the group name in the "Maps" menu and the maps in the sub-menu"
 - Create a new view to list custom maps, using an accordion control to collapse the maps into the group

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
