### PR TITLE
Fix for generic_data graphs for non-port graphs

### DIFF
--- a/includes/html/graphs/generic_data.inc.php
+++ b/includes/html/graphs/generic_data.inc.php
@@ -30,11 +30,15 @@ $rrd_filename_in ??= $rrd_filename ?? '';
 if ($inverse) {
     $in = 'out';
     $out = 'in';
-    [$ingress_speed, $egress_speed] = PortCache::get($port['port_id'])->getSpeeds();
+    if ($port) {
+        [$ingress_speed, $egress_speed] = PortCache::get($port['port_id'])->getSpeeds();
+    }
 } else {
     $in = 'in';
     $out = 'out';
-    [$egress_speed, $ingress_speed] = PortCache::get($port['port_id'])->getSpeeds();
+    if ($port) {
+        [$egress_speed, $ingress_speed] = PortCache::get($port['port_id'])->getSpeeds();
+    }
 }
 $stacked = generate_stacked_graphs(($egress_speed || $ingress_speed) && ($vars['port_speed_zoom'] ?? LibrenmsConfig::get('graphs.port_speed_zoom')));
 


### PR DESCRIPTION
This PR fixes a bug introduced in commit 863be6c00c3a95535a400e744ce70164e4bff447 by testing that a port is being graphed before fetching the speeds from the port.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
