### PR TITLE
Fix type hints for authSSOGetAttr() and set_null() to remove phpstan …

### DIFF
--- a/LibreNMS/Authentication/SSOAuthorizer.php
+++ b/LibreNMS/Authentication/SSOAuthorizer.php
@@ -79,10 +79,10 @@ class SSOAuthorizer extends MysqlAuthorizer
      * Return an attribute from the configured attribute store.
      * Returns null if the attribute cannot be found
      *
-     * @param  string  $attr  The name of the attribute to find
+     * @param  string|null  $attr  The name of the attribute to find
      * @return string|null
      */
-    public function authSSOGetAttr($attr, $prefix = 'HTTP_')
+    public function authSSOGetAttr(?string $attr, string $prefix = 'HTTP_')
     {
         // Check attribute originates from a trusted proxy - we check it on every attribute just in case this gets called after initial login
         if ($this->authSSOProxyTrusted()) {

--- a/includes/common.php
+++ b/includes/common.php
@@ -644,12 +644,12 @@ function mw_to_dbm($value)
 }
 
 /**
- * @param  $value
- * @param  null  $default
- * @param  int  $min
- * @return null
+ * @param  mixed  $value
+ * @param  mixed  $default
+ * @param  int|null  $min
+ * @return mixed
  */
-function set_null($value, $default = null, $min = null)
+function set_null(mixed $value, mixed $default = null, ?int $min = null)
 {
     if (! is_numeric($value)) {
         return $default;

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -164,17 +164,3 @@ parameters:
 			count: 1
 			path: app/Models/UserPref.php
 
-		-
-			message: "#^Parameter \\#1 \\$attr of method LibreNMS\\\\Authentication\\\\SSOAuthorizer\\:\\:authSSOGetAttr\\(\\) expects string, int given\\.$#"
-			count: 2
-			path: tests/AuthSSOTest.php
-
-		-
-			message: "#^Parameter \\#1 \\$attr of method LibreNMS\\\\Authentication\\\\SSOAuthorizer\\:\\:authSSOGetAttr\\(\\) expects string, null given\\.$#"
-			count: 2
-			path: tests/AuthSSOTest.php
-
-		-
-			message: "#^Parameter \\#2 \\$default of function set_null expects null, int given\\.$#"
-			count: 2
-			path: tests/CommonFunctionsTest.php

--- a/tests/AuthSSOTest.php
+++ b/tests/AuthSSOTest.php
@@ -280,14 +280,14 @@ final class AuthSSOTest extends DBTestCase
         LibrenmsConfig::set('sso.mode', 'env');
         $this->assertNull($a->authSSOGetAttr('foobar'));
         $this->assertNull($a->authSSOGetAttr(null));
-        $this->assertNull($a->authSSOGetAttr(1));
+        $this->assertNull($a->authSSOGetAttr(''));
         $this->assertIsString($a->authSSOGetAttr('alsoVALID-ATTR'));
         $this->assertIsString($a->authSSOGetAttr('HTTP_VALID_ATTR'));
 
         LibrenmsConfig::set('sso.mode', 'header');
         $this->assertNull($a->authSSOGetAttr('foobar'));
         $this->assertNull($a->authSSOGetAttr(null));
-        $this->assertNull($a->authSSOGetAttr(1));
+        $this->assertNull($a->authSSOGetAttr(''));
         $this->assertNull($a->authSSOGetAttr('alsoVALID-ATTR'));
         $this->assertIsString($a->authSSOGetAttr('VALID-ATTR'));
     }


### PR DESCRIPTION
…baseline entries

- Type-hint authSSOGetAttr() parameter as ?string and update test to pass '' instead of int
- Fix set_null() PHPDoc and type hints: $default is mixed, not null; return is mixed

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
