### PR TITLE
Add support for Cisco FTD 4245.

### DIFF
--- a/mibs/cisco/CISCO-PRODUCTS-MIB
+++ b/mibs/cisco/CISCO-PRODUCTS-MIB
@@ -2720,6 +2720,7 @@ ciscoC9300X12Y                       OBJECT IDENTIFIER ::= { ciscoProducts 3037 
 ciscoC9300X24Y                       OBJECT IDENTIFIER ::= { ciscoProducts 3038 } -- Catalyst 9300X Pacman 24 ports Catalyst 9300X switch 
 ciscoC9300X48HX                      OBJECT IDENTIFIER ::= { ciscoProducts 3039 } -- Catalyst 9300X 48 ports mGig with 90W POE Catalyst 9300X switch
 ciscoC9300X48TX                      OBJECT IDENTIFIER ::= { ciscoProducts 3040 } -- Catalyst 9300X 48 ports mGig 9300X switch
+ciscoFpr4245SM79                    OBJECT IDENTIFIER ::= { ciscoProducts 3041 } -- Cisco Secure Firewall 4245 Threat Defense Module 79
 ciscoISR1100X4G                     OBJECT IDENTIFIER ::= { ciscoProducts 3045 } -- Cisco ISR1100X-4G ( 4xGE, Flexible Core, 8G FLASH, 8G DRAM)
 ciscoISR1100X6G                     OBJECT IDENTIFIER ::= { ciscoProducts 3046 } -- Cisco ISR1100X-6G ( 4xGE, 2xSFP, Flexible Core, 8G FLASH, 8G DRAM)
 ciscoESS930010XE                    OBJECT IDENTIFIER ::= { ciscoProducts 3047 } -- Catalyst ESS9300 Embedded Series switch - 10p 10G, NE

--- a/resources/definitions/os_detection/ftd.yaml
+++ b/resources/definitions/os_detection/ftd.yaml
@@ -28,6 +28,7 @@ discovery:
             - .1.3.6.1.4.1.9.1.2294 # { ciscoProducts 2294 } -- Cisco FirePOWER 4120 Security Appliance, 1U with embedded security
             - .1.3.6.1.4.1.9.1.2778 # { ciscoProducts 2778 } -- Cisco FirePOWER 4125 Security Appliance, 1U with embedded security
             - .1.3.6.1.4.1.9.1.2870 # { ciscoProducts 2870 } -- Cisco FirePOWER 1150 Security Appliance, 1U with embedded security
+            - .1.3.6.1.4.1.9.1.3041 # { ciscoProducts 3041 } -- Cisco Secure Firewall 4245 Threat Defense Module 79
             - .1.3.6.1.4.1.9.1.3053 # { ciscoProducts 3053 } -- Cisco Secure Firewall 3110 Security Appliance
             - .1.3.6.1.4.1.9.1.3054 # { ciscoProducts 3054 } -- Cisco Secure Firewall 3120 Security Appliance
             - .1.3.6.1.4.1.9.1.3055 # { ciscoProducts 3055 } -- Cisco Secure Firewall 3130 Security Appliance


### PR DESCRIPTION
Add the sOID for the Cisco Firepower Threat Defense 4245 to the list of FTD sOIDs and update the CISCO-PRODUCTS-MIB with its entry.

<img width="824" height="222" alt="ftd4245" src="https://github.com/user-attachments/assets/3525d51a-2728-47fa-a423-c65614768f51" />

I've seen other PRs for FTD support, so I hope this will be sufficient.  But let me know if I need to add more stuff.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
