### PR TITLE
dispatcher polling frequency - fallback to rrd.step

### DIFF
--- a/LibreNMS/Validations/Poller/CheckDispatcherService.php
+++ b/LibreNMS/Validations/Poller/CheckDispatcherService.php
@@ -26,6 +26,7 @@
 
 namespace LibreNMS\Validations\Poller;
 
+use App\Facades\LibrenmsConfig;
 use App\Models\Device;
 use App\Models\Poller;
 use App\Models\PollerCluster;
@@ -41,6 +42,9 @@ class CheckDispatcherService implements \LibreNMS\Interfaces\Validation
     {
         if (PollerCluster::exists()) {
             return $this->checkDispatchService();
+        } elseif (LibrenmsConfig::get('schedule_type.poller') == 'dispatcher') {
+            // We have explicity set the scheduler to be the dispatcher, but no nodes have registered
+            return ValidationResult::fail(trans('validation.validations.poller.CheckDispatcherService.fail'));
         }
 
         return ValidationResult::ok(trans('validation.validations.poller.CheckDispatcherService.not_detected'));

--- a/LibreNMS/Validations/Poller/CheckSchedules.php
+++ b/LibreNMS/Validations/Poller/CheckSchedules.php
@@ -39,10 +39,8 @@ class CheckSchedules implements \LibreNMS\Interfaces\Validation
     {
         // First make sure the dispatcher service is allowed to run, otherwise we would need to check crontabs
         if (LibrenmsConfig::get('schedule_type.poller') == 'legacy' || LibrenmsConfig::get('schedule_type.poller') == 'dispatcher') {
-
             // Then check if the dispatcher polling schedule has been overridden, otherwise it is guaranteed to match the RRD step
             if (LibrenmsConfig::get('service_poller_frequency') != null) {
-
                 // Return an appropriate error if the polling schedule is different from the RRD step
                 if (LibrenmsConfig::get('service_poller_frequency') > LibrenmsConfig::get('rrd.step')) {
                     return ValidationResult::fail(trans('validation.validations.poller.CheckSchedules.dispatcher_poll_slow'));

--- a/LibreNMS/Validations/Poller/CheckSchedules.php
+++ b/LibreNMS/Validations/Poller/CheckSchedules.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * CheckDispatcherService.php
+ *
+ * -Description-
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * @link       https://www.librenms.org
+ *
+ * @copyright  2022 Tony Murray
+ * @author     Tony Murray <murraytony@gmail.com>
+ */
+
+namespace LibreNMS\Validations\Poller;
+
+use App\Facades\LibrenmsConfig;
+use LibreNMS\DB\Eloquent;
+use LibreNMS\ValidationResult;
+
+class CheckSchedules implements \LibreNMS\Interfaces\Validation
+{
+    /**
+     * @inheritDoc
+     */
+    public function validate(): ValidationResult
+    {
+        // First make sure the dispatcher service is allowed to run, otherwise we would need to check crontabs
+        if (LibrenmsConfig::get('schedule_type.poller') == 'legacy' || LibrenmsConfig::get('schedule_type.poller') == 'dispatcher') {
+
+            // Then check if the dispatcher polling schedule has been overridden, otherwise it is guaranteed to match the RRD step
+            if (LibrenmsConfig::get('service_poller_frequency') != null) {
+
+                // Return an appropriate error if the polling schedule is different from the RRD step
+                if (LibrenmsConfig::get('service_poller_frequency') > LibrenmsConfig::get('rrd.step')) {
+                    return ValidationResult::fail(trans('validation.validations.poller.CheckSchedules.dispatcher_poll_slow'));
+                } elseif (LibrenmsConfig::get('service_poller_frequency') < LibrenmsConfig::get('rrd.step')) {
+                    return ValidationResult::warn(trans('validation.validations.poller.CheckSchedules.dispatcher_poll_fast'));
+                }
+            }
+        }
+
+        return ValidationResult::ok(trans('validation.validations.poller.CheckSchedules.no_errors'));
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function enabled(): bool
+    {
+        return Eloquent::isConnected();
+    }
+}

--- a/LibreNMS/service.py
+++ b/LibreNMS/service.py
@@ -140,7 +140,8 @@ class ServiceConfig(DBConfig):
             "service_poller_workers", ServiceConfig.poller.workers
         )
         self.poller.frequency = config.get(
-            "service_poller_frequency", ServiceConfig.poller.frequency
+            "service_poller_frequency",
+            config.get("rrd").get("step", ServiceConfig.poller.frequency),
         )
         self.discovery.enabled = (
             config.get("service_discovery_enabled", True)

--- a/app/Models/PollerCluster.php
+++ b/app/Models/PollerCluster.php
@@ -73,7 +73,7 @@ class PollerCluster extends Model
 
     public function scopeIsInactive(Builder $query): Builder
     {
-        $default = (int) \App\Facades\LibrenmsConfig::get('service_poller_frequency') ?? \App\Facades\LibrenmsConfig::get('rrd.step'));
+        $default = (int) \App\Facades\LibrenmsConfig::get('service_poller_frequency') ?? \App\Facades\LibrenmsConfig::get('rrd.step');
 
         return $query->where('last_report', '<', \DB::raw("DATE_SUB(NOW(),INTERVAL COALESCE(`poller_frequency`, $default) SECOND)"));
     }
@@ -145,8 +145,8 @@ class PollerCluster extends Model
             ],
             [
                 'name' => 'poller_frequency',
-                'default' => \App\Facades\LibrenmsConfig::get('service_poller_frequency') ?? \App\Facades\LibrenmsConfig::get('rrd.step')),
-                'value' => $this->poller_frequency ?? \App\Facades\LibrenmsConfig::get('service_poller_frequency') ?? \App\Facades\LibrenmsConfig::get('rrd.step')),
+                'default' => \App\Facades\LibrenmsConfig::get('service_poller_frequency') ?? \App\Facades\LibrenmsConfig::get('rrd.step'),
+                'value' => $this->poller_frequency ?? \App\Facades\LibrenmsConfig::get('service_poller_frequency') ?? \App\Facades\LibrenmsConfig::get('rrd.step'),
                 'type' => 'integer',
                 'units' => 'seconds',
                 'advanced' => true,

--- a/app/Models/PollerCluster.php
+++ b/app/Models/PollerCluster.php
@@ -66,14 +66,14 @@ class PollerCluster extends Model
 
     public function scopeIsActive(Builder $query): Builder
     {
-        $default = (int) \App\Facades\LibrenmsConfig::get('service_poller_frequency');
+        $default = (int) \App\Facades\LibrenmsConfig::get('service_poller_frequency') ?? \App\Facades\LibrenmsConfig::get('rrd.step'));
 
         return $query->where('last_report', '>=', \DB::raw("DATE_SUB(NOW(),INTERVAL COALESCE(`poller_frequency`, $default) SECOND)"));
     }
 
     public function scopeIsInactive(Builder $query): Builder
     {
-        $default = (int) \App\Facades\LibrenmsConfig::get('service_poller_frequency');
+        $default = (int) \App\Facades\LibrenmsConfig::get('service_poller_frequency') ?? \App\Facades\LibrenmsConfig::get('rrd.step'));
 
         return $query->where('last_report', '<', \DB::raw("DATE_SUB(NOW(),INTERVAL COALESCE(`poller_frequency`, $default) SECOND)"));
     }
@@ -145,8 +145,8 @@ class PollerCluster extends Model
             ],
             [
                 'name' => 'poller_frequency',
-                'default' => \App\Facades\LibrenmsConfig::get('service_poller_frequency'),
-                'value' => $this->poller_frequency ?? \App\Facades\LibrenmsConfig::get('service_poller_frequency'),
+                'default' => \App\Facades\LibrenmsConfig::get('service_poller_frequency') ?? \App\Facades\LibrenmsConfig::get('rrd.step')),
+                'value' => $this->poller_frequency ?? \App\Facades\LibrenmsConfig::get('service_poller_frequency') ?? \App\Facades\LibrenmsConfig::get('rrd.step')),
                 'type' => 'integer',
                 'units' => 'seconds',
                 'advanced' => true,

