### PR TITLE
Modified Devices API end-point to mirror the Ports behavior

### DIFF
--- a/doc/API/Devices.md
+++ b/doc/API/Devices.md
@@ -1,3 +1,56 @@
+### `get_all_devices`
+
+Get all devices.
+
+Route: `/api/v0/devices`
+
+  -
+
+Input:
+
+- columns: Comma separated list of columns you want returned.
+
+Example:
+
+```curl
+curl -H 'X-Auth-Token: YOURAPITOKENHERE' https://librenms.org/api/v0/devices?columns=device_id%2Chostname%2Cip%2CsysName
+```
+
+Output:
+
+```json
+{
+  "status": "ok",
+  "devices": [
+    {
+      "device_id": 2,
+      "hostname": "10.10.10.2",
+      "ip": "10.10.10.5",
+      "sysName": "host_02"
+    },
+    {
+      "device_id": 3,
+      "hostname": "10.10.10.3",
+      "ip": "10.10.10.6",
+      "sysName": "host_03"
+    },
+    {
+      "device_id": 4,
+      "hostname": "10.10.10.4",
+      "ip": "10.10.10.4",
+      "sysName": "host_04"
+    },
+    ...
+    {
+      "device_id": 5,
+      "hostname": "10.10.10.5",
+      "ip": "10.10.10.5",
+      "sysName": "host_05"
+    }
+    ]
+}
+```
+
 ### `del_device`
 
 Delete a given device.
@@ -1097,7 +1150,7 @@ Output:
 
 Return a list of devices.
 
-Route: `/api/v0/devices`
+Route: `/api/v0/devices/list_devices`
 
 Input:
 
@@ -1126,7 +1179,7 @@ Input:
 Example:
 
 ```curl
-curl -H 'X-Auth-Token: YOURAPITOKENHERE' https://librenms.org/api/v0/devices?order=hostname%20DESC&type=down
+curl -H 'X-Auth-Token: YOURAPITOKENHERE' https://librenms.org/api/v0/devices/list_devices?order=hostname%20DESC&type=down
 ```
 
 Output:
@@ -1150,7 +1203,7 @@ Output:
 Example:
 
 ```curl
-curl -H 'X-Auth-Token: YOURAPITOKENHERE' https://librenms.org/api/v0/devices?type=mac&query=00000c9ff013
+curl -H 'X-Auth-Token: YOURAPITOKENHERE' https://librenms.org/api/v0/devices/list_devices?type=mac&query=00000c9ff013
 ```
 
 Output:
@@ -1626,7 +1679,7 @@ from `list_devices`.  See that entry point for more detailed information.
 Example:
 
 ```curl
-curl -H 'X-Auth-Token: YOURAPITOKENHERE' 'http://librenms.org/api/v0/devices?type=device_id&query=34'
+curl -H 'X-Auth-Token: YOURAPITOKENHERE' 'http://librenms.org/api/v0/devices/list_devices?type=device_id&query=34'
 ```
 
 Output:

--- a/doc/API/index.md
+++ b/doc/API/index.md
@@ -50,12 +50,12 @@ combination of two or three of these.
   devices details you will pass the hostname of the device in the route: `/api/v0/devices/:hostname`.
 - Passing parameters via the query string. For example you can list
   all devices on your install but limit the output to devices that are
-  currently down: `/api/v0/devices?type=down`
+  currently down: `/api/v0/devices/list_devices?type=down`
 - Passing data in via JSON, this will mainly be used when adding or
   updating information via the API, for instance adding a new device:
 
 ```curl
-curl -X POST -d '{"hostname":"localhost.localdomain","version":"v1","community":"public"}' -H 'X-Auth-Token: YOURAPITOKENHERE' https://librenms.org/api/v0/devices
+curl -X POST -d '{"hostname":"localhost.localdomain","version":"v1","community":"public"}' -H 'X-Auth-Token: YOURAPITOKENHERE' https://librenms.org/api/v0/devices/list_devices
 ```
 
 ## Output

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -404,6 +404,17 @@ function list_devices(Illuminate\Http\Request $request)
     return api_success($devices, 'devices');
 }
 
