### PR TITLE
Update os discovery yaml to use MIB::OID for U files

### DIFF
--- a/resources/definitions/os_discovery/ucopia.yaml
+++ b/resources/definitions/os_discovery/ucopia.yaml
@@ -1,17 +1,16 @@
-mib: CONTROLLER-MIB
 modules:
     sensors:
         additional_oids:
             data:
                 -
                     oid:
-                        - licenseUsers
+                        - CONTROLLER-MIB::licenseUsers
 
         state:
             data:
                 -
-                    oid: highAvailabilityStatus
-                    value: highAvailabilityStatus
+                    oid: CONTROLLER-MIB::highAvailabilityStatus
+                    value: CONTROLLER-MIB::highAvailabilityStatus
                     num_oid: '.1.3.6.1.4.1.31218.3.7.{{ $index }}'
                     descr: 'High Availability Status'
                     index: 'highAvailabilityStatus.{{ $index }}'
@@ -23,8 +22,8 @@ modules:
                         - { descr: Passive, graph: 1, value: 3, generic: 0 }
                         - { descr: Fault, graph: 1, value: 4, generic: 2 }
                 -
-                    oid: debugValue
-                    value: debugValue
+                    oid: CONTROLLER-MIB::debugValue
+                    value: CONTROLLER-MIB::debugValue
                     num_oid: '.1.3.6.1.4.1.31218.3.2.{{ $index }}'
                     descr: 'Debug Value'
                     index: 'debugValue.{{ $index }}'
@@ -39,8 +38,8 @@ modules:
                         - { descr: Informational, graph: 1, value: 6, generic: 0 }
                         - { descr: Debug, graph: 1, value: 7, generic: 0 }
                 -
-                    oid: webServerService
-                    value: webServerService
+                    oid: CONTROLLER-MIB::webServerService
+                    value: CONTROLLER-MIB::webServerService
                     num_oid: '.1.3.6.1.4.1.31218.4.1.{{ $index }}'
                     descr: 'Web Server Status'
                     index: 'webServerService.{{ $index }}'
@@ -50,8 +49,8 @@ modules:
                         - { descr: Stopped, graph: 1, value: 2, generic: 2 }
                         - { descr: Disabled, graph: 1, value: 3, generic: 0 }
                 -
-                    oid: sqlServerService
-                    value: sqlServerService
+                    oid: CONTROLLER-MIB::sqlServerService
+                    value: CONTROLLER-MIB::sqlServerService
                     num_oid: '.1.3.6.1.4.1.31218.4.2.{{ $index }}'
                     descr: 'SQL Server Status'
                     index: 'sqlServerService.{{ $index }}'
@@ -61,8 +60,8 @@ modules:
                         - { descr: Stopped, graph: 1, value: 2, generic: 2 }
                         - { descr: Disabled, graph: 1, value: 3, generic: 0 }
                 -
-                    oid: urlSnifferService
-                    value: urlSnifferService
+                    oid: CONTROLLER-MIB::urlSnifferService
+                    value: CONTROLLER-MIB::urlSnifferService
                     num_oid: '.1.3.6.1.4.1.31218.4.3.{{ $index }}'
                     descr: 'URL Sniffer Status'
                     index: 'urlSnifferService.{{ $index }}'
@@ -72,8 +71,8 @@ modules:
                         - { descr: Stopped, graph: 1, value: 2, generic: 2 }
                         - { descr: Disabled, graph: 1, value: 3, generic: 0 }
                 -
-                    oid: portalService
-                    value: portalService
+                    oid: CONTROLLER-MIB::portalService
+                    value: CONTROLLER-MIB::portalService
                     num_oid: '.1.3.6.1.4.1.31218.4.4.{{ $index }}'
                     descr: 'Portal Status'
                     index: 'portalService.{{ $index }}'
@@ -83,8 +82,8 @@ modules:
                         - { descr: Stopped, graph: 1, value: 2, generic: 2 }
                         - { descr: Disabled, graph: 1, value: 3, generic: 0 }
                 -
-                    oid: webProxyService
-                    value: webProxyService
+                    oid: CONTROLLER-MIB::webProxyService
+                    value: CONTROLLER-MIB::webProxyService
                     num_oid: '.1.3.6.1.4.1.31218.4.5.{{ $index }}'
                     descr: 'Web Proxy Status'
                     index: 'webProxyService.{{ $index }}'
@@ -94,8 +93,8 @@ modules:
                         - { descr: Stopped, graph: 1, value: 2, generic: 2 }
                         - { descr: Disabled, graph: 1, value: 3, generic: 0 }
                 -
-                    oid: autodisconnectService
-                    value: autodisconnectService
+                    oid: CONTROLLER-MIB::autodisconnectService
+                    value: CONTROLLER-MIB::autodisconnectService
                     num_oid: '.1.3.6.1.4.1.31218.4.6.{{ $index }}'
                     descr: 'Auto Disconnect Status'
                     index: 'autodisconnectService.{{ $index }}'
@@ -105,8 +104,8 @@ modules:
                         - { descr: Stopped, graph: 1, value: 2, generic: 2 }
                         - { descr: Disabled, graph: 1, value: 3, generic: 0 }
                 -
-                    oid: printingServerService
-                    value: printingServerService
+                    oid: CONTROLLER-MIB::printingServerService
+                    value: CONTROLLER-MIB::printingServerService
                     num_oid: '.1.3.6.1.4.1.31218.4.7.{{ $index }}'
                     descr: 'Printing Server Status'
                     index: 'printingServerService.{{ $index }}'
@@ -116,8 +115,8 @@ modules:
                         - { descr: Stopped, graph: 1, value: 2, generic: 2 }
                         - { descr: Disabled, graph: 1, value: 3, generic: 0 }
                 -
-                    oid: dhcpServerService
-                    value: dhcpServerService
+                    oid: CONTROLLER-MIB::dhcpServerService
+                    value: CONTROLLER-MIB::dhcpServerService
                     num_oid: '.1.3.6.1.4.1.31218.4.8.{{ $index }}'
                     descr: 'DHCP Server Status'
                     index: 'dhcpServerService.{{ $index }}'
@@ -127,8 +126,8 @@ modules:
                         - { descr: Stopped, graph: 1, value: 2, generic: 2 }
                         - { descr: Disabled, graph: 1, value: 3, generic: 0 }
                 -
-                    oid: dnsServerService
-                    value: dnsServerService
+                    oid: CONTROLLER-MIB::dnsServerService
+                    value: CONTROLLER-MIB::dnsServerService
                     num_oid: '.1.3.6.1.4.1.31218.4.9.{{ $index }}'
                     descr: 'DNS Server Status'
                     index: 'dnsServerService.{{ $index }}'
@@ -138,8 +137,8 @@ modules:
                         - { descr: Stopped, graph: 1, value: 2, generic: 2 }
                         - { descr: Disabled, graph: 1, value: 3, generic: 0 }
                 -
-                    oid: staticIpManagerService
-                    value: staticIpManagerService
+                    oid: CONTROLLER-MIB::staticIpManagerService
+                    value: CONTROLLER-MIB::staticIpManagerService
                     num_oid: '.1.3.6.1.4.1.31218.4.10.{{ $index }}'
                     descr: 'Static IP Manager Status'
                     index: 'staticIpManagerService.{{ $index }}'
@@ -149,8 +148,8 @@ modules:
                         - { descr: Stopped, graph: 1, value: 2, generic: 2 }
                         - { descr: Disabled, graph: 1, value: 3, generic: 0 }
                 -
