### PR TITLE
Updates to Alerta transport

### DIFF
--- a/LibreNMS/Alert/Transport/Alerta.php
+++ b/LibreNMS/Alert/Transport/Alerta.php
@@ -21,7 +21,6 @@ use LibreNMS\Alert\Transport;
 use LibreNMS\Enum\AlertState;
 use LibreNMS\Exceptions\AlertTransportDeliveryException;
 use LibreNMS\Util\Http;
-use LibreNMS\Util\Url;
 
 class Alerta extends Transport
 {
@@ -30,25 +29,21 @@ class Alerta extends Transport
         $severity = ($alert_data['state'] == AlertState::RECOVERED ? $this->config['recoverstate'] : $this->config['alertstate']);
         $data = [
             'resource' => $alert_data['display'],
-            'event' => $alert_data['name'],
+            'event' => $alert_data['title'],
             'environment' => $this->config['environment'],
             'severity' => $severity,
-            'service' => [$alert_data['title']],
+            'service' => [$alert_data['type']],
             'group' => $alert_data['name'],
             'value' => $alert_data['state'],
-            'text' => strip_tags($alert_data['msg']),
-            'tags' => [$alert_data['title']],
+            'text' => $alert_data['msg'],
             'attributes' => [
                 'sysName' => $alert_data['sysName'],
                 'sysDescr' => $alert_data['sysDescr'],
                 'os' => $alert_data['os'],
-                'type' => $alert_data['type'],
                 'ip' => $alert_data['ip'],
                 'uptime' => $alert_data['uptime_long'],
-                'moreInfo' => '<a href=' . Url::deviceUrl($alert_data['device_id']) . '>' . $alert_data['display'] . '</a>',
             ],
-            'origin' => $alert_data['rule'],
-            'type' => $alert_data['title'],
+            'origin' => $this->config['origin'],
         ];
 
         $res = Http::client()
@@ -75,16 +70,22 @@ class Alerta extends Transport
                     'type' => 'text',
                 ],
                 [
-                    'title' => 'Environment',
-                    'name' => 'environment',
-                    'descr' => 'An allowed environment from your alertad.conf.',
-                    'type' => 'text',
-                ],
-                [
                     'title' => 'Api Key',
                     'name' => 'apikey',
                     'descr' => 'Your alerta api key with minimally write:alert permissions.',
                     'type' => 'password',
+                ],
+                [
+                    'title' => 'Origin',
+                    'name' => 'origin',
+                    'descr' => 'Name of this monitoring source e.g. LibreNMS.',
+                    'type' => 'text',
+                ],
+                [
+                    'title' => 'Environment',
+                    'name' => 'environment',
+                    'descr' => 'An allowed environment from your alertad.conf.',
+                    'type' => 'text',
                 ],
                 [
                     'title' => 'Alert State',

--- a/doc/Alerting/Transports/Alerta.md
+++ b/doc/Alerting/Transports/Alerta.md
@@ -10,7 +10,8 @@ alerts from many other monitoring tools on a single screen.
 | Config | Example |
 | ------ | ------- |
 | API Endpoint   | http://alerta.example.com/api/alert |
-| Environment | Production |
 | Apy key | api key with write permission |
+| Origin | LibreNMS |
+| Environment | Production |
 | Alert state | critical |
 | Recover state | cleared |


### PR DESCRIPTION
Please give a short description what your pull request is for

Add 'Origin' field to the Alerta Transport to be able to filter for LibreNMS alerts in Alerta.

Also tidied up the alert data to make the alert better to read:
- Remove duplicate 'title' values in the data to clean up
- Set 'service' (affected service) to 'type' (network)
- Remove 'moreInfo' value that doesn't work

<img width="898" height="571" alt="Screenshot 2025-09-03 at 11 12 50" src="https://github.com/user-attachments/assets/59a6a3d9-f426-40e5-b1ae-5636a6c11ef9" />

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
