### PR TITLE
Double check unique IDs in DeviceGroup

### DIFF
--- a/app/Models/DeviceGroup.php
+++ b/app/Models/DeviceGroup.php
@@ -75,8 +75,10 @@ class DeviceGroup extends BaseModel
     public function updateDevices()
     {
         if ($this->type == 'dynamic') {
-            $this->devices()->sync(QueryBuilderFluentParser::fromJson($this->rules)->toQuery()
-                ->distinct()->pluck('devices.device_id'));
+            $ids = QueryBuilderFluentParser::fromJson($this->rules)
+                       ->toQuery()->pluck('devices.device_id');
+            $ids = collect($ids)->unique()->all();  // ensure unique device IDs
+            $this->devices()->sync($ids);
         }
     }
 


### PR DESCRIPTION
Ensure unique device IDs before syncing.

Been getting this Exception when creating Dynamic Device Groups. (Dynamic device group rule was simply devices.type = "network")

2025-10-24T14:50:15][CRITICAL] Exception: Illuminate\Database\UniqueConstraintViolationException SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry '307-337' for key 'PRIMARY' (Connection: mysql, SQL: insert into `device_group_device` (`device_group_id`, `device_id`) values (307, 337)) @ /opt/librenms/vendor/laravel/framework/src/Illuminate/Database/Connection.php:819

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
