### PR TITLE
Fix compact availability map ignore alerts display classes

### DIFF
--- a/html/css/styles.css
+++ b/html/css/styles.css
@@ -1828,6 +1828,20 @@ label {
   background-color: #36393D;
 }
 
+.availability-map-oldview-box-ignored-up {
+  height:12px;
+  width:12px;
+  float:left;
+  background-color: #5CB85C;
+}
+
+.availability-map-oldview-box-ignored-down {
+  height:12px;
+  width:12px;
+  float:left;
+  background-color: #36393D;
+}
+
 .availability-map-widget-header {
   line-height:34px;
 }


### PR DESCRIPTION
Devices with _Ignore alert tag_ set are breaking the compact availability map display when sorted by _Label_ or _Status_, as they are assigned missing classes:

![image](https://github.com/user-attachments/assets/8da501e8-38b2-459e-a2b0-35f395b4f973)

Enclosed are the missing classes following the standard box ignore status colours so it now displays the same (grey for ignored-down, and normal green for ignored-up):

![image](https://github.com/user-attachments/assets/c01d4347-ab91-47ba-97ea-ef56b5af3ac6)


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
