### PR TITLE
Version display change

### DIFF
--- a/LibreNMS/Util/Version.php
+++ b/LibreNMS/Util/Version.php
@@ -65,7 +65,21 @@ class Version
 
     public function name(): string
     {
-        return $this->git->tag() ?: self::VERSION;
+        $regex = '/^(?<year>\d+)\.(?<month>\d+)\.(?<minor>\d+)-(?<commits>\d+)-g(?<sha>[0-9a-f]{7,})$/';
+        if (preg_match($regex, $this->git->tag(), $matches)) {
+
+            // guess the next version
+            $year = (int) $matches['year'];
+            $month = (int) $matches['month'] + 1;
+            if ($month > 12) {
+                $year++;
+                $month = 1;
+            }
+
+            return sprintf('%d.%d.%d-dev.%s+%s', $year, $month, $matches['minor'], $matches['commits'], $matches['sha']);
+        }
+
+        return self::VERSION;
     }
 
     public function databaseServer(): string


### PR DESCRIPTION
Monthly release will remain 25.6.0 etc.
If you are between monthly releases the version will now be displayed as:

<next release>-dev.<commits since last release>+<git commit sha>

An example of the current version will be 25.7.0-dev.141+f30d292aa3 Once the monthly release is released, it will be 25.7.0 then the first commit after will be 25.8.0-dev.1+<sha>


#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
