### PR TITLE
Do not allow window.tz to be blank

### DIFF
--- a/html/js/librenms.js
+++ b/html/js/librenms.js
@@ -770,16 +770,11 @@ document.addEventListener('DOMContentLoaded', function () {
 });
 
 LibreNMS.Time.format = function (value, options = {}) {
-    let defaults = {
+    let compositeOptions = {
         dateStyle: "medium",
-        timeStyle: "medium"
+        timeStyle: "medium",
+        timeZone: window.tz
     };
-
-    if (window.tz) {
-        defaults.timeZone = window.tz;
-    }
-
-    let compositeOptions = {...defaults, ...options};
 
     return new Intl.DateTimeFormat(navigator.language, compositeOptions).format(new Date(value));
 };

--- a/resources/views/layouts/librenmsv1.blade.php
+++ b/resources/views/layouts/librenmsv1.blade.php
@@ -103,7 +103,7 @@
                 updateTimezone(tz, false);
             }
         @endif
-        window.tz = '{{ session('preferences.timezone') }}';
+        window.tz = '{{ session('preferences.timezone') }}' || window.Intl.DateTimeFormat().resolvedOptions().timeZone;
         </script>
         <script src="{{ asset('js/register-service-worker.js') }}" defer></script>
     @endauth


### PR DESCRIPTION
There may be other uses of window.tz (e.g #19115 plans on using it), so I think it's better to always give it a sensible default otherwise we may end up needing to add if/else code in multiple placed to handle window.tz being blank.  The only time the session timezone should be blank is if the user has selected browser timezone, so this actually sets it to the correct value on the first page load anyway.

It's also much simpler than the original fix.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
