### PR TITLE
Fix menu alert icon colors

### DIFF
--- a/html/css/blue.css
+++ b/html/css/blue.css
@@ -25,22 +25,6 @@
     color: #0052cc;
 }
 
-.fa-col-success {
-    color: #3c763d;
-}
-
-.fa-col-info {
-    color: #31708f;
-}
-
-.fa-col-primary {
-    color: #357ebd;
-}
-
-.fa-col-danger {
-    color: #e30613;
-}
-
 .icon-theme {
     color: #0052cc;
 }
@@ -139,7 +123,7 @@
   -webkit-box-shadow: none;
 }
 
-.dropdown-menu li a:focus, 
+.dropdown-menu li a:focus,
 .dropdown-menu li a:hover {
     color: #fff;
     text-decoration: none;

--- a/html/css/mono.css
+++ b/html/css/mono.css
@@ -2,22 +2,6 @@
     color: #ffffff;
 }
 
-.fa-col-success {
-    color: #3c763d;
-}
-
-.fa-col-info {
-    color: #31708f;
-}
-
-.fa-col-primary {
-    color: #357ebd;
-}
-
-.fa-col-danger {
-    color: #e30613;
-}
-
 .icon-theme {
     color: black;
 }

--- a/html/css/styles.css
+++ b/html/css/styles.css
@@ -2120,10 +2120,6 @@ label {
     color: #383637;
 }
 
-.fa-col-danger {
-    color: #e30613;
-}
-
 .icon-theme {
     color: black;
 }

--- a/html/css/tw_dark.css
+++ b/html/css/tw_dark.css
@@ -2,10 +2,6 @@
     color: #bfc0c0
 }
 
-.dark .fa-col-danger {
-    color: #e30613
-}
-
 .dark .icon-theme {
     color: #bfc0c0
 }

--- a/resources/views/layouts/menu.blade.php
+++ b/resources/views/layouts/menu.blade.php
@@ -294,13 +294,13 @@
                                 <li role="presentation" class="divider"></li>
                                 @if($service_counts['warning'])
                                     <li><a href="{{ url('services/state=warning') }}"><i
-                                                class="fa fa-bell fa-col-warning fa-fw fa-lg"
+                                                class="fa fa-bell text-warning fa-fw fa-lg"
                                                 aria-hidden="true"></i> {{ __('Warning :service_count', ['service_count' => $service_counts['warning']]) }}
                                         </a></li>
                                 @endif
                                 @if($service_counts['critical'])
                                     <li><a href="{{ url('services/state=critical') }}"><i
-                                                class="fa fa-bell fa-col-danger fa-fw fa-lg"
+                                                class="fa fa-bell text-danger fa-fw fa-lg"
                                                 aria-hidden="true"></i> {{ __('Critical :service_count', ['service_count' => $service_counts['critical']]) }}
                                         </a></li>
                                 @endif
@@ -535,7 +535,7 @@
 {{-- Alerts --}}
                 <li class="dropdown">
                     <a href="#" class="dropdown-toggle" data-hover="dropdown" data-toggle="dropdown"><i
-                            class="fa fa-exclamation-circle fa-col-{{ $alert_menu_class }} fa-fw fa-lg fa-nav-icons hidden-md"
+                            class="fa fa-exclamation-circle text-{{ $alert_menu_class }} fa-fw fa-lg hidden-md"
                             aria-hidden="true"></i> <span class="hidden-sm">{{ __('Alerts') }}</span></a>
                     <ul class="dropdown-menu">
                         <li><a href="{{ url('alerts') }}"><i class="fa fa-bell fa-fw fa-lg"


### PR DESCRIPTION
Use standard text-<status> colors.
Most are the same, but danger is a little more subdued

![image](https://github.com/user-attachments/assets/1b921afb-8752-454e-b0c4-21ad890cdaa7)

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
