### PR TITLE
Fix third level menu incorrect scrolling

### DIFF
--- a/html/js/librenms.js
+++ b/html/js/librenms.js
@@ -754,6 +754,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
             if (rect.bottom > window.innerHeight) {
                 submenu.style.maxHeight = availableHeight + 'px';
+                submenu.style.overflowY = 'auto';
             }
         });
 

--- a/resources/views/layouts/librenmsv1.blade.php
+++ b/resources/views/layouts/librenmsv1.blade.php
@@ -77,7 +77,7 @@
         });
         var ajax_url = "{{ url('/ajax') }}";
     </script>
-    <script src="{{ asset('js/librenms.js?ver=10092025') }}"></script>
+    <script src="{{ asset('js/librenms.js?ver=14102025') }}"></script>
     <script type="text/javascript" src="{{ asset('js/overlib_mini.js') }}"></script>
     <script type="text/javascript" src="{{ asset('js/toastr.min.js?ver=05072021') }}"></script>
     <script type="text/javascript" src="{{ asset('js/boot.js?ver=10272021') }}"></script>


### PR DESCRIPTION
Cheat a bit and only add scroll bars to the last level menu.  Normal LibreNMS menus do not use a 3rd level submenu, only plugins.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
