### PR TITLE
snmpwalk_cache_oid crash

### DIFF
--- a/includes/snmp.inc.php
+++ b/includes/snmp.inc.php
@@ -406,8 +406,12 @@ function snmpwalk_cache_oid($device, $oid, $array = [], $mib = null, $mibdir = n
 
             continue;
         }
-
         [$oid,$value] = explode('=', $entry, 2);
+
+        if (Str::contains($entry, ' = NULL')) {
+            continue;
+        }
+
         $oid = trim($oid);
         $value = trim($value, "\" \\\n\r");
         [$oid, $index] = explode('.', $oid, 2);

--- a/includes/snmp.inc.php
+++ b/includes/snmp.inc.php
@@ -408,7 +408,7 @@ function snmpwalk_cache_oid($device, $oid, $array = [], $mib = null, $mibdir = n
         }
         [$oid,$value] = explode('=', $entry, 2);
 
-        if (Str::contains($entry, ' = NULL')) {
+        if (preg_match('/^.+\s=\sNULL$/', $entry, $tmp)) {
             continue;
         }
 


### PR DESCRIPTION
```
SNMP['/usr/bin/snmpbulkwalk' '-v2c' '-c' 'COMMUNITY' '-OteQUsa' '-Ih' '-m' 'ELTEX-MES-ISS-CPU-UTIL-MIB:ELTEX-MES-ISS-ENV-MIB:ARICENT-ISS-MIB' '-M' '/opt/librenms/mibs:/opt/librenms/mibs/eltexmes24xx' 'udp:HOSTNAME:161' 'eltMesIssEnvFanTable']
eltMesIssEnvFanTable = NULL  
  
Error discovering sensors module for 169.254.2.39. ErrorException: Undefined array key 1 in /opt/librenms/includes/snmp.inc.php:413
Stack trace:
#0 /opt/librenms/vendor/laravel/framework/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php(256): Illuminate\Foundation\Bootstrap\HandleExceptions->handleError()
```

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
