### PR TITLE
Fix Availability Widget Labels Select

### DIFF
--- a/app/Http/Controllers/Widgets/AvailabilityMapController.php
+++ b/app/Http/Controllers/Widgets/AvailabilityMapController.php
@@ -182,7 +182,9 @@ class AvailabilityMapController extends WidgetController
 
     private function getDeviceLabel(Device $device, string $state_name): string
     {
-        return match ($this->getSettings()['color_only_select']) {
+        $choice = (int) ($this->getSettings()['color_only_select'] ?? 0);
+
+        return match ($choice) {
             1 => '',
             4 => $device->shortDisplayName(),
             2 => strtolower($device->hostname),
@@ -193,7 +195,9 @@ class AvailabilityMapController extends WidgetController
 
     private function getServiceLabel(Service $service): string
     {
-        if ($this->getSettings()['color_only_select'] == 1) {
+        $choice = (int) ($this->getSettings()['color_only_select'] ?? 0);
+
+        if ($choice == 1) {
             return '';
         }
 


### PR DESCRIPTION
For issue mentioned at: 

- https://community.librenms.org/t/deshboard-dont-show-the-system-name/28665
- https://community.librenms.org/t/after-updating-to-25-11-0-dev-71-95c6fd20e-my-availability-map-widget-no-longer-shows-the-displayname-label-for-devices/28663/5

Seems to be caused by PHP8's strict comparisons so cast to int.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
