### PR TITLE
Fix phpstan baseline entries for LibreNMS/Util

### DIFF
--- a/LibreNMS/Util/CiHelper.php
+++ b/LibreNMS/Util/CiHelper.php
@@ -509,7 +509,7 @@ class CiHelper
         echo "Running composer install to install developer dependencies.\n";
         passthru('scripts/composer_wrapper.php install');
 
-        if (is_executable($path)) {
+        if (is_executable($path)) { // @phpstan-ignore if.alwaysFalse (passthru may install the executable)
             return $path;
         }
 
@@ -544,7 +544,7 @@ class CiHelper
         echo "Running pip3 install to install developer dependencies.\n";
         passthru("pip3 install --user $exec"); // probably wrong in other cases...
 
-        if (is_executable($path)) {
+        if (is_executable($path)) { // @phpstan-ignore if.alwaysFalse (passthru may install the executable)
             return $path;
         }
 

--- a/LibreNMS/Util/Graph.php
+++ b/LibreNMS/Util/Graph.php
@@ -164,11 +164,11 @@ class Graph
             throw new RrdGraphException("{$type}_$subtype template missing", "{$type}_$subtype missing", $width, $height);
         }
 
-        if (empty($rrd_options)) {
+        if (empty($rrd_options)) { // @phpstan-ignore empty.variable ($rrd_options is populated by included graph templates)
             throw new RrdGraphException('Graph Definition Error', 'Def Error', $width, $height);
         }
 
-        $rrd_options = [...$graph_params->toRrdOptions(), ...$rrd_options];
+        $rrd_options = [...$graph_params->toRrdOptions(), ...$rrd_options]; // @phpstan-ignore deadCode.unreachable
 
         // Generating the graph!
         try {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -90,21 +90,6 @@ parameters:
 			path: LibreNMS/OS/SmOs.php
 
 		-
-			message: "#^If condition is always false\\.$#"
-			count: 2
-			path: LibreNMS/Util/CiHelper.php
-
-		-
-			message: "#^Unreachable statement \\- code above always terminates\\.$#"
-			count: 1
-			path: LibreNMS/Util/Graph.php
-
-		-
-			message: "#^Variable \\$rrd_options in empty\\(\\) always exists and is always falsy\\.$#"
-			count: 1
-			path: LibreNMS/Util/Graph.php
-
-		-
 			message: "#^Property App\\\\Console\\\\Commands\\\\InternalHttpRequest\\:\\:\\$app is never read, only written\\.$#"
 			count: 1
 			path: app/Console/Commands/InternalHttpRequest.php


### PR DESCRIPTION
Add inline @phpstan-ignore comments for false positives that phpstan cannot track: passthru() installing executables (CiHelper) and require'd files populating variables (Graph).

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
