### PR TITLE
Add FreeRADIUS App Key Checks

### DIFF
--- a/includes/polling/applications/freeradius.inc.php
+++ b/includes/polling/applications/freeradius.inc.php
@@ -1,7 +1,6 @@
 <?php
 
 use LibreNMS\RRD\RrdDefinition;
-use LibreNMS\Util\Number;
 
 $name = 'freeradius';
 


### PR DESCRIPTION
This is to address the issue reported in: https://github.com/librenms/librenms/issues/17964

tbh, I've never seen a FreeRADIUS server that couldn't return Type 31 stats before the SNMP timeout, so that's kind of troubling, but it doesn't seem like a bad idea to let people choose lower values anyway.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
