### PR TITLE
fixed graph for icmp services

### DIFF
--- a/includes/html/graphs/service/graph.inc.php
+++ b/includes/html/graphs/service/graph.inc.php
@@ -50,7 +50,6 @@ include 'includes/html/graphs/common.inc.php';
 $graph_params->scale_min = 0;
 
 $rrd_options[] = 'COMMENT:                      Now     Avg      Max\\n';
-$rrd_additions = '';
 
 // Remove encoded characters
 $services[$vars['service']]['service_ds'] = htmlspecialchars_decode((string) $services[$vars['service']]['service_ds']);
@@ -72,8 +71,7 @@ if ($services[$vars['service']]['service_ds'] != '') {
 
     if (Rrd::checkRrdExists($rrd_filename)) {
         if (isset($check_graph)) {
-            // We have a graph definition, use it.
-            $rrd_additions .= $check_graph[$ds];
+            $rrd_options = $check_graph[$ds];
         } else {
             // Build the graph ourselves
             if (preg_match('/loss/i', (string) $ds)) {

--- a/includes/services/check_icmp.inc.php
+++ b/includes/services/check_icmp.inc.php
@@ -9,25 +9,25 @@ if (isset($rrd_filename)) {
 
     // Build the graph data
     $check_graph = [];
-    $check_graph['rta'] = ' DEF:DS0=' . $rrd_filename . ':rta:AVERAGE ';
-    $check_graph['rta'] .= ' LINE1.25:DS0#' . \App\Facades\LibrenmsConfig::get('graph_colours.mixed.0') . ":'" . str_pad(substr('Round Trip Average', 0, 15), 15) . "' ";
-    $check_graph['rta'] .= ' GPRINT:DS0:LAST:%5.2lf%s ';
-    $check_graph['rta'] .= ' GPRINT:DS0:AVERAGE:%5.2lf%s ';
-    $check_graph['rta'] .= ' GPRINT:DS0:MAX:%5.2lf%s\\l ';
-    $check_graph['rtmax'] .= ' DEF:DS1=' . $rrd_filename . ':rtmax:AVERAGE ';
-    $check_graph['rtmax'] .= ' LINE1.25:DS1#' . \App\Facades\LibrenmsConfig::get('graph_colours.mixed.1') . ":'" . str_pad(substr('Round Trip Max', 0, 15), 15) . "' ";
-    $check_graph['rtmax'] .= ' GPRINT:DS1:LAST:%5.2lf%s ';
-    $check_graph['rtmax'] .= ' GPRINT:DS1:AVERAGE:%5.2lf%s ';
-    $check_graph['rtmax'] .= ' GPRINT:DS1:MAX:%5.2lf%s\\l ';
-    $check_graph['rtmin'] .= ' DEF:DS2=' . $rrd_filename . ':rtmin:AVERAGE ';
-    $check_graph['rtmin'] .= ' LINE1.25:DS2#' . \App\Facades\LibrenmsConfig::get('graph_colours.mixed.2') . ":'" . str_pad(substr('Round Trip Min', 0, 15), 15) . "' ";
-    $check_graph['rtmin'] .= ' GPRINT:DS2:LAST:%5.2lf%s ';
-    $check_graph['rtmin'] .= ' GPRINT:DS2:AVERAGE:%5.2lf%s ';
-    $check_graph['rtmin'] .= ' GPRINT:DS2:MAX:%5.2lf%s\\l ';
+    $check_graph['rta'][] = 'DEF:DS0=' . $rrd_filename . ':rta:AVERAGE';
+    $check_graph['rta'][] = 'LINE1.25:DS0#' . \App\Facades\LibrenmsConfig::get('graph_colours.mixed.0') . ":'" . str_pad(substr('Round Trip Average', 0, 15), 15) . "'";
+    $check_graph['rta'][] = 'GPRINT:DS0:LAST:%5.2lf%s';
+    $check_graph['rta'][] = 'GPRINT:DS0:AVERAGE:%5.2lf%s';
+    $check_graph['rta'][] = 'GPRINT:DS0:MAX:%5.2lf%s\\l';
+    $check_graph['rtmax'][] = 'DEF:DS1=' . $rrd_filename . ':rtmax:AVERAGE';
+    $check_graph['rtmax'][] = 'LINE1.25:DS1#' . \App\Facades\LibrenmsConfig::get('graph_colours.mixed.1') . ":'" . str_pad(substr('Round Trip Max', 0, 15), 15) . "'";
+    $check_graph['rtmax'][] = 'GPRINT:DS1:LAST:%5.2lf%s';
+    $check_graph['rtmax'][] = 'GPRINT:DS1:AVERAGE:%5.2lf%s';
+    $check_graph['rtmax'][] = 'GPRINT:DS1:MAX:%5.2lf%s\\l';
+    $check_graph['rtmin'][] = 'DEF:DS2=' . $rrd_filename . ':rtmin:AVERAGE';
+    $check_graph['rtmin'][] = 'LINE1.25:DS2#' . \App\Facades\LibrenmsConfig::get('graph_colours.mixed.2') . ":'" . str_pad(substr('Round Trip Min', 0, 15), 15) . "'";
+    $check_graph['rtmin'][] = 'GPRINT:DS2:LAST:%5.2lf%s';
+    $check_graph['rtmin'][] = 'GPRINT:DS2:AVERAGE:%5.2lf%s';
+    $check_graph['rtmin'][] = 'GPRINT:DS2:MAX:%5.2lf%s\\l';
 
-    $check_graph['pl'] = ' DEF:DS0=' . $rrd_filename . ':pl:AVERAGE ';
-    $check_graph['pl'] .= ' AREA:DS0#' . \App\Facades\LibrenmsConfig::get('graph_colours.mixed.2') . ":'" . str_pad(substr('Packet Loss (%)', 0, 15), 15) . "' ";
-    $check_graph['pl'] .= ' GPRINT:DS0:LAST:%5.2lf%s ';
-    $check_graph['pl'] .= ' GPRINT:DS0:AVERAGE:%5.2lf%s ';
-    $check_graph['pl'] .= ' GPRINT:DS0:MAX:%5.2lf%s\\l ';
+    $check_graph['pl'][] = 'DEF:DS0=' . $rrd_filename . ':pl:AVERAGE';
+    $check_graph['pl'][] = 'AREA:DS0#' . \App\Facades\LibrenmsConfig::get('graph_colours.mixed.2') . ":'" . str_pad(substr('Packet Loss (%)', 0, 15), 15) . "'";
+    $check_graph['pl'][] = 'GPRINT:DS0:LAST:%5.2lf%s';
+    $check_graph['pl'][] = 'GPRINT:DS0:AVERAGE:%5.2lf%s';
+    $check_graph['pl'][] = 'GPRINT:DS0:MAX:%5.2lf%s\\l';
 }


### PR DESCRIPTION
Fixed services graphs for icmp, i think they didn't work anymore because the rrd_options var is now an array, **i expect load and mysql services will have the same problem** since they fill the same var _check_graph_ but sadly i currently don't have a fast way to test them.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
