### PR TITLE
Improve graph theme dynamic changes

### DIFF
--- a/LibreNMS/Data/Graphing/GraphParameters.php
+++ b/LibreNMS/Data/Graphing/GraphParameters.php
@@ -43,6 +43,7 @@ class GraphParameters
     public readonly string $subtype;
     public readonly ImageFormat $imageFormat;
 
+    public readonly string $style;
     public readonly string $font;
     public readonly string $font_color;
     public readonly int $font_size;
@@ -84,6 +85,7 @@ class GraphParameters
         $this->full_size = ! empty($vars['absolute']);
         $this->is_small = $this->width < self::SMALL;
 
+        $this->style = $vars['style'] ?? '';
         $this->font = Config::get('mono_font');
         $this->font_color = Clean::alphaDash($vars['font'] ?? '');
         $this->font_size = $this->width <= self::MEDIUM_SMALL ? 7 : 8;
@@ -214,9 +216,9 @@ class GraphParameters
 
     private function graphColors(): array
     {
-        $config_suffix = Config::get('applied_site_style') == 'dark' ? '_dark' : '';
-        $def_colors = Config::get('rrdgraph_def_text' . $config_suffix);
-        $def_font = ltrim(Config::get('rrdgraph_def_text_color' . $config_suffix), '#');
+        $style = $this->style ?: session('applied_site_style');
+        $def_colors = Config::get($style == 'dark' ? 'rrdgraph_def_text_dark' : 'rrdgraph_def_text');
+        $def_font = ltrim(Config::get($style == 'dark' ? 'rrdgraph_def_text_color_dark' : 'rrdgraph_def_text_color'), '#');
 
         preg_match_all('/-c ([A-Z]+)#([0-9A-Fa-f]{6,8})/', $def_colors, $matches);
         $colors = ['FONT' => $def_font];

--- a/LibreNMS/Util/Url.php
+++ b/LibreNMS/Util/Url.php
@@ -301,7 +301,7 @@ class Url
             $args['bg'] = 'FFFFFF00';
         }
 
-        return '<img src="' . url('graph.php') . '?type=' . $args['graph_type'] . '&amp;id=' . $args['port_id'] . '&amp;from=' . $args['from'] . '&amp;to=' . $args['to'] . '&amp;width=' . $args['width'] . '&amp;height=' . $args['height'] . '&amp;bg=' . $args['bg'] . '">';
+        return '<img src="graph-image ' . url('graph.php') . '?type=' . $args['graph_type'] . '&amp;id=' . $args['port_id'] . '&amp;from=' . $args['from'] . '&amp;to=' . $args['to'] . '&amp;width=' . $args['width'] . '&amp;height=' . $args['height'] . '&amp;bg=' . $args['bg'] . '">';
     }
 
     public static function generate($vars, $new_vars = [])
@@ -359,7 +359,7 @@ class Url
             $urlargs[] = $key . '=' . ($arg === null ? '' : urlencode($arg));
         }
 
-        return '<img src="' . url('graph.php') . '?' . implode('&amp;', $urlargs) . '" style="border:0;" />';
+        return '<img class="graph-image" src="' . url('graph.php') . '?' . implode('&amp;', $urlargs) . '" style="border:0;" />';
     }
 
     public static function graphPopup($args, $content = null, $link = null)
@@ -399,7 +399,7 @@ class Url
             $urlargs[] = $key . '=' . ($arg === null ? '' : urlencode($arg));
         }
 
