### PR TITLE
Added api route for location maintenance along with the function and documentation

### DIFF
--- a/doc/API/Locations.md
+++ b/doc/API/Locations.md
@@ -139,3 +139,70 @@ Output:
     "count": 1
 }
 ```
+
+### `maintenance_location`
+
+Set a location into maintenance mode.
+
+Route: `/api/v0/locations/:location/maintenance`
+
+- location: name or id of the location to set
+
+Input (JSON):
+
+- `title`: *optional* -  Some title for the Maintenance  
+  Will be replaced with location name if omitted
+- `notes`: *optional* -  Some description for the Maintenance  
+  Will also be added to location notes if user prefs "Add schedule notes to locations notes" is set
+- `start`: *optional* - start time of Maintenance in full format `Y-m-d H:i:00`  
+  eg: 2022-08-01 22:45:00  
+  Current system time `now()` will be used if omitted
+- `duration`: *required* - Duration of Maintenance in format `H:i` / `Hrs:Mins`  
+  eg: 02:00
+
+Example with start time:
+
+```curl
+curl -H 'X-Auth-Token: YOURAPITOKENHERE' \
+  -X POST https://librenms.org/api/v0/locations/Mcewen/maintenance/ \
+  --data-raw '
+{
+  "title":"Location Mcewen Maintenance",
+  "notes":"A 2 hour Maintenance triggered via API with start time",
+  "start":"2022-08-01 08:00:00",
+  "duration":"2:00"
+}
+'
+```
+
+Output:
+
+```json
+{
+    "status": "ok",
+    "message": "Location Mcewen (37101) will begin maintenance mode at 2022-08-01 22:45:00 for 2:00h"
+}
+```
+
+Example with no start time and using location id:
+
+```curl
+curl -H 'X-Auth-Token: YOURAPITOKENHERE' \
+  -X POST https://librenms.org/api/v0/locations/37101/maintenance/ \
+  --data-raw '
+{
+  "title":"Location Mcewen Maintenance",
+  "notes":"A 2 hour Maintenance triggered via API with no start time",
+  "duration":"2:00"
+}
+'
+```
+
+Output:
+
+```json
+{
+    "status": "ok",
+    "message": "Location Mcewen (37101) moved into maintenance mode for 2:00h"
+}
+```

--- a/doc/API/Locations.md
+++ b/doc/API/Locations.md
@@ -150,14 +150,14 @@ Route: `/api/v0/locations/:location/maintenance`
 
 Input (JSON):
 
-- `title`: *optional* -  Some title for the Maintenance  
+- `title`: *optional* -  Some title for the Maintenance
   Will be replaced with location name if omitted
-- `notes`: *optional* -  Some description for the Maintenance  
+- `notes`: *optional* -  Some description for the Maintenance
   Will also be added to location notes if user prefs "Add schedule notes to locations notes" is set
-- `start`: *optional* - start time of Maintenance in full format `Y-m-d H:i:00`  
-  eg: 2022-08-01 22:45:00  
+- `start`: *optional* - start time of Maintenance in full format `Y-m-d H:i:00`
+  eg: 2022-08-01 22:45:00
   Current system time `now()` will be used if omitted
-- `duration`: *required* - Duration of Maintenance in format `H:i` / `Hrs:Mins`  
+- `duration`: *required* - Duration of Maintenance in format `H:i` / `Hrs:Mins`
   eg: 02:00
 
 Example with start time:

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -3389,6 +3389,62 @@ function del_location(Illuminate\Http\Request $request)
     return api_error(500, "Failed to delete the location $location");
 }
 
+function maintenance_location(Illuminate\Http\Request $request)
+{
+    $data = $request->json()->all();
+
+    if (empty($data)) {
+        return api_error(400, 'No information has been provided to set this location into maintenance');
+    }
+
+    $loc = $request->route('location');
+    if (! $loc) {
+        return api_error(400, 'No location was provided');
+    }
+
+    $location = ctype_digit($loc) ? Location::find($loc) : Location::where('location', $loc)->first();
+    if (empty($location)) {
+        return api_error(404, "Location $loc does not exist");
+    }
+
+    if (empty($data['duration'])) {
+        return api_error(400, 'Duration not provided');
+    }
+
+    $notes = $data['notes'] ?? '';
+    $title = $data['title'] ?? $location->location;
+    $behavior = MaintenanceBehavior::tryFrom((int) ($data['behavior'] ?? -1))
+        ?? LibrenmsConfig::get('alert.scheduled_maintenance_default_behavior');
+
+    $alert_schedule = new \App\Models\AlertSchedule([
+        'title' => $title,
+        'notes' => $notes,
+        'behavior' => $behavior,
+        'recurring' => 0,
+    ]);
+
+    $start = $data['start'] ?? \Carbon\Carbon::now()->format('Y-m-d H:i:00');
+    $alert_schedule->start = $start;
+
+    $duration = $data['duration'];
+
+    if (Str::contains($duration, ':')) {
+        [$duration_hour, $duration_min] = explode(':', $duration);
+        $alert_schedule->end = \Carbon\Carbon::createFromFormat('Y-m-d H:i:s', $start)
+            ->addHours((float) $duration_hour)->addMinutes((float) $duration_min)
+            ->format('Y-m-d H:i:00');
+    }
+
+    $alert_schedule->save();
+    $alert_schedule->locations()->attach($location);
+
+    if (isset($data['start'])) {
+        return api_success_noresult(201, "Location {$location->location} ({$location->id}) will begin maintenance mode at $start" . ($duration ? " for {$duration}h" : ''));
+    } else {
+        return api_success_noresult(201, "Location {$location->location} ({$location->id}) moved into maintenance mode" . ($duration ? " for {$duration}h" : ''));
+    }
+}
+
 function get_poller_group(Illuminate\Http\Request $request)
 {
     $poller_group = $request->route('poller_group_id_or_name');

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -3402,13 +3402,13 @@ function maintenance_location(Illuminate\Http\Request $request)
         return api_error(400, 'No location was provided');
     }
 
+    if (empty($data['duration'])) {
+        return api_error(400, 'Duration not provided');
+    }
+
     $location = ctype_digit($loc) ? Location::find($loc) : Location::where('location', $loc)->first();
     if (empty($location)) {
         return api_error(404, "Location $loc does not exist");
-    }
-
-    if (empty($data['duration'])) {
-        return api_error(400, 'Duration not provided');
     }
 
     $notes = $data['notes'] ?? '';

--- a/routes/api.php
+++ b/routes/api.php
@@ -98,6 +98,7 @@ Route::prefix('v0')->group(function () {
         Route::get('location/{location_id_or_name}', [App\Api\Controllers\LegacyApiController::class, 'get_location'])->name('get_location');
         Route::patch('locations/{location_id_or_name}', [App\Api\Controllers\LegacyApiController::class, 'edit_location'])->name('edit_location');
         Route::delete('locations/{location}', [App\Api\Controllers\LegacyApiController::class, 'del_location'])->name('del_location');
+        Route::post('locations/{location}/maintenance', [App\Api\Controllers\LegacyApiController::class, 'maintenance_location'])->name('maintenance_location');
         Route::delete('services/{id}', [App\Api\Controllers\LegacyApiController::class, 'del_service_from_host'])->name('del_service_from_host');
         Route::patch('services/{id}', [App\Api\Controllers\LegacyApiController::class, 'edit_service_for_host'])->name('edit_service_for_host');
         Route::post('bgp/{id}', [App\Api\Controllers\LegacyApiController::class, 'edit_bgp_descr'])->name('edit_bgp_descr');


### PR DESCRIPTION
Adds an API route for setting a location in maintenance mode.  Device and device groups were already supported but not locations.  This could already be configured in the UI, but the associated API route was missing.  

This is my first pull request for this project.  Please correct me if I did something out of sequence and should start elsewhere with this request.  Thanks!

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply 18227`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
