### PR TITLE
Logging improvements

### DIFF
--- a/LibreNMS/DB/SyncsModels.php
+++ b/LibreNMS/DB/SyncsModels.php
@@ -90,7 +90,11 @@ trait SyncsModels
     {
         $filter = function ($models, $params) {
             foreach ($params as $key => $value) {
-                $models = $models->where($key, '=', $value);
+                if (is_array($value)) {
+                    $models = $models->where(...$value);
+                } else {
+                    $models = $models->where($key, '=', $value);
+                }
             }
 
             return $models;

--- a/LibreNMS/Modules/Mpls.php
+++ b/LibreNMS/Modules/Mpls.php
@@ -30,7 +30,6 @@ namespace LibreNMS\Modules;
 
 use App\Models\Device;
 use App\Observers\ModuleModelObserver;
-use Illuminate\Support\Facades\Log;
 use LibreNMS\DB\SyncsModels;
 use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Discovery\MplsDiscovery;
@@ -65,37 +64,37 @@ class Mpls implements Module
     public function discover(OS $os): void
     {
         if ($os instanceof MplsDiscovery) {
-            Log::info('MPLS LSPs: ');
-            ModuleModelObserver::observe(\App\Models\MplsLsp::class);
+            ModuleModelObserver::observe(\App\Models\MplsLsp::class, 'MPLS LSPs');
             $lsps = $this->syncModels($os->getDevice(), 'mplsLsps', $os->discoverMplsLsps());
+            ModuleModelObserver::done();
 
-            Log::info('MPLS LSP Paths: ');
-            ModuleModelObserver::observe(\App\Models\MplsLspPath::class);
+            ModuleModelObserver::observe(\App\Models\MplsLspPath::class, 'MPLS LSP Paths');
             $paths = $this->syncModels($os->getDevice(), 'mplsLspPaths', $os->discoverMplsPaths($lsps));
+            ModuleModelObserver::done();
 
-            Log::info('MPLS SDPs: ');
-            ModuleModelObserver::observe(\App\Models\MplsSdp::class);
+            ModuleModelObserver::observe(\App\Models\MplsSdp::class, 'MPLS SDPs');
             $sdps = $this->syncModels($os->getDevice(), 'mplsSdps', $os->discoverMplsSdps());
+            ModuleModelObserver::done();
 
-            Log::info('MPLS Services: ');
-            ModuleModelObserver::observe(\App\Models\MplsService::class);
+            ModuleModelObserver::observe(\App\Models\MplsService::class, 'MPLS Services');
             $svcs = $this->syncModels($os->getDevice(), 'mplsServices', $os->discoverMplsServices());
+            ModuleModelObserver::done();
 
-            Log::info('MPLS SAPs: ');
-            ModuleModelObserver::observe(\App\Models\MplsSap::class);
+            ModuleModelObserver::observe(\App\Models\MplsSap::class, 'MPLS SAPs');
             $this->syncModels($os->getDevice(), 'mplsSaps', $os->discoverMplsSaps($svcs));
+            ModuleModelObserver::done();
 
-            Log::info('MPLS SDP Bindings: ');
-            ModuleModelObserver::observe(\App\Models\MplsSdpBind::class);
+            ModuleModelObserver::observe(\App\Models\MplsSdpBind::class, 'MPLS SDP Bindings');
             $this->syncModels($os->getDevice(), 'mplsSdpBinds', $os->discoverMplsSdpBinds($sdps, $svcs));
+            ModuleModelObserver::done();
 
-            Log::info('MPLS Tunnel Active Routing Hops: ');
-            ModuleModelObserver::observe(\App\Models\MplsTunnelArHop::class);
+            ModuleModelObserver::observe(\App\Models\MplsTunnelArHop::class, 'MPLS Tunnel Active Routing Hops');
             $this->syncModels($os->getDevice(), 'mplsTunnelArHops', $os->discoverMplsTunnelArHops($paths));
+            ModuleModelObserver::done();
 
-            Log::info('MPLS Tunnel Constrained Shortest Path First Hops: ');
-            ModuleModelObserver::observe(\App\Models\MplsTunnelCHop::class);
+            ModuleModelObserver::observe(\App\Models\MplsTunnelCHop::class, 'MPLS Tunnel Constrained Shortest Path First Hops');
             $this->syncModels($os->getDevice(), 'mplsTunnelCHops', $os->discoverMplsTunnelCHops($paths));
+            ModuleModelObserver::done();
         }
     }
 
@@ -117,51 +116,50 @@ class Mpls implements Module
             $device = $os->getDevice();
 
             if ($device->mplsLsps()->exists()) {
-                Log::info('MPLS LSPs: ');
-                ModuleModelObserver::observe(\App\Models\MplsLsp::class);
+                ModuleModelObserver::observe(\App\Models\MplsLsp::class, 'MPLS LSPs');
                 $lsps = $this->syncModels($device, 'mplsLsps', $os->pollMplsLsps());
             }
 
             if ($device->mplsLspPaths()->exists()) {
-                Log::info('MPLS LSP Paths: ');
-                ModuleModelObserver::observe(\App\Models\MplsLspPath::class);
+                ModuleModelObserver::observe(\App\Models\MplsLspPath::class, 'MPLS LSP Paths');
                 $paths = $this->syncModels($device, 'mplsLspPaths', $os->pollMplsPaths($lsps));
+                ModuleModelObserver::done();
             }
 
             if ($device->mplsSdps()->exists()) {
-                Log::info('MPLS SDPs: ');
-                ModuleModelObserver::observe(\App\Models\MplsSdp::class);
+                ModuleModelObserver::observe(\App\Models\MplsSdp::class, 'MPLS SDPs');
                 $sdps = $this->syncModels($device, 'mplsSdps', $os->pollMplsSdps());
+                ModuleModelObserver::done();
             }
 
             if ($device->mplsServices()->exists()) {
-                Log::info('MPLS Services: ');
-                ModuleModelObserver::observe(\App\Models\MplsService::class);
+                ModuleModelObserver::observe(\App\Models\MplsService::class, 'MPLS Services');
                 $svcs = $this->syncModels($device, 'mplsServices', $os->pollMplsServices());
+                ModuleModelObserver::done();
             }
 
             if ($device->mplsSaps()->exists() && isset($svcs)) {
-                Log::info('MPLS SAPs: ');
-                ModuleModelObserver::observe(\App\Models\MplsSap::class);
+                ModuleModelObserver::observe(\App\Models\MplsSap::class, 'MPLS SAPs');
                 $this->syncModels($device, 'mplsSaps', $os->pollMplsSaps($svcs));
+                ModuleModelObserver::done();
             }
 
             if ($device->mplsSdpBinds()->exists() && isset($sdps, $svcs)) {
-                Log::info('MPLS SDP Bindings: ');
-                ModuleModelObserver::observe(\App\Models\MplsSdpBind::class);
+                ModuleModelObserver::observe(\App\Models\MplsSdpBind::class, 'MPLS SDP Bindings');
                 $this->syncModels($device, 'mplsSdpBinds', $os->pollMplsSdpBinds($sdps, $svcs));
+                ModuleModelObserver::done();
             }
 
             if ($device->mplsTunnelArHops()->exists()) {
-                Log::info('MPLS Tunnel Active Routing Hops: ');
-                ModuleModelObserver::observe(\App\Models\MplsTunnelArHop::class);
+                ModuleModelObserver::observe(\App\Models\MplsTunnelArHop::class, 'MPLS Tunnel Active Routing Hops');
                 $this->syncModels($device, 'mplsTunnelArHops', $os->pollMplsTunnelArHops($paths));
+                ModuleModelObserver::done();
             }
 
             if ($device->mplsTunnelCHops()->exists()) {
-                Log::info('MPLS Tunnel Constrained Shortest Path First Hops: ');
-                ModuleModelObserver::observe(\App\Models\MplsTunnelCHop::class);
+                ModuleModelObserver::observe(\App\Models\MplsTunnelCHop::class, 'MPLS Tunnel Constrained Shortest Path First Hops');
                 $this->syncModels($device, 'mplsTunnelCHops', $os->pollMplsTunnelCHops($paths));
+                ModuleModelObserver::done();
             }
         }
     }

