### PR TITLE
Fix state sensor incorrect color

### DIFF
--- a/app/Models/StateTranslation.php
+++ b/app/Models/StateTranslation.php
@@ -45,7 +45,7 @@ class StateTranslation extends Model implements Keyable
 
     public function severity(): Severity
     {
-        return match ((int) $this->state_generic_value) {
+        return match ((int) $this->getAttribute('state_generic_value')) {
             0 => Severity::Ok,
             1 => Severity::Warning,
             2 => Severity::Error,

--- a/app/Models/StateTranslation.php
+++ b/app/Models/StateTranslation.php
@@ -45,7 +45,12 @@ class StateTranslation extends Model implements Keyable
 
     public function severity(): Severity
     {
-        return Severity::tryFrom((int) $this->state_generic_value) ?? Severity::Unknown;
+        return match ((int) $this->state_generic_value) {
+            0 => Severity::Ok,
+            1 => Severity::Warning,
+            2 => Severity::Error,
+            default => Severity::Unknown,
+        };
     }
 
     /**


### PR DESCRIPTION
The generic backing values don't match the Severity values.
https://community.librenms.org/t/loss-of-generic-color-of-sensor-states/28229

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
