### PR TITLE
Add port association mode to reporting stats

### DIFF
--- a/LibreNMS/Util/Stats.php
+++ b/LibreNMS/Util/Stats.php
@@ -127,6 +127,7 @@ class Stats
             'ospfv3_links' => $this->selectTotal('ospfv3_ports', ['ospfv3IfType']),
             'arch' => $this->selectTotal('packages', ['arch']),
             'pollers' => $this->selectTotal('pollers'),
+            'port_assoc' => $this->selectTotal('devices', ['port_association_mode']),
             'port_type' => $this->selectTotal('ports', ['ifType']),
             'port_ifspeed' => DB::table('ports')->select([DB::raw('COUNT(*) AS `total`'), DB::raw('ROUND(`ifSpeed`/1000/1000) as ifSpeed')])->groupBy(['ifSpeed'])->get(),
             'port_vlans' => $this->selectTotal('ports_vlans', ['state']),

--- a/LibreNMS/Util/Stats.php
+++ b/LibreNMS/Util/Stats.php
@@ -47,6 +47,11 @@ class Stats
         }
     }
 
+    public function dump(): array
+    {
+        return $this->collectData();
+    }
+
     public function isEnabled(): bool
     {
         $enabled = Callback::get('enabled');


### PR DESCRIPTION
Add port association mode to reporting

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
