### PR TITLE
Add widget registry code support for dashboards

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -30,6 +30,7 @@ use App\Models\Dashboard;
 use App\Models\User;
 use App\Models\UserPref;
 use App\Models\UserWidget;
+use App\Services\WidgetRegistry;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
@@ -38,37 +39,16 @@ use LibreNMS\Config;
 
 class DashboardController extends Controller
 {
-    /** @var string[] */
-    public static $widgets = [
-        'alerts',
-        'alertlog',
-        'alertlog-stats',
-        'availability-map',
-        'component-status',
-        'custom-map',
-        'device-summary-horiz',
-        'device-summary-vert',
-        'device-types',
-        'eventlog',
-        'globe',
-        'generic-graph',
-        'graylog',
-        'generic-image',
-        'notes',
-        'server-stats',
-        'syslog',
-        'top-devices',
-        'top-errors',
-        'top-interfaces',
-        'worldmap',
-    ];
-
     /** @var \Illuminate\Support\Collection<\App\Models\Dashboard> */
     private $dashboards;
 
-    public function __construct()
+    /** @var WidgetRegistry */
+    private $widgetRegistry;
+
+    public function __construct(WidgetRegistry $widgetRegistry)
     {
         $this->authorizeResource(Dashboard::class, 'dashboard');
+        $this->widgetRegistry = $widgetRegistry;
     }
 
     /**
@@ -153,9 +133,7 @@ class DashboardController extends Controller
             ];
         }
 
-        $widgets = array_combine(self::$widgets, array_map(function ($widget) {
-            return trans("widgets.$widget.title");
-        }, self::$widgets));
+        $widgets = $this->widgetRegistry->getWidgetTitles();
 
         $user_list = $user->can('manage', User::class)
             ? User::where('user_id', '!=', $user->user_id)

--- a/app/Http/Controllers/DashboardWidgetController.php
+++ b/app/Http/Controllers/DashboardWidgetController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\Dashboard;
 use App\Models\UserWidget;
+use App\Services\WidgetRegistry;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -11,12 +12,20 @@ use Illuminate\Validation\Rule;
 
 class DashboardWidgetController extends Controller
 {
+    /** @var WidgetRegistry */
+    private $widgetRegistry;
+
+    public function __construct(WidgetRegistry $widgetRegistry)
+    {
+        $this->widgetRegistry = $widgetRegistry;
+    }
+
     public function add(Dashboard $dashboard, Request $request): JsonResponse
     {
         $this->authorize('update', $dashboard);
 
         $this->validate($request, [
-            'widget_type' => Rule::in(DashboardController::$widgets),
+            'widget_type' => Rule::in($this->widgetRegistry->getWidgetNames()),
         ]);
 
         $type = $request->get('widget_type');

--- a/app/Http/Controllers/OverviewController.php
+++ b/app/Http/Controllers/OverviewController.php
@@ -28,7 +28,7 @@ class OverviewController extends Controller
         }
 
         // default to dashboard
-        return (new DashboardController())->index($request);
+        return app(DashboardController::class)->index($request);
     }
 
     /**

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -61,6 +61,10 @@ class AppServiceProvider extends ServiceProvider
         $this->app->singleton('sensor-discovery', function (Application $app) {
             return new \App\Discovery\Sensor($app->make('device-cache')->getPrimary());
         });
+
+        $this->app->singleton(\App\Services\WidgetRegistry::class, function ($app) {
+            return new \App\Services\WidgetRegistry($app);
+        });
     }
 
     /**

--- a/app/Services/WidgetRegistry.php
+++ b/app/Services/WidgetRegistry.php
@@ -5,7 +5,6 @@ namespace App\Services;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Facades\Route;
 use LibreNMS\Interfaces\Plugins\Hooks\DashboardWidgetHook;
 
 class WidgetRegistry
@@ -74,8 +73,8 @@ class WidgetRegistry
             $taggedWidgets = $this->app->tagged('librenms.widget');
 
             foreach ($taggedWidgets as $widget) {
-                if (!$widget instanceof DashboardWidgetHook) {
-                    Log::warning("Tagged widget service does not implement DashboardWidgetHook interface");
+                if (! $widget instanceof DashboardWidgetHook) {
+                    Log::warning('Tagged widget service does not implement DashboardWidgetHook interface');
                     continue;
                 }
 
@@ -90,14 +89,13 @@ class WidgetRegistry
                     'name' => $widgetName,
                     'title' => $widget->getWidgetTitle(),
                     'controller' => $widget->getWidgetController(),
-                    'type' => 'plugin'
+                    'type' => 'plugin',
                 ]);
             }
         } catch (\Exception $e) {
-            Log::error("Failed to register plugin widgets: " . $e->getMessage());
+            Log::error('Failed to register plugin widgets: ' . $e->getMessage());
         }
     }
-
 
     /**
      * Get all registered widgets
@@ -132,7 +130,7 @@ class WidgetRegistry
     /**
      * Get a specific widget by name
      *
-     * @param string $name
+     * @param  string  $name
      * @return array|null
      */
     public function getWidget(string $name): ?array
