### PR TITLE
Remove PHP 8.2 from OS testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,6 @@ jobs:
       fail-fast: false
       matrix:
         php-version:
-          - 8.2
           - 8.4
         arguments:
           - --os a
@@ -32,10 +31,6 @@ jobs:
           - --os u,v,w,x,y,z,0,1,2,3,4,5,6,7,8,9
         include:
           -
-            name: PHP 8.2
-            php-version: 8.2
-            database: mysql:8.0
-          -
             name: PHP 8.4
             php-version: 8.4
             database: mariadb:11.7
@@ -43,6 +38,11 @@ jobs:
             name: Other
             php-version: 8.4
             database: mariadb:11.7
+            arguments: --full --exclude-phpunit-group=browser,mibs,external-dependencies,os
+          -
+            name: Other
+            php-version: 8.2
+            database: mysql:8.0
             arguments: --full --exclude-phpunit-group=browser,mibs,external-dependencies,os
 
     services:


### PR DESCRIPTION
I have never seen it failing separately from 8.4, saves a lot of "runner cpu hours"

Add PHP 8.2 configuration for the "Other" test to maintain coverage

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
