### PR TITLE
Fix menus longer than viewport

### DIFF
--- a/html/css/styles.css
+++ b/html/css/styles.css
@@ -1299,11 +1299,9 @@ tr.search:nth-child(odd) {
 
 
 .scrollable-menu {
-    height: auto;
-    max-height: 600px;
+    overflow-y: auto;
     overflow-x: hidden;
 }
-
 
 .ui-autocomplete {
     max-height: 100px;

--- a/html/js/librenms.js
+++ b/html/js/librenms.js
@@ -741,3 +741,25 @@ function applySiteStyle(newStyle) {
         });
     }
 }
+
+// prevent dropdown menus from overflowing the viewport
+document.addEventListener('DOMContentLoaded', function () {
+    document.querySelectorAll('.dropdown-submenu').forEach(function (submenuParent) {
+        const submenu = submenuParent.querySelector('.dropdown-menu');
+        if (!submenu) return;
+
+        submenuParent.addEventListener('mouseenter', function () {
+            submenu.style.maxHeight = '';
+            submenu.style.overflowY = 'auto';
+
+            const rect = submenu.getBoundingClientRect();
+            const availableHeight = window.innerHeight - rect.top - 10;
+            submenu.style.maxHeight = availableHeight + 'px';
+        });
+
+        submenuParent.addEventListener('mouseleave', function () {
+            submenu.style.maxHeight = '';
+        });
+    });
+});
+

--- a/resources/views/layouts/librenmsv1.blade.php
+++ b/resources/views/layouts/librenmsv1.blade.php
@@ -41,7 +41,7 @@
     <link href="{{ asset('css/select2.min.css') }}" rel="stylesheet">
     <link href="{{ asset('css/select2-bootstrap.min.css') }}" rel="stylesheet">
     <link href="{{ asset('css/query-builder.default.min.css') }}" rel="stylesheet">
-    <link href="{{ asset(LibrenmsConfig::get('stylesheet', 'css/styles.css')) }}?ver=25052501" rel="stylesheet">
+    <link href="{{ asset(LibrenmsConfig::get('stylesheet', 'css/styles.css')) }}?ver=10092025" rel="stylesheet">
     <link href="{{ asset('css/tw_dark.css?ver=31072025') }}" rel="stylesheet">
     @if(!in_array(session('applied_site_style', 'light'), ['light', 'dark']))
     <link href="{{ asset('css/' . session('applied_site_style') . '.css?ver=732417643') }}" rel="stylesheet">
@@ -77,7 +77,7 @@
         });
         var ajax_url = "{{ url('/ajax') }}";
     </script>
-    <script src="{{ asset('js/librenms.js?ver=30062025') }}"></script>
+    <script src="{{ asset('js/librenms.js?ver=10092025') }}"></script>
     <script type="text/javascript" src="{{ asset('js/overlib_mini.js') }}"></script>
     <script type="text/javascript" src="{{ asset('js/toastr.min.js?ver=05072021') }}"></script>
     <script type="text/javascript" src="{{ asset('js/boot.js?ver=10272021') }}"></script>


### PR DESCRIPTION
This now prevents submenus from going out of the bottom of the viewport and properly shows a scrollbar.

Now go make 500 Custom Maps!



#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
