### PR TITLE
Fixed $rrd_options must be an array

### DIFF
--- a/LibreNMS/Util/Graph.php
+++ b/LibreNMS/Util/Graph.php
@@ -168,8 +168,7 @@ class Graph
             throw new RrdGraphException('Graph Definition Error', 'Def Error', $width, $height);
         }
 
-        $graph_params_array = explode(' ', $graph_params);
-        $rrd_options = array_merge($graph_params_array, $rrd_options);
+        array_push($rrd_options, ...$graph_params->toRrdOptions());
 
         // Generating the graph!
         try {


### PR DESCRIPTION
Graph retrieve API was broken because rrd_options were a string in Graph.php, it was made an array everywhere except here.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