@@ -143,7 +141,7 @@ class WidgetRegistry
     /**
      * Check if a widget exists
      *
-     * @param string $name
+     * @param  string  $name
      * @return bool
      */
     public function hasWidget(string $name): bool
@@ -154,7 +152,7 @@ class WidgetRegistry
     /**
      * Get the controller class for a core widget
      *
-     * @param string $widget
+     * @param  string  $widget
      * @return string
      */
     private function getControllerClass(string $widget): string
@@ -186,4 +184,3 @@ class WidgetRegistry
         return $controllerMap[$widget] ?? 'App\Http\Controllers\Widgets\PlaceholderController';
     }
 }
-

--- a/app/Services/WidgetRegistry.php
+++ b/app/Services/WidgetRegistry.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Route;
+use LibreNMS\Interfaces\Plugins\Hooks\DashboardWidgetHook;
+
+class WidgetRegistry
+{
+    /** @var Collection */
+    private $widgets;
+
+    /** @var Application */
+    private $app;
+
+    /** @var array core widgets part of LibreNMS */
+    private $coreWidgets = [
+        'alerts',
+        'alertlog',
+        'alertlog-stats',
+        'availability-map',
+        'component-status',
+        'custom-map',
+        'device-summary-horiz',
+        'device-summary-vert',
+        'device-types',
+        'eventlog',
+        'globe',
+        'generic-graph',
+        'graylog',
+        'generic-image',
+        'notes',
+        'server-stats',
+        'syslog',
+        'top-devices',
+        'top-errors',
+        'top-interfaces',
+        'worldmap',
+    ];
+
+    public function __construct(Application $app)
+    {
+        $this->app = $app;
+        $this->widgets = new Collection();
+        $this->registerCoreWidgets();
+        $this->registerPluginWidgets();
+    }
+
+    /**
+     * Register core widgets
+     */
+    private function registerCoreWidgets(): void
+    {
+        foreach ($this->coreWidgets as $widget) {
+            $this->widgets->put($widget, [
+                'name' => $widget,
+                'title' => trans("widgets.$widget.title"),
+                'controller' => $this->getControllerClass($widget),
+                'type' => 'core',
+                'metadata' => [],
+            ]);
+        }
+    }
+
+    /**
+     * Register widgets from plugins using service container tagged services
+     */
+    private function registerPluginWidgets(): void
+    {
+        try {
+            $taggedWidgets = $this->app->tagged('librenms.widget');
+
+            foreach ($taggedWidgets as $widget) {
+                if (!$widget instanceof DashboardWidgetHook) {
+                    Log::warning("Tagged widget service does not implement DashboardWidgetHook interface");
+                    continue;
+                }
+
+                $widgetName = $widget->getWidgetName();
+
+                if (in_array($widgetName, $this->coreWidgets)) {
+                    Log::warning("Plugin widget '$widgetName' conflicts with core widget name and will be skipped");
+                    continue;
+                }
+
+                $this->widgets->put($widgetName, [
+                    'name' => $widgetName,
+                    'title' => $widget->getWidgetTitle(),
+                    'controller' => $widget->getWidgetController(),
+                    'type' => 'plugin'
+                ]);
+            }
+        } catch (\Exception $e) {
+            Log::error("Failed to register plugin widgets: " . $e->getMessage());
+        }
+    }
+
+
+    /**
+     * Get all registered widgets
+     *
+     * @return Collection
+     */
+    public function getWidgets(): Collection
+    {
+        return $this->widgets;
+    }
+
+    /**
+     * Get widget names for dropdown selection
+     *
+     * @return array
+     */
+    public function getWidgetNames(): array
+    {
+        return $this->widgets->pluck('name')->toArray();
+    }
+
+    /**
+     * Get widget titles for dropdown display
+     *
+     * @return array
+     */
+    public function getWidgetTitles(): array
+    {
+        return $this->widgets->pluck('title', 'name')->sort()->toArray();
+    }
+
+    /**
+     * Get a specific widget by name
+     *
+     * @param string $name
+     * @return array|null
+     */
+    public function getWidget(string $name): ?array
+    {
+        return $this->widgets->get($name);
+    }
+
+    /**
+     * Check if a widget exists
+     *
+     * @param string $name
+     * @return bool
+     */
+    public function hasWidget(string $name): bool
+    {
+        return $this->widgets->has($name);
+    }
+
+    /**
+     * Get the controller class for a core widget
+     *
+     * @param string $widget
+     * @return string
+     */
+    private function getControllerClass(string $widget): string
+    {
+        $controllerMap = [
+            'alerts' => 'App\Http\Controllers\Widgets\AlertsController',
+            'alertlog' => 'App\Http\Controllers\Widgets\AlertlogController',
+            'alertlog-stats' => 'App\Http\Controllers\Widgets\AlertlogStatsController',
+            'availability-map' => 'App\Http\Controllers\Widgets\AvailabilityMapController',
+            'component-status' => 'App\Http\Controllers\Widgets\ComponentStatusController',
+            'custom-map' => 'App\Http\Controllers\Widgets\CustomMapController',
+            'device-summary-horiz' => 'App\Http\Controllers\Widgets\DeviceSummaryHorizController',
+            'device-summary-vert' => 'App\Http\Controllers\Widgets\DeviceSummaryVertController',
+            'device-types' => 'App\Http\Controllers\Widgets\DeviceTypeController',
+            'eventlog' => 'App\Http\Controllers\Widgets\EventlogController',
+            'globe' => 'App\Http\Controllers\Widgets\GlobeController',
+            'generic-graph' => 'App\Http\Controllers\Widgets\GraphController',
+            'graylog' => 'App\Http\Controllers\Widgets\GraylogController',
+            'generic-image' => 'App\Http\Controllers\Widgets\ImageController',
+            'notes' => 'App\Http\Controllers\Widgets\NotesController',
+            'server-stats' => 'App\Http\Controllers\Widgets\ServerStatsController',
+            'syslog' => 'App\Http\Controllers\Widgets\SyslogController',
+            'top-devices' => 'App\Http\Controllers\Widgets\TopDevicesController',
+            'top-errors' => 'App\Http\Controllers\Widgets\TopErrorsController',
+            'top-interfaces' => 'App\Http\Controllers\Widgets\TopInterfacesController',
+            'worldmap' => 'App\Http\Controllers\Widgets\WorldMapController',
+        ];
+
+        return $controllerMap[$widget] ?? 'App\Http\Controllers\Widgets\PlaceholderController';
+    }
+}
+

