### PR TITLE
FDB: fix entries with no port

### DIFF
--- a/includes/discovery/fdb-table.inc.php
+++ b/includes/discovery/fdb-table.inc.php
@@ -57,9 +57,10 @@ if (! empty($insert)) {
                 unset($existing_fdbs[$vlan_id][$mac_address_entry]);
             } else {
                 if (is_null($entry['port_id'])) {
-                    // If $entry['port_id'] truly is null then Illuminate throws a fatal error and all subsequent processing stops.
-                    // Cisco ISO (and others) may have null ids.
-                    continue;
+                    // fix SQLSTATE[23000]: Integrity constraint violation: 1048 Column 'port_id' cannot be null
+                    // If $entry['port_id'] truly is null then  Illuminate throws a fatal errory and all subsequent processing stops.
+                    // Cisco ISO (and others) may have null ids. We still want them inserted as new
+                    $entry['port_id'] = 0;
                 }
 
                 DB::table('ports_fdb')->insert([


### PR DESCRIPTION
Fix a bug in FDB table discovery. `port_id` was set to an empty string if null, although the datatype doesn't accept that. 

Proposed Resolution; the entry is skipped

https://community.librenms.org/t/critical-exception-sqlstate-22007-invalid-datetime-format-error-discovering-fdb-table/29082

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
