### PR TITLE
fix(syslog): remove stray "; causing JS syntax error in device syslog filters

### DIFF
--- a/resources/views/device/tabs/logs/syslog.blade.php
+++ b/resources/views/device/tabs/logs/syslog.blade.php
@@ -63,7 +63,7 @@
             '<select name="program" id="program" class="form-control">' +
                 '<option value="">All Programs&nbsp;&nbsp;</option>' +
             @if($program)
-                '<option value=\"' + @json($program) + '\">' + @json($program) + '</option>' +";
+                '<option value=\"' + @json($program) + '\">' + @json($program) + '</option>' +
             @endif
             '</select>' +
             '</div>' +
@@ -71,7 +71,7 @@
             '<select name="priority" id="priority" class="form-control">' +
                 '<option value="">All Priorities</option>' +
             @if($priority)
-                '<option value=\"' + @json($priority) + '\">' + @json($priority) + '</option>' +";
+                '<option value=\"' + @json($priority) + '\">' + @json($priority) + '</option>' +
             @endif
             '</select>' +
             '</div>' +


### PR DESCRIPTION
## Summary
- Remove stray `";` from program and priority filter option lines in the device syslog Blade template
- The `";` was left over from the PHP `echo` pattern used in the older `pages/syslog.inc.php` — in Blade it becomes literal JavaScript that creates an unterminated string literal, killing the entire `<script>` block

## Test plan
- [ ] Navigate to a device's Syslog tab (`/device/{id}/logs/syslog`)
- [ ] Select a value from the "Program" dropdown, click Filter — table should show filtered results
- [ ] Select a value from the "Priority" dropdown, click Filter — table should show filtered results
- [ ] Verify no JavaScript errors in the browser console

Fixes #19089

🤖 Generated with [Claude Code](https://claude.com/claude-code)