--- a/app/Models/PollerCluster.php
+++ b/app/Models/PollerCluster.php
@@ -66,14 +66,14 @@ class PollerCluster extends Model
 
     public function scopeIsActive(Builder $query): Builder
     {
-        $default = (int) \App\Facades\LibrenmsConfig::get('service_poller_frequency') ?? \App\Facades\LibrenmsConfig::get('rrd.step');
+        $default = (int) (\App\Facades\LibrenmsConfig::get('service_poller_frequency') ?? \App\Facades\LibrenmsConfig::get('rrd.step'));
 
         return $query->where('last_report', '>=', \DB::raw("DATE_SUB(NOW(),INTERVAL COALESCE(`poller_frequency`, $default) SECOND)"));
     }
 
     public function scopeIsInactive(Builder $query): Builder
     {
-        $default = (int) \App\Facades\LibrenmsConfig::get('service_poller_frequency') ?? \App\Facades\LibrenmsConfig::get('rrd.step');
+        $default = (int) (\App\Facades\LibrenmsConfig::get('service_poller_frequency') ?? \App\Facades\LibrenmsConfig::get('rrd.step'));
 
         return $query->where('last_report', '<', \DB::raw("DATE_SUB(NOW(),INTERVAL COALESCE(`poller_frequency`, $default) SECOND)"));
     }

