### PR TITLE
Fix alert rule xss

### DIFF
--- a/includes/html/modal/alert_rule_list.inc.php
+++ b/includes/html/modal/alert_rule_list.inc.php
@@ -59,8 +59,8 @@ if (! Auth::user()->hasGlobalAdmin()) {
                             }
                             echo "
                                 <tr>
-                                    <td>" . e(strip_tags((string)$rule['name'])) . "</td>
-                                    <td><i>" . e($rule_display) . "</i></td>
+                                    <td>" . e(strip_tags((string) $rule['name'])) . "</td>
+                                    <td><i>" . e(strip_tags((string) $rule_display)) . "</i></td>
                                     <td>{$rule['severity']}</td>
                                     <td>{$rule['id']}</td>
                                 </tr>


### PR DESCRIPTION
similar to alert rule name, alert rule display normal escape seems not enough for some reason.  Probably bootgrid turning it in to html...

https://github.com/librenms/librenms/security/advisories/GHSA-6xmx-xr9p-58p7

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
