### PR TITLE
Compare: Use Str function to prevent deprecation warning

### DIFF
--- a/LibreNMS/Util/Compare.php
+++ b/LibreNMS/Util/Compare.php
@@ -79,9 +79,9 @@ class Compare
             case 'not_ends':
                 return ! Str::endsWith($a, $b);
             case 'regex':
-                return (bool) preg_match($b, $a);
+                return Str::isMatch($b, $a);
             case 'not_regex':
-                return ! ((bool) preg_match($b, $a));
+                return ! Str::isMatch($b, $a);
             case 'in_array':
                 return in_array($a, $b);
             case 'not_in_array':


### PR DESCRIPTION
Prevents: preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
