### PR TITLE
fix: handle malformed SNMP responses in fdb-table module

### DIFF
--- a/includes/discovery/fdb-table/bridge.inc.php
+++ b/includes/discovery/fdb-table/bridge.inc.php
@@ -61,6 +61,10 @@ if (! empty($fdbPort_table)) {
     foreach ($vlan_cur_table as $a) {
         // Then by VLAN ID mapped to a single member array with the dot1qVlanFdbId
         foreach ($a as $vid => $data) {
+            // Skip if $data is not an array (can happen with malformed SNMP responses)
+            if (! is_array($data) || ! isset($data['dot1qVlanFdbId'])) {
+                continue;
+            }
             // Flip it round into the dictionary
             $vlan_fdb_dict[$data['dot1qVlanFdbId']] = $vid;
         }


### PR DESCRIPTION
Some devices return unexpected SNMP data when queried for OIDs they don't support, responding with unrelated OIDs like sysDescr instead of a proper "No Such Object" response. This causes "OID not increasing" errors and results in the SnmpResponse->table() method returning unexpected data structures where strings appear instead of arrays.

Added is_array() check to gracefully handle these malformed responses when processing dot1qVlanFdbId data.

Replaces #18764

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
