### PR TITLE
Remove extra ajax call from every page load

### DIFF
--- a/resources/views/layouts/librenmsv1.blade.php
+++ b/resources/views/layouts/librenmsv1.blade.php
@@ -115,7 +115,12 @@
 </head>
 <body>
 @if(Auth::check())
-    <script>updateResolution();</script>
+    <script>
+        // only update resolution if it doesn't match what is stored in the session
+        if (window.innerWidth !== {{ session('screen_width') }} || window.innerHeight !== {{ session('screen_height') }}) {
+            updateResolution(false);
+        }
+    </script>
 @endif
 
 @if(Request::get('bare') == 'yes')

--- a/resources/views/layouts/librenmsv1.blade.php
+++ b/resources/views/layouts/librenmsv1.blade.php
@@ -117,7 +117,7 @@
 @if(Auth::check())
     <script>
         // only update resolution if it doesn't match what is stored in the session
-        if (window.innerWidth !== {{ session('screen_width') }} || window.innerHeight !== {{ session('screen_height') }}) {
+        if (document.documentElement.clientWidth !== {{ session('screen_width') }} || document.documentElement.clientHeight !== {{ session('screen_height') }}) {
             updateResolution(false);
         }
     </script>


### PR DESCRIPTION
We don't need to send the current window resolution to the backend if it already matches what is stored in the session.



#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
