### PR TITLE
Replace backticks with shell_exec for command execution (partial fix for #18539)

### DIFF
--- a/app/ConfigRepository.php
+++ b/app/ConfigRepository.php
@@ -529,7 +529,7 @@ class ConfigRepository
     public function locateBinary($binary): mixed
     {
         if (! Str::contains($binary, '/')) {
-            $output = `whereis -b $binary`;
+            $output = shell_exec("whereis -b $binary");
             $list = trim(substr((string) $output, strpos((string) $output, ':') + 1));
             $targets = explode(' ', $list);
             foreach ($targets as $target) {


### PR DESCRIPTION
Partial fix for issue #18539

Fixes backtick-deprecation in [app/ConfigRepository.php](https://github.com/CKeckNorthIO/librenms/commit/eac1a2c2476c8e69dfd544140545906e2c09e756#diff-a57300d7186511082942fec64430a57e4c023d5d2f4925b766f971608452233c) for php 8.5.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
