### PR TITLE
Fix unix agent dmi parsing

### DIFF
--- a/includes/polling/unix-agent.inc.php
+++ b/includes/polling/unix-agent.inc.php
@@ -190,11 +190,12 @@ if ($device['os_group'] == 'unix' || $device['os'] == 'windows') {
     // Use agent DMI data if available
     if (isset($agent_data['dmi'])) {
         // Parse DMI string into associative array
-        $dmi = array_column(array_map(fn($l) => explode('=', $l, 2), explode("\n", trim($agent_data['dmi']))), 1, 0);
-        $getDmiValue = function($system_key, $baseboard_key, $generic_value) use ($dmi) {
+        $dmi = array_column(array_map(fn ($l) => explode('=', $l, 2), explode("\n", trim($agent_data['dmi']))), 1, 0);
+        $getDmiValue = function ($system_key, $baseboard_key, $generic_value) use ($dmi) {
             if (isset($dmi[$system_key]) && $dmi[$system_key] !== $generic_value) {
                 return $dmi[$system_key];
             }
+
             return $dmi[$baseboard_key] ?? '';
         };
 


### PR DESCRIPTION
add fallback from system -> baseboard keys
Code just errored out before as $agent['dmi'] is a string

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