+function get_all_devices(Illuminate\Http\Request $request): JsonResponse
+{
+    $columns = validate_column_list($request->get('columns'), 'devices', ['device_id', 'hostname', 'ip', 'sysName']);
+
+    $devices = Device::hasAccess(Auth::user())
+        ->select($columns)
+        ->get();
+
+    return api_success($devices, 'devices');
+}
+
 function add_device(Illuminate\Http\Request $request)
 {
     // This will add a device using the data passed encoded with json

--- a/routes/api.php
+++ b/routes/api.php
@@ -108,6 +108,7 @@ Route::prefix('v0')->group(function () {
 
     // restricted by access
     Route::prefix('devices')->group(function () {
+        Route::get('list_devices', [\App\Api\Controllers\LegacyApiController::class, 'list_devices'])->name('list_devices');
         Route::get('{hostname}', [\App\Api\Controllers\LegacyApiController::class, 'get_device'])->name('get_device');
         Route::get('{hostname}/discover', [\App\Api\Controllers\LegacyApiController::class, 'trigger_device_discovery'])->name('trigger_device_discovery');
         Route::get('{hostname}/availability', [\App\Api\Controllers\LegacyApiController::class, 'device_availability'])->name('device_availability');
@@ -132,8 +133,8 @@ Route::prefix('v0')->group(function () {
         Route::get('{hostname}/ports/{ifname}/{type}', [\App\Api\Controllers\LegacyApiController::class, 'get_graph_by_port_hostname'])->name('get_graph_by_port_hostname');
         Route::get('{hostname}/services/{id}/graphs/{datasource}', [\App\Api\Controllers\LegacyApiController::class, 'get_graph_by_service'])->name('get_graph_by_service');
 
-        Route::get('{hostname}/{type}', [\App\Api\Controllers\LegacyApiController::class, 'get_graph_generic_by_hostname'])->name('get_graph_generic_by_hostname');
-        Route::get('', [\App\Api\Controllers\LegacyApiController::class, 'list_devices'])->name('list_devices');
+	Route::get('{hostname}/{type}', [\App\Api\Controllers\LegacyApiController::class, 'get_graph_generic_by_hostname'])->name('get_graph_generic_by_hostname');
+	Route::get('', [\App\Api\Controllers\LegacyApiController::class, 'get_all_devices'])->name('get_all_devices');
     });
 
     Route::prefix('ports')->group(function () {

--- a/routes/api.php
+++ b/routes/api.php
@@ -133,8 +133,8 @@ Route::prefix('v0')->group(function () {
         Route::get('{hostname}/ports/{ifname}/{type}', [\App\Api\Controllers\LegacyApiController::class, 'get_graph_by_port_hostname'])->name('get_graph_by_port_hostname');
         Route::get('{hostname}/services/{id}/graphs/{datasource}', [\App\Api\Controllers\LegacyApiController::class, 'get_graph_by_service'])->name('get_graph_by_service');
 
-	Route::get('{hostname}/{type}', [\App\Api\Controllers\LegacyApiController::class, 'get_graph_generic_by_hostname'])->name('get_graph_generic_by_hostname');
-	Route::get('', [\App\Api\Controllers\LegacyApiController::class, 'get_all_devices'])->name('get_all_devices');
+        Route::get('{hostname}/{type}', [\App\Api\Controllers\LegacyApiController::class, 'get_graph_generic_by_hostname'])->name('get_graph_generic_by_hostname');
+        Route::get('', [\App\Api\Controllers\LegacyApiController::class, 'get_all_devices'])->name('get_all_devices');
     });
 
     Route::prefix('ports')->group(function () {

--- a/tests/BasicApiTest.php
+++ b/tests/BasicApiTest.php
@@ -42,7 +42,7 @@ class BasicApiTest extends DBTestCase
         $token = ApiToken::generateToken($user);
         $device = Device::factory()->create();
 
-        $this->json('GET', '/api/v0/devices', [], ['X-Auth-Token' => $token->token_hash])
+        $this->json('GET', '/api/v0/devices/list_devices', [], ['X-Auth-Token' => $token->token_hash])
             ->assertStatus(200)
             ->assertJson([
                 'status' => 'ok',


### PR DESCRIPTION
 (with columns). Moved /devices Route to /devices/list_devices

Please give a short description what your pull request is for

Make the `api/v0/ports` and `api/v0/devices` endpoints have similar behavior.  
Move the current `api/v0/devices` to `api/v0/devices/list_devices`. 

- `api/v0/ports` calls `get_all_ports()` (no change).

- `api/v0/devices` would now call `get_all_devices()` with the same `?columns=` filtering option  (`api/v0/devices?columns=sysName`) that the `api/v0/ports` endpoint uses.

- `api/v0/devices/list_devices` would now call `list_devices()` (no change to behavior, just a new route).


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
