### PR TITLE
Routes - Restore order of discovery from before #17537

### DIFF
--- a/LibreNMS/Modules/Routes.php
+++ b/LibreNMS/Modules/Routes.php
@@ -90,12 +90,11 @@ class Routes implements Module
 
         if ($routesFromOs->isEmpty()) {
             try {
-                // fetch VPN routes first so we get VPN routes even if we hit max routes
-                $routesFromDiscovery = $routesFromDiscovery->merge($this->discoverVpnVrfRoutes($os->getDevice(), $max_routes));
                 $routesFromDiscovery = $routesFromDiscovery->merge($this->discoverInetCidrRoutes($os->getDevice(), $max_routes));
                 $routesFromDiscovery = $routesFromDiscovery->merge($this->discoverIpCidrRoutes($os->getDevice(), $max_routes));
                 $routesFromDiscovery = $routesFromDiscovery->merge($this->discoverIpv6MibRoutes($os->getDevice(), $max_routes));
                 $routesFromDiscovery = $routesFromDiscovery->merge($this->discoverRfcRoutes($os->getDevice()));
+                $routesFromDiscovery = $routesFromDiscovery->merge($this->discoverVpnVrfRoutes($os->getDevice(), $max_routes)); // max_routes useless here
             } catch (TooManyRoutes $e) {
                 Log::error("More than $max_routes, skipping routes. " . $e->getMessage());
             }


### PR DESCRIPTION
from before [route] Route module Rewrite #17537

It is not safe to start with VpnVrf because the snmpwalk will be done completely before any count (and exception) can be raised. 
You may kill the router, or kill the PHP process (RAM) before you reach the counting code. 

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
