### PR TITLE
lnms device:discovery -> respect poller_group

### DIFF
--- a/app/Jobs/DiscoverDevice.php
+++ b/app/Jobs/DiscoverDevice.php
@@ -78,7 +78,6 @@ class DiscoverDevice implements ShouldQueue
             $this->deviceArray['os_group'] = $os_group;
         }
 
-
         Log::info(sprintf(<<<'EOH'
 Hostname:  %s %s
 ID:        %s
@@ -88,12 +87,13 @@ IP:        %s
 EOH, $this->device->hostname, $os_group ? " ($os_group)" : '', $this->device->device_id, $this->device->os, $this->device->ip));
 
         $poller_group = \App\Facades\LibrenmsConfig::get('distributed_poller_group');
-        if (!empty($poller_group) && $this->device->poller_group != $poller_group) {
+        if (! empty($poller_group) && $this->device->poller_group != $poller_group) {
             Log::info("Device does not belong in poller group: $poller_group\n");
+
             return false;
         }
 
-    return true;
+        return true;
     }
 
     private function discoverModules(): void


### PR DESCRIPTION
in case of distributed pollers, LNMS device:discovery should honor `poller_group`

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
