### PR TITLE
fix typo in I/O wait title

### DIFF
--- a/resources/definitions/config_definitions.json
+++ b/resources/definitions/config_definitions.json
@@ -4132,7 +4132,7 @@
             "default": {
                 "section": "system",
                 "order": 0,
-                "descr": "I/0 Wait"
+                "descr": "I/O Wait"
             },
             "type": "graph"
         },


### PR DESCRIPTION
Typo fix for I/O wait title graph. It's a `0` and not an `O` currently.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.

<img width="133" height="76" alt="image" src="https://github.com/user-attachments/assets/ccf1c5a5-5b25-456d-9429-c4dc8551ccf8" />
