### PR TITLE
Fixed error message when saving max repeaters and oids

### DIFF
--- a/includes/html/pages/device/edit/snmp.inc.php
+++ b/includes/html/pages/device/edit/snmp.inc.php
@@ -89,6 +89,7 @@ if (isset($_POST['editing'])) {
                 }
 
                 $get_devices_attrib = get_dev_attrib($device, $devices_attrib);
+                
                 $set_devices_attrib = false; // testing $set_devices_attrib === false is not a true indicator of a failure
 
                 if ($form_value != $get_devices_attrib && $form_value_is_numeric && is_numeric($form_value) && $form_value != 0) {
@@ -107,10 +108,8 @@ if (isset($_POST['editing'])) {
                     $device->forgetAttrib($devices_attrib);
                 }
 
-                if ($form_value != $get_devices_attrib && $set_devices_attrib) {
-                    unset($device->attribs); // unload relation
-                    $set_devices_attrib = $device->getAttrib($devices_attrib); // re-check the db value
-                }
+                unset($device->attribs); // unload relation
+                $set_devices_attrib = $device->getAttrib($devices_attrib); // re-check the db value
 
                 if ($form_value != $get_devices_attrib && $form_value == $set_devices_attrib && (is_null($set_devices_attrib) || $set_devices_attrib == '')) {
                     $update_message[] = "$feedback_prefix deleted";


### PR DESCRIPTION
I've tested saving the devices_attribs values and snmp values and this no longer errors like it did before. Can't find any unexpected issues from the change.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