-                    oid: highAvailabilityService
-                    value: highAvailabilityService
+                    oid: CONTROLLER-MIB::highAvailabilityService
+                    value: CONTROLLER-MIB::highAvailabilityService
                     num_oid: '.1.3.6.1.4.1.31218.4.11.{{ $index }}'
                     descr: 'High Availability Service Status'
                     index: 'highAvailabilityService.{{ $index }}'
@@ -160,8 +159,8 @@ modules:
                         - { descr: Stopped, graph: 1, value: 2, generic: 2 }
                         - { descr: Disabled, graph: 1, value: 3, generic: 0 }
                 -
-                    oid: ldapDirectoryService
-                    value: ldapDirectoryService
+                    oid: CONTROLLER-MIB::ldapDirectoryService
+                    value: CONTROLLER-MIB::ldapDirectoryService
                     num_oid: '.1.3.6.1.4.1.31218.4.12.{{ $index }}'
                     descr: 'LDAP Directory Status'
                     index: 'ldapDirectoryService.{{ $index }}'
@@ -171,8 +170,8 @@ modules:
                         - { descr: Stopped, graph: 1, value: 2, generic: 2 }
                         - { descr: Disabled, graph: 1, value: 3, generic: 0 }
                 -
-                    oid: ldapReplicationManagerService
-                    value: ldapReplicationManagerService
+                    oid: CONTROLLER-MIB::ldapReplicationManagerService
+                    value: CONTROLLER-MIB::ldapReplicationManagerService
                     num_oid: '.1.3.6.1.4.1.31218.4.13.{{ $index }}'
                     descr: 'LDAP Replication Manager Status'
                     index: 'ldapReplicationManagerService.{{ $index }}'
@@ -182,8 +181,8 @@ modules:
                         - { descr: Stopped, graph: 1, value: 2, generic: 2 }
                         - { descr: Disabled, graph: 1, value: 3, generic: 0 }
                 -
-                    oid: timeServerService
-                    value: timeServerService
+                    oid: CONTROLLER-MIB::timeServerService
+                    value: CONTROLLER-MIB::timeServerService
                     num_oid: '.1.3.6.1.4.1.31218.4.14.{{ $index }}'
                     descr: 'NTP Status'
                     index: 'timeServerService.{{ $index }}'
@@ -193,8 +192,8 @@ modules:
                         - { descr: Stopped, graph: 1, value: 2, generic: 2 }
                         - { descr: Disabled, graph: 1, value: 3, generic: 0 }
                 -
-                    oid: radiusServerService
-                    value: radiusServerService
+                    oid: CONTROLLER-MIB::radiusServerService
+                    value: CONTROLLER-MIB::radiusServerService
                     num_oid: '.1.3.6.1.4.1.31218.4.15.{{ $index }}'
                     descr: 'RADIUS Status'
                     index: 'radiusServerService.{{ $index }}'
@@ -204,8 +203,8 @@ modules:
                         - { descr: Stopped, graph: 1, value: 2, generic: 2 }
                         - { descr: Disabled, graph: 1, value: 3, generic: 0 }
                 -
-                    oid: sambaService
-                    value: sambaService
+                    oid: CONTROLLER-MIB::sambaService
+                    value: CONTROLLER-MIB::sambaService
                     num_oid: '.1.3.6.1.4.1.31218.4.16.{{ $index }}'
                     descr: 'SAMBA Status'
                     index: 'sambaService.{{ $index }}'
@@ -215,8 +214,8 @@ modules:
                         - { descr: Stopped, graph: 1, value: 2, generic: 2 }
                         - { descr: Disabled, graph: 1, value: 3, generic: 0 }
                 -
-                    oid: sshService
-                    value: sshService
+                    oid: CONTROLLER-MIB::sshService
+                    value: CONTROLLER-MIB::sshService
                     num_oid: '.1.3.6.1.4.1.31218.4.17.{{ $index }}'
                     descr: 'SSH Status'
                     index: 'sshService.{{ $index }}'
@@ -226,8 +225,8 @@ modules:
                         - { descr: Stopped, graph: 1, value: 2, generic: 2 }
                         - { descr: Disabled, graph: 1, value: 3, generic: 0 }
                 -
-                    oid: syslogService
-                    value: syslogService
+                    oid: CONTROLLER-MIB::syslogService
+                    value: CONTROLLER-MIB::syslogService
                     num_oid: '.1.3.6.1.4.1.31218.4.18.{{ $index }}'
                     descr: 'Syslog Status'
                     index: 'syslogService.{{ $index }}'
@@ -237,8 +236,8 @@ modules:
                         - { descr: Stopped, graph: 1, value: 2, generic: 2 }
                         - { descr: Disabled, graph: 1, value: 3, generic: 0 }
                 -
-                    oid: syslogService
-                    value: usersLogService
+                    oid: CONTROLLER-MIB::syslogService
+                    value: CONTROLLER-MIB::usersLogService
                     num_oid: '.1.3.6.1.4.1.31218.4.19.{{ $index }}'
                     descr: 'Users Log Status'
                     index: 'usersLogService.{{ $index }}'
@@ -248,8 +247,8 @@ modules:
                         - { descr: Stopped, graph: 1, value: 2, generic: 2 }
                         - { descr: Disabled, graph: 1, value: 3, generic: 0 }
                 -
-                    oid: pmsClientService
-                    value: pmsClientService
+                    oid: CONTROLLER-MIB::pmsClientService
+                    value: CONTROLLER-MIB::pmsClientService
                     num_oid: '.1.3.6.1.4.1.31218.4.20.{{ $index }}'
                     descr: 'PMSClient Status'
                     index: 'pmsClientService.{{ $index }}'
@@ -261,31 +260,31 @@ modules:
         count:
             data:
                 -
-                    oid: totalConnectedUsers
+                    oid: CONTROLLER-MIB::totalConnectedUsers
                     num_oid: '.1.3.6.1.4.1.31218.3.1.{{ $index }}'
                     index: 'totalConnectedUsers.{{ $index }}'
                     descr: Connected Users
-                    high_limit: licenseUsers
+                    high_limit: CONTROLLER-MIB::licenseUsers
 
         temperature:
             data:
                 -
-                    oid: cpuTemperature
+                    oid: CONTROLLER-MIB::cpuTemperature
                     num_oid: '.1.3.6.1.4.1.31218.3.3.{{ $index }}'
                     index: 'cpuTemperature.{{ $index }}'
                     descr: CPU Temperature
                     skip_values:
                          -
-                            oid: cpuTemperature
+                            oid: CONTROLLER-MIB::cpuTemperature
                             op: '='
                             value: ''
                 -
-                    oid: diskTemperature
+                    oid: CONTROLLER-MIB::diskTemperature
                     num_oid: '.1.3.6.1.4.1.31218.3.4.{{ $index }}'
                     index: 'diskTemperature.{{ $index }}'
                     descr: Disk Temperature
                     skip_values:
                          -
-                            oid: diskTemperature
+                            oid: CONTROLLER-MIB::diskTemperature
                             op: '='
                             value: ''

--- a/resources/definitions/os_discovery/ucos.yaml
+++ b/resources/definitions/os_discovery/ucos.yaml
@@ -1,4 +1,3 @@
-mib: CISCO-UNIFIED-COMPUTING-EQUIPMENT-MIB
 modules:
     os:
         hardware_mib: CISCO-PRODUCTS-MIB
