### PR TITLE
World Map widget, respect network_map_worldmap_show_disabled_alerts

### DIFF
--- a/app/Http/Controllers/Widgets/WorldMapController.php
+++ b/app/Http/Controllers/Widgets/WorldMapController.php
@@ -53,6 +53,7 @@ class WorldMapController extends WidgetController
         $settings = $this->getSettings();
         $settings['dimensions'] = $request->get('dimensions');
         $settings['status'] = array_map('intval', explode(',', $settings['status']));
+        $settings['disabled_alerts'] = LibrenmsConfig::get('network_map_worldmap_show_disabled_alerts') ? null : 0; // null to include 1 shows only notify disabled
         $settings['map_config'] = [
             'engine' => LibrenmsConfig::get('geoloc.engine'),
             'api_key' => LibrenmsConfig::get('geoloc.api_key'),

--- a/resources/definitions/config_definitions.json
+++ b/resources/definitions/config_definitions.json
@@ -5386,7 +5386,7 @@
             "default": "xdp",
             "group": "webui",
             "section": "worldmap",
-            "order": 3,
+            "order": 2,
             "type": "select",
             "options": {
                 "xdp": "CDP/LLDP Neighbours",
@@ -5403,7 +5403,7 @@
             "type": "boolean",
             "group": "webui",
             "section": "worldmap",
-            "order": 2
+            "order": 10
         },
         "nfdump": {
             "default": "/usr/bin/nfdump",

--- a/resources/views/widgets/world-map.blade.php
+++ b/resources/views/widgets/world-map.blade.php
@@ -5,6 +5,7 @@
         const map_id = 'worldmap_widget-{{ $id }}';
         const status = {{ Js::from($status) }};
         const device_group = {{ (int) $device_group }};
+        const disabled_alerts = {{ Js::from($disabled_alerts) }};
         const map_config = {{ Js::from($map_config) }};
         const group_radius = {{ (int) $group_radius }};
 
@@ -13,7 +14,7 @@
                 type: "POST",
                 url: '{{ route('maps.getdevices') }}',
                 dataType: "json",
-                data: { location_valid: 1, disabled: 0, disabled_alerts: 0, statuses: status, group: device_group },
+                data: { location_valid: 1, disabled: 0, disabled_alerts: disabled_alerts, statuses: status, group: device_group },
                 success: function (data) {
                     var markers = Object.values(data).map((device) => {
                         var deviceMarker = L.AwesomeMarkers.icon({


### PR DESCRIPTION
Note that this flips the previous behavior because the default for this setting is true and the widget was always false before.

Also, re-order settings in webui so they make more sense

fixes #18328

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
