### PR TITLE
Add example for extending alert templates

### DIFF
--- a/doc/Alerting/Templates.md
+++ b/doc/Alerting/Templates.md
@@ -141,6 +141,14 @@ In your alert template just use
 
 For more info on extending templates, see the [Laravel documentation](https://laravel.com/docs/blade#extending-a-layout).
 
+### Including other Alert templates
+
+Another way to extend a template, is to reuse the content of other Alert templates in LibreNMS. This can be done by leveraging the AlertTemplate database model. All inside the included template needed variables, need to be passed through to the second parameter (e.g.```["alert" => $alert]```) of the method Blade:render(). 
+With the following example the entire content of the template with the ID 5 will be included.  This could be useful to have all common text parts in seperate templates. E.g. headers or footers.
+```php
+{ \Illuminate\Support\Facades\Blade::render(\App\Models\AlertTemplate::find(5)->template , ["alert" => $alert]) }}
+```
+
 ## Examples
 
 ### Default Template


### PR DESCRIPTION
Add an example for extending the text of alert templates with contents of other alert templates

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
