### PR TITLE
Fix mysql auth null pointer exception on password

### DIFF
--- a/LibreNMS/Authentication/MysqlAuthorizer.php
+++ b/LibreNMS/Authentication/MysqlAuthorizer.php
@@ -17,7 +17,12 @@ class MysqlAuthorizer extends AuthorizerBase
         $username = $credentials['username'] ?? null;
         $password = $credentials['password'] ?? null;
 
-        $user_data = User::whereNotNull('password')->firstWhere(['username' => $username]);
+        $user_data = User::thisAuth()->whereNotNull('password')->firstWhere(['username' => $username]);
+
+        if (! $user_data) {
+            throw new AuthenticationException();
+        }
+
         $hash = $user_data->password;
         $enabled = $user_data->enabled;
 


### PR DESCRIPTION
If the username specified is unknown (not found), the app throws an errror exception. This ensures this not happen, instead redirect back to hope with the default error `Invalid credentials`.

$password will be empty if user is not found causing an ErrorException in Laravel. This can be seen with debug enabled.

![image](https://github.com/user-attachments/assets/79220154-3da5-4c89-817c-9e8221d8d9ba)

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
