### PR TITLE
Tweak AlertManager dynamic variables to include alert_data

### DIFF
--- a/LibreNMS/Alert/Transport/Alertmanager.php
+++ b/LibreNMS/Alert/Transport/Alertmanager.php
@@ -61,7 +61,7 @@ class Alertmanager extends Transport
             // To allow dynamic values
             if (preg_match('/^extra_[A-Za-z0-9_]+$/', $label) && ! empty($alert_data['faults'][1][$value])) {
                 $data[0]['labels'][$label] = strip_tags($alert_data['faults'][1][$value]);
-            } else if (preg_match('/^extra_[A-Za-z0-9_]+$/', $label) && ! empty($alert_data[$value])) {
+            } elseif (preg_match('/^extra_[A-Za-z0-9_]+$/', $label) && ! empty($alert_data[$value])) {
                 $data[0]['labels'][$label] = strip_tags($alert_data[$value]);
             } else {
                 $data[0]['labels'][$label] = strip_tags($value);


### PR DESCRIPTION
Alertmanager's dynamic variables currently only look at Fault data, and doesn't look at alert_data.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
