### PR TITLE
Add API endpoints for getting/setting Oxidized state for a device

### DIFF
--- a/doc/API/Devices.md
+++ b/doc/API/Devices.md
@@ -1420,6 +1420,70 @@ Output:
 ]
 ```
 
+### `get_oxidized_state`
+
+Check if a device has been excluded from Oxidized.
+
+Route: `/api/v0/oxidized/disabled/:hostname`
+
+  - hostname can be either the device hostname or id
+
+Examples:
+
+```curl
+curl -H 'X-Auth-Token: YOURAPITOKENHERE' https://librenms.org/api/v0/oxidized/disabled/localhost
+```
+
+Output:
+
+```json
+{
+  "status": "ok",
+  "oxidized_disabled": false
+}
+```
+
+### `set_oxidized_state`
+
+Enable or disable Oxidized for a device.
+
+Route: `/api/v0/oxidized/disabled/:hostname`
+
+  - hostname can be either the device hostname or id
+
+Input (JSON):
+
+  - oxidized_disabled: Should Oxidized be disabled for this device or not?
+
+Examples:
+
+```curl
+curl -X PUT -d '{"oxidized_disabled": true}' -H 'X-Auth-Token: YOURAPITOKENHERE' https://librenms.org/api/v0/oxidized/state/localhost
+```
+
+Output:
+
+```json
+{
+  "status": "ok",
+  "message": "Device localhost has been excluded from Oxidized"
+}
+```
+
+```curl
+curl -X PUT -d '{"oxidized_disabled": false}' -H 'X-Auth-Token: YOURAPITOKENHERE' https://librenms.org/api/v0/oxidized/state/localhost
+```
+
+Output:
+
+```json
+{
+  "status": "ok",
+  "message": "Device localhost is no longer excluded from Oxidized"
+}
+```
+
+
 ### `update_device_field`
 
 Update devices field in the database.

--- a/routes/api.php
+++ b/routes/api.php
@@ -87,6 +87,8 @@ Route::prefix('v0')->group(function () {
         Route::post('services/{hostname}', [App\Api\Controllers\LegacyApiController::class, 'add_service_for_host'])->name('add_service_for_host');
         Route::get('oxidized/config/search/{searchstring}', [App\Api\Controllers\LegacyApiController::class, 'search_oxidized'])->name('search_oxidized');
         Route::get('oxidized/config/{device_name}', [App\Api\Controllers\LegacyApiController::class, 'get_oxidized_config'])->name('get_oxidized_config');
+        Route::get('oxidized/disabled/{hostname}', 'LegacyApiController@get_oxidized_state')->name('get_oxidized_state');
+        Route::put('oxidized/disabled/{hostname}', 'LegacyApiController@set_oxidized_state')->name('set_oxidized_state');
         Route::post('devicegroups', [App\Api\Controllers\LegacyApiController::class, 'add_device_group'])->name('add_device_group');
         Route::patch('devices/{hostname}/port/{portid}', [App\Api\Controllers\LegacyApiController::class, 'update_device_port_notes'])->name('update_device_port_notes');
         Route::post('port_groups', [App\Api\Controllers\LegacyApiController::class, 'add_port_group'])->name('add_port_group');


### PR DESCRIPTION
Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

This adds API endpoints for getting and setting the Oxidized state for a device. (`GET /api/v0/oxidized/disabled/:hostname`, `PUT /api/v0/oxidized/disabled/:hostname`)

This is functionally equivalent to setting the "Exclude from Oxidized?" toggle in Device Settings -> Misc, and is also semantically equivalent (checks if Oxidized is *disabled*, not if it is *enabled*). 

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] ~~If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.~~
  - n/a
- [ ] ~~If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data]~~(https://docs.librenms.org/Developing/os/Test-Units/).
  - n/a

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.

