### PR TITLE
cleanup various possible undef messages CAPEv2 monitoring

### DIFF
--- a/includes/polling/applications/cape.inc.php
+++ b/includes/polling/applications/cape.inc.php
@@ -39,24 +39,24 @@ $rrd_def_general = RrdDefinition::make()
     ->addDataset('warning', 'GAUGE', 0)
     ->addDataset('wrong_prog', 'GAUGE', 0);
 $fields = [
-    'banned' => $returned['banned'],
-    'completed' => $returned['completed'],
-    'critical' => $returned['critical'],
-    'debug' => $returned['debug'],
-    'distributed' => $returned['distributed'],
-    'error' => $returned['error'],
-    'failed_analysis' => $returned['failed_analysis'],
-    'failed_processing' => $returned['failed_processing'],
-    'failed_reporting' => $returned['failed_reporting'],
-    'info' => $returned['info'],
-    'pending' => $returned['pending'],
-    'recovered' => $returned['recovered'],
-    'reported' => $returned['reported'],
-    'running' => $returned['running'],
-    'timedout' => $returned['timedout'],
-    'total_tasks' => $returned['total_tasks'],
-    'warning' => $returned['warning'],
-    'wrong_prog' => $returned['wrong_prog'],
+    'banned' => $returned['banned'] ?? null,
+    'completed' => $returned['completed'] ?? null,
+    'critical' => $returned['critical'] ?? null,
+    'debug' => $returned['debug'] ?? null,
+    'distributed' => $returned['distributed'] ?? null,
+    'error' => $returned['error'] ?? null,
+    'failed_analysis' => $returned['failed_analysis'] ?? null,
+    'failed_processing' => $returned['failed_processing'] ?? null,
+    'failed_reporting' => $returned['failed_reporting'] ?? null,
+    'info' => $returned['info'] ?? null,
+    'pending' => $returned['pending'] ?? null,
+    'recovered' => $returned['recovered'] ?? null,
+    'reported' => $returned['reported'] ?? null,
+    'running' => $returned['running'] ?? null,
+    'timedout' => $returned['timedout'] ?? null,
+    'total_tasks' => $returned['total_tasks'] ?? null,
+    'warning' => $returned['warning'] ?? null,
+    'wrong_prog' => $returned['wrong_prog'] ?? null,
 ];
 $tags = ['name' => $name, 'app_id' => $app->app_id, 'rrd_def' => $rrd_def_general, 'rrd_name' => $rrd_name];
 app('Datastore')->put($device, 'app', $tags, $fields);
@@ -77,16 +77,16 @@ $rrd_def_dropped_files = RrdDefinition::make()
     ->addDataset('s8dropped_files', 'GAUGE', 0)
     ->addDataset('s9dropped_files', 'GAUGE', 0);
 $fields = [
-    'dropped_files' => $returned['dropped_files'],
-    's0dropped_files' => $returned['min.dropped_files'],
-    's1dropped_files' => $returned['max.dropped_files'],
-    's2dropped_files' => $returned['range.dropped_files'],
-    's3dropped_files' => $returned['mean.dropped_files'],
-    's4dropped_files' => $returned['median.dropped_files'],
-    's5dropped_files' => $returned['mode.dropped_files'],
-    's6dropped_files' => $returned['v.dropped_files'],
-    's7dropped_files' => $returned['sd.dropped_files'],
-    's8dropped_files' => $returned['vp.dropped_files'],
+    'dropped_files' => $returned['dropped_files'] ?? null,
+    's0dropped_files' => $returned['min.dropped_files'] ?? null,
+    's1dropped_files' => $returned['max.dropped_files'] ?? null,
+    's2dropped_files' => $returned['range.dropped_files'] ?? null,
+    's3dropped_files' => $returned['mean.dropped_files'] ?? null,
+    's4dropped_files' => $returned['median.dropped_files'] ?? null,
+    's5dropped_files' => $returned['mode.dropped_files'] ?? null,
+    's6dropped_files' => $returned['v.dropped_files'] ?? null,
+    's7dropped_files' => $returned['sd.dropped_files'] ?? null,
+    's8dropped_files' => $returned['vp.dropped_files'] ?? null,
     's9dropped_files' => $returned['sdp.dropped_files'],
 ];
 $tags = ['name' => $name, 'app_id' => $app->app_id, 'rrd_def' => $rrd_def_dropped_files, 'rrd_name' => $rrd_name];
@@ -108,17 +108,17 @@ $rrd_def_running_processes = RrdDefinition::make()
     ->addDataset('s8running_processes', 'GAUGE', 0)
     ->addDataset('s9running_processes', 'GAUGE', 0);
 $fields_running_processes = [
-    'running_processes' => $returned['running_processes'],
-    's0running_processes' => $returned['min.running_processes'],
-    's1running_processes' => $returned['max.running_processes'],
-    's2running_processes' => $returned['range.running_processes'],
-    's3running_processes' => $returned['mean.running_processes'],
-    's4running_processes' => $returned['median.running_processes'],
-    's5running_processes' => $returned['mode.running_processes'],
-    's6running_processes' => $returned['v.running_processes'],
-    's7running_processes' => $returned['sd.running_processes'],
-    's8running_processes' => $returned['vp.running_processes'],
-    's9running_processes' => $returned['sdp.running_processes'],
+    'running_processes' => $returned['running_processes'] ?? null,
+    's0running_processes' => $returned['min.running_processes'] ?? null,
+    's1running_processes' => $returned['max.running_processes'] ?? null,
+    's2running_processes' => $returned['range.running_processes'] ?? null,
+    's3running_processes' => $returned['mean.running_processes'] ?? null,
+    's4running_processes' => $returned['median.running_processes'] ?? null,
+    's5running_processes' => $returned['mode.running_processes'] ?? null,
+    's6running_processes' => $returned['v.running_processes'] ?? null,
+    's7running_processes' => $returned['sd.running_processes'] ?? null,
+    's8running_processes' => $returned['vp.running_processes'] ?? null,
+    's9running_processes' => $returned['sdp.running_processes'] ?? null,
 ];
 $tags = ['name' => $name, 'app_id' => $app->app_id, 'rrd_def' => $rrd_def_running_processes, 'rrd_name' => $rrd_name];
 app('Datastore')->put($device, 'app', $tags, $fields_running_processes);
@@ -139,17 +139,17 @@ $rrd_def_api_calls = RrdDefinition::make()
     ->addDataset('s8api_calls', 'GAUGE', 0)
     ->addDataset('s9api_calls', 'GAUGE', 0);
 $fields_api_calls = [
-    'api_calls' => $returned['api_calls'],
-    's0api_calls' => $returned['min.api_calls'],
-    's1api_calls' => $returned['max.api_calls'],
-    's2api_calls' => $returned['range.api_calls'],
-    's3api_calls' => $returned['mean.api_calls'],
-    's4api_calls' => $returned['median.api_calls'],
-    's5api_calls' => $returned['mode.api_calls'],
-    's6api_calls' => $returned['v.api_calls'],
-    's7api_calls' => $returned['sd.api_calls'],
-    's8api_calls' => $returned['vp.api_calls'],
-    's9api_calls' => $returned['sdp.api_calls'],
+    'api_calls' => $returned['api_calls'] ?? null,
+    's0api_calls' => $returned['min.api_calls'] ?? null,
+    's1api_calls' => $returned['max.api_calls'] ?? null,
+    's2api_calls' => $returned['range.api_calls'] ?? null,
+    's3api_calls' => $returned['mean.api_calls'] ?? null,
+    's4api_calls' => $returned['median.api_calls'] ?? null,
+    's5api_calls' => $returned['mode.api_calls'] ?? null,
+    's6api_calls' => $returned['v.api_calls'] ?? null,
+    's7api_calls' => $returned['sd.api_calls'] ?? null,
+    's8api_calls' => $returned['vp.api_calls'] ?? null,
+    's9api_calls' => $returned['sdp.api_calls'] ?? null,
 ];
 $tags = ['name' => $name, 'app_id' => $app->app_id, 'rrd_def' => $rrd_def_api_calls, 'rrd_name' => $rrd_name];
 app('Datastore')->put($device, 'app', $tags, $fields_api_calls);
