### PR TITLE
SNMP Traps: run alert rules only when necessary

### DIFF
--- a/LibreNMS/Snmptrap/Dispatcher.php
+++ b/LibreNMS/Snmptrap/Dispatcher.php
@@ -66,7 +66,7 @@ class Dispatcher
         if ($logging == 'all' || ($fallback && $logging == 'unhandled')) {
             $trap->log($trap->toString($detailed));
         }
-        if ($logging == 'all' || ($fallback && $logging == 'unhandled') || ! $fallback) {
+        if ($logging != 'none' || ! $fallback) {
             $rules = new AlertRules;
             $rules->runRules($trap->getDevice()->device_id);
         }


### PR DESCRIPTION
Currently if you have snmptraps.eventlog=none then Alert Rules run for all unhandled SNMPTraps when nothing was changed in Libre by the Trap. i.e. running rules unnecessarily.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
