### PR TITLE
fix sensor table to link drill-down URL to the specific graph instead of to the device sensor list

### DIFF
--- a/app/Http/Controllers/Table/SensorsController.php
+++ b/app/Http/Controllers/Table/SensorsController.php
@@ -80,7 +80,7 @@ class SensorsController extends TableController
         $hostname = Blade::render('<x-device-link :device="$device" />', ['device' => $sensor->device]);
         $link = Url::generate(['page' => 'device', 'device' => $sensor['device_id'], 'tab' => 'health', 'metric' => $sensor->sensor_class]);
         $descr = Url::graphPopup($graph_array, $sensor->sensor_descr, $link);
-        $mini_graph = Url::graphPopup($graph_array, null, $link);
+        $mini_graph = Url::graphPopup($graph_array);
         $sensor_current = Html::severityToLabel($sensor->currentStatus(), $sensor->formatValue());
         $alert = $sensor->currentStatus() == Severity::Error ? '<i class="fa fa-flag fa-lg" style="color:red" aria-hidden="true"></i>' : '';
 


### PR DESCRIPTION
There was a code refactor in commit https://github.com/librenms/librenms/commit/2dc78539074c87294a07672770eede7f7885f624 which changed the behaviour of sensor table links.

Previously, if you clicked on the mini-graph on the sensor table view, this would link to the specific graph which appeared in the mouseover pop-up. The new behaviour is that it links to the device sensor table.

To see this in action:

1. navigate to https://foo.example.com/health/metric=snr
2. mouse-over and then click on one of the mini-graphs in the table display
3. this navigates to https://foo.example.com/device/device=<devicenum>/tab=health/metric=snr/ instead of the graph that appeared in the popup. This is counterintuitive and a regression on devices with a lot of interfaces.

This PR restores the previous behaviour, i.e. that clicking on the graph now brings up the specific graph view, instead of the table view of all available graphs on the device.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
