### PR TITLE
Update RRD graph code to use the option array natively

### DIFF
--- a/LibreNMS/Data/Store/Rrd.php
+++ b/LibreNMS/Data/Store/Rrd.php
@@ -611,7 +611,7 @@ class Rrd extends BaseDatastore
             return $process->getOutput();
         }
 
-        // Check if a valid image was returned in the output
+        // if valid image is returned with error, extract image and feedback
         // rrdtool defaults to png if imgformat not specified
         $imgformat_option = array_find($options, fn ($o) => str_starts_with((string) $o, '--imgformat='));
         $graph_type = $imgformat_option ? strtolower(substr((string) $imgformat_option, 12)) : 'png';


### PR DESCRIPTION
Update the RRD graph code to user the options array natively instead of converting to a quoted string and piping to rrdtool.

In my testing this gives a performance boost for generating graph images.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
