### PR TITLE
Update mail transports to generate a single event log if no e-mail addresses are found

### DIFF
--- a/LibreNMS/Alert/Transport/Mail.php
+++ b/LibreNMS/Alert/Transport/Mail.php
@@ -26,8 +26,8 @@ namespace LibreNMS\Alert\Transport;
 
 use App\Facades\LibrenmsConfig;
 use Exception;
-use Illuminate\Support\Str;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
 use LibreNMS\Alert\AlertUtil;
 use LibreNMS\Alert\Transport;
 use LibreNMS\Exceptions\AlertTransportDeliveryException;
@@ -46,6 +46,7 @@ class Mail extends Transport
 
         if (count($emails) == 0 && $this->config['ignore-no-emails']) {
             Log::info('No e-mail contacts found', ['color' => true]);
+
             return true;
         }
 

--- a/LibreNMS/Alert/Transport/Mail.php
+++ b/LibreNMS/Alert/Transport/Mail.php
@@ -44,7 +44,7 @@ class Mail extends Transport
             default => $this->config['email'] ?? $alert_data['contacts'] ?? [], // contacts is only used by legacy synthetic transport
         };
 
-        if (count($emails) == 0 && $this->config['ignore-no-emails']) {
+        if (is_array($emails) && count($emails) == 0 && $this->config['ignore-no-emails']) {
             Log::info('No e-mail contacts found', ['color' => true]);
 
             return true;

--- a/LibreNMS/Alert/Transport/Mail.php
+++ b/LibreNMS/Alert/Transport/Mail.php
@@ -24,12 +24,14 @@
 
 namespace LibreNMS\Alert\Transport;
 
+use App\Facades\DeviceCache;
 use App\Facades\LibrenmsConfig;
+use App\Models\Eventlog;
 use Exception;
-use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use LibreNMS\Alert\AlertUtil;
 use LibreNMS\Alert\Transport;
+use LibreNMS\Enum\Severity;
 use LibreNMS\Exceptions\AlertTransportDeliveryException;
 use Spatie\Permission\Models\Role;
 
@@ -44,8 +46,9 @@ class Mail extends Transport
             default => $this->config['email'] ?? $alert_data['contacts'] ?? [], // contacts is only used by legacy synthetic transport
         };
 
-        if (is_array($emails) && count($emails) == 0 && $this->config['ignore-no-emails']) {
-            Log::info('No e-mail contacts found', ['color' => true]);
+        if (is_array($emails) && count($emails) == 0) {
+            $device = DeviceCache::get($alert_data['device_id']);
+            Eventlog::log('No e-mail recipients found for transport ' . $alert_data['transport_name'], $device, 'alert', Severity::Notice);
 
             return true;
         }
@@ -115,13 +118,6 @@ class Mail extends Transport
                     'descr' => 'Include graph image data in the email.  Will be embedded if html5, otherwise attached. Template must use @signedGraphTag',
                     'type' => 'checkbox',
                     'default' => true,
-                ],
-                [
-                    'title' => 'OK if no contacts',
-                    'name' => 'ignore-no-emails',
-                    'descr' => 'Enabling this option will avoid generating event logs if this transport does not find any e-mail addresses to send to.  This may be useful if you have this transport as part of a group, and do not want to generate event logs for devices that do not find a contact for this transport (e.g. contact type is owner or syscontact).',
-                    'type' => 'checkbox',
-                    'default' => false,
                 ],
             ],
             'validation' => [


### PR DESCRIPTION
I want to have a transport group where there are some transports that always fire, and I also have an e-mail transport set to "Owner(s)" where additional e-mails will be sent for some devices that have owners.  

At the moment, this will generate event logs as follows for any device that does not have any owners:
<img width="1555" height="122" alt="image" src="https://github.com/user-attachments/assets/73f91825-6105-4147-82d1-91a059bdfc9c" />

Because I know that some of my devices will not have any owners, I would like to be able to disable these event logs on this mail transport because I know that this transport will sometime trigger without finding any e-mail addresses to send to.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
