### PR TITLE
Fix Undefined array key "afi" in bgp.inc.php

### DIFF
--- a/includes/html/pages/routing/bgp.inc.php
+++ b/includes/html/pages/routing/bgp.inc.php
@@ -325,7 +325,7 @@ if (! Auth::user()->hasGlobalRead()) {
             <td width=30><b>&#187;</b></td>
             <td width=150>' . $peeraddresslink . '<br />' . Url::deviceLink($peer_device, vars: ['tab' => 'routing', 'proto' => 'bgp']) . "</td>
             <td width=50><b>$peer_type</b></td>
-            <td width=50>" . $peer['afi'] ?? '' . '</td>
+            <td width=50>" . ($peer['afi'] ?? '') . '</td>
             <td><strong>AS' . $peer['bgpPeerRemoteAs'] . '</strong><br />' . $peer['astext'] . '</td>
             <td>' . $peer['bgpPeerDescr'] . "</td>
             <td><strong><span style='color: $admin_col;'>" . $peer['bgpPeerAdminStatus'] . "</span><br /><span style='color: $col;'>" . $peer['bgpPeerState'] . '</span></strong></td>


### PR DESCRIPTION
We need to make sure we wrap the ternary check in parentheses so it can do the evaluation rather than executing `$peer['afi']` first - leading to a php error

Fixes the following errors (and 502s) when going to the https://my.nms.net/routing/protocol=bgp/type=all/graph=NULL URL

```
2025/07/21 14:18:08 [error] 743#743: *8396600 FastCGI sent in stderr: "28; PHP message: PHP Error(2): Undefined array key "afi" in /opt/librenms/includes/html/pages/routing/bgp.inc.php:328; PHP message: PHP Error(2): Undefined array key "afi" in /opt/librenms/includes/html/pages/routing/bgp.inc.php:328; PHP message: PHP Error(2): Undefined array key "afi" in /opt/librenms/includes/html/pages/routing/bgp.inc.php:328; PHP message: PHP Error(2): Undefined array key "afi" in /opt/librenms/includes/html/pages/routing/bgp.inc.php:328; PHP message: PHP Error(2): Undefined array key "afi" in /opt/librenms/includes/html/pages/routing/bgp.inc.php:328; PHP message: PHP Error(2): Undefined array key "afi" in 
...
```

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [X] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