--- a/doc/Developing/Widget-Plugins.md
+++ b/doc/Developing/Widget-Plugins.md
@@ -1,0 +1,233 @@
+# Widget Plugin Development
+
+Create custom dashboard widgets using LibreNMS's V2 plugin system.
+
+## Quick Start
+
+Create a widget plugin in 4 steps:
+
+1. Create widget hook class implementing `DashboardWidgetHook`
+2. Create widget controller extending `WidgetController`
+3. Register widget in service provider with container tagging
+4. Create Blade templates for display and settings
+
+## Plugin Structure
+
+```
+your-plugin/
+├── composer.json
+├── src/
+│   ├── Hooks/
+│   │   └── YourWidgetHook.php
+│   ├── Http/Controllers/Widgets/
+│   │   └── YourWidgetController.php
+│   └── Providers/
+│       └── YourServiceProvider.php
+├── resources/
+│   ├── views/widgets/
+│   │   ├── your-widget.blade.php
+│   │   └── settings.blade.php
+│   └── lang/en/
+│       └── widgets.php
+└── routes/
+    └── web.php
+```
+
+## Widget Hook Implementation
+
+Create hook class implementing the required interface:
+
+```php
+<?php
+
+namespace YourPlugin\Hooks;
+
+use LibreNMS\Interfaces\Plugins\Hooks\DashboardWidgetHook;
+
+class YourWidgetHook implements DashboardWidgetHook
+{
+    public function getWidgetName(): string
+    {
+        return 'your-widget-name';
+    }
+
+    public function getWidgetController(): string
+    {
+        return 'YourPlugin\Http\Controllers\Widgets\YourWidgetController';
+    }
+
+    public function getWidgetTitle(): string
+    {
+        return __('your-plugin::widgets.your_widget.title');
+    }
+}
+```
+
+## Widget Controller
+
+Extend [`WidgetController`](../../app/Http/Controllers/Widgets/WidgetController.php:37) base class:
+
+```php
+<?php
+
+namespace YourPlugin\Http\Controllers\Widgets;
+
+use App\Http\Controllers\Widgets\WidgetController;
+use Illuminate\Http\Request;
+
+class YourWidgetController extends WidgetController
+{
+    protected $title;
+    
+    protected $defaults = [
+        'title' => null,
+        'refresh' => 60,
+        'your_setting' => 'default_value',
+    ];
+
+    public function __construct()
+    {
+        $this->title = __('your-plugin::widgets.your_widget.title');
+    }
+
+    public function getView(Request $request)
+    {
+        $settings = $this->getSettings();
+        $data = $this->getWidgetData($settings);
+        
+        return view('your-plugin::widgets.your-widget', [
+            'data' => $data,
+            'settings' => $settings,
+        ]);
+    }
+
+    public function getSettingsView(Request $request)
+    {
+        return view('your-plugin::widgets.settings', $this->getSettings(true));
+    }
+
+    private function getWidgetData(array $settings): array
+    {
+        // Implement data retrieval logic
+        return ['items' => [], 'count' => 0];
+    }
+}
+```
+
+## Service Provider Registration
+
+Register widget using Laravel container tagging:
+
+```php
+<?php
+
+namespace YourPlugin\Providers;
+
+use Illuminate\Support\ServiceProvider;
+use LibreNMS\Interfaces\Plugins\PluginManagerInterface;
+use YourPlugin\Hooks\YourWidgetHook;
+
+class YourServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        $this->registerWidgets();
+    }
+
+    public function boot(PluginManagerInterface $pluginManager): void
+    {
+        if (!$pluginManager->pluginEnabled('your-plugin-name')) {
+            return;
+        }
+
+        $this->loadViewsFrom(__DIR__ . '/../../resources/views', 'your-plugin');
+        $this->loadTranslationsFrom(__DIR__ . '/../../resources/lang', 'your-plugin');
+    }
+
+    protected function registerWidgets(): void
+    {
+        $this->app->bind(YourWidgetHook::class, function () {
+            return new YourWidgetHook();
+        });
+
+        $this->app->tag([YourWidgetHook::class], 'librenms.widget');
+    }
+}
+```
+
+## Widget Templates
+
+### Display Template
+
+Create `resources/views/widgets/your-widget.blade.php`:
+
+```blade
+<div class="widget-content">
+    @if(count($data['items']) > 0)
+        @foreach($data['items'] as $item)
+            <div class="widget-item">
+                <span>{{ $item['name'] }}</span>
+                <span>{{ $item['value'] }}</span>
+            </div>
+        @endforeach
+    @else
+        <div class="text-center text-muted p-3">
+            {{ __('your-plugin::widgets.your_widget.no_data') }}
+        </div>
+    @endif
+</div>
+```
+
+### Settings Template
+
+Create `resources/views/widgets/settings.blade.php`:
+
+```blade
+@extends('widgets.settings.base')
+
+@section('form')
+    <div class="form-group">
+        <label for="title-{{ $id }}">{{ __('Widget Title') }}</label>
+        <input type="text" class="form-control" name="title" id="title-{{ $id }}" 
+               value="{{ $title }}" placeholder="{{ __('Custom title') }}">
+    </div>
+
+    <div class="form-group">
+        <label for="your-setting-{{ $id }}">{{ __('Custom Setting') }}</label>
+        <input type="text" class="form-control" name="your_setting" id="your-setting-{{ $id }}" 
+               value="{{ $your_setting }}">
+    </div>
+@endsection
+```
+
+## Advanced Features
+
+### Data Caching
+
+Cache expensive operations:
+
+```php
+private function getWidgetData(array $settings): array
+{
+    $cacheKey = "widget.your-widget.{$settings['id']}";
+    
+    return Cache::remember($cacheKey, 300, function () use ($settings) {
+        return $this->fetchExpensiveData($settings);
+    });
+}
+```
+
+### Settings Validation
+
+Add validation in controller:
+
+```php
+public function getSettingsView(Request $request)
+{
+    $request->validate([
+        'your_setting' => 'required|string|max:255'
+    ]);
+    
+    return parent::getSettingsView($request);
+}
+```

