### PR TITLE
Cast Cisco QOS values to ints

### DIFF
--- a/LibreNMS/OS/Shared/Cisco.php
+++ b/LibreNMS/OS/Shared/Cisco.php
@@ -930,24 +930,24 @@ class Cisco extends OS implements
                 // Cisco CBQoS is one directional
                 if ($thisQos->ingress) {
                     $thisQos->last_polled = $poll_time;
-                    $thisQos->last_bytes_in = $preBytes ? $preBytes[$snmp_parts[0]][$snmp_parts[1]]['cbQosCMPrePolicyByte64'] : null;
+                    $thisQos->last_bytes_in = $preBytes ? (int) $preBytes[$snmp_parts[0]][$snmp_parts[1]]['cbQosCMPrePolicyByte64'] : null;
                     $thisQos->last_bytes_out = null;
-                    $thisQos->last_bytes_drop_in = $dropBytes ? $dropBytes[$snmp_parts[0]][$snmp_parts[1]]['cbQosCMDropByte64'] : null;
+                    $thisQos->last_bytes_drop_in = $dropBytes ? (int) $dropBytes[$snmp_parts[0]][$snmp_parts[1]]['cbQosCMDropByte64'] : null;
                     $thisQos->last_bytes_drop_out = null;
-                    $thisQos->last_packets_in = $prePackets ? $prePackets[$snmp_parts[0]][$snmp_parts[1]]['cbQosCMPrePolicyPkt64'] : null;
+                    $thisQos->last_packets_in = $prePackets ? (int) $prePackets[$snmp_parts[0]][$snmp_parts[1]]['cbQosCMPrePolicyPkt64'] : null;
                     $thisQos->last_packets_out = null;
-                    $thisQos->last_packets_drop_in = $dropPackets ? $dropPackets[$snmp_parts[0]][$snmp_parts[1]]['cbQosCMDropPkt64'] : null;
+                    $thisQos->last_packets_drop_in = $dropPackets ? (int) $dropPackets[$snmp_parts[0]][$snmp_parts[1]]['cbQosCMDropPkt64'] : null;
                     $thisQos->last_packets_drop_out = null;
                 } elseif ($thisQos->egress) {
                     $thisQos->last_polled = $poll_time;
                     $thisQos->last_bytes_in = null;
-                    $thisQos->last_bytes_out = $preBytes ? $preBytes[$snmp_parts[0]][$snmp_parts[1]]['cbQosCMPrePolicyByte64'] : null;
+                    $thisQos->last_bytes_out = $preBytes ? (int) $preBytes[$snmp_parts[0]][$snmp_parts[1]]['cbQosCMPrePolicyByte64'] : null;
                     $thisQos->last_bytes_drop_in = null;
-                    $thisQos->last_bytes_drop_out = $dropBytes ? $dropBytes[$snmp_parts[0]][$snmp_parts[1]]['cbQosCMDropByte64'] : null;
+                    $thisQos->last_bytes_drop_out = $dropBytes ? (int) $dropBytes[$snmp_parts[0]][$snmp_parts[1]]['cbQosCMDropByte64'] : null;
                     $thisQos->last_packets_in = null;
-                    $thisQos->last_packets_out = $prePackets ? $prePackets[$snmp_parts[0]][$snmp_parts[1]]['cbQosCMPrePolicyPkt64'] : null;
+                    $thisQos->last_packets_out = $prePackets ? (int) $prePackets[$snmp_parts[0]][$snmp_parts[1]]['cbQosCMPrePolicyPkt64'] : null;
                     $thisQos->last_packets_drop_in = null;
-                    $thisQos->last_packets_drop_out = $dropPackets ? $dropPackets[$snmp_parts[0]][$snmp_parts[1]]['cbQosCMDropPkt64'] : null;
+                    $thisQos->last_packets_drop_out = $dropPackets ? (int) $dropPackets[$snmp_parts[0]][$snmp_parts[1]]['cbQosCMDropPkt64'] : null;
                 } else {
                     d_echo('Cisco CBQoS ' . $thisQos->title . ' not processed because it it not marked as ingress or egress');
                 }


### PR DESCRIPTION
Not all of my Cisco gear returns QOS values as ints apparently?....

