### PR TITLE
Fix inconsistent dependency suppression parent count in alerts

### DIFF
--- a/LibreNMS/Alert/RunAlerts.php
+++ b/LibreNMS/Alert/RunAlerts.php
@@ -725,11 +725,24 @@ class RunAlerts
             return false;
         }
 
-        $down_parent_count = dbFetchCell("SELECT count(*) from devices as d LEFT JOIN devices_attribs as a ON d.device_id=a.device_id LEFT JOIN device_relationships as r ON d.device_id=r.parent_device_id WHERE d.status=0 AND d.ignore=0 AND d.disabled=0 AND r.child_device_id=? AND (d.status_reason='icmp' OR (a.attrib_type='override_icmp_disable' AND a.attrib_value=true))", [$device]);
-        if ($down_parent_count == $parent_count) {
-            return true;
-        }
+        $down_parent_count = dbFetchCell("SELECT count(DISTINCT d.device_id)
+            FROM devices AS d
+            INNER JOIN device_relationships AS r ON d.device_id = r.parent_device_id
+            WHERE d.status = 0
+              AND d.ignore = 0
+              AND d.disabled = 0
+              AND r.child_device_id = ?
+              AND (
+                d.status_reason = 'icmp'
+                OR EXISTS (
+                    SELECT 1
+                    FROM devices_attribs AS a
+                    WHERE a.device_id = d.device_id
+                      AND a.attrib_type = 'override_icmp_disable'
+                      AND a.attrib_value = 'true'
+                )
+              )", [$device]);
 
-        return false;
+        return $down_parent_count == $parent_count;
     }
 }


### PR DESCRIPTION
## Summary
Fix inconsistent dependency suppression by making parent-down counting deterministic and duplicate-safe.

In `RunAlerts::isParentDown()`, the previous query joined `devices_attribs` directly and used `count(*)`. If a parent device had multiple rows in `devices_attribs`, that parent could be counted multiple times, making `$down_parent_count` differ from `$parent_count` even when all parent devices were down.

This can cause intermittent failure to suppress child alerts in dependency scenarios.

## What changed
- Reworked the down-parent query to:
  - use `count(DISTINCT d.device_id)`
  - use `INNER JOIN` to `device_relationships`
  - replace the direct `LEFT JOIN devices_attribs` with `EXISTS(...)` for `override_icmp_disable`
- Simplified return path to direct boolean comparison.

## Why this helps #18979
This removes duplicate parent row inflation and makes the all-parents-down check stable across different parent attribute counts, preventing inconsistent child alert behavior.

## Validation
- PHP syntax lint in container: pass (`php -l LibreNMS/Alert/RunAlerts.php`)
- Query logic inspection confirms one count per parent device.

Refs #18979
