### PR TITLE
Optimize syslog count on About page by using information_schema

### DIFF
--- a/app/Http/Controllers/AboutController.php
+++ b/app/Http/Controllers/AboutController.php
@@ -54,6 +54,7 @@ use App\Models\Vrf;
 use App\Models\WirelessSensor;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
 use LibreNMS\Config;
 use LibreNMS\Data\Store\Rrd;
 use LibreNMS\Util\Http;
@@ -103,7 +104,10 @@ class AboutController extends Controller
             'stat_services' => Service::count(),
             'stat_slas' => Sla::count(),
             'stat_storage' => Storage::count(),
-            'stat_syslog' => Syslog::count(),
+            'stat_syslog' => DB::table('information_schema.tables')
+                ->where('table_schema', DB::raw('DATABASE()'))
+                ->where('table_name', 'syslog')
+                ->value('table_rows') ?? 0,
             'stat_toner' => PrinterSupply::count(),
             'stat_vlans' => Vlan::count(),
             'stat_vrf' => Vrf::count(),


### PR DESCRIPTION
Closes #17548

This PR improves the performance of the About page when the syslog table is very large.
Instead of using Syslog::count(), which performs a full table scan, it now reads an approximate count from information_schema.tables.

This dramatically speeds up page load times when syslog contains millions of rows.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
