### PR TITLE
str_getcsv: depending on the default value of escape is deprecated

### DIFF
--- a/includes/syslog.php
+++ b/includes/syslog.php
@@ -130,7 +130,7 @@ function process_syslog($entry, $update)
         } elseif ($os == 'zywall') {
             // Zwwall sends messages without all the fields, so the offset is wrong
             $msg = preg_replace('/" /', '";', stripslashes($entry['program'] . ':' . $entry['msg']));
-            $msg = str_getcsv($msg, ';', escape: "\\");
+            $msg = str_getcsv($msg, ';', escape: '\\');
             $entry['program'] = null;
             foreach ($msg as $param) {
                 [$var, $val] = explode('=', $param);

--- a/includes/syslog.php
+++ b/includes/syslog.php
@@ -130,7 +130,7 @@ function process_syslog($entry, $update)
         } elseif ($os == 'zywall') {
             // Zwwall sends messages without all the fields, so the offset is wrong
             $msg = preg_replace('/" /', '";', stripslashes($entry['program'] . ':' . $entry['msg']));
-            $msg = str_getcsv($msg, ';');
+            $msg = str_getcsv($msg, ';', escape: "\\");
             $entry['program'] = null;
             foreach ($msg as $param) {
                 [$var, $val] = explode('=', $param);


### PR DESCRIPTION
Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