--- a/LibreNMS/Modules/Ospf.php
+++ b/LibreNMS/Modules/Ospf.php
@@ -76,8 +76,7 @@ class Ospf implements Module
     public function poll(OS $os, DataStorageInterface $datastore): void
     {
         foreach ($os->getDevice()->getVrfContexts() as $context_name) {
-            Log::info('Processes: ');
-            ModuleModelObserver::observe(OspfInstance::class);
+            ModuleModelObserver::observe(OspfInstance::class, 'Processes');
 
             // Pull data from device
             $ospf_instances_poll = SnmpQuery::context($context_name)
@@ -109,6 +108,7 @@ class Ospf implements Module
                 ->where('context_name', $context_name)
                 ->whereNotIn('id', $ospf_instances->pluck('id'))->delete();
 
+            ModuleModelObserver::done();
             $instance_count = $ospf_instances->count();
             Log::info("Total processes: $instance_count");
             if ($instance_count == 0) {
@@ -116,8 +116,7 @@ class Ospf implements Module
                 return;
             }
 
-            Log::info('Areas: ');
-            ModuleModelObserver::observe(OspfArea::class);
+            ModuleModelObserver::observe(OspfArea::class, 'Areas');
 
             // Pull data from device
             $ospf_areas = SnmpQuery::context($context_name)
@@ -136,10 +135,10 @@ class Ospf implements Module
                 ->where('context_name', $context_name)
                 ->whereNotIn('id', $ospf_areas->pluck('id'))->delete();
 
+            ModuleModelObserver::done();
             Log::info('Total areas: ' . $ospf_areas->count());
 
-            Log::info('Ports: ');
-            ModuleModelObserver::observe(OspfPort::class);
+            ModuleModelObserver::observe(OspfPort::class, 'Ports');
 
             // Pull data from device
             $ospf_ports = SnmpQuery::context($context_name)
@@ -164,10 +163,10 @@ class Ospf implements Module
                 ->where('context_name', $context_name)
                 ->whereNotIn('id', $ospf_ports->pluck('id'))->delete();
 
+            ModuleModelObserver::done();
             Log::info('Total Ports: ' . $ospf_ports->count());
 
-            Log::info('Neighbours: ');
-            ModuleModelObserver::observe(OspfNbr::class);
+            ModuleModelObserver::observe(OspfNbr::class, 'Neighbours');
 
             // Pull data from device
             $ospf_neighbours = SnmpQuery::context($context_name)
@@ -189,6 +188,7 @@ class Ospf implements Module
                 ->where('context_name', $context_name)
                 ->whereNotIn('id', $ospf_neighbours->pluck('id'))->delete();
 
+            ModuleModelObserver::done();
             Log::info('Total neighbors: ' . $ospf_neighbours->count());
 
             Log::info('TOS Metrics: ');

--- a/LibreNMS/Modules/Ospfv3.php
+++ b/LibreNMS/Modules/Ospfv3.php
@@ -67,7 +67,7 @@ class Ospfv3 implements Module
      */
     public function discover(OS $os): void
     {
-        Log::info('Processes: ');
+        ModuleModelObserver::observe(Ospfv3Instance::class, 'Processes');
         $instances = new Collection;
         foreach ($os->getDevice()->getVrfContexts() as $context_name) {
             // Check for instance data
@@ -96,11 +96,10 @@ class Ospfv3 implements Module
             return;
         }
 
-        ModuleModelObserver::observe(Ospfv3Instance::class);
         $this->syncModels($os->getDevice(), 'ospfv3Instances', $instances);
         Log::info(' (Total processes: ' . $instances->count() . ')');
 
-        Log::info('Areas: ');
+        ModuleModelObserver::observe(Ospfv3Area::class, 'Areas');
         $ospf_areas = $instances->map(function (Ospfv3Instance $instance) {
             return SnmpQuery::context($instance->context_name)
                 ->hideMib()->enumStrings()
@@ -110,11 +109,10 @@ class Ospfv3 implements Module
                 });
         })->flatten(); // flatten one level
 
-        ModuleModelObserver::observe(Ospfv3Area::class);
         $ospf_areas = $this->syncModels($os->getDevice(), 'ospfv3Areas', $ospf_areas);
         Log::info(' (Total areas: ' . $ospf_areas->count() . ')');
 
-        Log::info('Ports: ');
+        ModuleModelObserver::observe(Ospfv3Port::class, 'Ports');
         $ospf_ports = $instances->map(function (Ospfv3Instance $instance) use ($ospf_areas) {
             return SnmpQuery::context($instance->context_name)
                 ->hideMib()->enumStrings()
@@ -124,11 +122,10 @@ class Ospfv3 implements Module
                 });
         })->flatten(); // flatten one level
 
