### PR TITLE
Cisco FTD 3105 detection update

### DIFF
--- a/resources/definitions/os_detection/ftd.yaml
+++ b/resources/definitions/os_detection/ftd.yaml
@@ -33,6 +33,7 @@ discovery:
             - .1.3.6.1.4.1.9.1.3055 # { ciscoProducts 3055 } -- Cisco Secure Firewall 3130 Security Appliance
             - .1.3.6.1.4.1.9.1.3056 # { ciscoProducts 3056 } -- Cisco Secure Firewall 3140 Security Appliance
             - .1.3.6.1.4.1.9.1.3057 # { ciscoProducts 3057 } -- Cisco Secure Firewall 3105 Security Appliance
+            - .1.3.6.1.4.1.9.1.3166 # { ciscoProducts 3166 } -- Cisco Secure Firewall 3105 Security Appliance - Cisco FTD 7.4.2.1 (Build 30)
             - .1.3.6.1.4.1.9.1.3305 # { ciscoProducts 3305 } -- Cisco Secure Firewall 1220 Threat Defense
 
 discovery_modules:


### PR DESCRIPTION
Adding support for FTD 3105 running Cisco FTD 7.4.2.1 (Build 30). Previously not detected - being "Generic Device".

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
