### PR TITLE
Don't report errors when @ symbol is used

### DIFF
--- a/app/Exceptions/ErrorReporting.php
+++ b/app/Exceptions/ErrorReporting.php
@@ -168,10 +168,12 @@ class ErrorReporting
                     [$file, $line] = self::findFirstNonVendorFrame();
                 }
 
-                error_log("\e[31mPHP Error($severity)\e[0m: $message in $file:$line");
+                if ((error_reporting() & $severity) !== 0) { // this check primarily allows @ to suppress errors
+                    error_log("\e[31mPHP Error($severity)\e[0m: $message in $file:$line");
+                }
 
                 // For notices and warnings, prevent conversion to exceptions
-                if (in_array($severity, [E_NOTICE, E_WARNING, E_USER_NOTICE, E_USER_WARNING, E_DEPRECATED])) {
+                if (($severity & (E_NOTICE | E_WARNING | E_USER_NOTICE | E_USER_WARNING | E_DEPRECATED)) !== 0) {
                     return true; // Prevent the standard error handler from running
                 }
 


### PR DESCRIPTION
Since we now have a sane error_reporting default value, we can actually ignore errors when @ is used and still report errors otherwise.


#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