[2025-11-07T16:16:41][CRITICAL] Exception: TypeError App\Observers\QosObserver::calcRate(): Argument #1 ($val) must be of type ?int, string given, called in /opt/librenms/app/Observers/QosObserver.php on line 21 @ /opt/librenms/app/Observers/QosObserver.php:36
#0 /opt/librenms/app/Observers/QosObserver.php(21): App\Observers\QosObserver->calcRate()
#1 /opt/librenms/vendor/laravel/framework/src/Illuminate/Events/Dispatcher.php(508): App\Observers\QosObserver->updating()
#2 /opt/librenms/vendor/laravel/framework/src/Illuminate/Events/Dispatcher.php(315): Illuminate\Events\Dispatcher->Illuminate\Events\{closure}()
#3 /opt/librenms/vendor/laravel/framework/src/Illuminate/Events/Dispatcher.php(295): Illuminate\Events\Dispatcher->invokeListeners()
#4 /opt/librenms/vendor/laravel/framework/src/Illuminate/Events/Dispatcher.php(255): Illuminate\Events\Dispatcher->dispatch()
#5 /opt/librenms/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php(224): Illuminate\Events\Dispatcher->until()
#6 /opt/librenms/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Model.php(1299): Illuminate\Database\Eloquent\Model->fireModelEvent()
#7 /opt/librenms/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Model.php(1233): Illuminate\Database\Eloquent\Model->performUpdate()
#8 /opt/librenms/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php(315): Illuminate\Database\Eloquent\Model->save()
#9 /opt/librenms/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php(340): Illuminate\Database\Eloquent\Relations\HasOneOrMany->save()
#10 /opt/librenms/LibreNMS/Modules/Qos.php(93): Illuminate\Database\Eloquent\Relations\HasOneOrMany->saveMany()
#11 /opt/librenms/app/Jobs/PollDevice.php(139): LibreNMS\Modules\Qos->poll()
#12 /opt/librenms/app/Jobs/PollDevice.php(63): App\Jobs\PollDevice->pollModules()
#13 /opt/librenms/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(36): App\Jobs\PollDevice->handle()
#14 /opt/librenms/vendor/laravel/framework/src/Illuminate/Container/Util.php(43): Illuminate\Container\BoundMethod::Illuminate\Container\{closure}()
#15 /opt/librenms/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(96): Illuminate\Container\Util::unwrapIfClosure()
#16 /opt/librenms/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(35): Illuminate\Container\BoundMethod::callBoundMethod()
#17 /opt/librenms/vendor/laravel/framework/src/Illuminate/Container/Container.php(836): Illuminate\Container\BoundMethod::call()
#18 /opt/librenms/vendor/laravel/framework/src/Illuminate/Bus/Dispatcher.php(132): Illuminate\Container\Container->call()
#19 /opt/librenms/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(180): Illuminate\Bus\Dispatcher->Illuminate\Bus\{closure}()
#20 /opt/librenms/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(137): Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}()
#21 /opt/librenms/vendor/laravel/framework/src/Illuminate/Bus/Dispatcher.php(136): Illuminate\Pipeline\Pipeline->then()
#22 /opt/librenms/vendor/laravel/framework/src/Illuminate/Queue/CallQueuedHandler.php(134): Illuminate\Bus\Dispatcher->dispatchNow()
#23 /opt/librenms/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(180): Illuminate\Queue\CallQueuedHandler->Illuminate\Queue\{closure}()
#24 /opt/librenms/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(137): Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}()
#25 /opt/librenms/vendor/laravel/framework/src/Illuminate/Queue/CallQueuedHandler.php(127): Illuminate\Pipeline\Pipeline->then()
#26 /opt/librenms/vendor/laravel/framework/src/Illuminate/Queue/CallQueuedHandler.php(68): Illuminate\Queue\CallQueuedHandler->dispatchThroughMiddleware()
#27 /opt/librenms/vendor/laravel/framework/src/Illuminate/Queue/Jobs/Job.php(102): Illuminate\Queue\CallQueuedHandler->call()
#28 /opt/librenms/vendor/laravel/framework/src/Illuminate/Queue/SyncQueue.php(130): Illuminate\Queue\Jobs\Job->fire()
#29 /opt/librenms/vendor/laravel/framework/src/Illuminate/Queue/SyncQueue.php(110): Illuminate\Queue\SyncQueue->executeJob()
#30 /opt/librenms/vendor/laravel/framework/src/Illuminate/Bus/Dispatcher.php(250): Illuminate\Queue\SyncQueue->push()
#31 /opt/librenms/vendor/laravel/framework/src/Illuminate/Bus/Dispatcher.php(234): Illuminate\Bus\Dispatcher->pushCommandToQueue()
#32 /opt/librenms/vendor/laravel/framework/src/Illuminate/Bus/Dispatcher.php(101): Illuminate\Bus\Dispatcher->dispatchToQueue()
#33 /opt/librenms/vendor/laravel/framework/src/Illuminate/Foundation/Bus/Dispatchable.php(76): Illuminate\Bus\Dispatcher->dispatchSync()
#34 /opt/librenms/app/Console/Commands/DevicePoll.php(79): App\Jobs\PollDevice::dispatchSync()
#35 /opt/librenms/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(36): App\Console\Commands\DevicePoll->handle()
#36 /opt/librenms/vendor/laravel/framework/src/Illuminate/Container/Util.php(43): Illuminate\Container\BoundMethod::Illuminate\Container\{closure}()
#37 /opt/librenms/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(96): Illuminate\Container\Util::unwrapIfClosure()
#38 /opt/librenms/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(35): Illuminate\Container\BoundMethod::callBoundMethod()
#39 /opt/librenms/vendor/laravel/framework/src/Illuminate/Container/Container.php(836): Illuminate\Container\BoundMethod::call()
#40 /opt/librenms/vendor/laravel/framework/src/Illuminate/Console/Command.php(211): Illuminate\Container\Container->call()
#41 /opt/librenms/vendor/symfony/console/Command/Command.php(318): Illuminate\Console\Command->execute()
#42 /opt/librenms/vendor/laravel/framework/src/Illuminate/Console/Command.php(180): Symfony\Component\Console\Command\Command->run()
#43 /opt/librenms/vendor/symfony/console/Application.php(1110): Illuminate\Console\Command->run()
#44 /opt/librenms/vendor/symfony/console/Application.php(359): Symfony\Component\Console\Application->doRunCommand()
#45 /opt/librenms/vendor/symfony/console/Application.php(194): Symfony\Component\Console\Application->doRun()
#46 /opt/librenms/vendor/laravel/framework/src/Illuminate/Foundation/Console/Kernel.php(197): Symfony\Component\Console\Application->run()
#47 /opt/librenms/lnms(35): Illuminate\Foundation\Console\Kernel->handle()
#48 {main}  


Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
