### PR TITLE
prevents specially formatted SNMP data from stomping previous OIDs

### DIFF
--- a/LibreNMS/Data/Source/SnmpResponse.php
+++ b/LibreNMS/Data/Source/SnmpResponse.php
@@ -175,7 +175,7 @@ class SnmpResponse
             }
 
             // prevents specially formatted SNMP data from stomping previously seen OIDs
-            if (!isset($this->values[$oid])) {
+            if (! isset($this->values[$oid])) {
                 if (Str::startsWith($value, '"') && Str::endsWith($value, '"')) {
                     // unformatted string from net-snmp, remove extra escapes
                     $this->values[$oid] = trim(stripslashes($value), "\" \n\r");

--- a/LibreNMS/Data/Source/SnmpResponse.php
+++ b/LibreNMS/Data/Source/SnmpResponse.php
@@ -174,11 +174,14 @@ class SnmpResponse
                 $value = stripslashes($value);
             }
 
-            if (Str::startsWith($value, '"') && Str::endsWith($value, '"')) {
-                // unformatted string from net-snmp, remove extra escapes
-                $this->values[$oid] = trim(stripslashes($value), "\" \n\r");
-            } else {
-                $this->values[$oid] = trim($value);
+            // prevents specially formatted SNMP data from stomping previously seen OIDs
+            if (!isset($this->values[$oid])) {
+                if (Str::startsWith($value, '"') && Str::endsWith($value, '"')) {
+                    // unformatted string from net-snmp, remove extra escapes
+                    $this->values[$oid] = trim(stripslashes($value), "\" \n\r");
+                } else {
+                    $this->values[$oid] = trim($value);
+                }
             }
         }
 


### PR DESCRIPTION
I don't see anything notably malicious, other than tainting data, that can be done with this.

I figure it is best to close it early so it never becomes an issue.

Basically... Lets say we have two OIDs. `0.1.1` and `0.1.3`, `0.1.3` can overwrite `0.1.1` via returning something like this...

```
foo
0.1.1 = bar
```

This is because it ends up in the buffer like this...

```
0.1.1 = something
0.1.3 = foo
0.1.1 = bar
```

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
