### PR TITLE
fix: device edit legacy urls

### DIFF
--- a/app/Http/Controllers/DeviceController.php
+++ b/app/Http/Controllers/DeviceController.php
@@ -69,7 +69,6 @@ class DeviceController
         $init_modules = ['web', 'auth'];
         require base_path('/includes/init.php');
 
-        $vars = Url::parseLegacyPath(request()->path())->all();
         $vars['device'] = $device['device_id'];
         $vars['tab'] = $tab;
 


### PR DESCRIPTION
When navigating to device edit sub-sections (e.g. /device/device=188/tab=edit/section=apps), the section parameter was not being parsed from the URL path, causing edit.inc.php to default to the 'device' section and fail to render content (device.inc.php does not exist).

Fix by parsing the full legacy URL path with Url::parseLegacyPath() before setting device and tab, consistent with how port tab vars are already handled in DeviceController::index().

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

fixes #19102

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
