### PR TITLE
Fix MTU alert rule

### DIFF
--- a/resources/definitions/alert_rules.json
+++ b/resources/definitions/alert_rules.json
@@ -15,7 +15,7 @@
     "notes": "Device may responds on ICMP but not on SNMP."
   },
   {
-    "builder": {"condition":"AND","rules":[{"id":"devices.mtu_status","field":"devices.mtu_status","type":"integer","input":"text","operator":"equal","value":"1"}],"valid":true},
+    "builder": {"condition":"AND","rules":[{"id":"devices.mtu_status","field":"devices.mtu_status","type":"integer","input":"text","operator":"equal","value":"0"}],"valid":true},
     "name": "Device MTU issues",
     "notes": "Device is online but large packets are failing."
   },


### PR DESCRIPTION
The MTU alert rule needs to be reversed (0=bad, 1=OK).

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
