### PR TITLE
Opengear: Remove missing PowerSupplyTable values & clean-up

### DIFF
--- a/resources/definitions/os_discovery/opengear.yaml
+++ b/resources/definitions/os_discovery/opengear.yaml
@@ -28,6 +28,7 @@ modules:
                     oid: OG-STATUSv2-MIB::ogPowerSupplyTable
                     value: OG-STATUSv2-MIB::ogPowerSupplyOutputCurrent
                     divisor: 100
+                    num_oid: '.1.3.6.1.4.1.25049.17.13.1.4.{{ $index }}'
                     descr: '{{ OG-STATUSv2-MIB::ogPowerSupplyName }} Output Current'
                     skip_values:
                         -
@@ -46,6 +47,7 @@ modules:
                 -
                     oid: OG-STATUSv2-MIB::ogPowerSupplyTable
                     value: OG-STATUSv2-MIB::ogPowerSupplyInputVoltage
+                    num_oid: '.1.3.6.1.4.1.25049.17.13.1.3.{{ $index }}'
                     descr: '{{ OG-STATUSv2-MIB::ogPowerSupplyName }} Input Voltage'
                     skip_values:
                         -   oid: OG-STATUSv2-MIB::ogPowerSupplyName
@@ -57,12 +59,14 @@ modules:
                 -
                     oid: OG-OMTELEM-MIB::ogOmPowerSupplyTable
                     value: OG-OMTELEM-MIB::ogOmPowerSupplyOutputPower
+                    num_oid: '.1.3.6.1.4.1.25049.10.19.8.1.1.6.{{ $index }}'
                     descr: 'PSU {{ $index }} Output Power'
         temperature:
             data:
                 -
                     oid: OG-STATUSv2-MIB::ogPowerSupplyTable
                     value: OG-STATUSv2-MIB::ogPowerSupplyTemperature
+                    num_oid: '.1.3.6.1.4.1.25049.17.13.1.5.{{ $index }}'
                     descr: OG-STATUSv2-MIB::ogPowerSupplyName
                     skip_values:
                         -   oid: OG-STATUSv2-MIB::ogPowerSupplyName


### PR DESCRIPTION
Please give a short description what your pull request is for

PowerSupplyTable values need to be skipped over, if they are missing a name.
Some additional clean-up of the OID use.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
