### PR TITLE
cisco-entity-sensors: Avoid DivisionByZeroError

### DIFF
--- a/includes/discovery/sensors/cisco-entity-sensor.inc.php
+++ b/includes/discovery/sensors/cisco-entity-sensor.inc.php
@@ -92,7 +92,7 @@ if ($device['os_group'] == 'cisco') {
                 $type = $entitysensor[$entry['entSensorType']];
 
                 // Try to handle the scale
-                [$divisor, $multiplier] = match ($entry['entPhySensorScale']) {
+                [$divisor, $multiplier] = match ($entry['entSensorScale']) {
                     'zepto' => [1000000000000000000, 1],
                     'nano' => [1000000000, 1],
                     'micro' => [1000000, 1],


### PR DESCRIPTION
Please give a short description what your pull request is for

Fixes the same divide by zero error in Cisco entity sensors as https://github.com/librenms/librenms/pull/16464 does generically

Also tidies up the code in the same way

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
