### PR TITLE
wireguard: extract only the interface names to log

### DIFF
--- a/includes/polling/applications/wireguard.inc.php
+++ b/includes/polling/applications/wireguard.inc.php
@@ -176,11 +176,11 @@ if (count($added_interfaces) > 0 || count($removed_interfaces) > 0) {
     $log_message = 'Wireguard Interfaces Change:';
     $log_message .=
         count($added_interfaces) > 0
-            ? ' Added ' . implode(',', $added_interfaces)
+            ? ' Added ' . implode(',', array_keys($added_interfaces))
             : '';
     $log_message .=
         count($removed_interfaces) > 0
-            ? ' Removed ' . implode(',', $removed_interfaces)
+            ? ' Removed ' . implode(',', array_keys($removed_interfaces))
             : '';
     Eventlog::log($log_message, $device['device_id'], 'application');
 }


### PR DESCRIPTION
it's a multidimensional array, and we only need the interface names here.
```
array:1 [
  "wg0" => array:5 [
    0 => "client1.domain.com"
    1 => "client2"
    2 => "my_phone"
    3 => "it_admin.domain.org"
    4 => "computer"
  ]
]
```

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
