### PR TITLE
Switch to using nanosecond precision

### DIFF
--- a/LibreNMS/Data/Store/InfluxDB.php
+++ b/LibreNMS/Data/Store/InfluxDB.php
@@ -119,10 +119,9 @@ class InfluxDB extends BaseDatastore
         }
 
         try {
-            // Add timestamp to points as current time in milliseconds
-            // This is important for InfluxDB to correctly order and store the data
-            // This is especially important for batch writes to ensure data is aggregated correctly
-            $timestamp = (int) floor(microtime(true) * 1000); // Convert timestamp to milliseconds
+            // Add timestamp to points as current time in nanoseconds
+            // This is important for batch writes to ensure data is ordered and aggregated correctly
+            $timestamp = (int) floor(microtime(true) * 1_000_000_000); // Convert timestamp to nanoseconds
 
             $this->batchPoints[] = new \InfluxDB\Point(
                 $measurement,
@@ -156,7 +155,7 @@ class InfluxDB extends BaseDatastore
             Log::debug('Flushing InfluxDB batch of ' . count($this->batchPoints) . ' points');
         }
         try {
-            $this->connection->writePoints($this->batchPoints, 'ms'); // Added timestamps are in milliseconds
+            $this->connection->writePoints($this->batchPoints, \InfluxDB\Database::PRECISION_NANOSECONDS); // Added timestamps are in nanoseconds
         } catch (\InfluxDB\Exception $e) {
             Log::error('InfluxDB batch write failed: ' . $e->getMessage());
         }

--- a/tests/Unit/Data/InfluxDBStoreTest.php
+++ b/tests/Unit/Data/InfluxDBStoreTest.php
@@ -70,7 +70,7 @@ class InfluxDBStoreTest extends TestCase
                     && $point->getMeasurement() === $measurement
                     && $point->getTags() == (['hostname' => $device->hostname] + $tags)
                     && $point->getFields() == $fields;
-            }), 'ms')
+            }), 'n') // Expects nanosecond precision
             ->once();
         $influx->write($measurement, $fields, $tags, $meta);
     }


### PR DESCRIPTION
We should use nanoseconds instead of milliseconds for InfluxDB write precision. This helps ensure compatibility with external services that use / require InfluxDB's default time precision; such as the `prometheus/influxdb_exporter`.

```
$timestamp = microtime(true); // Seconds with microsecond (decimal) precision
$timestamp = $timestamp * 1000; // Milliseconds with microsecond (decimal) precision
$timestamp = $timestamp * 1000; // Microsecond precision
$timestamp = $timestamp * 1000; // Nanosecond precision
```

Related to discussions from: https://github.com/librenms/librenms/pull/18074

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
