### PR TITLE
[zebra] Revive discovery_modules configuration missing in merge process

### DIFF
--- a/resources/definitions/os_detection/zebra.yaml
+++ b/resources/definitions/os_detection/zebra.yaml
@@ -10,3 +10,5 @@ discovery:
         sysObjectID:
             - .1.3.6.1.4.1.683.
             - .1.3.6.1.4.1.10642.
+discovery_modules:
+    arp-table: false    # This modules output errors for zebra


### PR DESCRIPTION
Please give a short description what your pull request is for

Revive discovery_modules configuration missing in merge process of #17106 ,
These lines correspond to the following improvement mentioned in that PR.

- Suppress discovery error by disabling arp-table module

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
