### PR TITLE
Apply ping_rrd_step to new icmp-perf.rrd files

### DIFF
--- a/LibreNMS/Data/Source/FpingResponse.php
+++ b/LibreNMS/Data/Source/FpingResponse.php
@@ -26,6 +26,7 @@
 
 namespace LibreNMS\Data\Source;
 
+use App\Facades\LibrenmsConfig;
 use App\Facades\Rrd;
 use App\Models\Device;
 use Carbon\Carbon;
@@ -146,6 +147,7 @@ class FpingResponse
 
         // detailed multi-ping capable graph
         app('Datastore')->put($device->toArray(), 'icmp-perf', [
+            'rrd_step' => LibrenmsConfig::get('ping_rrd_step'),
             'rrd_def' => RrdDefinition::make()
                 ->addDataset('avg', 'GAUGE', 0, 65535, source_ds: 'ping', source_file: Rrd::name($device->hostname, 'ping-perf'))
                 ->addDataset('xmt', 'GAUGE', 0, 65535)

--- a/resources/definitions/config_definitions.json
+++ b/resources/definitions/config_definitions.json
@@ -6636,7 +6636,7 @@
             "units": "Seconds"
         },
         "ping_rrd_step": {
-            "default": 60,
+            "default": 300,
             "group": "poller",
             "section": "dispatcherservice",
             "order": 21,


### PR DESCRIPTION
Change default ping_rrd_step to 300.
This could cause incorrectly stepped rrd files (but no worse than the previous code, where it was always 300).

If the user followed the docs and set ping_rrd_step this should still stay set to their current step.


#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
