### PR TITLE
Update to allow maintenance:fetch-rss to use proxy servers

### DIFF
--- a/LibreNMS/Util/Notifications.php
+++ b/LibreNMS/Util/Notifications.php
@@ -31,7 +31,6 @@ namespace LibreNMS\Util;
 use App\Facades\LibrenmsConfig;
 use App\Models\Notification;
 use Illuminate\Support\Arr;
-use LibreNMS\Util\Http;
 
 class Notifications
 {

--- a/LibreNMS/Util/Notifications.php
+++ b/LibreNMS/Util/Notifications.php
@@ -102,7 +102,7 @@ class Notifications
             }
 
             if (is_file($url)) {
-                file_get_contents($url);
+                $data = file_get_contents($url);
             } else {
                 $data = Http::client()->get($url)->body();
             }

--- a/LibreNMS/Util/Notifications.php
+++ b/LibreNMS/Util/Notifications.php
@@ -31,6 +31,7 @@ namespace LibreNMS\Util;
 use App\Facades\LibrenmsConfig;
 use App\Models\Notification;
 use Illuminate\Support\Arr;
+use LibreNMS\Util\Http;
 
 class Notifications
 {
@@ -101,7 +102,13 @@ class Notifications
                 $url = str_starts_with($url, '/') ? $url : base_path($url);
             }
 
-            $feed = json_decode(json_encode(simplexml_load_string(file_get_contents($url))), true);
+            if (is_file($url)) {
+                file_get_contents($url);
+            } else {
+                $data = Http::client()->get($url)->body();
+            }
+
+            $feed = json_decode(json_encode(simplexml_load_string($data)), true);
             $feed = isset($feed['channel']) ? self::parseRss($feed) : self::parseAtom($feed);
 
             array_walk($feed, function (&$items, $key, $url): void {


### PR DESCRIPTION
The maintenance:fetch-rss command currently uses file_get_contents() to fetch the RSS feed from the LibreNMS website.  This PR changes this to use the LibreNMS HTTP client, which uses the configured proxy settings to fetch URLs.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
