### PR TITLE
Fixed mariadb configuration doc for Debian 13 

### DIFF
--- a/doc/Installation/Install-LibreNMS.md
+++ b/doc/Installation/Install-LibreNMS.md
@@ -165,10 +165,24 @@ timedatectl set-timezone Etc/UTC
     ```
     vi /etc/mysql/mariadb.conf.d/50-server.cnf
     ```
+    
+    Within the `[mysqld]` section add:
+
+    ```
+    innodb_file_per_table=1
+    lower_case_table_names=0
+    ```
 
 === "Ubuntu 22.04"
     ```
     vi /etc/mysql/mariadb.conf.d/50-server.cnf
+    ```
+
+    Within the `[mysqld]` section add:
+
+    ```
+    innodb_file_per_table=1
+    lower_case_table_names=0
     ```
 
 === "CentOS 8"
@@ -176,22 +190,37 @@ timedatectl set-timezone Etc/UTC
     vi /etc/my.cnf.d/mariadb-server.cnf
     ```
 
+    Within the `[mysqld]` section add:
+
+    ```
+    innodb_file_per_table=1
+    lower_case_table_names=0
+    ```
+
 === "Debian 12"
     ```
     vi /etc/mysql/mariadb.conf.d/50-server.cnf
     ```
+
+    Within the `[mysqld]` section add:
+
+    ```
+    innodb_file_per_table=1
+    lower_case_table_names=0
+    ```    
 
 === "Debian 13"
     ```
     vi /etc/mysql/mariadb.conf.d/50-server.cnf
     ```
 
-Within the `[mysqld]` section add:
+    Within the `[mariadbd]` section add:
 
-```
-innodb_file_per_table=1
-lower_case_table_names=0
-```
+    ```
+    innodb_file_per_table=1
+    lower_case_table_names=0
+    ```
+
 
 Then restart MariaDB
 


### PR DESCRIPTION
Fixed mariadb configuration doc for Debian 13 from the old mysqld, not available by default to mariadbd section.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [X] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
