### PR TITLE
Fix device select pagination when hostnames are duplicated

### DIFF
--- a/app/Http/Controllers/Select/DeviceController.php
+++ b/app/Http/Controllers/Select/DeviceController.php
@@ -61,7 +61,7 @@ class DeviceController extends SelectController
                         ->from('devices_perms')
                         ->where('user_id', $user_id);
                 })
-                ->distinct()
+                // hostnames are not guaranteed unique, use a stable tiebreaker
                 ->orderBy('hostname')
                 ->orderBy('device_id');
         }
@@ -69,7 +69,7 @@ class DeviceController extends SelectController
         return Device::hasAccess($request->user())
             ->when($request->input('exclude'), fn ($query, $exclude) => $query->where('device_id', '!=', $exclude))
             ->select(['device_id', 'hostname', 'sysName', 'display', 'icon'])
-            ->distinct()
+            // hostnames are not guaranteed unique, use a stable tiebreaker
             ->orderBy('hostname')
             ->orderBy('device_id');
     }


### PR DESCRIPTION
Resubmitting with reviewer feedback addressed.

### What changed
- Removed `distinct()` from `Select\\DeviceController` device query path
- Kept stable ordering with `orderBy('hostname')->orderBy('device_id')`

### Why
Hostnames are not unique, so using `distinct()` on selected columns can destabilize pagination/selection behavior in depends-on device select. Ordering by hostname + device_id preserves deterministic pagination while allowing duplicate hostnames.
