### PR TITLE
Update HV Monitor.md Debian dependencies

### DIFF
--- a/doc/Extensions/Applications/HV Monitor.md
+++ b/doc/Extensions/Applications/HV Monitor.md
@@ -14,7 +14,7 @@ or [MetaCPAN](https://metacpan.org/dist/HV-Monitor).
 
     === "Debian/Ubuntu"
         ```bash
-        apt-get install libjson-perl libmime-base64-perl cpanminus
+        apt-get install libjson-perl libmime-base64-perl cpanminus net-tools
         cpanm HV::Monitor
         ```
 


### PR DESCRIPTION
Add `net-tools` dependency.

`ifconfig` is not available by default on Debian 13 at least, resulting in `sh: 1: ifconfig: not found` when running `hv_monitor`.  Somewhere the script tries to run `execve("/bin/sh", ["sh", "-c", "ifconfig | grep '^[A-Za-z]' | cu"...]`

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [✔︎] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
