### PR TITLE
influxdb.create_db setting

### DIFF
--- a/LibreNMS/Data/Store/InfluxDB.php
+++ b/LibreNMS/Data/Store/InfluxDB.php
@@ -44,7 +44,7 @@ class InfluxDB extends BaseDatastore
         parent::__construct();
         $this->db = $influx;
 
-        if( Config::get('influxdb.create_db', false) ){
+        if( Config::get('influxdb.create_db', true) ){
             // if the database doesn't exist, create it.
             try {
                 if (! $this->db->exists()) {

--- a/LibreNMS/Data/Store/InfluxDB.php
+++ b/LibreNMS/Data/Store/InfluxDB.php
@@ -37,20 +37,22 @@ use Log;
 class InfluxDB extends BaseDatastore
 {
     /** @var Database */
-    private $connection;
+    private $db;
 
     public function __construct(Database $influx)
     {
         parent::__construct();
-        $this->connection = $influx;
+        $this->db = $influx;
 
-        // if the database doesn't exist, create it.
-        try {
-            if (! $influx->exists()) {
-                $influx->create();
+        if( Config::get('influxdb.create_db', false) ){
+            // if the database doesn't exist, create it.
+            try {
+                if (! $this->db->exists()) {
+                    $this->db->create();
+                }
+            } catch (\Exception $e) {
+                Log::warning('InfluxDB: Could not create database');
             }
-        } catch (\Exception $e) {
-            Log::warning('InfluxDB: Could not create database');
         }
     }
 
@@ -122,7 +124,7 @@ class InfluxDB extends BaseDatastore
                 ),
             ];
 
-            $this->connection->writePoints($points);
+            $this->db->writePoints($points);
             $this->recordStatistic($stat->end());
         } catch (\InfluxDB\Exception $e) {
             Log::error('InfluxDB exception: ' . $e->getMessage());

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -1056,6 +1056,10 @@ return [
                 'description' => 'Verify SSL',
                 'help' => 'Verify the SSL certificate is valid and trusted',
             ],
+            'create_db' => [
+                'description' => 'Create Database',
+                'help' => 'Tests if database exists, create if not',
+            ],
         ],
         'influxdbv2' => [
             'bucket' => [

--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -4472,7 +4472,7 @@
             "order": 8
         },
         "influxdb.create_db": {
-            "default": false,
+            "default": true,
             "type": "boolean",
             "group": "poller",
             "section": "influxdb",

--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -4471,6 +4471,13 @@
             "section": "influxdb",
             "order": 8
         },
+        "influxdb.create_db": {
+            "default": false,
+            "type": "boolean",
+            "group": "poller",
+            "section": "influxdb",
+            "order": 9
+        },
 	"influxdbv2.enable": {
             "default": false,
             "type": "boolean",


### PR DESCRIPTION

This setting allows users to turn off the auto-creation of influxdb databases when influxdb data store is enabled.

This can also be useful if using a influx proxy service (like a telegraf sidecar) that causes exceptions to occur when ->exists() is called since it returns an empty json set from 'show databases' which the client doesn't like parsing.

In this instance this suppresses the thousands of 'InfluxDB: Could not create database' lines in your logs.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
