### PR TITLE
fix: Force logger cache refresh when debug output level changes

### DIFF
--- a/LibreNMS/Util/Debug.php
+++ b/LibreNMS/Util/Debug.php
@@ -26,6 +26,8 @@
 
 namespace LibreNMS\Util;
 
+use Illuminate\Support\Facades\Log;
+
 class Debug
 {
     /** @var bool */
@@ -90,6 +92,9 @@ class Debug
     {
         if (Laravel::isBooted()) {
             config(['logging.channels.stdout.level' => 'debug']);
+            // Clear cached logger instances so they pick up the new level
+            Log::forgetChannel('console');
+            Log::forgetChannel('stdout');
         } else {
             putenv('STDOUT_LOG_LEVEL=debug');
         }
@@ -99,6 +104,9 @@ class Debug
     {
         if (Laravel::isBooted()) {
             config(['logging.channels.stdout.level' => 'info']);
+            // Clear cached logger instances so they pick up the new level
+            Log::forgetChannel('console');
+            Log::forgetChannel('stdout');
         } else {
             putenv('STDOUT_LOG_LEVEL=info');
         }
@@ -108,6 +116,9 @@ class Debug
     {
         if (Laravel::isBooted()) {
             config(['logging.channels.stdout.level' => 'emergency']);
+            // Clear cached logger instances so they pick up the new level
+            Log::forgetChannel('console');
+            Log::forgetChannel('stdout');
         } else {
             putenv('STDOUT_LOG_LEVEL=emergency');
         }


### PR DESCRIPTION
Cached Laravel logger instances ignore config changes made at runtime, causing log messages below the cached level threshold to be silently filtered out. This particularly affects the ModuleTestHelper::collectOids() method which:

1. Calls Debug::set() to enable debug logging
2. Runs discovery/polling to capture SNMP commands
3. Parses the output via regex to extract OIDs

Without this fix, SNMP debug commands aren't captured because the cached logger instances retain their original log level (info), filtering out debug-level Log::debug() calls.

Solution: Clear cached logger instances after changing log level config, forcing Laravel to recreate them with the new configuration. Applied consistently to all three methods that modify CLI debug output:
- enableCliDebugOutput()
- disableCliDebugOutput()
- setCliQuietOutput()

Fixes SNMP OID discovery issues in test data collection when run without explicit --debug flag.

Fixes bug encountered generating test data for #18713

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