--- a/app/Models/PollerCluster.php
+++ b/app/Models/PollerCluster.php
@@ -66,7 +66,7 @@ class PollerCluster extends Model
 
     public function scopeIsActive(Builder $query): Builder
     {
-        $default = (int) \App\Facades\LibrenmsConfig::get('service_poller_frequency') ?? \App\Facades\LibrenmsConfig::get('rrd.step'));
+        $default = (int) \App\Facades\LibrenmsConfig::get('service_poller_frequency') ?? \App\Facades\LibrenmsConfig::get('rrd.step');
 
         return $query->where('last_report', '>=', \DB::raw("DATE_SUB(NOW(),INTERVAL COALESCE(`poller_frequency`, $default) SECOND)"));
     }

--- a/doc/Extensions/Dispatcher-Service.md
+++ b/doc/Extensions/Dispatcher-Service.md
@@ -67,7 +67,7 @@ Nodes appear automatically after running for a few minutes.
     lnms config:set service_poller_workers 24
     lnms config:set service_services_workers 8
     lnms config:set service_discovery_workers 16
-    lnms config:set service_poller_frequency 300
+    lnms config:set service_poller_frequency null
     lnms config:set service_services_frequency 300
     lnms config:set service_discovery_frequency 21600
     lnms config:set service_billing_frequency 300

--- a/doc/Support/1-Minute-Polling.md
+++ b/doc/Support/1-Minute-Polling.md
@@ -6,8 +6,9 @@ LibreNMS can poll data at the interval that you select.
 
 - For faster up and down alerts, [Fast
   Ping](../Extensions/Fast-Ping-Check.md) is a much easier method.
-- If you change the interval from the default of 300 seconds, you must
-  also change the cron entry for `poller-wrapper.py`.
+- If you are still using the cron wrapper, you must also change your
+  cron entry for `poller-wrapper.py` for this to work (if you change
+  from the default 300 seconds).
 - The polling _MUST_ complete within the heartbeat step value. Open
   `/poller` in your web interface to see the current value.
 - The change applies only to RRD files that LibreNMS creates after the
@@ -29,6 +30,11 @@ interval and the heartbeat interval:
   set this value to 60.
 - Heartbeat is the time to wait for data before LibreNMS records a null
   value. An example value is 120 seconds.
