### PR TITLE
Fix some array key null errors

### DIFF
--- a/LibreNMS/Interfaces/Models/Keyable.php
+++ b/LibreNMS/Interfaces/Models/Keyable.php
@@ -33,5 +33,5 @@ interface Keyable
      *
      * @return string|int
      */
-    public function getCompositeKey();
+    public function getCompositeKey(): string|int;
 }

--- a/LibreNMS/Modules/Mempools.php
+++ b/LibreNMS/Modules/Mempools.php
@@ -147,10 +147,10 @@ class Mempools implements Module
 
         $mempools->each(function (Mempool $mempool) use ($data): void {
             $mempool->fillUsage(
-                $data[$mempool->mempool_used_oid] ?? null,
-                $data[$mempool->mempool_total_oid] ?? null,
-                $data[$mempool->mempool_free_oid] ?? null,
-                $data[$mempool->mempool_perc_oid] ?? null
+                $data[(string) $mempool->mempool_used_oid] ?? null,
+                $data[(string) $mempool->mempool_total_oid] ?? null,
+                $data[(string) $mempool->mempool_free_oid] ?? null,
+                $data[(string) $mempool->mempool_perc_oid] ?? null
             );
         });
 

--- a/LibreNMS/Modules/Storage.php
+++ b/LibreNMS/Modules/Storage.php
@@ -126,10 +126,10 @@ class Storage implements Module
 
         return $storages->each(function (\App\Models\Storage $storage) use ($data): void {
             $storage->fillUsage(
-                $data[$storage->storage_used_oid] ?? null,
+                $data[(string) $storage->storage_used_oid] ?? null,
                 $storage->storage_units ? $storage->storage_size / $storage->storage_units : null,
-                $data[$storage->storage_free_oid] ?? null,
-                $data[$storage->storage_perc_oid] ?? null,
+                $data[(string) $storage->storage_free_oid] ?? null,
+                $data[(string) $storage->storage_perc_oid] ?? null,
             );
         });
     }

--- a/app/Models/AccessPoint.php
+++ b/app/Models/AccessPoint.php
@@ -24,7 +24,7 @@ class AccessPoint extends DeviceRelatedModel implements Keyable
         'interference',
     ];
 
-    public function getCompositeKey()
+    public function getCompositeKey(): string
     {
         return "{$this->name}_{$this->radio_number}";
     }

--- a/app/Models/DiskIo.php
+++ b/app/Models/DiskIo.php
@@ -16,8 +16,8 @@ class DiskIo extends DeviceRelatedModel implements Keyable
         'diskio_descr',
     ];
 
-    public function getCompositeKey()
+    public function getCompositeKey(): string
     {
-        return $this->diskio_index . $this->diskio_descr;
+        return "$this->diskio_index-$this->diskio_descr";
     }
 }

--- a/app/Models/EntPhysical.php
+++ b/app/Models/EntPhysical.php
@@ -29,8 +29,8 @@ class EntPhysical extends DeviceRelatedModel implements Keyable
         'ifIndex',
     ];
 
-    public function getCompositeKey()
+    public function getCompositeKey(): int
     {
-        return $this->entPhysicalIndex;
+        return (int) $this->entPhysicalIndex;
     }
 }

--- a/app/Models/HrDevice.php
+++ b/app/Models/HrDevice.php
@@ -18,8 +18,8 @@ class HrDevice extends DeviceRelatedModel implements Keyable
         'hrProcessorLoad',
     ];
 
-    public function getCompositeKey()
+    public function getCompositeKey(): int
     {
-        return $this->hrDeviceIndex;
+        return (int) $this->hrDeviceIndex;
     }
 }

--- a/app/Models/IsisAdjacency.php
+++ b/app/Models/IsisAdjacency.php
@@ -62,8 +62,8 @@ class IsisAdjacency extends PortRelatedModel implements Keyable
         return $this->belongsTo(Port::class, 'device_id');
     }
 
-    public function getCompositeKey()
+    public function getCompositeKey(): string
     {
-        return $this->ifIndex . $this->index;
+        return "$this->ifIndex-$this->index";
     }
 }

