### PR TITLE
add in info for clearing the boot strap cache for manual updating docs

### DIFF
--- a/doc/General/Updating.md
+++ b/doc/General/Updating.md
@@ -21,6 +21,7 @@ you can do so by running the following commands:
 ```bash
 cd /opt/librenms
 git pull
+rm bootstrap/cache/*.php
 ./scripts/composer_wrapper.php install --no-dev
 ./lnms migrate
 ./validate.php


### PR DESCRIPTION
Add in info on clearing the boot strap cache for when doing manual updates.

Figure this is good to have in the docs given https://github.com/librenms/librenms/pull/17511 .

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
