### PR TITLE
SVG logo currentColor support

### DIFF
--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -2059,7 +2059,7 @@ return [
         ],
         'title_image' => [
             'description' => 'Title Image',
-            'help' => 'Overrides the default Title Image.',
+            'help' => 'Overrides the default Title Image. SVG from the same server will be include and can use currentColor to match the current theme dynamically.',
         ],
         'traceroute' => [
             'description' => 'Path to traceroute',

--- a/resources/views/components/logo.blade.php
+++ b/resources/views/components/logo.blade.php
@@ -1,9 +1,18 @@
 @props([
     'responsive' => false, // crop text at given breakpoint sm,md,lg,xl, etc
+    'image' => LibrenmsConfig::get('title_image'),
+    'alt' => LibrenmsConfig::get('project_name')
 ])
 
-@if(LibrenmsConfig::get('title_image'))
-    <img {{ $attributes }} src="{{ asset(LibrenmsConfig::get('title_image')) }}" alt="{{ LibrenmsConfig::get('project_name') }}">
+@if($image)
+    {{-- Include svgs inline so they can use currentColor for light/dark mode, but only if they are hosted on the same server (browser will reject it otherwise) --}}
+    @if(str_ends_with($image, '.svg') && ! str_contains($image, '//'))
+        <svg {{ $attributes->class(['tw:dark:text-white', 'tw:text-gray-600']) }}>
+            <use href="{{ asset($image) }}"></use>
+        </svg>
+    @else
+        <img {{ $attributes }} src="{{ asset($image) }}" alt="{{ $alt }}">
+    @endif
 @else
     <svg {{ $attributes->class(['tw:dark:text-white', 'tw:text-gray-600'])->class($responsive ? ['tw:hidden', "tw:$responsive:inline-block"] : []) }}
          xmlns="http://www.w3.org/2000/svg" viewBox="0 0 170 32.275086">


### PR DESCRIPTION
If title_image is set and it is on the same server (browser won't include it otherwise), inline the SVG so the SVG can use currentColor and react to theme changes.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
