### PR TITLE
Alerting: Improve timing of marking the alert resolved

### DIFF
--- a/LibreNMS/Alert/RunAlerts.php
+++ b/LibreNMS/Alert/RunAlerts.php
@@ -598,13 +598,13 @@ class RunAlerts
                 $noiss = true;
             }
 
-            if (! $noiss) {
-                $this->issueAlert($alert);
-                dbUpdate(['alerted' => $alert['state']], 'alerts', 'rule_id = ? && device_id = ?', [$alert['rule_id'], $alert['device_id']]);
+            if (! $noacc) {
+                dbUpdate(['open' => 0], 'alerts', 'rule_id = ? && device_id = ? && state = 0', [$alert['rule_id'], $alert['device_id']]);
             }
 
-            if (! $noacc) {
-                dbUpdate(['open' => 0], 'alerts', 'rule_id = ? && device_id = ?', [$alert['rule_id'], $alert['device_id']]);
+            if (! $noiss) {
+                dbUpdate(['alerted' => $alert['state']], 'alerts', 'rule_id = ? && device_id = ?', [$alert['rule_id'], $alert['device_id']]);
+                $this->issueAlert($alert);
             }
         }
     }


### PR DESCRIPTION
I'm running this in a large(ish) install right now.

So the issue I've seen and this fixes is that recovery alerts aren't always sent out.

This PR fixes a few things along the way:

1. Update the database before running `issueAlert()` as this can take a while to run depending on the number of transports and the types. This stops multiple alerts running.
2. Moved noacc check above noiss as again, we don't want to wait for `issueAlert()` to run.
3. The main fix, only update open=0 when state=0 (I.e alert has cleared).

I've tested alerts with devices that have alerting disabled, maintenance windows in place and acks.

One side effect of the change (but this is how it should be) is that if a rule clears before an alert is sent, no recovery notification is sent. For some reason before, a recovery notification would be sent even if an initial notification hadn't been sent.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
