### PR TITLE
Fix the device alert log tab to correctly filter the alerts

### DIFF
--- a/includes/html/common/alert-log.inc.php
+++ b/includes/html/common/alert-log.inc.php
@@ -43,7 +43,7 @@ if (Auth::user()->hasGlobalAdmin()) {
     $admin_verbose_details = '<th data-column-id="verbose_details" data-sortable="false">Details</th>';
 }
 
-$device_id = (int) ($vars['device_id'] ?? 0);
+$device_id = (int) ($vars['device'] ?? 0);
 
 $common_output[] = '<div class="panel panel-default panel-condensed">
                 <div class="panel-heading">


### PR DESCRIPTION
Following the most recent update we noticed that the device alert history tab was returning data for all devices.  This PR fixes the issue.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
