### PR TITLE
Add missing EN labels/descriptions for AD Auth Section

### DIFF
--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -343,6 +343,14 @@ return [
             'description' => 'Active Directory Domain',
             'help' => 'Active Directory Domain Example: example.com',
         ],
+        'auth_ad_global_read' => [
+            'description' => 'Global Read',
+            'help' => 'Allow global-read access to all users',
+        ],
+        'auth_ad_group' => [
+            'description' => 'Access group DN',
+            'help' => 'Distinguished name for a group to give normal level access. Example: cn=groupname,ou=groups,dc=example,dc=com',
+        ],
         'auth_ad_group_filter' => [
             'description' => 'Group LDAP filter',
             'help' => 'Active Directory LDAP filter for selecting groups',
@@ -354,6 +362,10 @@ return [
         'auth_ad_require_groupmembership' => [
             'description' => 'Require group membership',
             'help' => 'Only allow users to log in if they are part of a defined group',
+        ],
+        'auth_ad_timeout' => [
+            'description' => 'Connection timeout',
+            'help' => 'If one or more servers are unresponsive, higher timeouts will cause slow logins. To low may cause connection failures in some cases',
         ],
         'auth_ad_user_filter' => [
             'description' => 'User LDAP filter',


### PR DESCRIPTION
Add some missing labels and help descriptions for AD Auth Section.  EN language only.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
