### PR TITLE
Skip ports polling if we have not discovered any ports

### DIFF
--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -196,6 +196,11 @@ $dot3_oids = [
 // Query known ports and mapping table in order of discovery to make sure
 // the latest discoverd/polled port is in the mapping tables.
 $ports_mapped = get_ports_mapped($device['device_id'], true);
+if (empty($ports_mapped['ports'])) {
+    Log::info("No ports found for device {$device['hostname']}, discovery needs to be run first.");
+    return;
+}
+
 $ports = $ports_mapped['ports'];
 
 //


### PR DESCRIPTION
If polling starts before any ports have been discovered then we risk duplicating ports in the DB.

I have another possible fix I'm going to propose as well.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
