### PR TITLE
Fix install database issue from Laravel 11.x defaults

### DIFF
--- a/config/session.php
+++ b/config/session.php
@@ -3,6 +3,22 @@
 return [
     /*
     |--------------------------------------------------------------------------
+    | Default Session Driver
+    |--------------------------------------------------------------------------
+    |
+    | This option controls the default session "driver" that will be used on
+    | requests. By default, we will use the lightweight native driver but
+    | you may specify any of the other wonderful drivers provided here.
+    |
+    | Supported: "file", "cookie", "database", "apc",
+    |            "memcached", "redis", "dynamodb", "array"
+    |
+    */
+
+    'driver' => env('SESSION_DRIVER', 'file'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Session Lifetime
     |--------------------------------------------------------------------------
     |


### PR DESCRIPTION
Attempt to fix https://github.com/librenms/librenms/issues/17546 to let installs work again.

Appears to be due to Laravel 11.x default changes to session database which came up via https://github.com/librenms/librenms/pull/17384

Putting it back to database gets it updating the sessions table post-install as you'd expect.  Unsure what the long term plan is here and if it's meant to be set to database, nor do I know how to update it later, so maybe needs deeper handling to make that so later.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
