### PR TITLE
Clean up some unused time and timezone relates variables in http controllers

### DIFF
--- a/app/Http/Controllers/Device/Tabs/LatencyController.php
+++ b/app/Http/Controllers/Device/Tabs/LatencyController.php
@@ -28,7 +28,6 @@ namespace App\Http\Controllers\Device\Tabs;
 
 use App\Facades\LibrenmsConfig;
 use App\Models\Device;
-use Carbon\Carbon;
 use Illuminate\Http\Request;
 use LibreNMS\Interfaces\UI\DeviceTab;
 use LibreNMS\Util\Smokeping;
@@ -57,9 +56,6 @@ class LatencyController implements DeviceTab
 
     public function data(Device $device, Request $request): array
     {
-        $from = $request->input('dtpickerfrom', Carbon::now(session('preferences.timezone'))->subDays(2)->format(LibrenmsConfig::get('dateformat.byminute')));
-        $to = $request->input('dtpickerto', Carbon::now(session('preferences.timezone'))->format(LibrenmsConfig::get('dateformat.byminute')));
-
         $smokeping = new Smokeping($device);
         $smokeping_tabs = [];
         if ($smokeping->hasInGraph()) {
@@ -70,8 +66,6 @@ class LatencyController implements DeviceTab
         }
 
         return [
-            'from' => $from,
-            'to' => $to,
             'smokeping' => $smokeping,
             'smokeping_tabs' => $smokeping_tabs,
         ];

--- a/app/Http/Controllers/OutagesController.php
+++ b/app/Http/Controllers/OutagesController.php
@@ -4,7 +4,6 @@ namespace App\Http\Controllers;
 
 use App\Facades\LibrenmsConfig;
 use App\Models\Device;
-use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Validation\Rule;
 
@@ -31,7 +30,6 @@ class OutagesController extends Controller
         $from = $request->input('from');
         $to = $request->input('to');
 
-        $tz = $request->session()->get('preferences.timezone');
         $date_format = LibrenmsConfig::get('dateformat.byminute', 'Y-m-d H:i');
 
         return view('outages.index', [
@@ -41,8 +39,6 @@ class OutagesController extends Controller
             'to' => $to,
             'status' => $request->input('status', 'current'),
             'preset' => $request->input('preset', true),
-            'default_start_date' => Carbon::now($tz)->subMonth()->format($date_format),
-            'default_end_date' => Carbon::now($tz)->format($date_format),
             'show_device_list' => true, // when html is shared with device tab
         ]);
     }

--- a/app/Http/Controllers/PollerController.php
+++ b/app/Http/Controllers/PollerController.php
@@ -47,7 +47,6 @@ class PollerController extends Controller
         $this->authorize('viewAny', PollerCluster::class);
 
         return view('poller.poller', [
-            'timezone' => session('preferences.timezone'),
             'current_tab' => 'poller',
             'pollers' => $this->poller(),
             'poller_cluster' => $this->pollerCluster(),


### PR DESCRIPTION
While looking at other timezone related work, I came across a few controllers with unused variables.  This PR cleans these up.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