--- a/doc/Developing/Widget-Plugins.md
+++ b/doc/Developing/Widget-Plugins.md
@@ -65,7 +65,8 @@ class YourWidgetHook implements DashboardWidgetHook
 
 ## Widget Controller
 
-Extend [`WidgetController`](../../app/Http/Controllers/Widgets/WidgetController.php:37) base class:
+This class is responsible for displaying widget related data.
+Extend the `WidgetController` with your own code.
 
 ```php
 <?php

--- a/doc/Extensions/Plugin-System.md
+++ b/doc/Extensions/Plugin-System.md
@@ -143,3 +143,7 @@ class DeviceOverview extends DeviceOverviewHook
     }
 }
 ```
+
+## See Also
+
+The [Developing/Widget-Plugins.md](Widget Plugins) for creating dashboard widgets.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -287,7 +287,9 @@ nav:
       - Sensor State Support: Developing/Sensor-State-Support.md
     - SNMP Traps: Developing/SNMP-Traps.md
     - Dynamic Config: Developing/Dynamic-Config.md
-    - Plugin System: Extensions/Plugin-System.md
+    - Plugin System:
+      - Intro: Extensions/Plugin-System.md
+      - Widget Plugin: Developing/Widget-Plugins.md
     - Developer notes:
       - Merging Pull Requests: Developing/Merging-Pull-Requests.md
       - Creating Release: Developing/Creating-Release.md

