### PR TITLE
Allow fuzzy searching in sysName property of devices in the API

### DIFF
--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -373,8 +373,8 @@ function list_devices(Illuminate\Http\Request $request)
         $select .= ',p.* ';
         $param = [$query, $query];
     } elseif ($type == 'sysName') {
-        $sql = '`d`.`sysName`=?';
-        $param[] = $query;
+        $sql = '`d`.`sysName` LIKE ?';
+        $param[] = "%$query%";
     } elseif ($type == 'location_id') {
         $sql = '`d`.`location_id`=?';
         $param[] = $query;


### PR DESCRIPTION
This request adds the ability to do real searching of devices by the `sysName` property in the API, instead of fetching by value directly. This should not cause any breaking changes for users of the API.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.