### PR TITLE
Fix unstable device select pagination in depends-on field

### DIFF
--- a/app/Http/Controllers/Select/DeviceController.php
+++ b/app/Http/Controllers/Select/DeviceController.php
@@ -61,13 +61,17 @@ class DeviceController extends SelectController
                         ->from('devices_perms')
                         ->where('user_id', $user_id);
                 })
-                ->orderBy('hostname');
+                ->distinct()
+                ->orderBy('hostname')
+                ->orderBy('device_id');
         }
 
         return Device::hasAccess($request->user())
             ->when($request->input('exclude'), fn ($query, $exclude) => $query->where('device_id', '!=', $exclude))
             ->select(['device_id', 'hostname', 'sysName', 'display', 'icon'])
-            ->orderBy('hostname');
+            ->distinct()
+            ->orderBy('hostname')
+            ->orderBy('device_id');
     }
 
     public function formatItem($device)


### PR DESCRIPTION
## Summary
Fix unstable pagination in the device Select2 endpoint used by the **"This device depends on"** field on device edit pages.

The endpoint was ordered only by `hostname`, which can contain duplicates and produce non-deterministic page boundaries in paginated Select2 requests. This can surface as repeated chunks while scrolling and missing devices from later pages.

## What changed
- Updated `App\\Http\\Controllers\\Select\\DeviceController` query builder to:
  - add `distinct()`
  - use stable ordering: `orderBy('hostname')->orderBy('device_id')`
- Applied in both normal and inverted-access query paths.

## Why
Select2 infinite scroll relies on stable ordering across pages. Non-unique ordering can cause records to shift between pages and appear duplicated/repeated.

## Validation
- PHP syntax check in container: pass
- Runtime query inspection in containerized app context confirms generated ordering is now deterministic in both query paths:
  - `hostname ASC`
  - `device_id ASC`

Fixes #19111
