### PR TITLE
Update deltaups.yaml to add values

### DIFF
--- a/resources/definitions/os_discovery/deltaups.yaml
+++ b/resources/definitions/os_discovery/deltaups.yaml
@@ -5,3 +5,24 @@ modules:
             - DeltaUPS-MIB::dupsIdentModel.0
         hardware_template: '{{ DeltaUPS-MIB::dupsIdentManufacturer.0 }} {{ DeltaUPS-MIB::dupsIdentModel.0 }}'
         version: DeltaUPS-MIB::dupsIdentUPSSoftwareVersion.0
+    sensors:
+        count:
+            options:
+                skip_value_lt: 1
+            data:
+                -
+                    oid: 'DeltaUPS-MIB::dupsConfigExternalBatteryPack'
+                    num_oid: '.1.3.6.1.4.1.2254.2.4.3.8.0'
+                    descr: 'External Battery Packs'
+        temperature:
+            data:
+                -
+                    oid: 'DeltaUPS-MIB::dupsEnvTemperature'
+                    num_oid: '.1.3.6.1.4.1.2254.2.4.10.1.0'
+                    descr: 'Environment Temperature'
+                    skip_values:
+                        -
+                            oid: 'DeltaUPS-MIB::dupsEnvTemperature'
+                            op: '='
+                            value: 0
+


### PR DESCRIPTION
Add environment temperature and external battery pack count for Delta UPSes.  Do not record zeros for either value.  

Environment temperature returns zero even when the environment sensor is not plugged in or enabled, hence the ignoring of zero values.  

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