+
+If you are using the dispatcher service, you also need to navigate to
+`/settings/poller/dispatcherservice/` within your WebUI. And either
+set the poller frequency to null, or at least the same value as the
+RRD step setting above (60 for 1 minute polling).
 
 ## Converting existing RRD files
 

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -2032,7 +2032,8 @@ return [
                 'description' => 'Change the rrd heartbeat value (default 600)',
             ],
             'step' => [
-                'description' => 'Change the rrd step value (default 300)',
+                'description' => 'Change the rrd step value (default 300) (Warning!)',
+                'help' => 'Warning! Changing this without fixing rrd files and changing your polling schedule will break graphs. See docs for more info.',
             ],
         ],
         'rrd_dir' => [
@@ -2139,7 +2140,7 @@ return [
         ],
         'service_poller_frequency' => [
             'description' => 'Poller Frequency (Warning!)',
-            'help' => 'How often to poll devices. Sets the default value for all nodes. Warning! If you change this without a fix to the rrd files, graphs break. For more information, see the documentation.',
+            'help' => 'How often to poll devices. Sets the default value for all nodes. Warning! This should normally be null to match the rrd step option, otherwise you may break graphs. See docs for more info.',
         ],
         'service_poller_down_retry' => [
             'description' => 'Device Down Retry',

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -2140,7 +2140,7 @@ return [
         ],
         'service_poller_frequency' => [
             'description' => 'Poller Frequency (Warning!)',
-            'help' => 'How often to poll devices. Sets the default value for all nodes. Warning! This should normally be null to match the rrd step option, otherwise you may break graphs. See docs for more info.',
+            'help' => 'How often to poll devices. Sets the default value for all nodes. Warning! This should normally be blank/null to match the rrd step option, otherwise you may break graphs. See docs for more info.',
         ],
         'service_poller_down_retry' => [
             'description' => 'Device Down Retry',

--- a/lang/en/validation.php
+++ b/lang/en/validation.php
@@ -196,6 +196,11 @@ return [
                 'ok' => 'Redis is functional',
                 'unavailable' => 'Redis is unavailable',
             ],
+            'CheckSchedules' => [
+                'dispatcher_poll_fast' => 'Dispatcher service is set to poll faster than the RRD step.  This will cause unnecessary load on the server if you are not saving to other time series databases becuase the RRD fill cannot store data at the granularity of polling.',
+                'dispatcher_poll_slow' => 'Dispatcher service is set to poll slower than the RRD step.  This can cause errors with graphs because the RRD file is expecting data more frequently. It is recommneded to set service_poller_frequency to null so polling frequency will match the RRD step.',
+                'no_errors' => 'No errors found with polling frequencies.',
+            ],
         ],
     ],
 ];

--- a/lang/it/settings.php
+++ b/lang/it/settings.php
@@ -1272,7 +1272,7 @@ return [
         ],
         'service_poller_frequency' => [
             'description' => 'Poller Frequency (Warning!)',
-            'help' => 'How often to poll devices. Sets the default value for all nodes. Warning! This should normally be null to match the rrd step option, otherwise you may break graphs. See docs for more info.',
+            'help' => 'How often to poll devices. Sets the default value for all nodes. Warning! This should normally be blank/null to match the rrd step option, otherwise you may break graphs. See docs for more info.',
         ],
         'service_poller_down_retry' => [
             'description' => 'Device Down Retry',

--- a/lang/it/settings.php
+++ b/lang/it/settings.php
@@ -1231,7 +1231,8 @@ return [
                 'description' => 'Change the rrd heartbeat value (default 600)',
             ],
             'step' => [
-                'description' => 'Change the rrd step value (default 300)',
+                'description' => 'Change the rrd step value (default 300)  (Warning!)',
+                'help' => 'Warning! Changing this without fixing rrd files and changing your polling schedule will break graphs. See docs for more info.',
             ],
         ],
         'rrd_dir' => [

--- a/resources/definitions/config_definitions.json
+++ b/resources/definitions/config_definitions.json
@@ -6757,7 +6757,6 @@
             "units": "Workers"
         },
         "service_poller_frequency": {
-            "default": null,
             "group": "poller",
             "section": "dispatcherservice",
             "order": 7,

--- a/resources/definitions/config_definitions.json
+++ b/resources/definitions/config_definitions.json
@@ -6762,7 +6762,10 @@
             "section": "dispatcherservice",
             "order": 7,
             "type": "integer",
-            "units": "Seconds"
+            "units": "Seconds",
+            "validate": {
+                "value": "int|nullable|between:1,3600"
+            }
         },
         "service_poller_down_retry": {
             "default": 60,

--- a/resources/definitions/config_definitions.json
+++ b/resources/definitions/config_definitions.json
@@ -6757,7 +6757,7 @@
             "units": "Workers"
         },
         "service_poller_frequency": {
-            "default": 300,
+            "default": null,
             "group": "poller",
             "section": "dispatcherservice",
             "order": 7,


### PR DESCRIPTION
The dispatcher poller frequency should match the rrd step, so I have made them the same by default.

I have also updated the documentation, and added some validation code to warn if the options drift on an installation.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.

