### PR TITLE
Added ArubaCX VSF topology sensor state.

### DIFF
--- a/includes/discovery/sensors/state/arubaos-cx.inc.php
+++ b/includes/discovery/sensors/state/arubaos-cx.inc.php
@@ -45,6 +45,12 @@ $vsfMemberTableStates = [
     ['value' => 15, 'generic' => 2, 'graph' => 0, 'descr' => 'In Other Fragment'],
 ];
 
+$vsfTopologyStates = [
+    ['value' => 0, 'generic' => 0, 'graph' => 0, 'descr' => 'Standalone'],
+    ['value' => 1, 'generic' => 2, 'graph' => 0, 'descr' => 'Chain'],
+    ['value' => 2, 'generic' => 0, 'graph' => 0, 'descr' => 'Ring'],
+];
+
 $stateLookupTable = [
     // arubaWiredVsfv2OperStatus
     'no_split' => 0,
@@ -58,8 +64,29 @@ $stateLookupTable = [
     'version_mismatch' => 13,
     'communication_failure' => 14,
     'in_other_fragment' => 15,
+
+    //arubaWiredVsfv2Topology
+    'standalone' => 0,
+    'chain' => 1,
+    'ring' => 2,
 ];
 
+
+$temp = snmpwalk_cache_multi_oid($device, 'arubaWiredVsfv2Topology', [], 'ARUBAWIRED-VSFv2-MIB');
+if (is_array($temp)) {
+    echo 'ArubaOS-CX VSF Topology: ';
+    //Create State Index
+    $state_name = 'arubaWiredVsfv2Topology';
+    create_state_index($state_name, $vsfTopologyStates);
+
+    foreach ($temp as $index => $data) {
+        $sensor_value = $stateLookupTable[$data['arubaWiredVsfv2Topology']];
+
+        $descr = 'VSF Topology';
+        $oid = '.1.3.6.1.4.1.47196.4.1.1.3.15.1.1.2.' . $index;
+        discover_sensor(null, 'state', $device, $oid, $index, $state_name, $descr, 1, 1, null, null, null, null, $sensor_value, 'snmp', null, null, null, 'VSF');
+    }
+}
 $temp = snmpwalk_cache_multi_oid($device, 'arubaWiredVsfv2OperStatus', [], 'ARUBAWIRED-VSFv2-MIB');
 if (is_array($temp)) {
     echo 'ArubaOS-CX VSF Operational Status: ';


### PR DESCRIPTION
I have added a ArubaCX VSF topology state check. This check will check the state of the VSF topology and if the state is ring or standalone the check will we OK. If the state is chain the check will be critical.
I have run the test in [https://docs.librenms.org/Developing/os/Test-Units/](url) and they fail as "snmpwalk_cache_multi_oid()" is deprecated. I plan to try and rewrite the whole check using SnmpQuery, but I need to figure that out first,
<img width="1131" height="77" alt="arubacx-vsf-chain-crop" src="https://github.com/user-attachments/assets/a64effa9-2b0d-47ff-8459-2282b47eac46" />
 

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
