### PR TITLE
Allow to hide totals in availability map

### DIFF
--- a/app/Http/Controllers/Widgets/AvailabilityMapController.php
+++ b/app/Http/Controllers/Widgets/AvailabilityMapController.php
@@ -48,6 +48,7 @@ class AvailabilityMapController extends WidgetController
             'tile_size' => 12,
             'color_only_select' => 0,
             'show_disabled_and_ignored' => 0,
+            'show_totals' => 1,
             'mode_select' => 0,
             'order_by' => LibrenmsConfig::get('webui.availability_map_sort_status') ? 'status' : 'display-name',
             'device_group' => null,

--- a/resources/views/widgets/availability-map.blade.php
+++ b/resources/views/widgets/availability-map.blade.php
@@ -1,3 +1,4 @@
+@if($show_totals)
 @if($device_totals)
 <div class="widget-availability-host">
     <span>{{ __('Total hosts') }}</span>
@@ -24,6 +25,7 @@
 @endif
 
 <br style="clear:both;">
+@endif
 
 @foreach($devices as $row)
     <a href="{{ $row['link'] }}" title="{{$row['tooltip'] }}">

--- a/resources/views/widgets/settings/availability-map.blade.php
+++ b/resources/views/widgets/settings/availability-map.blade.php
@@ -7,6 +7,14 @@
     </div>
 
     <div class="form-group">
+        <label for="show_totals-{{ $id }}" class="control-label">{{ __('Display totals') }}</label>
+        <select class="form-control" name="show_totals" id="show_totals-{{ $id }}">
+            <option value="1" @if($show_totals) selected @endif>{{ __('Show') }}</option>
+            <option value="0" @unless($show_totals) selected @endunless>{{ __('Hide') }}</option>
+        </select>
+    </div>
+
+    <div class="form-group">
         <label for="type-{{ $id }}" class="control-label">{{ __('Display type') }}</label>
         <select class="form-control" name="type" id="type-{{ $id }}" onchange="toggle_availability_type(this, '{{ $id }}');">
             <option value="0" @if($type == 0) selected @endif>{{ __('boxes') }}</option>


### PR DESCRIPTION
Add a setting to the avialability map widget to allow hiding of totals.

Before:

<img width="628" height="167" alt="image" src="https://github.com/user-attachments/assets/ada399ae-e575-4840-9cc5-d4d0b45dd281" />

Setting:

<img width="631" height="194" alt="image" src="https://github.com/user-attachments/assets/2152308b-7b29-4915-964e-2a2725018cac" />

When set to 'Hide':

<img width="631" height="158" alt="image" src="https://github.com/user-attachments/assets/c5fec6e1-9398-4f7b-93f8-b2af42aba803" />


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