@@ -8,18 +7,19 @@ modules:
             data:
                 -
                     oid:
-                        - cucsEquipmentChassisDn
-                        - cucsEquipmentFanModuleDn
-                        - cucsEquipmentPsuDn
+                        - CISCO-UNIFIED-COMPUTING-EQUIPMENT-MIB::cucsEquipmentChassisDn
+                        - CISCO-UNIFIED-COMPUTING-EQUIPMENT-MIB::cucsEquipmentFanModuleDn
+                        - CISCO-UNIFIED-COMPUTING-EQUIPMENT-MIB::cucsEquipmentPsuDn
         state:
             data:
                 -
-                    oid: cucsEquipmentChassisOperState
-                    value: cucsEquipmentChassisOperState
+                    oid: CISCO-UNIFIED-COMPUTING-EQUIPMENT-MIB::cucsEquipmentChassisOperState
+                    value: CISCO-UNIFIED-COMPUTING-EQUIPMENT-MIB::cucsEquipmentChassisOperState
                     num_oid: '.1.3.6.1.4.1.9.9.719.1.15.7.1.27.{{ $index }}'
-                    descr: 'Chassis - {{ $cucsEquipmentChassisDn }}'
+                    descr: 'Chassis - {{ CISCO-UNIFIED-COMPUTING-EQUIPMENT-MIB::cucsEquipmentChassisDn }}'
                     index: '{{ $index }}'
                     group: Chassis
+                    state_name: cucsEquipmentChassisOperState
                     states:
                         - { value: 0, descr: unknown, graph: 1, generic: 3 }
                         - { value: 1, descr: operable, graph: 1, generic: 0 }
@@ -52,12 +52,13 @@ modules:
                         - { value: 107, descr: auto upgrade, graph: 1, generic: 3 }
 
                 -
-                    oid: cucsEquipmentFanModuleOperState
-                    value: cucsEquipmentFanModuleOperState
+                    oid: CISCO-UNIFIED-COMPUTING-EQUIPMENT-MIB::cucsEquipmentFanModuleOperState
+                    value: CISCO-UNIFIED-COMPUTING-EQUIPMENT-MIB::cucsEquipmentFanModuleOperState
                     num_oid: '.1.3.6.1.4.1.9.9.719.1.15.13.1.7.{{ $index }}'
-                    descr: 'Fan Module - {{ $cucsEquipmentFanModuleDn }}'
+                    descr: 'Fan Module - {{ CISCO-UNIFIED-COMPUTING-EQUIPMENT-MIB::cucsEquipmentFanModuleDn }}'
                     index: '{{ $index }}'
                     group: Fans
+                    state_name: cucsEquipmentFanModuleOperState
                     states:
                         - { value: 0, descr: unknown, graph: 1, generic: 3 }
                         - { value: 1, descr: ok, graph: 1, generic: 0 }
@@ -70,12 +71,13 @@ modules:
                         - { value: 100, descr: not supported, graph: 1, generic: 3 }
 
                 -
-                    oid: cucsEquipmentPsuPower
-                    value: cucsEquipmentPsuPower
+                    oid: CISCO-UNIFIED-COMPUTING-EQUIPMENT-MIB::cucsEquipmentPsuPower
+                    value: CISCO-UNIFIED-COMPUTING-EQUIPMENT-MIB::cucsEquipmentPsuPower
                     num_oid: '.1.3.6.1.4.1.9.9.719.1.15.56.1.10.{{ $index }}'
-                    descr: 'PSU - {{ $cucsEquipmentPsuDn }}'
+                    descr: 'PSU - {{ CISCO-UNIFIED-COMPUTING-EQUIPMENT-MIB::cucsEquipmentPsuDn }}'
                     index: '{{ $index }}'
                     group: PSU
+                    state_name: cucsEquipmentPsuPower
                     states:
                         - { value: 0, descr: unknown, graph: 1, generic: 3 }
                         - { value: 1, descr: on, graph: 1, generic: 0 }

--- a/resources/definitions/os_discovery/uhp.yaml
+++ b/resources/definitions/os_discovery/uhp.yaml
@@ -1,4 +1,3 @@
-mib: UHP-MIB
 modules:
   os:
     version: UHP-MIB::swVersion.0
@@ -6,15 +5,15 @@ modules:
   processors:
     data:
       -
-        oid: cpuLoad
+        oid: UHP-MIB::cpuLoad
         num_oid: .1.3.6.1.4.1.8000.22.8.2.{{ $index }}
         type: uhp
   sensors:
     temperature:
       data:
         -
-          oid: temperature
-          value: temperature
+          oid: UHP-MIB::temperature
+          value: UHP-MIB::temperature
           num_oid: .1.3.6.1.4.1.8000.22.2.1.{{ $index }}
           index: 'temperature.{{ $index }}'
           descr: 'Temperature'
@@ -22,16 +21,16 @@ modules:
     snr:
       data:
         -
-          oid: lbandSNR1
-          value: lbandSNR1
+          oid: UHP-MIB::lbandSNR1
+          value: UHP-MIB::lbandSNR1
           num_oid: .1.3.6.1.4.1.8000.22.2.1.{{ $index }}
           index: 'lbandSNR1.{{ $index }}'
           descr: 'Ratio at L-band'
           group: 'Demodulator 1'
           divisor: 10
         -
-          oid: lbandSNR2
-          value: lbandSNR2
+          oid: UHP-MIB::lbandSNR2
+          value: UHP-MIB::lbandSNR2
           num_oid: .1.3.6.1.4.1.8000.22.3.1.{{ $index }}
           index: 'lbandSNR2.{{ $index }}'
           descr: 'Ratio at L-band'
@@ -40,214 +39,214 @@ modules:
     frequency:
       data:
         -
-          oid: lbandOffset1
-          value: lbandOffset1
+          oid: UHP-MIB::lbandOffset1
+          value: UHP-MIB::lbandOffset1
           num_oid: .1.3.6.1.4.1.8000.22.2.2.{{ $index }}
           index: 'lbandOffset1.{{ $index }}'
           descr: 'PLL and carrier offset'
           group: 'Demodulator 1'
           multiplier: 1000
         -
-          oid: lbandOffset2
-          value: lbandOffset2
+          oid: UHP-MIB::lbandOffset2
+          value: UHP-MIB::lbandOffset2
           num_oid: .1.3.6.1.4.1.8000.22.3.2.{{ $index }}
           index: 'lbandOffset2.{{ $index }}'
           descr: 'PLL and carrier offset'
           group: 'Demodulator 2'
           multiplier: 1000
         -
-          oid: tdelta
-          value: tdelta
+          oid: UHP-MIB::tdelta
+          value: UHP-MIB::tdelta
           num_oid: .1.3.6.1.4.1.8000.22.5.1.{{ $index }}
           index: 'tdelta.{{ $index }}'
           descr: 'Delta between station and hub'
           group: 'TTS'
         -
-          oid: hubTTS
-          value: hubTTS
+          oid: UHP-MIB::hubTTS
+          value: UHP-MIB::hubTTS
           num_oid: .1.3.6.1.4.1.8000.22.5.1.5.{{ $index }}
           index: 'hubTTS.{{ $index }}'
           descr: 'HUB TTS'
           group: 'TTS'
         -
-          oid: remoteTTS
-          value: remoteTTS
+          oid: UHP-MIB::remoteTTS
+          value: UHP-MIB::remoteTTS
           num_oid: .1.3.6.1.4.1.8000.22.5.1.7.{{ $index }}
           index: 'remoteTTS.{{ $index }}'
           descr: 'Remote TTS'
           group: 'TTS'
         -
