### PR TITLE
[arp-table] fix for pure IPv6 network

### DIFF
--- a/includes/discovery/arp-table.inc.php
+++ b/includes/discovery/arp-table.inc.php
@@ -58,7 +58,7 @@ foreach (DeviceCache::getPrimary()->getVrfContexts() as $context_name) {
 
         $port_arp = array_merge(
             Arr::wrap($data['IP-MIB::ipNetToMediaPhysAddress'] ?? []),
-            isset($data['IP-MIB::ipNetToPhysicalPhysAddress']) && is_array($data['IP-MIB::ipNetToPhysicalPhysAddress']) ? (array) $data['IP-MIB::ipNetToPhysicalPhysAddress']['ipv4'] : []
+            (! empty($data['IP-MIB::ipNetToPhysicalPhysAddress']['ipv4']) && is_array($data['IP-MIB::ipNetToPhysicalPhysAddress']['ipv4'])) ? (array) $data['IP-MIB::ipNetToPhysicalPhysAddress']['ipv4'] : [],
         );
 
         echo "{$interface['ifName']}: \n";


### PR DESCRIPTION
in pure IPv6 network, arp-table will fail because there is no [ipv4] array

```
#### Load disco module arp-table ####
SQL[select * from `vrf_lite_cisco` where `vrf_lite_cisco`.`device_id` = ? and `vrf_lite_cisco`.`device_id` is not null [4103] 1.05ms] 
  
SNMP['/usr/bin/snmpbulkwalk' '-M' '/opt/librenms/mibs' '-m' 'SNMPv2-TC:SNMPv2-MIB:IF-MIB:IP-MIB:TCP-MIB:UDP-MIB:NET-SNMP-VACM-MIB' '-v2c' '-c' 'COMMUNITY' '-OQXUte' '-Pu' 'udp6:HOSTNAME:0:4:255::103]:161' 'IP-MIB::ipNetToPhysicalPhysAddress']  
IP-MIB::ipNetToPhysicalPhysAddress[12][ipv6]["fd:fd:00:00:00:04:02:55:00:00:00:00:00:00:00:01"] = 6c:3b:6b:c2:37:a6
IP-MIB::ipNetToPhysicalPhysAddress[12][ipv6]["fe:80:00:00:00:00:00:00:6e:3b:6b:ff:fe:c2:37:a6"] = 6c:3b:6b:c2:37:a6
  
  
SNMP['/usr/bin/snmpbulkwalk' '-M' '/opt/librenms/mibs' '-m' 'SNMPv2-TC:SNMPv2-MIB:IF-MIB:IP-MIB:TCP-MIB:UDP-MIB:NET-SNMP-VACM-MIB' '-v2c' '-c' 'COMMUNITY' '-OQXUte' '-Pu' 'udp6:HOSTNAME:0:4:255::103]:161' 'IP-MIB::ipNetToMediaPhysAddress']  
IP-MIB::ipNetToMediaPhysAddress = No Such Instance currently exists at this OID
  
  
SQL[SELECT * from `ipv4_mac` WHERE `device_id`=? AND `context_name`=? [4103,""] 1.21ms] 
  
SQL[SELECT * FROM `ports` WHERE `device_id` = ? AND `ifIndex` = ? [4103,12] 1.54ms] 
  
Error discovering arp-table module for fdfd:0:4:255::103. ErrorException: Undefined array key "ipv4" in /opt/librenms/includes/discovery/arp-table.inc.php:61
```

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
