### PR TITLE
Add more flexibility to integer Macro names

### DIFF
--- a/LibreNMS/Alerting/QueryBuilderFilter.php
+++ b/LibreNMS/Alerting/QueryBuilderFilter.php
@@ -71,7 +71,7 @@ class QueryBuilderFilter implements \JsonSerializable
                 continue; // don't include the time based macros, they don't work like that
             }
 
-            if (Str::endsWith($key, '_perc') || Str::startsWith($key, 'packet_loss_')) {
+            if (Str::endsWith($key, '_perc') || Str::endsWith($key, '_delta') || Str::startsWith($key, 'packet_loss_')) {
                 $this->filter[$field] = [
                     'id' => $field,
                     'type' => 'integer',

--- a/doc/Alerting/Macros.md
+++ b/doc/Alerting/Macros.md
@@ -7,7 +7,7 @@ Macros can be defined through the `lnms` command. Using the `config.php` is disc
 Example for adding a a macro that returns the delta of a sensor:
 
 ```bash
-lnms config:set alert.macros.rule.sensor_delta_current 'ABS(%sensors.sensor_current - %sensors.sensor_prev)'
+lnms config:set alert.macros.rule.sensor_delta 'ABS(%sensors.sensor_current - %sensors.sensor_prev)'
 ```
 
 Example for adding macro through `config.php` that is a boolean test:
@@ -24,7 +24,7 @@ These rules can then be used in the alerting rules. Example:
 
 ## Writing Macros
 
-The naming of the macro determines the type of the macro. If the macro name ends with `_perc` it interpreted as integer allowing for a comparison of the value. Any other name is a boolean test that will appear as `yes` or `no` selection in the rule.
+The naming of the macro determines the type of the macro. If the macro name ends with `_perc` or '_delta' it interpreted as integer allowing for a comparison of the value. Any other name is a boolean test that will appear as `yes` or `no` selection in the rule.
 
 The macro can contain placeholders that are replaced with the actual values when the rule is evaluated. The placeholders are prefixed with `%` that represents the actual value of the sensor, port, device, etc. For example `%sensors.sensor_current` will be replaced with the actual value of the sensor. While the prefix `%` is optional, it is recommended to use it to avoid ambiguity.
 
@@ -336,7 +336,7 @@ Below are some examples of custom macros that can be be added.
 
 #### Sensor Delta Current (Decimal)
 
-Entity: `macros.sensor_delta_current`
+Entity: `macros.sensor_delta`
 
 Description: Returns the delta of a sensor.
 


### PR DESCRIPTION
Not all integer based macros are percentages.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
