### PR TITLE
STP port discovery BUG :  fix  pvst discovery

### DIFF
--- a/LibreNMS/OS/Traits/BridgeMib.php
+++ b/LibreNMS/OS/Traits/BridgeMib.php
@@ -109,51 +109,41 @@ trait BridgeMib
 
             // prep base port to port_id map for this specific VLAN context
             $baseIfIndex = SnmpQuery::context($vlanContext, 'vlan-')->walk('BRIDGE-MIB::dot1dBasePortIfIndex')->pluck();
+            $basePortIdMap = array_map(fn ($ifIndex) => PortCache::getIdFromIfIndex($ifIndex, $this->getDevice()), $baseIfIndex);
 
             $vlan_ports = SnmpQuery::context($vlanContext, 'vlan-')
                 ->enumStrings()
                 ->cache()
                 ->walk('BRIDGE-MIB::dot1dStpPortTable')
-                ->mapTable(function ($data, $port) use ($instance, $baseIfIndex) {
-                    $enable = $data['BRIDGE-MIB::dot1dStpPortEnable'] ?? 'unknown';
-                    if ($enable === 'disabled') {
-                        d_echo("$port ($instance->vlan) disabled skipping\n");
-
-                        return null;
+                ->mapTable(fn ($data, $port) => new PortStp([
+                    'vlan' => $instance->vlan,
+                    'port_id' => $basePortIdMap[$port] ?? 0,
+                    'port_index' => $port,
+                    'priority' => $data['BRIDGE-MIB::dot1dStpPortPriority'] ?? 0,
+                    'state' => $data['BRIDGE-MIB::dot1dStpPortState'] ?? 'unknown',
+                    'enable' => $data['BRIDGE-MIB::dot1dStpPortEnable'] ?? 'unknown',
+                    'pathCost' => $data['BRIDGE-MIB::dot1dStpPortPathCost32'] ?? $data['BRIDGE-MIB::dot1dStpPortPathCost'] ?? 0,
+                    'designatedRoot' => Mac::parseBridge($data['BRIDGE-MIB::dot1dStpPortDesignatedRoot'] ?? '')->hex(),
+                    'designatedCost' => $data['BRIDGE-MIB::dot1dStpPortDesignatedCost'] ?? 0,
+                    'designatedBridge' => Mac::parseBridge($data['BRIDGE-MIB::dot1dStpPortDesignatedBridge'] ?? '')->hex(),
+                    'designatedPort' => $this->designatedPort($data['BRIDGE-MIB::dot1dStpPortDesignatedPort'] ?? ''),
+                    'forwardTransitions' => $data['BRIDGE-MIB::dot1dStpPortForwardTransitions'] ?? 0,
+                ]))->filter(function (PortStp $port) {
+                    if ($port->enable === 'disabled') {
+                        d_echo("$port->port_index ($port->vlan) disabled skipping\n");
+                        return false;
                     }
-
-                    $state = $data['BRIDGE-MIB::dot1dStpPortState'] ?? 'unknown';
-                    if ($state === 'disabled') {
-                        d_echo("$port ($instance->vlan) state disabled skipping\n");
-
-                        return null;
+                    if ($port->state === 'disabled') {
+                        d_echo("$port->port_index ($port->vlan) state disabled skipping\n");
+                        return false;
                     }
-
-                    $portId = PortCache::getIdFromIfIndex($baseIfIndex[$port] ?? null, $this->getDevice());
-                    if (! $portId) {
-                        d_echo("$port ($instance->vlan) port not found skipping\n");
-
-                        return null;
+                    if (! $port->port_id) {
+                        d_echo("$port->port_index ($port->vlan) port not found skipping\n");
+                        return false;
                     }
-
-                    d_echo("Discovered STP port $port ($instance->vlan): $portId");
-
-                    return new PortStp([
-                        'vlan' => $instance->vlan,
-                        'port_id' => $portId,
-                        'port_index' => $port,
-                        'priority' => $data['BRIDGE-MIB::dot1dStpPortPriority'] ?? 0,
-                        'state' => $state,
-                        'enable' => $enable,
-                        'pathCost' => $data['BRIDGE-MIB::dot1dStpPortPathCost32'] ?? $data['BRIDGE-MIB::dot1dStpPortPathCost'] ?? 0,
-                        'designatedRoot' => Mac::parseBridge($data['BRIDGE-MIB::dot1dStpPortDesignatedRoot'] ?? '')->hex(),
-                        'designatedCost' => $data['BRIDGE-MIB::dot1dStpPortDesignatedCost'] ?? 0,
-                        'designatedBridge' => Mac::parseBridge($data['BRIDGE-MIB::dot1dStpPortDesignatedBridge'] ?? '')->hex(),
-                        'designatedPort' => $this->designatedPort($data['BRIDGE-MIB::dot1dStpPortDesignatedPort'] ?? ''),
-                        'forwardTransitions' => $data['BRIDGE-MIB::dot1dStpPortForwardTransitions'] ?? 0,
-                    ]);
-                })
-                ->filter(); // drop nulls from mapTable
+                    d_echo("Discovered STP port $port->port_index ($port->vlan): $port->port_id");
+                    return true;
+                });
 
             $ports = $ports->merge($vlan_ports);
         }

--- a/LibreNMS/OS/Traits/BridgeMib.php
+++ b/LibreNMS/OS/Traits/BridgeMib.php
@@ -108,7 +108,7 @@ trait BridgeMib
             $vlanContext = $instance->vlan == 1 ? '' : (string) $instance->vlan;
 
             // prep base port to port_id map for this specific VLAN context
-            $baseIfIndex = SnmpQuery::context($vlanContext, 'vlan-')->walk('BRIDGE-MIB::dot1dBasePortIfIndex')->pluck();
+            $baseIfIndex = SnmpQuery::context($vlanContext, 'vlan-')->cache()->walk('BRIDGE-MIB::dot1dBasePortIfIndex')->pluck();
             $basePortIdMap = array_map(fn ($ifIndex) => PortCache::getIdFromIfIndex($ifIndex, $this->getDevice()), $baseIfIndex);
 
             $vlan_ports = SnmpQuery::context($vlanContext, 'vlan-')

--- a/LibreNMS/OS/Traits/BridgeMib.php
+++ b/LibreNMS/OS/Traits/BridgeMib.php
@@ -131,17 +131,21 @@ trait BridgeMib
                 ]))->filter(function (PortStp $port) {
                     if ($port->enable === 'disabled') {
                         d_echo("$port->port_index ($port->vlan) disabled skipping\n");
+
                         return false;
                     }
                     if ($port->state === 'disabled') {
                         d_echo("$port->port_index ($port->vlan) state disabled skipping\n");
                         return false;
+
                     }
                     if (! $port->port_id) {
                         d_echo("$port->port_index ($port->vlan) port not found skipping\n");
+
                         return false;
                     }
                     d_echo("Discovered STP port $port->port_index ($port->vlan): $port->port_id");
+
                     return true;
                 });
 

