### PR TITLE
Fix IP parsing php error

### DIFF
--- a/LibreNMS/Util/IP.php
+++ b/LibreNMS/Util/IP.php
@@ -270,11 +270,15 @@ abstract class IP
      * Extract an address from a cidr, assume a host is given if it does not contain /
      *
      * @param  string  $ip
-     * @return array [$ip, $cidr]
+     * @return array{0: string, 1: int} [$ip, $cidr]
      */
-    protected function extractCidr($ip)
+    protected function extractCidr($ip): array
     {
-        return array_pad(explode('/', $ip, 2), 2, $this->host_bits);
+        $parts = explode('/', $ip, 2);
+        $addr = $parts[0];
+        $cidr = $parts[1] ?? $this->host_bits;
+
+        return [$addr, (int) $cidr];
     }
 
     /**


### PR DESCRIPTION
Exception: TypeError Unsupported operand types: string - int @ /opt/librenms/LibreNMS/Util/IPv6.php:153

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
