### PR TITLE
Convert SNMP get to walk for netmask discovery

### DIFF
--- a/includes/discovery/ipv4-addresses.inc.php
+++ b/includes/discovery/ipv4-addresses.inc.php
@@ -25,9 +25,10 @@ foreach (DeviceCache::getPrimary()->getVrfContexts() as $context_name) {
     } else {
         unset($valid_v4);
         $oids = SnmpQuery::hideMib()->walk('IP-MIB::ipAdEntIfIndex')->table(1);
+        $masks = SnmpQuery::hideMib()->walk('IP-MIB::ipAdEntNetMask')->table(1);
         foreach ($oids as $ipv4_address => $indexArray) {
             $ifIndex = intval($indexArray['ipAdEntIfIndex']);
-            $mask = SnmpQuery::get('IP-MIB::ipAdEntNetMask.' . $ipv4_address)->value();
+            $mask = $masks[$ipv4_address]['ipAdEntNetMask'];
             discover_process_ipv4($valid_v4, $device, $ifIndex, $ipv4_address, $mask, $context_name);
         }
     } // if [custom / standard]


### PR DESCRIPTION
While testing some other work I noticed a large number of SNMP get requests being run in the IPv4 discovery code.  This PR converts the netmask lookup to a walk query instead of doing a get for each IP address.  

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
