### PR TITLE
Fix device neighbour maps

### DIFF
--- a/app/Http/Controllers/Maps/MapDataController.php
+++ b/app/Http/Controllers/Maps/MapDataController.php
@@ -258,10 +258,10 @@ class MapDataController extends Controller
             // If we have a device ID, we want to show if we are the soure or target of a link
             $linkQuery->where(function ($q) use ($device_id, $remote_port_attr): void {
                 $q->whereHas($remote_port_attr, function ($q) use ($device_id): void {
-                    $q->where('device_id', $device_id);
+                    $q->where($q->qualifyColumn('device_id'), $device_id);
                 })
                     ->orWhereHas('device', function ($q) use ($device_id): void {
-                        $q->where('device_id', $device_id);
+                        $q->where($q->qualifyColumn('device_id'), $device_id);
                     });
             });
         }


### PR DESCRIPTION
Another fix for https://github.com/librenms/librenms/issues/18266

The initial error is still occurring with the first fix in place, with the exact same log lines. 

The error starts `Column 'device_id' in WHERE is ambiguous ...`, which this fix attempts to resolve by qualifying the column in the WHERE clauses further down the file from the original fix.


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
