### PR TITLE
Fix: allow array|string|null for ValidationResult::$fix to prevent TypeError

### DIFF
--- a/LibreNMS/ValidationResult.php
+++ b/LibreNMS/ValidationResult.php
@@ -48,7 +48,7 @@ class ValidationResult
      * @param  int  $status  The status of this result FAILURE, WARNING, or SUCCESS
      * @param  string|null  $fix  a suggested fix to highlight for the user
      */
-    public function __construct(private string $message, private int $status, private ?string $fix = null)
+    public function __construct(private string $message, private int $status, private string|array|null $fix = null)
     {
     }
 


### PR DESCRIPTION
```
Exception: TypeError Cannot assign array to property LibreNMS\ValidationResult::$fix of type ?string @ /opt/librenms/LibreNMS/ValidationResult.php:162
#0 /opt/librenms/LibreNMS/Validations/Scheduler.php(52): LibreNMS\ValidationResult->setFix()
#1 /opt/librenms/LibreNMS/Validator.php(90): LibreNMS\Validations\Scheduler->validate()
#2 /opt/librenms/validate.php(147): LibreNMS\Validator->validate()
#3 {main}

In ValidationResult.php line 162:

  Cannot assign array to property LibreNMS\ValidationResult::$fix of type ?string
```

This restores compatibility with existing validators (User.php, Scheduler.php)
that pass arrays to setFix(), which recently caused a TypeError after strict
typing was added in commit 7ae25571a.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
