### PR TITLE
Convert Cisco BGP peer poll to use snmpwalk and SnmpQuery

### DIFF
--- a/LibreNMS/Util/IPv4.php
+++ b/LibreNMS/Util/IPv4.php
@@ -132,11 +132,21 @@ class IPv4 extends IP
     }
 
     /**
-     * Convert this IP to an snmp index hex encoded
+     * Convert this IP to an snmp index decimal encoded
      *
      * @return string
      */
     public function toSnmpIndex()
+    {
+        return (string) $this->ip;
+    }
+
+    /**
+     * Convert this IP to an snmp string
+     *
+     * @return string
+     */
+    public function toSnmpString()
     {
         return (string) $this->ip;
     }

--- a/LibreNMS/Util/IPv6.php
+++ b/LibreNMS/Util/IPv6.php
@@ -202,7 +202,7 @@ class IPv6 extends IP
     }
 
     /**
-     * Convert this IP to an snmp index hex encoded
+     * Convert this IP to an snmp index decimal encoded
      *
      * @return string
      */
@@ -211,5 +211,15 @@ class IPv6 extends IP
         $ipv6_split = str_split(str_replace(':', '', $this->uncompressed()), 2);
 
         return implode('.', array_map(hexdec(...), $ipv6_split));
+    }
+
+    /**
+     * Convert this IP to an snmp string hex encoded
+     *
+     * @return string
+     */
+    public function toSnmpString()
+    {
+        return implode(':', str_split(str_replace(':', '', $this->uncompressed()), 2));
     }
 }

