### PR TITLE
Update bill alert test data

### DIFF
--- a/tests/data/misc/querybuilder.json
+++ b/tests/data/misc/querybuilder.json
@@ -122,8 +122,8 @@
         "%bills.bill_name = \"Neil's Bill\"",
         {"condition":"AND","rules":[{"id":"bills.bill_name","field":"bills.bill_name","type":"string","input":"text","operator":"equal","value":"Neil's Bill"}],"valid":true},
         "bills.bill_name = \"Neil's Bill\"",
-        "SELECT * FROM devices,ports,bill_ports,bills WHERE (devices.device_id = ? AND devices.device_id = ports.device_id AND ports.port_id = bill_ports.port_id AND bill_ports.bill_id = bills.bill_id) AND bills.bill_name = \"Neil's Bill\"",
-        ["select * from `devices` left join `ports` on `devices`.`device_id` = `ports`.`device_id` left join `bill_ports` on `ports`.`port_id` = `bill_ports`.`port_id` left join `bills` on `bill_ports`.`bill_id` = `bills`.`bill_id` where (`bills`.`bill_name` = ?)", ["Neil's Bill"]]
+        "SELECT * FROM devices,ports,bill_port_counters,bills WHERE (devices.device_id = ? AND devices.device_id = ports.device_id AND ports.port_id = bill_port_counters.port_id AND bill_port_counters.bill_id = bills.bill_id) AND bills.bill_name = \"Neil's Bill\"",
+        ["select * from `devices` left join `ports` on `devices`.`device_id` = `ports`.`device_id` left join `bill_port_counters` on `ports`.`port_id` = `bill_port_counters`.`port_id` left join `bills` on `bill_port_counters`.`bill_id` = `bills`.`bill_id` where (`bills`.`bill_name` = ?)", ["Neil's Bill"]]
     ],
     [
         "%ports.ifOutErrors_rate >= \"100\" || %ports.ifInErrors_rate >= \"100\"",


### PR DESCRIPTION
#17664 changed the order of the tables so bill_port_counters comes first. It looked like altering the test was the right way as we don't care about how we get to device_id just that we do.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
