### PR TITLE
fix(settings): add idField to RoleController for role selector filtering

### DIFF
--- a/app/Http/Controllers/Select/RoleController.php
+++ b/app/Http/Controllers/Select/RoleController.php
@@ -33,6 +33,8 @@ use Spatie\Permission\Models\Role;
 
 class RoleController extends SelectController
 {
+    protected ?string $idField = 'name';
+
     protected function searchFields(Request $request): array
     {
         return ['name'];


### PR DESCRIPTION
The RoleController returns role names as IDs, but the parent SelectController uses 'id' by default for filtering. This caused the role selector to not properly filter when editing settings that use role selection.

Setting $idField = 'name' ensures the filtering works correctly with the role name values.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
