### PR TITLE
SnmpResponse filter No Such Object

### DIFF
--- a/LibreNMS/Data/Source/SnmpResponse.php
+++ b/LibreNMS/Data/Source/SnmpResponse.php
@@ -301,7 +301,7 @@ class SnmpResponse
     public function getRawWithoutBadLines(): string
     {
         return (string) preg_replace([
-            '/^.*No Such Instance currently exists.*$/m',
+            '/^.*No Such (Instance currently exists|Object available on this agent at this OID).*$/m',
             '/(\n[^\r\n]+No more variables left[^\r\n]+)+$/m',
         ], '', $this->raw);
     }


### PR DESCRIPTION
Fixes issues with the collect-snmp-data.php script adding empty oids `||`

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
