### PR TITLE
fix: handle malformed SNMP responses in discovery-protocols module

### DIFF
--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -326,13 +326,25 @@ if (($device['os'] == 'routeros') && version_compare($device['version'], '7.7', 
 
     if (! empty($lldpv2_array)) {
         // map it to lldp_array
-        foreach ($lldpv2_array as $lldpV2RemTimeMark => $value) {
-            foreach ($value as $lldpV2RemLocalIfIndex => $value) {
-                foreach ($value as $lldpV2RemLocalDestMACAddress => $value) {
-                    foreach ($value as $lldpV2RemIndex => $lldpv2_array_entries) {
-                        foreach ($lldpv2_array_entries as $key => $value) {
+        foreach ($lldpv2_array as $lldpV2RemTimeMark => $timeMark_data) {
+            if (! is_array($timeMark_data)) {
+                continue;
+            }
+            foreach ($timeMark_data as $lldpV2RemLocalIfIndex => $ifIndex_data) {
+                if (! is_array($ifIndex_data)) {
+                    continue;
+                }
+                foreach ($ifIndex_data as $lldpV2RemLocalDestMACAddress => $mac_data) {
+                    if (! is_array($mac_data)) {
+                        continue;
+                    }
+                    foreach ($mac_data as $lldpV2RemIndex => $lldpv2_array_entries) {
+                        if (! is_array($lldpv2_array_entries)) {
+                            continue;
+                        }
+                        foreach ($lldpv2_array_entries as $key => $entry_value) {
                             $newKey = $mapV2toV1[$key] ?? $key;
-                            $lldp_array[$lldpV2RemTimeMark][$lldpV2RemLocalIfIndex][$lldpV2RemIndex][$newKey] = $value;
+                            $lldp_array[$lldpV2RemTimeMark][$lldpV2RemLocalIfIndex][$lldpV2RemIndex][$newKey] = $entry_value;
                         }
                         $lldp_array[$lldpV2RemTimeMark][$lldpV2RemLocalIfIndex][$lldpV2RemIndex]['lldpRemLocalDestMACAddress'] = $lldpV2RemLocalDestMACAddress;
                     }


### PR DESCRIPTION
Some devices return unexpected SNMP data when queried for OIDs they don't support, responding with unrelated OIDs like sysDescr instead of a proper "No Such Object" response. This causes "OID not increasing" errors and results in the SnmpResponse->table() method returning unexpected data structures where strings appear instead of arrays.

Added is_array() checks to gracefully handle these malformed responses and renamed reused $value variables for clarity in the LLDP-V2-MIB data processing loop.

Replaces #18764

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
