### PR TITLE
API functions: fix preg_match deprecation error

### DIFF
--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -323,7 +323,7 @@ function list_devices(Illuminate\Http\Request $request)
     $query = $request->get('query');
     $param = [];
 
-    if (preg_match('/^([a-z_]+)(?: (desc|asc))?$/i', $order, $matches)) {
+    if (is_string($order) && preg_match('/^([a-z_]+)(?: (desc|asc))?$/i', $order, $matches)) {
         $order = "d.`$matches[1]` " . ($matches[2] ?? 'ASC');
     } else {
         $order = 'd.`hostname` ASC';


### PR DESCRIPTION
PHP Error(8192): preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated in /home/runner/work/librenms/librenms/includes/html/api_functions.inc.php on line 326

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