-        ModuleModelObserver::observe(Ospfv3Port::class);
         $this->syncModels($os->getDevice(), 'ospfv3Ports', $ospf_ports);
         Log::info(' (Total ports: ' . $ospf_ports->count() . ')');
 
-        Log::info('Neighbors: ');
+        ModuleModelObserver::observe(Ospfv3Nbr::class, 'Neighbors');
         $ospf_neighbors = $instances->map(function (Ospfv3Instance $instance) {
             return SnmpQuery::context($instance->context_name)
                 ->hideMib()->enumStrings()
@@ -138,7 +135,6 @@ class Ospfv3 implements Module
                 });
         })->flatten(); // flatten one level
 
-        ModuleModelObserver::observe(Ospfv3Nbr::class);
         $this->syncModels($os->getDevice(), 'ospfv3Nbrs', $ospf_neighbors);
         Log::info(' (Total neighbors: ' . $ospf_neighbors->count() . ')');
     }
@@ -161,8 +157,7 @@ class Ospfv3 implements Module
         }
 
         // go through each instance (unique context) and fetch values displayed in ui
-        Log::info('Instances: ');
-        ModuleModelObserver::observe(Ospfv3Instance::class);
+        ModuleModelObserver::observe(Ospfv3Instance::class, 'Instances');
         $instances->each(function (Ospfv3Instance $instance) {
             $instanceValues = SnmpQuery::context($instance->context_name)->enumStrings()->get([
                 'OSPFV3-MIB::ospfv3AdminStatus.0',
@@ -174,8 +169,10 @@ class Ospfv3 implements Module
             $instance->ospfv3ASBdrRtrStatus = $instanceValues->value('OSPFV3-MIB::ospfv3ASBdrRtrStatus');
             $instance->save();
         });
+        ModuleModelObserver::done();
 
         // Areas
+        ModuleModelObserver::observe(Ospfv3Area::class, 'Areas');
         $ospf_areas = $instances->map(function (Ospfv3Instance $instance) {
             return SnmpQuery::context($instance->context_name)
                 ->hideMib()->walk([
@@ -188,11 +185,11 @@ class Ospfv3 implements Module
 
         // fill data in new areas
         Ospfv3Area::creating([$this, 'fetchAndFillArea']);
-        Log::info("\nAreas: ");
-        ModuleModelObserver::observe(Ospfv3Area::class);
         $ospf_areas = $this->syncModels($device, 'ospfv3Areas', $ospf_areas);
+        ModuleModelObserver::done();
 
         // Ports
+        ModuleModelObserver::observe(Ospfv3Port::class, 'Ports');;
         $ospf_ports = $instances->map(function (Ospfv3Instance $instance) use ($ospf_areas) {
             return SnmpQuery::context($instance->context_name)
                 ->hideMib()->enumStrings()
@@ -208,11 +205,11 @@ class Ospfv3 implements Module
         })->flatten();
 
         Ospfv3Port::creating([$this, 'fetchAndFillPort']);
-        Log::info("\nPorts: ");
-        ModuleModelObserver::observe(Ospfv3Port::class);
         $this->syncModels($device, 'ospfv3Ports', $ospf_ports);
+        ModuleModelObserver::done();
 
         // Neighbors
+        ModuleModelObserver::observe(Ospfv3Nbr::class, 'Neighbors');;
         $ospf_neighbors = $instances->map(function (Ospfv3Instance $instance) {
             return SnmpQuery::context($instance->context_name)
                 ->hideMib()->enumStrings()
@@ -225,9 +222,8 @@ class Ospfv3 implements Module
         })->flatten();
 
         Ospfv3Nbr::creating([$this, 'fetchAndFillNeighbor']);
-        Log::info("\nNeighbors: ");
-        ModuleModelObserver::observe(Ospfv3Nbr::class);
         $this->syncModels($device, 'ospfv3Nbrs', $ospf_neighbors);
+        ModuleModelObserver::done();
 
         // Create device-wide statistics RRD
         $rrd_def = RrdDefinition::make()

--- a/LibreNMS/Modules/PrinterSupplies.php
+++ b/LibreNMS/Modules/PrinterSupplies.php
@@ -64,12 +64,15 @@ class PrinterSupplies implements Module
     {
         $device = $os->getDeviceArray();
 
-        $data = collect()
-            ->concat($this->discoveryLevels($device))
-            ->concat($this->discoveryPapers($device));
+        ModuleModelObserver::observe(PrinterSupply::class, 'Printer Supplies');;
+        $levels = $this->discoveryLevels($device);
+        $this->syncModelsByGroup($os->getDevice(), 'printerSupplies', $levels, [['supply_type', '!=', 'input']]);
+        ModuleModelObserver::done();
 
-        ModuleModelObserver::observe(PrinterSupply::class);
-        $this->syncModels($os->getDevice(), 'printerSupplies', $data);
+        ModuleModelObserver::observe(PrinterSupply::class, 'Tray Paper Level');;
+        $papers = $this->discoveryPapers($device);
+        $this->syncModelsByGroup($os->getDevice(), 'printerSupplies', $papers, ['supply_type' => 'input']);
+        ModuleModelObserver::done();
     }
 
     public function shouldPoll(OS $os, ModuleStatus $status): bool
@@ -232,7 +235,6 @@ class PrinterSupplies implements Module
 
     private function discoveryPapers($device): Collection
     {
-        Log::info('Tray Paper Level: ');
         $papers = new Collection();
 
         $tray_oids = snmpwalk_cache_oid($device, 'prtInputName', [], 'Printer-MIB');

--- a/LibreNMS/Modules/Stp.php
+++ b/LibreNMS/Modules/Stp.php
@@ -29,7 +29,6 @@ namespace LibreNMS\Modules;
 use App\Models\Device;
 use App\Models\PortStp;
 use App\Observers\ModuleModelObserver;
-use Illuminate\Support\Facades\Log;
 use LibreNMS\DB\SyncsModels;
 use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Module;
@@ -58,14 +57,14 @@ class Stp implements Module
         $device = $os->getDevice();
 
         $instances = $os->discoverStpInstances();
-        Log::info('Instances: ');
-        ModuleModelObserver::observe(\App\Models\Stp::class);
+        ModuleModelObserver::observe(\App\Models\Stp::class, 'Instances');
         $this->syncModels($device, 'stpInstances', $instances);
+        ModuleModelObserver::done();
 
         $ports = $os->discoverStpPorts($instances);
-        Log::info('Ports: ');
-        ModuleModelObserver::observe(PortStp::class);
+        ModuleModelObserver::observe(PortStp::class, 'Ports');
         $this->syncModels($device, 'stpPorts', $ports);
+        ModuleModelObserver::done();
     }
 
     public function shouldPoll(OS $os, ModuleStatus $status): bool
@@ -77,16 +76,16 @@ class Stp implements Module
     {
         $device = $os->getDevice();
 
-        Log::info('Instances: ');
         $instances = $device->stpInstances;
         $instances = $os->pollStpInstances($instances);
-        ModuleModelObserver::observe(\App\Models\Stp::class);
+        ModuleModelObserver::observe(\App\Models\Stp::class, 'Instances');
         $this->syncModels($device, 'stpInstances', $instances);
+        ModuleModelObserver::done();
 
-        Log::info('Ports: ');
         $ports = $device->stpPorts;
-        ModuleModelObserver::observe(PortStp::class);
+        ModuleModelObserver::observe(PortStp::class, 'Ports');
         $this->syncModels($device, 'stpPorts', $ports);
+        ModuleModelObserver::done();
     }
 
     public function dataExists(Device $device): bool

--- a/LibreNMS/Util/Debug.php
+++ b/LibreNMS/Util/Debug.php
@@ -88,17 +88,29 @@ class Debug
 
     public static function enableCliDebugOutput(): void
     {
-        config(['logging.channels.stdout.level' => 'debug']);
+        if (Laravel::isBooted()) {
+            config(['logging.channels.stdout.level' => 'debug']);
+        } else {
+            putenv('STDOUT_LOG_LEVEL=debug');
+        }
     }
 
     public static function disableCliDebugOutput(): void
     {
-        config(['logging.channels.stdout.level' => 'info']);
+        if (Laravel::isBooted()) {
+            config(['logging.channels.stdout.level' => 'info']);
+        } else {
+            putenv('STDOUT_LOG_LEVEL=info');
+        }
     }
 
     public static function setCliQuietOutput(): void
     {
-        config(['logging.channels.stdout.level' => 'emergency']);
+        if (Laravel::isBooted()) {
+            config(['logging.channels.stdout.level' => 'emergency']);
+        } else {
+            putenv('STDOUT_LOG_LEVEL=emergency');
+        }
     }
 
     public static function enableQueryDebug(): void

--- a/LibreNMS/Util/Debug.php
+++ b/LibreNMS/Util/Debug.php
@@ -26,9 +26,6 @@
 
 namespace LibreNMS\Util;
 
-use App;
-use Log;
-
 class Debug
 {
     /** @var bool */
@@ -42,10 +39,9 @@ class Debug
      * Enable/disable debug output
      *
      * @param  bool  $debug  whether to enable or disable debug output
-     * @param  bool  $silence  Silence error output or output all errors except notices
      * @return bool returns $debug
      */
-    public static function set($debug = true, bool $silence = false): bool
+    public static function set($debug = true): bool
     {
         self::$debug = (bool) $debug;
 
@@ -54,8 +50,8 @@ class Debug
             self::enableCliDebugOutput();
             self::enableQueryDebug();
         } else {
-            self::disableErrorReporting($silence);
-            self::disableCliDebugOutput($silence);
+            self::disableErrorReporting();
+            self::disableCliDebugOutput();
             self::disableQueryDebug();
         }
 
@@ -92,18 +88,17 @@ class Debug
 
     public static function enableCliDebugOutput(): void
     {
-        if (Laravel::isBooted() && App::runningInConsole()) {
-            Log::setDefaultDriver('console_debug');
-        } else {
-            putenv('LOG_CHANNEL=console_debug');
-        }
+        config(['logging.channels.stdout.level' => 'debug']);
     }
 
-    public static function disableCliDebugOutput(bool $silence): void
+    public static function disableCliDebugOutput(): void
     {
-        if (Laravel::isBooted() && Log::getDefaultDriver() !== 'stack') {
-            Log::setDefaultDriver(app()->runningInConsole() && ! $silence ? 'console' : 'stack');
-        }
+        config(['logging.channels.stdout.level' => 'info']);
+    }
+
+    public static function setCliQuietOutput(): void
+    {
+        config(['logging.channels.stdout.level' => 'emergency']);
     }
 
     public static function enableQueryDebug(): void
@@ -119,7 +114,7 @@ class Debug
     /**
      * Disable error reporting, do not use with new code
      */
-    public static function disableErrorReporting(bool $silence = false): void
+    public static function disableErrorReporting(): void
     {
         ini_set('display_startup_errors', '1');
         ini_set('display_errors', '0');

--- a/app/Console/LnmsCommand.php
+++ b/app/Console/LnmsCommand.php
@@ -31,6 +31,7 @@ use Illuminate\Validation\Rule;
 use Illuminate\Validation\ValidationException;
 use LibreNMS\Util\Debug;
 use Symfony\Component\Console\Exception\InvalidArgumentException;
+use Symfony\Component\Console\Output\OutputInterface;
 use Validator;
 
 abstract class LnmsCommand extends Command
@@ -165,10 +166,20 @@ abstract class LnmsCommand extends Command
 
     protected function configureOutputOptions(): void
     {
-        \Log::setDefaultDriver($this->getOutput()->isQuiet() ? 'stack' : 'console');
-        if (($verbosity = $this->getOutput()->getVerbosity()) >= 128) {
+        $verbosity = $this->getOutput()->getVerbosity();
+
+        if ($verbosity === OutputInterface::VERBOSITY_QUIET) {
+            \Log::setDefaultDriver('stack'); // this omits stdout
+            Debug::setCliQuietOutput();
+
+            return;
+        }
+
+        \Log::setDefaultDriver('console');
+
+        if ($verbosity >= OutputInterface::VERBOSITY_VERY_VERBOSE) {
             Debug::set();
-            if ($verbosity >= 256) {
+            if ($verbosity >= OutputInterface::VERBOSITY_DEBUG) {
                 Debug::setVerbose();
             }
         }

--- a/app/Logging/CliColorFormatter.php
+++ b/app/Logging/CliColorFormatter.php
@@ -50,6 +50,15 @@ class CliColorFormatter extends \Monolog\Formatter\LineFormatter
 
     public function format(\Monolog\LogRecord $record): string
     {
+        // if no line break is specified, just output the raw message (maybe colored)
+        if (isset($record->context['nlb']) && $record->context['nlb'] === true) {
+            if (isset($record->context['color']) && $record->context['color']) {
+                return $this->console_color->convert($record->message, $this->console);
+            }
+
+            return $record->message;
+        }
+
         // only format messages where color is enabled
         if (isset($record->context['color']) && $record->context['color']) {
             $context = $record->context;

--- a/app/Observers/ModuleModelObserver.php
+++ b/app/Observers/ModuleModelObserver.php
@@ -83,7 +83,7 @@ class ModuleModelObserver
     {
         if (Debug::isEnabled()) {
             $this->logger->debug('Updated data:   ', ['nlb' => true]);
-            $this->logger->debug($model->getDirty());
+            $this->logger->debug(var_export($model->getDirty(), true));
         } else {
             $this->logger->info('U', ['nlb' => true]);
         }
@@ -96,7 +96,7 @@ class ModuleModelObserver
     {
         if (Debug::isEnabled()) {
             $this->logger->debug('Restored data:   ', ['nlb' => true]);
-            $this->logger->debug($model->getDirty());
+            $this->logger->debug(var_export($model->getDirty(), true));
         } else {
             $this->logger->info('R', ['nlb' => true]);
         }

--- a/app/Observers/ModuleModelObserver.php
+++ b/app/Observers/ModuleModelObserver.php
@@ -26,18 +26,34 @@
 namespace App\Observers;
 
 use Illuminate\Database\Eloquent\Model as Eloquent;
+use Illuminate\Log\Logger;
+use Illuminate\Support\Facades\Log;
+use LibreNMS\Util\Debug;
+use Psr\Log\LoggerInterface;
 
 class ModuleModelObserver
 {
+    private LoggerInterface $logger;
+
+    public function __construct(
+        ?Logger $logger = null,
+    ) {
+        $this->logger = $logger ?? Log::channel('stdout');
+    }
+
     /**
      * Install observers to output +, -, U for models being created, deleted, and updated
      *
      * @param  string|Eloquent  $model  The model name including namespace
      */
-    public static function observe($model)
+    public static function observe($model, string $name = ''): void
     {
         static $observed_models = []; // keep track of observed models so we don't duplicate output
         $class = ltrim($model, '\\');
+
+        if ($name) {
+            Log::channel('stdout')->info(ucwords($name) . ': ', ['nlb' => true]);
+        }
 
         if (! in_array($class, $observed_models)) {
             $model::observe(new static());
@@ -45,13 +61,18 @@ class ModuleModelObserver
         }
     }
 
+    public static function done(): void
+    {
+        Log::channel('stdout')->info(PHP_EOL, ['nlb' => true]);
+    }
+
     /**
      * @param  Eloquent  $model
      */
-    public function saving($model)
+    public function saving($model): void
     {
         if (! $model->isDirty()) {
-            echo '.';
+            $this->logger->info('.', ['nlb' => true]);
         }
     }
 
@@ -60,8 +81,12 @@ class ModuleModelObserver
      */
     public function updated($model): void
     {
-        d_echo('Updated data:', 'U');
-        d_echo($model->getDirty());
+        if (Debug::isEnabled()) {
+            $this->logger->debug('Updated data:   ', ['nlb' => true]);
+            $this->logger->debug($model->getDirty());
+        } else {
+            $this->logger->info('U', ['nlb' => true]);
+        }
     }
 
     /**
@@ -69,8 +94,12 @@ class ModuleModelObserver
      */
     public function restored($model): void
     {
-        d_echo('Restored data:', 'R');
-        d_echo($model->getDirty());
+        if (Debug::isEnabled()) {
+            $this->logger->debug('Restored data:   ', ['nlb' => true]);
+            $this->logger->debug($model->getDirty());
+        } else {
+            $this->logger->info('R', ['nlb' => true]);
+        }
     }
 
     /**
@@ -78,7 +107,7 @@ class ModuleModelObserver
      */
     public function created($model): void
     {
-        echo '+';
+        $this->logger->info('+', ['nlb' => true]);
     }
 
     /**
@@ -86,6 +115,6 @@ class ModuleModelObserver
      */
     public function deleted($model): void
     {
-        echo '-';
+        $this->logger->info('-', ['nlb' => true]);
     }
 }

--- a/config/logging.php
+++ b/config/logging.php
@@ -40,15 +40,6 @@ return [
             'replace_placeholders' => true,
         ],
 
-        'daily' => [
-            'driver' => 'daily',
-            'path' => env('APP_LOG', base_path('logs/librenms.log')),
-            'formatter' => App\Logging\NoColorFormatter::class,
-            'level' => env('LOG_LEVEL', 'error'),
-            'days' => 14,
-            'replace_placeholders' => true,
-        ],
-
         'stdout' => [
             'driver' => 'monolog',
             'handler' => StreamHandler::class,
@@ -56,7 +47,7 @@ return [
             'with' => [
                 'stream' => 'php://output',
             ],
-            'level' => 'info',
+            'level' => env('STDOUT_LOG_LEVEL', 'info'),
         ],
 
         'stderr' => [

--- a/config/logging.php
+++ b/config/logging.php
@@ -22,23 +22,17 @@ return [
     'channels' => [
         'stack' => [
             'driver' => 'stack',
-            'channels' => ['single', 'flare'],
+            'channels' => ['log_file', 'flare'],
             'ignore_exceptions' => false,
         ],
 
         'console' => [
             'driver' => 'stack',
-            'channels' => ['single', 'stdout', 'flare'],
+            'channels' => ['log_file', 'stdout', 'flare'],
             'ignore_exceptions' => false,
         ],
 
-        'console_debug' => [
-            'driver' => 'stack',
-            'channels' => ['single', 'stdout_debug'],
-            'ignore_exceptions' => false,
-        ],
-
-        'single' => [
+        'log_file' => [
             'driver' => 'single',
             'path' => env('APP_LOG', base_path('logs/librenms.log')),
             'formatter' => App\Logging\LogFileFormatter::class,
@@ -53,16 +47,6 @@ return [
             'level' => env('LOG_LEVEL', 'error'),
             'days' => 14,
             'replace_placeholders' => true,
-        ],
-
-        'stdout_debug' => [
-            'driver' => 'monolog',
-            'handler' => StreamHandler::class,
-            'formatter' => App\Logging\CliColorFormatter::class,
-            'with' => [
-                'stream' => 'php://output',
-            ],
-            'level' => 'debug',
         ],
 
         'stdout' => [

--- a/discovery.php
+++ b/discovery.php
@@ -64,7 +64,7 @@ if (isset($options['i']) && $options['i'] && isset($options['n'])) {
     $doing = $options['n'] . '/' . $options['i'];
 }
 
-if (Debug::set(isset($options['d']), false) || isset($options['v'])) {
+if (Debug::set(isset($options['d'])) || isset($options['v'])) {
     echo \LibreNMS\Util\Version::get()->header();
 
     echo "DEBUG!\n";

--- a/includes/init.php
+++ b/includes/init.php
@@ -76,8 +76,6 @@ if (module_selected('polling', $init_modules)) {
     require_once $install_dir . '/includes/polling/functions.inc.php';
 }
 
-Debug::set($debug ?? false); // disable debug initially
-
 // Boot Laravel
 if (module_selected('web', $init_modules)) {
     Laravel::bootWeb(module_selected('auth', $init_modules));

--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -200,7 +200,7 @@ function record_sensor_data($device, $all_sensors)
                 'state_value'
             );
 
-            Eventlog::log('$class sensor ' . ($sensor['sensor_descr'] ?? '') . ' has changed from ' . ($trans[$prev_sensor_value] ?? '#unamed state#') . "($prev_sensor_value) to " . ($trans[$sensor_value] ?? '#unamed state#') . " ($sensor_value)", $device['device_id'], $class, Severity::Notice, $sensor['sensor_id']);
+            Eventlog::log($class . ' sensor ' . ($sensor['sensor_descr'] ?? '') . ' has changed from ' . ($trans[$prev_sensor_value] ?? '#unamed state#') . "($prev_sensor_value) to " . ($trans[$sensor_value] ?? '#unamed state#') . " ($sensor_value)", $device['device_id'], $class, Severity::Notice, $sensor['sensor_id']);
         }
         if ($sensor_value != $prev_sensor_value) {
             dbUpdate(['sensor_current' => $sensor_value, 'sensor_prev' => $prev_sensor_value, 'lastupdate' => ['NOW()']], 'sensors', '`sensor_class` = ? AND `sensor_id` = ?', [$sensor['sensor_class'], $sensor['sensor_id']]);


### PR DESCRIPTION
Reduced number of channels
Change stdout level at runtime
ModuleModelObserver now uses logging and includes more tools to improve output consistency
Option to output directly to stdout without new line

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
