### PR TITLE
Reduce DNS queries, use cached IP

### DIFF
--- a/LibreNMS/Data/Source/NetSnmpQuery.php
+++ b/LibreNMS/Data/Source/NetSnmpQuery.php
@@ -353,7 +353,7 @@ class NetSnmpQuery implements SnmpQueryInterface
             array_push($cmd, '-r', $retries);
         }
 
-        $hostname = Rewrite::addIpv6Brackets((string) ($this->device->overwrite_ip ?: $this->device->hostname));
+        $hostname = Rewrite::addIpv6Brackets($this->device->pollerTarget());
         $cmd[] = ($this->device->transport ?? 'udp') . ':' . $hostname . ':' . $this->device->port;
 
         return array_merge($cmd, $oids);

--- a/app/Jobs/PingCheck.php
+++ b/app/Jobs/PingCheck.php
@@ -121,7 +121,7 @@ class PingCheck implements ShouldQueue
         // just add any left over
         $ordered_device_list = $ordered_device_list->merge($pending_children);
 
-        return $ordered_device_list->map(fn (Device $device) => $device->overwrite_ip ?: $device->hostname)->all();
+        return $ordered_device_list->map(fn (Device $device) => $device->pollerTarget())->all();
     }
 
     /**
@@ -134,7 +134,7 @@ class PingCheck implements ShouldQueue
         }
 
         $query = Device::canPing()
-            ->select(['devices.device_id', 'hostname', 'overwrite_ip', 'status', 'status_reason', 'last_ping', 'last_ping_timetaken'])
+            ->select(['devices.device_id', 'hostname', 'ip', 'overwrite_ip', 'status', 'status_reason', 'last_ping', 'last_ping_timetaken'])
             ->with([
                 'parents' => function ($q): void {
                     $q->canPing()->select('devices.device_id');
@@ -149,7 +149,7 @@ class PingCheck implements ShouldQueue
             $query->whereIntegerInRaw('poller_group', $this->groups);
         }
 
-        $this->devices = $query->get()->keyBy(fn ($device) => $device->overwrite_ip ?: $device->hostname);
+        $this->devices = $query->get()->keyBy(fn (Device $device) => $device->pollerTarget());
 
         return $this->devices;
     }

--- a/app/Models/Device.php
+++ b/app/Models/Device.php
@@ -117,7 +117,7 @@ class Device extends BaseModel
 
     public function pollerTarget(): string
     {
-        return ($this->overwrite_ip ?: $this->hostname) ?: '';
+        return $this->overwrite_ip ?: $this->ip ?: $this->hostname ?: '';
     }
 
     public function ipFamily(): AddressFamily


### PR DESCRIPTION
Use IP from dns lookup at start of every poll
Should allow polling to continue to work in event of a DNS outage too. Needs testing

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
