### PR TITLE
Close XSS in node image manager

### DIFF
--- a/app/Http/Controllers/Maps/CustomMapNodeImageController.php
+++ b/app/Http/Controllers/Maps/CustomMapNodeImageController.php
@@ -87,7 +87,7 @@ class CustomMapNodeImageController extends Controller
         return response()->json([
             'result' => 'success',
             'id' => $image->custom_map_node_image_id,
-            'name' => $image->name,
+            'name' => htmlentities($image->name),
             'version' => $image->version,
         ]);
     }
@@ -105,7 +105,7 @@ class CustomMapNodeImageController extends Controller
 
         return response()->json([
             'result' => 'success',
-            'name' => $request['name'],
+            'name' => htmlentities($image->name),
             'version' => $image->version,
         ]);
     }


### PR DESCRIPTION
Return a sanitized version of node image names so the user who adds or updates an image can't inject javasript into their own session (the list view already generates sanitized names).

fixes https://github.com/librenms/librenms/security/advisories/GHSA-j8cq-7f6p-256x

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