-          oid: frqOffset
-          value: frqOffset
+          oid: UHP-MIB::frqOffset
+          value: UHP-MIB::frqOffset
           num_oid: .1.3.6.1.4.1.8000.22.5.5.7.{{ $index }}
           index: 'frqOffset.{{ $index }}'
           descr: 'Frequency offset'
         -
-          oid: frqAdjust
-          value: frqAdjust
+          oid: UHP-MIB::frqAdjust
+          value: UHP-MIB::frqAdjust
           num_oid: .1.3.6.1.4.1.8000.22.5.5.7.{{ $index }}
           index: 'frqAdjust.{{ $index }}'
           descr: 'TX frequency adjustment'
     bitrate:
       data:
         -
-          oid: prioAll
-          value: outBytesA
+          oid: UHP-MIB::prioAll
+          value: UHP-MIB::outBytesA
           num_oid: .1.3.6.1.4.1.8000.22.4.1.1.{{ $index }}
           index: 'outBytesA.{{ $index }}'
           descr: 'Traffic'
           group: 'Modulator'
           divisor: 8
         -
-          oid: outBytesP1
-          value: outBytesP1
+          oid: UHP-MIB::outBytesP1
+          value: UHP-MIB::outBytesP1
           num_oid: .1.3.6.1.4.1.8000.22.4.2.1.{{ $index }}
           index: 'outBytesP1.{{ $index }}'
           descr: 'P1(low) priority traffic'
           group: 'Modulator'
           divisor: 8
         -
-          oid: outBytesP2
-          value: outBytesP2
+          oid: UHP-MIB::outBytesP2
+          value: UHP-MIB::outBytesP2
           num_oid: .1.3.6.1.4.1.8000.22.4.7.1.{{ $index }}
           index: 'outBytesP2.{{ $index }}'
           descr: 'P2 priority traffic'
           group: 'Modulator'
           divisor: 8
         -
-          oid: outBytesP3
-          value: outBytesP3
+          oid: UHP-MIB::outBytesP3
+          value: UHP-MIB::outBytesP3
           num_oid: .1.3.6.1.4.1.8000.22.4.8.1.{{ $index }}
           index: 'outBytesP3.{{ $index }}'
           descr: 'P3 priority traffic'
           group: 'Modulator'
           divisor: 8
         -
-          oid: outBytesP4
-          value: outBytesP4
+          oid: UHP-MIB::outBytesP4
+          value: UHP-MIB::outBytesP4
           num_oid: .1.3.6.1.4.1.8000.22.4.3.1.{{ $index }}
           index: 'outBytesP4.{{ $index }}'
           descr: 'P4(med) priority traffic'
           group: 'Modulator'
           divisor: 8
         -
-          oid: outBytesP5
-          value: outBytesP5
+          oid: UHP-MIB::outBytesP5
+          value: UHP-MIB::outBytesP5
           num_oid: .1.3.6.1.4.1.8000.22.4.9.1.{{ $index }}
           index: 'outBytesP5.{{ $index }}'
           descr: 'P5 priority traffic'
           group: 'Modulator'
           divisor: 8
         -
-          oid: outBytesP6
-          value: outBytesP6
+          oid: UHP-MIB::outBytesP6
+          value: UHP-MIB::outBytesP6
           num_oid: .1.3.6.1.4.1.8000.22.4.10.1.{{ $index }}
           index: 'outBytesP6.{{ $index }}'
           descr: 'P6 priority traffic'
           group: 'Modulator'
           divisor: 8
         -
-          oid: outBytesP7
-          value: outBytesP7
+          oid: UHP-MIB::outBytesP7
+          value: UHP-MIB::outBytesP7
           num_oid: .1.3.6.1.4.1.8000.22.4.4.1.{{ $index }}
           index: 'outBytesP7.{{ $index }}'
           descr: 'P7(high) priority traffic'
           group: 'Modulator'
           divisor: 8
         -
-          oid: outBytesC
-          value: outBytesC
+          oid: UHP-MIB::outBytesC
+          value: UHP-MIB::outBytesC
           num_oid: .1.3.6.1.4.1.8000.22.4.5.1.{{ $index }}
           index: 'outBytesC.{{ $index }}'
           descr: 'Control traffic'
           group: 'Modulator'
           divisor: 8
         -
-          oid: prioAll
-          value: queueLenBA
+          oid: UHP-MIB::prioAll
+          value: UHP-MIB::queueLenBA
           num_oid: .1.3.6.1.4.1.8000.22.4.1.4.{{ $index }}
           index: 'queueLenBA.{{ $index }}'
           descr: 'Queue length'
           divisor: 8
           group: 'Modulator'
         -
-          oid: queueLenBP1
-          value: queueLenBP1
+          oid: UHP-MIB::queueLenBP1
+          value: UHP-MIB::queueLenBP1
           num_oid: .1.3.6.1.4.1.8000.22.4.2.4.{{ $index }}
           index: 'queueLenBP1.{{ $index }}'
           descr: 'P1(low) queue length'
           divisor: 8
           group: 'Modulator'
         -
-          oid: queueLenBP2
-          value: queueLenBP2
+          oid: UHP-MIB::queueLenBP2
+          value: UHP-MIB::queueLenBP2
           num_oid: .1.3.6.1.4.1.8000.22.4.7.4.{{ $index }}
           index: 'queueLenBP2.{{ $index }}'
           descr: 'P2 queue length'
           divisor: 8
           group: 'Modulator'
         -
-          oid: queueLenBP3
-          value: queueLenBP3
+          oid: UHP-MIB::queueLenBP3
+          value: UHP-MIB::queueLenBP3
           num_oid: .1.3.6.1.4.1.8000.22.4.8.4.{{ $index }}
           index: 'queueLenBP3.{{ $index }}'
           descr: 'P3 queue length'
           divisor: 8
           group: 'Modulator'
         -
-          oid: queueLenBP4
-          value: queueLenBP4
+          oid: UHP-MIB::queueLenBP4
+          value: UHP-MIB::queueLenBP4
           num_oid: .1.3.6.1.4.1.8000.22.4.3.4.{{ $index }}
           index: 'queueLenBP4.{{ $index }}'
           descr: 'P4(med) queue length'
           divisor: 8
           group: 'Modulator'
         -
-          oid: queueLenBP5
-          value: queueLenBP5
+          oid: UHP-MIB::queueLenBP5
+          value: UHP-MIB::queueLenBP5
           num_oid: .1.3.6.1.4.1.8000.22.4.9.4.{{ $index }}
           index: 'queueLenBP5.{{ $index }}'
           descr: 'P5 queue length'
           divisor: 8
           group: 'Modulator'
         -
-          oid: queueLenBP6
-          value: queueLenBP6
+          oid: UHP-MIB::queueLenBP6
+          value: UHP-MIB::queueLenBP6
           num_oid: .1.3.6.1.4.1.8000.22.4.10.4.{{ $index }}
           index: 'queueLenBP6.{{ $index }}'
           descr: 'P6 queue length'
           divisor: 8
           group: 'Modulator'
         -
-          oid: queueLenBP7
-          value: queueLenBP7
+          oid: UHP-MIB::queueLenBP7
+          value: UHP-MIB::queueLenBP7
           num_oid: .1.3.6.1.4.1.8000.22.4.4.4.{{ $index }}
           index: 'queueLenBP7.{{ $index }}'
           descr: 'P7(high) queue length'
           divisor: 8
           group: 'Modulator'
         -
