### PR TITLE
Fix printer supplies icon

### DIFF
--- a/app/Http/Controllers/SensorController.php
+++ b/app/Http/Controllers/SensorController.php
@@ -101,7 +101,7 @@ class SensorController
             'printer-supply' => [
                 'text' => __('sensors.printer-supply.long'),
                 'link' => route('sensor.index', $request->all() + ['metric' => 'printer-supply']),
-                'icon' => 'fa-printer',
+                'icon' => 'fa-print',
             ],
         ];
 


### PR DESCRIPTION
Fixes "Printer Supplies" fa-icon selection on Health page

Old:
![2025-07-01_10-01-10](https://github.com/user-attachments/assets/52780673-4742-45df-9b53-d012504ce82b)

New:
![2025-07-01_10-01-35](https://github.com/user-attachments/assets/bb8b60a2-4687-436d-b03e-08342375f0e3)

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