@@ -170,17 +170,17 @@ $rrd_def_domains = RrdDefinition::make()
     ->addDataset('s8domains', 'GAUGE', 0)
     ->addDataset('s9domains', 'GAUGE', 0);
 $fields_domains = [
-    'domains' => $returned['domains'],
-    's0domains' => $returned['min.domains'],
-    's1domains' => $returned['max.domains'],
-    's2domains' => $returned['range.domains'],
-    's3domains' => $returned['mean.domains'],
-    's4domains' => $returned['median.domains'],
-    's5domains' => $returned['mode.domains'],
-    's6domains' => $returned['v.domains'],
-    's7domains' => $returned['sd.domains'],
-    's8domains' => $returned['vp.domains'],
-    's9domains' => $returned['sdp.domains'],
+    'domains' => $returned['domains'] ?? null,
+    's0domains' => $returned['min.domains'] ?? null,
+    's1domains' => $returned['max.domains'] ?? null,
+    's2domains' => $returned['range.domains'] ?? null,
+    's3domains' => $returned['mean.domains'] ?? null,
+    's4domains' => $returned['median.domains'] ?? null,
+    's5domains' => $returned['mode.domains'] ?? null,
+    's6domains' => $returned['v.domains'] ?? null,
+    's7domains' => $returned['sd.domains'] ?? null,
+    's8domains' => $returned['vp.domains'] ?? null,
+    's9domains' => $returned['sdp.domains'] ?? null,
 ];
 $tags = ['name' => $name, 'app_id' => $app->app_id, 'rrd_def' => $rrd_def_domains, 'rrd_name' => $rrd_name];
 app('Datastore')->put($device, 'app', $tags, $fields_domains);
@@ -201,17 +201,17 @@ $rrd_def_signatures_total = RrdDefinition::make()
     ->addDataset('s8signatures_total', 'GAUGE', 0)
     ->addDataset('s9signatures_total', 'GAUGE', 0);
 $fields_signatures_total = [
-    'signatures_total' => $returned['signatures_total'],
-    's0signatures_total' => $returned['min.signatures_total'],
-    's1signatures_total' => $returned['max.signatures_total'],
-    's2signatures_total' => $returned['range.signatures_total'],
-    's3signatures_total' => $returned['mean.signatures_total'],
-    's4signatures_total' => $returned['median.signatures_total'],
-    's5signatures_total' => $returned['mode.signatures_total'],
-    's6signatures_total' => $returned['v.signatures_total'],
-    's7signatures_total' => $returned['sd.signatures_total'],
-    's8signatures_total' => $returned['vp.signatures_total'],
-    's9signatures_total' => $returned['sdp.signatures_total'],
+    'signatures_total' => $returned['signatures_total'] ?? null,
+    's0signatures_total' => $returned['min.signatures_total'] ?? null,
+    's1signatures_total' => $returned['max.signatures_total'] ?? null,
+    's2signatures_total' => $returned['range.signatures_total'] ?? null,
+    's3signatures_total' => $returned['mean.signatures_total'] ?? null,
+    's4signatures_total' => $returned['median.signatures_total'] ?? null,
+    's5signatures_total' => $returned['mode.signatures_total'] ?? null,
+    's6signatures_total' => $returned['v.signatures_total'] ?? null,
+    's7signatures_total' => $returned['sd.signatures_total'] ?? null,
+    's8signatures_total' => $returned['vp.signatures_total'] ?? null,
+    's9signatures_total' => $returned['sdp.signatures_total'] ?? null,
 ];
 $tags = ['name' => $name, 'app_id' => $app->app_id, 'rrd_def' => $rrd_def_signatures_total, 'rrd_name' => $rrd_name];
 app('Datastore')->put($device, 'app', $tags, $fields_signatures_total);
@@ -232,17 +232,17 @@ $rrd_def_signatures_alert = RrdDefinition::make()
     ->addDataset('s8signatures_alert', 'GAUGE', 0)
     ->addDataset('s9signatures_alert', 'GAUGE', 0);
 $fields = [
-    'signatures_alert' => $returned['signatures_alert'],
-    's0signatures_alert' => $returned['min.signatures_alert'],
-    's1signatures_alert' => $returned['max.signatures_alert'],
-    's2signatures_alert' => $returned['range.signatures_alert'],
-    's3signatures_alert' => $returned['mean.signatures_alert'],
-    's4signatures_alert' => $returned['median.signatures_alert'],
-    's5signatures_alert' => $returned['mode.signatures_alert'],
-    's6signatures_alert' => $returned['v.signatures_alert'],
-    's7signatures_alert' => $returned['sd.signatures_alert'],
-    's8signatures_alert' => $returned['vp.signatures_alert'],
-    's9signatures_alert' => $returned['sdp.signatures_alert'],
+    'signatures_alert' => $returned['signatures_alert'] ?? null,
+    's0signatures_alert' => $returned['min.signatures_alert'] ?? null,
+    's1signatures_alert' => $returned['max.signatures_alert'] ?? null,
+    's2signatures_alert' => $returned['range.signatures_alert'] ?? null,
+    's3signatures_alert' => $returned['mean.signatures_alert'] ?? null,
+    's4signatures_alert' => $returned['median.signatures_alert'] ?? null,
+    's5signatures_alert' => $returned['mode.signatures_alert'] ?? null,
+    's6signatures_alert' => $returned['v.signatures_alert'] ?? null,
+    's7signatures_alert' => $returned['sd.signatures_alert'] ?? null,
+    's8signatures_alert' => $returned['vp.signatures_alert'] ?? null,
+    's9signatures_alert' => $returned['sdp.signatures_alert'] ?? null,
 ];
 $tags = ['name' => $name, 'app_id' => $app->app_id, 'rrd_def' => $rrd_def_signatures_alert, 'rrd_name' => $rrd_name];
 app('Datastore')->put($device, 'app', $tags, $fields);
@@ -263,17 +263,17 @@ $rrd_def_reg_keys_mod = RrdDefinition::make()
     ->addDataset('s8regkeysmod', 'GAUGE', 0)
     ->addDataset('s9regkeysmod', 'GAUGE', 0);
 $fields = [
-    'reg_keys_mod' => $returned['registry_keys_modified'],
-    's0regkeysmod' => $returned['min.registry_keys_modified'],
-    's1regkeysmod' => $returned['max.registry_keys_modified'],
-    's2regkeysmod' => $returned['range.registry_keys_modified'],
-    's3regkeysmod' => $returned['mean.registry_keys_modified'],
-    's4regkeysmod' => $returned['median.registry_keys_modified'],
-    's5regkeysmod' => $returned['mode.registry_keys_modified'],
-    's6regkeysmod' => $returned['v.registry_keys_modified'],
-    's7regkeysmod' => $returned['sd.registry_keys_modified'],
-    's8regkeysmod' => $returned['vp.registry_keys_modified'],
-    's9regkeysmod' => $returned['sdp.registry_keys_modified'],
+    'reg_keys_mod' => $returned['registry_keys_modified'] ?? null,
+    's0regkeysmod' => $returned['min.registry_keys_modified'] ?? null,
+    's1regkeysmod' => $returned['max.registry_keys_modified'] ?? null,
+    's2regkeysmod' => $returned['range.registry_keys_modified'] ?? null,
+    's3regkeysmod' => $returned['mean.registry_keys_modified'] ?? null,
+    's4regkeysmod' => $returned['median.registry_keys_modified'] ?? null,
+    's5regkeysmod' => $returned['mode.registry_keys_modified'] ?? null,
+    's6regkeysmod' => $returned['v.registry_keys_modified'] ?? null,
+    's7regkeysmod' => $returned['sd.registry_keys_modified'] ?? null,
+    's8regkeysmod' => $returned['vp.registry_keys_modified'] ?? null,
+    's9regkeysmod' => $returned['sdp.registry_keys_modified'] ?? null,
 ];
 $tags = ['name' => $name, 'app_id' => $app->app_id, 'rrd_def' => $rrd_def_reg_keys_mod, 'rrd_name' => $rrd_name];
 app('Datastore')->put($device, 'app', $tags, $fields);