-        $tag = '<img class="img-responsive" src="' . url('graph.php') . '?' . implode('&amp;', $urlargs) . '" style="border:0;"';
+        $tag = '<img class="graph-image img-responsive" src="' . url('graph.php') . '?' . implode('&amp;', $urlargs) . '" style="border:0;"';
 
         if (Config::get('enable_lazy_load', true)) {
             return $tag . ' loading="lazy" />';
@@ -465,7 +465,7 @@ class Url
     {
         $vars = ['device=' . $device->device_id, "from=$start", "to=$end", "width=$width", "height=$height", "type=$type", "legend=$legend", "absolute=$absolute_size"];
 
-        return '<img class="' . $class . '" width="' . $width . '" height="' . $height . '" src="' . url('graph.php') . '?' . implode($sep, $vars) . '">';
+        return '<img class="graph-image ' . $class . '" width="' . $width . '" height="' . $height . '" src="' . url('graph.php') . '?' . implode($sep, $vars) . '">';
     }
 
     /**

--- a/app/Http/Controllers/Ajax/SessionController.php
+++ b/app/Http/Controllers/Ajax/SessionController.php
@@ -26,14 +26,25 @@
 
 namespace App\Http\Controllers\Ajax;
 
-use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
-class ResolutionController extends Controller
+class SessionController
 {
-    public function set(Request $request)
+    public function style(Request $request): JsonResponse
     {
-        $this->validate($request, [
+        $request->validate([
+            'style' => 'required|string|in:dark,light',
+        ]);
+
+        $request->session()->put('applied_site_style', $request->style);
+
+        return response()->json(['style' => $request->style]);
+    }
+
+    public function resolution(Request $request): string
+    {
+        $request->validate([
             'width' => 'required|numeric',
             'height' => 'required|numeric',
         ]);

--- a/app/Http/Middleware/LoadUserPreferences.php
+++ b/app/Http/Middleware/LoadUserPreferences.php
@@ -4,7 +4,6 @@ namespace App\Http\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
-use LibreNMS\Config;
 use Symfony\Component\HttpFoundation\Response;
 
 class LoadUserPreferences
@@ -25,11 +24,13 @@ class LoadUserPreferences
                 app()->setLocale($locale);
             });
 
-            $this->setPreference($request, 'site_style', function ($style) {
-                Config::set('applied_site_style', $style);
+            $this->setPreference($request, 'site_style', function ($style, $request) {
+                if ($style !== 'device' && $style !== $request->session()->get('applied_site_style')) {
+                    $request->session()->put('applied_site_style', $style);
+                }
             });
 
-            $this->setPreference($request, 'timezone', function ($timezone) use ($request) {
+            $this->setPreference($request, 'timezone', function ($timezone, $request) {
                 $request->session()->put('preferences.timezone', $timezone);
                 $request->session()->put('preferences.timezone_static', true);
             });
@@ -62,7 +63,7 @@ class LoadUserPreferences
     {
         $value = $request->session()->get("preferences.$pref");
         if ($value !== null) {
-            $callable($value);
+            $callable($value, $request);
         }
     }
 }

--- a/app/Http/ViewComposers/MenuComposer.php
+++ b/app/Http/ViewComposers/MenuComposer.php
@@ -64,7 +64,7 @@ class MenuComposer
         $vars = [];
         /** @var User $user */
         $user = Auth::user();
-        $site_style = Config::get('applied_site_style');
+        $site_style = session('applied_site_style');
 
         //global Settings
         $vars['hide_dashboard_editor'] = UserPref::getPref($user, 'hide_dashboard_editor');

--- a/html/js/librenms.js
+++ b/html/js/librenms.js
@@ -629,6 +629,23 @@ function popUp(URL)
     window.open(URL, '_blank', 'toolbar=0,scrollbars=1,location=0,statusbar=0,menubar=0,resizable=1,width=550,height=600');
 }
 
