### PR TITLE
Fix AD Auth group escaping

### DIFF
--- a/LibreNMS/Authentication/ActiveDirectoryAuthorizer.php
+++ b/LibreNMS/Authentication/ActiveDirectoryAuthorizer.php
@@ -66,7 +66,8 @@ class ActiveDirectoryAuthorizer extends AuthorizerBase
         $connection = $this->getConnection();
 
         // check if user is member of the given group or nested groups
-        $search_filter = "(&(objectClass=group)(cn=$groupname))";
+        $ldap_group = ldap_escape($groupname, '', LDAP_ESCAPE_FILTER);
+        $search_filter = "(&(objectClass=group)(cn=$ldap_group))";
 
         // get DN for auth_ad_group
         $search = ldap_search(


### PR DESCRIPTION
previously did not escape group names, so CNs with ( in them for example, would not work

This is a breaking change, because users may have added escapes to their configurations causing a double escape once this code is merged.


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
