### PR TITLE
Ruckus Radius Traps v2

### DIFF
--- a/LibreNMS/Snmptrap/Handlers/RuckusSzApRadiusServerReachableTrap.php
+++ b/LibreNMS/Snmptrap/Handlers/RuckusSzApRadiusServerReachableTrap.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * RuckusSzApRadiusServerReachableTrap.php
+ *
+ * -Description-
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Ruckus RuckusSZAPRadiusServerReachableTrap occurs when the SmartZone receives
+ * an event from a connected access point that it detects the RADIUS server as up from
+ * down.
+ *
+ * @link       https://www.librenms.org
+ *
+ * @copyright  2025 KanREN, Inc.
+ * @author     Heath Barnhart <hbarnhart@kanren.net>
+ */
+
+namespace LibreNMS\Snmptrap\Handlers;
+
+use App\Models\Device;
+use LibreNMS\Enum\Severity;
+use LibreNMS\Interfaces\SnmptrapHandler;
+use LibreNMS\Snmptrap\Trap;
+
+class RuckusSzApRadiusServerReachableTrap implements SnmptrapHandler
+{
+    /**
+     * Handle snmptrap.
+     * Data is pre-parsed and delivered as a Trap.
+     *
+     * @param  Device  $device
+     * @param  Trap  $trap
+     * @return void
+     */
+    public function handle(Device $device, Trap $trap)
+    {
+        $apName = $trap->getOidData($trap->findOid('RUCKUS-SZ-EVENT-MIB::ruckusSZEventAPName'));
+        $apIpv4 = $trap->getOidData($trap->findOid('RUCKUS-SZ-EVENT-MIB::ruckusSZEventAPIP'));
+        $apIpv6 = $trap->getOidData($trap->findOid('RUCKUS-SZ-EVENT-MIB::ruckusSZEventAPIPv6'));
+        $radiusIp = $trap->getOidData($trap->findOid('RUCKUS-SZ-EVENT-MIB::ruckusSZRadSrvrIp'));
+
+        $message = "AP $apName ($apIpv4) is able to reach radius server $radiusIp";
+        if (! empty($apIpv6)) {
+            $message = "AP $apName ($apIpv4, $apIpv6) is able to reach radius server $radiusIp";
+        }
+
+        $trap->log("$message", Severity::Ok);
+    }
+}

--- a/LibreNMS/Snmptrap/Handlers/RuckusSzApRadiusServerUnreachableTrap.php
+++ b/LibreNMS/Snmptrap/Handlers/RuckusSzApRadiusServerUnreachableTrap.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * RuckusSzApRadiusServerUnreachableTrap.php
+ *
+ * -Description-
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Ruckus RuckusSzApRadiusServerUnreachableTrapTrap occurs when the SmartZone receives
+ * an event from a connected access point that it detects the RADIUS server as down.
+ *
+ * @link       https://www.librenms.org
+ *
+ * @copyright  2025 KanREN, Inc.
+ * @author     Heath Barnhart <hbarnhart@kanren.net>
+ */
+
+namespace LibreNMS\Snmptrap\Handlers;
+
+use App\Models\Device;
+use LibreNMS\Enum\Severity;
+use LibreNMS\Interfaces\SnmptrapHandler;
+use LibreNMS\Snmptrap\Trap;
+
+class RuckusSzApRadiusServerUnreachableTrap implements SnmptrapHandler
+{
+    /**
+     * Handle snmptrap.
+     * Data is pre-parsed and delivered as a Trap.
+     *
+     * @param  Device  $device
+     * @param  Trap  $trap
+     * @return void
+     */
+    public function handle(Device $device, Trap $trap)
+    {
+        $apName = $trap->getOidData($trap->findOid('RUCKUS-SZ-EVENT-MIB::ruckusSZEventAPName'));
+        $apIpv4 = $trap->getOidData($trap->findOid('RUCKUS-SZ-EVENT-MIB::ruckusSZEventAPIP'));
+        $apIpv6 = $trap->getOidData($trap->findOid('RUCKUS-SZ-EVENT-MIB::ruckusSZEventAPIPv6'));
+        $radiusIp = $trap->getOidData($trap->findOid('RUCKUS-SZ-EVENT-MIB::ruckusSZRadSrvrIp'));
+
+        $message = "AP $apName ($apIpv4) is unable to reach radius server $radiusIp";
+        if (! empty($apIpv6)) {
+            $message = "AP $apName ($apIpv4, $apIpv6) is unable to reach radius server $radiusIp";
+        }
+
+        $trap->log("$message", Severity::Warning);
+    }
+}

