### PR TITLE
fix error in discovery-protocols

### DIFF
--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -395,7 +395,7 @@ if (($device['os'] == 'routeros') && version_compare($device['version'], '7.7', 
                     }
                 }
 
-                if ( ! empty($remote_device_id)) {
+                if (! empty($remote_device_id)) {
                     $remote_device = device_by_id_cache($remote_device_id);
                     if ($remote_device['os'] == 'calix') {
                         $remote_port_name = 'EthPort ' . $lldp['lldpRemPortId'];


### PR DESCRIPTION
```
[2025-05-01T02:22:35][ERROR] Error discovering discovery-protocols module for 172.25.0.216. ErrorException: Undefined array key “lldpRemManAddr” in /opt/librenms/includes/discovery/discovery-protocols.inc.php:376
```

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
