### PR TITLE
Fix DivisionByZeroError in Billing::getPredictedUsage when $since is 0

### DIFF
--- a/LibreNMS/Billing.php
+++ b/LibreNMS/Billing.php
@@ -73,6 +73,7 @@ class Billing
         $total = $end->diff($start)->format('%a');
         $since = $now->diff($start)->format('%a');
 
+        // Prevent DivisionByZeroError when short previous months cause date_sub() to overflow the start date, making $since equal to 0.
         if ($since == 0) {
             $since = 1;
         }


### PR DESCRIPTION
Prevent a fatal `DivisionByZeroError` that occurs when predicting usage on the very first day of a billing cycle. 

This rare edge case is triggered when:
1. The billing day is set to the 29th, 30th, or 31st.
2. The previous month has fewer days (e.g., February), causing PHP's `date_sub` to overflow the start date to the 1st of the current month.
3. The calculation runs on that exact start date, making the elapsed days (`$since`) equal to `0`.

Setting `$since` to `1` when it evaluates to `0` safely avoids the crash while maintaining the existing calculation logic for the rest of the month.


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
