### PR TITLE
Add options to allow MTU test to be configurable

### DIFF
--- a/LibreNMS/Data/Source/Icmp/Fping.php
+++ b/LibreNMS/Data/Source/Icmp/Fping.php
@@ -174,8 +174,14 @@ class Fping
         $args = [
             '-q',
             '-b', (string) $bytes,
-            $host,
         ];
+
+        if(LibrenmsConfig::get('mtu_options.fragmentation', 'pmtu') == 'deny') {
+            $args[] = '-M';
+        };
+
+        $args[] = $host;
+
         $cmd = array_merge($this->fpingCommand($address_family), $args);
 
         Log::debug('[MTU] ' . implode(' ', $cmd) . PHP_EOL);

--- a/LibreNMS/Data/Source/Icmp/Fping.php
+++ b/LibreNMS/Data/Source/Icmp/Fping.php
@@ -176,9 +176,9 @@ class Fping
             '-b', (string) $bytes,
         ];
 
-        if(LibrenmsConfig::get('mtu_options.fragmentation', 'pmtu') == 'deny') {
+        if (LibrenmsConfig::get('mtu_options.fragmentation', 'pmtu') == 'deny') {
             $args[] = '-M';
-        };
+        }
 
         $args[] = $host;
 

--- a/LibreNMS/Data/Source/Icmp/Ping.php
+++ b/LibreNMS/Data/Source/Icmp/Ping.php
@@ -27,6 +27,7 @@
 namespace LibreNMS\Data\Source\Icmp;
 
 use App\Facades\LibrenmsConfig;
+use LibreNMS\Enum\AddressFamily;
 use Log;
 use Symfony\Component\Process\Process;
 
@@ -45,18 +46,18 @@ class Ping
      * @param  string  $host  hostname or ip
      * @param  int  $size  packet size in bytes (headers included)
      */
-    public function testMtu(string $host, int $size): bool
+    public function testMtu(string $host, int $size, AddressFamily $address_family = AddressFamily::IPv4): bool
     {
         $bytes = $size > 28 ? $size - 28 : $size;
 
-        $cmd = [
-            $this->ping_bin,
+        $args = [
             '-c', '1',
             '-M', 'dont',
             '-s', (string) $bytes,
             '-w', '4',
             $host,
         ];
+        $cmd = array_merge($this->pingCommand($address_family), $args);
 
         Log::debug('[MTU] ' . implode(' ', $cmd) . PHP_EOL);
 
@@ -65,5 +66,19 @@ class Ping
         $process->run();
 
         return $process->isSuccessful();
+    }
+
+    /**
+     * Get the fping command for a given address family
+     *
+     * @return string[]
+     */
+    private function pingCommand(?AddressFamily $af = null): array
+    {
+        return match ($af) {
+            AddressFamily::IPv4 => [$this->ping_bin, '-4'],
+            AddressFamily::IPv6 => [$this->ping_bin, '-6'],
+            default => [$this->ping_bin],
+        };
     }
 }

--- a/LibreNMS/Data/Source/Icmp/Ping.php
+++ b/LibreNMS/Data/Source/Icmp/Ping.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * Ping.php
+ *
+ * -Description-
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * @package    LibreNMS
+ * @link       https://librenms.org
+ * @copyright  2026 Steven Wilton
+ * @author     Steven Wilton <swilton@fluentit.au>
+ */
+
+namespace LibreNMS\Data\Source\Icmp;
+
+use App\Facades\LibrenmsConfig;
+use Log;
+use Symfony\Component\Process\Process;
+
+class Ping
+{
+    private readonly string $ping_bin;
+
+    public function __construct()
+    {
+        $this->ping_bin = LibrenmsConfig::get('ping', 'ping');
+    }
+
+    /**
+     * Test MTU by sending a ping with a specific payload size.
+     *
+     * @param  string  $host  hostname or ip
+     * @param  int  $size  packet size in bytes (headers included)
+     */
+    public function testMtu(string $host, int $size): bool
+    {
+        $bytes = $size > 28 ? $size - 28 : $size;
+
+        $cmd = [
+            $this->ping_bin,
+            '-c', '1',
+            '-M', 'dont',
+            '-s', (string) $bytes,
+            '-w', '4',
+            $host,
+        ];
+
+        Log::debug('[MTU] ' . implode(' ', $cmd) . PHP_EOL);
+
+        $process = app()->make(Process::class, ['command' => $cmd]);
+        $process->disableOutput();
+        $process->run();
+
+        return $process->isSuccessful();
+    }
+}

