### PR TITLE
More accurate running user check

### DIFF
--- a/app/Checks.php
+++ b/app/Checks.php
@@ -84,48 +84,4 @@ class Checks
             }
         }
     }
-
-    /**
-     * Check the script is running as the right user (works before config is available)
-     */
-    public static function runningUser()
-    {
-        if (function_exists('posix_getpwuid') && posix_getpwuid(posix_geteuid())['name'] !== get_current_user()) {
-            if (get_current_user() == 'root') {
-                self::printMessage(
-                    'Error: lnms file is owned by root, it should be owned and ran by a non-privileged user.',
-                    null,
-                    true
-                );
-            }
-
-            self::printMessage(
-                'Error: You must run lnms as the user ' . get_current_user(),
-                null,
-                true
-            );
-        }
-    }
-
-    private static function printMessage($title, $content, $exit = false)
-    {
-        $content = (array) $content;
-
-        if (PHP_SAPI == 'cli') {
-            $format = "%s\n\n%s\n\n";
-            $message = implode(PHP_EOL, $content);
-        } else {
-            $format = "<h3 style='color: firebrick;'>%s</h3><p>%s</p>";
-            $message = '';
-            foreach ($content as $line) {
-                $message .= "<p style='margin:0.5em'>$line</p>\n";
-            }
-        }
-
-        printf($format, $title, $message);
-
-        if ($exit) {
-            exit(1);
-        }
-    }
 }

--- a/app/Exceptions/RunningAsIncorrectUserException.php
+++ b/app/Exceptions/RunningAsIncorrectUserException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Exceptions;
+
+use Symfony\Component\Console\Exception\ExceptionInterface;
+
+class RunningAsIncorrectUserException extends \Exception implements ExceptionInterface
+{
+    //
+}


### PR DESCRIPTION
Previously we did not have access to config, so we had to infer the librenms user from the owner of the executable. Because we are running later in the boot now, we can just use config.
Clean up code a bit too since we can

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
