### PR TITLE
Remove log driver output overrides

### DIFF
--- a/LibreNMS/Util/ModuleTestHelper.php
+++ b/LibreNMS/Util/ModuleTestHelper.php
@@ -599,7 +599,7 @@ class ModuleTestHelper
             Debug::setVerbose();
         }
         ob_start();
-        Log::setDefaultDriver('console');
+        Log::setDefaultDriver('stdout');
 
         (new DiscoverDevice($device_id, $this->modules))->handle();
 
@@ -629,7 +629,7 @@ class ModuleTestHelper
             Debug::setVerbose();
         }
         ob_start();
-        Log::setDefaultDriver('console');
+        Log::setDefaultDriver('stdout');
 
         (new PollDevice($device_id, $this->modules))->handle();
 

--- a/app/Console/Commands/DevicePoll.php
+++ b/app/Console/Commands/DevicePoll.php
@@ -80,7 +80,6 @@ class DevicePoll extends LnmsCommand
 
     private function dispatchWork(): int
     {
-        \Log::setDefaultDriver('stack');
         $modules = ModuleList::fromUserOverrides($this->option('modules'));
         $devices = Device::whereDeviceSpec($this->argument('device spec'))->pluck('device_id');
 


### PR DESCRIPTION
This allows LOG_CHANNEL to be properly set externally to LibreNMS.
`Log::setDefaultDriver('stack');` is not needed in CommandStartingListener.php we already set the level to emergency
We ensure stdout is include for cli commands to prevent users from accidentally preventing output
ModuleTestHelper change is a bonus as we only need stdout, so we can prevent output log file and flare

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