--- a/LibreNMS/Data/Source/Icmp/Ping.php
+++ b/LibreNMS/Data/Source/Icmp/Ping.php
@@ -50,9 +50,15 @@ class Ping
     {
         $bytes = $size > 28 ? $size - 28 : $size;
 
+        $frag = match(LibrenmsConfig::get('mtu_options.fragmentation', 'pmtu')) {
+            'allow' => 'dont',
+            'deny' => 'do',
+            default => 'want',
+        };
+
         $args = [
             '-c', '1',
-            '-M', 'dont',
+            '-M', $frag,
             '-s', (string) $bytes,
             '-w', '4',
             $host,

--- a/LibreNMS/Data/Source/Icmp/Ping.php
+++ b/LibreNMS/Data/Source/Icmp/Ping.php
@@ -50,7 +50,7 @@ class Ping
     {
         $bytes = $size > 28 ? $size - 28 : $size;
 
-        $frag = match(LibrenmsConfig::get('mtu_options.fragmentation', 'pmtu')) {
+        $frag = match (LibrenmsConfig::get('mtu_options.fragmentation', 'pmtu')) {
             'allow' => 'dont',
             'deny' => 'do',
             default => 'want',

--- a/app/Actions/Device/DeviceMtuTest.php
+++ b/app/Actions/Device/DeviceMtuTest.php
@@ -5,15 +5,14 @@ namespace App\Actions\Device;
 use App\Facades\LibrenmsConfig;
 use App\Models\Device;
 use LibreNMS\Data\Source\Icmp\Fping;
+use LibreNMS\Data\Source\Icmp\Ping;
 use LibreNMS\Polling\ConnectivityHelper;
 
 class DeviceMtuTest
 {
     private readonly ?int $bytes;
 
-    public function __construct(
-        private readonly Fping $fping,
-    ) {
+    public function __construct() {
         $this->bytes = LibrenmsConfig::get('mtu_options.bytes');
     }
 
@@ -27,6 +26,10 @@ class DeviceMtuTest
             return true;
         }
 
-        return $this->fping->testMtu($device->pollerTarget(), $this->bytes, $device->ipFamily());
+        if (LibrenmsConfig::get('mtu_options.command', 'fping') == 'ping') {
+            return (new Ping())->testMtu($device->pollerTarget(), $this->bytes);
+        }
+
+        return (new Fping())->testMtu($device->pollerTarget(), $this->bytes, $device->ipFamily());
     }
 }

--- a/app/Actions/Device/DeviceMtuTest.php
+++ b/app/Actions/Device/DeviceMtuTest.php
@@ -27,7 +27,7 @@ class DeviceMtuTest
         }
 
         if (LibrenmsConfig::get('mtu_options.command', 'fping') == 'ping') {
-            return (new Ping())->testMtu($device->pollerTarget(), $this->bytes);
+            return (new Ping())->testMtu($device->pollerTarget(), $this->bytes, $device->ipFamily());
         }
 
         return (new Fping())->testMtu($device->pollerTarget(), $this->bytes, $device->ipFamily());

--- a/app/Actions/Device/DeviceMtuTest.php
+++ b/app/Actions/Device/DeviceMtuTest.php
@@ -11,9 +11,16 @@ use LibreNMS\Polling\ConnectivityHelper;
 class DeviceMtuTest
 {
     private readonly ?int $bytes;
+    private Ping|Fping $tester;
 
-    public function __construct() {
+    public function __construct()
+    {
         $this->bytes = LibrenmsConfig::get('mtu_options.bytes');
+
+        $this->tester = match (LibrenmsConfig::get('mtu_options.command', 'fping')) {
+            'ping' => new Ping(),
+            default => new Fping(),
+        };
     }
 
     public function execute(Device $device): bool
@@ -26,10 +33,6 @@ class DeviceMtuTest
             return true;
         }
 
-        if (LibrenmsConfig::get('mtu_options.command', 'fping') == 'ping') {
-            return (new Ping())->testMtu($device->pollerTarget(), $this->bytes, $device->ipFamily());
-        }
-
-        return (new Fping())->testMtu($device->pollerTarget(), $this->bytes, $device->ipFamily());
+        return $this->tester->testMtu($device->pollerTarget(), $this->bytes, $device->ipFamily());
     }
 }

--- a/app/Actions/Device/DeviceMtuTest.php
+++ b/app/Actions/Device/DeviceMtuTest.php
@@ -11,7 +11,7 @@ use LibreNMS\Polling\ConnectivityHelper;
 class DeviceMtuTest
 {
     private readonly ?int $bytes;
-    private Ping|Fping $tester;
+    private readonly Ping|Fping $tester;
 
     public function __construct()
     {

--- a/app/Actions/Device/DeviceMtuTest.php
+++ b/app/Actions/Device/DeviceMtuTest.php
@@ -17,10 +17,14 @@ class DeviceMtuTest
     {
         $this->bytes = LibrenmsConfig::get('mtu_options.bytes');
 
-        $this->tester = match (LibrenmsConfig::get('mtu_options.command', 'fping')) {
-            'ping' => new Ping(),
-            default => new Fping(),
-        };
+        if (LibrenmsConfig::get('mtu_options.fragmentation', 'pmtu') == 'allow') {
+            $this->tester = new Ping();
+        } else {
+            $this->tester = match (LibrenmsConfig::get('mtu_options.command', 'fping')) {
+                'ping' => new Ping(),
+                default => new Fping(),
+            };
+        }
     }
 
     public function execute(Device $device): bool

--- a/doc/Support/Configuration.md
+++ b/doc/Support/Configuration.md
@@ -768,21 +768,7 @@ without fragmentation. It tests two-way communication. The packets can
 still need fragmentation at any point on the path.
 
 If you have many devices that require fragmentation with the chosen MTU setting and start getting false
-positives, you may need to disable PMTU discovery.  The standard Linux ping can do this with the "-M dont"
-command argument, but fping does not support this.
-
-One option to resolve the false positive alerts is to disable PMTU discovery as follows:
-
-```bash
-echo 1 > /proc/sys/net/ipv4/ip_no_pmtu_disc
-```
-
-You will need to add the following line to `/etc/sysctl.conf` or `/etc/sysctl.d/librenms.conf` to keep the
-setting across reboots.
-
-```
-net.ipv4.ip_no_pmtu_disc = 1
-```
+positives, you should change your system to use the ping command for MTU checks.
 
 ## Auto discovery settings
 

--- a/doc/Support/Configuration.md
+++ b/doc/Support/Configuration.md
@@ -767,6 +767,23 @@ The MTU check does not test whether the packets cross the network
 without fragmentation. It tests two-way communication. The packets can
 still need fragmentation at any point on the path.
 
+If you have many devices that require fragmentation with the chosen MTU setting and start getting false
+positives, you may need to disable PMTU discovery.  The standard Linux ping can do this with the "-M dont"
+command argument, but fping does not support this.
+
+One option to resolve the false positive alerts is to disable PMTU discovery as follows:
+
+```bash
+echo 1 > /proc/sys/net/ipv4/ip_no_pmtu_disc
+```
+
+You will need to add the following line to `/etc/sysctl.conf` or `/etc/sysctl.d/librenms.conf` to keep the
+setting across reboots.
+
+```
+net.ipv4.ip_no_pmtu_disc = 1
+```
+
 ## Auto discovery settings
 
 Read [Auto-Discovery](../Extensions/Auto-Discovery.md).

--- a/doc/Support/Configuration.md
+++ b/doc/Support/Configuration.md
@@ -763,12 +763,20 @@ pings enabled. The setting below enables the MTU check:
 
 To disable the MTU test, set the packet size to null (the default).
 
-The MTU check does not test whether the packets cross the network
-without fragmentation. It tests two-way communication. The packets can
-still need fragmentation at any point on the path.
+The MTU check has 3 options regarding fragmentation.
+- Allow: Will allow any router on the path to fragment the packets as needed
+- PMTU: Will allow routers to signal the poller to fragment the packets
+- Not Allowed: Will prevent any frgmentation
 
-If you have many devices that require fragmentation with the chosen MTU setting and start getting false
-positives, you should change the fragmentation setting to Allow (which will use the ping instead of fping)
+Select the appropriate setting for your network.  The first 2 will make
+sure that packets of the chosen size can traverse the network even if
+fragmentation is required, and will pick up instances where a layer 2
+MTU is dropping packets.  The third option will make sure that the chosen
+packet size can traverse your network end to end.
+
+If you get a lot of intermittent false alerts with PMTU, it is possible
+that you are hitting a rate limit on a router sending the need to fragment
+packets, and you should switch to Allow to resolve the issues.
 
 ## Auto discovery settings
 

--- a/doc/Support/Configuration.md
+++ b/doc/Support/Configuration.md
@@ -768,7 +768,7 @@ without fragmentation. It tests two-way communication. The packets can
 still need fragmentation at any point on the path.
 
 If you have many devices that require fragmentation with the chosen MTU setting and start getting false
-positives, you should change your system to use the ping command for MTU checks.
+positives, you should change the fragmentation setting to Allow (which will use the ping instead of fping)
 
 ## Auto discovery settings
 

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -1532,6 +1532,10 @@ return [
                 'description' => 'MTU test packet size',
                 'help' => 'Size of packets for MTU test in bytes (blank to disable MTU tests)',
             ],
+            'command' => [
+                'description' => 'MTU test command',
+                'help' => 'FPing is good for many systems.  Ping will set the -M dont flag to prevent PMTU discovery, which is not supported by fping.',
+            ],
         ],
         'mydomain' => [
             'description' => 'Primary Domain',
@@ -1694,6 +1698,9 @@ return [
                     'description' => 'Enable user access via dynamic Device Groups',
                 ],
             ],
+        ],
+        'ping' => [
+            'description' => 'Path to ping',
         ],
         'bad_if' => [
             'description' => 'Bad Interface ifDescr',

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -1537,7 +1537,7 @@ return [
             ],
             'fragmentation' => [
                 'description' => 'MTU test packet fragmenataion',
-                'help' => 'Choose how you want to handle packet fragmentaion.  Allow with PMTU will allow packet fragmenation when PTMU discovery works, but may cause false positives if a router throttles PMTU packets.  Allow will allow routers to fragment the packets locally, but only works with the ping command.  Not allowed will ensure that the configured packet size can traverse the network end to end without fragmentation.',
+                'help' => 'Choose how you want to handle packet fragmentaion.  For more information, see the Configuration documentation.',
             ],
         ],
         'mydomain' => [

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -1537,7 +1537,7 @@ return [
             ],
             'fragmentation' => [
                 'description' => 'MTU test packet fragmenataion',
-                'help' => 'Choose how you want to handle packet fragmentaion.  Allow with PMTU will allow packet fragmenation when PTMU discovery works, but may cause false positives if a router throttles PMTU packets.  Allow will allow routers to fragment the packets locally, but only works with the ping command.  Not allowed will ensure that the configured packet size can trverse the network end to end without fragmentation.',
+                'help' => 'Choose how you want to handle packet fragmentaion.  Allow with PMTU will allow packet fragmenation when PTMU discovery works, but may cause false positives if a router throttles PMTU packets.  Allow will allow routers to fragment the packets locally, but only works with the ping command.  Not allowed will ensure that the configured packet size can traverse the network end to end without fragmentation.',
             ],
         ],
         'mydomain' => [

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -1534,7 +1534,10 @@ return [
             ],
             'command' => [
                 'description' => 'MTU test command',
-                'help' => 'FPing is good for many systems.  Ping will set the -M dont flag to prevent PMTU discovery, which is not supported by fping.',
+            ],
+            'fragmentation' => [
+                'description' => 'MTU test packet fragmenataion',
+                'help' => 'Choose how you want to handle packet fragmentaion.  Allow with PMTU will allow packet fragmenation when PTMU discovery works, but may cause false positives if a router throttles PMTU packets.  Allow will allow routers to fragment the packets locally, but only works with the ping command.  Not allowed will ensure that the configured packet size can trverse the network end to end without fragmentation.',
             ],
         ],
         'mydomain' => [

--- a/resources/definitions/config_definitions.json
+++ b/resources/definitions/config_definitions.json
@@ -5374,6 +5374,17 @@
                 "value": "int|nullable|between:9,65535"
             }
         },
+        "mtu_options.command": {
+            "default": "fping",
+            "group": "poller",
+            "section": "mtu",
+            "order": 2,
+            "type": "select",
+            "options": {
+                "fping": "FPing",
+                "ping": "Ping"
+            }
+        },
         "mydomain": {
             "type": "text",
             "group": "discovery",
@@ -5954,6 +5965,13 @@
         },
         "php_memory_limit": {
             "type": "integer"
+        },
+        "ping": {
+            "default": "ping",
+            "group": "external",
+            "section": "binaries",
+            "order": 1,
+            "type": "executable"
         },
         "plugin_dir": {
             "type": "directory"

--- a/resources/definitions/config_definitions.json
+++ b/resources/definitions/config_definitions.json
@@ -5378,11 +5378,31 @@
             "default": "fping",
             "group": "poller",
             "section": "mtu",
-            "order": 2,
+            "order": 3,
             "type": "select",
             "options": {
                 "fping": "FPing",
                 "ping": "Ping"
+            },
+            "when": {
+                "setting": "mtu_options.fragmentation",
+                "operator": "in",
+                "value": [
+                    "pmtu",
+                    "deny"
+                ]
+            }
+        },
+        "mtu_options.fragmentation": {
+            "default": "pmtu",
+            "group": "poller",
+            "section": "mtu",
+            "order": 2,
+            "type": "select",
+            "options": {
+                "pmtu": "Allow with PMTU",
+                "allow": "Allow",
+                "deny": "Not Allowed"
             }
         },
         "mydomain": {


### PR DESCRIPTION
I ran into some issues with fping and the MTU discovery code across a few thousand devices where fragmentation is needed.  This adds some documentation around the fix I needed to apply to my system.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.

