### PR TITLE
fix(smtp): use FQDN for EHLO/HELO greeting per RFC2821

### DIFF
--- a/LibreNMS/Util/Mail.php
+++ b/LibreNMS/Util/Mail.php
@@ -74,7 +74,7 @@ class Mail
         if (is_array($emails) || ($emails = self::parseEmails($emails))) {
             d_echo("Attempting to email $subject to: " . implode('; ', array_keys($emails)) . PHP_EOL);
             $mail = new PHPMailer(true);
-            $mail->Hostname = php_uname('n');
+            $mail->Hostname = gethostbyaddr(gethostbyname(gethostname()));
 
             foreach (self::parseEmails((string) LibrenmsConfig::get('email_from')) as $from => $from_name) {
                 $mail->setFrom($from, $from_name);


### PR DESCRIPTION
php_uname('n') returns only the short hostname, which causes strict RFC2821-compliant mail servers to reject the connection with:
  "Your HELO/EHLO greeting is a single word. According to RFC2821 you
   must use your fully-qualified domain-name."

Replace with gethostbyaddr(gethostbyname(gethostname())) which resolves the FQDN via DNS, producing a compliant EHLO greeting.

Fixes #19081

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
