### PR TITLE
Revert "Fix php errors when loading invalid graph sensor"

### DIFF
--- a/includes/html/graphs/sensor/generic.inc.php
+++ b/includes/html/graphs/sensor/generic.inc.php
@@ -3,10 +3,6 @@
 use LibreNMS\Data\Store\Rrd;
 use LibreNMS\Util\Number;
 
-if (empty($sensor)) {
-    throw new RrdGraphException('Invalid sensor');
-}
-
 $sensor_descr_fixed = Rrd::fixedSafeDescr($sensor->sensor_descr, 25);
 $sensor_color = session('applied_site_style') == 'dark' ? '#f2f2f2' : '#272b30';
 $background_color = session('applied_site_style') == 'dark' ? '#272b30' : '#ffffff';


### PR DESCRIPTION
Reverts librenms/librenms#18076

Initially after analyzing all commits and an error in the log indicates this deployment.

[2025-09-15T09:51:05][CRITICAL] Exception: Error Class "RrdGraphException" not found @ /opt/librenms/includes/html/graphs/sensor/generic.inc.php:7
#0 /opt/librenms/LibreNMS/Util/Graph.php(162): require()
#1 /opt/librenms/LibreNMS/Util/Graph.php(85): LibreNMS\Util\Graph::get()
#2 /opt/librenms/LibreNMS/Util/Mail.php(156): LibreNMS\Util\Graph::getImage()
#3 /opt/librenms/LibreNMS/Util/Mail.php(101): LibreNMS\Util\Mail::embedGraphs()
#4 /opt/librenms/LibreNMS/Alert/Transport/Mail.php(57): LibreNMS\Util\Mail::send()
#5 /opt/librenms/LibreNMS/Alert/RunAlerts.php(636): LibreNMS\Alert\Transport\Mail->deliverAlert()
#6 /opt/librenms/LibreNMS/Alert/RunAlerts.php(268): LibreNMS\Alert\RunAlerts->extTransports()
#7 /opt/librenms/LibreNMS/Alert/RunAlerts.php(586): LibreNMS\Alert\RunAlerts->issueAlert()
#8 /opt/librenms/alerts.php(61): LibreNMS\Alert\RunAlerts->runAlerts()
#9 {main}  