### PR TITLE
Use discovered sensor limits on update

### DIFF
--- a/app/Observers/SensorObserver.php
+++ b/app/Observers/SensorObserver.php
@@ -79,19 +79,11 @@ class SensorObserver
             $sensor->sensor_limit_low_warn = $sensor->getOriginal('sensor_limit_low_warn');
             $sensor->sensor_limit_low = $sensor->getOriginal('sensor_limit_low');
         } else {
-            // only allow update if it wasn't previously set
-            if ($sensor->getOriginal('sensor_limit') !== null) {
-                $sensor->sensor_limit = $sensor->getOriginal('sensor_limit');
-            }
-            if ($sensor->getOriginal('sensor_limit_warn') !== null) {
-                $sensor->sensor_limit_warn = $sensor->getOriginal('sensor_limit_warn');
-            }
-            if ($sensor->getOriginal('sensor_limit_low_warn') !== null) {
-                $sensor->sensor_limit_low_warn = $sensor->getOriginal('sensor_limit_low_warn');
-            }
-            if ($sensor->getOriginal('sensor_limit_low') !== null) {
-                $sensor->sensor_limit_low = $sensor->getOriginal('sensor_limit_low');
-            }
+            // change unset sensor limits to current values
+            $sensor->sensor_limit ??= $sensor->getOriginal('sensor_limit');
+            $sensor->sensor_limit_warn ??= $sensor->getOriginal('sensor_limit_warn');
+            $sensor->sensor_limit_low_warn ??= $sensor->getOriginal('sensor_limit_low_warn');
+            $sensor->sensor_limit_low ??= $sensor->getOriginal('sensor_limit_low');
         }
     }
 


### PR DESCRIPTION
While trying to fix some sensor limit, I noticed that the discovered sensor limits were not being saved to the database.  I tracked this to when the sensor observer was added.

git diff 4efad1ae691742dbb462a9209d40ff59689f4377 f15f8fa63a7b70da6542312d461931513acafb3d

Under the original code the new limits were set to the original value only if they discovery did not find a limit, and then were only saved to the database if "sensor_custom" was set to "No".  This PR restores this original behviour, which is correct (any authoritative limit that is discovered should be used unless sensor_custom is set to "Yes")

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
