### PR TITLE
[webui] fix ipv4/ipv6 address search, enable address sort

### DIFF
--- a/includes/html/pages/search/ipv4.inc.php
+++ b/includes/html/pages/search/ipv4.inc.php
@@ -7,7 +7,7 @@
             <tr>
                 <th data-column-id="hostname" data-order="asc">Device</th>
                 <th data-column-id="interface">Interface</th>
-                <th data-column-id="address" data-sortable="false" data-formatter="tooltip">Address</th>
+                <th data-column-id="address" data-formatter="tooltip">Address</th>
                 <th data-column-id="description" data-sortable="false" data-formatter="tooltip">Description</th>
             </tr>
         </thead>

--- a/includes/html/pages/search/ipv6.inc.php
+++ b/includes/html/pages/search/ipv6.inc.php
@@ -7,7 +7,7 @@
             <tr>
                 <th data-column-id="hostname">Device</th>
                 <th data-column-id="interface">Interface</th>
-                <th data-column-id="address" data-sortable="false" data-formatter="tooltip">Address</th>
+                <th data-column-id="address" data-formatter="tooltip">Address</th>
                 <th data-column-id="description" data-sortable="false" data-formatter="tooltip">Description</th>
             </tr>
         <thead>

--- a/includes/html/table/address-search.inc.php
+++ b/includes/html/table/address-search.inc.php
@@ -20,20 +20,24 @@ if (str_contains($address, '/')) {
 }
 
 if ($search_type == 'ipv4') {
-    $sql = ' FROM `ipv4_addresses` AS A, `ports` AS I, `ipv4_networks` AS N, `devices` AS D';
-    $sql .= " WHERE I.port_id = A.port_id AND I.device_id = D.device_id AND N.ipv4_network_id = A.ipv4_network_id $where ";
+    $sql = ' FROM `ipv4_addresses` AS A, `ports` AS I, `devices` AS D';
+    $sql .= ' WHERE I.port_id = A.port_id AND I.device_id = D.device_id ' . $where . ' ';
+
     if (! empty($address)) {
         $sql .= ' AND ipv4_address LIKE ?';
         $param[] = "%$address%";
     }
 
     if (! empty($prefix)) {
-        $sql .= " AND ipv4_prefixlen='?'";
-        $param[] = [$prefix];
+        $sql .= " AND ipv4_prefixlen='$prefix'";
     }
+
+    $sql .= ' group by ipv4_address_id';
+
 } elseif ($search_type == 'ipv6') {
-    $sql = ' FROM `ipv6_addresses` AS A, `ports` AS I, `ipv6_networks` AS N, `devices` AS D';
-    $sql .= " WHERE I.port_id = A.port_id AND I.device_id = D.device_id AND N.ipv6_network_id = A.ipv6_network_id $where ";
+    $sql = ' FROM `ipv6_addresses` AS A, `ports` AS I, `devices` AS D';
+    $sql .= ' WHERE I.port_id = A.port_id AND I.device_id = D.device_id ' . $where . ' ';
+
     if (! empty($address)) {
         $sql .= ' AND (ipv6_address LIKE ? OR ipv6_compressed LIKE ?)';
         $param[] = "%$address%";
@@ -43,6 +47,9 @@ if ($search_type == 'ipv4') {
     if (! empty($prefix)) {
         $sql .= " AND ipv6_prefixlen = '$prefix'";
     }
+
+    $sql .= ' group by ipv6_address_id';
+
 } elseif ($search_type == 'mac') {
     $sql = ' FROM `ports` AS I, `devices` AS D';
     $sql .= " WHERE I.device_id = D.device_id  $where ";

--- a/includes/html/table/address-search.inc.php
+++ b/includes/html/table/address-search.inc.php
@@ -33,7 +33,6 @@ if ($search_type == 'ipv4') {
     }
 
     $sql .= ' group by ipv4_address_id';
-
 } elseif ($search_type == 'ipv6') {
     $sql = ' FROM `ipv6_addresses` AS A, `ports` AS I, `devices` AS D';
     $sql .= ' WHERE I.port_id = A.port_id AND I.device_id = D.device_id ' . $where . ' ';
@@ -49,7 +48,6 @@ if ($search_type == 'ipv4') {
     }
 
     $sql .= ' group by ipv6_address_id';
-
 } elseif ($search_type == 'mac') {
     $sql = ' FROM `ports` AS I, `devices` AS D';
     $sql .= " WHERE I.device_id = D.device_id  $where ";

--- a/includes/html/table/address-search.inc.php
+++ b/includes/html/table/address-search.inc.php
@@ -15,6 +15,8 @@ if (! Auth::user()->hasGlobalRead()) {
 $search_type = $vars['search_type'] ?? 'ipv4';
 $address = $vars['address'] ?? '';
 $prefix = '';
+$sort = trim($sort);
+
 if (str_contains($address, '/')) {
     [$address, $prefix] = explode('/', $address, 2);
 }
@@ -32,6 +34,10 @@ if ($search_type == 'ipv4') {
         $sql .= " AND ipv4_prefixlen='$prefix'";
     }
 
+    if (str_contains($sort, 'address')) {
+        $order = explode(' ', $sort)[1];
+        $sort = 'INET_ATON(ipv4_address) ' . $order;
+    }
 } elseif ($search_type == 'ipv6') {
     $sql = ' FROM `ipv6_addresses` AS A, `ports` AS I, `devices` AS D';
     $sql .= ' WHERE I.port_id = A.port_id AND I.device_id = D.device_id ' . $where . ' ';
@@ -46,6 +52,10 @@ if ($search_type == 'ipv4') {
         $sql .= " AND ipv6_prefixlen = '$prefix'";
     }
 
+    if (str_contains($sort, 'address')) {
+        $order = explode(' ', $sort)[1];
+        $sort = 'INET6_ATON(ipv6_address) ' . $order;
+    }
 } elseif ($search_type == 'mac') {
     $sql = ' FROM `ports` AS I, `devices` AS D';
     $sql .= " WHERE I.device_id = D.device_id  $where ";

--- a/includes/html/table/address-search.inc.php
+++ b/includes/html/table/address-search.inc.php
@@ -32,7 +32,6 @@ if ($search_type == 'ipv4') {
         $sql .= " AND ipv4_prefixlen='$prefix'";
     }
 
-    $sql .= ' group by ipv4_address_id';
 } elseif ($search_type == 'ipv6') {
     $sql = ' FROM `ipv6_addresses` AS A, `ports` AS I, `devices` AS D';
     $sql .= ' WHERE I.port_id = A.port_id AND I.device_id = D.device_id ' . $where . ' ';
@@ -47,7 +46,6 @@ if ($search_type == 'ipv4') {
         $sql .= " AND ipv6_prefixlen = '$prefix'";
     }
 
-    $sql .= ' group by ipv6_address_id';
 } elseif ($search_type == 'mac') {
     $sql = ' FROM `ports` AS I, `devices` AS D';
     $sql .= " WHERE I.device_id = D.device_id  $where ";


### PR DESCRIPTION
since new IPv4 / IPv6 address discovery modules does NOT create network for /128 and /32 addresses
webui search will not work because php code is linked to ipv[4/6]_networks. Why ? IDK

fix address search
fix IPv4 prefix search
enabled IPv4/IPv6 address sort

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
