### PR TITLE
AD Auth: better auth failure

### DIFF
--- a/LibreNMS/Authentication/ActiveDirectoryAuthorizer.php
+++ b/LibreNMS/Authentication/ActiveDirectoryAuthorizer.php
@@ -118,6 +118,11 @@ class ActiveDirectoryAuthorizer extends AuthorizerBase
             $this->userFilter($username),
             ['samaccountname']
         );
+
+        if ($search === false) {
+            throw new AuthenticationException('User search failed: ' . ldap_error($connection));
+        }
+
         $entries = ldap_get_entries($connection, $search);
 
         if ($entries['count']) {


### PR DESCRIPTION
Throw an AuthenticationException if we cannot search for a user (permission removed or no bind user when enabling remember me)

https://community.librenms.org/t/issue-with-firefox-and-possibly-ad-authentication-involvement/28702

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