@@ -294,17 +294,17 @@ $rrd_def_crash_issues = RrdDefinition::make()
     ->addDataset('s8crash_issues', 'GAUGE', 0)
     ->addDataset('s9crash_issues', 'GAUGE', 0);
 $fields = [
-    'crash_issues' => $returned['crash_issues'],
-    's0crash_issues' => $returned['min.crash_issues'],
-    's1crash_issues' => $returned['max.crash_issues'],
-    's2crash_issues' => $returned['range.crash_issues'],
-    's3crash_issues' => $returned['mean.crash_issues'],
-    's4crash_issues' => $returned['median.crash_issues'],
-    's5crash_issues' => $returned['mode.crash_issues'],
-    's6crash_issues' => $returned['v.crash_issues'],
-    's7crash_issues' => $returned['sd.crash_issues'],
-    's8crash_issues' => $returned['vp.crash_issues'],
-    's9crash_issues' => $returned['sdp.crash_issues'],
+    'crash_issues' => $returned['crash_issues'] ?? null,
+    's0crash_issues' => $returned['min.crash_issues'] ?? null,
+    's1crash_issues' => $returned['max.crash_issues'] ?? null,
+    's2crash_issues' => $returned['range.crash_issues'] ?? null,
+    's3crash_issues' => $returned['mean.crash_issues'] ?? null,
+    's4crash_issues' => $returned['median.crash_issues'] ?? null,
+    's5crash_issues' => $returned['mode.crash_issues'] ?? null,
+    's6crash_issues' => $returned['v.crash_issues'] ?? null,
+    's7crash_issues' => $returned['sd.crash_issues'] ?? null,
+    's8crash_issues' => $returned['vp.crash_issues'] ?? null,
+    's9crash_issues' => $returned['sdp.crash_issues'] ?? null,
 ];
 $tags = ['name' => $name, 'app_id' => $app->app_id, 'rrd_def' => $rrd_def_crash_issues, 'rrd_name' => $rrd_name];
 app('Datastore')->put($device, 'app', $tags, $fields);
@@ -326,16 +326,16 @@ $rrd_def_anti_issues = RrdDefinition::make()
     ->addDataset('s9anti_issues', 'GAUGE', 0);
 $fields = [
     'anti_issues' => $returned['anti_issues'],
-    's0anti_issues' => $returned['min.anti_issues'],
-    's1anti_issues' => $returned['max.anti_issues'],
-    's2anti_issues' => $returned['range.anti_issues'],
-    's3anti_issues' => $returned['mean.anti_issues'],
-    's4anti_issues' => $returned['median.anti_issues'],
-    's5anti_issues' => $returned['mode.anti_issues'],
-    's6anti_issues' => $returned['v.anti_issues'],
-    's7anti_issues' => $returned['sd.anti_issues'],
-    's8anti_issues' => $returned['vp.anti_issues'],
-    's9anti_issues' => $returned['sdp.anti_issues'],
+    's0anti_issues' => $returned['min.anti_issues'] ?? null,
+    's1anti_issues' => $returned['max.anti_issues'] ?? null,
+    's2anti_issues' => $returned['range.anti_issues'] ?? null,
+    's3anti_issues' => $returned['mean.anti_issues'] ?? null,
+    's4anti_issues' => $returned['median.anti_issues'] ?? null,
+    's5anti_issues' => $returned['mode.anti_issues'] ?? null,
+    's6anti_issues' => $returned['v.anti_issues'] ?? null,
+    's7anti_issues' => $returned['sd.anti_issues'] ?? null,
+    's8anti_issues' => $returned['vp.anti_issues'] ?? null,
+    's9anti_issues' => $returned['sdp.anti_issues'] ?? null,
 ];
 $tags = ['name' => $name, 'app_id' => $app->app_id, 'rrd_def' => $rrd_def_anti_issues, 'rrd_name' => $rrd_name];
 app('Datastore')->put($device, 'app', $tags, $fields);
@@ -356,17 +356,17 @@ $rrd_def_files_written = RrdDefinition::make()
     ->addDataset('s8files_written', 'GAUGE', 0)
     ->addDataset('s9files_written', 'GAUGE', 0);
 $fields = [
-    'files_written' => $returned['files_written'],
-    's0files_written' => $returned['min.files_written'],
-    's1files_written' => $returned['max.files_written'],
-    's2files_written' => $returned['range.files_written'],
-    's3files_written' => $returned['mean.files_written'],
-    's4files_written' => $returned['median.files_written'],
-    's5files_written' => $returned['mode.files_written'],
-    's6files_written' => $returned['v.files_written'],
-    's7files_written' => $returned['sd.files_written'],
-    's8files_written' => $returned['vp.files_written'],
-    's9files_written' => $returned['sdp.files_written'],
+    'files_written' => $returned['files_written'] ?? null,
+    's0files_written' => $returned['min.files_written'] ?? null,
+    's1files_written' => $returned['max.files_written'] ?? null,
+    's2files_written' => $returned['range.files_written'] ?? null,
+    's3files_written' => $returned['mean.files_written'] ?? null,
+    's4files_written' => $returned['median.files_written'] ?? null,
+    's5files_written' => $returned['mode.files_written'] ?? null,
+    's6files_written' => $returned['v.files_written'] ?? null,
+    's7files_written' => $returned['sd.files_written'] ?? null,
+    's8files_written' => $returned['vp.files_written'] ?? null,
+    's9files_written' => $returned['sdp.files_written'] ?? null,
 ];
 $tags = ['name' => $name, 'app_id' => $app->app_id, 'rrd_def' => $rrd_def_files_written, 'rrd_name' => $rrd_name];
 app('Datastore')->put($device, 'app', $tags, $fields);
@@ -387,17 +387,17 @@ $rrd_def_malscore = RrdDefinition::make()
     ->addDataset('s8malscore', 'GAUGE', 0)
     ->addDataset('s9malscore', 'GAUGE', 0);
 $fields = [
-    'malscore' => $returned['malscore'],
-    's0malscore' => $returned['min.malscore'],
-    's1malscore' => $returned['max.malscore'],
-    's2malscore' => $returned['range.malscore'],
-    's3malscore' => $returned['mean.malscore'],
-    's4malscore' => $returned['median.malscore'],
-    's5malscore' => $returned['mode.malscore'],
-    's6malscore' => $returned['v.malscore'],
-    's7malscore' => $returned['sd.malscore'],
-    's8malscore' => $returned['vp.malscore'],
-    's9malscore' => $returned['sdp.malscore'],
+    'malscore' => $returned['malscore'] ?? null,
+    's0malscore' => $returned['min.malscore'] ?? null,
+    's1malscore' => $returned['max.malscore'] ?? null,
+    's2malscore' => $returned['range.malscore'] ?? null,
+    's3malscore' => $returned['mean.malscore'] ?? null,
+    's4malscore' => $returned['median.malscore'] ?? null,
+    's5malscore' => $returned['mode.malscore'] ?? null,
+    's6malscore' => $returned['v.malscore'] ?? null,
+    's7malscore' => $returned['sd.malscore'] ?? null,
+    's8malscore' => $returned['vp.malscore'] ?? null,
+    's9malscore' => $returned['sdp.malscore'] ?? null,
 ];
 $tags = ['name' => $name, 'app_id' => $app->app_id, 'rrd_def' => $rrd_def_malscore, 'rrd_name' => $rrd_name];
 app('Datastore')->put($device, 'app', $tags, $fields);
@@ -418,17 +418,17 @@ $rrd_def_severity = RrdDefinition::make()
     ->addDataset('s8severity', 'GAUGE', 0)
     ->addDataset('s9severity', 'GAUGE', 0);
 $fields = [
-    'severity' => $returned['severity'],
-    's0severity' => $returned['min.severity'],
-    's1severity' => $returned['max.severity'],
-    's2severity' => $returned['range.severity'],
-    's3severity' => $returned['mean.severity'],
-    's4severity' => $returned['median.severity'],
-    's5severity' => $returned['mode.severity'],
-    's6severity' => $returned['v.severity'],
-    's7severity' => $returned['sd.severity'],
-    's8severity' => $returned['vp.severity'],
-    's9severity' => $returned['sdp.severity'],
+    'severity' => $returned['severity'] ?? null,
+    's0severity' => $returned['min.severity'] ?? null,
+    's1severity' => $returned['max.severity'] ?? null,
+    's2severity' => $returned['range.severity'] ?? null,
+    's3severity' => $returned['mean.severity'] ?? null,
+    's4severity' => $returned['median.severity'] ?? null,
+    's5severity' => $returned['mode.severity'] ?? null,
+    's6severity' => $returned['v.severity'] ?? null,
+    's7severity' => $returned['sd.severity'] ?? null,
+    's8severity' => $returned['vp.severity'] ?? null,
+    's9severity' => $returned['sdp.severity'] ?? null,
 ];
 $tags = ['name' => $name, 'app_id' => $app->app_id, 'rrd_def' => $rrd_def_severity, 'rrd_name' => $rrd_name];
 app('Datastore')->put($device, 'app', $tags, $fields);