--- a/LibreNMS/OS/Traits/BridgeMib.php
+++ b/LibreNMS/OS/Traits/BridgeMib.php
@@ -136,8 +136,8 @@ trait BridgeMib
                     }
                     if ($port->state === 'disabled') {
                         d_echo("$port->port_index ($port->vlan) state disabled skipping\n");
-                        return false;
 
+                        return false;
                     }
                     if (! $port->port_id) {
                         d_echo("$port->port_index ($port->vlan) port not found skipping\n");

--- a/LibreNMS/OS/Traits/BridgeMib.php
+++ b/LibreNMS/OS/Traits/BridgeMib.php
@@ -104,12 +104,12 @@ trait BridgeMib
     {
         $ports = new Collection;
 
-        // prep base port to port_id map if we have instances
-        $baseIfIndex = $stpInstances->isEmpty() ? [] : $this->getCacheByIndex('BRIDGE-MIB::dot1dBasePortIfIndex');
-        $basePortIdMap = array_map(fn ($ifIndex) => PortCache::getIdFromIfIndex($ifIndex, $this->getDevice()), $baseIfIndex);
-
         foreach ($stpInstances as $instance) {
             $vlanContext = $instance->vlan == 1 ? '' : (string) $instance->vlan;
+
+            // prep base port to port_id map for this specific VLAN context
+            $baseIfIndex = SnmpQuery::context($vlanContext, 'vlan-')->walk('BRIDGE-MIB::dot1dBasePortIfIndex')->pluck();
+            $basePortIdMap = array_map(fn ($ifIndex) => PortCache::getIdFromIfIndex($ifIndex, $this->getDevice()), $baseIfIndex);
 
             $vlan_ports = SnmpQuery::context($vlanContext, 'vlan-')
                 ->enumStrings()

--- a/LibreNMS/OS/Traits/BridgeMib.php
+++ b/LibreNMS/OS/Traits/BridgeMib.php
@@ -109,48 +109,51 @@ trait BridgeMib
 
             // prep base port to port_id map for this specific VLAN context
             $baseIfIndex = SnmpQuery::context($vlanContext, 'vlan-')->walk('BRIDGE-MIB::dot1dBasePortIfIndex')->pluck();
-            $basePortIdMap = array_map(fn ($ifIndex) => PortCache::getIdFromIfIndex($ifIndex, $this->getDevice()), $baseIfIndex);
 
             $vlan_ports = SnmpQuery::context($vlanContext, 'vlan-')
                 ->enumStrings()
                 ->cache()
                 ->walk('BRIDGE-MIB::dot1dStpPortTable')
-                ->mapTable(fn ($data, $port) => new PortStp([
-                    'vlan' => $instance->vlan,
-                    'port_id' => $basePortIdMap[$port] ?? 0,
-                    'port_index' => $port,
-                    'priority' => $data['BRIDGE-MIB::dot1dStpPortPriority'] ?? 0,
-                    'state' => $data['BRIDGE-MIB::dot1dStpPortState'] ?? 'unknown',
-                    'enable' => $data['BRIDGE-MIB::dot1dStpPortEnable'] ?? 'unknown',
-                    'pathCost' => $data['BRIDGE-MIB::dot1dStpPortPathCost32'] ?? $data['BRIDGE-MIB::dot1dStpPortPathCost'] ?? 0,
-                    'designatedRoot' => Mac::parseBridge($data['BRIDGE-MIB::dot1dStpPortDesignatedRoot'] ?? '')->hex(),
-                    'designatedCost' => $data['BRIDGE-MIB::dot1dStpPortDesignatedCost'] ?? 0,
-                    'designatedBridge' => Mac::parseBridge($data['BRIDGE-MIB::dot1dStpPortDesignatedBridge'] ?? '')->hex(),
-                    'designatedPort' => $this->designatedPort($data['BRIDGE-MIB::dot1dStpPortDesignatedPort'] ?? ''),
-                    'forwardTransitions' => $data['BRIDGE-MIB::dot1dStpPortForwardTransitions'] ?? 0,
-                ]))->filter(function (PortStp $port) {
-                    if ($port->enable === 'disabled') {
-                        d_echo("$port->port_index ($port->vlan) disabled skipping\n");
+                ->mapTable(function ($data, $port) use ($instance, $baseIfIndex) {
+                    $enable = $data['BRIDGE-MIB::dot1dStpPortEnable'] ?? 'unknown';
+                    if ($enable === 'disabled') {
+                        d_echo("$port ($instance->vlan) disabled skipping\n");
 
-                        return false;
+                        return null;
                     }
 
-                    if ($port->state === 'disabled') {
-                        d_echo("$port->port_index ($port->vlan) state disabled skipping\n");
+                    $state = $data['BRIDGE-MIB::dot1dStpPortState'] ?? 'unknown';
+                    if ($state === 'disabled') {
+                        d_echo("$port ($instance->vlan) state disabled skipping\n");
 
-                        return false;
+                        return null;
                     }
 
-                    if (! $port->port_id) {
-                        d_echo("$port->port_index ($port->vlan) port not found skipping\n");
+                    $portId = PortCache::getIdFromIfIndex($baseIfIndex[$port] ?? null, $this->getDevice());
+                    if (! $portId) {
+                        d_echo("$port ($instance->vlan) port not found skipping\n");
 
-                        return false;
+                        return null;
                     }
 
-                    d_echo("Discovered STP port $port->port_index ($port->vlan): $port->port_id");
+                    d_echo("Discovered STP port $port ($instance->vlan): $portId");
 
-                    return true;
-                });
+                    return new PortStp([
+                        'vlan' => $instance->vlan,
+                        'port_id' => $portId,
+                        'port_index' => $port,
+                        'priority' => $data['BRIDGE-MIB::dot1dStpPortPriority'] ?? 0,
+                        'state' => $state,
+                        'enable' => $enable,
+                        'pathCost' => $data['BRIDGE-MIB::dot1dStpPortPathCost32'] ?? $data['BRIDGE-MIB::dot1dStpPortPathCost'] ?? 0,
+                        'designatedRoot' => Mac::parseBridge($data['BRIDGE-MIB::dot1dStpPortDesignatedRoot'] ?? '')->hex(),
+                        'designatedCost' => $data['BRIDGE-MIB::dot1dStpPortDesignatedCost'] ?? 0,
+                        'designatedBridge' => Mac::parseBridge($data['BRIDGE-MIB::dot1dStpPortDesignatedBridge'] ?? '')->hex(),
+                        'designatedPort' => $this->designatedPort($data['BRIDGE-MIB::dot1dStpPortDesignatedPort'] ?? ''),
+                        'forwardTransitions' => $data['BRIDGE-MIB::dot1dStpPortForwardTransitions'] ?? 0,
+                    ]);
+                })
+                ->filter(); // drop nulls from mapTable
 
             $ports = $ports->merge($vlan_ports);
         }

--- a/includes/discovery/fdb-table/arubaos.inc.php
+++ b/includes/discovery/fdb-table/arubaos.inc.php
@@ -52,6 +52,7 @@ if (! empty($fdbPort_table)) {
     foreach ($fdbPort_table as $vlan => $data) {
         Log::debug("VLAN: $vlan\n");
         $dot1dBasePortIfIndex = SnmpQuery::context($vlan, 'vlan-')
+            ->cache()
             ->walk('BRIDGE-MIB::dot1dBasePortIfIndex')
             ->table(1, $dot1dBasePortIfIndex);
     }

--- a/includes/discovery/fdb-table/ios.inc.php
+++ b/includes/discovery/fdb-table/ios.inc.php
@@ -29,7 +29,7 @@ foreach ($vtpdomains as $vtpdomain_id => $vtpdomain) {
             $fdbPort_table = SnmpQuery::context($vlan_raw, 'vlan-')->walk('BRIDGE-MIB::dot1dTpFdbPort')->table();
 
             $portid_dict = [];
-            $dot1dBasePortIfIndex = SnmpQuery::context($vlan_raw, 'vlan-')->walk('BRIDGE-MIB::dot1dBasePortIfIndex')->table(1);
+            $dot1dBasePortIfIndex = SnmpQuery::context($vlan_raw, 'vlan-')->cache()->walk('BRIDGE-MIB::dot1dBasePortIfIndex')->table(1);
             foreach ($dot1dBasePortIfIndex as $portLocal => $data) {
                 $portid_dict[$portLocal] = PortCache::getIdFromIfIndex($data['BRIDGE-MIB::dot1dBasePortIfIndex'], $device['device_id']);
             }


### PR DESCRIPTION
The old discovery method passes VLAN 1 STP port information to ALL STP instances because dot1BasePortIfIndex was called without context. So, every stp instance had the same port data.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
