### PR TITLE
Ports: show ifIndex to allow restoring sort to ifIndex

### DIFF
--- a/app/Http/Controllers/Device/Tabs/PortsController.php
+++ b/app/Http/Controllers/Device/Tabs/PortsController.php
@@ -80,7 +80,7 @@ class PortsController implements DeviceTab
         Validator::validate($request->all(), [
             'page' => 'int',
             'perPage' => ['regex:/^(\d+|all)$/'],
-            'sort' => 'in:media,mac,port,traffic,speed',
+            'sort' => 'in:media,mac,port,traffic,speed,index',
             'order' => 'in:asc,desc',
             'disabled' => 'in:0,1',
             'ignored' => 'in:0,1',

--- a/resources/views/device/tabs/ports/detail.blade.php
+++ b/resources/views/device/tabs/ports/detail.blade.php
@@ -2,6 +2,7 @@
     <table id="ports-fdb" class="table table-condensed table-hover table-striped tw:mt-1 tw:mb-0!">
         <thead>
         <tr>
+            <th width="50"><a href="{{ $request->fullUrlWithQuery(['sort' => 'index', 'order' => $data['sort'] !== 'index' ? 'asc' : $data['next_order']]) }}">{{ __('Index') }}</a></th>
             <th width="350"><a href="{{ $request->fullUrlWithQuery(['sort' => 'port', 'order' => $data['sort'] == 'port' ? $data['next_order'] : 'asc']) }} ">{{ __('Port') }}</a></th>
             <th width="100" class="tw:hidden tw:md:table-cell">{{ __('Port Groups') }}</th>
             <th width="100">{{ __('Graphs') }}</th>

--- a/resources/views/device/tabs/ports/includes/port_row.blade.php
+++ b/resources/views/device/tabs/ports/includes/port_row.blade.php
@@ -1,4 +1,5 @@
 <tr>
+    <td>{{ $port->ifIndex }}</td>
     <td>
         <div>
             <x-port-link :port="$port" class="tw:inline">


### PR DESCRIPTION
Keep in mind sort order is saved per-user.  So previously, if you sorted by anything you could never get back to ifIndex.


<img width="203" height="151" alt="image" src="https://github.com/user-attachments/assets/cd218750-1f7c-4fd0-9ed5-d03cbf784969" />

fixes #16554

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
