### PR TITLE
Fix device active tab underline in dark mode

### DIFF
--- a/html/css/tw_dark.css
+++ b/html/css/tw_dark.css
@@ -543,7 +543,7 @@
 .dark .nav .open > a:hover,
 .dark .nav .open > a:focus {
     background-color: #3e444c;
-    border-color: #fff
+    border-color: rgba(0, 0, 0, 0.6)
 }
 
 .dark .nav-tabs {
@@ -564,6 +564,7 @@
     color: #fff;
     background-color: #3e444c;
     border-color: #1c1e22;
+    border-bottom-color: rgba(0, 0, 0, 0.2);
 }
 
 @media (min-width: 768px) {
@@ -1098,18 +1099,6 @@
     border-left-color: #2e3338;
 }
 
-.dark .navbar .navbar-nav > li > a:hover {
-    border-left-color: transparent
-}
-
-.dark .navbar .nav .open > a {
-    border-color: transparent
-}
-
-.dark .navbar-nav > li.active > a {
-    border-left-color: transparent
-}
-
 .dark .table .success,
 .dark .table .warning,
 .dark .table .danger,
@@ -1192,12 +1181,6 @@
     background-color: #3a3f44;
     color: #fff;
     border-color: rgba(0, 0, 0, 0.6);
-}
-
-.dark .nav .open > a,
-.dark .nav .open > a:hover,
-.dark .nav .open > a:focus {
-    border-color: rgba(0, 0, 0, 0.6)
 }
 
 .dark .pagination > li.disabled > a,


### PR DESCRIPTION
remove some other unused css

new:
<img width="189" height="57" alt="image" src="https://github.com/user-attachments/assets/356cd512-f88b-4e89-aa0c-5c330bd4dccd" />


old:
<img width="189" height="57" alt="image" src="https://github.com/user-attachments/assets/88095d0b-327c-4ce8-84eb-00c1b988df29" />


#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