--- a/app/Models/Mempool.php
+++ b/app/Models/Mempool.php
@@ -127,7 +127,7 @@ class Mempool extends DeviceRelatedModel implements Keyable
         $this->attributes['mempool_perc'] = is_numeric($percent) ? round($percent) : null;
     }
 
-    public function getCompositeKey()
+    public function getCompositeKey(): string
     {
         return "$this->mempool_type-$this->mempool_index";
     }

--- a/app/Models/Package.php
+++ b/app/Models/Package.php
@@ -42,7 +42,7 @@ class Package extends DeviceRelatedModel implements Keyable
         'size',
     ];
 
-    public function getCompositeKey()
+    public function getCompositeKey(): string
     {
         return "$this->manager-$this->name-$this->arch";
     }

--- a/app/Models/PortAdsl.php
+++ b/app/Models/PortAdsl.php
@@ -33,8 +33,8 @@ class PortAdsl extends PortRelatedModel implements Keyable
     /**
      * @inheritDoc
      */
-    public function getCompositeKey()
+    public function getCompositeKey(): int
     {
-        return $this->port_id;
+        return (int) $this->port_id;
     }
 }

--- a/app/Models/PortSecurity.php
+++ b/app/Models/PortSecurity.php
@@ -26,9 +26,9 @@ class PortSecurity extends DeviceRelatedModel implements Keyable
         'sticky_enable',
     ];
 
-    public function getCompositeKey()
+    public function getCompositeKey(): int
     {
-        return $this->port_id;
+        return (int) $this->port_id;
     }
 
     public function port(): BelongsTo

--- a/app/Models/PortStack.php
+++ b/app/Models/PortStack.php
@@ -18,7 +18,7 @@ class PortStack extends DeviceRelatedModel implements Keyable
         'ifStackStatus',
     ];
 
-    public function getCompositeKey()
+    public function getCompositeKey(): string
     {
         return $this->high_ifIndex . '-' . $this->low_ifIndex;
     }

--- a/app/Models/PortStp.php
+++ b/app/Models/PortStp.php
@@ -26,7 +26,7 @@ class PortStp extends PortRelatedModel implements Keyable
         'forwardTransitions',
     ];
 
-    public function getCompositeKey()
+    public function getCompositeKey(): string
     {
         return "$this->vlan-$this->port_index";
     }

--- a/app/Models/PortVdsl.php
+++ b/app/Models/PortVdsl.php
@@ -22,8 +22,8 @@ class PortVdsl extends PortRelatedModel implements Keyable
     /**
      * @inheritDoc
      */
-    public function getCompositeKey()
+    public function getCompositeKey(): int
     {
-        return $this->port_id;
+        return (int) $this->port_id;
     }
 }

--- a/app/Models/PortVlan.php
+++ b/app/Models/PortVlan.php
@@ -32,7 +32,7 @@ class PortVlan extends PortRelatedModel implements Keyable
         return $value;
     }
 
-    public function getCompositeKey()
+    public function getCompositeKey(): string
     {
         return $this->port_id . '-' . $this->vlan;
     }

--- a/app/Models/PrinterSupply.php
+++ b/app/Models/PrinterSupply.php
@@ -20,7 +20,7 @@ class PrinterSupply extends DeviceRelatedModel implements Keyable
         'supply_current',
     ];
 
-    public function getCompositeKey()
+    public function getCompositeKey(): string
     {
         return "$this->supply_type-$this->supply_index";
     }

--- a/app/Models/Qos.php
+++ b/app/Models/Qos.php
@@ -33,7 +33,7 @@ class Qos extends Model implements Keyable
      *
      * @return string
      */
-    public function getCompositeKey()
+    public function getCompositeKey(): string
     {
         return $this->device_id . '-' . $this->type . '-' . $this->rrd_id;
     }

--- a/app/Models/Sla.php
+++ b/app/Models/Sla.php
@@ -24,7 +24,7 @@ class Sla extends DeviceRelatedModel implements Keyable
         'deleted' => 0,
     ];
 
-    public function getCompositeKey()
+    public function getCompositeKey(): string
     {
         return "$this->owner-$this->tag";
     }

