### PR TITLE
Update topChanges in stp table to unsigned int

### DIFF
--- a/database/migrations/2026_02_13_000000_change_stp_top_changes_to_unsigned_int.php
+++ b/database/migrations/2026_02_13_000000_change_stp_top_changes_to_unsigned_int.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('stp', function (Blueprint $table) {
+            $table->unsignedInteger('topChanges')->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('stp', function (Blueprint $table) {
+            $table->mediumInteger('topChanges')->change();
+        });
+    }
+};

--- a/resources/definitions/schema/db_schema.yaml
+++ b/resources/definitions/schema/db_schema.yaml
@@ -2355,7 +2355,7 @@ stp:
     - { Field: protocolSpecification, Type: varchar(16), 'Null': false, Extra: '' }
     - { Field: priority, Type: mediumint, 'Null': false, Extra: '' }
     - { Field: timeSinceTopologyChange, Type: varchar(32), 'Null': false, Extra: '' }
-    - { Field: topChanges, Type: mediumint, 'Null': false, Extra: '' }
+    - { Field: topChanges, Type: 'int unsigned', 'Null': false, Extra: '' }
     - { Field: designatedRoot, Type: varchar(32), 'Null': false, Extra: '' }
     - { Field: rootCost, Type: 'int unsigned', 'Null': false, Extra: '' }
     - { Field: rootPort, Type: int, 'Null': true, Extra: '' }


### PR DESCRIPTION
Seeing this being hit in the wild. It's a counter32 value so switched to an unsigned int.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
