### PR TITLE
Fix typo in Devices.md

### DIFF
--- a/doc/API/Devices.md
+++ b/doc/API/Devices.md
@@ -1670,7 +1670,7 @@ Output:
 
 ### `list_parents_of_host`
 
-This is not a seperate API call.  Instead, you obtain the list of parents
+This is not a separate API call.  Instead, you obtain the list of parents
 from `list_devices`.  See that entry point for more detailed information.
 
 Example:


### PR DESCRIPTION
Correct the typo "seperate" to "separate" in doc/API/Devices.md