### PR TITLE
Don't pass str_replace a null value

### DIFF
--- a/includes/rewrites.php
+++ b/includes/rewrites.php
@@ -4,6 +4,7 @@ use LibreNMS\Config;
 
 function rewrite_entity_descr($descr)
 {
+    $descr = (string) $descr;
     $descr = str_replace('Distributed Forwarding Card', 'DFC', $descr);
     $descr = preg_replace('/7600 Series SPA Interface Processor-/', '7600 SIP-', $descr);
     $descr = preg_replace('/Rev\.\ [0-9\.]+\ /', '', $descr);


### PR DESCRIPTION
PHP Error(8192): str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in /home/runner/work/librenms/librenms/includes/rewrites.php on line 7

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
