### PR TITLE
Service last_changed time display bug fix

### DIFF
--- a/includes/html/pages/device/services.inc.php
+++ b/includes/html/pages/device/services.inc.php
@@ -86,17 +86,13 @@ if (count($services) > '0') {
             $status_label = 'label-info';
         }
 
-        if ($service['service_changed'] == '0') {
-            $service['service_changed'] = time();
-        }
-
         echo '<tr id="row_' . $service['service_id'] . '">';
         echo '<td class="col-sm-2"><span class="alert-status ' . $status_label . '"><span class="device-services-page text-nowrap">' . htmlentities((string) $service['service_name']) . '</span></span></td>';
         echo '<td class="col-sm-1 text-muted">' . htmlentities((string) $service['service_type']) . '</td>';
         echo '<td class="col-sm-1 text-muted">' . nl2br(htmlentities((string) $service['service_ip'])) . '</td>';
         echo '<td class="col-sm-4">' . nl2br(htmlentities(trim((string) $service['service_message']))) . '</td>';
         echo '<td class="col-sm-2 text-muted">' . htmlentities((string) $service['service_desc']) . '</td>';
-        echo '<td class="col-sm-1 text-muted">' . \LibreNMS\Util\Time::formatInterval(time() - $service['service_changed']) . '</td>';
+        echo '<td class="col-sm-1 text-muted">' . ($service['service_changed'] ? \LibreNMS\Util\Time::formatInterval(time() - $service['service_changed']) : 'Waiting for first service check') . '</td>';
         echo '<td class="col-sm-1">';
         if (Auth::user()->hasGlobalAdmin()) {
             echo '<div class="pull-right">';

--- a/includes/html/pages/services.inc.php
+++ b/includes/html/pages/services.inc.php
@@ -157,10 +157,6 @@ require_once 'includes/html/modal/delete_service.inc.php';
                             $label = 'label-info';
                             $title = 'UNKNOWN';
                         }
-                        
-                        if ($service['service_changed'] == '0') {
-                            $service['service_changed'] = time();
-                        }
 
                         $service_iteration++;
 
@@ -191,7 +187,7 @@ require_once 'includes/html/modal/delete_service.inc.php';
                         echo '<td>' . nl2br(\LibreNMS\Util\Clean::html($service['service_ip'], [])) . '</td>';
                         echo '<td>' . nl2br(\LibreNMS\Util\Clean::html($service['service_message'], [])) . '</td>';
                         echo '<td>' . nl2br(\LibreNMS\Util\Clean::html($service['service_desc'], [])) . '</td>';
-                        echo '<td>' . \LibreNMS\Util\Time::formatInterval(time() - $service['service_changed']) . '</td>';
+                        echo '<td>' . ($service['service_changed'] ? \LibreNMS\Util\Time::formatInterval(time() - $service['service_changed']) : 'Waiting for first service check') . '</td>';
 
                         $service_checked = '';
                         $ico = 'pause';


### PR DESCRIPTION
Currently when a new service is added to a device, the initial value in the service_changed database field will be 0.

Until the service changes status, the "last changed" field on the gui  will display time sync epoch (eg 55 years)

This is a bit of a band-aid fix, perhaps the best way to fix would be during service discovery or addition should set it to current time?
before:
<img width="1880" height="115" alt="Screenshot 2025-12-18 134917" src="https://github.com/user-attachments/assets/5aea124f-89b8-4990-900b-9ff51575bd6b" />

after:
<img width="1892" height="189" alt="Screenshot 2025-12-18 134948" src="https://github.com/user-attachments/assets/6cbfe2fe-e8e4-46a9-956f-03f1cdf51a5f" />

at least one other person noticed this a few years ago

https://community.librenms.org/t/when-a-new-service-is-checked-the-last-changed-field-shows-51-years/15222


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
