### PR TITLE
InfluxDBv2: Add a new tag with sysname

### DIFF
--- a/LibreNMS/Data/Store/InfluxDBv2.php
+++ b/LibreNMS/Data/Store/InfluxDBv2.php
@@ -132,6 +132,11 @@ class InfluxDBv2 extends BaseDatastore
         $stat = Measurement::start('write');
         $tmp_fields = [];
         $tmp_tags['hostname'] = $device->hostname;
+
+        if (LibrenmsConfig::get('influxdbv2.attach_sysname', false)) {
+            $tmp_tags['sysName'] = $device->sysName;
+        }
+
         foreach ($tags as $k => $v) {
             if (empty($v)) {
                 $v = '_blank_';

--- a/doc/Extensions/metrics/InfluxDBv2.md
+++ b/doc/Extensions/metrics/InfluxDBv2.md
@@ -42,6 +42,7 @@ continue to function as normal.
     lnms config:set influxdbv2.debug false
     lnms config:set influxdbv2.log_file '/opt/librenms/logs/influxdbv2.log'
     lnms config:set influxdbv2.groups-exclude ["group_name_1","group_name_2"]
+    lnms config:set influxdbv2.attach_sysname false
     lnms config:set influxdbv2.timeout 5
     lnms config:set influxdbv2.verify false
     lnms config:set influxdbv2.batch_size 1000

--- a/resources/definitions/config_definitions.json
+++ b/resources/definitions/config_definitions.json
@@ -4738,6 +4738,13 @@
             "default": [
             ]
         },
+        "influxdbv2.attach_sysname": {
+            "default": false,
+            "type": "boolean",
+            "group": "poller",
+            "section": "influxdbv2",
+            "order": 11
+        },
         "kafka.enable": {
             "default": false,
             "type": "boolean",


### PR DESCRIPTION
The InfluxDBv2 datastore currently relies on the device's hostname field to identify measurements. However, when devices are added using their IP address, this can lead to less readable or less convenient metric identifiers.

This PR introduces the option to include the device's sysName in the InfluxDB measurements. This can improve clarity and usability, especially in environments where devices are primarily referenced by IP.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
