### PR TITLE
Remove unused dispatcher legacy settings

### DIFF
--- a/LibreNMS/service.py
+++ b/LibreNMS/service.py
@@ -132,19 +132,6 @@ class ServiceConfig(DBConfig):
         self.master_timeout = config.get(
             "service_master_timeout", ServiceConfig.master_timeout
         )
-        self.poller.workers = config.get(
-            "poller_service_workers", ServiceConfig.poller.workers
-        )
-        self.poller.frequency = config.get(
-            "poller_service_poll_frequency", ServiceConfig.poller.frequency
-        )
-        self.discovery.frequency = config.get(
-            "poller_service_discover_frequency", ServiceConfig.discovery.frequency
-        )
-        self.down_retry = config.get(
-            "poller_service_down_retry", ServiceConfig.down_retry
-        )
-        self.log_level = config.get("poller_service_loglevel", ServiceConfig.log_level)
 
         # new options
         self.poller.enabled = (

--- a/LibreNMS/service.py
+++ b/LibreNMS/service.py
@@ -128,12 +128,9 @@ class ServiceConfig(DBConfig):
             config.get("distributed_poller_group", ServiceConfig.group)
         )
 
-        # backward compatible options
         self.master_timeout = config.get(
             "service_master_timeout", ServiceConfig.master_timeout
         )
-
-        # new options
         self.poller.enabled = (
             config.get("service_poller_enabled", True)
             if config.get("schedule_type").get("poller", "legacy") == "legacy"


### PR DESCRIPTION
These settings are overwritten lower in the file with a fallback to the default values instead of the current value.  Effectively this discards the previous setting, so the "legacy" settings were never used.

I checked git history and it has always been that way, so this will not change behavior in any way.
I also searched the codebase for these "legacy" settings and they were not defined anywhere.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
