### PR TITLE
Hide sensor observer output during tests

### DIFF
--- a/app/Observers/SensorObserver.php
+++ b/app/Observers/SensorObserver.php
@@ -11,16 +11,16 @@ use LibreNMS\Enum\Severity;
 
 class SensorObserver
 {
-    private bool $runningInConsole;
+    private bool $consoleOutputEnabled;
 
     public function __construct(Application $app)
     {
-        $this->runningInConsole = $app->runningInConsole();
+        $this->consoleOutputEnabled = $app->runningInConsole() && ! $app->runningUnitTests();
     }
 
     public function saving(Sensor $sensor): void
     {
-        if ($this->runningInConsole && ! $sensor->isDirty()) {
+        if ($this->consoleOutputEnabled && ! $sensor->isDirty()) {
             echo '.';
         }
     }
@@ -58,7 +58,7 @@ class SensorObserver
         Eventlog::log('Sensor Added: ' . $sensor->sensor_class . ' ' . $sensor->sensor_type . ' ' . $sensor->sensor_index . ' ' . $sensor->sensor_descr, $sensor->device_id, 'sensor', Severity::Notice, $sensor->sensor_id);
         Log::info("$sensor->sensor_descr: Cur $sensor->sensor_current, Low: $sensor->sensor_limit_low, Low Warn: $sensor->sensor_limit_low_warn, Warn: $sensor->sensor_limit_warn, High: $sensor->sensor_limit");
 
-        if ($this->runningInConsole) {
+        if ($this->consoleOutputEnabled) {
             echo '+';
         }
     }
@@ -102,7 +102,7 @@ class SensorObserver
             if ($sensor->isDirty('sensor_limit')) {
                 Eventlog::log('Sensor High Limit Updated: ' . $sensor->sensor_class . ' ' . $sensor->sensor_type . ' ' . $sensor->sensor_index . ' ' . $sensor->sensor_descr . ' (' . $sensor->sensor_limit . ')', $sensor->device_id, 'sensor', Severity::Notice, $sensor->sensor_id);
 
-                if ($this->runningInConsole) {
+                if ($this->consoleOutputEnabled) {
                     echo 'H';
                 }
             }
@@ -110,7 +110,7 @@ class SensorObserver
             if ($sensor->isDirty('sensor_limit_low')) {
                 Eventlog::log('Sensor Low Limit Updated: ' . $sensor->sensor_class . ' ' . $sensor->sensor_type . ' ' . $sensor->sensor_index . ' ' . $sensor->sensor_descr . ' (' . $sensor->sensor_limit_low . ')', $sensor->device_id, 'sensor', Severity::Notice, $sensor->sensor_id);
 
-                if ($this->runningInConsole) {
+                if ($this->consoleOutputEnabled) {
                     echo 'L';
                 }
             }
@@ -118,7 +118,7 @@ class SensorObserver
             if ($sensor->isDirty('sensor_limit_warn')) {
                 Eventlog::log('Sensor Warn High Limit Updated: ' . $sensor->sensor_class . ' ' . $sensor->sensor_type . ' ' . $sensor->sensor_index . ' ' . $sensor->sensor_descr . ' (' . $sensor->sensor_limit_warn . ')', $sensor->device_id, 'sensor', Severity::Notice, $sensor->sensor_id);
 
-                if ($this->runningInConsole) {
+                if ($this->consoleOutputEnabled) {
                     echo 'WH';
                 }
             }
@@ -126,13 +126,13 @@ class SensorObserver
             if ($sensor->isDirty('sensor_limit_low_warn')) {
                 Eventlog::log('Sensor Warn Low Limit Updated: ' . $sensor->sensor_class . ' ' . $sensor->sensor_type . ' ' . $sensor->sensor_index . ' ' . $sensor->sensor_descr . ' (' . $sensor->sensor_limit_low_warn . ')', $sensor->device_id, 'sensor', Severity::Notice, $sensor->sensor_id);
 
-                if ($this->runningInConsole) {
+                if ($this->consoleOutputEnabled) {
                     echo 'WL';
                 }
             }
         }
 
-        if ($this->runningInConsole) {
+        if ($this->consoleOutputEnabled) {
             echo 'U';
         }
 
@@ -144,7 +144,7 @@ class SensorObserver
 
     public function deleted(): void
     {
-        if ($this->runningInConsole) {
+        if ($this->consoleOutputEnabled) {
             echo '-';
         }
     }


### PR DESCRIPTION
Fixed by @Jellyfrog #17509

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
