### PR TITLE
Fix the ports_page_default setting

### DIFF
--- a/app/Http/Controllers/Device/Tabs/PortsController.php
+++ b/app/Http/Controllers/Device/Tabs/PortsController.php
@@ -290,7 +290,7 @@ class PortsController implements DeviceTab
     {
         $tabs = [
             ['name' => __('Basic'), 'url' => 'basic'],
-            ['name' => __('Detail'), 'url' => ''],
+            ['name' => __('Detail'), 'url' => 'detail'],
         ];
 
         if ($device->macs()->exists()) {
@@ -422,7 +422,7 @@ class PortsController implements DeviceTab
             };
         }
 
-        return $request->route('vars', 'detail'); // fourth segment is called vars to handle legacy urls
+        return $request->route('vars', LibrenmsConfig::get('ports_page_default')); // fourth segment is called vars to handle legacy urls
     }
 
     private function pageLinks(Request $request): array

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -830,6 +830,9 @@ return [
             'description' => 'Memcached port',
             'help' => 'The port for the memcached server. Default is 11211',
         ],
+        'enable_ports_etherlike' => [
+            'description' => 'Enable etherlike graphs for ports',
+        ],
         'email_auto_tls' => [
             'description' => 'Auto TLS support',
             'help' => 'Tries to use TLS before falling back to un-encrypted',
@@ -1798,6 +1801,10 @@ return [
         'ports_nac_purge' => [
             'description' => 'Port NAC entries older than',
             'help' => 'Cleanup done by daily.sh',
+        ],
+        'ports_page_default' => [
+            'description' => 'Default ports tab',
+            'help' => 'Default tab to open when viewing ports on the device page',
         ],
         'ports_purge' => [
             'description' => 'Purge ports deleted',

--- a/resources/definitions/config_definitions.json
+++ b/resources/definitions/config_definitions.json
@@ -2243,6 +2243,9 @@
             "type": "boolean"
         },
         "enable_ports_etherlike": {
+            "group": "webui",
+            "section": "device",
+            "order": 22,
             "default": false,
             "type": "boolean"
         },
@@ -6292,11 +6295,14 @@
             "type": "integer"
         },
         "ports_page_default": {
-            "default": "details",
+            "default": "detail",
             "type": "select",
+            "group": "webui",
+            "section": "device",
+            "order": 21,
             "options":{
                 "basic": "Basic",
-                "details": "Details",
+                "detail": "Details",
                 "arp": "ARP",
                 "fdb": "FDB"
             }

--- a/resources/views/device/tabs/ports.blade.php
+++ b/resources/views/device/tabs/ports.blade.php
@@ -3,7 +3,7 @@
 @section('content')
     <x-device.page :device="$device" :dropdown-links="$data['dropdownLinks'] ?? []">
     @isset($data['submenu'])
-        <x-submenu :title="$title" :menu="$data['submenu']" :device-id="$device->device_id" :current-tab="$current_tab" :selected="$vars" />
+        <x-submenu :title="$title" :menu="$data['submenu']" :device-id="$device->device_id" :current-tab="$current_tab" :selected="$data['tab']" />
     @endisset
 
     @includeFirst(['device.tabs.ports.' . $data['tab'], 'device.tabs.ports.detail'])


### PR DESCRIPTION
 - Update the route request to use the setting if it is not provided in $vars
 - Update the port blade to use the calculated tab value instead of $vars
 - Expose the existing option in the global configuration page

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
