### PR TITLE
devices: improve Adtran AOS and Omnitron iConverter OS detection

### DIFF
--- a/resources/definitions/os_detection/adtran-aos.yaml
+++ b/resources/definitions/os_detection/adtran-aos.yaml
@@ -9,8 +9,4 @@ over:
     - { graph: device_mempool, text: 'Memory Usage' }
 discovery:
     -
-        sysObjectID: .1.3.6.1.4.1.664
-    -
-        sysDescr: 'NetVanta'
-good_if:
-    - EtsecBasedVirtualEthernet1
+        sysObjectID: .1.3.6.1.4.1.664.1.747

--- a/resources/definitions/os_detection/omnitron-iconverter.yaml
+++ b/resources/definitions/os_detection/omnitron-iconverter.yaml
@@ -3,6 +3,8 @@ text: 'Omnitron iConverter'
 type: management
 icon: omnitron
 mib_dir: omnitron
+over:
+    - { graph: device_bits, text: 'Device Traffic' }
 discovery:
     -
         sysObjectID:

--- a/resources/definitions/os_discovery/adtran-aos.yaml
+++ b/resources/definitions/os_discovery/adtran-aos.yaml
@@ -1,16 +1,54 @@
-mib: ADTRAN-AOSCPU
+mib: ADTRAN-MIB
 modules:
+    os:
+        hardware: ADTRAN-MIB::adProdName.0
+        serial: ADTRAN-MIB::adProdSerialNumber.0
+        version: ADTRAN-MIB::adProdSwVersion.0
     mempools:
         data:
             -
-                total: ADTRAN-AOSCPU::adGenAOSMemPool
-                free: ADTRAN-AOSCPU::adGenAOSHeapFree
-    os:
-        hardware: ADTRAN-AOSUNIT::adAOSDeviceProductName.0
-        serial: ADTRAN-AOSUNIT::adAOSDeviceSerialNumber.0
-        version: ADTRAN-AOSUNIT::adAOSDeviceVersion.0
+                total: ADTRAN-GENPROCESSES-MIB::adGenProcessesMemStatHeapSize
+                used: ADTRAN-GENPROCESSES-MIB::adGenProcessesMemStatHeapUsed
     processors:
         data:
             -
-                oid: adGenAOSCurrentCpuUtil
-                num_oid: '.1.3.6.1.4.1.664.5.53.1.4.1.{{ $index }}'
+                oid: ADTRAN-GENPROCESSES-MIB::adGenProcessesCpuStatCurUtilization
+                num_oid: '.1.3.6.1.4.1.664.5.70.22.2.2.1.1.{{ $index }}'
+                precision: 100
+    sensors:
+        fanspeed:
+            data:
+            -
+                oid: ADTRAN-TA5000FAN-MIB::adTA5kFanStatusFan1Speed
+                num_oid: '.1.3.6.1.4.1.664.2.751.2.1.1.1.{{ $index }}'
+                index: 'adTA5kFanStatusFan1Speed.{{ $index }}'
+                descr: 'FAN 1'
+            -
+                oid: ADTRAN-TA5000FAN-MIB::adTA5kFanStatusFan2Speed
+                num_oid: '.1.3.6.1.4.1.664.2.751.2.1.1.2.{{ $index }}'
+                index: 'adTA5kFanStatusFan2Speed.{{ $index }}'
+                descr: 'FAN 2'
+            -
+                oid: ADTRAN-TA5000FAN-MIB::adTA5kFanStatusFan3Speed
+                num_oid: '.1.3.6.1.4.1.664.2.751.2.1.1.3.{{ $index }}'
+                index: 'adTA5kFanStatusFan3Speed.{{ $index }}'
+                descr: 'FAN 3'
+            -
+                oid: ADTRAN-TA5000FAN-MIB::adTA5kFanStatusFan4Speed
+                num_oid: '.1.3.6.1.4.1.664.2.751.2.1.1.4.{{ $index }}'
+                index: 'adTA5kFanStatusFan4Speed.{{ $index }}'
+                descr: 'FAN 4'
+        voltage:
+            data:
+            -
+                oid: ADTRAN-TA5000FAN-MIB::adTA5kFanStatusVoltageAux
+                num_oid: '.1.3.6.1.4.1.664.2.751.2.1.1.7.{{ $index }}'
+                descr: 'VOLTAGE'
+        temperature:
+            data:
+            -
+                oid: ADTRAN-TA5000FAN-MIB::adTA5kFanStatusTable
+                value: ADTRAN-TA5000FAN-MIB::adTA5kFanStatusTemp
+                num_oid: '.1.3.6.1.4.1.664.2.751.2.1.1.6.{{ $index }}'
+                descr: 'FAN TEMPERATURE'
+                user_func: fahrenheit_to_celsius


### PR DESCRIPTION
Please give a short description what your pull request is for

### Summary
Improve OS detection and discovery for Adtran AOS and Omnitron iConverter devices.

### Motivation
These devices were previously mis-detected or not detected reliably in production environments.

### Changes
- Improved Adtran AOS OS discovery
- Adjusted Adtran AOS OS detection
- Improved Omnitron iConverter OS detection

### Tested
- Adtran AOS (multiple models / firmware)
- Omnitron iConverter (multiple models)

Detection is based on sysObjectID and sysDescr values observed in production.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.

