### PR TITLE
Microsoft Oauth: Roles/Groups Fix

### DIFF
--- a/app/Http/Controllers/Auth/SocialiteController.php
+++ b/app/Http/Controllers/Auth/SocialiteController.php
@@ -176,7 +176,14 @@ class SocialiteController extends Controller
                 }
                 $attributes = $parsed_attributes;
             }
-
+            
+            // MICROSOFT-SPECIFIC-PATCH: Check for 'roles' attribute (when groups emitted as roles)
+            if ($provider === 'microsoft' && isset($attributes['roles']) && is_array($attributes['roles'])) {
+                foreach ($attributes['roles'] as $group_id) {
+                    $roles = array_merge($roles, $claims[$group_id]['roles'] ?? []);
+                }
+            }
+            
             foreach ($scopes as $scope) {
                 foreach ($attributes as $attribute_name => $attribute_values) {
                     if (str_contains($attribute_name, $scope)) {


### PR DESCRIPTION
Patch SocialiteController to Librenms Roles/Scopes/Groups, so that Microsoft groups set to emit as Roles can be used to bind groups to roles in LibreNMS.

See Article: https://community.librenms.org/t/librenms-microsoft-oauth/28657

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
