### PR TITLE
add --allow-releaseinfo-change to apt-get update 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,7 +88,7 @@ jobs:
       -
         name: Install packages
         run: |
-          sudo apt-get -qq update
+          sudo apt-get -qq update --allow-releaseinfo-change
           sudo apt-get install -y fping python3-pip python3-setuptools snmp sqlite3
       -
         name: Pip install


### PR DESCRIPTION

Tests currently failing with

```
Run sudo apt-get -qq update
E: Repository 'https://ppa.launchpadcontent.net/ondrej/php/ubuntu noble InRelease' changed its 'Label' value from '***** The main PPA for supported PHP versions with many PECL extensions *****' to 'PPA for PHP'
Error: Process completed with exit code 100.
```

Unsure if this is something unexpected to do with https://github.com/librenms/librenms/pull/17528


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
