### PR TITLE
Add configurable permission for oxidized config view

### DIFF
--- a/includes/html/pages/device/showconfig.inc.php
+++ b/includes/html/pages/device/showconfig.inc.php
@@ -4,7 +4,17 @@
 use App\Facades\LibrenmsConfig;
 use Symfony\Component\Process\Process;
 
-if (Auth::user()->hasGlobalAdmin()) {
+$required_role = LibrenmsConfig::get('oxidized.config_view_permission', 'admin');
+
+$hasPermission = match ($required_role) {
+    'admin' => Auth::user()->hasGlobalAdmin(),
+    'global-read' => Auth::user()->can('global-read'),
+    'user' => Auth::user()->can('read'),
+    default => Auth::user()->hasGlobalAdmin(),
+};
+
+if ($hasPermission) {
+
     if (LibrenmsConfig::get('rancid_repo_type') == 'git-bare' && is_dir($rancid_path)) {
         echo '<div style="clear: both;">';
 

--- a/resources/definitions/config_definitions.json
+++ b/resources/definitions/config_definitions.json
@@ -5789,6 +5789,18 @@
                 "value": "url"
             }
         },
+	oxidized.config_view_permission: {
+	    default: admin,
+	    type: select,
+	    group: external,
+	    section: oxidized,
+	    order: 10,
+	    options: {
+		admin: Admin only,
+		global-read: Global Read,
+		user: Normal User
+	    }
+	},
         "radius.default_level": {
             "default": 1,
             "type": "integer"


### PR DESCRIPTION
The Oxidized config page currently requires admin access. This pull request adds a configurable option oxidized.config_view_permission (admin/global-read/user) to control who can view the oxidized device configurations.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
