### PR TITLE
Fix graph type dropdown

### DIFF
--- a/includes/common.php
+++ b/includes/common.php
@@ -281,25 +281,29 @@ function is_client_authorized($clientip)
 /*
  * @return an array of all graph subtypes for the given type
  */
-function get_graph_subtypes($type, $device = null)
+function get_graph_subtypes(string $type): array
 {
-    $type = basename((string) $type);
+    $dir = base_path('includes/html/graphs/' . basename($type));
+
+    if (! is_dir($dir)) {
+        return [];
+    }
+
     $types = [];
 
-    // find the subtypes defined in files
-    if ($handle = opendir(LibrenmsConfig::get('install_dir') . "/includes/html/graphs/$type/")) {
-        while (false !== ($file = readdir($handle))) {
-            if ($file != '.' && $file != '..' && $file != 'auth.inc.php' && strstr($file, '.inc.php')) {
-                $types[] = str_replace('.inc.php', '', $file);
+    foreach (new DirectoryIterator($dir) as $file) {
+        if ($file->isFile() && str_ends_with($file->getFilename(), '.inc.php')) {
+            $name = $file->getBasename('.inc.php');
+            if ($name !== 'auth') {
+                $types[] = $name;
             }
         }
-        closedir($handle);
     }
 
     sort($types);
 
     return $types;
-} // get_graph_subtypes
+}
 
 function generate_smokeping_file($device, $file = '')
 {

--- a/includes/html/pages/graphs.inc.php
+++ b/includes/html/pages/graphs.inc.php
@@ -63,20 +63,23 @@ if (! $auth) {
     echo $title;
 
     // FIXME allow switching between types for sensor and wireless also restrict types to ones that have data
-    if ($type != 'sensor' && ! empty($device)) {
-        echo '<div style="float: right;"><form action="">';
-        echo csrf_field();
-        echo "<select name='type' id='type' onchange=\"window.open(this.options[this.selectedIndex].value,'_top')\" class='devices-graphs-select'>";
+    if (! in_array($type, ['sensor', 'wireless'])) {
+        $graph_subtypes = get_graph_subtypes($type);
+        if (count($graph_subtypes) > 1) {
+            echo '<div style="float: right;"><form action="">';
+            echo csrf_field();
+            echo "<select name='type' id='type' onchange=\"window.open(this.options[this.selectedIndex].value,'_top')\" class='devices-graphs-select'>";
 
-        foreach (get_graph_subtypes($type, $device) as $avail_type) {
-            echo "<option value='" . \LibreNMS\Util\Url::generate($vars, ['type' => $type . '_' . $avail_type, 'page' => 'graphs']) . "'";
-            if ($avail_type == $subtype) {
-                echo ' selected';
+            foreach ($graph_subtypes as $avail_type) {
+                echo "<option value='" . \LibreNMS\Util\Url::generate($vars, ['type' => $type . '_' . $avail_type, 'page' => 'graphs']) . "'";
+                if ($avail_type == $subtype) {
+                    echo ' selected';
+                }
+                $display_type = \LibreNMS\Util\StringHelpers::niceCase($avail_type);
+                echo ">$display_type</option>";
             }
-            $display_type = \LibreNMS\Util\StringHelpers::niceCase($avail_type);
-            echo ">$display_type</option>";
+            echo '</select></form></div>';
         }
-        echo '</select></form></div>';
     }
 
     print_optionbar_end();


### PR DESCRIPTION
for non-"device" graphs
remove dropdown for wireless (and keep it removed for sensors) Keeping the sensor id and switching the graph type makes no sense.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
