### PR TITLE
[ciscosb] Add trunk port detection for ports poller

### DIFF
--- a/includes/polling/ports/os/ciscosb.inc.php
+++ b/includes/polling/ports/os/ciscosb.inc.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+    LibreNMS port poller for CiscoSB
+*/
+$vlan_port_mode_state_array = SnmpQuery::walk('CISCOSB-vlan-MIB::vlanPortModeState')->pluck();
+Log::debug('vlan_port_mode_state_array: ' . print_r($vlan_port_mode_state_array,true));
+
+foreach ($vlan_port_mode_state_array as $index => $vlan_port_mode_state) {
+    /* vlanPortModeState means:
+      10 (General mode)
+      11 (Access mode)
+      12 (Trunk mode)
+      13 (Private-VLAN permiscouos mode)
+      14 (Private-VLAN host mode)
+      15 (Customer)
+          (according to "Cisco Business 350 Series Switches Administration Guide")
+    */
+    Log::debug(print_r($index,true) . '=>' . print_r($vlan_port_mode_state,true));
+    if ($vlan_port_mode_state == 12 && isset($port_stats[$index])) {
+        $port_stats[$index]['ifTrunk'] = 'dot1Q';
+    }
+}
+


### PR DESCRIPTION
Please give a short description what your pull request is for

If a port is "trunk", set "dot1Q" string to `ifTrunk` column of `ports` table.

This column seems not appear on WebUI currently, but I use it through direct DB access.
Would be helpful on network-wide FDB search (to get results only for non-trunk ports).

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