--- a/tests/Unit/WidgetRegistryTest.php
+++ b/tests/Unit/WidgetRegistryTest.php
@@ -85,7 +85,7 @@ class WidgetRegistryTest extends TestCase
 
         $widgetNames = $registry->getWidgetNames();
 
-        $this->assertIsArray($widgetNames);
+        $this->assertNotEmpty($widgetNames);
         $this->assertContains('alerts', $widgetNames);
         $this->assertContains('worldmap', $widgetNames);
     }
@@ -99,7 +99,7 @@ class WidgetRegistryTest extends TestCase
 
         $widgetTitles = $registry->getWidgetTitles();
 
-        $this->assertIsArray($widgetTitles);
+        $this->assertNotEmpty($widgetTitles);
         $this->assertArrayHasKey('alerts', $widgetTitles);
         $this->assertArrayHasKey('worldmap', $widgetTitles);
     }

--- a/tests/Unit/WidgetRegistryTest.php
+++ b/tests/Unit/WidgetRegistryTest.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Services\WidgetRegistry;
+use Illuminate\Contracts\Foundation\Application;
+use LibreNMS\Interfaces\Plugins\Hooks\DashboardWidgetHook;
+use LibreNMS\Tests\TestCase;
+use Mockery;
+
+class WidgetRegistryTest extends TestCase
+{
+    public function testCoreWidgetsAreRegistered()
+    {
+        $app = Mockery::mock(Application::class);
+        $app->shouldReceive('tagged')->with('librenms.widget')->andReturn([]);
+
+        $registry = new WidgetRegistry($app);
+
+        $widgets = $registry->getWidgets();
+
+        // Test that core widgets are registered
+        $this->assertTrue($widgets->has('alerts'));
+        $this->assertTrue($widgets->has('alertlog'));
+        $this->assertTrue($widgets->has('worldmap'));
+
+        // Test widget structure
+        $alertsWidget = $widgets->get('alerts');
+        $this->assertEquals('alerts', $alertsWidget['name']);
+        $this->assertEquals('core', $alertsWidget['type']);
+        $this->assertArrayHasKey('title', $alertsWidget);
+        $this->assertArrayHasKey('controller', $alertsWidget);
+    }
+
+    public function testPluginWidgetsAreRegistered()
+    {
+        $mockHook = Mockery::mock(DashboardWidgetHook::class);
+        $mockHook->shouldReceive('getWidgetName')->andReturn('test-widget');
+        $mockHook->shouldReceive('getWidgetTitle')->andReturn('Test Widget');
+        $mockHook->shouldReceive('getWidgetController')->andReturn('TestController');
+
+        $app = Mockery::mock(Application::class);
+        $app->shouldReceive('tagged')->with('librenms.widget')->andReturn([$mockHook]);
+
+        $registry = new WidgetRegistry($app);
+
+        $widgets = $registry->getWidgets();
+
+        // Test that plugin widget is registered
+        $this->assertTrue($widgets->has('test-widget'));
+
+        $testWidget = $widgets->get('test-widget');
+        $this->assertEquals('test-widget', $testWidget['name']);
+        $this->assertEquals('Test Widget', $testWidget['title']);
+        $this->assertEquals('TestController', $testWidget['controller']);
+        $this->assertEquals('plugin', $testWidget['type']);
+    }
+
+    public function testConflictingWidgetNamesAreSkipped()
+    {
+        $mockHook = Mockery::mock(DashboardWidgetHook::class);
+        $mockHook->shouldReceive('getWidgetName')->andReturn('alerts'); // Conflicts with core widget
+        $mockHook->shouldReceive('getWidgetTitle')->andReturn('Conflicting Widget');
+        $mockHook->shouldReceive('getWidgetController')->andReturn('ConflictingController');
+
+        $app = Mockery::mock(Application::class);
+        $app->shouldReceive('tagged')->with('librenms.widget')->andReturn([$mockHook]);
+
+        $registry = new WidgetRegistry($app);
+
+        $widgets = $registry->getWidgets();
+
+        // Test that the core widget is preserved, not the conflicting plugin widget
+        $alertsWidget = $widgets->get('alerts');
+        $this->assertEquals('core', $alertsWidget['type']);
+        $this->assertNotEquals('Conflicting Widget', $alertsWidget['title']);
+    }
+
+    public function testGetWidgetNames()
+    {
+        $app = Mockery::mock(Application::class);
+        $app->shouldReceive('tagged')->with('librenms.widget')->andReturn([]);
+
+        $registry = new WidgetRegistry($app);
+
+        $widgetNames = $registry->getWidgetNames();
+
+        $this->assertIsArray($widgetNames);
+        $this->assertContains('alerts', $widgetNames);
+        $this->assertContains('worldmap', $widgetNames);
+    }
+
+    public function testGetWidgetTitles()
+    {
+        $app = Mockery::mock(Application::class);
+        $app->shouldReceive('tagged')->with('librenms.widget')->andReturn([]);
+
+        $registry = new WidgetRegistry($app);
+
+        $widgetTitles = $registry->getWidgetTitles();
+
+        $this->assertIsArray($widgetTitles);
+        $this->assertArrayHasKey('alerts', $widgetTitles);
+        $this->assertArrayHasKey('worldmap', $widgetTitles);
+    }
+
+    public function testHasWidget()
+    {
+        $app = Mockery::mock(Application::class);
+        $app->shouldReceive('tagged')->with('librenms.widget')->andReturn([]);
+
+        $registry = new WidgetRegistry($app);
+
+        $this->assertTrue($registry->hasWidget('alerts'));
+        $this->assertFalse($registry->hasWidget('non-existent-widget'));
+    }
+
+    public function testGetWidget()
+    {
+        $app = Mockery::mock(Application::class);
+        $app->shouldReceive('tagged')->with('librenms.widget')->andReturn([]);
+
+        $registry = new WidgetRegistry($app);
+
+        $widget = $registry->getWidget('alerts');
+        $this->assertNotNull($widget);
+        $this->assertEquals('alerts', $widget['name']);
+
+        $nonExistent = $registry->getWidget('non-existent-widget');
+        $this->assertNull($nonExistent);
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+}


### PR DESCRIPTION
This PR makes it possible for a V2 plugin to register as widgets that can be added dashboards. The implementation uses a service based container where a widget hook extends a `DashboardWidgetHook` and tags the same class with `librenms.widget` in the service provider. The actual widget controller code is implemented in a new class that extends `WidgetController`.

I've added docs and unit tests. Let me know if any refactoring is needed.

See also related PR for plugin repo: https://github.com/librenms/plugin-interfaces/pull/1

Example widget plugin is created here: https://github.com/dot-mike/nmswidgetalertrules/tree/widget-registry-pattern

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
