### PR TITLE
Hide redis connection errors in validate

### DIFF
--- a/LibreNMS/Validations/Poller/CheckLocking.php
+++ b/LibreNMS/Validations/Poller/CheckLocking.php
@@ -35,6 +35,8 @@ class CheckLocking implements \LibreNMS\Interfaces\Validation
      */
     public function validate(): ValidationResult
     {
+        set_error_handler(function () {}); // hide connection errors, we will send our own message
+
         try {
             $lock = \Cache::lock('dist_test_validation', 5);
             $lock->get();
@@ -43,6 +45,8 @@ class CheckLocking implements \LibreNMS\Interfaces\Validation
             return ValidationResult::ok(trans('validation.validations.poller.CheckLocking.ok'));
         } catch (\Exception $e) {
             return ValidationResult::fail(trans('validation.validations.poller.CheckLocking.fail', ['message' => $e->getMessage()]));
+        } finally {
+            restore_error_handler();
         }
     }
 

--- a/LibreNMS/Validations/Poller/CheckRedis.php
+++ b/LibreNMS/Validations/Poller/CheckRedis.php
@@ -63,12 +63,16 @@ class CheckRedis implements \LibreNMS\Interfaces\Validation
 
     private function redisIsAvailable(): bool
     {
+        set_error_handler(function () {}); // hide connection errors, we will send our own message
+
         try {
             Redis::command('ping');
 
             return true;
         } catch (\Exception $e) {
             return false;
+        } finally {
+            restore_error_handler();
         }
     }
 }


### PR DESCRIPTION
@librenms/reviewers what do we think of this solution?

When running validate and not upgrading errors to exceptions (the default now), these errors are shown.  They are really duplicate of the failure we print, but not as clear.

Checking poller:PHP Error(2): stream_socket_client(): Unable to connect to tcp://127.0.0.1:6379 (Connection refused) from vendor/predis/predis/src/Connection/Resource/StreamFactory.php:209 in /home/murrant/projects/librenms/LibreNMS/Validations/Poller/CheckLocking.php:40
PHP Error(2): stream_socket_client(): Unable to connect to tcp://127.0.0.1:6379 (Connection refused) from vendor/predis/predis/src/Connection/Resource/StreamFactory.php:209 in /home/murrant/projects/librenms/LibreNMS/Validations/Poller/CheckRedis.php:67



#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
