### PR TITLE
Fix SnmpResponse table parsing previous leaf

### DIFF
--- a/LibreNMS/Data/Source/SnmpResponse.php
+++ b/LibreNMS/Data/Source/SnmpResponse.php
@@ -242,8 +242,8 @@ class SnmpResponse
 
     public function table(int $group = 0, array &$array = []): array
     {
-        foreach ($this->values() as $key => $value) {
-            $parts = $this->getOidParts($key);
+        foreach ($this->values() as $full_oid => $value) {
+            $parts = $this->getOidParts($full_oid);
 
             // move the oid name to the correct depth
             array_splice($parts, $group, 0, array_shift($parts));
@@ -252,6 +252,12 @@ class SnmpResponse
             $tmp = &$array;
             foreach ($parts as $part) {
                 $key = trim($part, '"');
+
+                // handle leafs that are now branches. eg .1.4 = 42 && .1.4.1 = 13
+                if (isset($tmp[$key]) && ! is_array($tmp[$key])) {
+                    $tmp[$key] = ['' => $tmp[$key]];
+                }
+
                 $tmp = &$tmp[$key];
             }
             $tmp = $value; // assign the value as the leaf


### PR DESCRIPTION
If we are parsing a walk and we go back to an oid we already processed all the way to a leaf, but add more children, we need to convert it from a string to an array, so we use an empty key. This will not happen if walking a single table, but could easily happen if walking multiple tables without MIBs.  Don't do this and use things as intended :)  for mixed oids, use ->values()

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
