### PR TITLE
Fix ghost X bug in multiport selector widget

### DIFF
--- a/resources/views/widgets/settings/graph.blade.php
+++ b/resources/views/widgets/settings/graph.blade.php
@@ -132,7 +132,7 @@
         init_select2('#graph_customoid-{{ $id }}', 'customoid', {limit: 100}, '{{ $graph_customoid ?: '' }}');
         init_select2('#graph_bill-{{ $id }}', 'bill', {limit: 100}, '{{ $graph_bill ?: '' }}');
         init_select2('#graph_custom-{{ $id }}', 'graph-aggregate', {}, false);
-        init_select2('#graph_ports-{{ $id }}', 'port', {limit: 100}, {{ $graph_port_ids }});
+        init_select2('#graph_ports-{{ $id }}', 'port', {limit: 100}, false);
 
         function switch_graph_type{{ $id }}(data) {
             $('.graph_select_extra-{{ $id }}').hide();


### PR DESCRIPTION
The init_select2() function expects either a scalar (converted to {id: val, text: val}) or an object with .id and .text properties. When an array like [123, 456] was passed via $graph_port_ids, the array.id and array.text properties were undefined, creating a ghost option that appeared as an unremovable X in the selector.

Since the <option> elements are already rendered in the blade template with the selected attribute, no initial selection needs to be passed to init_select2(). Pass false instead to skip initial value handling.

Fixes the ghost X appearing in Dashboard Graph widget port selector.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
