### PR TITLE
Remove explicit default null from config definition

### DIFF
--- a/resources/definitions/config_definitions.json
+++ b/resources/definitions/config_definitions.json
@@ -502,8 +502,7 @@
             "group": "auth",
             "section": "ad",
             "order": 4,
-            "type": "text",
-            "default": null
+            "type": "text"
         },
         "auth_ad_require_groupmembership": {
             "group": "auth",
@@ -782,7 +781,6 @@
             }
         },
         "auth_ldap_port": {
-            "default": null,
             "group": "auth",
             "section": "ldap",
             "order": 1,
@@ -982,7 +980,6 @@
             }
         },
         "bad_entity_sensor_regex": {
-            "default": null,
             "type": "array",
             "validate": {
                 "value": "array",
@@ -1128,18 +1125,15 @@
             "type": "text"
         },
         "callback_proxy": {
-            "default": null,
             "type": "text"
         },
         "collectd_dir": {
-            "default": null,
             "type": "directory",
             "group": "external",
             "section": "collectd",
             "order": 0
         },
         "collectd_sock": {
-            "default": null,
             "type": "text",
             "group": "external",
             "section": "collectd",
@@ -1200,7 +1194,6 @@
             }
         },
         "custom_map.background_data.layer": {
-            "default": null,
             "type": "select",
             "group": "webui",
             "section": "custom-map",
@@ -1289,7 +1282,6 @@
             "order": 2
         },
         "custom_map.legend_colours": {
-            "default": null,
             "type": "array",
             "validate": {
                  "value": "array",
@@ -1471,7 +1463,6 @@
             "group": "webui",
             "section": "device",
             "order": 1,
-            "default": null,
             "type": "select",
             "options": {
                 "{{ $hostname }}": "hostname",
@@ -1593,14 +1584,12 @@
             }
         },
         "disabled_sensors": {
-            "default": null,
             "type": "array",
             "group": "discovery",
             "section": "sensors",
             "order": 1
         },
         "disabled_sensors_regex": {
-            "default": null,
             "type": "array",
             "validate": {
                 "value": "array",
@@ -2082,7 +2071,6 @@
             }
         },
         "email_from": {
-            "default": null,
             "group": "alerting",
             "section": "email",
             "order": 2,
@@ -2319,7 +2307,6 @@
             "type": "boolean"
         },
         "error_font": {
-            "default": null,
             "type": "text"
         },
         "eventlog_purge": {
@@ -2412,7 +2399,6 @@
             "order": 3
         },
         "gateone.server": {
-            "default": null,
             "type": "text"
         },
         "gateone.use_librenms_user": {
@@ -2500,7 +2486,6 @@
             "type": "text"
         },
         "good_if": {
-            "default": null,
             "type": "array",
             "group": "discovery",
             "section": "ports",
@@ -5215,7 +5200,6 @@
             "order": 2
         },
         "libvirt_username": {
-            "default": null,
             "type": "text",
             "group": "discovery",
             "section": "virtualization",
@@ -5250,7 +5234,6 @@
             "type": "color"
         },
         "location_map": {
-            "default": null,
             "type": "array",
             "validate": {
                 "value": "array",
@@ -5261,7 +5244,6 @@
             "order": 9
         },
         "location_map_regex": {
-            "default": null,
             "type": "array",
             "validate": {
                 "value": "array",
@@ -5272,7 +5254,6 @@
             "order": 10
         },
         "location_map_regex_sub": {
-            "default": null,
             "type": "array",
             "validate": {
                 "value": "array",
@@ -5329,7 +5310,6 @@
             "type": "executable"
         },
         "mtu_options.bytes": {
-            "default": null,
             "group": "poller",
             "section": "mtu",
             "order": 1,
@@ -5368,7 +5348,6 @@
             "type": "boolean"
         },
         "network_map_dependencymap_vis_options": {
-            "default": null,
             "type": "text"
         },
         "network_map_items": {
@@ -5624,7 +5603,6 @@
             "type": "boolean"
         },
         "opentsdb.co": {
-            "default": null,
             "type": "boolean",
             "group": "poller",
             "section": "opentsdb",
@@ -5816,11 +5794,9 @@
             "type": "integer"
         },
         "radius.hostname": {
-            "default": null,
             "type": "text"
         },
         "radius.port": {
-            "default": null,
             "type": "integer"
         },
         "radius.users_purge": {
@@ -5829,11 +5805,9 @@
             "type": "integer"
         },
         "radius.secret": {
-            "default": null,
             "type": "text"
         },
         "radius.suffix": {
-            "default": null,
             "type": "text"
         },
         "rrd.enable": {
@@ -5930,7 +5904,6 @@
             "type": "boolean"
         },
         "php_memory_limit": {
-            "default": null,
             "type": "integer"
         },
         "ping": {
@@ -6489,7 +6462,6 @@
             "order": 2
         },
         "rancid_repo_url": {
-            "default": null,
             "type": "text",
             "group": "external",
             "section": "rancid",
@@ -6627,7 +6599,6 @@
             "type": "boolean"
         },
         "rrdtool_version": {
-            "default": null,
             "group": "poller",
             "section": "rrdtool",
             "order": 12,
@@ -7064,35 +7035,30 @@
             "order": 0
         },
         "sso.descr_attr":{
-            "default": null,
             "type": "text",
             "group": "auth",
             "section": "sso",
             "order": 1
         },
         "sso.email_attr":{
-            "default": null,
             "type": "text",
             "group": "auth",
             "section": "sso",
             "order": 2
         },
         "sso.group_attr":{
-            "default": null,
             "type": "text",
             "group": "auth",
             "section": "sso",
             "order": 3
         },
         "sso.group_delimiter":{
-            "default": null,
             "type": "text",
             "group": "auth",
             "section": "sso",
             "order": 4
         },
         "sso.group_filter":{
-            "default": null,
             "type": "text",
             "group": "auth",
             "section": "sso",
@@ -7115,7 +7081,6 @@
             "order": 6
         },
         "sso.group_strategy": {
-            "default": null,
             "type": "select",
             "options": {
                 "attribute": "attribute",
@@ -7127,7 +7092,6 @@
             "order": 7
         },
         "sso.level_attr":{
-            "default": null,
             "type": "text",
             "group": "auth",
             "section": "sso",
@@ -7145,14 +7109,12 @@
             "order": 9
         },
         "sso.realname_attr":{
-            "default": null,
             "type": "text",
             "group": "auth",
             "section": "sso",
             "order": 10
         },
         "sso.static_level":{
-            "default": null,
             "type": "integer",
             "group": "auth",
             "section": "sso",


### PR DESCRIPTION
Clean up all instances where the config default has been explicitly set to null.  This was raised as a concern in a code review on #19059 

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
