### PR TITLE
SimpleTemplate allow yaml use

### DIFF
--- a/LibreNMS/Device/YamlDiscovery.php
+++ b/LibreNMS/Device/YamlDiscovery.php
@@ -198,6 +198,13 @@ class YamlDiscovery
             foreach (explode('.', $index) as $pos => $subindex) {
                 $variables['subindex' . $pos] = $subindex;
             }
+
+            // try simple replacement first
+            if (isset($def['oid']) && isset($pre_cache[$def['oid']][$index]) && is_array($pre_cache[$def['oid']][$index])) {
+                $variables = array_merge($variables, $pre_cache[$def['oid']][$index]);
+            }
+
+//            if($pre_cache) dd($pre_cache, $def);
             $value = (string) (new SimpleTemplate($def[$name] ?? '', $variables))->keepEmptyTemplates();
 
             // search discovery data for values

--- a/app/View/SimpleTemplate.php
+++ b/app/View/SimpleTemplate.php
@@ -156,6 +156,13 @@ class SimpleTemplate
      */
     private function parseArgumentValue(string $value): mixed
     {
+        $value = trim($value);
+
+        // Handle single-quoted strings by removing quotes directly since json decode doesn't work there
+        if (strlen($value) >= 2 && $value[0] === "'" && $value[strlen($value) - 1] === "'") {
+            return substr($value, 1, -1);
+        }
+
         $decoded = json_decode($value);
         if (json_last_error() === JSON_ERROR_NONE) {
             return $decoded;

--- a/tests/Unit/View/SimpleTemplateTest.php
+++ b/tests/Unit/View/SimpleTemplateTest.php
@@ -117,6 +117,24 @@ class SimpleTemplateTest extends TestCase
         $this->assertEquals('hello universe', (string) $template);
     }
 
+    public function testReplaceFilterWithSingleQuotes()
+    {
+        $template = new SimpleTemplate("{{ value|replace('\"anon\" ', '') }}", ['value' => 'john "anon" doe']);
+        $this->assertEquals('john doe', (string) $template);
+    }
+
+    public function testReplaceFilterReplacementWithSingleQuotes()
+    {
+        $template = new SimpleTemplate("{{ value|replace(\"ryan's\", 'hello') }}", ['value' => "ryan's world"]);
+        $this->assertEquals('hello world', (string) $template);
+    }
+
+    public function testReplaceFilterWithNoQuotes()
+    {
+        $template = new SimpleTemplate('{{ value|replace(world, universe) }}', ['value' => 'hello world']);
+        $this->assertEquals('hello universe', (string) $template);
+    }
+
     public function testSliceFilter()
     {
         $template = new SimpleTemplate('{{ value|slice(0, 5) }}', ['value' => 'Hello World']);


### PR DESCRIPTION
Yaml did not include snmp data at the stage when the filters were applied previously.
Add the most common table data shape so it works in most situations. We can evaluate options then.
Fix an issue with single quotes.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
