### PR TITLE
Fix packet size calculation for MTU test

### DIFF
--- a/app/Actions/Device/DeviceMtuTest.php
+++ b/app/Actions/Device/DeviceMtuTest.php
@@ -27,7 +27,7 @@ class DeviceMtuTest
             return true;
         }
 
-        $bytes = $this->bytes > 8 ? $this->bytes - 8 : $this->bytes;
+        $bytes = $this->bytes > 28 ? $this->bytes - 28 : $this->bytes;
 
         $cmd = array_merge(LibrenmsConfig::fpingCommand($device->ipFamily()), [
             '-q',


### PR DESCRIPTION
FPing does not include the 20 byte IP or 8 byte ICMP headers when specifying the bytes.  This PR changes the packet size adjustment to 28 bytes so the packet size specified in the MTU config option matches the packet data on the wire.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
