### PR TITLE
feat: Add `/var/snap` to ignored mounts (ignore Ubuntu snaps)

### DIFF
--- a/resources/definitions/config_definitions.json
+++ b/resources/definitions/config_definitions.json
@@ -4609,8 +4609,7 @@
                 "/dev",
                 "/compat/linux/proc",
                 "/compat/linux/sys",
-                "/sys/fs/cgroup",
-                "/var/snap"
+                "/sys/fs/cgroup"
             ],
             "type": "array"
         },

--- a/resources/definitions/os_detection/linux.yaml
+++ b/resources/definitions/os_detection/linux.yaml
@@ -28,3 +28,4 @@ discovery:
 ignore_mount_regexp:
     - '#^/run($|/)#'
     - '#^/dev/shm$#'
+    - '#^/var/snap/#'


### PR DESCRIPTION
Ubuntu Snaps create mounts for each program (e.g., firefox). I can't imagine why anyone would really want to track those mounts as storage devices. Hence, this PR ignores them.

This is alongside similar ignores like `/mnt/cdrom`, `/compat/linux/proc`, etc.

The full path of the mount I'm ignoring on Ubuntu 24 is `/var/snap/firefox/common/host-hunspell`

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
