### PR TITLE
Fix Graylog timestamp on device page

### DIFF
--- a/resources/views/device/tabs/logs/graylog.blade.php
+++ b/resources/views/device/tabs/logs/graylog.blade.php
@@ -83,14 +83,14 @@
         rowCount: [{{ $range }}, 25, 50, 100, 250, -1],
         formatters: {
             "browserTime": function (column, row) {
-                let timezone =
-                @json($timezone)
+                    let timezone = @json($timezone);
 
-                if (timezone) {
-                    return 'row.timestamp;';
+                    if (timezone) {
+                        return row.timestamp;
+                    }
+
+                    return moment.parseZone(row.timestamp).local().format("YYYY-MM-DD HH:mm:ss");
                 }
-                return 'moment.parseZone(row.timestamp).local().format("YYYY-MM-DD HH:MM:SS");'
-            }
         },
 
     @if($show_form)


### PR DESCRIPTION
Fix for timestamp variable rendering as string.

More details at:
https://community.librenms.org/t/graylog-timestamp-with-row-timestamp-value-instead-of-the-actual-time/28554/2

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
