### PR TITLE
Update date range picker to be timezone aware

### DIFF
--- a/app/Http/Controllers/Table/OutagesController.php
+++ b/app/Http/Controllers/Table/OutagesController.php
@@ -86,15 +86,27 @@ class OutagesController extends TableController
                     });
                 } else {
                     // All outages: use original logic (any overlap with range)
-                    // Outage starts within range
-                    $this->applyDateRangeCondition($query, 'going_down', $from_ts, $to_ts);
-
-                    // Outage either has not ended, or end is within date range
                     $query->where(function ($q) use ($from_ts, $to_ts): void {
+                        // Outage starts within range
+                        $this->applyDateRangeCondition($q, 'going_down', $from_ts, $to_ts);
+
                         // OR outage ends within range (if it has ended)
-                        $q->where(function ($subQuery) use ($from_ts, $to_ts): void {
+                        $q->orWhere(function ($subQuery) use ($from_ts, $to_ts): void {
+                            $subQuery->whereNotNull('up_again');
                             $this->applyDateRangeCondition($subQuery, 'up_again', $from_ts, $to_ts);
-                            $subQuery->orWhereNull('up_again');
+                        });
+
+                        // OR outage spans the entire range (started before, still ongoing or ended after)
+                        $q->orWhere(function ($subQuery) use ($from_ts, $to_ts): void {
+                            if ($from_ts) {
+                                $subQuery->where('going_down', '<', $from_ts);
+                            }
+                            if ($to_ts) {
+                                $subQuery->where(function ($q) use ($to_ts): void {
+                                    $q->whereNull('up_again') // Still ongoing
+                                    ->orWhere('up_again', '>', $to_ts); // Ended after range
+                                });
+                            }
                         });
                     });
                 }

--- a/app/Http/Controllers/Table/OutagesController.php
+++ b/app/Http/Controllers/Table/OutagesController.php
@@ -86,27 +86,15 @@ class OutagesController extends TableController
                     });
                 } else {
                     // All outages: use original logic (any overlap with range)
+                    // Outage starts within range
+                    $this->applyDateRangeCondition($query, 'going_down', $from_ts, $to_ts);
+
+                    // Outage either has not ended, or end is within date range
                     $query->where(function ($q) use ($from_ts, $to_ts): void {
-                        // Outage starts within range
-                        $this->applyDateRangeCondition($q, 'going_down', $from_ts, $to_ts);
-
                         // OR outage ends within range (if it has ended)
-                        $q->orWhere(function ($subQuery) use ($from_ts, $to_ts): void {
-                            $subQuery->whereNotNull('up_again');
+                        $q->where(function ($subQuery) use ($from_ts, $to_ts): void {
                             $this->applyDateRangeCondition($subQuery, 'up_again', $from_ts, $to_ts);
-                        });
-
-                        // OR outage spans the entire range (started before, still ongoing or ended after)
-                        $q->orWhere(function ($subQuery) use ($from_ts, $to_ts): void {
-                            if ($from_ts) {
-                                $subQuery->where('going_down', '<', $from_ts);
-                            }
-                            if ($to_ts) {
-                                $subQuery->where(function ($q) use ($to_ts): void {
-                                    $q->whereNull('up_again') // Still ongoing
-                                    ->orWhere('up_again', '>', $to_ts); // Ended after range
-                                });
-                            }
+                            $subQuery->orWhereNull('up_again');
                         });
                     });
                 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -221,7 +221,7 @@ class AppServiceProvider extends ServiceProvider
                 return true;
             }
 
-            if (is_string($value) && preg_match('/^[+-]?\d+[hdmwy]$/', $value)) {
+            if (is_string($value) && preg_match('/^[+-]?\d+(y|mo|w|d|h|m|s)$/', $value)) {
                 return true;
             }
 

--- a/resources/views/outages/index.blade.php
+++ b/resources/views/outages/index.blade.php
@@ -96,8 +96,8 @@ $refresh = request()->input('refresh', 30);
             return {
                 device: document.getElementById('device').value,
                 status: document.getElementById('status').value,
-                to: range.end?.toISOString(),
-                from: range.start?.toISOString(),
+                to: range.end,
+                from: range.start,
             };
         },
     }).on("loaded.rs.jquery.bootgrid", function() {


### PR DESCRIPTION
The date range picker is not timezone aware.  This PR uses the moment-tz JS library to convert the dates selected in the picker to the correct timezone and back again.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
