### PR TITLE
Get rid of dashboard white tint

### DIFF
--- a/html/css/styles.css
+++ b/html/css/styles.css
@@ -1430,11 +1430,6 @@ nav.navbar-sticky-top {
 
 .gridster {
     margin: 0 auto;
-    -webkit-transition: opacity .6s;
-    -moz-transition: opacity .6s;
-    -o-transition: opacity .6s;
-    -ms-transition: opacity .6s;
-    transition: opacity .6s;
 }
 
 .gridster .gs-w {


### PR DESCRIPTION
Everything on the dashboard looks whiter than it should. This is especially noticeable when using a map with satellite view.

Based on the spacing above/below the opacity line (see commit of this pull request), this seems to be a debugging thing from 10 years ago when the dashboard was initially created.

### Before the change:
<img width="2560" height="1305" alt="chrome_i9fj1RL1L3" src="https://github.com/user-attachments/assets/49a73cfa-7869-41db-ac61-e3ba7b282671" />

### After this change:
<img width="2560" height="1305" alt="chrome_cweBkBmkuF" src="https://github.com/user-attachments/assets/b4a29d7f-6ad2-4c35-a660-771be1b081b7" />

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