--- a/app/Models/StateTranslation.php
+++ b/app/Models/StateTranslation.php
@@ -79,8 +79,8 @@ class StateTranslation extends Model implements Keyable
         return $this->belongsTo(StateIndex::class, 'state_index_id', 'state_index_id');
     }
 
-    public function getCompositeKey()
+    public function getCompositeKey(): int
     {
-        return $this->state_value;
+        return (int) $this->state_value;
     }
 }

--- a/app/Models/Storage.php
+++ b/app/Models/Storage.php
@@ -29,7 +29,7 @@ class Storage extends DeviceRelatedModel implements Keyable
         'storage_perc_warn',
     ];
 
-    public function getCompositeKey()
+    public function getCompositeKey(): string
     {
         return "$this->type-$this->storage_index";
     }

--- a/app/Models/Stp.php
+++ b/app/Models/Stp.php
@@ -30,8 +30,8 @@ class Stp extends DeviceRelatedModel implements Keyable
         'bridgeForwardDelay',
     ];
 
-    public function getCompositeKey()
+    public function getCompositeKey(): string
     {
-        return $this->vlan;
+        return (string) $this->vlan;
     }
 }

--- a/app/Models/Transceiver.php
+++ b/app/Models/Transceiver.php
@@ -40,8 +40,8 @@ class Transceiver extends PortRelatedModel implements Keyable
         ];
     }
 
-    public function getCompositeKey()
+    public function getCompositeKey(): string
     {
-        return $this->index;
+        return (string) $this->index;
     }
 }

--- a/app/Models/Vminfo.php
+++ b/app/Models/Vminfo.php
@@ -70,8 +70,8 @@ class Vminfo extends DeviceRelatedModel implements Keyable
         return $this->hasOne(Device::class, 'hostname', 'vmwVmDisplayName');
     }
 
-    public function getCompositeKey()
+    public function getCompositeKey(): string
     {
-        return $this->vm_type . $this->vmwVmVMID;
+        return "$this->vm_type-$this->vmwVmVMID";
     }
 }

--- a/includes/polling/applications/rrdcached.inc.php
+++ b/includes/polling/applications/rrdcached.inc.php
@@ -32,7 +32,7 @@ use LibreNMS\Util\Number;
 $data = '';
 $name = 'rrdcached';
 
-if ($agent_data['app'][$name]) {
+if (! empty($agent_data['app'][$name])) {
     $data = $agent_data['app'][$name];
 } else {
     d_echo("\nNo Agent Data. Attempting to connect directly to the rrdcached server " . $device['hostname'] . ":42217\n");
@@ -47,14 +47,14 @@ if ($agent_data['app'][$name]) {
         $data = str_replace("<<<rrdcached>>>\n", '', $data);
     }
     if (strlen($data) < 100) {
-        $socket = \App\Facades\LibrenmsConfig::get('rrdcached');
+        $socket = (string) \App\Facades\LibrenmsConfig::get('rrdcached');
         if (str_starts_with($socket, 'unix:/')) {
             $socket_file = substr($socket, 5);
             if (file_exists($socket_file)) {
                 $sock = fsockopen('unix://' . $socket_file);
             }
+            d_echo("\nNo SnmpData " . $device['hostname'] . ' fallback to local rrdcached unix://' . $socket_file . "\n");
         }
-        d_echo("\nNo SnmpData " . $device['hostname'] . ' fallback to local rrdcached unix://' . $socket_file . "\n");
     }
     if ($sock) {
         fwrite($sock, "STATS\n");

--- a/includes/polling/unix-agent.inc.php
+++ b/includes/polling/unix-agent.inc.php
@@ -220,7 +220,7 @@ if ($device['os_group'] == 'unix' || $device['os'] == 'windows') {
     }
 
     // store results in array cache
-    Cache::driver('array')->put('agent_data', $agent_data);
+    Cache::driver('array')->put('agent_data', $agent_data ?? null);
 
     if (! empty($agent_sensors)) {
         echo 'Sensors: ';


### PR DESCRIPTION
one was in SyncsModels attribute, simply required stricter types for getCompositeKey()

PHP 8.5 deprecation

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
