### PR TITLE
 Device - reformat service table ( follow up to #17527 )

### DIFF
--- a/includes/html/pages/device/services.inc.php
+++ b/includes/html/pages/device/services.inc.php
@@ -67,9 +67,10 @@ echo '<table class="table table-hover table-condensed">';
 echo '<thead>';
 echo '<td class="col-sm-2"><strong>Name</strong></td>';
 echo '<td class="col-sm-1"><strong>Check Type</strong></td>';
+echo '<td class="col-sm-1"><strong>Remote Host</strong></td>';
 echo '<td class="col-sm-4"><strong>Message</strong></td>';
 echo '<td class="col-sm-2"><strong>Description</strong></td>';
-echo '<td class="col-sm-2"><strong>Last Changed</strong></td>';
+echo '<td class="col-sm-1"><strong>Last Changed</strong></td>';
 echo '<td class="col-sm-1"></td>';
 echo '</thead>';
 
@@ -96,12 +97,12 @@ if (count($services) > '0') {
         echo '<td class="col-sm-2 text-muted">' . htmlentities($service['service_desc']) . '</td>';
         echo '<td class="col-sm-1 text-muted">' . \LibreNMS\Util\Time::formatInterval(time() - $service['service_changed']) . '</td>';
         echo '<td class="col-sm-1">';
-        echo '<div class="pull-right">';
         if (Auth::user()->hasGlobalAdmin()) {
-            echo "<button type='button' class='btn btn-primary btn-sm' aria-label='Edit' data-toggle='modal' data-target='#create-service' data-service_id='{$service['service_id']}' name='edit-service'><i class='fa fa-pencil' aria-hidden='true'></i></button>
-        <button type='button' class='btn btn-danger btn-sm' aria-label='Delete' data-toggle='modal' data-target='#confirm-delete' data-service_id='{$service['service_id']}' name='delete-service'><i class='fa fa-trash' aria-hidden='true'></i></button";
+            echo '<div class="pull-right">';
+            echo "<button type='button' class='btn btn-primary btn-sm' aria-label='Edit' data-toggle='modal' data-target='#create-service' data-service_id='{$service['service_id']}' name='edit-service'><i class='fa fa-pencil' aria-hidden='true'></i></button>";
+            echo "<button type='button' class='btn btn-danger btn-sm' aria-label='Delete' data-toggle='modal' data-target='#confirm-delete' data-service_id='{$service['service_id']}' name='delete-service'><i class='fa fa-trash' aria-hidden='true'></i></button";
+            echo '</div>';
         }
-        echo '</div>';
         echo '</td>';
         echo '</tr>';
 
@@ -126,7 +127,7 @@ if (count($services) > '0') {
                 $graph_array['ds'] = $k;
 
                 echo '<tr>';
-                echo '<td class="col-sm-12"">';
+                echo '<td colspan="7">';
 
                 include 'includes/html/print-graphrow.inc.php';
 

--- a/includes/html/pages/device/services.inc.php
+++ b/includes/html/pages/device/services.inc.php
@@ -67,16 +67,16 @@ echo '</div><div>';
 if (count($services) > '0') {
     // Loop over each service, pulling out the details.
 
-echo '<table class="table table-hover table-condensed">';
-echo '<thead>';
-echo '<td class="col-sm-2"><strong>Name</strong></td>';
-echo '<td class="col-sm-1"><strong>Check Type</strong></td>';
-echo '<td class="col-sm-1"><strong>Remote Host</strong></td>';
-echo '<td class="col-sm-4"><strong>Message</strong></td>';
-echo '<td class="col-sm-2"><strong>Description</strong></td>';
-echo '<td class="col-sm-1"><strong>Last Changed</strong></td>';
-echo '<td class="col-sm-1"></td>';
-echo '</thead>';
+    echo '<table class="table table-hover table-condensed">';
+    echo '<thead>';
+    echo '<td class="col-sm-2"><strong>Name</strong></td>';
+    echo '<td class="col-sm-1"><strong>Check Type</strong></td>';
+    echo '<td class="col-sm-1"><strong>Remote Host</strong></td>';
+    echo '<td class="col-sm-4"><strong>Message</strong></td>';
+    echo '<td class="col-sm-2"><strong>Description</strong></td>';
+    echo '<td class="col-sm-1"><strong>Last Changed</strong></td>';
+    echo '<td class="col-sm-1"></td>';
+    echo '</thead>';
 
     foreach ($services as $service) {
         $service['service_ds'] = htmlspecialchars_decode($service['service_ds']);

--- a/includes/html/pages/device/services.inc.php
+++ b/includes/html/pages/device/services.inc.php
@@ -63,18 +63,19 @@ if (Auth::user()->hasGlobalAdmin()) {
 }
 
 echo '</div><div>';
+echo '<table class="table table-hover table-condensed">';
+echo '<thead>';
+echo '<td class="col-sm-2"><strong>Name</strong></td>';
+echo '<td class="col-sm-1"><strong>Check Type</strong></td>';
+echo '<td class="col-sm-4"><strong>Message</strong></td>';
+echo '<td class="col-sm-2"><strong>Description</strong></td>';
+echo '<td class="col-sm-2"><strong>Last Changed</strong></td>';
+echo '<td class="col-sm-1"></td>';
+echo '</thead>';
 
 if (count($services) > '0') {
     // Loop over each service, pulling out the details.
 
-    echo '<table class="table table-hover table-condensed">';
-    echo '<td class="col-sm-2"><strong>Name</strong></td>';
-    echo '<td class="col-sm-1"><strong>Check Type</strong></td>';
-    echo '<td class="col-sm-1">Remote Host</td>';
-    echo '<td class="col-sm-4"><strong>Message</strong></td>';
-    echo '<td class="col-sm-2"><strong>Description</strong></td>';
-    echo '<td class="col-sm-1"><strong>Last Changed</strong></td>';
-    echo '<td class="col-sm-1"></td>';
     foreach ($services as $service) {
         $service['service_ds'] = htmlspecialchars_decode($service['service_ds']);
         if ($service['service_status'] == '2') {

--- a/includes/html/pages/device/services.inc.php
+++ b/includes/html/pages/device/services.inc.php
@@ -63,6 +63,10 @@ if (Auth::user()->hasGlobalAdmin()) {
 }
 
 echo '</div><div>';
+
+if (count($services) > '0') {
+    // Loop over each service, pulling out the details.
+
 echo '<table class="table table-hover table-condensed">';
 echo '<thead>';
 echo '<td class="col-sm-2"><strong>Name</strong></td>';
@@ -73,9 +77,6 @@ echo '<td class="col-sm-2"><strong>Description</strong></td>';
 echo '<td class="col-sm-1"><strong>Last Changed</strong></td>';
 echo '<td class="col-sm-1"></td>';
 echo '</thead>';
-
-if (count($services) > '0') {
-    // Loop over each service, pulling out the details.
 
     foreach ($services as $service) {
         $service['service_ds'] = htmlspecialchars_decode($service['service_ds']);

--- a/includes/html/pages/device/services.inc.php
+++ b/includes/html/pages/device/services.inc.php
@@ -96,10 +96,12 @@ if (count($services) > '0') {
         echo '<td class="col-sm-2 text-muted">' . htmlentities($service['service_desc']) . '</td>';
         echo '<td class="col-sm-1 text-muted">' . \LibreNMS\Util\Time::formatInterval(time() - $service['service_changed']) . '</td>';
         echo '<td class="col-sm-1">';
+        echo '<div class="pull-right">';
         if (Auth::user()->hasGlobalAdmin()) {
             echo "<button type='button' class='btn btn-primary btn-sm' aria-label='Edit' data-toggle='modal' data-target='#create-service' data-service_id='{$service['service_id']}' name='edit-service'><i class='fa fa-pencil' aria-hidden='true'></i></button>
         <button type='button' class='btn btn-danger btn-sm' aria-label='Delete' data-toggle='modal' data-target='#confirm-delete' data-service_id='{$service['service_id']}' name='delete-service'><i class='fa fa-trash' aria-hidden='true'></i></button";
         }
+        echo '</div>';
         echo '</td>';
         echo '</tr>';
 


### PR DESCRIPTION
Fix details layout so graphs span all colums 
Align admin buttons horizontally on right

Services > Basic:
![image](https://github.com/user-attachments/assets/72fee789-bf28-4d17-b0dc-9cf2b070125b)

Services > Details:
![image](https://github.com/user-attachments/assets/c036dfcc-bbf1-4c91-97a8-c41d1597da9f)


#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
