### PR TITLE
Prometheus escape sysName with slashes

### DIFF
--- a/LibreNMS/Data/Store/Prometheus.php
+++ b/LibreNMS/Data/Store/Prometheus.php
@@ -96,17 +96,18 @@ class Prometheus extends BaseDatastore
             }
         }
 
+        $device = $this->getDevice($meta);
+        if (LibrenmsConfig::get('prometheus.attach_sysname', false)) {
+            $tags['sysName'] = $device->sysName;
+        }
+
         foreach ($tags as $t => $v) {
             if ($v !== null) {
                 $promtags .= (Str::contains($v, '/') ? "/$t@base64/" . base64_encode($v) : "/$t/$v");
             }
         }
 
-        $device = $this->getDevice($meta);
         $promurl = $device->hostname . $promtags;
-        if (LibrenmsConfig::get('prometheus.attach_sysname', false)) {
-            $promurl .= '/sysName/' . $device->sysName;
-        }
         $promurl = str_replace(' ', '-', $promurl); // Prometheus doesn't handle tags with spaces in url
 
         Log::debug("Prometheus put $promurl: ", [


### PR DESCRIPTION
If you have a device with a slash in the sysName and also enable `prometheus.attach_sysname`, pushing to prometheus will not work because the slash in the URL doesn't get escaped.

With this PR, sysName is treated the same as other other tags passed to prometheus – which are properly escaped.


#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