--- a/includes/polling/bgp-peers.inc.php
+++ b/includes/polling/bgp-peers.inc.php
@@ -371,7 +371,7 @@ if (! empty($peers)) {
                         $peer_data['bgpPeerLastErrorCode'] = intval($error_data[0]);
                         $peer_data['bgpPeerLastErrorSubCode'] = intval($error_data[1]);
                     } elseif ($device['os_group'] == 'cisco') {
-                        $peer_identifiers = [$ip_ver, $bgp_peer_ident];
+                        $peer_identifiers = [$ip_ver, $peer_ip->toSnmpString()];
                         $mib = 'CISCO-BGP4-MIB';
                         $oid_map = [
                             'cbgpPeer2State' => 'bgpPeerState',
@@ -585,7 +585,7 @@ if (! empty($peers)) {
                 $safi = $peer_afi['safi'];
                 d_echo("$afi $safi\n");
                 if ($device['os_group'] == 'cisco') {
-                    $bgp_peer_ident = $peer_ip->toSnmpIndex();
+                    $bgp_peer_ident = $peer_ip->toSnmpString();
 
                     $ip_ver = $peer_ip->getFamily();
 

--- a/includes/polling/bgp-peers.inc.php
+++ b/includes/polling/bgp-peers.inc.php
@@ -588,6 +588,7 @@ if (! empty($peers)) {
 
                     $ip_ver = $peer_ip->getFamily();
 
+                    // Try the new OIDs first
                     $snmp_raw = SnmpQuery::enumStrings()->cache()->walk([
                         'CISCO-BGP4-MIB::cbgpPeer2AcceptedPrefixes',
                         'CISCO-BGP4-MIB::cbgpPeer2DeniedPrefixes',
@@ -597,14 +598,6 @@ if (! empty($peers)) {
                         'CISCO-BGP4-MIB::cbgpPeer2AdvertisedPrefixes',
                         'CISCO-BGP4-MIB::cbgpPeer2SuppressedPrefixes',
                         'CISCO-BGP4-MIB::cbgpPeer2WithdrawnPrefixes',
-                        'CISCO-BGP4-MIB::cbgpPeerAcceptedPrefixes',
-                        'CISCO-BGP4-MIB::cbgpPeerDeniedPrefixes',
-                        'CISCO-BGP4-MIB::cbgpPeerPrefixAdminLimit',
-                        'CISCO-BGP4-MIB::cbgpPeerPrefixThreshold',
-                        'CISCO-BGP4-MIB::cbgpPeerPrefixClearThreshold',
-                        'CISCO-BGP4-MIB::cbgpPeerAdvertisedPrefixes',
-                        'CISCO-BGP4-MIB::cbgpPeerSuppressedPrefixes',
-                        'CISCO-BGP4-MIB::cbgpPeerWithdrawnPrefixes',
                     ])->table(4);
 
                     if (isset($snmp_raw[$ip_ver])) {
@@ -619,6 +612,18 @@ if (! empty($peers)) {
                             'CISCO-BGP4-MIB::cbgpPeerWithdrawnPrefixes' => $snmp_raw[$ip_ver][$bgp_peer_ident][$afi][$safi]['CISCO-BGP4-MIB::cbgpPeer2WithdrawnPrefixes'] ?? null,
                         ];
                     } else {
+                        // Use the legacy OIDs if we don't get a result above
+                        $snmp_raw = SnmpQuery::enumStrings()->cache()->walk([
+                            'CISCO-BGP4-MIB::cbgpPeerAcceptedPrefixes',
+                            'CISCO-BGP4-MIB::cbgpPeerDeniedPrefixes',
+                            'CISCO-BGP4-MIB::cbgpPeerPrefixAdminLimit',
+                            'CISCO-BGP4-MIB::cbgpPeerPrefixThreshold',
+                            'CISCO-BGP4-MIB::cbgpPeerPrefixClearThreshold',
+                            'CISCO-BGP4-MIB::cbgpPeerAdvertisedPrefixes',
+                            'CISCO-BGP4-MIB::cbgpPeerSuppressedPrefixes',
+                            'CISCO-BGP4-MIB::cbgpPeerWithdrawnPrefixes',
+                        ])->table(4);
+
                         $cbgp_data = $snmp_raw[$bgp_peer_ident][$afi][$safi];
                     }
                     d_echo($cbgp_data);

--- a/includes/polling/bgp-peers.inc.php
+++ b/includes/polling/bgp-peers.inc.php
@@ -104,7 +104,7 @@ if (! empty($peers)) {
         try {
             $peer_ip = IP::parse($peer['bgpPeerIdentifier']);
 
-            echo "Checking BGP peer $peer_ip ";
+            d_echo("Checking BGP peer $peer_ip ");
 
             // --- Collect BGP data ---
             // If a Cisco device has BGP peers in VRF(s),
@@ -115,7 +115,7 @@ if (! empty($peers)) {
             // ($peer_data_check isn't used in the Cisco code path,)
             if (count($peer_data_check) > 0 || $cisco_with_vrf) {
                 if ($generic) {
-                    echo "\nfallback to default mib";
+                    d_echo("\nfallback to default mib");
 
                     $peer_identifier = $peer['bgpPeerIdentifier'];
                     $mib = 'BGP4-MIB';
@@ -167,7 +167,7 @@ if (! empty($peers)) {
                     }
                     d_echo("State = {$peer_data['bgpPeerState']} - AdminStatus: {$peer_data['bgpPeerAdminStatus']}\n");
                 } elseif ($device['os'] == 'vrp') {
-                    echo "\nCaching Oids VRP...";
+                    d_echo("\nCaching Oids VRP...");
                     if (! isset($bgpPeers)) {
                         //if not available, we timeout each time, to be fixed when split
                         $bgpPeersCache = snmpwalk_cache_oid($device, 'hwBgpPeerEntry', [], 'HUAWEI-BGP-VPN-MIB', 'huawei');
@@ -827,7 +827,7 @@ if (! empty($peers)) {
                 app('Datastore')->put($device, 'cbgp', $tags, $fields);
             } //end foreach
         } //end if
-        echo "\n";
+        d_echo("\n");
     } //end foreach
 } //end if
 

--- a/includes/polling/bgp-peers.inc.php
+++ b/includes/polling/bgp-peers.inc.php
@@ -450,11 +450,11 @@ if (! empty($peers)) {
                 $snmp_raw = SnmpQuery::mibs([$mib])->enumStrings()->hideMib()->cache()->walk(array_keys($oid_map))->table(count($peer_identifiers));
 
                 // Fetch the snmp item related to this peer
-                $peer_data_raw = array_reduce($peer_identifiers, fn ($ret, $item) => $ret[$item], $snmp_raw);
+                $peer_data_raw = array_reduce($peer_identifiers, fn ($ret, $item) => $ret[$item] ?? [], $snmp_raw);
             }
 
             // --- Fill in peer data if raw data has been fetched ---
-            if (isset($peer_data_raw)) {
+            if (! empty($peer_data_raw)) {
                 $peer_data = [];
 
                 foreach ($oid_map as $source => $target) {

--- a/includes/polling/bgp-peers.inc.php
+++ b/includes/polling/bgp-peers.inc.php
@@ -439,13 +439,13 @@ if (! empty($peers)) {
 
             // --- Fetch peer data if it is not already filled in ---
             if (empty($peer_data) && isset($peer_identifier, $oid_map, $mib)) {
-                echo "Fetching $mib data... \n";
+                d_echo("Fetching $mib data... \n");
 
                 $get_oids = array_map(fn ($oid) => "$oid.$peer_identifier", array_keys($oid_map));
                 $peer_data_raw = snmp_get_multi($device, $get_oids, '-OQUs', $mib);
                 $peer_data_raw = reset($peer_data_raw);  // get the first element of the array
             } elseif (empty($peer_data) && isset($peer_identifiers, $oid_map, $mib)) {
-                echo "Fetching $mib data... \n";
+                d_echo("Walking $mib data... \n");
 
                 $snmp_raw = SnmpQuery::mibs([$mib])->enumStrings()->hideMib()->cache()->walk(array_keys($oid_map))->table(count($peer_identifiers));
 

--- a/includes/polling/bgp-peers.inc.php
+++ b/includes/polling/bgp-peers.inc.php
@@ -372,19 +372,18 @@ if (! empty($peers)) {
                         $peer_data['bgpPeerLastErrorSubCode'] = intval($error_data[1]);
                     } elseif ($device['os_group'] == 'cisco') {
                         $peer_identifiers = [$ip_ver, $peer_ip->toSnmpString()];
-                        $mib = 'CISCO-BGP4-MIB';
                         $oid_map = [
-                            'cbgpPeer2State' => 'bgpPeerState',
-                            'cbgpPeer2AdminStatus' => 'bgpPeerAdminStatus',
-                            'cbgpPeer2InUpdates' => 'bgpPeerInUpdates',
-                            'cbgpPeer2OutUpdates' => 'bgpPeerOutUpdates',
-                            'cbgpPeer2InTotalMessages' => 'bgpPeerInTotalMessages',
-                            'cbgpPeer2OutTotalMessages' => 'bgpPeerOutTotalMessages',
-                            'cbgpPeer2FsmEstablishedTime' => 'bgpPeerFsmEstablishedTime',
-                            'cbgpPeer2InUpdateElapsedTime' => 'bgpPeerInUpdateElapsedTime',
-                            'cbgpPeer2LocalAddr' => 'bgpLocalAddr',
-                            'cbgpPeer2LastError' => 'bgpPeerLastErrorCode',
-                            'cbgpPeer2LastErrorTxt' => 'bgpPeerLastErrorText',
+                            'CISCO-BGP4-MIB::cbgpPeer2State' => 'bgpPeerState',
+                            'CISCO-BGP4-MIB::cbgpPeer2AdminStatus' => 'bgpPeerAdminStatus',
+                            'CISCO-BGP4-MIB::cbgpPeer2InUpdates' => 'bgpPeerInUpdates',
+                            'CISCO-BGP4-MIB::cbgpPeer2OutUpdates' => 'bgpPeerOutUpdates',
+                            'CISCO-BGP4-MIB::cbgpPeer2InTotalMessages' => 'bgpPeerInTotalMessages',
+                            'CISCO-BGP4-MIB::cbgpPeer2OutTotalMessages' => 'bgpPeerOutTotalMessages',
+                            'CISCO-BGP4-MIB::cbgpPeer2FsmEstablishedTime' => 'bgpPeerFsmEstablishedTime',
+                            'CISCO-BGP4-MIB::cbgpPeer2InUpdateElapsedTime' => 'bgpPeerInUpdateElapsedTime',
+                            'CISCO-BGP4-MIB::cbgpPeer2LocalAddr' => 'bgpLocalAddr',
+                            'CISCO-BGP4-MIB::cbgpPeer2LastError' => 'bgpPeerLastErrorCode',
+                            'CISCO-BGP4-MIB::cbgpPeer2LastErrorTxt' => 'bgpPeerLastErrorText',
                         ];
                     } elseif ($device['os'] == 'cumulus') {
                         $peer_identifier = $peer['bgpPeerIdentifier'];
@@ -444,10 +443,10 @@ if (! empty($peers)) {
                 $get_oids = array_map(fn ($oid) => "$oid.$peer_identifier", array_keys($oid_map));
                 $peer_data_raw = snmp_get_multi($device, $get_oids, '-OQUs', $mib);
                 $peer_data_raw = reset($peer_data_raw);  // get the first element of the array
-            } elseif (empty($peer_data) && isset($peer_identifiers, $oid_map, $mib)) {
-                d_echo("Walking $mib data... \n");
+            } elseif (empty($peer_data) && isset($peer_identifiers, $oid_map)) {
+                d_echo("Walking data... \n");
 
-                $snmp_raw = SnmpQuery::mibs([$mib])->enumStrings()->hideMib()->cache()->walk(array_keys($oid_map))->table(count($peer_identifiers));
+                $snmp_raw = SnmpQuery::enumStrings()->cache()->walk(array_keys($oid_map))->table(count($peer_identifiers));
 
                 // Fetch the snmp item related to this peer
                 $peer_data_raw = array_reduce($peer_identifiers, fn ($ret, $item) => $ret[$item] ?? [], $snmp_raw);
@@ -589,50 +588,50 @@ if (! empty($peers)) {
 
                     $ip_ver = $peer_ip->getFamily();
 
-                    $snmp_raw = SnmpQuery::mibs(['CISCO-BGP4-MIB'])->enumStrings()->hideMib()->cache()->walk([
-                        'cbgpPeer2AcceptedPrefixes',
-                        'cbgpPeer2DeniedPrefixes',
-                        'cbgpPeer2PrefixAdminLimit',
-                        'cbgpPeer2PrefixThreshold',
-                        'cbgpPeer2PrefixClearThreshold',
-                        'cbgpPeer2AdvertisedPrefixes',
-                        'cbgpPeer2SuppressedPrefixes',
-                        'cbgpPeer2WithdrawnPrefixes',
-                        'cbgpPeerAcceptedPrefixes',
-                        'cbgpPeerDeniedPrefixes',
-                        'cbgpPeerPrefixAdminLimit',
-                        'cbgpPeerPrefixThreshold',
-                        'cbgpPeerPrefixClearThreshold',
-                        'cbgpPeerAdvertisedPrefixes',
-                        'cbgpPeerSuppressedPrefixes',
-                        'cbgpPeerWithdrawnPrefixes',
+                    $snmp_raw = SnmpQuery::enumStrings()->cache()->walk([
+                        'CISCO-BGP4-MIB::cbgpPeer2AcceptedPrefixes',
+                        'CISCO-BGP4-MIB::cbgpPeer2DeniedPrefixes',
+                        'CISCO-BGP4-MIB::cbgpPeer2PrefixAdminLimit',
+                        'CISCO-BGP4-MIB::cbgpPeer2PrefixThreshold',
+                        'CISCO-BGP4-MIB::cbgpPeer2PrefixClearThreshold',
+                        'CISCO-BGP4-MIB::cbgpPeer2AdvertisedPrefixes',
+                        'CISCO-BGP4-MIB::cbgpPeer2SuppressedPrefixes',
+                        'CISCO-BGP4-MIB::cbgpPeer2WithdrawnPrefixes',
+                        'CISCO-BGP4-MIB::cbgpPeerAcceptedPrefixes',
+                        'CISCO-BGP4-MIB::cbgpPeerDeniedPrefixes',
+                        'CISCO-BGP4-MIB::cbgpPeerPrefixAdminLimit',
+                        'CISCO-BGP4-MIB::cbgpPeerPrefixThreshold',
+                        'CISCO-BGP4-MIB::cbgpPeerPrefixClearThreshold',
+                        'CISCO-BGP4-MIB::cbgpPeerAdvertisedPrefixes',
+                        'CISCO-BGP4-MIB::cbgpPeerSuppressedPrefixes',
+                        'CISCO-BGP4-MIB::cbgpPeerWithdrawnPrefixes',
                     ])->table(4);
 
                     if (isset($snmp_raw[$ip_ver])) {
                         $cbgp_data = [
-                            'cbgpPeerAcceptedPrefixes' => $snmp_raw[$ip_ver][$bgp_peer_ident][$afi][$safi]['cbgpPeer2AcceptedPrefixes'] ?? null,
-                            'cbgpPeerDeniedPrefixes' => $snmp_raw[$ip_ver][$bgp_peer_ident][$afi][$safi]['cbgpPeer2DeniedPrefixes'] ?? null,
-                            'cbgpPeerPrefixAdminLimit' => $snmp_raw[$ip_ver][$bgp_peer_ident][$afi][$safi]['cbgpPeer2PrefixAdminLimit'] ?? null,
-                            'cbgpPeerPrefixThreshold' => $snmp_raw[$ip_ver][$bgp_peer_ident][$afi][$safi]['cbgpPeer2PrefixThreshold'] ?? null,
-                            'cbgpPeerPrefixClearThreshold' => $snmp_raw[$ip_ver][$bgp_peer_ident][$afi][$safi]['cbgpPeer2PrefixClearThreshold'] ?? null,
-                            'cbgpPeerAdvertisedPrefixes' => $snmp_raw[$ip_ver][$bgp_peer_ident][$afi][$safi]['cbgpPeer2AdvertisedPrefixes'] ?? null,
-                            'cbgpPeerSuppressedPrefixes' => $snmp_raw[$ip_ver][$bgp_peer_ident][$afi][$safi]['cbgpPeer2SuppressedPrefixes'] ?? null,
-                            'cbgpPeerWithdrawnPrefixes' => $snmp_raw[$ip_ver][$bgp_peer_ident][$afi][$safi]['cbgpPeer2WithdrawnPrefixes'] ?? null,
+                            'CISCO-BGP4-MIB::cbgpPeerAcceptedPrefixes' => $snmp_raw[$ip_ver][$bgp_peer_ident][$afi][$safi]['CISCO-BGP4-MIB::cbgpPeer2AcceptedPrefixes'] ?? null,
+                            'CISCO-BGP4-MIB::cbgpPeerDeniedPrefixes' => $snmp_raw[$ip_ver][$bgp_peer_ident][$afi][$safi]['CISCO-BGP4-MIB::cbgpPeer2DeniedPrefixes'] ?? null,
+                            'CISCO-BGP4-MIB::cbgpPeerPrefixAdminLimit' => $snmp_raw[$ip_ver][$bgp_peer_ident][$afi][$safi]['CISCO-BGP4-MIB::cbgpPeer2PrefixAdminLimit'] ?? null,
+                            'CISCO-BGP4-MIB::cbgpPeerPrefixThreshold' => $snmp_raw[$ip_ver][$bgp_peer_ident][$afi][$safi]['CISCO-BGP4-MIB::cbgpPeer2PrefixThreshold'] ?? null,
+                            'CISCO-BGP4-MIB::cbgpPeerPrefixClearThreshold' => $snmp_raw[$ip_ver][$bgp_peer_ident][$afi][$safi]['CISCO-BGP4-MIB::cbgpPeer2PrefixClearThreshold'] ?? null,
+                            'CISCO-BGP4-MIB::cbgpPeerAdvertisedPrefixes' => $snmp_raw[$ip_ver][$bgp_peer_ident][$afi][$safi]['CISCO-BGP4-MIB::cbgpPeer2AdvertisedPrefixes'] ?? null,
+                            'CISCO-BGP4-MIB::cbgpPeerSuppressedPrefixes' => $snmp_raw[$ip_ver][$bgp_peer_ident][$afi][$safi]['CISCO-BGP4-MIB::cbgpPeer2SuppressedPrefixes'] ?? null,
+                            'CISCO-BGP4-MIB::cbgpPeerWithdrawnPrefixes' => $snmp_raw[$ip_ver][$bgp_peer_ident][$afi][$safi]['CISCO-BGP4-MIB::cbgpPeer2WithdrawnPrefixes'] ?? null,
                         ];
                     } else {
                         $cbgp_data = $snmp_raw[$bgp_peer_ident][$afi][$safi];
                     }
                     d_echo($cbgp_data);
 
-                    $cbgpPeerAcceptedPrefixes = $cbgp_data['cbgpPeerAcceptedPrefixes'];
-                    $cbgpPeerDeniedPrefixes = $cbgp_data['cbgpPeerDeniedPrefixes'];
-                    $cbgpPeerPrefixAdminLimit = $cbgp_data['cbgpPeerPrefixAdminLimit'] ?? null;
-                    $cbgpPeerPrefixThreshold = $cbgp_data['cbgpPeerPrefixThreshold'] ?? null;
-                    $cbgpPeerPrefixClearThreshold = $cbgp_data['cbgpPeerPrefixClearThreshold'] ?? null;
-                    $cbgpPeerAdvertisedPrefixes = max(0, $cbgp_data['cbgpPeerAdvertisedPrefixes'] - $cbgp_data['cbgpPeerWithdrawnPrefixes']);
+                    $cbgpPeerAcceptedPrefixes = $cbgp_data['CISCO-BGP4-MIB::cbgpPeerAcceptedPrefixes'];
+                    $cbgpPeerDeniedPrefixes = $cbgp_data['CISCO-BGP4-MIB::cbgpPeerDeniedPrefixes'];
+                    $cbgpPeerPrefixAdminLimit = $cbgp_data['CISCO-BGP4-MIB::cbgpPeerPrefixAdminLimit'] ?? null;
+                    $cbgpPeerPrefixThreshold = $cbgp_data['CISCO-BGP4-MIB::cbgpPeerPrefixThreshold'] ?? null;
+                    $cbgpPeerPrefixClearThreshold = $cbgp_data['CISCO-BGP4-MIB::cbgpPeerPrefixClearThreshold'] ?? null;
+                    $cbgpPeerAdvertisedPrefixes = max(0, $cbgp_data['CISCO-BGP4-MIB::cbgpPeerAdvertisedPrefixes'] - $cbgp_data['CISCO-BGP4-MIB::cbgpPeerWithdrawnPrefixes']);
                     $cbgpPeerWithdrawnPrefixes = 0; // no use, it is a gauge32 value, only the difference between cbgpPeerAdvertisedPrefixes  and cbgpPeerWithdrawnPrefixes makes sense.
                     // CF CISCO-BGP4-MIB definition for both
-                    $cbgpPeerSuppressedPrefixes = $cbgp_data['cbgpPeerSuppressedPrefixes'];
+                    $cbgpPeerSuppressedPrefixes = $cbgp_data['CISCO-BGP4-MIB::cbgpPeerSuppressedPrefixes'];
                     unset($cbgp_data, $snmp_raw);
                 } //end if
 

--- a/includes/polling/bgp-peers.inc.php
+++ b/includes/polling/bgp-peers.inc.php
@@ -450,7 +450,7 @@ if (! empty($peers)) {
                 $snmp_raw = SnmpQuery::mibs([$mib])->enumStrings()->hideMib()->cache()->walk(array_keys($oid_map))->table(count($peer_identifiers));
 
                 // Fetch the snmp item related to this peer
-                $peer_data_raw = array_reduce($peer_identifiers, fn($ret, $item) => $ret[$item], $snmp_raw);
+                $peer_data_raw = array_reduce($peer_identifiers, fn ($ret, $item) => $ret[$item], $snmp_raw);
             }
 
             // --- Fill in peer data if raw data has been fetched ---

--- a/includes/polling/bgp-peers.inc.php
+++ b/includes/polling/bgp-peers.inc.php
@@ -446,10 +446,12 @@ if (! empty($peers)) {
             } elseif (empty($peer_data) && isset($peer_identifiers, $oid_map)) {
                 d_echo("Walking data... \n");
 
-                $snmp_raw = SnmpQuery::enumStrings()->cache()->walk(array_keys($oid_map))->table(count($peer_identifiers));
+                if (! isset($bgp_cache)) {
+                    $bgp_cache = SnmpQuery::enumStrings()->walk(array_keys($oid_map))->table(count($peer_identifiers));
+                }
 
                 // Fetch the snmp item related to this peer
-                $peer_data_raw = array_reduce($peer_identifiers, fn ($ret, $item) => $ret[$item] ?? [], $snmp_raw);
+                $peer_data_raw = array_reduce($peer_identifiers, fn ($ret, $item) => $ret[$item] ?? [], $bgp_cache);
             }
 
             // --- Fill in peer data if raw data has been fetched ---
@@ -588,43 +590,47 @@ if (! empty($peers)) {
 
                     $ip_ver = $peer_ip->getFamily();
 
-                    // Try the new OIDs first
-                    $snmp_raw = SnmpQuery::enumStrings()->cache()->walk([
-                        'CISCO-BGP4-MIB::cbgpPeer2AcceptedPrefixes',
-                        'CISCO-BGP4-MIB::cbgpPeer2DeniedPrefixes',
-                        'CISCO-BGP4-MIB::cbgpPeer2PrefixAdminLimit',
-                        'CISCO-BGP4-MIB::cbgpPeer2PrefixThreshold',
-                        'CISCO-BGP4-MIB::cbgpPeer2PrefixClearThreshold',
-                        'CISCO-BGP4-MIB::cbgpPeer2AdvertisedPrefixes',
-                        'CISCO-BGP4-MIB::cbgpPeer2SuppressedPrefixes',
-                        'CISCO-BGP4-MIB::cbgpPeer2WithdrawnPrefixes',
-                    ])->table(4);
+                    if (! isset($cbgp_cache)) {
+                        // Try the new OIDs first
+                        $cbgp_cache = SnmpQuery::enumStrings()->walk([
+                            'CISCO-BGP4-MIB::cbgpPeer2AcceptedPrefixes',
+                            'CISCO-BGP4-MIB::cbgpPeer2DeniedPrefixes',
+                            'CISCO-BGP4-MIB::cbgpPeer2PrefixAdminLimit',
+                            'CISCO-BGP4-MIB::cbgpPeer2PrefixThreshold',
+                            'CISCO-BGP4-MIB::cbgpPeer2PrefixClearThreshold',
+                            'CISCO-BGP4-MIB::cbgpPeer2AdvertisedPrefixes',
+                            'CISCO-BGP4-MIB::cbgpPeer2SuppressedPrefixes',
+                            'CISCO-BGP4-MIB::cbgpPeer2WithdrawnPrefixes',
+                        ])->table(4);
 
-                    if (isset($snmp_raw[$ip_ver])) {
+                        if (count(array_keys($cbgp_cache)) == 0) {
+                            $cbgp_cache = SnmpQuery::enumStrings()->walk([
+                                'CISCO-BGP4-MIB::cbgpPeerAcceptedPrefixes',
+                                'CISCO-BGP4-MIB::cbgpPeerDeniedPrefixes',
+                                'CISCO-BGP4-MIB::cbgpPeerPrefixAdminLimit',
+                                'CISCO-BGP4-MIB::cbgpPeerPrefixThreshold',
+                                'CISCO-BGP4-MIB::cbgpPeerPrefixClearThreshold',
+                                'CISCO-BGP4-MIB::cbgpPeerAdvertisedPrefixes',
+                                'CISCO-BGP4-MIB::cbgpPeerSuppressedPrefixes',
+                                'CISCO-BGP4-MIB::cbgpPeerWithdrawnPrefixes',
+                            ])->table(4);
+                        }
+                    }
+
+                    if (isset($cbgp_cache[$ip_ver])) {
                         $cbgp_data = [
-                            'CISCO-BGP4-MIB::cbgpPeerAcceptedPrefixes' => $snmp_raw[$ip_ver][$bgp_peer_ident][$afi][$safi]['CISCO-BGP4-MIB::cbgpPeer2AcceptedPrefixes'] ?? null,
-                            'CISCO-BGP4-MIB::cbgpPeerDeniedPrefixes' => $snmp_raw[$ip_ver][$bgp_peer_ident][$afi][$safi]['CISCO-BGP4-MIB::cbgpPeer2DeniedPrefixes'] ?? null,
-                            'CISCO-BGP4-MIB::cbgpPeerPrefixAdminLimit' => $snmp_raw[$ip_ver][$bgp_peer_ident][$afi][$safi]['CISCO-BGP4-MIB::cbgpPeer2PrefixAdminLimit'] ?? null,
-                            'CISCO-BGP4-MIB::cbgpPeerPrefixThreshold' => $snmp_raw[$ip_ver][$bgp_peer_ident][$afi][$safi]['CISCO-BGP4-MIB::cbgpPeer2PrefixThreshold'] ?? null,
-                            'CISCO-BGP4-MIB::cbgpPeerPrefixClearThreshold' => $snmp_raw[$ip_ver][$bgp_peer_ident][$afi][$safi]['CISCO-BGP4-MIB::cbgpPeer2PrefixClearThreshold'] ?? null,
-                            'CISCO-BGP4-MIB::cbgpPeerAdvertisedPrefixes' => $snmp_raw[$ip_ver][$bgp_peer_ident][$afi][$safi]['CISCO-BGP4-MIB::cbgpPeer2AdvertisedPrefixes'] ?? null,
-                            'CISCO-BGP4-MIB::cbgpPeerSuppressedPrefixes' => $snmp_raw[$ip_ver][$bgp_peer_ident][$afi][$safi]['CISCO-BGP4-MIB::cbgpPeer2SuppressedPrefixes'] ?? null,
-                            'CISCO-BGP4-MIB::cbgpPeerWithdrawnPrefixes' => $snmp_raw[$ip_ver][$bgp_peer_ident][$afi][$safi]['CISCO-BGP4-MIB::cbgpPeer2WithdrawnPrefixes'] ?? null,
+                            'CISCO-BGP4-MIB::cbgpPeerAcceptedPrefixes' => $cbgp_cache[$ip_ver][$bgp_peer_ident][$afi][$safi]['CISCO-BGP4-MIB::cbgpPeer2AcceptedPrefixes'] ?? null,
+                            'CISCO-BGP4-MIB::cbgpPeerDeniedPrefixes' => $cbgp_cache[$ip_ver][$bgp_peer_ident][$afi][$safi]['CISCO-BGP4-MIB::cbgpPeer2DeniedPrefixes'] ?? null,
+                            'CISCO-BGP4-MIB::cbgpPeerPrefixAdminLimit' => $cbgp_cache[$ip_ver][$bgp_peer_ident][$afi][$safi]['CISCO-BGP4-MIB::cbgpPeer2PrefixAdminLimit'] ?? null,
+                            'CISCO-BGP4-MIB::cbgpPeerPrefixThreshold' => $cbgp_cache[$ip_ver][$bgp_peer_ident][$afi][$safi]['CISCO-BGP4-MIB::cbgpPeer2PrefixThreshold'] ?? null,
+                            'CISCO-BGP4-MIB::cbgpPeerPrefixClearThreshold' => $cbgp_cache[$ip_ver][$bgp_peer_ident][$afi][$safi]['CISCO-BGP4-MIB::cbgpPeer2PrefixClearThreshold'] ?? null,
+                            'CISCO-BGP4-MIB::cbgpPeerAdvertisedPrefixes' => $cbgp_cache[$ip_ver][$bgp_peer_ident][$afi][$safi]['CISCO-BGP4-MIB::cbgpPeer2AdvertisedPrefixes'] ?? null,
+                            'CISCO-BGP4-MIB::cbgpPeerSuppressedPrefixes' => $cbgp_cache[$ip_ver][$bgp_peer_ident][$afi][$safi]['CISCO-BGP4-MIB::cbgpPeer2SuppressedPrefixes'] ?? null,
+                            'CISCO-BGP4-MIB::cbgpPeerWithdrawnPrefixes' => $cbgp_cache[$ip_ver][$bgp_peer_ident][$afi][$safi]['CISCO-BGP4-MIB::cbgpPeer2WithdrawnPrefixes'] ?? null,
                         ];
                     } else {
                         // Use the legacy OIDs if we don't get a result above
-                        $snmp_raw = SnmpQuery::enumStrings()->cache()->walk([
-                            'CISCO-BGP4-MIB::cbgpPeerAcceptedPrefixes',
-                            'CISCO-BGP4-MIB::cbgpPeerDeniedPrefixes',
-                            'CISCO-BGP4-MIB::cbgpPeerPrefixAdminLimit',
-                            'CISCO-BGP4-MIB::cbgpPeerPrefixThreshold',
-                            'CISCO-BGP4-MIB::cbgpPeerPrefixClearThreshold',
-                            'CISCO-BGP4-MIB::cbgpPeerAdvertisedPrefixes',
-                            'CISCO-BGP4-MIB::cbgpPeerSuppressedPrefixes',
-                            'CISCO-BGP4-MIB::cbgpPeerWithdrawnPrefixes',
-                        ])->table(4);
-
-                        $cbgp_data = $snmp_raw[$bgp_peer_ident][$afi][$safi];
+                        $cbgp_data = $cbgp_cache[$bgp_peer_ident][$afi][$safi];
                     }
                     d_echo($cbgp_data);
 
@@ -637,7 +643,7 @@ if (! empty($peers)) {
                     $cbgpPeerWithdrawnPrefixes = 0; // no use, it is a gauge32 value, only the difference between cbgpPeerAdvertisedPrefixes  and cbgpPeerWithdrawnPrefixes makes sense.
                     // CF CISCO-BGP4-MIB definition for both
                     $cbgpPeerSuppressedPrefixes = $cbgp_data['CISCO-BGP4-MIB::cbgpPeerSuppressedPrefixes'];
-                    unset($cbgp_data, $snmp_raw);
+                    unset($cbgp_data);
                 } //end if
 
                 if ($device['os'] == 'junos') {
@@ -836,4 +842,4 @@ if (! empty($peers)) {
     } //end foreach
 } //end if
 
-unset($peers, $peer_data_tmp, $j_prefixes);
+unset($peers, $peer_data_tmp, $j_prefixes, $bgp_cache, $cbgp_cache);

--- a/includes/polling/bgp-peers.inc.php
+++ b/includes/polling/bgp-peers.inc.php
@@ -590,9 +590,9 @@ if (! empty($peers)) {
 
                     $ip_ver = $peer_ip->getFamily();
 
-                    if (! isset($cbgp_cache)) {
+                    if (! isset($cbgpv2_cache)) {
                         // Try the new OIDs first
-                        $cbgp_cache = SnmpQuery::enumStrings()->walk([
+                        $cbgpv2_cache = SnmpQuery::enumStrings()->walk([
                             'CISCO-BGP4-MIB::cbgpPeer2AcceptedPrefixes',
                             'CISCO-BGP4-MIB::cbgpPeer2DeniedPrefixes',
                             'CISCO-BGP4-MIB::cbgpPeer2PrefixAdminLimit',
@@ -602,8 +602,21 @@ if (! empty($peers)) {
                             'CISCO-BGP4-MIB::cbgpPeer2SuppressedPrefixes',
                             'CISCO-BGP4-MIB::cbgpPeer2WithdrawnPrefixes',
                         ])->table(4);
+                    }
 
-                        if (count(array_keys($cbgp_cache)) == 0) {
+                    if (isset($cbgpv2_cache[$ip_ver])) {
+                        $cbgp_data = [
+                            'CISCO-BGP4-MIB::cbgpPeerAcceptedPrefixes' => $cbgpv2_cache[$ip_ver][$bgp_peer_ident][$afi][$safi]['CISCO-BGP4-MIB::cbgpPeer2AcceptedPrefixes'] ?? null,
+                            'CISCO-BGP4-MIB::cbgpPeerDeniedPrefixes' => $cbgpv2_cache[$ip_ver][$bgp_peer_ident][$afi][$safi]['CISCO-BGP4-MIB::cbgpPeer2DeniedPrefixes'] ?? null,
+                            'CISCO-BGP4-MIB::cbgpPeerPrefixAdminLimit' => $cbgpv2_cache[$ip_ver][$bgp_peer_ident][$afi][$safi]['CISCO-BGP4-MIB::cbgpPeer2PrefixAdminLimit'] ?? null,
+                            'CISCO-BGP4-MIB::cbgpPeerPrefixThreshold' => $cbgpv2_cache[$ip_ver][$bgp_peer_ident][$afi][$safi]['CISCO-BGP4-MIB::cbgpPeer2PrefixThreshold'] ?? null,
+                            'CISCO-BGP4-MIB::cbgpPeerPrefixClearThreshold' => $cbgpv2_cache[$ip_ver][$bgp_peer_ident][$afi][$safi]['CISCO-BGP4-MIB::cbgpPeer2PrefixClearThreshold'] ?? null,
+                            'CISCO-BGP4-MIB::cbgpPeerAdvertisedPrefixes' => $cbgpv2_cache[$ip_ver][$bgp_peer_ident][$afi][$safi]['CISCO-BGP4-MIB::cbgpPeer2AdvertisedPrefixes'] ?? null,
+                            'CISCO-BGP4-MIB::cbgpPeerSuppressedPrefixes' => $cbgpv2_cache[$ip_ver][$bgp_peer_ident][$afi][$safi]['CISCO-BGP4-MIB::cbgpPeer2SuppressedPrefixes'] ?? null,
+                            'CISCO-BGP4-MIB::cbgpPeerWithdrawnPrefixes' => $cbgpv2_cache[$ip_ver][$bgp_peer_ident][$afi][$safi]['CISCO-BGP4-MIB::cbgpPeer2WithdrawnPrefixes'] ?? null,
+                        ];
+                    } else {
+                        if (! isset($cbgp_cache)) {
                             $cbgp_cache = SnmpQuery::enumStrings()->walk([
                                 'CISCO-BGP4-MIB::cbgpPeerAcceptedPrefixes',
                                 'CISCO-BGP4-MIB::cbgpPeerDeniedPrefixes',
@@ -615,20 +628,7 @@ if (! empty($peers)) {
                                 'CISCO-BGP4-MIB::cbgpPeerWithdrawnPrefixes',
                             ])->table(4);
                         }
-                    }
 
-                    if (isset($cbgp_cache[$ip_ver])) {
-                        $cbgp_data = [
-                            'CISCO-BGP4-MIB::cbgpPeerAcceptedPrefixes' => $cbgp_cache[$ip_ver][$bgp_peer_ident][$afi][$safi]['CISCO-BGP4-MIB::cbgpPeer2AcceptedPrefixes'] ?? null,
-                            'CISCO-BGP4-MIB::cbgpPeerDeniedPrefixes' => $cbgp_cache[$ip_ver][$bgp_peer_ident][$afi][$safi]['CISCO-BGP4-MIB::cbgpPeer2DeniedPrefixes'] ?? null,
-                            'CISCO-BGP4-MIB::cbgpPeerPrefixAdminLimit' => $cbgp_cache[$ip_ver][$bgp_peer_ident][$afi][$safi]['CISCO-BGP4-MIB::cbgpPeer2PrefixAdminLimit'] ?? null,
-                            'CISCO-BGP4-MIB::cbgpPeerPrefixThreshold' => $cbgp_cache[$ip_ver][$bgp_peer_ident][$afi][$safi]['CISCO-BGP4-MIB::cbgpPeer2PrefixThreshold'] ?? null,
-                            'CISCO-BGP4-MIB::cbgpPeerPrefixClearThreshold' => $cbgp_cache[$ip_ver][$bgp_peer_ident][$afi][$safi]['CISCO-BGP4-MIB::cbgpPeer2PrefixClearThreshold'] ?? null,
-                            'CISCO-BGP4-MIB::cbgpPeerAdvertisedPrefixes' => $cbgp_cache[$ip_ver][$bgp_peer_ident][$afi][$safi]['CISCO-BGP4-MIB::cbgpPeer2AdvertisedPrefixes'] ?? null,
-                            'CISCO-BGP4-MIB::cbgpPeerSuppressedPrefixes' => $cbgp_cache[$ip_ver][$bgp_peer_ident][$afi][$safi]['CISCO-BGP4-MIB::cbgpPeer2SuppressedPrefixes'] ?? null,
-                            'CISCO-BGP4-MIB::cbgpPeerWithdrawnPrefixes' => $cbgp_cache[$ip_ver][$bgp_peer_ident][$afi][$safi]['CISCO-BGP4-MIB::cbgpPeer2WithdrawnPrefixes'] ?? null,
-                        ];
-                    } else {
                         // Use the legacy OIDs if we don't get a result above
                         $cbgp_data = $cbgp_cache[$bgp_peer_ident][$afi][$safi];
                     }
@@ -842,4 +842,4 @@ if (! empty($peers)) {
     } //end foreach
 } //end if
 
-unset($peers, $peer_data_tmp, $j_prefixes, $bgp_cache, $cbgp_cache);
+unset($peers, $peer_data_tmp, $j_prefixes, $bgp_cache, $cbgp_cache, $cbgpv2_cache);


### PR DESCRIPTION
We have a few cisco routers with a lot of BGP sessions that are taking up to 4 minutes to poll due to the large number of SNMP GET requests.  This PR converts these to SNMP WALK commands, and also converts the cisco code to use SnmpQuery.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
