### PR TITLE
Update the device_stats migration to make the timestamp field nullable

### DIFF
--- a/database/migrations/2025_05_28_092148_create_device_stats.php
+++ b/database/migrations/2025_05_28_092148_create_device_stats.php
@@ -16,7 +16,7 @@ return new class extends Migration
             $table->id();
             $table->timestamps();
             $table->unsignedInteger('device_id')->unique();
-            $table->timestamp('ping_last_timestamp');
+            $table->timestamp('ping_last_timestamp')->nullable();
             $table->float('ping_rtt_last')->unsigned()->nullable();
             $table->float('ping_rtt_prev')->unsigned()->nullable();
             $table->float('ping_rtt_avg')->unsigned()->nullable();

--- a/database/migrations/2025_11_26_170658_set_device_stats_timestamp_nullable.php
+++ b/database/migrations/2025_11_26_170658_set_device_stats_timestamp_nullable.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('device_stats', function (Blueprint $table) {
+            $table->timestamp('ping_last_timestamp')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        // No rollback - the original migration has also been changed to make this field nullable
+    }
+};

--- a/resources/definitions/schema/db_schema.yaml
+++ b/resources/definitions/schema/db_schema.yaml
@@ -739,7 +739,7 @@ device_stats:
     - { Field: created_at, Type: timestamp, 'Null': true, Extra: '' }
     - { Field: updated_at, Type: timestamp, 'Null': true, Extra: '' }
     - { Field: device_id, Type: 'int unsigned', 'Null': false, Extra: '' }
-    - { Field: ping_last_timestamp, Type: timestamp, 'Null': false, Extra: '' }
+    - { Field: ping_last_timestamp, Type: timestamp, 'Null': true, Extra: '' }
     - { Field: ping_rtt_last, Type: 'double unsigned', 'Null': true, Extra: '' }
     - { Field: ping_rtt_prev, Type: 'double unsigned', 'Null': true, Extra: '' }
     - { Field: ping_rtt_avg, Type: 'double unsigned', 'Null': true, Extra: '' }


### PR DESCRIPTION
Fix for #18566

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
