### PR TITLE
[webui] fix mac search

### DIFF
--- a/includes/html/table/address-search.inc.php
+++ b/includes/html/table/address-search.inc.php
@@ -38,8 +38,11 @@ if ($vars['search_type'] == 'ipv4') {
     }
 } elseif ($vars['search_type'] == 'mac') {
     $sql = ' FROM `ports` AS I, `devices` AS D';
-    $sql .= " WHERE I.device_id = D.device_id AND `ifPhysAddress` LIKE ? $where ";
-    $param[] = '%' . trim(str_replace([':', ' ', '-', '.', '0x'], '', $vars['address'])) . '%';
+    $sql .= " WHERE I.device_id = D.device_id  $where ";
+    if (! empty($address)) {
+        $sql .= ' AND `ifPhysAddress` LIKE ?';
+        $param[] = '%' . trim(str_replace([':', ' ', '-', '.', '0x'], '', $vars['address'])) . '%';
+    }
 }//end if
 if (is_numeric($vars['device_id'])) {
     $sql .= ' AND I.device_id = ?';


### PR DESCRIPTION
old code have incorrect SQL query
```
SELECT *,`I`.`ifDescr` AS `interface`  FROM `ports` AS I, `devices` AS D WHERE I.device_id = D.device_id AND `ifPhysAddress` LIKE ?  AND `D`.`device_id` IN (?
,?,?,?,?,?,?,?,?,?,?,?,?,?)  ORDER BY  hostname ASC LIMIT 0,50

Array
(
    [0] => 3301
    [1] => 3302
    [2] => 3412
    [3] => 3413
    [4] => 3710
    [5] => 3711
    [6] => 3714
    [7] => 3715
    [8] => 3716
    [9] => 3717
    [10] => 3042
    [11] => 3072
    [12] => 3203
    [13] => 3204
    [14] => %b379%
)
```
MAC is on the last place, but ifPhysAddres is first in query

now:
```
SELECT *,`I`.`ifDescr` AS `interface`  FROM `ports` AS I, `devices` AS D WHERE I.device_id = D.device_id   AND `D`.`device_id` IN (?,?,?,?,?,?,?,?,?,?,?,?,?,?
)  AND `ifPhysAddress` LIKE ? ORDER BY  hostname ASC LIMIT 0,50

Array
(
    [0] => 3301
    [1] => 3302
    [2] => 3412
    [3] => 3413
    [4] => 3710
    [5] => 3711
    [6] => 3714
    [7] => 3715
    [8] => 3716
    [9] => 3717
    [10] => 3042
    [11] => 3072
    [12] => 3203
    [13] => 3204
    [14] => %b379%
)
```

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
