### PR TITLE
Fix DiscoverDevice destructor crash during test teardown

### DIFF
--- a/app/Jobs/DiscoverDevice.php
+++ b/app/Jobs/DiscoverDevice.php
@@ -147,6 +147,9 @@ EOH, $this->device->hostname, $os_group ? " ($os_group)" : '', $this->device->de
                 Log::info("#### Unload discovery module $module ####\n");
             }
         }
+
+        // Remove listener to allow this object to be garbage collected
+        Event::forget(OsChangedEvent::class);
     }
 
     private function handleOsChange(OS $os): OS


### PR DESCRIPTION
The OsChangedEvent listener closure captured $this, keeping the DiscoverDevice instance alive in the Event dispatcher. When the destructor ran during PHP shutdown, the Laravel container was already destroyed, causing a fatal error.

Fix by forgetting the event listener after discovery completes.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
