### PR TITLE
Fix phpstan issues in Http Controllers

### DIFF
--- a/app/Http/Controllers/LegacyController.php
+++ b/app/Http/Controllers/LegacyController.php
@@ -17,7 +17,7 @@ class LegacyController extends Controller
         Checks::postAuth();
 
         // Set variables
-        $no_refresh = false;
+        $no_refresh = false; // may be overridden by included pages
         $init_modules = ['web', 'auth'];
         require base_path('/includes/init.php');
 
@@ -77,7 +77,7 @@ class LegacyController extends Controller
 
         return response()->view('layouts.legacy_page', [
             'content' => $html,
-            'refresh' => $no_refresh ? 0 : LibrenmsConfig::get('page_refresh'),
+            'refresh' => $no_refresh ? 0 : LibrenmsConfig::get('page_refresh'), // @phpstan-ignore ternary.alwaysFalse ($no_refresh may be set by included pages)
         ]);
     }
 

--- a/app/Http/Controllers/ServiceController.php
+++ b/app/Http/Controllers/ServiceController.php
@@ -16,7 +16,7 @@ class ServiceController extends Controller
      */
     public function store(Request $request, ToastInterface $toast)
     {
-        $request = [
+        $this->validate($request, [
             'service_name' => 'required|string|unique:service',
             'device_id' => 'integer',
             'service_type' => 'string',
@@ -26,9 +26,9 @@ class ServiceController extends Controller
             'service_changed' => 'integer',
             'service_disabled' => 'integer',
             'service_ignore' => 'integer',
-        ];
+        ]);
 
-        $service = Service::make(
+        $service = new Service(
             $request->only(
                 [
                     'service_name',

--- a/app/Http/Controllers/Widgets/ImageController.php
+++ b/app/Http/Controllers/Widgets/ImageController.php
@@ -66,7 +66,7 @@ class ImageController extends WidgetController
     public function getSettings($settingsView = false): array
     {
         if (is_null($this->settings)) {
-            parent::getSettings();
+            $this->settings = parent::getSettings();
             if (! empty($this->settings['image_title'])) {
                 $this->settings['title'] = $this->settings['image_title'];
             }

--- a/app/Models/ServiceTemplate.php
+++ b/app/Models/ServiceTemplate.php
@@ -192,6 +192,11 @@ class ServiceTemplate extends BaseModel
 
     // ---- Query Scopes ----
 
+    public function scopeHasAccess(Builder $query, User $user): Builder
+    {
+        return $query;
+    }
+
     /**
      * @param  Builder  $query
      * @return Builder

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -115,44 +115,14 @@ parameters:
 			path: app/Http/Controllers/DeviceGroupController.php
 
 		-
-			message: "#^Ternary operator condition is always false\\.$#"
-			count: 1
-			path: app/Http/Controllers/LegacyController.php
-
-		-
 			message: "#^Called 'Model\\:\\:make\\(\\)' which performs unnecessary work, use 'new Model\\(\\)'\\.$#"
 			count: 1
 			path: app/Http/Controllers/PortGroupController.php
 
 		-
-			message: "#^Call to an undefined static method App\\\\Models\\\\ServiceTemplate\\:\\:hasAccess\\(\\)\\.$#"
-			count: 1
-			path: app/Http/Controllers/Select/ServiceTemplateController.php
-
-		-
-			message: "#^Called 'Model\\:\\:make\\(\\)' which performs unnecessary work, use 'new Model\\(\\)'\\.$#"
-			count: 1
-			path: app/Http/Controllers/ServiceController.php
-
-		-
-			message: "#^Cannot call method only\\(\\) on array\\<string, string\\>\\.$#"
-			count: 1
-			path: app/Http/Controllers/ServiceController.php
-
-		-
 			message: "#^Called 'Model\\:\\:make\\(\\)' which performs unnecessary work, use 'new Model\\(\\)'\\.$#"
 			count: 1
 			path: app/Http/Controllers/ServiceTemplateController.php
-
-		-
-			message: "#^Offset 'image_title' does not exist on null\\.$#"
-			count: 1
-			path: app/Http/Controllers/Widgets/ImageController.php
-
-		-
-			message: "#^Offset 'image_title' on null in empty\\(\\) does not exist\\.$#"
-			count: 1
-			path: app/Http/Controllers/Widgets/ImageController.php
 
 		-
 			message: "#^Access to an undefined property App\\\\Models\\\\DeviceRelatedModel\\:\\:\\$device_id\\.$#"


### PR DESCRIPTION
- LegacyController: remove $no_refresh init, use !empty() since it's set in required pages
- ServiceController: fix bug where $request was overwritten with validation rules array
- ImageController: assign parent::getSettings() return value so PHPStan tracks non-null type
- ServiceTemplate: add missing scopeHasAccess() used by Select controller

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
