### PR TITLE
Restore header menu alerts color

### DIFF
--- a/resources/views/layouts/menu.blade.php
+++ b/resources/views/layouts/menu.blade.php
@@ -534,7 +534,7 @@
 {{-- Alerts --}}
                 <li class="dropdown">
                     <a href="#" class="dropdown-toggle" data-hover="dropdown" data-toggle="dropdown"><i
-                            class="fa fa-exclamation-circle fa-col-{{ $alert_menu_class }} fa-fw fa-lg"
+                            class="fa fa-exclamation-circle text-{{ $alert_menu_class }} fa-fw fa-lg"
                             aria-hidden="true"></i> <span class="tw:md:hidden tw:2xl:inline-block">{{ __('Alerts') }}</span></a>
                     <ul class="dropdown-menu">
                         <li><a href="{{ url('alerts') }}"><i class="fa fa-bell fa-fw fa-lg"


### PR DESCRIPTION
Restore header menu alerts color to orange or red when warning or critical alerts are active.

Before:
![image](https://github.com/user-attachments/assets/753e6a9b-cdb4-4ac9-ace5-f79294d6e24d)

After:
![image](https://github.com/user-attachments/assets/a3496a83-5c63-4900-8d92-8c732da26970)
![image](https://github.com/user-attachments/assets/6a529f0c-f260-48f2-8e21-c08458a2bd1f)



DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