+function applySiteStyle(newStyle) {
+    // translate device to actual style
+    if (newStyle === 'device') {
+        newStyle = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    }
+
+    document.documentElement.classList.toggle('dark', newStyle === 'dark');
+
+    if (window.siteStyle !== newStyle) {
+        window.siteStyle = newStyle;
+        $.post(ajax_url + '/set_style', { style: newStyle });
+        document.querySelectorAll('img.graph-image').forEach(img => {
+            img.src = img.src.replace(/&style=\w+/g, '') + '&style=' + newStyle;
+        });
+    }
+}
+
 // popup component javascript.  Hopefully temporary.
 document.addEventListener("alpine:init", () => {
     Alpine.data("popup", () => ({

--- a/includes/html/functions.inc.php
+++ b/includes/html/functions.inc.php
@@ -164,7 +164,7 @@ function generate_dynamic_graph_tag($args)
         $urlargs[] = $key . '=' . $value;
     }
 
-    return '<img style="width:' . $width . 'px;height:100%" class="graph img-responsive" data-src-template="graph.php?' . implode('&amp;', $urlargs) . '" border="0" />';
+    return '<img style="width:' . $width . 'px;height:100%" class="graph graph-image img-responsive" data-src-template="graph.php?' . implode('&amp;', $urlargs) . '" border="0" />';
 }//end generate_dynamic_graph_tag()
 
 function generate_dynamic_graph_js($args)

--- a/includes/html/graphs/device/icmp_perf.inc.php
+++ b/includes/html/graphs/device/icmp_perf.inc.php
@@ -16,7 +16,7 @@ require 'includes/html/graphs/common.inc.php';
 
 $graph_params->scale_min = 0;
 
-if (\LibreNMS\Config::get('applied_site_style') != 'dark') {
+if (session('applied_site_style') != 'dark') {
     // light
     $line_color = '#36393d';
     $jitter_color = '#ccd2decc';

--- a/includes/html/graphs/sensor/generic.inc.php
+++ b/includes/html/graphs/sensor/generic.inc.php
@@ -1,13 +1,12 @@
 <?php
 
-use LibreNMS\Config;
 use LibreNMS\Data\Store\Rrd;
 use LibreNMS\Util\Number;
 
 $sensor_descr_fixed = Rrd::fixedSafeDescr($sensor->sensor_descr, 25);
-$sensor_color = (Config::get('applied_site_style') == 'dark') ? '#f2f2f2' : '#272b30';
-$background_color = (Config::get('applied_site_style') == 'dark') ? '#272b30' : '#ffffff';
-$variance_color = (Config::get('applied_site_style') == 'dark') ? '#3e444c' : '#c5c5c5';
+$sensor_color = session('applied_site_style') == 'dark' ? '#f2f2f2' : '#272b30';
+$background_color = session('applied_site_style') == 'dark' ? '#272b30' : '#ffffff';
+$variance_color = session('applied_site_style') == 'dark' ? '#3e444c' : '#c5c5c5';
 $unit_label = str_replace('%', '%%', $sensor->unit());
 
 // Next line is a workaround while rrdtool --left-axis-format doesn't support %S

--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -6007,7 +6007,7 @@
             "type": "color"
         },
         "rrdgraph_def_text_color_dark": {
-            "default": "bfc0c0",
+            "default": "f8f9f9",
             "type": "color"
         },
         "rrdgraph_real_percentile": {

--- a/resources/views/layouts/librenmsv1.blade.php
+++ b/resources/views/layouts/librenmsv1.blade.php
@@ -43,8 +43,8 @@
     <link href="{{ asset('css/query-builder.default.min.css') }}" rel="stylesheet">
     <link href="{{ asset(LibrenmsConfig::get('stylesheet', 'css/styles.css')) }}?ver=16042501" rel="stylesheet">
     <link href="{{ asset('css/tw_dark.css?ver=03052025') }}" rel="stylesheet">
-    @if(!in_array(LibrenmsConfig::get('applied_site_style'), ['device', 'light', 'dark']))
-    <link href="{{ asset('css/' . LibrenmsConfig::get('applied_site_style') . '.css?ver=732417643') }}" rel="stylesheet">
+    @if(!in_array(session('applied_site_style', 'light'), ['light', 'dark']))
+    <link href="{{ asset('css/' . session('applied_site_style') . '.css?ver=732417643') }}" rel="stylesheet">
     @endif
     @foreach(LibrenmsConfig::get('webui.custom_css', []) as $custom_css)
         <link href="{{ $custom_css }}" rel="stylesheet">
@@ -78,27 +78,23 @@
         });
         var ajax_url = "{{ url('/ajax') }}";
     </script>
-    <script src="{{ asset('js/librenms.js?ver=29042025') }}"></script>
+    <script src="{{ asset('js/librenms.js?ver=16052025') }}"></script>
     <script type="text/javascript" src="{{ asset('js/overlib_mini.js') }}"></script>
     <script type="text/javascript" src="{{ asset('js/toastr.min.js?ver=05072021') }}"></script>
     <script type="text/javascript" src="{{ asset('js/boot.js?ver=10272021') }}"></script>
     <script>
+        window.siteStyle = '{{ session('applied_site_style') }}';
+        window.siteStylePreference = '{{ session('preferences.site_style') }}';
+
         // Apply color scheme
-        (function () {
-            const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
-            const theme = '{{ LibrenmsConfig::get('applied_site_style') }}';
-            const applyTheme = (isDark) => {
-                document.documentElement.classList.toggle('dark', isDark);
-            };
+        applySiteStyle(window.siteStylePreference);
 
-            applyTheme(theme === 'dark' || (theme === 'device' && mediaQuery.matches));
-
-            mediaQuery.addEventListener('change', (event) => {
-                if (theme === 'device') {
-                    applyTheme(event.matches);
-                }
-            });
-        })();
+        // Listen for system theme changes in device mode
+        window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (event) => {
+            if (window.siteStylePreference === 'device') {
+                applySiteStyle(event.matches ? 'dark' : 'light');
+            }
+        });
     </script>
     @auth
         @if(session('preferences.timezone_static') == null || ! session('preferences.timezone_static'))

--- a/routes/web.php
+++ b/routes/web.php
@@ -210,7 +210,8 @@ Route::middleware(['auth'])->group(function () {
         Route::get('search/port', Ajax\PortSearchController::class);
         Route::post('set_map_group', [Ajax\AvailabilityMapController::class, 'setGroup']);
         Route::post('set_map_view', [Ajax\AvailabilityMapController::class, 'setView']);
-        Route::post('set_resolution', [Ajax\ResolutionController::class, 'set']);
+        Route::post('set_resolution', [Ajax\SessionController::class, 'resolution']);
+        Route::post('set_style', [Ajax\SessionController::class, 'style']);
         Route::get('netcmd', [Ajax\NetCommand::class, 'run']);
         Route::post('ripe/raw', [Ajax\RipeNccApiController::class, 'raw']);
         Route::get('snmp/capabilities', Ajax\SnmpCapabilities::class)->name('snmp.capabilities');


### PR DESCRIPTION
If theme changes without reloading the page, force all graphs to update
Make sure theme state is consistent across backend and frontend (html+javascript)

(this fixes graphs having black legend text on dark modes in some situations)

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
