### PR TITLE
Fix alert rule overrides being reset during daily

### DIFF
--- a/daily.php
+++ b/daily.php
@@ -305,7 +305,7 @@ if ($options['f'] === 'refresh_alert_rules') {
         $rules = dbFetchRows('SELECT `id`, `builder`, `extra` FROM `alert_rules`');
         foreach ($rules as $rule) {
             $rule_options = json_decode($rule['extra'], true);
-            if ($rule_options['options']['override_query'] !== 'on') {
+            if ($rule_options['options']['override_query'] !== 'on' && $rule_options['options']['override_query'] !== true) {
                 $data['query'] = QueryBuilderParser::fromJson($rule['builder'])->toSql();
                 if (! empty($data['query'])) {
                     dbUpdate($data, 'alert_rules', 'id=?', [$rule['id']]);

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -1500,7 +1500,7 @@ function add_edit_rule(Illuminate\Http\Request $request)
     ];
     $extra_json = json_encode($extra);
 
-    if ($override_query === 'on') {
+    if ($override_query === 'on' || $override_query === true) {
         $query = $adv_query;
     } else {
         $query = QueryBuilderParser::fromJson($builder)->toSql();

--- a/includes/html/modal/alert_rule_list.inc.php
+++ b/includes/html/modal/alert_rule_list.inc.php
@@ -52,7 +52,7 @@ if (! Auth::user()->hasGlobalAdmin()) {
                         <?php
                         $alert_rules = dbFetchRows('SELECT * FROM alert_rules order by name');
                         foreach ($alert_rules as $rule) {
-                            if (isset($rule_extra['options']['override_query']) && $rule_extra['options']['override_query'] === 'on') {
+                            if (isset($rule_extra['options']['override_query']) && ($rule_extra['options']['override_query'] === 'on' || $rule_extra['options']['override_query'] === true)) {
                                 $rule_display = 'Custom SQL Query';
                             } else {
                                 $rule_display = QueryBuilderParser::fromJson($rule['builder'])->toSql(false);

--- a/includes/html/output/query.inc.php
+++ b/includes/html/output/query.inc.php
@@ -57,7 +57,7 @@ switch ($type) {
             }
 
             $extra = json_decode($rule['extra'], true);
-            if ($extra['options']['override_query'] === 'on') {
+            if ($extra['options']['override_query'] === 'on' || $extra['options']['override_query'] === true) {
                 $qb = $extra['options']['override_query'];
             } else {
                 $qb = QueryBuilderParser::fromJson($rule['builder'] ?? []);

--- a/includes/html/print-alert-rules.php
+++ b/includes/html/print-alert-rules.php
@@ -372,7 +372,7 @@ foreach ($rule_list as $rule) {
         echo '<strong><em>Inverted</em></strong> ';
     }
 
-    if (isset($rule_extra['options']['override_query']) && $rule_extra['options']['override_query'] === 'on') {
+    if (isset($rule_extra['options']['override_query']) && ($rule_extra['options']['override_query'] === 'on' || $rule_extra['options']['override_query'] === true)) {
         $rule_display = 'Custom SQL Query';
     } else {
         $rule_display = QueryBuilderParser::fromJson($rule['builder'])->toSql(false);


### PR DESCRIPTION
Alert override can be a boolean now
This was not an intentional change, but now we need to handle it.
Only applies to rules with override created/edited after recent change.

fixes #18201

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