-          oid: sectionBW
+          oid: UHP-MIB::sectionBW
           num_oid: .1.3.6.1.4.1.8000.22.5.2.3.{{ $index }}
           index: 'sectionBW.{{ $index }}'
           descr: 'Bandwidth of single slot in frame'
           divisor: 8
         -
-          oid: inBytes1
+          oid: UHP-MIB::inBytes1
           num_oid: .1.3.6.1.4.1.8000.22.2.4.{{ $index }}
           index: 'inBytes1.{{ $index }}'
           descr: 'Traffic'
           group: 'Demodulator 1'
           divisor: 8
         -
-          oid: inBytes2
+          oid: UHP-MIB::inBytes2
           num_oid: .1.3.6.1.4.1.8000.22.3.4.{{ $index }}
           index: 'inBytes2.{{ $index }}'
           descr: 'Traffic'
           group: 'Demodulator 2'
           divisor: 8
         -
-          oid: sectionBW
+          oid: UHP-MIB::sectionBW
           num_oid: .1.3.6.1.4.1.8000.22.5.2.3.{{ $index }}
           index: 'sectionBW.{{ $index }}'
           descr: 'Bandwidth of single slot in frame'
@@ -255,287 +254,287 @@ modules:
     count:
       data:
         -
-          oid: prioAll
-          value: outPktsA
+          oid: UHP-MIB::prioAll
+          value: UHP-MIB::outPktsA
           num_oid: .1.3.6.1.4.1.8000.22.4.1.2.{{ $index }}
           index: 'outPktsA.{{ $index }}'
           descr: 'Traffic in packets'
           group: 'Modulator'
         -
-          oid: outPktsC
-          value: outPktsC
+          oid: UHP-MIB::outPktsC
+          value: UHP-MIB::outPktsC
           num_oid: .1.3.6.1.4.1.8000.22.4.5.2.{{ $index }}
           index: 'outPktsC.{{ $index }}'
           descr: 'Control traffic in packets'
           group: 'Modulator'
         -
-          oid: outPktsP1
-          value: outPktsP1
+          oid: UHP-MIB::outPktsP1
+          value: UHP-MIB::outPktsP1
           num_oid: .1.3.6.1.4.1.8000.22.4.2.2.{{ $index }}
           index: 'outPktsP1.{{ $index }}'
           descr: 'P1(low) priority traffic in packets'
           group: 'Modulator'
         -
-          oid: outPktsP2
-          value: outPktsP2
+          oid: UHP-MIB::outPktsP2
+          value: UHP-MIB::outPktsP2
           num_oid: .1.3.6.1.4.1.8000.22.4.7.2.{{ $index }}
           index: 'outPktsP2.{{ $index }}'
           descr: 'P2 priority traffic in packets'
           group: 'Modulator'
         -
-          oid: outPktsP3
-          value: outPktsP3
+          oid: UHP-MIB::outPktsP3
+          value: UHP-MIB::outPktsP3
           num_oid: .1.3.6.1.4.1.8000.22.4.8.2.{{ $index }}
           index: 'outPktsP3.{{ $index }}'
           descr: 'P3 priority traffic in packets'
           group: 'Modulator'
         -
-          oid: outPktsP4
-          value: outPktsP4
+          oid: UHP-MIB::outPktsP4
+          value: UHP-MIB::outPktsP4
           num_oid: .1.3.6.1.4.1.8000.22.4.3.2.{{ $index }}
           index: 'outPktsP4.{{ $index }}'
           descr: 'P4(med) priority traffic in packets'
           group: 'Modulator'
         -
-          oid: outPktsP5
-          value: outPktsP5
+          oid: UHP-MIB::outPktsP5
+          value: UHP-MIB::outPktsP5
           num_oid: .1.3.6.1.4.1.8000.22.4.9.2.{{ $index }}
           index: 'outPktsP5.{{ $index }}'
           descr: 'P5 priority traffic in packets'
           group: 'Modulator'
         -
-          oid: outPktsP6
-          value: outPktsP6
+          oid: UHP-MIB::outPktsP6
+          value: UHP-MIB::outPktsP6
           num_oid: .1.3.6.1.4.1.8000.22.4.10.2.{{ $index }}
           index: 'outPktsP6.{{ $index }}'
           descr: 'P6 priority traffic in packets'
           group: 'Modulator'
         -
-          oid: outPktsP7
-          value: outPktsP7
+          oid: UHP-MIB::outPktsP7
+          value: UHP-MIB::outPktsP7
           num_oid: .1.3.6.1.4.1.8000.22.4.4.2.{{ $index }}
           index: 'outPktsP7.{{ $index }}'
           descr: 'P7(high) priority traffic in packets'
           group: 'Modulator'
         -
-          oid: prioAll
-          value: dropsA
+          oid: UHP-MIB::prioAll
+          value: UHP-MIB::dropsA
           num_oid: .1.3.6.1.4.1.8000.22.4.1.3.{{ $index }}
           index: 'dropsA.{{ $index }}'
           descr: 'Dropped packets'
           group: 'Modulator'
-        - oid: dropsP1
-          value: dropsP1
+        - oid: UHP-MIB::dropsP1
+          value: UHP-MIB::dropsP1
           num_oid: .1.3.6.1.4.1.8000.22.4.2.3.{{ $index }}
           index: 'dropsP1.{{ $index }}'
           descr: 'P1(low) dropped packets'
           group: 'Modulator'
-        - oid: dropsP2
-          value: dropsP2
+        - oid: UHP-MIB::dropsP2
+          value: UHP-MIB::dropsP2
           num_oid: .1.3.6.1.4.1.8000.22.4.7.3.{{ $index }}
           index: 'dropsP2.{{ $index }}'
           descr: 'P2 dropped packets'
           group: 'Modulator'
-        - oid: dropsP3
-          value: dropsP3
+        - oid: UHP-MIB::dropsP3
+          value: UHP-MIB::dropsP3
           num_oid: .1.3.6.1.4.1.8000.22.4.8.3.{{ $index }}
           index: 'dropsP3.{{ $index }}'
           descr: 'P3 dropped packets'
           group: 'Modulator'
-        - oid: dropsP4
-          value: dropsP4
+        - oid: UHP-MIB::dropsP4
+          value: UHP-MIB::dropsP4
           num_oid: .1.3.6.1.4.1.8000.22.4.3.3.{{ $index }}
           index: 'dropsP4.{{ $index }}'
           descr: 'P4(med) dropped packets'
           group: 'Modulator'
-        - oid: dropsP5
-          value: dropsP5
+        - oid: UHP-MIB::dropsP5
+          value: UHP-MIB::dropsP5
           num_oid: .1.3.6.1.4.1.8000.22.4.9.3.{{ $index }}
           index: 'dropsP5.{{ $index }}'
           descr: 'P5 dropped packets'
           group: 'Modulator'
-        - oid: dropsP6
-          value: dropsP6
+        - oid: UHP-MIB::dropsP6
+          value: UHP-MIB::dropsP6
           num_oid: .1.3.6.1.4.1.8000.22.4.10.3.{{ $index }}
           index: 'dropsP6.{{ $index }}'
           descr: 'P6 dropped packets'
           group: 'Modulator'
