### PR TITLE
Major error handling change

### DIFF
--- a/LibreNMS/Modules/LegacyModule.php
+++ b/LibreNMS/Modules/LegacyModule.php
@@ -106,13 +106,10 @@ class LegacyModule implements Module
         }
 
         $device = &$os->getDeviceArray();
-        Debug::disableErrorReporting(); // ignore errors in legacy code
 
         include_once base_path('includes/dbFacile.php');
         include_once base_path('includes/rewrites.php');
         include base_path("includes/polling/$this->name.inc.php");
-
-        Debug::enableErrorReporting(); // and back to normal
     }
 
     public function dataExists(Device $device): bool

--- a/LibreNMS/Util/Debug.php
+++ b/LibreNMS/Util/Debug.php
@@ -121,10 +121,9 @@ class Debug
      */
     public static function disableErrorReporting(bool $silence = false): void
     {
+        ini_set('display_startup_errors', '1');
         ini_set('display_errors', '0');
-        ini_set('display_startup_errors', '0');
         ini_set('log_errors', '1');
-        error_reporting($silence ? 0 : E_ERROR);
     }
 
     /**
@@ -132,9 +131,8 @@ class Debug
      */
     public static function enableErrorReporting(): void
     {
-        ini_set('display_errors', '1');
         ini_set('display_startup_errors', '1');
-        ini_set('log_errors', '0');
-        error_reporting(-1);
+        ini_set('display_errors', '1');
+        ini_set('log_errors', '1');
     }
 }

