### PR TITLE
Avoid calling last for every RRD update with rrdcached

### DIFF
--- a/LibreNMS/Data/Store/Rrd.php
+++ b/LibreNMS/Data/Store/Rrd.php
@@ -428,7 +428,7 @@ class Rrd extends BaseDatastore
         if (in_array($command, ['last', 'list', 'lastupdate']) && $this->init(false)) {
             // send this to our synchronous process so output is guaranteed
             $output = $this->sync_process->sendCommand(implode(' ', $cmd));
-            while (! strrpos($output[0], 'OK u:')) {
+            while (! strrpos((string) $output[0], 'OK u:')) {
                 $moreoutput = $this->sync_process->getOutput();
 
                 // Error if we get no output before we reach the end of command
@@ -576,7 +576,7 @@ class Rrd extends BaseDatastore
 
             // Check and fill cache for this host if needed
             if (! isset($this->rrd_file_cache[$hostpart])) {
-                $this->rrd_file_cache[$hostpart] = array_fill_keys(explode("\n", trim(($this->command('list', '/' . $hostpart, ['--recursive']))[0] ?? '')), true);
+                $this->rrd_file_cache[$hostpart] = array_fill_keys(explode("\n", trim($this->command('list', '/' . $hostpart, ['--recursive'])[0] ?? '')), true);
             }
 
             return isset($this->rrd_file_cache[$hostpart][$filepart]);


### PR DESCRIPTION
We currently run 2 rrdtool commands for every update - "last" to check that the file exists and "update" to do the update.  This PR replaces the "last" commands with a single "list" command, then we cache the results of "list" to allow for faster checks of whether a given file exists.

In my testing this reduced the time the poller spends doing RRD commands by around 50% (0.04s reduction with 72 updates / 0.34s with 1600 updates).

It also includes a fix for Rrd::command() where it was possible that not all the output was returned for calls to the sync_process.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
