### PR TITLE
Fix parse ipv6 prefix len

### DIFF
--- a/LibreNMS/Modules/Ipv6Addresses.php
+++ b/LibreNMS/Modules/Ipv6Addresses.php
@@ -252,7 +252,7 @@ class Ipv6Addresses implements Module
                     try {
                         // broken output, parse from raw index
                         if ($prefixLen === 'IP-MIB::ipAddressPrefixOrigin') {
-                            if (preg_match('/^\.(?<ip>.+)\.(?<prefix_len>\d{1,3})$/', $prefix, $prefix_match)) {
+                            if (preg_match('/^\.(?<ip>.+)\.(?<prefix_len>\d{1,3})$/', (string) $prefix, $prefix_match)) {
                                 $prefix = $prefix_match['ip'];
                                 $prefixLen = (int) $prefix_match['prefix_len'];
                             }


### PR DESCRIPTION
In the fallback prefix parsing, we did not handle the broken index case.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