--- a/config/snmptraps.php
+++ b/config/snmptraps.php
@@ -137,6 +137,8 @@ return [
         'RUCKUS-SZ-EVENT-MIB::ruckusSZAPConnectedTrap' => LibreNMS\Snmptrap\Handlers\RuckusSzApConnect::class,
         'RUCKUS-SZ-EVENT-MIB::ruckusSZClusterInMaintenanceStateTrap' => LibreNMS\Snmptrap\Handlers\RuckusSzClusterInMaintenance::class,
         'RUCKUS-SZ-EVENT-MIB::ruckusSZClusterBackToInServiceTrap' => LibreNMS\Snmptrap\Handlers\RuckusSzClusterInService::class,
+        'RUCKUS-SZ-EVENT-MIB::ruckusSZAPRadiusServerUnreachableTrap' => LibreNMS\Snmptrap\Handlers\RuckusSzApRadiusServerUnreachableTrap::class,
+        'RUCKUS-SZ-EVENT-MIB::ruckusSZAPRadiusServerReachableTrap' => LibreNMS\Snmptrap\Handlers\RuckusSzApRadiusServerReachableTrap::class,
         'SNMPv2-MIB::authenticationFailure' => LibreNMS\Snmptrap\Handlers\AuthenticationFailure::class,
         'SNMPv2-MIB::coldStart' => LibreNMS\Snmptrap\Handlers\ColdBoot::class,
         'SNMPv2-MIB::warmStart' => LibreNMS\Snmptrap\Handlers\WarmBoot::class,

--- a/tests/Feature/SnmpTraps/RuckusSzApRadiusServerReachabilityTrapTest.php
+++ b/tests/Feature/SnmpTraps/RuckusSzApRadiusServerReachabilityTrapTest.php
@@ -1,0 +1,136 @@
+<?php
+
+/**
+ * RuckusSzApRadiusServerReachabilityTrapTest.php
+ *
+ * -Description-
+ *
+ * Test Ruckus RADIUS reachability traps.
+ * Tests RuckusSzApRadiusServerUnreachableTrap and
+ * RuckusSzApRadiusServerReachableTrap.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * @link       https://www.librenms.org
+ *
+ * @copyright  2025 Heath Barnhart
+ * @author     Heath Barnhart <hbarnhart@kanren.net>
+ */
+
+namespace LibreNMS\Tests\Feature\SnmpTraps;
+
+use LibreNMS\Enum\Severity;
+
+class RuckusSzApRadiusServerReachabilityTrapTest extends SnmpTrapTestCase
+{
+    public function testRadiusUnreachableIpv4()
+    {
+        $this->assertTrapLogsMessage(<<<'TRAP'
+{{ hostname }}
+UDP: [{{ ip }}]:57602->[192.168.5.5]:162
+DISMAN-EVENT-MIB::sysUpTimeInstance 4:8:26:09.00
+SNMPv2-MIB::snmpTrapOID.0 RUCKUS-SZ-EVENT-MIB::ruckusSZAPRadiusServerUnreachableTrap
+RUCKUS-SZ-EVENT-MIB::ruckusSZEventSeverity.0 Major
+RUCKUS-SZ-EVENT-MIB::ruckusSZEventCode.0 2102
+RUCKUS-SZ-EVENT-MIB::ruckusSZEventType.0 radiusServerUnreachable
+RUCKUS-SZ-EVENT-MIB::ruckusSZEventAPName.0 test-ap-720
+RUCKUS-SZ-EVENT-MIB::ruckusSZEventAPMacAddr.0 18:4B:DE:AD:BE:EF
+RUCKUS-SZ-EVENT-MIB::ruckusSZEventAPIP.0 192.168.0.1
+RUCKUS-SZ-EVENT-MIB::ruckusSZEventAPLocation.0 somewhere
+RUCKUS-SZ-EVENT-MIB::ruckusSZEventAPDescription.0 someplace
+RUCKUS-SZ-EVENT-MIB::ruckusSZEventAPGPSCoordinates.0 0.0000 0.0000
+RUCKUS-SZ-EVENT-MIB::ruckusSZRadSrvrIp.0 10.0.0.1
+RUCKUS-SZ-EVENT-MIB::ruckusSZEventAPIPv6.0 
+TRAP,
+            'AP test-ap-720 (192.168.0.1) is unable to reach radius server 10.0.0.1',
+            'Could not handle RuckusSzApRadiusServerUnreachableTrapTest IPv4 only.',
+            [Severity::Warning],
+        );
+    }
+
+    public function testRadiusUnreachableIpBoth()
+    {
+        $this->assertTrapLogsMessage(<<<'TRAP'
+{{ hostname }}
+UDP: [{{ ip }}]:57602->[192.168.5.5]:162
+DISMAN-EVENT-MIB::sysUpTimeInstance 4:8:26:09.00
+SNMPv2-MIB::snmpTrapOID.0 RUCKUS-SZ-EVENT-MIB::ruckusSZAPRadiusServerUnreachableTrap
+RUCKUS-SZ-EVENT-MIB::ruckusSZEventSeverity.0 Major
+RUCKUS-SZ-EVENT-MIB::ruckusSZEventCode.0 2102
+RUCKUS-SZ-EVENT-MIB::ruckusSZEventType.0 radiusServerUnreachable
+RUCKUS-SZ-EVENT-MIB::ruckusSZEventAPName.0 test-ap-720
+RUCKUS-SZ-EVENT-MIB::ruckusSZEventAPMacAddr.0 18:4B:DE:AD:BE:EF
+RUCKUS-SZ-EVENT-MIB::ruckusSZEventAPIP.0 192.168.0.1
+RUCKUS-SZ-EVENT-MIB::ruckusSZEventAPLocation.0 somewhere
+RUCKUS-SZ-EVENT-MIB::ruckusSZEventAPDescription.0 someplace
+RUCKUS-SZ-EVENT-MIB::ruckusSZEventAPGPSCoordinates.0 0.0000 0.0000
+RUCKUS-SZ-EVENT-MIB::ruckusSZRadSrvrIp.0 10.0.0.1
+RUCKUS-SZ-EVENT-MIB::ruckusSZEventAPIPv6.0 2001:db8::dead:beef
+TRAP,
+            'AP test-ap-720 (192.168.0.1, 2001:db8::dead:beef) is unable to reach radius server 10.0.0.1',
+            'Could not handle RuckusSzApRadiusServerUnreachableTrapTest IPv4 and IPv6.',
+            [Severity::Warning],
+        );
+    }
+
+    public function testRadiusReachableIpv4()
+    {
+        $this->assertTrapLogsMessage(<<<'TRAP'
+{{ hostname }}
+UDP: [{{ ip }}]:57602->[192.168.5.5]:162
+DISMAN-EVENT-MIB::sysUpTimeInstance 5:8:26:54.00
+SNMPv2-MIB::snmpTrapOID.0 RUCKUS-SZ-EVENT-MIB::ruckusSZAPRadiusServerReachableTrap
+RUCKUS-SZ-EVENT-MIB::ruckusSZEventSeverity.0 Informational
+RUCKUS-SZ-EVENT-MIB::ruckusSZEventCode.0 2101
+RUCKUS-SZ-EVENT-MIB::ruckusSZEventType.0 radiusServerReachable
+RUCKUS-SZ-EVENT-MIB::ruckusSZEventAPName.0 test-ap-22
+RUCKUS-SZ-EVENT-MIB::ruckusSZEventAPMacAddr.0 18:4B:DE:AD:BE:EF
+RUCKUS-SZ-EVENT-MIB::ruckusSZEventAPIP.0 192.168.0.1
+RUCKUS-SZ-EVENT-MIB::ruckusSZEventAPLocation.0 somewhere
+RUCKUS-SZ-EVENT-MIB::ruckusSZEventAPDescription.0 someplace
+RUCKUS-SZ-EVENT-MIB::ruckusSZEventAPGPSCoordinates.0 180.0000 180.000
+RUCKUS-SZ-EVENT-MIB::ruckusSZRadSrvrIp.0 10.0.0.1
+RUCKUS-SZ-EVENT-MIB::ruckusSZEventAPIPv6.0 
+TRAP,
+            'AP test-ap-22 (192.168.0.1) is able to reach radius server 10.0.0.1',
+            'Could not handle RuckusSZAPRadiusServerReachableTrap IPv4 only.',
+            [Severity::Ok],
+        );
+    }
+
+    public function testRadiusReachableIpBoth()
+    {
+        $this->assertTrapLogsMessage(<<<'TRAP'
+{{ hostname }}
+UDP: [{{ ip }}]:57602->[192.168.5.5]:162
+DISMAN-EVENT-MIB::sysUpTimeInstance 5:8:26:54.00
+SNMPv2-MIB::snmpTrapOID.0 RUCKUS-SZ-EVENT-MIB::ruckusSZAPRadiusServerReachableTrap
+RUCKUS-SZ-EVENT-MIB::ruckusSZEventSeverity.0 Informational
+RUCKUS-SZ-EVENT-MIB::ruckusSZEventCode.0 2101
+RUCKUS-SZ-EVENT-MIB::ruckusSZEventType.0 radiusServerReachable
+RUCKUS-SZ-EVENT-MIB::ruckusSZEventAPName.0 test-ap-22
+RUCKUS-SZ-EVENT-MIB::ruckusSZEventAPMacAddr.0 18:4B:DE:AD:BE:EF
+RUCKUS-SZ-EVENT-MIB::ruckusSZEventAPIP.0 192.168.0.1
+RUCKUS-SZ-EVENT-MIB::ruckusSZEventAPLocation.0 somewhere
+RUCKUS-SZ-EVENT-MIB::ruckusSZEventAPDescription.0 someplace
+RUCKUS-SZ-EVENT-MIB::ruckusSZEventAPGPSCoordinates.0 180.0000 180.000
+RUCKUS-SZ-EVENT-MIB::ruckusSZRadSrvrIp.0 10.0.0.1
+RUCKUS-SZ-EVENT-MIB::ruckusSZEventAPIPv6.0 2001:db8::dead:beef
+TRAP,
+            'AP test-ap-22 (192.168.0.1, 2001:db8::dead:beef) is able to reach radius server 10.0.0.1',
+            'Could not handle RuckusSZAPRadiusServerReachableTrap IPv4 and IPv6.',
+            [Severity::Ok],
+        );
+    }
+}


### PR DESCRIPTION
Re-submitting due to test failure after an update in PR 17457.

Jellyfrog pointed out the issue might be a missing value, my guess its in the IPv6 OID. If IPv6 is not configured then value is blank. In my original submission I had deleted the space after the OID. If there is another way I should be supplying no value (not sure if its null or empty), let me know. (I'm more of a network engineer than a programmer).

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
