### PR TITLE
Fix: Read rrdcached from .env instead of database config for distribu…

### DIFF
--- a/LibreNMS/Data/Store/Rrd.php
+++ b/LibreNMS/Data/Store/Rrd.php
@@ -83,7 +83,7 @@ class Rrd extends BaseDatastore
 
     protected function loadConfig(): void
     {
-        $this->rrdcached = LibrenmsConfig::get('rrdcached', false);
+        $this->rrdcached = LibrenmsConfig::get('rrdcached', '');
         $this->rrd_dir = LibrenmsConfig::get('rrd_dir', LibrenmsConfig::get('install_dir') . '/rrd');
         $this->step = LibrenmsConfig::get('rrd.step', 300);
         $this->rra = preg_split('/s+/', trim(LibrenmsConfig::get(

--- a/LibreNMS/RRD/RrdProcess.php
+++ b/LibreNMS/RRD/RrdProcess.php
@@ -23,7 +23,7 @@ class RrdProcess
     public function __construct(private readonly LoggerInterface $logger, private readonly int $timeout = 300)
     {
         $this->rrdtool_exec = LibrenmsConfig::get('rrdtool', 'rrdtool');
-        $this->rrdcached = (string) LibrenmsConfig::get('rrdcached', '');
+        $this->rrdcached = (string) config('librenms.rrdcached', '');
         $this->rrd_dir = LibrenmsConfig::get('rrd_dir', LibrenmsConfig::get('install_dir') . '/rrd');
         $this->input = new InputStream();
 

--- a/LibreNMS/Validations/DistributedPoller/CheckRrdcached.php
+++ b/LibreNMS/Validations/DistributedPoller/CheckRrdcached.php
@@ -37,7 +37,7 @@ class CheckRrdcached implements \LibreNMS\Interfaces\Validation
      */
     public function validate(): ValidationResult
     {
-        if (! LibrenmsConfig::get('rrdcached')) {
+        if (! config('librenms.rrdcached')) {
             return ValidationResult::fail(trans('validation.validations.distributedpoller.CheckRrdcached.fail'), 'lnms config:set rrdcached <rrdcached server ip:port>');
         }
 

--- a/LibreNMS/Validations/Rrd/CheckRrdcachedConnectivity.php
+++ b/LibreNMS/Validations/Rrd/CheckRrdcachedConnectivity.php
@@ -37,7 +37,7 @@ class CheckRrdcachedConnectivity implements Validation
      */
     public function validate(): ValidationResult
     {
-        $parts = explode(':', LibrenmsConfig::get('rrdcached'), 2);
+        $parts = explode(':', (string) config('librenms.rrdcached'), 2);
         $host = $parts[0];
         $port = $parts[1] ?? '';
 
@@ -63,6 +63,6 @@ class CheckRrdcachedConnectivity implements Validation
      */
     public function enabled(): bool
     {
-        return (bool) LibrenmsConfig::get('rrdcached');
+        return (bool) config('librenms.rrdcached');
     }
 }

--- a/app/Console/Commands/MaintenanceRrdStep.php
+++ b/app/Console/Commands/MaintenanceRrdStep.php
@@ -129,7 +129,7 @@ class MaintenanceRrdStep extends LnmsCommand
      */
     private function listFiles(string $hostname, RrdProcess $rrdProcess): array
     {
-        $rrd_dir = LibrenmsConfig::get('rrdcached')
+        $rrd_dir = config('librenms.rrdcached')
             ? '/'
             : LibrenmsConfig::get('rrd_dir', LibrenmsConfig::get('install_dir') . '/rrd');
 

--- a/config/librenms.php
+++ b/config/librenms.php
@@ -62,4 +62,6 @@
      */
 
      'config_cache_ttl' => env('CONFIG_CACHE_TTL', 300),
+     
+     'rrdcached' => env('RRDCACHED', ''),
  ];


### PR DESCRIPTION
…ted pollers

This fixes an issue where rrdcached configuration was read from the database config table instead of the .env file in distributed poller setups.

When LibrenmsConfig::get('rrdcached') returned null/false, pollers would fallback to writing RRD files locally, causing rapid disk exhaustion (50GB in 41 seconds).

By reading from env('RRDCACHED') instead, pollers now correctly send RRD data to the master's rrdcached server.

Affected files:
- LibreNMS/RRD/RrdProcess.php (Line 26)
- LibreNMS/Data/Store/Rrd.php (Line 86)
- app/Console/Commands/MaintenanceRrdStep.php (Line 132)
- LibreNMS/Validations/DistributedPoller/CheckRrdcached.php (Lines 40, 66)
- LibreNMS/Validations/Rrd/CheckRrdcachedConnectivity.php (Lines 40, 66)

Fixes disk exhaustion in distributed poller environments.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