-        - oid: dropsP7
-          value: dropsP7
+        - oid: UHP-MIB::dropsP7
+          value: UHP-MIB::dropsP7
           num_oid: .1.3.6.1.4.1.8000.22.4.4.3.{{ $index }}
           index: 'dropsP7.{{ $index }}'
           descr: 'P7(high) dropped packets'
           group: 'Modulator'
         -
-          oid: prioAll
-          value: queueLenPA
+          oid: UHP-MIB::prioAll
+          value: UHP-MIB::queueLenPA
           num_oid: .1.3.6.1.4.1.8000.22.4.2.5.{{ $index }}
           index: 'queueLenPA.{{ $index }}'
           descr: 'Queue length in packets'
           group: 'Modulator'
         -
-          oid: queueLenPP1
-          value: queueLenPP1
+          oid: UHP-MIB::queueLenPP1
+          value: UHP-MIB::queueLenPP1
           num_oid: .1.3.6.1.4.1.8000.22.4.2.5.{{ $index }}
           index: 'queueLenPP1.{{ $index }}'
           descr: 'P1(low) queue length in packets'
           group: 'Modulator'
         -
-          oid: queueLenPP2
-          value: queueLenPP2
+          oid: UHP-MIB::queueLenPP2
+          value: UHP-MIB::queueLenPP2
           num_oid: .1.3.6.1.4.1.8000.22.4.7.5.{{ $index }}
           index: 'queueLenPP2.{{ $index }}'
           descr: 'P2 queue length in packets'
           group: 'Modulator'
         -
-          oid: queueLenPP3
-          value: queueLenPP3
+          oid: UHP-MIB::queueLenPP3
+          value: UHP-MIB::queueLenPP3
           num_oid: .1.3.6.1.4.1.8000.22.4.8.5.{{ $index }}
           index: 'queueLenPP3.{{ $index }}'
           descr: 'P3 queue length in packets'
           group: 'Modulator'
         -
-          oid: queueLenPP4
-          value: queueLenPP4
+          oid: UHP-MIB::queueLenPP4
+          value: UHP-MIB::queueLenPP4
           num_oid: .1.3.6.1.4.1.8000.22.4.3.5.{{ $index }}
           index: 'queueLenPP4.{{ $index }}'
           descr: 'P4(med) queue length in packets'
           group: 'Modulator'
         -
-          oid: queueLenPP5
-          value: queueLenPP5
+          oid: UHP-MIB::queueLenPP5
+          value: UHP-MIB::queueLenPP5
           num_oid: .1.3.6.1.4.1.8000.22.4.9.5.{{ $index }}
           index: 'queueLenPP5.{{ $index }}'
           descr: 'P5 queue length in packets'
           group: 'Modulator'
         -
-          oid: queueLenPP6
-          value: queueLenPP6
+          oid: UHP-MIB::queueLenPP6
+          value: UHP-MIB::queueLenPP6
           num_oid: .1.3.6.1.4.1.8000.22.4.10.5.{{ $index }}
           index: 'queueLenPP6.{{ $index }}'
           descr: 'P6 queue length in packets'
           group: 'Modulator'
         -
-          oid: queueLenPP7
-          value: queueLenPP7
+          oid: UHP-MIB::queueLenPP7
+          value: UHP-MIB::queueLenPP7
           num_oid: .1.3.6.1.4.1.8000.22.4.4.5.{{ $index }}
           index: 'queueLenPP7.{{ $index }}'
           descr: 'P7(high) queue length in packets'
           group: 'Modulator'
         -
-          oid: prioAll
-          value: numStations
+          oid: UHP-MIB::prioAll
+          value: UHP-MIB::numStations
           num_oid: .1.3.6.1.4.1.8000.22.4.1.6.{{ $index }}
           index: 'numStations.{{ $index }}'
           descr: 'Stations per ACM channel'
           group: 'Modulator'
         -
-          oid: unroutedPkts
+          oid: UHP-MIB::unroutedPkts
           num_oid: .1.3.6.1.4.1.8000.22.6.1.{{ $index }}
           index: 'unroutedPkts.{{ $index }}'
           descr: 'Unroutable packets'
         -
-          oid: frameDelay
+          oid: UHP-MIB::frameDelay
           num_oid: .1.3.6.1.4.1.8000.22.5.2.2.{{ $index }}
           index: 'frameDelay.{{ $index }}'
           descr: 'TX-RX processing delay'
         -
-          oid: netRequest
+          oid: UHP-MIB::netRequest
           num_oid: .1.3.6.1.4.1.8000.22.5.2.4.{{ $index }}
           index: 'netRequest.{{ $index }}'
           descr: 'Requests of all stations'
         -
-          oid: freeSlots
+          oid: UHP-MIB::freeSlots
           num_oid: .1.3.6.1.4.1.8000.22.5.2.5.{{ $index }}
           index: 'freeSlots.{{ $index }}'
           descr: 'Free-allocated slots in current frame'
         -
-          oid: frameDuration
+          oid: UHP-MIB::frameDuration
           num_oid: .1.3.6.1.4.1.8000.22.5.3.2.{{ $index }}
           index: 'frameDuration.{{ $index }}'
           descr: 'Frame duration'
         -
-          oid: outVlanBytes
+          oid: UHP-MIB::outVlanBytes
           num_oid: .1.3.6.1.4.1.8000.22.6.4.{{ $index }}
           index: 'outVlanBytes.{{ $index }}'
           descr: 'Bytes transmitted via VLAN {{ $index }}'
           group: 'VLAN {{ $index }}'
         -
-          oid: inVlanBytes
+          oid: UHP-MIB::inVlanBytes
           num_oid: .1.3.6.1.4.1.8000.22.6.5.{{ $index }}
           index: 'inVlanBytes.{{ $index }}'
           descr: 'Bytes received via VLAN {{ $index }}'
           group: 'VLAN {{ $index }}'
         -
-          oid: outSvlanBytes
+          oid: UHP-MIB::outSvlanBytes
           num_oid: .1.3.6.1.4.1.8000.22.6.5.{{ $index }}
           index: 'outSvlanBytes.{{ $index }}'
           descr: 'Bytes tranmitted via SVLAN {{ $index }}'
           group: 'VLAN {{ $index }}'
         -
-          oid: inSvlanBytes
+          oid: UHP-MIB::inSvlanBytes
           num_oid: .1.3.6.1.4.1.8000.22.6.7.{{ $index }}
           index: 'inSvlanBytes.{{ $index }}'
           descr: 'Bytes received via SVLAN {{ $index }}'
           group: 'VLAN {{ $index }}'
         -
-          oid: inSvlanPackets
+          oid: UHP-MIB::inSvlanPackets
           num_oid: .1.3.6.1.4.1.8000.22.6.8.{{ $index }}
           index: 'inSvlanBytes.{{ $index }}'
           descr: 'Packets received via SVLAN {{ $index }}'
           group: 'VLAN {{ $index }}'
         -
-          oid: tdtConfidence
+          oid: UHP-MIB::tdtConfidence
           num_oid: .1.3.6.1.4.1.8000.22.5.1.2.{{ $index }}
           index: 'tdtConfidence.{{ $index }}'
           descr: 'Tdelta confidence 0-64'
           group: 'TTS'
         -
-          oid: softErrors
+          oid: UHP-MIB::softErrors
           num_oid: .1.3.6.1.4.1.8000.22.5.1.3.{{ $index }}
           index: 'softErrors.{{ $index }}'
           descr: 'Soft errors of TTS/Tdelta'
           group: 'TTS'
         -