--- a/app/Exceptions/ErrorReporting.php
+++ b/app/Exceptions/ErrorReporting.php
@@ -158,7 +158,7 @@ class ErrorReporting
     private function adjustErrorHandlingForAppEnv(string $environment): void
     {
         // TODO remove APP_DEBUG requirement when issues are cleaned up
-        if ($environment == 'production' || ! env('APP_DEBUG')) {
+        if ($environment == 'production' || ! config('app.debug')) {
             // in production, don't halt execution on non-fatal errors
             set_error_handler(function ($severity, $message, $file, $line) {
                 error_log("PHP Error($severity): $message in $file on line $line");

--- a/app/Exceptions/ErrorReporting.php
+++ b/app/Exceptions/ErrorReporting.php
@@ -39,7 +39,6 @@ use Throwable;
 class ErrorReporting
 {
     private ?bool $reportingEnabled = null;
-    private ?bool $dumpErrors = null;
     protected array $upgradable = [
         \LibreNMS\Exceptions\FilePermissionsException::class,
         \LibreNMS\Exceptions\DatabaseConnectException::class,
@@ -54,7 +53,7 @@ class ErrorReporting
         $this->adjustErrorHandlingForAppEnv(app()->environment());
 
         $exceptions->dontReportDuplicates();
-        $exceptions->throttle(fn(Throwable $e) => Limit::perMinute(LibrenmsConfig::get('reporting.throttle', 30)));
+        $exceptions->throttle(fn (Throwable $e) => Limit::perMinute(LibrenmsConfig::get('reporting.throttle', 30)));
         $exceptions->reportable([$this, 'reportable']);
         $exceptions->report([$this, 'report']);
         $exceptions->render([$this, 'render']);

--- a/app/Exceptions/ErrorReporting.php
+++ b/app/Exceptions/ErrorReporting.php
@@ -157,7 +157,8 @@ class ErrorReporting
 
     private function adjustErrorHandlingForAppEnv(string $environment): void
     {
-        if ($environment == 'production') {
+        // TODO remove APP_DEBUG requirement when issues are cleaned up
+        if ($environment == 'production' || ! env('APP_DEBUG')) {
             // in production, don't halt execution on non-fatal errors
             set_error_handler(function ($severity, $message, $file, $line) {
                 error_log("PHP Error($severity): $message in $file on line $line");

--- a/app/Jobs/PollDevice.php
+++ b/app/Jobs/PollDevice.php
@@ -146,7 +146,6 @@ class PollDevice implements ShouldQueue
                 }
 
                 // isolate module exceptions so they don't disrupt the polling process
-                Log::error("%rError polling $module module for {$this->device->hostname}.%n $e", ['color' => true]);
                 Eventlog::log("Error polling $module module. Check log file for more details.", $this->device, 'poller', Severity::Error);
                 report($e);
             }

--- a/app/Providers/LegacyUserProvider.php
+++ b/app/Providers/LegacyUserProvider.php
@@ -64,9 +64,7 @@ class LegacyUserProvider implements UserProvider
      */
     public function retrieveByLegacyId($identifier)
     {
-        error_reporting(0);
         $legacy_user = LegacyAuth::get()->getUser($identifier);
-        error_reporting(-1);
 
         return $this->retrieveByCredentials(['username' => $legacy_user['username'] ?? null]);
     }
@@ -127,8 +125,6 @@ class LegacyUserProvider implements UserProvider
      */
     public function validateCredentials(Authenticatable $user, array $credentials)
     {
-        error_reporting(0);
-
         $authorizer = LegacyAuth::get();
 
         try {
@@ -152,8 +148,6 @@ class LegacyUserProvider implements UserProvider
             $username = $username ?? Session::get('username', $credentials['username']);
 
             DB::table('authlog')->insert(['user' => $username, 'address' => Request::ip(), 'result' => $auth_message]);
-        } finally {
-            error_reporting(-1);
         }
 
         return false;
@@ -167,8 +161,6 @@ class LegacyUserProvider implements UserProvider
      */
     public function retrieveByCredentials(array $credentials)
     {
-        error_reporting(0);
-
         $auth = LegacyAuth::get();
         $type = LegacyAuth::getType();
 
@@ -181,18 +173,12 @@ class LegacyUserProvider implements UserProvider
         $auth_id = $auth->getUserid($username);
         $new_user = $auth->getUser($auth_id);
 
-        error_reporting(-1);
-
         if (empty($new_user)) {
             // some legacy auth create users in the authenticate method, if it doesn't exist yet, lets try authenticate (Laravel calls retrieveByCredentials first)
             try {
-                error_reporting(0);
-
                 $auth->authenticate($credentials);
                 $auth_id = $auth->getUserid($username);
                 $new_user = $auth->getUser($auth_id);
-
-                error_reporting(-1);
             } catch (AuthenticationException $ae) {
                 toast()->error($ae->getMessage());
             }

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -178,7 +178,6 @@ function discover_device(&$device, $force_module = false)
                 }
 
                 // isolate module exceptions so they don't disrupt the polling process
-                Log::error("%rError discovering $module module for {$device['hostname']}.%n $e", ['color' => true]);
                 Eventlog::log("Error discovering $module module. Check log file for more details.", $device['device_id'], 'discovery', Severity::Error);
                 report($e);
             }

--- a/includes/discovery/ports.inc.php
+++ b/includes/discovery/ports.inc.php
@@ -105,6 +105,11 @@ if ($device['port_association_mode']) {
 $ports_mapped = get_ports_mapped($device['device_id']);
 $ports_db = $ports_mapped['ports'];
 
+str_contains(null, '');
+strtok('');
+$a = $ports['undefined'];
+
+throw new ErrorException('fatal');
 //
 // Rename any old RRD files still named after the previous ifIndex based naming schema.
 foreach ($ports_mapped['maps']['ifIndex'] as $ifIndex => $port_id) {

--- a/includes/discovery/ports.inc.php
+++ b/includes/discovery/ports.inc.php
@@ -105,11 +105,6 @@ if ($device['port_association_mode']) {
 $ports_mapped = get_ports_mapped($device['device_id']);
 $ports_db = $ports_mapped['ports'];
 
-str_contains(null, '');
-strtok('');
-$a = $ports['undefined'];
-
-throw new ErrorException('fatal');
 //
 // Rename any old RRD files still named after the previous ifIndex based naming schema.
 foreach ($ports_mapped['maps']['ifIndex'] as $ifIndex => $port_id) {

--- a/includes/init.php
+++ b/includes/init.php
@@ -35,13 +35,8 @@ use LibreNMS\Util\Laravel;
 
 global $vars, $console_color;
 
-error_reporting(E_ERROR | E_PARSE | E_CORE_ERROR | E_COMPILE_ERROR);
 ini_set('display_errors', 1);
 ini_set('display_startup_errors', 1);
-
-if (! defined('IGNORE_ERRORS')) {
-    define('IGNORE_ERRORS', true);
-}
 
 $install_dir = realpath(__DIR__ . '/..');
 chdir($install_dir);

--- a/resources/definitions/config_definitions.json
+++ b/resources/definitions/config_definitions.json
@@ -5941,13 +5941,6 @@
             "default": false,
             "type": "boolean"
         },
-        "reporting.dump_errors": {
-            "group": "system",
-            "section": "reporting",
-            "order": 2,
-            "default": false,
-            "type": "boolean"
-        },
         "reporting.throttle": {
             "default": 30,
             "type": "integer",

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -31,7 +31,6 @@ require $install_dir . '/includes/init.php';
 chdir($install_dir);
 
 ini_set('display_errors', '1');
-//error_reporting(E_ALL & ~E_WARNING);
 
 if (getenv('DBTEST')) {
     // create testing table if needed


### PR DESCRIPTION
Show non-fatal errors in prod but keep going

If APP_ENV is production, log non-fatal errors, but only halt on fatal errors
For dev environments all errors are fatal

Gate this behind APP_DEBUG for now so we can work through errors.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
