### PR TITLE
feat: configure PHP and Python redis clients to use TLS when REDIS_SCHEME=tls

### DIFF
--- a/LibreNMS/queuemanager.py
+++ b/LibreNMS/queuemanager.py
@@ -219,6 +219,7 @@ class QueueManager:
                 sentinel=self.config.redis_sentinel,
                 sentinel_service=self.config.redis_sentinel_service,
                 socket_timeout=self.config.redis_timeout,
+                ssl=(self.config.redis_scheme == "tls"),
             )
 
         except ImportError:

--- a/LibreNMS/service.py
+++ b/LibreNMS/service.py
@@ -90,6 +90,7 @@ class ServiceConfig(DBConfig):
 
     redis_host = "localhost"
     redis_port = 6379
+    redis_scheme = "tcp"
     redis_db = 0
     redis_user = None
     redis_pass = None
@@ -220,6 +221,9 @@ class ServiceConfig(DBConfig):
         )
         self.redis_port = int(
             os.getenv("REDIS_PORT", config.get("redis_port", ServiceConfig.redis_port))
+        )
+        self.redis_scheme = os.getenv(
+            "REDIS_SCHEME", config.get("redis_scheme", ServiceConfig.redis_scheme)
         )
         self.redis_socket = os.getenv(
             "REDIS_SOCKET", config.get("redis_socket", ServiceConfig.redis_socket)
@@ -708,6 +712,7 @@ class Service:
                 sentinel=self.config.redis_sentinel,
                 sentinel_service=self.config.redis_sentinel_service,
                 socket_timeout=self.config.redis_timeout,
+                ssl=(self.config.redis_scheme == "tls"),
             )
         except ImportError:
             if self.config.distributed:

--- a/config/database.php
+++ b/config/database.php
@@ -140,6 +140,7 @@ return [
         ],
 
         'cache' => [
+            'scheme' => env('REDIS_SCHEME', 'tcp'),
             'url' => env('REDIS_URL'),
             'host' => env('REDIS_HOST', '127.0.0.1'),
             'username' => env('REDIS_USERNAME'),


### PR DESCRIPTION

This pull request is intended to allow for Redis communication over TLS in a poller clustering configuration.

From what we were able to determine, LibreNMS does not currently pick up the procotol to use when communicating with Redis through PhpRedis or redis-py.

The current PR uses the environment variable REDIS_SCHEME, which is already supported by the Laravel framework to set the appropriate communication flags when the "tls" scheme is specified.
Our company has tested this internally against an Amazon Elasticache instance with encryption enabled and communications seems to work properly. 

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