-          oid: hardErrors
+          oid: UHP-MIB::hardErrors
           num_oid: .1.3.6.1.4.1.8000.22.5.1.4.{{ $index }}
           index: 'hardErrors.{{ $index }}'
           descr: 'Hard errors of TTS/Tdelta'
           group: 'TTS'
         -
-          oid: hubTTSconfidence
+          oid: UHP-MIB::hubTTSconfidence
           num_oid: .1.3.6.1.4.1.8000.22.5.1.6.{{ $index }}
           index: 'hubTTSconfidence.{{ $index }}'
           descr: 'HUB TTS confidence 0-64'
           group: 'TTS'
         -
-          oid: remnrtRequest
+          oid: UHP-MIB::remnrtRequest
           num_oid: .1.3.6.1.4.1.8000.22.5.5.2.{{ $index }}
           index: 'remnrtRequest.{{ $index }}'
           descr: 'Request for non-real-time bandwidth'
         -
-          oid: remrtRequest
+          oid: UHP-MIB::remrtRequest
           num_oid: .1.3.6.1.4.1.8000.22.5.5.3.{{ $index }}
           index: 'remrtRequest.{{ $index }}'
           descr: 'Request for real-time bandwidth'
         -
-          oid: fpLost
+          oid: UHP-MIB::fpLost
           num_oid: .1.3.6.1.4.1.8000.22.5.5.4.{{ $index }}
           index: 'fpLost.{{ $index }}'
           descr: 'Lost frame plans'
         -
-          oid: lvlOffset
+          oid: UHP-MIB::lvlOffset
           num_oid: .1.3.6.1.4.1.8000.22.5.5.5.{{ $index }}
           index: 'lvlOffset.{{ $index }}'
           descr: 'Reference level C/N level offset'
         -
-          oid: timeOffset
+          oid: UHP-MIB::timeOffset
           num_oid: .1.3.6.1.4.1.8000.22.5.5.9.{{ $index }}
           index: 'timeOffset.{{ $index }}'
           descr: 'Timing offset'
           divisor: 100000000
         -
-          oid: timeAdjust
+          oid: UHP-MIB::timeAdjust
           num_oid: .1.3.6.1.4.1.8000.22.5.5.10.{{ $index }}
           index: 'timeAdjust.{{ $index }}'
           descr: 'TX timing adjustment'
@@ -543,48 +542,48 @@ modules:
     dbm:
       data:
         -
-          oid: txLevel
+          oid: UHP-MIB::txLevel
           num_oid: .1.3.6.1.4.1.8000.22.4.6.1.{{ $index }}
           index: txLevel.{{ $index }}
           descr: 'TX level'
           group: 'Modulator'
           divisor: 10
         -
-          oid: txLevelDelta
+          oid: UHP-MIB::txLevelDelta
           num_oid: .1.3.6.1.4.1.8000.22.4.6.2.{{ $index }}
           index: txLevelDelta.{{ $index }}
           descr: 'TX level delta'
           group: 'Modulator'
           divisor: 10
         -
-          oid: txMaxLevel
+          oid: UHP-MIB::txMaxLevel
           num_oid: .1.3.6.1.4.1.8000.22.4.6.3.{{ $index }}
           index: txMaxLevel.{{ $index }}
           descr: 'Max TLC level'
           group: 'Modulator'
           divisor: 10
         -
-          oid: inLvl1
+          oid: UHP-MIB::inLvl1
           num_oid: .1.3.6.1.4.1.8000.22.2.3.{{ $index }}
           index: inLvl1.{{ $index }}
           descr: 'Input level'
           group: 'Demodulator 1'
           divisor: 10
         -
-          oid: inLvl2
+          oid: UHP-MIB::inLvl2
           num_oid: .1.3.6.1.4.1.8000.22.3.3.{{ $index }}
           index: inLvl2.{{ $index }}
           descr: 'Input level'
           group: 'Demodulator 2'
           divisor: 10
         -
-          oid: lvlAdjust
+          oid: UHP-MIB::lvlAdjust
           num_oid: .1.3.6.1.4.1.8000.22.5.5.6.{{ $index }}
           index: lvlAdjust.{{ $index }}
           descr: 'TX power level adjustment'
           divisor: 10
         -
-          oid: inputLevel
+          oid: UHP-MIB::inputLevel
           num_oid: .1.3.6.1.4.1.8000.22.9.3.0.{{ $index }}
           index: inputLevel.{{ $index }}
           descr: 'Input baseband RF'
@@ -592,7 +591,7 @@ modules:
     state:
       data:
         -
-          oid: netState
+          oid: UHP-MIB::netState
           num_oid: '.1.3.6.1.4.1.8000.22.5.2.1.{{ $index }}'
           descr: 'Operation status'
           index: 'netState.{{ $index }}'
@@ -617,7 +616,7 @@ modules:
               - { value: 16, generic: 0, graph: 0, descr: 'noStations' }
               - { value: 17, generic: 0, graph: 0, descr: 'operation' }
         -
-          oid: serverStatus
+          oid: UHP-MIB::serverStatus
           num_oid: '.1.3.6.1.4.1.8000.22.5.3.1.{{ $index }}'
           descr: 'Server reply status'
           index: 'serverStatus.{{ $index }}'
@@ -642,7 +641,7 @@ modules:
               - { value: 16, generic: 0, graph: 0, descr: 'noStations' }
               - { value: 17, generic: 0, graph: 0, descr: 'operation' }
         -
-          oid: stationState
+          oid: UHP-MIB::stationState
           num_oid: '.1.3.6.1.4.1.8000.22.5.5.1.{{ $index }}'
           descr: 'Remote status'
           index: 'stationState.{{ $index }}'
@@ -667,7 +666,7 @@ modules:
               - { value: 16, generic: 0, graph: 0, descr: 'noStations' }
               - { value: 17, generic: 0, graph: 0, descr: 'operation' }
         -
-          oid: redundancy
+          oid: UHP-MIB::redundancy
           num_oid: '.1.3.6.1.4.1.8000.22.8.4.{{ $index }}'
           descr: 'Redundancy status'
           index: 'redundancy.{{ $index }}'
@@ -680,7 +679,7 @@ modules:
               - { value: 4, generic: 0, graph: 0, descr: 'active' }
               - { value: 5, generic: 0, graph: 0, descr: 'off' }
         -
-          oid: rxState
+          oid: UHP-MIB::rxState
           num_oid: '.1.3.6.1.4.1.8000.22.9.4.{{ $index }}'
           descr: 'RX status'
           index: 'rxState.{{ $index }}'
@@ -690,7 +689,7 @@ modules:
               - { value: 1, generic: 0, graph: 0, descr: 'absence of coordinates' }
               - { value: 2, generic: 0, graph: 0, descr: 'absence of TX status' }
         -
-          oid: txControl
+          oid: UHP-MIB::txControl
           num_oid: '.1.3.6.1.4.1.8000.22.9.6.{{ $index }}'
           descr: 'TX status'
           index: 'txControl.{{ $index }}'
@@ -701,17 +700,17 @@ modules:
     percent:
       data:
         -
-          oid: netLoad
+          oid: UHP-MIB::netLoad
           num_oid: .1.3.6.1.4.1.8000.22.5.2.6.{{ $index }}
           index: 'netLoad.{{ $index }}'
           descr: 'Network load'
         -
-          oid: buffers
+          oid: UHP-MIB::buffers
           num_oid: .1.3.6.1.4.1.8000.22.8.3.{{ $index }}
           index: 'buffers.{{ $index }}'
           descr: 'Buffer usage'
         -