@@ -449,17 +449,17 @@ $rrd_def_confidence = RrdDefinition::make()
     ->addDataset('s8confidence', 'GAUGE', 0)
     ->addDataset('s9confidence', 'GAUGE', 0);
 $fields = [
-    'confidence' => $returned['confidence'],
-    's0confidence' => $returned['min.confidence'],
-    's1confidence' => $returned['max.confidence'],
-    's2confidence' => $returned['range.confidence'],
-    's3confidence' => $returned['mean.confidence'],
-    's4confidence' => $returned['median.confidence'],
-    's5confidence' => $returned['mode.confidence'],
-    's6confidence' => $returned['v.confidence'],
-    's7confidence' => $returned['sd.confidence'],
-    's8confidence' => $returned['vp.confidence'],
-    's9confidence' => $returned['sdp.confidence'],
+    'confidence' => $returned['confidence'] ?? null,
+    's0confidence' => $returned['min.confidence'] ?? null,
+    's1confidence' => $returned['max.confidence'] ?? null,
+    's2confidence' => $returned['range.confidence'] ?? null,
+    's3confidence' => $returned['mean.confidence'] ?? null,
+    's4confidence' => $returned['median.confidence'] ?? null,
+    's5confidence' => $returned['mode.confidence'] ?? null,
+    's6confidence' => $returned['v.confidence'] ?? null,
+    's7confidence' => $returned['sd.confidence'] ?? null,
+    's8confidence' => $returned['vp.confidence'] ?? null,
+    's9confidence' => $returned['sdp.confidence'] ?? null,
 ];
 $tags = ['name' => $name, 'app_id' => $app->app_id, 'rrd_def' => $rrd_def_confidence, 'rrd_name' => $rrd_name];
 app('Datastore')->put($device, 'app', $tags, $fields);
@@ -480,17 +480,17 @@ $rrd_def_weight = RrdDefinition::make()
     ->addDataset('s8weight', 'GAUGE', 0)
     ->addDataset('s9weight', 'GAUGE', 0);
 $fields = [
-    'weight' => $returned['weight'],
-    's0weight' => $returned['min.weight'],
-    's1weight' => $returned['max.weight'],
-    's2weight' => $returned['range.weight'],
-    's3weight' => $returned['mean.weight'],
-    's4weight' => $returned['median.weight'],
-    's5weight' => $returned['mode.weight'],
-    's6weight' => $returned['v.weight'],
-    's7weight' => $returned['sd.weight'],
-    's8weight' => $returned['vp.weight'],
-    's9weight' => $returned['sdp.weight'],
+    'weight' => $returned['weight'] ?? null,
+    's0weight' => $returned['min.weight'] ?? null,
+    's1weight' => $returned['max.weight'] ?? null,
+    's2weight' => $returned['range.weight'] ?? null,
+    's3weight' => $returned['mean.weight'] ?? null,
+    's4weight' => $returned['median.weight'] ?? null,
+    's5weight' => $returned['mode.weight'] ?? null,
+    's6weight' => $returned['v.weight'] ?? null,
+    's7weight' => $returned['sd.weight'] ?? null,
+    's8weight' => $returned['vp.weight'] ?? null,
+    's9weight' => $returned['sdp.weight'] ?? null,
 ];
 $tags = ['name' => $name, 'app_id' => $app->app_id, 'rrd_def' => $rrd_def_weight, 'rrd_name' => $rrd_name];
 app('Datastore')->put($device, 'app', $tags, $fields);
