### PR TITLE
Fix : inconsistent label in getServiceLabel

### DIFF
--- a/app/Http/Controllers/Widgets/AvailabilityMapController.php
+++ b/app/Http/Controllers/Widgets/AvailabilityMapController.php
@@ -216,7 +216,7 @@ class AvailabilityMapController extends WidgetController
             return '';
         }
 
-        return $service->service_type . ' - ' . __($state_name);
+        return $service->service_name;
     }
 
     private function getDeviceTooltip(Device $device, string $state_name): string


### PR DESCRIPTION
This pull request updates the getServiceLabel method to return service_name instead of service_type.
This change improves label clarity and UI consistency:

1. The service state is already visually represented by the availability map's color.
2. service_type is a technical label and not appropriate for user-facing display.
3. Using service_name ensures the correct label is shown.