-          oid: searchState
+          oid: UHP-MIB::searchState
           num_oid: .1.3.6.1.4.1.8000.22.9.5.{{ $index }}
           index: 'searchState.{{ $index }}'
           descr: 'Search state'

--- a/resources/definitions/os_discovery/ulaf.yaml
+++ b/resources/definitions/os_discovery/ulaf.yaml
@@ -1,4 +1,3 @@
-mib: ULAF2-MIB
 modules:
     os:
         version: .1.3.6.1.4.1.1887.1.1.1.2.1.1.0
@@ -6,10 +5,10 @@ modules:
         state:
             data:
                 -
-                    oid:  deviceLinkEntry
-                    value:  deviceLinkAlarm
+                    oid:  ULAF2-MIB::deviceLinkEntry
+                    value:  ULAF2-MIB::deviceLinkAlarm
                     num_oid: '.1.3.6.1.4.1.1887.1.1.3.2.2.1.1.4.{{ $index }}'
-                    descr: 'Module {{ $index }} State - {{ $deviceLinkName }}'
+                    descr: 'Module {{ $index }} State - {{ ULAF2-MIB::deviceLinkName }}'
                     state_name: deviceLinkAlarm
                     states:
                         - { value: 0, generic: 0, graph: 0, descr: 'no Alarm' }

--- a/resources/definitions/os_discovery/uniping.yaml
+++ b/resources/definitions/os_discovery/uniping.yaml
@@ -1,21 +1,20 @@
-mib: DKSF-70-6-X-X-1
 modules:
     sensors:
         humidity:
             data:
                 -
-                    oid: npRelHumTable
-                    value: npRelHumValue
+                    oid: DKSF-70-6-X-X-1::npRelHumTable
+                    value: DKSF-70-6-X-X-1::npRelHumValue
                     num_oid: '.1.3.6.1.4.1.25728.8400.1.1.2.{{ $index }}'
-                    low_limit: npRelHumSafeRangeLow
-                    high_limit: npRelHumSafeRangeHigh
+                    low_limit: DKSF-70-6-X-X-1::npRelHumSafeRangeLow
+                    high_limit: DKSF-70-6-X-X-1::npRelHumSafeRangeHigh
                     skip_values: 0
                     descr: 'Relative Humidity {{ $index }}'
         state:
             data:
                 -
-                    oid: npSmokeTable
-                    value: npSmokeStatus
+                    oid: DKSF-70-6-X-X-1::npSmokeTable
+                    value: DKSF-70-6-X-X-1::npSmokeStatus
                     num_oid: '.1.3.6.1.4.1.25728.8200.1.1.2.{{ $index }}'
                     descr: 'Smoke {{ $index }}'
                     skip_values: 5
@@ -27,8 +26,8 @@ modules:
                         - { descr: off, graph: 0, value: 4, generic: 1 }
                         - { descr: failed, graph: 0, value: 5, generic: 2 }
                 -
-                    oid: npCurLoopTable
-                    value: npCurLoopStatus
+                    oid: DKSF-70-6-X-X-1::npCurLoopTable
+                    value: DKSF-70-6-X-X-1::npCurLoopStatus
                     num_oid: '.1.3.6.1.4.1.25728.8300.1.1.2.{{ $index }}'
                     descr: 'Loop {{ $index }}'
                     index: 'npCurLoopStatus.{{ $index }}'
@@ -40,8 +39,8 @@ modules:
                         - { descr: short, graph: 0, value: 3, generic: 1 }
                         - { descr: notPowered, graph: 0, value: 4, generic: 3 }
                 -
-                    oid: npRelayTable
-                    value: npRelayState
+                    oid: DKSF-70-6-X-X-1::npRelayTable
+                    value: DKSF-70-6-X-X-1::npRelayState
                     num_oid: '.1.3.6.1.4.1.25728.5500.5.1.15.{{ $index }}'
                     descr: 'Relay {{ $index }}'
                     index: 'npRelayState.{{ $index }}'
@@ -50,8 +49,8 @@ modules:
                         - { descr: off, graph: 0, value: 0, generic: 2 }
                         - { descr: on, graph: 0, value: 1, generic: 0 }
                 -
-                    oid: npThermoTable
-                    value: npThermoStatus
+                    oid: DKSF-70-6-X-X-1::npThermoTable
+                    value: DKSF-70-6-X-X-1::npThermoStatus
                     num_oid: '.1.3.6.1.4.1.25728.8800.1.1.3.{{ $index }}'
                     descr: 'Thermo {{ $index }}'
                     skip_values: 0
@@ -63,8 +62,8 @@ modules:
                         - { descr: norm, graph: 0, value: 2, generic: 0 }
                         - { descr: high, graph: 0, value: 3, generic: 2 }
                 -
-                    oid: npRelHumTable
-                    value: npRelHumStatus
+                    oid: DKSF-70-6-X-X-1::npRelHumTable
+                    value: DKSF-70-6-X-X-1::npRelHumStatus
                     num_oid: '.1.3.6.1.4.1.25728.8400.1.1.3.{{ $index }}'
                     descr: 'Relative Humidity {{ $index }}'
                     skip_values: 0
@@ -76,8 +75,8 @@ modules:
                         - { descr: inSafeRange, graph: 0, value: 2, generic: 0 }
                         - { descr: aboveSafeRange, graph: 0, value: 3, generic: 2 }
                 -
-                    oid: npRelHumTable
-                    value: npRelHumTempStatus
+                    oid: DKSF-70-6-X-X-1::npRelHumTable
+                    value: DKSF-70-6-X-X-1::npRelHumTempStatus
                     num_oid: '.1.3.6.1.4.1.25728.8400.1.1.5.{{ $index }}'
                     descr: 'Humidity Temp {{ $index }}'
                     skip_values: 0
@@ -91,18 +90,18 @@ modules:
         temperature:
             data:
                 -
-                    oid: npThermoTable
-                    value: npThermoValue
+                    oid: DKSF-70-6-X-X-1::npThermoTable
+                    value: DKSF-70-6-X-X-1::npThermoValue
                     num_oid: '.1.3.6.1.4.1.25728.8800.1.1.2.{{ $index }}'
-                    low_limit: npThermoLow
-                    high_limit: npThermoHigh
+                    low_limit: DKSF-70-6-X-X-1::npThermoLow
+                    high_limit: DKSF-70-6-X-X-1::npThermoHigh
                     skip_values: 0
                     descr: 'Thermo {{ $index }}'
                 -
-                    oid: npRelHumTable
-                    value: npRelHumTempValue
+                    oid: DKSF-70-6-X-X-1::npRelHumTable
+                    value: DKSF-70-6-X-X-1::npRelHumTempValue
                     num_oid: '.1.3.6.1.4.1.25728.8400.1.1.4.{{ $index }}'
-                    low_limit: npRelHumTempSafeRangeLow
-                    high_limit: npRelHumTempSafeRangeHigh
+                    low_limit: DKSF-70-6-X-X-1::npRelHumTempSafeRangeLow
+                    high_limit: DKSF-70-6-X-X-1::npRelHumTempSafeRangeHigh
                     skip_values: 0
                     descr: 'Humidity Temp {{ $index }}'


### PR DESCRIPTION
Remove top-level mib: lines and prefix all bare OID references with their fully-qualified MIB names for ucopia, ucos, uhp, ulaf, uniping.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
