### PR TITLE
Fix SQL query when looking at all outages

### DIFF
--- a/app/Http/Controllers/Table/OutagesController.php
+++ b/app/Http/Controllers/Table/OutagesController.php
@@ -86,27 +86,15 @@ class OutagesController extends TableController
                     });
                 } else {
                     // All outages: use original logic (any overlap with range)
+                    // Outage starts within range
+                    $this->applyDateRangeCondition($query, 'going_down', $from_ts, $to_ts);
+
+                    // Outage either has not ended, or end is within date range
                     $query->where(function ($q) use ($from_ts, $to_ts): void {
-                        // Outage starts within range
-                        $this->applyDateRangeCondition($q, 'going_down', $from_ts, $to_ts);
-
                         // OR outage ends within range (if it has ended)
-                        $q->orWhere(function ($subQuery) use ($from_ts, $to_ts): void {
-                            $subQuery->whereNotNull('up_again');
+                        $q->where(function ($subQuery) use ($from_ts, $to_ts): void {
                             $this->applyDateRangeCondition($subQuery, 'up_again', $from_ts, $to_ts);
-                        });
-
-                        // OR outage spans the entire range (started before, still ongoing or ended after)
-                        $q->orWhere(function ($subQuery) use ($from_ts, $to_ts): void {
-                            if ($from_ts) {
-                                $subQuery->where('going_down', '<', $from_ts);
-                            }
-                            if ($to_ts) {
-                                $subQuery->where(function ($q) use ($to_ts): void {
-                                    $q->whereNull('up_again') // Still ongoing
-                                    ->orWhere('up_again', '>', $to_ts); // Ended after range
-                                });
-                            }
+                            $subQuery->orWhereNull('up_again');
                         });
                     });
                 }


### PR DESCRIPTION
The date range filter does not work correctly when looking at "all" outages on the outage controller.  There is another PR that fixes timezone, but the existing SQL does not filter "all" outages in a consistent way that it filters "current" and "previous" outages.

This PR fixes this so "all" outages will apply the filter as follows:
- Only include outages that start within the selected date ranges
- Include outages all that are:
  - still ongoing OR
  - ended within the specified time period

My testing with the new code makes the results for "all" the union of the results for "current" and "previous", which I think is the correct behaviour.

I figured out how to break the old code... Only put in a start or end date.
<img width="158" height="272" alt="image" src="https://github.com/user-attachments/assets/0efcb41c-0f75-4a2f-9b15-3f2a762609b5" />

Both the original code and this PR give the following for Current and Previous:
<img width="285" height="305" alt="image" src="https://github.com/user-attachments/assets/0e5374ee-82d5-4919-afad-d175de98d911" />

<img width="243" height="240" alt="image" src="https://github.com/user-attachments/assets/a30f50df-143a-4bbb-8306-ef5029b7a5df" />

The difference shows when using the "All" filter.
Old:
<img width="515" height="889" alt="image" src="https://github.com/user-attachments/assets/889f9df9-7e80-4849-a1bc-7172c23d4f19" />

New:
<img width="284" height="303" alt="image" src="https://github.com/user-attachments/assets/ff639d93-334a-4bb2-b12d-e997fca03a3a" />


It's the same when only choosing a start date:
Old (same list as above, all outages shown):
<img width="556" height="871" alt="image" src="https://github.com/user-attachments/assets/51ec9006-a5d2-4868-b613-9e737fca6c89" />

New (you can see it only shows items since the 1st of Feb):
<img width="405" height="439" alt="image" src="https://github.com/user-attachments/assets/653b4799-1c01-43ce-bdf0-4aeb5304b37f" />


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
