### PR TITLE
handle Other entSensorThresholdSeverity

### DIFF
--- a/includes/discovery/sensors/cisco-entity-sensor.inc.php
+++ b/includes/discovery/sensors/cisco-entity-sensor.inc.php
@@ -159,13 +159,13 @@ if ($device['os_group'] == 'cisco') {
 
                         // Handle Other limit only if Warning limit is not set
                         if (! isset($warn_limit)) {
-	                        if ($key['entSensorThresholdSeverity'] == 'other' && ($key['entSensorThresholdRelation'] == 'greaterOrEqual' || $key['entSensorThresholdRelation'] == 'greaterThan')) {
+                            if ($key['entSensorThresholdSeverity'] == 'other' && ($key['entSensorThresholdRelation'] == 'greaterOrEqual' || $key['entSensorThresholdRelation'] == 'greaterThan')) {
                                 $warn_limit = ($key['entSensorThresholdValue'] * $multiplier / $divisor);
-                        	}
+                            }
                         }
 
                         if (! isset($warn_limit_low)) {
-                        	if ($key['entSensorThresholdSeverity'] == 'other' && ($key['entSensorThresholdRelation'] == 'lessOrEqual' || $key['entSensorThresholdRelation'] == 'lessThan')) {
+                            if ($key['entSensorThresholdSeverity'] == 'other' && ($key['entSensorThresholdRelation'] == 'lessOrEqual' || $key['entSensorThresholdRelation'] == 'lessThan')) {
                                 $warn_limit_low = ($key['entSensorThresholdValue'] * $multiplier / $divisor);
                             }
                         }


### PR DESCRIPTION
This is a proposal to address https://github.com/librenms/librenms/issues/18972

If the device does not report any Minor/Major/Critical entSensorThresholdSeverity, but it reports only Other entSensorThresholdSeverity, then use the following logic:

- if the Warning limits are not set, then treat Other entSensorThresholdSeverity as a Warning limit
- if the Critical limits are not set (this means that originally there was nothing for both the Warning and the Critical limit), then transfer the previously discovered value from the Warning to the Critical limit and reset the Warning limit back to NULL


Alternatively, instead of "moving" the value from Warning to Critical limit, I could also simply copy the value from Warning to Critical limit, but this would result in both the Warning and the Critical limit being the same, and I see no benefit in that, if there is only a single threshold reported by the device.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
