### PR TITLE
fix(alerts): reset alerted flag when a new alert cycle begins

### DIFF
--- a/LibreNMS/Alert/AlertRules.php
+++ b/LibreNMS/Alert/AlertRules.php
@@ -131,7 +131,7 @@ class AlertRules
                         if (is_null($current_state)) {
                             dbInsert(['state' => AlertState::ACTIVE, 'device_id' => $device_id, 'rule_id' => $rule['id'], 'open' => 1, 'alerted' => 0], 'alerts');
                         } else {
-                            dbUpdate(['state' => AlertState::ACTIVE, 'open' => 1, 'timestamp' => Carbon::now()], 'alerts', 'device_id = ? && rule_id = ?', [$device_id, $rule['id']]);
+                            dbUpdate(['state' => AlertState::ACTIVE, 'open' => 1, 'alerted' => 0, 'timestamp' => Carbon::now()], 'alerts', 'device_id = ? && rule_id = ?', [$device_id, $rule['id']]);
                         }
                         Log::info(PHP_EOL . 'Status: %rALERT%n', ['color' => true]);
                     }


### PR DESCRIPTION
## Summary

When a device transitions from RECOVERED back to ACTIVE, the `alerted` column in the `alerts` table was not reset to `0`. The first-time `INSERT` (when no prior alert exists) already sets `alerted => 0` explicitly, but the `UPDATE` on re-activation did not.

This left a stale `alerted = 1` (from a previous cycle where the active alert was sent but the recovery was suppressed — e.g. device was in maintenance, muted, parent down, or `recovery=false`) carrying over into the new cycle.

When the device then came back up **within the delay window** — so no active alert was sent for the new cycle — the recovery alert fired anyway, because `alerted (1) != state (0 = RECOVERED)` passed the suppression check in `RunAlerts::runAlerts()`.

**Fix:** add `'alerted' => 0` to the `dbUpdate` call at cycle re-activation, making it consistent with the first-time `dbInsert`.

Fixes #16015

## Root cause trace

```
Cycle 1 (long outage)
  active sent       → alerted = 1
  recovery suppressed (maintenance/muted/parent-down/recovery=false)
                    → alerted = 1  ← stale value persists

Cycle 2 (short outage, within delay)
  line 115 dbUpdate → alerted unchanged (= 1)   ← bug
  delay suppresses active alert
  device recovers
  alerted(1) != state(RECOVERED=0) → noiss=false → recovery sent  ✗

With fix:
  line 115 dbUpdate → alerted = 0  ← reset
  delay suppresses active alert
  device recovers
  alerted(0) == state(RECOVERED=0) → noiss=true → recovery suppressed  ✓
```

## Test plan

- [ ] Configure an alert rule with a delay (e.g. 5 minutes)
- [ ] Trigger the rule, wait for the active alert to send (`alerted` becomes 1)
- [ ] Simulate a suppressed recovery (put device in maintenance, let it recover, take it out of maintenance)
- [ ] Trigger the rule again and clear it within the delay window
- [ ] Verify **no** recovery alert is sent for the second cycle
- [ ] Trigger the rule again and let it stay active past the delay; verify active alert fires and subsequent recovery is sent normally