@@ -518,220 +518,220 @@ foreach ($returned['pkg_stats'] as $pkg => $stats) {
 
     $rrd_name = ['app', $name, $app->app_id, 'pkg___-___', $pkg];
     $fields = [
-        'tasks' => $returned['pkg_stats'][$pkg]['tasks'],
+        'tasks' => $returned['pkg_stats'][$pkg]['tasks'] ?? null,
         'pending' => null,
-        'banned' => $returned['pkg_stats'][$pkg]['banned'],
-        'running' => $returned['pkg_stats'][$pkg]['running'],
-        'completed' => $returned['pkg_stats'][$pkg]['completed'],
-        'distributed' => $returned['pkg_stats'][$pkg]['distributed'],
-        'reported' => $returned['pkg_stats'][$pkg]['reported'],
-        'recovered' => $returned['pkg_stats'][$pkg]['recovered'],
-        'failed_analysis' => $returned['pkg_stats'][$pkg]['failed_analysis'],
-        'failed_processing' => $returned['pkg_stats'][$pkg]['failed_processing'],
+        'banned' => $returned['pkg_stats'][$pkg]['banned'] ?? null,
+        'running' => $returned['pkg_stats'][$pkg]['running'] ?? null,
+        'completed' => $returned['pkg_stats'][$pkg]['completed'] ?? null,
+        'distributed' => $returned['pkg_stats'][$pkg]['distributed'] ?? null,
+        'reported' => $returned['pkg_stats'][$pkg]['reported'] ?? null,
+        'recovered' => $returned['pkg_stats'][$pkg]['recovered'] ?? null,
+        'failed_analysis' => $returned['pkg_stats'][$pkg]['failed_analysis'] ?? null,
+        'failed_processing' => $returned['pkg_stats'][$pkg]['failed_processing'] ?? null,
     ];
     $tags = ['name' => $name, 'app_id' => $app->app_id, 'rrd_def' => $rrd_def_pkg, 'rrd_name' => $rrd_name];
     app('Datastore')->put($device, 'app', $tags, $fields);
 
     $rrd_name = ['app', $name, $app->app_id, 'pkg-dropped_files___-___', $pkg];
     $fields = [
-        'dropped_files' => $returned['pkg_stats'][$pkg]['dropped_files'],
-        's0dropped_files' => $returned['pkg_stats'][$pkg]['min.dropped_files'],
-        's1dropped_files' => $returned['pkg_stats'][$pkg]['max.dropped_files'],
-        's2dropped_files' => $returned['pkg_stats'][$pkg]['range.dropped_files'],
-        's3dropped_files' => $returned['pkg_stats'][$pkg]['mean.dropped_files'],
-        's4dropped_files' => $returned['pkg_stats'][$pkg]['median.dropped_files'],
-        's5dropped_files' => $returned['pkg_stats'][$pkg]['mode.dropped_files'],
-        's6dropped_files' => $returned['pkg_stats'][$pkg]['v.dropped_files'],
-        's7dropped_files' => $returned['pkg_stats'][$pkg]['sd.dropped_files'],
-        's8dropped_files' => $returned['pkg_stats'][$pkg]['vp.dropped_files'],
-        's9dropped_files' => $returned['pkg_stats'][$pkg]['sdp.dropped_files'],
+        'dropped_files' => $returned['pkg_stats'][$pkg]['dropped_files'] ?? null,
+        's0dropped_files' => $returned['pkg_stats'][$pkg]['min.dropped_files'] ?? null,
+        's1dropped_files' => $returned['pkg_stats'][$pkg]['max.dropped_files'] ?? null,
+        's2dropped_files' => $returned['pkg_stats'][$pkg]['range.dropped_files'] ?? null,
+        's3dropped_files' => $returned['pkg_stats'][$pkg]['mean.dropped_files'] ?? null,
+        's4dropped_files' => $returned['pkg_stats'][$pkg]['median.dropped_files'] ?? null,
+        's5dropped_files' => $returned['pkg_stats'][$pkg]['mode.dropped_files'] ?? null,
+        's6dropped_files' => $returned['pkg_stats'][$pkg]['v.dropped_files'] ?? null,
+        's7dropped_files' => $returned['pkg_stats'][$pkg]['sd.dropped_files'] ?? null,
+        's8dropped_files' => $returned['pkg_stats'][$pkg]['vp.dropped_files'] ?? null,
+        's9dropped_files' => $returned['pkg_stats'][$pkg]['sdp.dropped_files'] ?? null,
     ];
     $tags = ['name' => $name, 'app_id' => $app->app_id, 'rrd_def' => $rrd_def_dropped_files, 'rrd_name' => $rrd_name];
     app('Datastore')->put($device, 'app', $tags, $fields);
 
     $rrd_name = ['app', $name, $app->app_id, 'pkg-running_processes___-___', $pkg];
     $fields = [
-        'running_processes' => $returned['pkg_stats'][$pkg]['running_processes'],
-        's0running_processes' => $returned['pkg_stats'][$pkg]['min.running_processes'],
-        's1running_processes' => $returned['pkg_stats'][$pkg]['max.running_processes'],
-        's2running_processes' => $returned['pkg_stats'][$pkg]['range.running_processes'],
-        's3running_processes' => $returned['pkg_stats'][$pkg]['mean.running_processes'],
-        's4running_processes' => $returned['pkg_stats'][$pkg]['median.running_processes'],
-        's5running_processes' => $returned['pkg_stats'][$pkg]['mode.running_processes'],
-        's6running_processes' => $returned['pkg_stats'][$pkg]['v.running_processes'],
-        's7running_processes' => $returned['pkg_stats'][$pkg]['sd.running_processes'],
-        's8running_processes' => $returned['pkg_stats'][$pkg]['vp.running_processes'],
-        's9running_processes' => $returned['pkg_stats'][$pkg]['sdp.running_processes'],
+        'running_processes' => $returned['pkg_stats'][$pkg]['running_processes'] ?? null,
+        's0running_processes' => $returned['pkg_stats'][$pkg]['min.running_processes'] ?? null,
+        's1running_processes' => $returned['pkg_stats'][$pkg]['max.running_processes'] ?? null,
+        's2running_processes' => $returned['pkg_stats'][$pkg]['range.running_processes'] ?? null,
+        's3running_processes' => $returned['pkg_stats'][$pkg]['mean.running_processes'] ?? null,
+        's4running_processes' => $returned['pkg_stats'][$pkg]['median.running_processes'] ?? null,
+        's5running_processes' => $returned['pkg_stats'][$pkg]['mode.running_processes'] ?? null,
+        's6running_processes' => $returned['pkg_stats'][$pkg]['v.running_processes'] ?? null,
+        's7running_processes' => $returned['pkg_stats'][$pkg]['sd.running_processes'] ?? null,
+        's8running_processes' => $returned['pkg_stats'][$pkg]['vp.running_processes'] ?? null,
+        's9running_processes' => $returned['pkg_stats'][$pkg]['sdp.running_processes'] ?? null,
     ];
     $tags = ['name' => $name, 'app_id' => $app->app_id, 'rrd_def' => $rrd_def_running_processes, 'rrd_name' => $rrd_name];
     app('Datastore')->put($device, 'app', $tags, $fields);
 
     $rrd_name = ['app', $name, $app->app_id, 'pkg-api_calls___-___', $pkg];
     $fields = [
-        'api_calls' => $returned['pkg_stats'][$pkg]['api_calls'],
-        's0api_calls' => $returned['pkg_stats'][$pkg]['min.api_calls'],
-        's1api_calls' => $returned['pkg_stats'][$pkg]['max.api_calls'],
-        's2api_calls' => $returned['pkg_stats'][$pkg]['range.api_calls'],
-        's3api_calls' => $returned['pkg_stats'][$pkg]['mean.api_calls'],
-        's4api_calls' => $returned['pkg_stats'][$pkg]['median.api_calls'],
-        's5api_calls' => $returned['pkg_stats'][$pkg]['mode.api_calls'],
-        's6api_calls' => $returned['pkg_stats'][$pkg]['v.api_calls'],
-        's7api_calls' => $returned['pkg_stats'][$pkg]['sd.api_calls'],
-        's8api_calls' => $returned['pkg_stats'][$pkg]['vp.api_calls'],
-        's9api_calls' => $returned['pkg_stats'][$pkg]['sdp.api_calls'],
+        'api_calls' => $returned['pkg_stats'][$pkg]['api_calls'] ?? null,
+        's0api_calls' => $returned['pkg_stats'][$pkg]['min.api_calls'] ?? null,
+        's1api_calls' => $returned['pkg_stats'][$pkg]['max.api_calls'] ?? null,
+        's2api_calls' => $returned['pkg_stats'][$pkg]['range.api_calls'] ?? null,
+        's3api_calls' => $returned['pkg_stats'][$pkg]['mean.api_calls'] ?? null,
+        's4api_calls' => $returned['pkg_stats'][$pkg]['median.api_calls'] ?? null,
+        's5api_calls' => $returned['pkg_stats'][$pkg]['mode.api_calls'] ?? null,
+        's6api_calls' => $returned['pkg_stats'][$pkg]['v.api_calls'] ?? null,
+        's7api_calls' => $returned['pkg_stats'][$pkg]['sd.api_calls'] ?? null,
+        's8api_calls' => $returned['pkg_stats'][$pkg]['vp.api_calls'] ?? null,
+        's9api_calls' => $returned['pkg_stats'][$pkg]['sdp.api_calls'] ?? null,
     ];
     $tags = ['name' => $name, 'app_id' => $app->app_id, 'rrd_def' => $rrd_def_api_calls, 'rrd_name' => $rrd_name];
     app('Datastore')->put($device, 'app', $tags, $fields);
 
     $rrd_name = ['app', $name, $app->app_id, 'pkg-domains___-___', $pkg];
     $fields = [
-        'domains' => $returned['pkg_stats'][$pkg]['domains'],
-        's0domains' => $returned['pkg_stats'][$pkg]['min.domains'],
-        's1domains' => $returned['pkg_stats'][$pkg]['max.domains'],
-        's2domains' => $returned['pkg_stats'][$pkg]['range.domains'],
-        's3domains' => $returned['pkg_stats'][$pkg]['mean.domains'],
-        's4domains' => $returned['pkg_stats'][$pkg]['median.domains'],
-        's5domains' => $returned['pkg_stats'][$pkg]['mode.domains'],
-        's6domains' => $returned['pkg_stats'][$pkg]['v.domains'],
-        's7domains' => $returned['pkg_stats'][$pkg]['sd.domains'],
-        's8domains' => $returned['pkg_stats'][$pkg]['vp.domains'],
-        's9domains' => $returned['pkg_stats'][$pkg]['sdp.domains'],
+        'domains' => $returned['pkg_stats'][$pkg]['domains'] ?? null,
+        's0domains' => $returned['pkg_stats'][$pkg]['min.domains'] ?? null,
+        's1domains' => $returned['pkg_stats'][$pkg]['max.domains'] ?? null,
+        's2domains' => $returned['pkg_stats'][$pkg]['range.domains'] ?? null,
+        's3domains' => $returned['pkg_stats'][$pkg]['mean.domains'] ?? null,
+        's4domains' => $returned['pkg_stats'][$pkg]['median.domains'] ?? null,
+        's5domains' => $returned['pkg_stats'][$pkg]['mode.domains'] ?? null,
+        's6domains' => $returned['pkg_stats'][$pkg]['v.domains'] ?? null,
+        's7domains' => $returned['pkg_stats'][$pkg]['sd.domains'] ?? null,
+        's8domains' => $returned['pkg_stats'][$pkg]['vp.domains'] ?? null,
+        's9domains' => $returned['pkg_stats'][$pkg]['sdp.domains'] ?? null,
     ];
     $tags = ['name' => $name, 'app_id' => $app->app_id, 'rrd_def' => $rrd_def_domains, 'rrd_name' => $rrd_name];
     app('Datastore')->put($device, 'app', $tags, $fields);
 
     $rrd_name = ['app', $name, $app->app_id, 'pkg-signatures_total___-___', $pkg];
     $fields = [
-        'signatures_total' => $returned['pkg_stats'][$pkg]['signatures_total'],
-        's0signatures_total' => $returned['pkg_stats'][$pkg]['min.signatures_total'],
-        's1signatures_total' => $returned['pkg_stats'][$pkg]['max.signatures_total'],
-        's2signatures_total' => $returned['pkg_stats'][$pkg]['range.signatures_total'],
-        's3signatures_total' => $returned['pkg_stats'][$pkg]['mean.signatures_total'],
-        's4signatures_total' => $returned['pkg_stats'][$pkg]['median.signatures_total'],
-        's5signatures_total' => $returned['pkg_stats'][$pkg]['mode.signatures_total'],
-        's6signatures_total' => $returned['pkg_stats'][$pkg]['v.signatures_total'],
-        's7signatures_total' => $returned['pkg_stats'][$pkg]['sd.signatures_total'],
-        's8signatures_total' => $returned['pkg_stats'][$pkg]['vp.signatures_total'],
-        's9signatures_total' => $returned['pkg_stats'][$pkg]['sdp.signatures_total'],
+        'signatures_total' => $returned['pkg_stats'][$pkg]['signatures_total'] ?? null,
+        's0signatures_total' => $returned['pkg_stats'][$pkg]['min.signatures_total'] ?? null,
+        's1signatures_total' => $returned['pkg_stats'][$pkg]['max.signatures_total'] ?? null,
+        's2signatures_total' => $returned['pkg_stats'][$pkg]['range.signatures_total'] ?? null,
+        's3signatures_total' => $returned['pkg_stats'][$pkg]['mean.signatures_total'] ?? null,
+        's4signatures_total' => $returned['pkg_stats'][$pkg]['median.signatures_total'] ?? null,
+        's5signatures_total' => $returned['pkg_stats'][$pkg]['mode.signatures_total'] ?? null,
+        's6signatures_total' => $returned['pkg_stats'][$pkg]['v.signatures_total'] ?? null,
+        's7signatures_total' => $returned['pkg_stats'][$pkg]['sd.signatures_total'] ?? null,
+        's8signatures_total' => $returned['pkg_stats'][$pkg]['vp.signatures_total'] ?? null,
+        's9signatures_total' => $returned['pkg_stats'][$pkg]['sdp.signatures_total'] ?? null,
     ];
     $tags = ['name' => $name, 'app_id' => $app->app_id, 'rrd_def' => $rrd_def_signatures_total, 'rrd_name' => $rrd_name];
     app('Datastore')->put($device, 'app', $tags, $fields);
 
     $rrd_name = ['app', $name, $app->app_id, 'pkg-signatures_alert___-___', $pkg];
     $fields = [
-        'signatures_alert' => $returned['pkg_stats'][$pkg]['signatures_alert'],
-        's0signatures_alert' => $returned['pkg_stats'][$pkg]['min.signatures_alert'],
-        's1signatures_alert' => $returned['pkg_stats'][$pkg]['max.signatures_alert'],
-        's2signatures_alert' => $returned['pkg_stats'][$pkg]['range.signatures_alert'],
-        's3signatures_alert' => $returned['pkg_stats'][$pkg]['mean.signatures_alert'],
-        's4signatures_alert' => $returned['pkg_stats'][$pkg]['median.signatures_alert'],
-        's5signatures_alert' => $returned['pkg_stats'][$pkg]['mode.signatures_alert'],
-        's6signatures_alert' => $returned['pkg_stats'][$pkg]['v.signatures_alert'],
-        's7signatures_alert' => $returned['pkg_stats'][$pkg]['sd.signatures_alert'],
-        's8signatures_alert' => $returned['pkg_stats'][$pkg]['vp.signatures_alert'],
-        's9signatures_alert' => $returned['pkg_stats'][$pkg]['sdp.signatures_alert'],
+        'signatures_alert' => $returned['pkg_stats'][$pkg]['signatures_alert'] ?? null,
+        's0signatures_alert' => $returned['pkg_stats'][$pkg]['min.signatures_alert'] ?? null,
+        's1signatures_alert' => $returned['pkg_stats'][$pkg]['max.signatures_alert'] ?? null,
+        's2signatures_alert' => $returned['pkg_stats'][$pkg]['range.signatures_alert'] ?? null,
+        's3signatures_alert' => $returned['pkg_stats'][$pkg]['mean.signatures_alert'] ?? null,
+        's4signatures_alert' => $returned['pkg_stats'][$pkg]['median.signatures_alert'] ?? null,
+        's5signatures_alert' => $returned['pkg_stats'][$pkg]['mode.signatures_alert'] ?? null,
+        's6signatures_alert' => $returned['pkg_stats'][$pkg]['v.signatures_alert'] ?? null,
+        's7signatures_alert' => $returned['pkg_stats'][$pkg]['sd.signatures_alert'] ?? null,
+        's8signatures_alert' => $returned['pkg_stats'][$pkg]['vp.signatures_alert'] ?? null,
+        's9signatures_alert' => $returned['pkg_stats'][$pkg]['sdp.signatures_alert'] ?? null,
     ];
     $tags = ['name' => $name, 'app_id' => $app->app_id, 'rrd_def' => $rrd_def_signatures_alert, 'rrd_name' => $rrd_name];
     app('Datastore')->put($device, 'app', $tags, $fields);
 
     $rrd_name = ['app', $name, $app->app_id, 'pkg-reg_keys_mod___-___', $pkg];
     $fields = [
-        'reg_keys_mod' => $returned['pkg_stats'][$pkg]['registry_keys_modified'],
-        's0regkeysmod' => $returned['pkg_stats'][$pkg]['min.registry_keys_modified'],
-        's1regkeysmod' => $returned['pkg_stats'][$pkg]['max.registry_keys_modified'],
-        's2regkeysmod' => $returned['pkg_stats'][$pkg]['range.registry_keys_modified'],
-        's3regkeysmod' => $returned['pkg_stats'][$pkg]['mean.registry_keys_modified'],
-        's4regkeysmod' => $returned['pkg_stats'][$pkg]['median.registry_keys_modified'],
-        's5regkeysmod' => $returned['pkg_stats'][$pkg]['mode.registry_keys_modified'],
-        's6regkeysmod' => $returned['pkg_stats'][$pkg]['v.registry_keys_modified'],
-        's7regkeysmod' => $returned['pkg_stats'][$pkg]['sd.registry_keys_modified'],
-        's8regkeysmod' => $returned['pkg_stats'][$pkg]['vp.registry_keys_modified'],
-        's9regkeysmod' => $returned['pkg_stats'][$pkg]['sdp.registry_keys_modified'],
+        'reg_keys_mod' => $returned['pkg_stats'][$pkg]['registry_keys_modified'] ?? null,
+        's0regkeysmod' => $returned['pkg_stats'][$pkg]['min.registry_keys_modified'] ?? null,
+        's1regkeysmod' => $returned['pkg_stats'][$pkg]['max.registry_keys_modified'] ?? null,
+        's2regkeysmod' => $returned['pkg_stats'][$pkg]['range.registry_keys_modified'] ?? null,
+        's3regkeysmod' => $returned['pkg_stats'][$pkg]['mean.registry_keys_modified'] ?? null,
+        's4regkeysmod' => $returned['pkg_stats'][$pkg]['median.registry_keys_modified'] ?? null,
+        's5regkeysmod' => $returned['pkg_stats'][$pkg]['mode.registry_keys_modified'] ?? null,
+        's6regkeysmod' => $returned['pkg_stats'][$pkg]['v.registry_keys_modified'] ?? null,
+        's7regkeysmod' => $returned['pkg_stats'][$pkg]['sd.registry_keys_modified'] ?? null,
+        's8regkeysmod' => $returned['pkg_stats'][$pkg]['vp.registry_keys_modified'] ?? null,
+        's9regkeysmod' => $returned['pkg_stats'][$pkg]['sdp.registry_keys_modified'] ?? null,
     ];
     $tags = ['name' => $name, 'app_id' => $app->app_id, 'rrd_def' => $rrd_def_reg_keys_mod, 'rrd_name' => $rrd_name];
     app('Datastore')->put($device, 'app', $tags, $fields);
 
     $rrd_name = ['app', $name, $app->app_id, 'pkg-crash_issues___-___', $pkg];
     $fields = [
-        'crash_issues' => $returned['pkg_stats'][$pkg]['crash_issues'],
-        's0crash_issues' => $returned['pkg_stats'][$pkg]['min.crash_issues'],
-        's1crash_issues' => $returned['pkg_stats'][$pkg]['max.crash_issues'],
-        's2crash_issues' => $returned['pkg_stats'][$pkg]['range.crash_issues'],
-        's3crash_issues' => $returned['pkg_stats'][$pkg]['mean.crash_issues'],
-        's4crash_issues' => $returned['pkg_stats'][$pkg]['median.crash_issues'],
-        's5crash_issues' => $returned['pkg_stats'][$pkg]['mode.crash_issues'],
-        's6crash_issues' => $returned['pkg_stats'][$pkg]['v.crash_issues'],
-        's7crash_issues' => $returned['pkg_stats'][$pkg]['sd.crash_issues'],
-        's8crash_issues' => $returned['pkg_stats'][$pkg]['vp.crash_issues'],
-        's9crash_issues' => $returned['pkg_stats'][$pkg]['sdp.crash_issues'],
+        'crash_issues' => $returned['pkg_stats'][$pkg]['crash_issues'] ?? null,
+        's0crash_issues' => $returned['pkg_stats'][$pkg]['min.crash_issues'] ?? null,
+        's1crash_issues' => $returned['pkg_stats'][$pkg]['max.crash_issues'] ?? null,
+        's2crash_issues' => $returned['pkg_stats'][$pkg]['range.crash_issues'] ?? null,
+        's3crash_issues' => $returned['pkg_stats'][$pkg]['mean.crash_issues'] ?? null,
+        's4crash_issues' => $returned['pkg_stats'][$pkg]['median.crash_issues'] ?? null,
+        's5crash_issues' => $returned['pkg_stats'][$pkg]['mode.crash_issues'] ?? null,
+        's6crash_issues' => $returned['pkg_stats'][$pkg]['v.crash_issues'] ?? null,
+        's7crash_issues' => $returned['pkg_stats'][$pkg]['sd.crash_issues'] ?? null,
+        's8crash_issues' => $returned['pkg_stats'][$pkg]['vp.crash_issues'] ?? null,
+        's9crash_issues' => $returned['pkg_stats'][$pkg]['sdp.crash_issues'] ?? null,
     ];
     $tags = ['name' => $name, 'app_id' => $app->app_id, 'rrd_def' => $rrd_def_crash_issues, 'rrd_name' => $rrd_name];
     app('Datastore')->put($device, 'app', $tags, $fields);
 
     $rrd_name = ['app', $name, $app->app_id, 'pkg-anti_issues___-___', $pkg];
     $fields = [
-        'anti_issues' => $returned['pkg_stats'][$pkg]['anti_issues'],
-        's0anti_issues' => $returned['pkg_stats'][$pkg]['min.anti_issues'],
-        's1anti_issues' => $returned['pkg_stats'][$pkg]['max.anti_issues'],
-        's2anti_issues' => $returned['pkg_stats'][$pkg]['range.anti_issues'],
-        's3anti_issues' => $returned['pkg_stats'][$pkg]['mean.anti_issues'],
-        's4anti_issues' => $returned['pkg_stats'][$pkg]['median.anti_issues'],
-        's5anti_issues' => $returned['pkg_stats'][$pkg]['mode.anti_issues'],
-        's6anti_issues' => $returned['pkg_stats'][$pkg]['v.anti_issues'],
-        's7anti_issues' => $returned['pkg_stats'][$pkg]['sd.anti_issues'],
-        's8anti_issues' => $returned['pkg_stats'][$pkg]['vp.anti_issues'],
-        's9anti_issues' => $returned['pkg_stats'][$pkg]['sdp.anti_issues'],
+        'anti_issues' => $returned['pkg_stats'][$pkg]['anti_issues'] ?? null,
+        's0anti_issues' => $returned['pkg_stats'][$pkg]['min.anti_issues'] ?? null,
+        's1anti_issues' => $returned['pkg_stats'][$pkg]['max.anti_issues'] ?? null,
+        's2anti_issues' => $returned['pkg_stats'][$pkg]['range.anti_issues'] ?? null,
+        's3anti_issues' => $returned['pkg_stats'][$pkg]['mean.anti_issues'] ?? null,
+        's4anti_issues' => $returned['pkg_stats'][$pkg]['median.anti_issues'] ?? null,
+        's5anti_issues' => $returned['pkg_stats'][$pkg]['mode.anti_issues'] ?? null,
+        's6anti_issues' => $returned['pkg_stats'][$pkg]['v.anti_issues'] ?? null,
+        's7anti_issues' => $returned['pkg_stats'][$pkg]['sd.anti_issues'] ?? null,
+        's8anti_issues' => $returned['pkg_stats'][$pkg]['vp.anti_issues'] ?? null,
+        's9anti_issues' => $returned['pkg_stats'][$pkg]['sdp.anti_issues'] ?? null,
     ];
     $tags = ['name' => $name, 'app_id' => $app->app_id, 'rrd_def' => $rrd_def_anti_issues, 'rrd_name' => $rrd_name];
     app('Datastore')->put($device, 'app', $tags, $fields);
 
     $rrd_name = ['app', $name, $app->app_id, 'pkg-files_written___-___', $pkg];
     $fields = [
-        'files_written' => $returned['pkg_stats'][$pkg]['files_written'],
-        's0files_written' => $returned['pkg_stats'][$pkg]['min.files_written'],
-        's1files_written' => $returned['pkg_stats'][$pkg]['max.files_written'],
-        's2files_written' => $returned['pkg_stats'][$pkg]['range.files_written'],
-        's3files_written' => $returned['pkg_stats'][$pkg]['mean.files_written'],
-        's4files_written' => $returned['pkg_stats'][$pkg]['median.files_written'],
-        's5files_written' => $returned['pkg_stats'][$pkg]['mode.files_written'],
-        's6files_written' => $returned['pkg_stats'][$pkg]['v.files_written'],
-        's7files_written' => $returned['pkg_stats'][$pkg]['sd.files_written'],
-        's8files_written' => $returned['pkg_stats'][$pkg]['vp.files_written'],
-        's9files_written' => $returned['pkg_stats'][$pkg]['sdp.files_written'],
+        'files_written' => $returned['pkg_stats'][$pkg]['files_written'] ?? null,
+        's0files_written' => $returned['pkg_stats'][$pkg]['min.files_written'] ?? null,
+        's1files_written' => $returned['pkg_stats'][$pkg]['max.files_written'] ?? null,
+        's2files_written' => $returned['pkg_stats'][$pkg]['range.files_written'] ?? null,
+        's3files_written' => $returned['pkg_stats'][$pkg]['mean.files_written'] ?? null,
+        's4files_written' => $returned['pkg_stats'][$pkg]['median.files_written'] ?? null,
+        's5files_written' => $returned['pkg_stats'][$pkg]['mode.files_written'] ?? null,
+        's6files_written' => $returned['pkg_stats'][$pkg]['v.files_written'] ?? null,
+        's7files_written' => $returned['pkg_stats'][$pkg]['sd.files_written'] ?? null,
+        's8files_written' => $returned['pkg_stats'][$pkg]['vp.files_written'] ?? null,
+        's9files_written' => $returned['pkg_stats'][$pkg]['sdp.files_written'] ?? null,
     ];
     $tags = ['name' => $name, 'app_id' => $app->app_id, 'rrd_def' => $rrd_def_files_written, 'rrd_name' => $rrd_name];
     app('Datastore')->put($device, 'app', $tags, $fields);
 
     $rrd_name = ['app', $name, $app->app_id, 'pkg-malscore___-___', $pkg];
     $fields = [
-        'malscore' => $returned['pkg_stats'][$pkg]['malscore'],
-        's0malscore' => $returned['pkg_stats'][$pkg]['min.malscore'],
-        's1malscore' => $returned['pkg_stats'][$pkg]['max.malscore'],
-        's2malscore' => $returned['pkg_stats'][$pkg]['range.malscore'],
-        's3malscore' => $returned['pkg_stats'][$pkg]['mean.malscore'],
-        's4malscore' => $returned['pkg_stats'][$pkg]['median.malscore'],
-        's5malscore' => $returned['pkg_stats'][$pkg]['mode.malscore'],
-        's6malscore' => $returned['pkg_stats'][$pkg]['v.malscore'],
-        's7malscore' => $returned['pkg_stats'][$pkg]['sd.malscore'],
-        's8malscore' => $returned['pkg_stats'][$pkg]['vp.malscore'],
-        's9malscore' => $returned['pkg_stats'][$pkg]['sdp.malscore'],
+        'malscore' => $returned['pkg_stats'][$pkg]['malscore'] ?? null,
+        's0malscore' => $returned['pkg_stats'][$pkg]['min.malscore'] ?? null,
+        's1malscore' => $returned['pkg_stats'][$pkg]['max.malscore'] ?? null,
+        's2malscore' => $returned['pkg_stats'][$pkg]['range.malscore'] ?? null,
+        's3malscore' => $returned['pkg_stats'][$pkg]['mean.malscore'] ?? null,
+        's4malscore' => $returned['pkg_stats'][$pkg]['median.malscore'] ?? null,
+        's5malscore' => $returned['pkg_stats'][$pkg]['mode.malscore'] ?? null,
+        's6malscore' => $returned['pkg_stats'][$pkg]['v.malscore'] ?? null,
+        's7malscore' => $returned['pkg_stats'][$pkg]['sd.malscore'] ?? null,
+        's8malscore' => $returned['pkg_stats'][$pkg]['vp.malscore'] ?? null,
+        's9malscore' => $returned['pkg_stats'][$pkg]['sdp.malscore'] ?? null,
     ];
     $tags = ['name' => $name, 'app_id' => $app->app_id, 'rrd_def' => $rrd_def_malscore, 'rrd_name' => $rrd_name];
     app('Datastore')->put($device, 'app', $tags, $fields);
 
     $rrd_name = ['app', $name, $app->app_id, 'pkg-confidence___-___', $pkg];
     $fields = [
-        'confidence' => $returned['pkg_stats'][$pkg]['confidence'],
-        's0confidence' => $returned['pkg_stats'][$pkg]['min.confidence'],
-        's1confidence' => $returned['pkg_stats'][$pkg]['max.confidence'],
-        's2confidence' => $returned['pkg_stats'][$pkg]['range.confidence'],
-        's3confidence' => $returned['pkg_stats'][$pkg]['mean.confidence'],
-        's4confidence' => $returned['pkg_stats'][$pkg]['median.confidence'],
-        's5confidence' => $returned['pkg_stats'][$pkg]['mode.confidence'],
-        's6confidence' => $returned['pkg_stats'][$pkg]['v.confidence'],
-        's7confidence' => $returned['pkg_stats'][$pkg]['sd.confidence'],
-        's8confidence' => $returned['pkg_stats'][$pkg]['vp.confidence'],
-        's9confidence' => $returned['pkg_stats'][$pkg]['sdp.confidence'],
+        'confidence' => $returned['pkg_stats'][$pkg]['confidence'] ?? null,
+        's0confidence' => $returned['pkg_stats'][$pkg]['min.confidence'] ?? null,
+        's1confidence' => $returned['pkg_stats'][$pkg]['max.confidence'] ?? null,
+        's2confidence' => $returned['pkg_stats'][$pkg]['range.confidence'] ?? null,
+        's3confidence' => $returned['pkg_stats'][$pkg]['mean.confidence'] ?? null,
+        's4confidence' => $returned['pkg_stats'][$pkg]['median.confidence'] ?? null,
+        's5confidence' => $returned['pkg_stats'][$pkg]['mode.confidence'] ?? null,
+        's6confidence' => $returned['pkg_stats'][$pkg]['v.confidence'] ?? null,
+        's7confidence' => $returned['pkg_stats'][$pkg]['sd.confidence'] ?? null,
+        's8confidence' => $returned['pkg_stats'][$pkg]['vp.confidence'] ?? null,
+        's9confidence' => $returned['pkg_stats'][$pkg]['sdp.confidence'] ?? null,
     ];
     $tags = ['name' => $name, 'app_id' => $app->app_id, 'rrd_def' => $rrd_def_confidence, 'rrd_name' => $rrd_name];
     app('Datastore')->put($device, 'app', $tags, $fields);
@@ -739,16 +739,16 @@ foreach ($returned['pkg_stats'] as $pkg => $stats) {
     $rrd_name = ['app', $name, $app->app_id, 'pkg-weight___-___', $pkg];
     $fields = [
         'weight' => $returned['pkg_stats'][$pkg]['weight'],
-        's0weight' => $returned['pkg_stats'][$pkg]['min.weight'],
-        's1weight' => $returned['pkg_stats'][$pkg]['max.weight'],
-        's2weight' => $returned['pkg_stats'][$pkg]['range.weight'],
-        's3weight' => $returned['pkg_stats'][$pkg]['mean.weight'],
-        's4weight' => $returned['pkg_stats'][$pkg]['median.weight'],
-        's5weight' => $returned['pkg_stats'][$pkg]['mode.weight'],
-        's6weight' => $returned['pkg_stats'][$pkg]['v.weight'],
-        's7weight' => $returned['pkg_stats'][$pkg]['sd.weight'],
-        's8weight' => $returned['pkg_stats'][$pkg]['vp.weight'],
-        's9weight' => $returned['pkg_stats'][$pkg]['sdp.weight'],
+        's0weight' => $returned['pkg_stats'][$pkg]['min.weight'] ?? null,
+        's1weight' => $returned['pkg_stats'][$pkg]['max.weight'] ?? null,
+        's2weight' => $returned['pkg_stats'][$pkg]['range.weight'] ?? null,
+        's3weight' => $returned['pkg_stats'][$pkg]['mean.weight'] ?? null,
+        's4weight' => $returned['pkg_stats'][$pkg]['median.weight'] ?? null,
+        's5weight' => $returned['pkg_stats'][$pkg]['mode.weight'] ?? null,
+        's6weight' => $returned['pkg_stats'][$pkg]['v.weight'] ?? null,
+        's7weight' => $returned['pkg_stats'][$pkg]['sd.weight'] ?? null,
+        's8weight' => $returned['pkg_stats'][$pkg]['vp.weight'] ?? null,
+        's9weight' => $returned['pkg_stats'][$pkg]['sdp.weight'] ?? null,
     ];
     $tags = ['name' => $name, 'app_id' => $app->app_id, 'rrd_def' => $rrd_def_weight, 'rrd_name' => $rrd_name];
     app('Datastore')->put($device, 'app', $tags, $fields);

--- a/includes/polling/applications/cape.inc.php
+++ b/includes/polling/applications/cape.inc.php
@@ -738,7 +738,7 @@ foreach ($returned['pkg_stats'] as $pkg => $stats) {
 
     $rrd_name = ['app', $name, $app->app_id, 'pkg-weight___-___', $pkg];
     $fields = [
-        'weight' => $returned['pkg_stats'][$pkg]['weight'],
+        'weight' => $returned['pkg_stats'][$pkg]['weight'] ?? null,
         's0weight' => $returned['pkg_stats'][$pkg]['min.weight'] ?? null,
         's1weight' => $returned['pkg_stats'][$pkg]['max.weight'] ?? null,
         's2weight' => $returned['pkg_stats'][$pkg]['range.weight'] ?? null,


### PR DESCRIPTION
Cleanup stuff that can result in messages like below...

```
PHP Error(2): Undefined array key "wrong_prog" in /home/runner/work/librenms/librenms/includes/polling/applications/cape.inc.php:59
PHP Error(2): Undefined array key "malscore" in /home/runner/work/librenms/librenms/includes/polling/applications/cape.inc.php:390
PHP Error(2): Undefined array key "severity" in /home/runner/work/librenms/librenms/includes/polling/applications/cape.inc.php:421
PHP Error(2): Undefined array key "confidence" in /home/runner/work/librenms/librenms/includes/polling/applications/cape.inc.php:452
PHP Error(2): Undefined array key "weight" in /home/runner/work/librenms/librenms/includes/polling/applications/cape.inc.php:483
```

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
