### PR TITLE
Cleanup permissions when user is deleted

### DIFF
--- a/app/Observers/UserObserver.php
+++ b/app/Observers/UserObserver.php
@@ -3,6 +3,7 @@
 namespace App\Observers;
 
 use App\Models\User;
+use Illuminate\Support\Facades\DB;
 
 class UserObserver
 {
@@ -14,6 +15,12 @@ class UserObserver
      */
     public function deleted(User $user): void
     {
+        // Remove permission rows that reference this user (alternative to FK cascade)
+        DB::table('ports_perms')->where('user_id', $user->user_id)->delete();
+        DB::table('devices_perms')->where('user_id', $user->user_id)->delete();
+        DB::table('bill_perms')->where('user_id', $user->user_id)->delete();
+
+        // Remove related user-owned records
         $user->apiTokens()->delete();
         $user->notificationAttribs()->delete();
         $user->preferences()->delete();


### PR DESCRIPTION
Enhance user deletion to clean up additional permissions tables.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
