### PR TITLE
Remove duplicate ssCpuRawWait from ucd-mib poller

### DIFF
--- a/includes/polling/ucd-mib.inc.php
+++ b/includes/polling/ucd-mib.inc.php
@@ -74,7 +74,6 @@ if (isset($ss[0])) {
         'ssRawContexts',
         'ssRawSwapIn',
         'ssRawSwapOut',
-        'ssCpuRawWait',
         'ssCpuRawSteal',
     ];
 


### PR DESCRIPTION
The ucd-mib poller currently sends 2 updates for the ssCpuRawWait value, and rrdtool errors on one of them because the update time is the same.  We don't currently see the errors because they are sent through the async process.

The other entry is on line 70 of the changed file.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
