### PR TITLE
Fix device tabs missing

### DIFF
--- a/app/Http/Controllers/Device/Tabs/RoutingController.php
+++ b/app/Http/Controllers/Device/Tabs/RoutingController.php
@@ -39,7 +39,6 @@ class RoutingController implements DeviceTab
     public function __construct()
     {
         $device = DeviceCache::getPrimary();
-        //dd($device);
         $this->tabs = [
             'ospf' => $device->ospfInstances()->count(),
             'ospfv3' => $device->ospfv3Instances()->count(),

--- a/app/View/Components/Device/Page.php
+++ b/app/View/Components/Device/Page.php
@@ -26,6 +26,7 @@
 
 namespace App\View\Components\Device;
 
+use App\Facades\DeviceCache;
 use App\Facades\LibrenmsConfig;
 use App\Models\Device;
 use App\Models\Vminfo;
@@ -47,6 +48,7 @@ class Page extends Component
         public readonly array $dropdownLinks = [],
         public readonly string $subtitle = '',
     ) {
+        DeviceCache::setPrimary($device->device_id); // set primary device in case it was not set by controller
         $this->pagetitle = $subtitle ? ($device->displayName() . ': ' . $subtitle) : $device->displayName();
         $this->alertClass = $device->disabled ? 'alert-info' : ($device->status ? '' : 'alert-danger');
         $this->parentDeviceId = Vminfo::guessFromDevice($device)->value('device_id');


### PR DESCRIPTION
Primary device was not set in controllers as there should be a controller for each page now, instead just set it in the common device page component.

fixes #18344

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
