### PR TITLE
Error Reporting: skip vendor frames

### DIFF
--- a/app/Exceptions/ErrorReporting.php
+++ b/app/Exceptions/ErrorReporting.php
@@ -161,7 +161,14 @@ class ErrorReporting
         if ($environment == 'production' || $environment == 'testing' || ! config('app.debug')) {
             // in production, don't halt execution on non-fatal errors
             set_error_handler(function ($severity, $message, $file, $line) {
-                error_log("PHP Error($severity): $message in $file on line $line");
+                // If file is from a package, find the first non-vendor frame
+                if (str_contains($file, '/vendor/')) {
+                    // add vendor file to message
+                    $message .= ' from ' . strstr($file, 'vendor') . ':' . $line;
+                    [$file, $line] = self::findFirstNonVendorFrame();
+                }
+
+                error_log("PHP Error($severity): $message in $file:$line");
 
                 // For notices and warnings, prevent conversion to exceptions
                 if (in_array($severity, [E_NOTICE, E_WARNING, E_USER_NOTICE, E_USER_WARNING, E_DEPRECATED])) {
@@ -179,5 +186,23 @@ class ErrorReporting
                 ]);
             });
         }
+    }
+
+    private static function findFirstNonVendorFrame(): array
+    {
+        foreach (debug_backtrace() as $trace) {
+            // not vendor frames
+            if (isset($trace['file']) && str_contains($trace['file'], '/vendor/')) {
+                continue;
+            }
+            // not this class
+            if (isset($trace['class']) && $trace['class'] === self::class) {
+                continue;
+            }
+
+            return [$trace['file'], $trace['line']];
+        }
+
+        return ['', ''];
     }
 }


### PR DESCRIPTION
This allows a better error message while sticking to one line


#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
