### PR TITLE
Fix dispatcher billing

### DIFF
--- a/LibreNMS/queuemanager.py
+++ b/LibreNMS/queuemanager.py
@@ -362,11 +362,11 @@ class BillingQueueManager(TimedQueueManager):
     def do_work(self, run_type, group):
         if run_type == "poll":
             logger.info("Polling billing")
-            args = ("-d", "-f") if self.config.debug else ("-f")
+            args = ("-d", "-f") if self.config.debug else ("-f",)
             exit_code, output = LibreNMS.call_script("poll-billing.php", args)
         else:  # run_type == 'calculate'
             logger.info("Calculating billing")
-            args = ("-d", "-f") if self.config.debug else ("-f")
+            args = ("-d", "-f") if self.config.debug else ("-f",)
             exit_code, output = LibreNMS.call_script("billing-calculate.php", args)
 
         if exit_code != 0:


### PR DESCRIPTION
queuemanager.py calls the LibreNMS.call_script partially wrong. 
Calling the script with just one value for args(e.g. '-f'), will result in providing a string instead of a tuple.

For the poll-billing.php and billing-calculate.php script this will result in not calling the script properly if the debug mode isn't enabled.  This problem is discovered then the dispatcher service is used only. Using just one argument results in calling the billing script like `poll-billing.php - f` instead of `poll-billing.php -f`

Example:
```
>>> ("-f")
'-f'
>>> ("-f", "-d")
('-f', '-d')
>>> ("-f",) # <- fix
('-f',)

>>> type(("-f"))
<class 'str'>
>>> type(("-f",))
<class 'tuple'>


>>> tuple(map(str, ("-f")))
('-', 'f')
>>> tuple(map(str, ("-f",)))
('-f',)
>>> tuple(map(str, ("-f","-d")))
('-f', '-d')
```

The same issue was resolved for alerts.php in https://github.com/librenms/librenms/pull/16873 
 


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
