### PR TITLE
Use SensorEnum in discovery sensor files

### DIFF
--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -20,6 +20,7 @@ use App\Models\Port;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use LibreNMS\Device\YamlDiscovery;
+use LibreNMS\Enum\Sensor as SensorEnum;
 use LibreNMS\Enum\Severity;
 use LibreNMS\Exceptions\HostExistsException;
 use LibreNMS\Exceptions\InvalidIpException;
@@ -122,7 +123,7 @@ function discover_new_device($hostname, $device, $method, $interface = null)
 //end discover_new_device()
 
 // Discover sensors
-function discover_sensor($unused, $class, $device, $oid, $index, $type, $descr, $divisor = 1, $multiplier = 1, $low_limit = null, $low_warn_limit = null, $warn_limit = null, $high_limit = null, $current = null, $poller_type = 'snmp', $entPhysicalIndex = null, $entPhysicalIndex_measured = null, $user_func = null, $group = null, $rrd_type = 'GAUGE'): bool
+function discover_sensor($unused, SensorEnum $class, $device, $oid, $index, $type, $descr, $divisor = 1, $multiplier = 1, $low_limit = null, $low_warn_limit = null, $warn_limit = null, $high_limit = null, $current = null, $poller_type = 'snmp', $entPhysicalIndex = null, $entPhysicalIndex_measured = null, $user_func = null, $group = null, $rrd_type = 'GAUGE'): bool
 {
     $low_limit = set_null($low_limit);
     $low_warn_limit = set_null($low_warn_limit);
@@ -268,14 +269,14 @@ function check_entity_sensor($string, $device)
  *
  * @param  array  $device  device array
  * @param  string  $os_version  firmware version poweralert quirks
- * @param  string  $sensor_type  the type of this sensor
+ * @param  SensorEnum  $sensor_type  the type of this sensor
  * @param  string  $oid  the OID of this sensor
  * @return int
  */
-function get_device_divisor($device, $os_version, $sensor_type, $oid)
+function get_device_divisor($device, $os_version, SensorEnum $sensor_type, $oid)
 {
     if ($device['os'] == 'poweralert') {
-        if ($sensor_type == 'current' || $sensor_type == 'frequency') {
+        if ($sensor_type === SensorEnum::Current || $sensor_type === SensorEnum::Frequency) {
             if (version_compare($os_version, '12.06.0068', '>=')) {
                 return 10;
             } elseif (version_compare($os_version, '12.04.0055', '=')) {
@@ -283,7 +284,7 @@ function get_device_divisor($device, $os_version, $sensor_type, $oid)
             } elseif (version_compare($os_version, '12.04.0056', '>=')) {
                 return 1;
             }
-        } elseif ($sensor_type == 'load') {
+        } elseif ($sensor_type === SensorEnum::Load) {
             if (version_compare($os_version, '12.06.0064', '=')) {
                 return 10;
             } else {
@@ -291,7 +292,7 @@ function get_device_divisor($device, $os_version, $sensor_type, $oid)
             }
         }
     } elseif ($device['os'] == 'huaweiups') {
-        if ($sensor_type == 'frequency') {
+        if ($sensor_type === SensorEnum::Frequency) {
             if (Str::startsWith($device['hardware'], 'UPS2000')) {
                 return 10;
             }
@@ -299,30 +300,30 @@ function get_device_divisor($device, $os_version, $sensor_type, $oid)
             return 100;
         }
     } elseif ($device['os'] == 'hpe-rtups') {
-        if ($sensor_type == 'voltage' && ! Str::startsWith($oid, '.1.3.6.1.2.1.33.1.2.5.') && ! Str::startsWith($oid, '.1.3.6.1.2.1.33.1.3.3.1.3')) {
+        if ($sensor_type === SensorEnum::Voltage && ! Str::startsWith($oid, '.1.3.6.1.2.1.33.1.2.5.') && ! Str::startsWith($oid, '.1.3.6.1.2.1.33.1.3.3.1.3')) {
             return 1;
         }
     } elseif ($device['os'] == 'apc-mgeups') {
-        if ($sensor_type == 'voltage') {
+        if ($sensor_type === SensorEnum::Voltage) {
             return 10;
         }
     } elseif ($device['os'] == 'cxc') {
-        if ($sensor_type == 'voltage' && str_starts_with($oid, '.1.3.6.1.2.1.33.1.3.3.1.3')) {
+        if ($sensor_type === SensorEnum::Voltage && str_starts_with($oid, '.1.3.6.1.2.1.33.1.3.3.1.3')) {
             return 10;
         }
     }
 
     // UPS-MIB Defaults
 
-    if ($sensor_type == 'load') {
+    if ($sensor_type === SensorEnum::Load) {
         return 1;
     }
 
-    if ($sensor_type == 'voltage' && ! Str::startsWith($oid, '.1.3.6.1.2.1.33.1.2.5.')) {
+    if ($sensor_type === SensorEnum::Voltage && ! Str::startsWith($oid, '.1.3.6.1.2.1.33.1.2.5.')) {
         return 1;
     }
 
-    if ($sensor_type == 'runtime') {
+    if ($sensor_type === SensorEnum::Runtime) {
         if (Str::startsWith($oid, '.1.3.6.1.2.1.33.1.2.2.')) {
             return 60;
         }
@@ -344,21 +345,21 @@ function get_device_divisor($device, $os_version, $sensor_type, $oid)
  * @param  $sensor_type
  * @param  $pre_cache
  */
-function discovery_process($os, $sensor_class, $pre_cache)
+function discovery_process($os, SensorEnum $sensor_class, $pre_cache)
 {
     $discovery = $os->getDiscovery('sensors');
     $device = $os->getDeviceArray();
 
-    if (! empty($discovery[$sensor_class]) && ! app('sensor-discovery')->canSkip(new \App\Models\Sensor(['sensor_class' => $sensor_class]))) {
+    if (! empty($discovery[$sensor_class->value]) && ! app('sensor-discovery')->canSkip(new \App\Models\Sensor(['sensor_class' => $sensor_class]))) {
         $sensor_options = [];
-        if (isset($discovery[$sensor_class]['options'])) {
-            $sensor_options = $discovery[$sensor_class]['options'];
+        if (isset($discovery[$sensor_class->value]['options'])) {
+            $sensor_options = $discovery[$sensor_class->value]['options'];
         }
 
-        Log::debug("Dynamic Discovery ($sensor_class): ");
-        Log::debug($discovery[$sensor_class]);
+        Log::debug("Dynamic Discovery ({$sensor_class->value}): ");
+        Log::debug($discovery[$sensor_class->value]);
 
-        foreach ($discovery[$sensor_class]['data'] as $data) {
+        foreach ($discovery[$sensor_class->value]['data'] as $data) {
             $tmp_name = $data['oid'];
 
             if (! isset($pre_cache[$tmp_name])) {
@@ -382,7 +383,7 @@ function discovery_process($os, $sensor_class, $pre_cache)
 
                 $snmp_value = $snmp_data[$data['value']] ?? '';
                 if (! is_numeric($snmp_value)) {
-                    if ($sensor_class === 'temperature') {
+                    if ($sensor_class === SensorEnum::Temperature) {
                         // For temp sensors, try and detect fahrenheit values
                         if (is_string($snmp_value) && Str::endsWith($snmp_value, ['f', 'F'])) {
                             $user_function = 'fahrenheit_to_celsius';
@@ -396,7 +397,7 @@ function discovery_process($os, $sensor_class, $pre_cache)
 
                 if (is_numeric($snmp_value)) {
                     $value = $snmp_value;
-                } elseif ($sensor_class === 'state') {
+                } elseif ($sensor_class === SensorEnum::State) {
                     // translate string states to values (poller does this as well)
                     $states = array_column($data['states'], 'value', 'descr');
                     $value = $states[$snmp_value] ?? false;
@@ -482,7 +483,7 @@ function discovery_process($os, $sensor_class, $pre_cache)
 
                     $sensor_name = $device['os'];
 
-                    if ($sensor_class === 'state') {
+                    if ($sensor_class === SensorEnum::State) {
                         $sensor_name = $data['state_name'] ?? $data['oid'];
                         create_state_index($sensor_name, $data['states']);
                     } else {
@@ -527,17 +528,18 @@ function sensors($types, $os, $pre_cache = [])
 {
     $device = &$os->getDeviceArray();
     foreach ((array) $types as $sensor_class) {
-        echo ucfirst((string) $sensor_class) . ': ';
+        $class_value = $sensor_class->value;
+        echo ucfirst((string) $class_value) . ': ';
 
-        if (isset($device['os_group']) && is_file(base_path("includes/discovery/sensors/$sensor_class/{$device['os_group']}.inc.php"))) {
-            include base_path("includes/discovery/sensors/$sensor_class/{$device['os_group']}.inc.php");
+        if (isset($device['os_group']) && is_file(base_path("includes/discovery/sensors/$class_value/{$device['os_group']}.inc.php"))) {
+            include base_path("includes/discovery/sensors/$class_value/{$device['os_group']}.inc.php");
         }
-        $os_file = base_path("includes/discovery/sensors/$sensor_class/{$device['os']}.inc.php");
+        $os_file = base_path("includes/discovery/sensors/$class_value/{$device['os']}.inc.php");
         if (is_file($os_file)) {
             include $os_file;
         }
         if (LibrenmsConfig::getOsSetting($device['os'], 'rfc1628_compat', false)) {
-            $ups_file = base_path("includes/discovery/sensors/$sensor_class/rfc1628.inc.php");
+            $ups_file = base_path("includes/discovery/sensors/$class_value/rfc1628.inc.php");
             if (is_file($ups_file)) {
                 include $ups_file;
             }

--- a/includes/discovery/sensors.inc.php
+++ b/includes/discovery/sensors.inc.php
@@ -45,7 +45,7 @@ if ($device['os'] == 'gw-eydfa') {
 }
 
 // filter submodules
-$run_sensors = array_intersect(Sensor::values(), LibrenmsConfig::get('discovery_submodules.sensors', Sensor::values()));
+$run_sensors = array_map(Sensor::from(...), array_intersect(Sensor::values(), LibrenmsConfig::get('discovery_submodules.sensors', Sensor::values())));
 
 sensors($run_sensors, $os, $pre_cache);
 unset(

--- a/includes/discovery/sensors/airflow/apc.inc.php
+++ b/includes/discovery/sensors/airflow/apc.inc.php
@@ -29,6 +29,6 @@ foreach ($pre_cache['cooling_unit_analog'] as $index => $data) {
     $scale = $data['coolingUnitStatusAnalogScale'] ?? null;
     $value = $data['coolingUnitStatusAnalogValue'] ?? null;
     if (preg_match('/Airflow/', (string) $descr) && $data['coolingUnitStatusAnalogUnits'] == 'CFM' && $value >= 0) {
-        discover_sensor(null, 'airflow', $device, $cur_oid, $cur_oid, 'apc', $descr, $scale, 1, null, null, null, null, $value);
+        discover_sensor(null, \LibreNMS\Enum\Sensor::Airflow, $device, $cur_oid, $cur_oid, 'apc', $descr, $scale, 1, null, null, null, null, $value);
     }
 }

--- a/includes/discovery/sensors/airflow/geist-watchdog.inc.php
+++ b/includes/discovery/sensors/airflow/geist-watchdog.inc.php
@@ -27,5 +27,5 @@ $value = snmp_get($device, 'climateAirflow', '-Oqv', 'GEIST-MIB-V3');
 $current_oid = '.1.3.6.1.4.1.21239.2.2.1.9.1';
 $descr = 'Airflow';
 if (is_numeric($value)) {
-    discover_sensor(null, 'airflow', $device, $current_oid, 'climateAirflow', 'geist-watchdog', $descr, 1, 1, null, null, null, null, $value);
+    discover_sensor(null, \LibreNMS\Enum\Sensor::Airflow, $device, $current_oid, 'climateAirflow', 'geist-watchdog', $descr, 1, 1, null, null, null, null, $value);
 }

--- a/includes/discovery/sensors/ber/infinera-groove.inc.php
+++ b/includes/discovery/sensors/ber/infinera-groove.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 /**
  * infinera-groove.inc.php
  *
@@ -34,13 +36,13 @@ foreach ($pre_cache['infineragroove_portTable'] as $index => $data) {
         $oid = '.1.3.6.1.4.1.42229.1.2.13.1.1.1.1.' . $index;
         $value = $data['bitErrorRatePreFecInstant'];
         $divisor = 1;
-        discover_sensor(null, 'ber', $device, $oid, 'bitErrorRatePreFecInstant.' . $index, 'infinera-groove', $descr, $divisor, '1', null, null, null, null, $value, 'snmp', null, null, null, $portAlias, 'GAUGE');
+        discover_sensor(null, SensorEnum::Ber, $device, $oid, 'bitErrorRatePreFecInstant.' . $index, 'infinera-groove', $descr, $divisor, '1', null, null, null, null, $value, 'snmp', null, null, null, $portAlias, 'GAUGE');
     }
     if (isset($data['bitErrorRatePostFecInstant']) && is_numeric($data['bitErrorRatePostFecInstant']) && in_array($pre_cache['infineragroove_portTable'][$portAliasIndex]['portAdminStatus'], ['up', '3'], true)) {
         $descr = $portAlias . ' PostFecBer';
         $oid = '.1.3.6.1.4.1.42229.1.2.13.2.1.1.1.' . $index;
         $value = $data['bitErrorRatePostFecInstant'];
         $divisor = 1;
-        discover_sensor(null, 'ber', $device, $oid, 'bitErrorRatePostFecInstant.' . $index, 'infinera-groove', $descr, $divisor, '1', null, null, null, null, $value, 'snmp', null, null, null, $portAlias, 'GAUGE');
+        discover_sensor(null, SensorEnum::Ber, $device, $oid, 'bitErrorRatePostFecInstant.' . $index, 'infinera-groove', $descr, $divisor, '1', null, null, null, null, $value, 'snmp', null, null, null, $portAlias, 'GAUGE');
     }
 }

--- a/includes/discovery/sensors/bitrate/luminato.inc.php
+++ b/includes/discovery/sensors/bitrate/luminato.inc.php
@@ -72,7 +72,7 @@ if (! empty($oids)) {
 
             app('sensor-discovery')->discover(new \App\Models\Sensor([
                 'poller_type' => 'snmp',
-                'sensor_class' => 'bitrate',
+                'sensor_class' => \LibreNMS\Enum\Sensor::Bitrate,
                 'sensor_oid' => $oid,
                 'sensor_index' => $index,
                 'sensor_type' => 'Transfer_' . $mname,

--- a/includes/discovery/sensors/bitrate/terra-sdi410c.inc.php
+++ b/includes/discovery/sensors/bitrate/terra-sdi410c.inc.php
@@ -23,6 +23,7 @@
  *
  * @author     Peca Nesovanovic <peca.nesovanovic@sattrakt.com>
  */
+
 $divisor = 1;
 $multiplier = 1000;
 
@@ -44,7 +45,7 @@ if (is_array($oids)) {
 
             app('sensor-discovery')->discover(new \App\Models\Sensor([
                 'poller_type' => 'snmp',
-                'sensor_class' => 'bitrate',
+                'sensor_class' => \LibreNMS\Enum\Sensor::Bitrate,
                 'sensor_oid' => $oid,
                 'sensor_index' => $streamid,
                 'sensor_type' => $type,

--- a/includes/discovery/sensors/bitrate/terra-sdi480.inc.php
+++ b/includes/discovery/sensors/bitrate/terra-sdi480.inc.php
@@ -23,6 +23,9 @@
  *
  * @author     Peca Nesovanovic <peca.nesovanovic@sattrakt.com>
  */
+
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 $divisor = 1;
 $multiplier = 100 * 1000;
 $limit = 60 * 1000 * 1000;  // 50 mbps
@@ -46,7 +49,7 @@ if (is_array($oids)) {
 
             app('sensor-discovery')->discover(new \App\Models\Sensor([
                 'poller_type' => 'snmp',
-                'sensor_class' => 'bitrate',
+                'sensor_class' => SensorEnum::Bitrate,
                 'sensor_oid' => $oid,
                 'sensor_index' => $inputid,
                 'sensor_type' => $type,
@@ -77,7 +80,7 @@ if (is_array($oids)) {
 
             app('sensor-discovery')->discover(new \App\Models\Sensor([
                 'poller_type' => 'snmp',
-                'sensor_class' => 'bitrate',
+                'sensor_class' => SensorEnum::Bitrate,
                 'sensor_oid' => $oid,
                 'sensor_index' => $outputid,
                 'sensor_type' => $type,

--- a/includes/discovery/sensors/charge/apc.inc.php
+++ b/includes/discovery/sensors/charge/apc.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 $oids = snmp_get($device, '.1.3.6.1.4.1.318.1.1.1.2.3.1.0', '-OsqnU');
 d_echo($oids . "\n");
 
@@ -18,7 +20,7 @@ if (! empty($oids)) {
     $warnlimit = 10;
     $descr = 'Battery Charge';
 
-    discover_sensor(null, 'charge', $device, $current_oid, $index, $sensorType, $descr, $precision, 1, $lowlimit, $warnlimit, null, null, $current_val);
+    discover_sensor(null, SensorEnum::Charge, $device, $current_oid, $index, $sensorType, $descr, $precision, 1, $lowlimit, $warnlimit, null, null, $current_val);
 } else {
     // Try to just get capacity
     $oids = snmp_get($device, '.1.3.6.1.4.1.318.1.1.1.2.2.1.0', '-OsqnU');
@@ -38,6 +40,6 @@ if (! empty($oids)) {
         $warnlimit = 10;
         $descr = 'Battery Charge';
 
-        discover_sensor(null, 'charge', $device, $current_oid, $index, $sensorType, $descr, $precision, 1, $lowlimit, $warnlimit, null, null, $current_val);
+        discover_sensor(null, SensorEnum::Charge, $device, $current_oid, $index, $sensorType, $descr, $precision, 1, $lowlimit, $warnlimit, null, null, $current_val);
     }
 }//end if

--- a/includes/discovery/sensors/charge/dell-powervault.inc.php
+++ b/includes/discovery/sensors/charge/dell-powervault.inc.php
@@ -19,7 +19,7 @@ if (is_array($oids)) {
             $descr = implode(':', $connUnitSensorMessage);
             app('sensor-discovery')->discover(new \App\Models\Sensor([
                 'poller_type' => 'snmp',
-                'sensor_class' => 'charge',
+                'sensor_class' => \LibreNMS\Enum\Sensor::Charge,
                 'sensor_oid' => $cur_oid . $index,
                 'sensor_index' => $index,
                 'sensor_type' => 'dellme',

--- a/includes/discovery/sensors/charge/dsm.inc.php
+++ b/includes/discovery/sensors/charge/dsm.inc.php
@@ -25,5 +25,5 @@ $ups_device_model = str_replace('"', '', snmp_get($device, $ups_device_model_oid
 $ups_charge_oid = '.1.3.6.1.4.1.6574.4.3.1.1.0';
 $ups_charge = snmp_get($device, $ups_charge_oid, '-Oqv');
 if (is_numeric($ups_charge)) {
-    discover_sensor(null, 'charge', $device, $ups_charge_oid, 'UPSChargeValue', $ups_device_manufacturer . ' ' . $ups_device_model, 'UPS Charge Value', 1, 1, 0, 10, null, null, $ups_charge);
+    discover_sensor(null, \LibreNMS\Enum\Sensor::Charge, $device, $ups_charge_oid, 'UPSChargeValue', $ups_device_manufacturer . ' ' . $ups_device_model, 'UPS Charge Value', 1, 1, 0, 10, null, null, $ups_charge);
 }

--- a/includes/discovery/sensors/charge/linux.inc.php
+++ b/includes/discovery/sensors/charge/linux.inc.php
@@ -11,6 +11,6 @@ if (preg_match('/(Linux).+(ntc)/', (string) $device['sysDescr'])) {
     $index = '116.8';
     $value = snmp_get($device, $oid . $index, '-Oqv');
     if (is_numeric($value)) {
-        discover_sensor(null, 'charge', $device, $oid . $index, $index, $sensor_type, $descr, 1, 1, $lowlimit, $lowwarnlimit, $warnlimit, $limit, $value);
+        discover_sensor(null, \LibreNMS\Enum\Sensor::Charge, $device, $oid . $index, $index, $sensor_type, $descr, 1, 1, $lowlimit, $lowwarnlimit, $warnlimit, $limit, $value);
     }
 }

--- a/includes/discovery/sensors/charge/netagent2.inc.php
+++ b/includes/discovery/sensors/charge/netagent2.inc.php
@@ -37,7 +37,7 @@ if (! empty($charge)) {
 
     discover_sensor(
         null,
-        'charge',
+        $sensor_class,
         $device,
         $charge_oid,
         $index,

--- a/includes/discovery/sensors/charge/rfc1628.inc.php
+++ b/includes/discovery/sensors/charge/rfc1628.inc.php
@@ -8,7 +8,7 @@ $value = snmp_get($device, 'upsEstimatedChargeRemaining.0', '-OvqU', 'UPS-MIB');
 if (is_numeric($value)) {
     discover_sensor(
         null,
-        'charge',
+        $sensor_class,
         $device,
         '.1.3.6.1.2.1.33.1.2.4.0',
         500,

--- a/includes/discovery/sensors/charge/unix.inc.php
+++ b/includes/discovery/sensors/charge/unix.inc.php
@@ -39,7 +39,7 @@ if (! empty($snmpData)) {
                 $oid = Oid::of('NET-SNMP-EXTEND-MIB::nsExtendOutLine."ups-nut".' . $index)->toNumeric();
                 discover_sensor(
                     null,
-                    'charge',
+                    $sensor_class,
                     $device,
                     $oid,
                     $index,

--- a/includes/discovery/sensors/chromatic_dispersion/infinera-groove.inc.php
+++ b/includes/discovery/sensors/chromatic_dispersion/infinera-groove.inc.php
@@ -28,6 +28,6 @@ foreach ($pre_cache['infineragroove_portTable'] as $index => $data) {
         $descr = $data['portAlias'] . ' CD';
         $oid = '.1.3.6.1.4.1.42229.1.2.4.1.19.1.1.23.' . $index;
         $value = $data['ochOsCD'];
-        discover_sensor(null, 'chromatic_dispersion', $device, $oid, 'ochOsCD.' . $index, 'infinera-groove', $descr, null, '1', null, null, null, null, $value);
+        discover_sensor(null, \LibreNMS\Enum\Sensor::ChromaticDispersion, $device, $oid, 'ochOsCD.' . $index, 'infinera-groove', $descr, null, '1', null, null, null, null, $value);
     }
 }

--- a/includes/discovery/sensors/cisco-entity-sensor.inc.php
+++ b/includes/discovery/sensors/cisco-entity-sensor.inc.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Str;
+use LibreNMS\Enum\Sensor as SensorEnum;
 
 if ($device['os_group'] == 'cisco') {
     echo ' CISCO-ENTITY-SENSOR: ';
@@ -49,16 +50,16 @@ if ($device['os_group'] == 'cisco') {
 
     d_echo($oids);
 
-    $entitysensor['voltsDC'] = 'voltage';
-    $entitysensor['voltsAC'] = 'voltage';
-    $entitysensor['amperes'] = 'current';
-    $entitysensor['watt'] = 'power';
-    $entitysensor['hertz'] = 'freq';
-    $entitysensor['percentRH'] = 'humidity';
-    $entitysensor['rpm'] = 'fanspeed';
-    $entitysensor['celsius'] = 'temperature';
-    $entitysensor['watts'] = 'power';
-    $entitysensor['dBm'] = 'dbm';
+    $entitysensor['voltsDC'] = SensorEnum::Voltage;
+    $entitysensor['voltsAC'] = SensorEnum::Voltage;
+    $entitysensor['amperes'] = SensorEnum::Current;
+    $entitysensor['watt'] = SensorEnum::Power;
+    $entitysensor['hertz'] = SensorEnum::Frequency;
+    $entitysensor['percentRH'] = SensorEnum::Humidity;
+    $entitysensor['rpm'] = SensorEnum::Fanspeed;
+    $entitysensor['celsius'] = SensorEnum::Temperature;
+    $entitysensor['watts'] = SensorEnum::Power;
+    $entitysensor['dBm'] = SensorEnum::Dbm;
 
     if (is_array($oids)) {
         foreach ($oids as $index => $entry) {
@@ -130,7 +131,7 @@ if ($device['os_group'] == 'cisco') {
                         // Skip invalid treshold values
                         if (! isset($key['entSensorThresholdValue']) || $key['entSensorThresholdValue'] == '-32768' || $key['entSensorThresholdValue'] == '2147483647') {
                             continue;
-                        } elseif ($type == 'fanspeed' && $key['entSensorThresholdValue'] == '-1') {
+                        } elseif ($type === SensorEnum::Fanspeed && $key['entSensorThresholdValue'] == '-1') {
                             continue;
                         }
                         // Critical Limit
@@ -172,7 +173,7 @@ if ($device['os_group'] == 'cisco') {
 
                 // If temperature sensor, set low thresholds to -1 and -5. Many sensors don't return low thresholds, therefore LibreNMS takes the runtime low
                 // Also changing 0 values (not just null) as Libre loses these somewhere along the line and shows an empty value in the Web UI
-                if ($type == 'temperature') {
+                if ($type === SensorEnum::Temperature) {
                     if ($warn_limit_low == 0) {
                         $warn_limit_low = -1;
                     }
@@ -241,10 +242,10 @@ if ($device['os_group'] == 'cisco') {
 
                     discover_sensor(null, $type, $device, $oid, $index, 'cisco-entity-sensor', ucwords($descr), $divisor, $multiplier, $limit_low, $warn_limit_low, $warn_limit, $limit, $current, 'snmp', $entPhysicalIndex, $entry['entSensorMeasuredEntity'] ?? null, null, $group);
                     //Cisco IOS-XR : add a fake sensor to graph as dbm
-                    if ($type == 'power' and $device['os'] == 'iosxr' and (preg_match('/power (R|T)x/i', $descr) or preg_match('/(R|T)x Power/i', $descr) or preg_match('/(R|T)x Lane/i', $descr))) {
+                    if ($type === SensorEnum::Power and $device['os'] == 'iosxr' and (preg_match('/power (R|T)x/i', $descr) or preg_match('/(R|T)x Power/i', $descr) or preg_match('/(R|T)x Lane/i', $descr))) {
                         // convert Watts to dbm
                         $user_func = 'mw_to_dbm';
-                        $type = 'dbm';
+                        $type = SensorEnum::Dbm;
                         $multiplier = 1000;
                         $limit_low = isset($limit_low) ? round(mw_to_dbm($limit_low * $multiplier), 3) : null;
                         $warn_limit_low = isset($limit_low) ? round(mw_to_dbm($warn_limit_low * $multiplier), 3) : null;
@@ -265,7 +266,5 @@ if ($device['os_group'] == 'cisco') {
         $entity_array
     );
 
-    foreach (array_flip($entitysensor) as $type) {
-        app('sensor-discovery')->sync(sensor_class: $type, poller_type: 'snmp');
-    }
+    // sync is handled by the sensors() loop for each sensor type
 }//end if

--- a/includes/discovery/sensors/count/christie-projector.inc.php
+++ b/includes/discovery/sensors/count/christie-projector.inc.php
@@ -21,7 +21,7 @@ use Illuminate\Support\Str;
 if (Str::startsWith($device['sysObjectID'], '.1.3.6.1.4.1.25766')) {
     discover_sensor(
         null,
-        'count',
+        $sensor_class,
         $device,
         '.1.3.6.1.4.1.25766.1.12.1.1.3.5.1.6.1',
         0,

--- a/includes/discovery/sensors/count/cisco.inc.php
+++ b/includes/discovery/sensors/count/cisco.inc.php
@@ -32,6 +32,6 @@ foreach ($tables as $tablevalue) {
         } else {
             $descr = ucwords((string) $temp[$index][$tablevalue['descr']]);
         }
-        discover_sensor(null, 'count', $device, $cur_oid . $index, $index, $state_name, $descr, 1, 1, null, null, null, null, $temp[$index][$tablevalue['state_name']], 'snmp', $index);
+        discover_sensor(null, \LibreNMS\Enum\Sensor::Count, $device, $cur_oid . $index, $index, $state_name, $descr, 1, 1, null, null, null, null, $temp[$index][$tablevalue['state_name']], 'snmp', $index);
     }
 }

--- a/includes/discovery/sensors/count/dhcpatriot.inc.php
+++ b/includes/discovery/sensors/count/dhcpatriot.inc.php
@@ -35,7 +35,7 @@ $oids = [
     ],
 ];
 
-$class = 'count';
+$class = $sensor_class;
 $divisor = 1;
 $multiplier = 1;
 $low_limit = null;

--- a/includes/discovery/sensors/count/epson-projector.inc.php
+++ b/includes/discovery/sensors/count/epson-projector.inc.php
@@ -21,7 +21,7 @@ use Illuminate\Support\Str;
 if (Str::startsWith($device['sysObjectID'], '.1.3.6.1.4.1.1248.4.1')) {
     discover_sensor(
         null,
-        'count',
+        $sensor_class,
         $device,
         '.1.3.6.1.4.1.1248.4.1.1.1.1.0',
         0,

--- a/includes/discovery/sensors/count/fortigate.inc.php
+++ b/includes/discovery/sensors/count/fortigate.inc.php
@@ -33,7 +33,7 @@ if (! empty($licenseOids)) {
 
             discover_sensor(
                 null,
-                'count',
+                $sensor_class,
                 $device,
                 '.1.3.6.1.4.1.12356.101.4.6.3.1.2.1.2.' . $index,
                 'fgLicContractExpiry.' . $index,
@@ -73,7 +73,7 @@ foreach ($session_rate as $descr => $oid) {
 
     discover_sensor(
         null,
-        'count',
+        $sensor_class,
         $device,
         $oid_num,
         $oid_txt,
@@ -102,7 +102,7 @@ if ($systemMode == 'activePassive' || $systemMode == 'activeActive') {
     // Create a count sensor and set warning to current cluster count
     discover_sensor(
         null,
-        'count',
+        $sensor_class,
         $device,
         '.1.3.6.1.4.1.12356.101.13.2.1.1.1',
         'fgHaStatsIndex',

--- a/includes/discovery/sensors/count/printer.inc.php
+++ b/includes/discovery/sensors/count/printer.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 /*
  * LibreNMS
  *
@@ -17,7 +19,7 @@ $walk = snmpwalk_cache_oid($device, 'prtMarkerTable', [], 'Printer-MIB');
 foreach ($walk as $index => $data) {
     discover_sensor(
         null,
-        'count',
+        $sensor_class,
         $device,
         '.1.3.6.1.2.1.43.10.2.1.4.' . $index, // Printer-MIB::prtMarkerLifeCount.1.1
         'prtMarkerLifeCount',
@@ -34,7 +36,7 @@ foreach ($walk as $index => $data) {
 
     discover_sensor(
         null,
-        'count',
+        $sensor_class,
         $device,
         '.1.3.6.1.2.1.43.10.2.1.5.' . $index, // Printer-MIB::prtMarkerPowerOnCount.1.1
         'prtMarkerPowerOnCount',
@@ -69,7 +71,7 @@ if ($device['os'] == 'konica') {
             $oidArray = explode('.', $oid);
             $maxKey = max(array_keys($oidArray));
             $index = str_replace(' ', '', ucwords($cntName)) . '.' . $oidArray[$maxKey - 1] . '.' . $oidArray[$maxKey];
-            discover_sensor(null, 'count', $device, $oid, $index, $device['os'], $cntName, 1, 1, null, null, null, null, $value, 'snmp', null, null, null, 'Konica MIB');
+            discover_sensor(null, SensorEnum::Count, $device, $oid, $index, $device['os'], $cntName, 1, 1, null, null, null, null, $value, 'snmp', null, null, null, 'Konica MIB');
         }
     }
 }
@@ -84,7 +86,7 @@ if ($device['os'] == 'sharp') {
                 $value = $valuesData[$index1][$index2][$index3];
                 $oid = '.1.3.6.1.4.1.2385.1.1.19.2.1.3.' . $index1 . '.' . $index2 . '.' . $index3;
                 $index = $sensorName . '.' . $index3;
-                discover_sensor(null, 'count', $device, $oid, $index, $device['os'], $sensorName, 1, 1, null, null, null, null, $value, 'snmp', null, null, null, 'Sharp MIB');
+                discover_sensor(null, SensorEnum::Count, $device, $oid, $index, $device['os'], $sensorName, 1, 1, null, null, null, null, $value, 'snmp', null, null, null, 'Sharp MIB');
             }
         }
     }

--- a/includes/discovery/sensors/count/rfc1628.inc.php
+++ b/includes/discovery/sensors/count/rfc1628.inc.php
@@ -15,7 +15,7 @@ if (is_numeric($ups_alarms_present)) {
 
     discover_sensor(
         null,
-        'count',
+        $sensor_class,
         $device,
         $ups_alarms_present_oid,
         '0',

--- a/includes/discovery/sensors/count/sonicwall.inc.php
+++ b/includes/discovery/sensors/count/sonicwall.inc.php
@@ -25,7 +25,7 @@ if (Str::startsWith($device['sysObjectID'], '.1.3.6.1.4.1.8741.6')) {
 
     discover_sensor(
         null,
-        'count',
+        $sensor_class,
         $device,
         '.1.3.6.1.4.1.8741.6.2.1.9.0', // SNWL-SSLVPN-MIB::activeUserLicense.0
         0,

--- a/includes/discovery/sensors/count/timos.inc.php
+++ b/includes/discovery/sensors/count/timos.inc.php
@@ -73,7 +73,7 @@ if (! empty($resrcData)) {
 
                     discover_sensor(
                         null,
-                        'count',
+                        $sensor_class,
                         $device,
                         $oid,
                         "tmnxNatIsaMemberResrcVal.$index",
@@ -160,7 +160,7 @@ foreach ($vappStatsData as $oid => $value) {
 
     discover_sensor(
         null,
-        'count',
+        $sensor_class,
         $device,
         $oid,
         "tmnxNatVappPlcyStatsVal.$index",

--- a/includes/discovery/sensors/count/webmon.inc.php
+++ b/includes/discovery/sensors/count/webmon.inc.php
@@ -46,7 +46,7 @@ foreach ($prefixes as $prefix => $numOidPrefix) {
             if ($oid[$prefix . 'Units']) {
                 $descr .= '(' . $oid[$prefix . 'Units'] . ')';
             }
-            discover_sensor(null, 'count', $device, $num_oid, $prefix . 'LiveRaw.' . $index, 'webmon', $descr, '1', '1', $lowLimit, $lowWarnLimit, $highWarnLimit, $highLimit, $value, 'snmp', null, null, null, $group);
+            discover_sensor(null, \LibreNMS\Enum\Sensor::Count, $device, $num_oid, $prefix . 'LiveRaw.' . $index, 'webmon', $descr, '1', '1', $lowLimit, $lowWarnLimit, $highWarnLimit, $highLimit, $value, 'snmp', null, null, null, $group);
         }
     }
 }

--- a/includes/discovery/sensors/current/adva_fsp150.inc.php
+++ b/includes/discovery/sensors/current/adva_fsp150.inc.php
@@ -42,7 +42,7 @@ foreach (array_keys($pre_cache['adva_fsp150']) as $index) {
 
             discover_sensor(
                 null,
-                'current',
+                $sensor_class,
                 $device,
                 $oid,
                 $entry['sensor_name'] . $index,
@@ -75,7 +75,7 @@ foreach ($pre_cache['adva_fsp150_ports'] as $index => $entry) {
 
             discover_sensor(
                 null,
-                'current',
+                $sensor_class,
                 $device,
                 $oid,
                 'cmEthernetNetPortStatsLBC.' . $index,
@@ -104,7 +104,7 @@ foreach ($pre_cache['adva_fsp150_ports'] as $index => $entry) {
             $descr = ($pre_cache['adva_fsp150_ifName'][$entry['cmEthernetAccPortIfIndex']]['ifName'] ?? 'ifIndex ' . $entry['cmEthernetAccPortIfIndex']) . ' BIAS';
             discover_sensor(
                 null,
-                'current',
+                $sensor_class,
                 $device,
                 $oid,
                 'cmEthernetAccPortStatsLBC.' . $index,
@@ -134,7 +134,7 @@ foreach ($pre_cache['adva_fsp150_ports'] as $index => $entry) {
 
             discover_sensor(
                 null,
-                'current',
+                $sensor_class,
                 $device,
                 $oid,
                 'cmEthernetTrafficPortStatsLBC.' . $index,

--- a/includes/discovery/sensors/current/adva_fsp3kr7.inc.php
+++ b/includes/discovery/sensors/current/adva_fsp3kr7.inc.php
@@ -33,7 +33,7 @@ if (is_array($pre_cache['adva_fsp3kr7_Card'])) {
 
             discover_sensor(
                 null,
-                'current',
+                $sensor_class,
                 $device,
                 $oid,
                 'eqptPhysInstValuePsuAmpere' . $index,

--- a/includes/discovery/sensors/current/apc.inc.php
+++ b/includes/discovery/sensors/current/apc.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 // PDU - Phase
 $oids = snmp_walk($device, 'rPDUStatusPhaseIndex', '-OsqnU', 'PowerNet-MIB');
 if (isset($oids) && $oids) {
@@ -39,7 +41,7 @@ if (isset($oids) && $oids) {
             } else {
                 $descr = 'Output';
             }
-            discover_sensor(null, 'current', $device, $current_oid, $index, $type, $descr, '10', '1', $lowlimit, null, $warnlimit, $limit, $current);
+            discover_sensor(null, SensorEnum::Current, $device, $current_oid, $index, $type, $descr, '10', '1', $lowlimit, null, $warnlimit, $limit, $current);
         }
     }
 }
@@ -86,7 +88,7 @@ if (isset($oids) && $oids) {
             } else {
                 $descr = 'Output';
             }
-            discover_sensor(null, 'current', $device, $current_oid, $index, $type, $descr, '10', '1', $lowlimit, null, $warnlimit, $limit, $current);
+            discover_sensor(null, SensorEnum::Current, $device, $current_oid, $index, $type, $descr, '10', '1', $lowlimit, null, $warnlimit, $limit, $current);
         }
     }
 }
@@ -130,7 +132,7 @@ if (isset($oids) && $oids) {
             $lowlimit = snmp_get($device, $lowlimit_oid, '-Oqv', '');
             $warnlimit = snmp_get($device, $warnlimit_oid, '-Oqv', '');
             if ($limit != -1 && $lowlimit != -1 && $warnlimit != -1) {
-                discover_sensor(null, 'current', $device, $current_oid, $index, $type, $descr, '10', '1', $lowlimit, null, $warnlimit, $limit, $current);
+                discover_sensor(null, SensorEnum::Current, $device, $current_oid, $index, $type, $descr, '10', '1', $lowlimit, null, $warnlimit, $limit, $current);
             }
         }
     }
@@ -177,7 +179,7 @@ if (isset($oids) && $oids) {
             }
 
             $descr = 'Outlet ' . $index . ' - ' . snmp_get($device, $name_oid, '-Oqv', '');
-            discover_sensor(null, 'current', $device, $current_oid, $index, $type, $descr, '10', '1', $lowlimit, null, $warnlimit, $limit, $current);
+            discover_sensor(null, SensorEnum::Current, $device, $current_oid, $index, $type, $descr, '10', '1', $lowlimit, null, $warnlimit, $limit, $current);
         }
     }
 }
@@ -209,7 +211,7 @@ if (isset($oids) && $oids) {
     $warnlimit = snmp_get($device, $warnlimit_oid, '-Oqv', '');
     // No / $precision here! Nice, APC!
     $descr = 'Output Feed';
-    discover_sensor(null, 'current', $device, $current_oid, $index, $type, $descr, '10', '1', $lowlimit, null, $warnlimit, $limit, $current);
+    discover_sensor(null, SensorEnum::Current, $device, $current_oid, $index, $type, $descr, '10', '1', $lowlimit, null, $warnlimit, $limit, $current);
 }
 unset($oids);
 
@@ -231,10 +233,10 @@ if (isset($in_oids)) {
         $in_index = '3.1.4.' . $index;
         if (substr((string) $index, 0, 1) == 2 && $data['upsPhaseInputCurrent'] != -1) {
             $descr = 'Phase ' . substr((string) $index, -1) . ' Bypass Input';
-            discover_sensor(null, 'current', $device, $current_oid, $in_index, $type, $descr, $divisor, 0, null, null, null, null, $current);
+            discover_sensor(null, SensorEnum::Current, $device, $current_oid, $in_index, $type, $descr, $divisor, 0, null, null, null, null, $current);
         } elseif (substr((string) $index, 0, 1) == 1) {
             $descr = 'Phase ' . substr((string) $index, -1) . ' Input';
-            discover_sensor(null, 'current', $device, $current_oid, $in_index, $type, $descr, $divisor, 0, null, null, null, null, $current);
+            discover_sensor(null, SensorEnum::Current, $device, $current_oid, $in_index, $type, $descr, $divisor, 0, null, null, null, null, $current);
         }
     }
 }
@@ -253,7 +255,7 @@ foreach ($oids as $index => $data) {
         $current = $data['upsPhaseOutputCurrent'] / $divisor;
     }
     if ($current >= -1) {
-        discover_sensor(null, 'current', $device, $current_oid, $index, $type, $descr, $divisor, 1, null, null, null, null, $current);
+        discover_sensor(null, SensorEnum::Current, $device, $current_oid, $index, $type, $descr, $divisor, 1, null, null, null, null, $current);
     }
 }
 unset($index);

--- a/includes/discovery/sensors/current/ciscosb.inc.php
+++ b/includes/discovery/sensors/current/ciscosb.inc.php
@@ -29,7 +29,7 @@ foreach ($oids as $index => $ciscosb_data) {
         if (is_numeric($current)) {
             app('sensor-discovery')->discover(new \App\Models\Sensor([
                 'poller_type' => 'snmp',
-                'sensor_class' => 'current',
+                'sensor_class' => \LibreNMS\Enum\Sensor::Current,
                 'sensor_oid' => $oid,
                 'sensor_index' => $index,
                 'sensor_type' => 'rlPhyTestTableTxBias',

--- a/includes/discovery/sensors/current/commander-plus.inc.php
+++ b/includes/discovery/sensors/current/commander-plus.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 /**
  * commander-plus.inc.php
  *
@@ -28,7 +30,7 @@ $oid = '.1.3.6.1.4.1.18642.1.2.2.1.0';
 $descr = 'Battery current';
 $divisor = 1;
 $multiplier = 1;
-discover_sensor(null, 'current', $device, $oid, 'batteryCurrent', 'commander-plus', $descr, $divisor, $multiplier, null, null, null, null, $current);
+discover_sensor(null, SensorEnum::Current, $device, $oid, 'batteryCurrent', 'commander-plus', $descr, $divisor, $multiplier, null, null, null, null, $current);
 
 $current = snmp_get($device, 'rectifierLoadCurrent.0', '-Oqv', 'CCPOWER-MIB');
 $oid = '.1.3.6.1.4.1.18642.1.2.1.2.0';
@@ -37,4 +39,4 @@ $divisor = 1;
 $multiplier = 1;
 $limit_low = 0;
 $limit = 5000;
-discover_sensor(null, 'current', $device, $oid, 'rectifierLoadCurrent', 'commander-plus', $descr, $divisor, $multiplier, $limit_low, null, null, $limit, $current);
+discover_sensor(null, SensorEnum::Current, $device, $oid, 'rectifierLoadCurrent', 'commander-plus', $descr, $divisor, $multiplier, $limit_low, null, null, $limit, $current);

--- a/includes/discovery/sensors/current/comware.inc.php
+++ b/includes/discovery/sensors/current/comware.inc.php
@@ -35,6 +35,6 @@ foreach ($hh3cTransceiverInfoTable as $index => $entry) {
         $entPhysicalIndex_measured = 'ports';
 
         $descr = $port->getShortLabel() . ' Bias Current';
-        discover_sensor(null, 'current', $device, $oid, 'bias-' . $index, 'comware', $descr, $divisor, $multiplier, $limit_low, $warn_limit_low, $warn_limit, $limit, $current, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured, group: 'transceiver');
+        discover_sensor(null, \LibreNMS\Enum\Sensor::Current, $device, $oid, 'bias-' . $index, 'comware', $descr, $divisor, $multiplier, $limit_low, $warn_limit_low, $warn_limit, $limit, $current, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured, group: 'transceiver');
     }
 }

--- a/includes/discovery/sensors/current/dell-powervault.inc.php
+++ b/includes/discovery/sensors/current/dell-powervault.inc.php
@@ -19,7 +19,7 @@ if (is_array($oids)) {
             $descr = implode(':', $connUnitSensorMessage);
             app('sensor-discovery')->discover(new \App\Models\Sensor([
                 'poller_type' => 'snmp',
-                'sensor_class' => 'current',
+                'sensor_class' => \LibreNMS\Enum\Sensor::Current,
                 'sensor_oid' => $cur_oid . $index,
                 'sensor_index' => $index,
                 'sensor_type' => 'dellme',

--- a/includes/discovery/sensors/current/edgecos.inc.php
+++ b/includes/discovery/sensors/current/edgecos.inc.php
@@ -23,4 +23,4 @@
  * @copyright  2026 Frederik Kriewitz
  * @author     Frederik Kriewitz <frederik@kriewitz.eu>
  */
-$os->discoverTransceiverSensors(['current']);
+$os->discoverTransceiverSensors([\LibreNMS\Enum\Sensor::Current]);

--- a/includes/discovery/sensors/current/eltex-mes21xx.inc.php
+++ b/includes/discovery/sensors/current/eltex-mes21xx.inc.php
@@ -40,7 +40,7 @@ foreach ($oids as $ifIndex => $data) {
 
         app('sensor-discovery')->discover(new \App\Models\Sensor([
             'poller_type' => 'snmp',
-            'sensor_class' => 'current',
+            'sensor_class' => \LibreNMS\Enum\Sensor::Current,
             'sensor_oid' => $oid,
             'sensor_index' => 'txbias' . $ifIndex,
             'sensor_type' => 'rlPhyTestTableTxBias',

--- a/includes/discovery/sensors/current/eltex-mes23xx.inc.php
+++ b/includes/discovery/sensors/current/eltex-mes23xx.inc.php
@@ -23,6 +23,7 @@
  *
  * @author     Peca Nesovanovic <peca.nesovanovic@sattrakt.com>
  */
+
 $divisor = 1000000;
 $multiplier = 1;
 
@@ -42,7 +43,7 @@ foreach ($oids as $ifIndex => $data) {
 
         app('sensor-discovery')->discover(new \App\Models\Sensor([
             'poller_type' => 'snmp',
-            'sensor_class' => 'current',
+            'sensor_class' => \LibreNMS\Enum\Sensor::Current,
             'sensor_oid' => $oid,
             'sensor_index' => 'SfpTxBias' . $ifIndex,
             'sensor_type' => 'rlPhyTestTableTxBias',

--- a/includes/discovery/sensors/current/eltex-mes24xx.inc.php
+++ b/includes/discovery/sensors/current/eltex-mes24xx.inc.php
@@ -51,7 +51,7 @@ if (! empty($eltexPhyTransceiverDiagnosticTable['txBiasCurrent'])) {
 
             app('sensor-discovery')->discover(new \App\Models\Sensor([
                 'poller_type' => 'snmp',
-                'sensor_class' => 'current',
+                'sensor_class' => \LibreNMS\Enum\Sensor::Current,
                 'sensor_oid' => $oid,
                 'sensor_index' => 'SfpTxBias' . $ifIndex,
                 'sensor_type' => 'ELTEX-PHY-MIB',

--- a/includes/discovery/sensors/current/exa.inc.php
+++ b/includes/discovery/sensors/current/exa.inc.php
@@ -12,7 +12,7 @@ foreach ($ponTable as $e7OltPonPortShelf => $ponShelf) {
 
                 app('sensor-discovery')->discover(new \App\Models\Sensor([
                     'poller_type' => 'snmp',
-                    'sensor_class' => 'current',
+                    'sensor_class' => \LibreNMS\Enum\Sensor::Current,
                     'sensor_oid' => ".1.3.6.1.4.1.6321.1.2.2.2.1.6.2.1.6.$index",
                     'sensor_index' => $index,
                     'sensor_type' => 'exa',

--- a/includes/discovery/sensors/current/exos.inc.php
+++ b/includes/discovery/sensors/current/exos.inc.php
@@ -13,7 +13,7 @@ if (is_array($oids)) {
             $value = str_replace('A', '', $temp_value[1]);
             app('sensor-discovery')->discover(new \App\Models\Sensor([
                 'poller_type' => 'snmp',
-                'sensor_class' => 'current',
+                'sensor_class' => \LibreNMS\Enum\Sensor::Current,
                 'sensor_oid' => '.1.3.6.1.3.94.1.8.1.6.' . $index,
                 'sensor_index' => $entry['connUnitSensorIndex'],
                 'sensor_type' => 'exos',

--- a/includes/discovery/sensors/current/fs-centec.inc.php
+++ b/includes/discovery/sensors/current/fs-centec.inc.php
@@ -14,7 +14,7 @@ foreach ($biasTable as $ifIndex => $current) {
 
             app('sensor-discovery')->discover(new \App\Models\Sensor([
                 'poller_type' => 'snmp',
-                'sensor_class' => 'current',
+                'sensor_class' => \LibreNMS\Enum\Sensor::Current,
                 'sensor_oid' => ".1.3.6.1.4.1.52642.1.37.1.10.4.1.5.$ifIndex",
                 'sensor_index' => "$ifIndex.$channel",
                 'sensor_type' => 'fs-centec',

--- a/includes/discovery/sensors/current/fs-net-pdu.inc.php
+++ b/includes/discovery/sensors/current/fs-net-pdu.inc.php
@@ -26,5 +26,5 @@
 $oid = '.1.3.6.1.4.1.30966.10.3.2.4.0';
 $current = snmp_get($device, $oid, '-Oqv') / 10;
 if ($current > 0) {
-    discover_sensor(null, 'current', $device, $oid, 0, 'PDU L1', 'Current', 10, 1, null, null, null, null, $current);
+    discover_sensor(null, \LibreNMS\Enum\Sensor::Current, $device, $oid, 0, 'PDU L1', 'Current', 10, 1, null, null, null, null, $current);
 }

--- a/includes/discovery/sensors/current/gamatronicups.inc.php
+++ b/includes/discovery/sensors/current/gamatronicups.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 for ($i = 1; $i <= 3; $i++) {
     $current_oid = ".1.3.6.1.4.1.6050.5.4.1.1.3.$i";
     $descr = "Input Phase $i";
@@ -11,7 +13,7 @@ for ($i = 1; $i <= 3; $i++) {
     $warnlimit = null;
     $limit = null;
 
-    discover_sensor(null, 'current', $device, $current_oid, $index, $type, $descr, '1', '1', $lowlimit, null, null, null, $current);
+    discover_sensor(null, SensorEnum::Current, $device, $current_oid, $index, $type, $descr, '1', '1', $lowlimit, null, null, null, $current);
 }
 
 for ($i = 1; $i <= 3; $i++) {
@@ -25,5 +27,5 @@ for ($i = 1; $i <= 3; $i++) {
     $warnlimit = null;
     $limit = null;
 
-    discover_sensor(null, 'current', $device, $current_oid, $index, $type, $descr, '1', '1', $lowlimit, null, null, null, $current);
+    discover_sensor(null, SensorEnum::Current, $device, $current_oid, $index, $type, $descr, '1', '1', $lowlimit, null, null, null, $current);
 }

--- a/includes/discovery/sensors/current/ict-pdu.inc.php
+++ b/includes/discovery/sensors/current/ict-pdu.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 /**
  * ict-pdu.inc.php
  *
@@ -40,7 +42,7 @@ foreach ($oids as $index => $entry) {
     $type = 'ict-pdu';
     $current = (float) $entry['outputCurrent'] / $divisor;
 
-    discover_sensor(null, 'current', $device, $oid, $index, $type, $descr, $divisor, '1', null, null, null, null, $current);
+    discover_sensor(null, SensorEnum::Current, $device, $oid, $index, $type, $descr, $divisor, '1', null, null, null, null, $current);
 }
 
 // System Current
@@ -53,5 +55,5 @@ if (! empty($systemCurrent)) {
     $oid = '.1.3.6.1.4.1.39145.10.7.0';
     $current = $systemCurrent / $divisor;
 
-    discover_sensor(null, 'current', $device, $oid, $index, $type, $descr, $divisor, '1', null, null, null, null, $current);
+    discover_sensor(null, SensorEnum::Current, $device, $oid, $index, $type, $descr, $divisor, '1', null, null, null, null, $current);
 }

--- a/includes/discovery/sensors/current/ict-psu.inc.php
+++ b/includes/discovery/sensors/current/ict-psu.inc.php
@@ -36,5 +36,5 @@ if (! empty($outputCurrent)) {
     $type = 'ict-psu';
     $currentValue = $outputCurrent / $divisor;
 
-    discover_sensor(null, 'current', $device, $oid, $index, $type, $descr, $divisor, '1', null, null, null, null, $currentValue);
+    discover_sensor(null, \LibreNMS\Enum\Sensor::Current, $device, $oid, $index, $type, $descr, $divisor, '1', null, null, null, null, $currentValue);
 }

--- a/includes/discovery/sensors/current/ipoman.inc.php
+++ b/includes/discovery/sensors/current/ipoman.inc.php
@@ -4,6 +4,8 @@
  * @author     Peca Nesovanovic <peca.nesovanovic@sattrakt.com>
  */
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 // pre-cache
 $oidsOut = SnmpQuery::cache()->hideMib()->walk([
     'IPOMANII-MIB::outletConfigDesc',
@@ -33,7 +35,7 @@ foreach ($oidsCurrIn as $index => $entry) {
     // FIXME: iPoMan 1201 also says it has 2 inlets, at least until firmware 1.06 - wtf?
     app('sensor-discovery')->discover(new \App\Models\Sensor([
         'poller_type' => 'snmp',
-        'sensor_class' => 'current',
+        'sensor_class' => SensorEnum::Current,
         'sensor_oid' => $oid,
         'sensor_index' => '1.3.1.3.' . $index,
         'sensor_type' => 'ipoman',
@@ -61,7 +63,7 @@ foreach ($oidsCurrOut as $index => $entry) {
 
     app('sensor-discovery')->discover(new \App\Models\Sensor([
         'poller_type' => 'snmp',
-        'sensor_class' => 'current',
+        'sensor_class' => SensorEnum::Current,
         'sensor_oid' => $oid,
         'sensor_index' => '2.3.1.3.' . $index,
         'sensor_type' => 'ipoman',

--- a/includes/discovery/sensors/current/liebert.inc.php
+++ b/includes/discovery/sensors/current/liebert.inc.php
@@ -27,7 +27,7 @@ $entPhysicalIndex = null;
 $entPhysicalIndex_measured = null;
 $user_func = null;
 $group = null;
-$class = 'current';
+$class = $sensor_class;
 $poller_type = 'snmp';
 
 $psline_data = snmpwalk_cache_oid($device, 'lgpPduPsLineTable', [], 'LIEBERT-GP-PDU-MIB', 'liebert');

--- a/includes/discovery/sensors/current/linux.inc.php
+++ b/includes/discovery/sensors/current/linux.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 if (preg_match('/(Linux).+(ntc)/', (string) $device['sysDescr'])) {
     $sensor_type = 'chip_currents';
     $oid = '.1.3.6.1.4.1.8072.1.3.2.4.1.2.10.112.111.119.101.114.45.115.116.97.';
@@ -11,18 +13,18 @@ if (preg_match('/(Linux).+(ntc)/', (string) $device['sysDescr'])) {
     $current = '116.3';
     $value = snmp_get($device, $oid . $current, '-Oqv');
     if (is_numeric($value)) {
-        discover_sensor(null, 'current', $device, $oid . $current, $current, $sensor_type, $descr, '1', '1', $lowlimit, $lowwarnlimit, $warnlimit, $limit, $value);
+        discover_sensor(null, SensorEnum::Current, $device, $oid . $current, $current, $sensor_type, $descr, '1', '1', $lowlimit, $lowwarnlimit, $warnlimit, $limit, $value);
     }
     $descr = 'VBUS current';
     $current = '116.5';
     $value = snmp_get($device, $oid . $current, '-Oqv');
     if (is_numeric($value)) {
-        discover_sensor(null, 'current', $device, $oid . $current, $current, $sensor_type, $descr, '1', '1', $lowlimit, $lowwarnlimit, $warnlimit, $limit, $value);
+        discover_sensor(null, SensorEnum::Current, $device, $oid . $current, $current, $sensor_type, $descr, '1', '1', $lowlimit, $lowwarnlimit, $warnlimit, $limit, $value);
     }
     $descr = 'Battery current';
     $current = '116.7';
     $value = snmp_get($device, $oid . $current, '-Oqv');
     if (is_numeric($value)) {
-        discover_sensor(null, 'current', $device, $oid . $current, $current, $sensor_type, $descr, '1', '1', $lowlimit, $lowwarnlimit, $warnlimit, $limit, $value);
+        discover_sensor(null, SensorEnum::Current, $device, $oid . $current, $current, $sensor_type, $descr, '1', '1', $lowlimit, $lowwarnlimit, $warnlimit, $limit, $value);
     }
 }

--- a/includes/discovery/sensors/current/mgeups.inc.php
+++ b/includes/discovery/sensors/current/mgeups.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 echo 'MGE ';
 $oids = trim((string) snmp_walk($device, '.1.3.6.1.4.1.705.1.7.2.1.5', '-OsqnU')); // OID: mgoutputCurrent
 d_echo($oids . "\n");
@@ -28,7 +30,7 @@ for ($i = 1; $i <= $numPhase; $i++) {
     $limit = null;
     $lowwarnlimit = null;
 
-    discover_sensor(null, 'current', $device, $current_oid, $index, $type, $descr, '10', '1', $lowlimit, $lowwarnlimit, $warnlimit, $limit, $current);
+    discover_sensor(null, SensorEnum::Current, $device, $current_oid, $index, $type, $descr, '10', '1', $lowlimit, $lowwarnlimit, $warnlimit, $limit, $current);
 }//end for
 
 $oids = trim((string) snmp_walk($device, '.1.3.6.1.4.1.705.1.6.2.1.6', '-OsqnU')); // OID: mginputCurrent
@@ -58,5 +60,5 @@ for ($i = 1; $i <= $numPhase; $i++) {
     $limit = null;
     $lowwarnlimit = null;
 
-    discover_sensor(null, 'current', $device, $current_oid, $index, $type, $descr, '10', '1', $lowlimit, $lowwarnlimit, $warnlimit, $limit, $current);
+    discover_sensor(null, SensorEnum::Current, $device, $current_oid, $index, $type, $descr, '10', '1', $lowlimit, $lowwarnlimit, $warnlimit, $limit, $current);
 }//end for

--- a/includes/discovery/sensors/current/netagent2.inc.php
+++ b/includes/discovery/sensors/current/netagent2.inc.php
@@ -39,7 +39,7 @@ if (! empty($battery_current) || $battery_current == 0) {
 
     discover_sensor(
         null,
-        'current',
+        $sensor_class,
         $device,
         $battery_current_oid,
         $index,

--- a/includes/discovery/sensors/current/nokia-1830.inc.php
+++ b/includes/discovery/sensors/current/nokia-1830.inc.php
@@ -20,7 +20,6 @@
 // *************************************************************
 // ***** Current Sensors for Nokia PSD
 // *************************************************************
-
 if (str_contains((string) $device['sysObjectID'], '.1.3.6.1.4.1.7483.1.3.1.12')) {
     d_echo('Nokia PSD DDM Current Sensors\n');
     $ifIndexToName = SnmpQuery::cache()->walk('IF-MIB::ifName')->pluck();
@@ -33,7 +32,7 @@ if (str_contains((string) $device['sysObjectID'], '.1.3.6.1.4.1.7483.1.3.1.12'))
             $divisor = 1000000;
             app('sensor-discovery')->discover(new \App\Models\Sensor([
                 'poller_type' => 'snmp',
-                'sensor_class' => 'current',
+                'sensor_class' => \LibreNMS\Enum\Sensor::Current,
                 'sensor_oid' => ".1.3.6.1.4.1.7483.2.2.7.3.1.4.1.2.$ifIndex.3",
                 'sensor_index' => "$ifIndex.3",
                 'sensor_type' => 'nokia-1830',

--- a/includes/discovery/sensors/current/ocnos.inc.php
+++ b/includes/discovery/sensors/current/ocnos.inc.php
@@ -20,7 +20,7 @@ if ($os instanceof \LibreNMS\OS\Ocnos) {
 
                     app('sensor-discovery')->discover(new \App\Models\Sensor([
                         'poller_type' => 'snmp',
-                        'sensor_class' => 'current',
+                        'sensor_class' => \LibreNMS\Enum\Sensor::Current,
                         'sensor_oid' => ".1.3.6.1.4.1.36673.100.1.2.3.1.12.$cmmStackUnitIndex.$cmmTransIndex.$cmmTransChannelIndex",
                         'sensor_index' => "$cmmStackUnitIndex.$cmmTransIndex.$cmmTransChannelIndex",
                         'sensor_type' => 'ocnos',

--- a/includes/discovery/sensors/current/pbn.inc.php
+++ b/includes/discovery/sensors/current/pbn.inc.php
@@ -27,6 +27,6 @@ foreach ($pre_cache['pbn_oids'] as $index => $entry) {
         $value = $entry['curr'] / $divisor;
         $entPhysicalIndex = $index;
         $entPhysicalIndex_measured = 'ports';
-        discover_sensor(null, 'current', $device, $oid, '' . $index, 'pbn', $descr, $divisor, $multiplier, $limit_low, $warn_limit_low, $warn_limit, $limit, $value, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured);
+        discover_sensor(null, \LibreNMS\Enum\Sensor::Current, $device, $oid, '' . $index, 'pbn', $descr, $divisor, $multiplier, $limit_low, $warn_limit_low, $warn_limit, $limit, $value, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured);
     }
 }

--- a/includes/discovery/sensors/current/procurve.inc.php
+++ b/includes/discovery/sensors/current/procurve.inc.php
@@ -14,6 +14,6 @@ foreach (SnmpQuery::cache()->walk('HP-ICF-TRANSCEIVER-MIB::hpicfXcvrInfoTable')-
         $entPhysicalIndex = $index;
         $entPhysicalIndex_measured = 'ports';
         $descr = Rewrite::shortenIfName($entry['HP-ICF-TRANSCEIVER-MIB::hpicfXcvrPortDesc']) . ' Bias Current';
-        discover_sensor(null, 'current', $device, $oid, 'hpicfXcvrBias.' . $index, 'procurve', $descr, $divisor, 1, $limit_low, $warn_limit_low, $warn_limit, $limit, $current, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured, group: 'transceiver');
+        discover_sensor(null, \LibreNMS\Enum\Sensor::Current, $device, $oid, 'hpicfXcvrBias.' . $index, 'procurve', $descr, $divisor, 1, $limit_low, $warn_limit_low, $warn_limit, $limit, $current, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured, group: 'transceiver');
     }
 }

--- a/includes/discovery/sensors/current/raritan-pdu.inc.php
+++ b/includes/discovery/sensors/current/raritan-pdu.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 /**
  * raritan.inc.php
  *
@@ -48,7 +50,7 @@ if ($outlet_oids) {
             $outlet_high_limit = snmp_get($device, "outletCurrentUpperCritical.$outletsuffix", '-Ovq', 'PDU-MIB') / $divisor;
             $outlet_current = snmp_get($device, "outletCurrent.$outletsuffix", '-Ovq', 'PDU-MIB') / $divisor;
             if ($outlet_current >= 0) {
-                discover_sensor(null, 'current', $device, $outlet_oid, $outlet_insert_index, 'raritan', $outlet_descr, $divisor, $multiplier, $outlet_low_limit, $outlet_low_warn_limit, $outlet_high_warn_limit, $outlet_high_limit, $outlet_current);
+                discover_sensor(null, SensorEnum::Current, $device, $outlet_oid, $outlet_insert_index, 'raritan', $outlet_descr, $divisor, $multiplier, $outlet_low_limit, $outlet_low_warn_limit, $outlet_high_warn_limit, $outlet_high_limit, $outlet_current);
             }
         }
     }
@@ -66,6 +68,6 @@ foreach ($pre_cache['raritan_inletTable'] as $index => $raritan_data) {
         $warn_limit = isset($raritan_data['inletCurrentUpperWarning']) ? $raritan_data['inletCurrentUpperWarning'] / $divisor : null;
         $high_limit = isset($raritan_data['inletCurrentUpperCritical']) ? $raritan_data['inletCurrentUpperCritical'] / $divisor : null;
         $current = $pre_cache['raritan_inletPoleTable'][$index][$x]['inletPoleCurrent'] / $divisor;
-        discover_sensor(null, 'current', $device, $oid, $tmp_index, 'raritan', $descr, $divisor, 1, $low_limit, $low_warn_limit, $warn_limit, $high_limit, $current);
+        discover_sensor(null, SensorEnum::Current, $device, $oid, $tmp_index, 'raritan', $descr, $divisor, 1, $low_limit, $low_warn_limit, $warn_limit, $high_limit, $current);
     }
 }

--- a/includes/discovery/sensors/current/rfc1628.inc.php
+++ b/includes/discovery/sensors/current/rfc1628.inc.php
@@ -9,11 +9,11 @@ $battery_current = snmp_get($device, 'upsBatteryCurrent.0', '-OqvU', 'UPS-MIB');
 
 if (is_numeric($battery_current)) {
     $oid = '.1.3.6.1.2.1.33.1.2.6.0';
-    $divisor = get_device_divisor($device, $pre_cache['poweralert_serial'] ?? '', 'current', $oid);
+    $divisor = get_device_divisor($device, $pre_cache['poweralert_serial'] ?? '', $sensor_class, $oid);
 
     discover_sensor(
         null,
-        'current',
+        $sensor_class,
         $device,
         $oid,
         500,
@@ -32,7 +32,7 @@ if (is_numeric($battery_current)) {
 $output_current = snmpwalk_group($device, 'upsOutputCurrent', 'UPS-MIB');
 foreach ($output_current as $index => $data) {
     $oid = ".1.3.6.1.2.1.33.1.4.4.1.3.$index";
-    $divisor = get_device_divisor($device, $pre_cache['poweralert_serial'] ?? '', 'current', $oid);
+    $divisor = get_device_divisor($device, $pre_cache['poweralert_serial'] ?? '', $sensor_class, $oid);
     $descr = 'Output';
     if (count($output_current) > 1) {
         $descr .= " Phase $index";
@@ -51,7 +51,7 @@ foreach ($output_current as $index => $data) {
 
     discover_sensor(
         null,
-        'current',
+        $sensor_class,
         $device,
         $oid,
         $index,
@@ -70,7 +70,7 @@ foreach ($output_current as $index => $data) {
 $input_current = snmpwalk_group($device, 'upsInputCurrent', 'UPS-MIB');
 foreach ($input_current as $index => $data) {
     $oid = ".1.3.6.1.2.1.33.1.3.3.1.4.$index";
-    $divisor = get_device_divisor($device, $pre_cache['poweralert_serial'] ?? '', 'current', $oid);
+    $divisor = get_device_divisor($device, $pre_cache['poweralert_serial'] ?? '', $sensor_class, $oid);
     $descr = 'Input';
     if (count($input_current) > 1) {
         $descr .= " Phase $index";
@@ -89,7 +89,7 @@ foreach ($input_current as $index => $data) {
 
     discover_sensor(
         null,
-        'current',
+        $sensor_class,
         $device,
         $oid,
         100 + $index,
@@ -108,7 +108,7 @@ foreach ($input_current as $index => $data) {
 $bypass_current = snmpwalk_group($device, 'upsBypassCurrent', 'UPS-MIB');
 foreach ($bypass_current as $index => $data) {
     $oid = ".1.3.6.1.2.1.33.1.5.3.1.3.$index";
-    $divisor = get_device_divisor($device, $pre_cache['poweralert_serial'] ?? '', 'current', $oid);
+    $divisor = get_device_divisor($device, $pre_cache['poweralert_serial'] ?? '', $sensor_class, $oid);
     $descr = 'Bypass';
     if (count($bypass_current) > 1) {
         $descr .= " Phase $index";
@@ -127,7 +127,7 @@ foreach ($bypass_current as $index => $data) {
 
     discover_sensor(
         null,
-        'current',
+        $sensor_class,
         $device,
         $oid,
         200 + $index,

--- a/includes/discovery/sensors/current/schleifenbauer.inc.php
+++ b/includes/discovery/sensors/current/schleifenbauer.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 echo 'Schleifenbauer ';
 $divisor = 100;
 
@@ -16,7 +18,7 @@ foreach ($pre_cache['sdbMgmtCtrlDevUnitAddress'] ?? [] as $sdbMgmtCtrlDevUnitAdd
         // See includes/discovery/entity-physical/schleifenbauer.inc.php for an explanation why we set this as the entPhysicalIndex.
         $entPhysicalIndex = $sdbMgmtCtrlDevUnitAddress * 1000000 + 100000 + $sdbDevInIndex * 1000 + 120;
 
-        discover_sensor(null, 'current', $device, $current_oid, $serial_input, 'schleifenbauer', $descr, $divisor, '1', null, null, $warn_limit, $high_limit, $current, 'snmp', $entPhysicalIndex);
+        discover_sensor(null, SensorEnum::Current, $device, $current_oid, $serial_input, 'schleifenbauer', $descr, $divisor, '1', null, null, $warn_limit, $high_limit, $current, 'snmp', $entPhysicalIndex);
     }
 }
 
@@ -35,6 +37,6 @@ if (isset($pre_cache['sdbDevOutMtActualCurrent']) && is_array($pre_cache['sdbDev
         // See includes/discovery/entity-physical/schleifenbauer.inc.php for an explanation why we set this as the entPhysicalIndex.
         $entPhysicalIndex = $sdbMgmtCtrlDevUnitAddress * 1000000 + 200000 + $sdbDevOutMtIndex * 1000 + 120;
 
-        discover_sensor(null, 'current', $device, $current_oid, $serial_output, 'schleifenbauer', $descr, $divisor, '1', null, null, $warn_limit, $high_limit, $current, 'snmp', $entPhysicalIndex);
+        discover_sensor(null, SensorEnum::Current, $device, $current_oid, $serial_output, 'schleifenbauer', $descr, $divisor, '1', null, null, $warn_limit, $high_limit, $current, 'snmp', $entPhysicalIndex);
     }
 }

--- a/includes/discovery/sensors/current/sitemonitor.inc.php
+++ b/includes/discovery/sensors/current/sitemonitor.inc.php
@@ -26,5 +26,5 @@
 $oid = '.1.3.6.1.4.1.32050.2.1.27.5.4';
 $current = (snmp_get($device, $oid, '-Oqv') / 10);
 if ($current > 0) {
-    discover_sensor(null, 'current', $device, $oid, 0, 'sitemonitor', 'Current', 10, 1, null, null, null, null, $current);
+    discover_sensor(null, \LibreNMS\Enum\Sensor::Current, $device, $oid, 0, 'sitemonitor', 'Current', 10, 1, null, null, null, null, $current);
 }

--- a/includes/discovery/sensors/current/tpdin.inc.php
+++ b/includes/discovery/sensors/current/tpdin.inc.php
@@ -52,7 +52,7 @@ $tpdin_oids = [
 
 foreach ($tpdin_oids as $data) {
     if ($data['current'] > 0) {
-        discover_sensor(null, 'current', $device, $data['oid'], $data['index'], $device['os'], $data['descr'], 10, '1', null, null, null, null, $data['current']);
+        discover_sensor(null, \LibreNMS\Enum\Sensor::Current, $device, $data['oid'], $data['index'], $device['os'], $data['descr'], 10, '1', null, null, null, null, $data['current']);
     }
 }
 

--- a/includes/discovery/sensors/dbm/adva_fsp150.inc.php
+++ b/includes/discovery/sensors/dbm/adva_fsp150.inc.php
@@ -52,7 +52,7 @@ foreach ($pre_cache['adva_fsp150_ports'] as $index => $entry) {
             $descrRx = ($pre_cache['adva_fsp150_ifName'][$entry['cmEthernetNetPortIfIndex']]['ifName'] ?? 'ifIndex ' . $entry['cmEthernetNetPortIfIndex']) . ' Rx Power';
             discover_sensor(
                 null,
-                'dbm',
+                $sensor_class,
                 $device,
                 $oidRx,
                 'cmEthernetNetPortStatsOPR.' . $index,
@@ -74,7 +74,7 @@ foreach ($pre_cache['adva_fsp150_ports'] as $index => $entry) {
             $descrTx = ($pre_cache['adva_fsp150_ifName'][$entry['cmEthernetNetPortIfIndex']]['ifName'] ?? 'ifIndex ' . $entry['cmEthernetNetPortIfIndex']) . ' Tx Power';
             discover_sensor(
                 null,
-                'dbm',
+                $sensor_class,
                 $device,
                 $oidTx,
                 'cmEthernetNetPortStatsOPT.' . $index,
@@ -109,7 +109,7 @@ foreach ($pre_cache['adva_fsp150_ports'] as $index => $entry) {
 
             discover_sensor(
                 null,
-                'dbm',
+                $sensor_class,
                 $device,
                 $oidRx,
                 'cmEthernetAccPortStatsOPR.' . $index,
@@ -131,7 +131,7 @@ foreach ($pre_cache['adva_fsp150_ports'] as $index => $entry) {
 
             discover_sensor(
                 null,
-                'dbm',
+                $sensor_class,
                 $device,
                 $oidTx,
                 'cmEthernetAccPortStatsOPT.' . $index,
@@ -165,7 +165,7 @@ foreach ($pre_cache['adva_fsp150_ports'] as $index => $entry) {
             $descrRx = ($pre_cache['adva_fsp150_ifName'][$entry['cmEthernetTrafficPortIfIndex']]['ifName'] ?? 'ifIndex ' . $entry['cmEthernetTrafficPortIfIndex']) . ' Rx Power';
             discover_sensor(
                 null,
-                'dbm',
+                $sensor_class,
                 $device,
                 $oidRx,
                 'cmEthernetTrafficPortStatsOPR.' . $index,
@@ -186,7 +186,7 @@ foreach ($pre_cache['adva_fsp150_ports'] as $index => $entry) {
             $descrTx = ($pre_cache['adva_fsp150_ifName'][$entry['cmEthernetTrafficPortIfIndex']]['ifName'] ?? 'ifIndex ' . $entry['cmEthernetTrafficPortIfIndex']) . ' Tx Power';
             discover_sensor(
                 null,
-                'dbm',
+                $sensor_class,
                 $device,
                 $oidTx,
                 'cmEthernetTrafficPortStatsOPT.' . $index,

--- a/includes/discovery/sensors/dbm/adva_fsp3kr7.inc.php
+++ b/includes/discovery/sensors/dbm/adva_fsp3kr7.inc.php
@@ -31,7 +31,7 @@ foreach ($pre_cache['adva_fsp3kr7'] as $index => $entry) {
 
         discover_sensor(
             null,
-            'dbm',
+            $sensor_class,
             $device,
             $oidRX,
             'pmSnapshotCurrentInputPower' . $index,
@@ -54,7 +54,7 @@ foreach ($pre_cache['adva_fsp3kr7'] as $index => $entry) {
 
         discover_sensor(
             null,
-            'dbm',
+            $sensor_class,
             $device,
             $oidTX,
             'pmSnapshotCurrentOutputPower' . $index,

--- a/includes/discovery/sensors/dbm/ciscoepc.inc.php
+++ b/includes/discovery/sensors/dbm/ciscoepc.inc.php
@@ -29,6 +29,6 @@ foreach ($pre_cache['ciscoepc_docsIfDownstreamChannelTable'] as $index => $data)
         $oid = '.1.3.6.1.2.1.10.127.1.1.1.1.6.' . $index;
         $divisor = 10;
         $value = $data['docsIfDownChannelPower'];
-        discover_sensor(null, 'dbm', $device, $oid, 'docsIfDownChannelPower.' . $index, 'ciscoepc', $descr, $divisor, '1', null, null, null, null, $value);
+        discover_sensor(null, \LibreNMS\Enum\Sensor::Dbm, $device, $oid, 'docsIfDownChannelPower.' . $index, 'ciscoepc', $descr, $divisor, '1', null, null, null, null, $value);
     }
 }

--- a/includes/discovery/sensors/dbm/ciscosb.inc.php
+++ b/includes/discovery/sensors/dbm/ciscosb.inc.php
@@ -11,6 +11,8 @@
  * the source code distribution for details.
  */
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 $oids = SnmpQuery::cache()->hideMib()->walk('CISCOSB-PHY-MIB::rlPhyTestGetResult')->table(1);
 
 $multiplier = 1;
@@ -24,7 +26,7 @@ foreach ($oids as $index => $ciscosb_data) {
             $dbm = $value['rlPhyTestTableTxOutput'] / $divisor;
             app('sensor-discovery')->discover(new \App\Models\Sensor([
                 'poller_type' => 'snmp',
-                'sensor_class' => 'dbm',
+                'sensor_class' => SensorEnum::Dbm,
                 'sensor_oid' => $oid,
                 'sensor_index' => 'tx-' . $index,
                 'sensor_type' => 'rlPhyTestTableTxOutput',
@@ -50,7 +52,7 @@ foreach ($oids as $index => $ciscosb_data) {
             $dbm = $value['rlPhyTestTableRxOpticalPower'] / $divisor;
             app('sensor-discovery')->discover(new \App\Models\Sensor([
                 'poller_type' => 'snmp',
-                'sensor_class' => 'dbm',
+                'sensor_class' => SensorEnum::Dbm,
                 'sensor_oid' => $oid,
                 'sensor_index' => 'rx-' . $index,
                 'sensor_type' => 'rlPhyTestTableRxOpticalPower',

--- a/includes/discovery/sensors/dbm/comware.inc.php
+++ b/includes/discovery/sensors/dbm/comware.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 /*
  * LibreNMS
  *
@@ -33,7 +35,7 @@ foreach ($hh3cTransceiverInfoTable as $index => $entry) {
         $entPhysicalIndex = $index;
         $entPhysicalIndex_measured = 'ports';
         $descr = $port?->getShortLabel() . ' Receive Power';
-        discover_sensor(null, 'dbm', $device, $oid, 'rx-' . $index, 'comware', $descr, $divisor, $multiplier, $limit_low, $warn_limit_low, $warn_limit, $limit, $current, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured, group: 'transceiver');
+        discover_sensor(null, SensorEnum::Dbm, $device, $oid, 'rx-' . $index, 'comware', $descr, $divisor, $multiplier, $limit_low, $warn_limit_low, $warn_limit, $limit, $current, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured, group: 'transceiver');
     }
 
     if (is_numeric($entry['HH3C-TRANSCEIVER-INFO-MIB::hh3cTransceiverCurTXPower']) && $entry['HH3C-TRANSCEIVER-INFO-MIB::hh3cTransceiverCurTXPower'] != 2147483647 && isset($entry['HH3C-TRANSCEIVER-INFO-MIB::hh3cTransceiverDiagnostic'])) {
@@ -48,7 +50,7 @@ foreach ($hh3cTransceiverInfoTable as $index => $entry) {
         $port = PortCache::getByIfIndex($index, $device['device_id']);
         if ($port?->ifAdminStatus == 'up') {
             $descr = $port->getShortLabel() . ' Transmit Power';
-            discover_sensor(null, 'dbm', $device, $oid, 'tx-' . $index, 'comware', $descr, $divisor, $multiplier, $limit_low, $warn_limit_low, $warn_limit, $limit, $current, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured, group: 'transceiver');
+            discover_sensor(null, SensorEnum::Dbm, $device, $oid, 'tx-' . $index, 'comware', $descr, $divisor, $multiplier, $limit_low, $warn_limit_low, $warn_limit, $limit, $current, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured, group: 'transceiver');
         }
     }
 }

--- a/includes/discovery/sensors/dbm/edgecos.inc.php
+++ b/includes/discovery/sensors/dbm/edgecos.inc.php
@@ -23,4 +23,4 @@
  * @copyright  2026 Frederik Kriewitz
  * @author     Frederik Kriewitz <frederik@kriewitz.eu>
  */
-$os->discoverTransceiverSensors(['dbm']);
+$os->discoverTransceiverSensors([\LibreNMS\Enum\Sensor::Dbm]);

--- a/includes/discovery/sensors/dbm/eltex-mes21xx.inc.php
+++ b/includes/discovery/sensors/dbm/eltex-mes21xx.inc.php
@@ -24,6 +24,8 @@
  * @author     Peca Nesovanovic <peca.nesovanovic@sattrakt.com>
  */
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 $divisor = 1000;
 $multiplier = 1;
 
@@ -42,7 +44,7 @@ foreach ($oids as $ifIndex => $data) {
 
         app('sensor-discovery')->discover(new \App\Models\Sensor([
             'poller_type' => 'snmp',
-            'sensor_class' => 'dbm',
+            'sensor_class' => SensorEnum::Dbm,
             'sensor_oid' => $oid,
             'sensor_index' => 'txdbm' . $ifIndex,
             'sensor_type' => 'rlPhyTestTableTxOutput',
@@ -71,7 +73,7 @@ foreach ($oids as $ifIndex => $data) {
 
         app('sensor-discovery')->discover(new \App\Models\Sensor([
             'poller_type' => 'snmp',
-            'sensor_class' => 'dbm',
+            'sensor_class' => SensorEnum::Dbm,
             'sensor_oid' => $oid,
             'sensor_index' => 'rxdbm' . $ifIndex,
             'sensor_type' => 'rlPhyTestTableRxOpticalPower',

--- a/includes/discovery/sensors/dbm/eltex-mes23xx.inc.php
+++ b/includes/discovery/sensors/dbm/eltex-mes23xx.inc.php
@@ -23,6 +23,9 @@
  *
  * @author     Peca Nesovanovic <peca.nesovanovic@sattrakt.com>
  */
+
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 $divisor = 1000;
 $multiplier = 1;
 
@@ -44,7 +47,7 @@ foreach ($oids as $ifIndex => $data) {
 
         app('sensor-discovery')->discover(new \App\Models\Sensor([
             'poller_type' => 'snmp',
-            'sensor_class' => 'dbm',
+            'sensor_class' => SensorEnum::Dbm,
             'sensor_oid' => $oid,
             'sensor_index' => 'SfpTxDbm' . $ifIndex,
             'sensor_type' => 'rlPhyTestTableTxOpticalPower',
@@ -75,7 +78,7 @@ foreach ($oids as $ifIndex => $data) {
 
         app('sensor-discovery')->discover(new \App\Models\Sensor([
             'poller_type' => 'snmp',
-            'sensor_class' => 'dbm',
+            'sensor_class' => SensorEnum::Dbm,
             'sensor_oid' => $oid,
             'sensor_index' => 'SfpRxDbm' . $ifIndex,
             'sensor_type' => 'rlPhyTestTableRxOpticalPower',

--- a/includes/discovery/sensors/dbm/eltex-mes24xx.inc.php
+++ b/includes/discovery/sensors/dbm/eltex-mes24xx.inc.php
@@ -23,6 +23,7 @@
  * @author     Peca Nesovanovic <peca.nesovanovic@sattrakt.com>
  */
 
+use LibreNMS\Enum\Sensor as SensorEnum;
 use LibreNMS\Util\Oid;
 
 echo 'eltexPhyTransceiverDiagnosticTable' . PHP_EOL;
@@ -52,7 +53,7 @@ if (! empty($eltexPhyTransceiverDiagnosticTable['txOpticalPower'])) {
 
             app('sensor-discovery')->discover(new \App\Models\Sensor([
                 'poller_type' => 'snmp',
-                'sensor_class' => 'dbm',
+                'sensor_class' => SensorEnum::Dbm,
                 'sensor_oid' => $oid,
                 'sensor_index' => 'SfpTxDbm' . $ifIndex,
                 'sensor_type' => 'ELTEX-PHY-MIB',
@@ -87,7 +88,7 @@ if (! empty($eltexPhyTransceiverDiagnosticTable['rxOpticalPower'])) {
 
             app('sensor-discovery')->discover(new \App\Models\Sensor([
                 'poller_type' => 'snmp',
-                'sensor_class' => 'dbm',
+                'sensor_class' => SensorEnum::Dbm,
                 'sensor_oid' => $oid,
                 'sensor_index' => 'SfpRxDbm' . $ifIndex,
                 'sensor_type' => 'ELTEX-PHY-MIB',

--- a/includes/discovery/sensors/dbm/exa.inc.php
+++ b/includes/discovery/sensors/dbm/exa.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 $ponTable = SnmpQuery::cache()->walk('E7-Calix-MIB::e7OltPonPortTable')->table(3);
 
 foreach ($ponTable as $e7OltPonPortShelf => $ponShelf) {
@@ -12,7 +14,7 @@ foreach ($ponTable as $e7OltPonPortShelf => $ponShelf) {
 
                 app('sensor-discovery')->discover(new \App\Models\Sensor([
                     'poller_type' => 'snmp',
-                    'sensor_class' => 'dbm',
+                    'sensor_class' => SensorEnum::Dbm,
                     'sensor_oid' => ".1.3.6.1.4.1.6321.1.2.2.2.1.6.2.1.7.$index",
                     'sensor_index' => 'tx.' . $index,
                     'sensor_type' => 'exa',
@@ -32,7 +34,7 @@ foreach ($ponTable as $e7OltPonPortShelf => $ponShelf) {
 
                 app('sensor-discovery')->discover(new \App\Models\Sensor([
                     'poller_type' => 'snmp',
-                    'sensor_class' => 'dbm',
+                    'sensor_class' => SensorEnum::Dbm,
                     'sensor_oid' => ".1.3.6.1.4.1.6321.1.2.2.2.1.6.2.1.8.$index",
                     'sensor_index' => 'rx.' . $index,
                     'sensor_type' => 'exa',

--- a/includes/discovery/sensors/dbm/fs-centec.inc.php
+++ b/includes/discovery/sensors/dbm/fs-centec.inc.php
@@ -1,5 +1,6 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
 use LibreNMS\Util\Number;
 
 $powerTables = SnmpQuery::walk('FS-SWITCH-V2-MIB::transReceivePowerTable')->table(1);
@@ -18,7 +19,7 @@ foreach ($powerTables as $ifIndex => $current) {
         foreach (explode(',', (string) $current['FS-SWITCH-V2-MIB::receivepowerCurrent']) as $channel => $value) {
             app('sensor-discovery')->discover(new \App\Models\Sensor([
                 'poller_type' => 'snmp',
-                'sensor_class' => 'dbm',
+                'sensor_class' => SensorEnum::Dbm,
                 'sensor_oid' => ".1.3.6.1.4.1.52642.1.37.1.10.6.1.5.$ifIndex",
                 'sensor_index' => "rx-$ifIndex.$channel",
                 'sensor_type' => 'fs-centec',
@@ -43,7 +44,7 @@ foreach ($powerTables as $ifIndex => $current) {
         foreach (explode(',', (string) $current['FS-SWITCH-V2-MIB::transpowerCurrent']) as $channel => $value) {
             app('sensor-discovery')->discover(new \App\Models\Sensor([
                 'poller_type' => 'snmp',
-                'sensor_class' => 'dbm',
+                'sensor_class' => SensorEnum::Dbm,
                 'sensor_oid' => ".1.3.6.1.4.1.52642.1.37.1.10.5.1.5.$ifIndex",
                 'sensor_index' => "tx-$ifIndex.$channel",
                 'sensor_type' => 'fs-centec',

--- a/includes/discovery/sensors/dbm/fs-nmu.inc.php
+++ b/includes/discovery/sensors/dbm/fs-nmu.inc.php
@@ -74,7 +74,7 @@ if (is_numeric($a1_tx)) {
     $multiplier = '1';
     discover_sensor(
         null,
-        'dbm',
+        $sensor_class,
         $device,
         $oid_a1_tx,
         $index,
@@ -99,7 +99,7 @@ if (is_numeric($a1_rx)) {
     $multiplier = '1';
     discover_sensor(
         null,
-        'dbm',
+        $sensor_class,
         $device,
         $oid_a1_rx,
         $index,
@@ -124,7 +124,7 @@ if (is_numeric($a2_tx)) {
     $multiplier = '1';
     discover_sensor(
         null,
-        'dbm',
+        $sensor_class,
         $device,
         $oid_a2_tx,
         $index,
@@ -149,7 +149,7 @@ if (is_numeric($a2_rx)) {
     $multiplier = '1';
     discover_sensor(
         null,
-        'dbm',
+        $sensor_class,
         $device,
         $oid_a2_rx,
         $index,
@@ -172,7 +172,7 @@ if (is_numeric($b1_tx)) {
     $index = 'vSFPB1TxPower.0';
     discover_sensor(
         null,
-        'dbm',
+        $sensor_class,
         $device,
         $oid_b1_tx,
         $index,
@@ -197,7 +197,7 @@ if (is_numeric($b1_rx)) {
     $multiplier = '1';
     discover_sensor(
         null,
-        'dbm',
+        $sensor_class,
         $device,
         $oid_b1_rx,
         $index,
@@ -222,7 +222,7 @@ if (is_numeric($b2_tx)) {
     $multiplier = '1';
     discover_sensor(
         null,
-        'dbm',
+        $sensor_class,
         $device,
         $oid_b2_tx,
         $index,
@@ -247,7 +247,7 @@ if (is_numeric($b2_rx)) {
     $multiplier = '1';
     discover_sensor(
         null,
-        'dbm',
+        $sensor_class,
         $device,
         $oid_b2_rx,
         $index,
@@ -272,7 +272,7 @@ if (is_numeric($c1_tx)) {
     $multiplier = '1';
     discover_sensor(
         null,
-        'dbm',
+        $sensor_class,
         $device,
         $oid_c1_tx,
         $index,
@@ -297,7 +297,7 @@ if (is_numeric($c1_rx)) {
     $multiplier = '1';
     discover_sensor(
         null,
-        'dbm',
+        $sensor_class,
         $device,
         $oid_c1_rx,
         $index,
@@ -322,7 +322,7 @@ if (is_numeric($c2_tx)) {
     $multiplier = '1';
     discover_sensor(
         null,
-        'dbm',
+        $sensor_class,
         $device,
         $oid_c2_tx,
         $index,
@@ -347,7 +347,7 @@ if (is_numeric($c2_rx)) {
     $multiplier = '1';
     discover_sensor(
         null,
-        'dbm',
+        $sensor_class,
         $device,
         $oid_c2_rx,
         $index,
@@ -370,7 +370,7 @@ if (is_numeric($d1_tx)) {
     $index = 'vSFPD1TxPower.0';
     discover_sensor(
         null,
-        'dbm',
+        $sensor_class,
         $device,
         $oid_d1_tx,
         $index,
@@ -395,7 +395,7 @@ if (is_numeric($d1_rx)) {
     $multiplier = '1';
     discover_sensor(
         null,
-        'dbm',
+        $sensor_class,
         $device,
         $oid_d1_rx,
         $index,
@@ -420,7 +420,7 @@ if (is_numeric($d2_tx)) {
     $multiplier = '1';
     discover_sensor(
         null,
-        'dbm',
+        $sensor_class,
         $device,
         $oid_d2_tx,
         $index,
@@ -445,7 +445,7 @@ if (is_numeric($d2_rx)) {
     $multiplier = '1';
     discover_sensor(
         null,
-        'dbm',
+        $sensor_class,
         $device,
         $oid_d2_rx,
         $index,

--- a/includes/discovery/sensors/dbm/infinera-groove.inc.php
+++ b/includes/discovery/sensors/dbm/infinera-groove.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 /**
  * infinera-groove.inc.php
  *
@@ -31,7 +33,7 @@ foreach ($pre_cache['infineragroove_portTable'] as $index => $data) {
         $descr = $portAlias . ' Port Receive Power';
         $oid = '.1.3.6.1.4.1.42229.1.2.3.6.1.1.4.' . $index;
         $value = $data['portRxOpticalPower'];
-        discover_sensor(null, 'dbm', $device, $oid, 'portRxOpticalPower.' . $index, 'infinera-groove', $descr, $divisor, '1', null, null, null, null, $value, 'snmp', null, null, null, $portAlias, 'GAUGE');
+        discover_sensor(null, SensorEnum::Dbm, $device, $oid, 'portRxOpticalPower.' . $index, 'infinera-groove', $descr, $divisor, '1', null, null, null, null, $value, 'snmp', null, null, null, $portAlias, 'GAUGE');
     }
 
     // Discover Tx Power
@@ -39,6 +41,6 @@ foreach ($pre_cache['infineragroove_portTable'] as $index => $data) {
         $descr = $portAlias . ' Port Transmit Power';
         $oid = '.1.3.6.1.4.1.42229.1.2.3.6.1.1.5.' . $index;
         $value = $data['portTxOpticalPower'];
-        discover_sensor(null, 'dbm', $device, $oid, 'portTxOpticalPower.' . $index, 'infinera-groove', $descr, $divisor, '1', null, null, null, null, $value, 'snmp', null, null, null, $portAlias, 'GAUGE');
+        discover_sensor(null, SensorEnum::Dbm, $device, $oid, 'portTxOpticalPower.' . $index, 'infinera-groove', $descr, $divisor, '1', null, null, null, null, $value, 'snmp', null, null, null, $portAlias, 'GAUGE');
     }
 }

--- a/includes/discovery/sensors/dbm/nokia-1830.inc.php
+++ b/includes/discovery/sensors/dbm/nokia-1830.inc.php
@@ -17,10 +17,11 @@
  * the source code distribution for details.
  **/
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 // *************************************************************
 // ***** dBm Sensors for Nokia PSD
 // *************************************************************
-
 if (str_contains((string) $device['sysObjectID'], '.1.3.6.1.4.1.7483.1.3.1.12')) {
     d_echo('Nokia PSD DDM dBm Sensors\n');
     $ifIndexToName = SnmpQuery::cache()->walk('IF-MIB::ifName')->pluck();
@@ -33,7 +34,7 @@ if (str_contains((string) $device['sysObjectID'], '.1.3.6.1.4.1.7483.1.3.1.12'))
             $divisor = 10;
             app('sensor-discovery')->discover(new \App\Models\Sensor([
                 'poller_type' => 'snmp',
-                'sensor_class' => 'dbm',
+                'sensor_class' => SensorEnum::Dbm,
                 'sensor_oid' => ".1.3.6.1.4.1.7483.2.2.7.3.1.4.1.2.$ifIndex.4",
                 'sensor_index' => "$ifIndex.4",
                 'sensor_type' => 'nokia-1830',
@@ -50,7 +51,7 @@ if (str_contains((string) $device['sysObjectID'], '.1.3.6.1.4.1.7483.1.3.1.12'))
             $divisor = 10;
             app('sensor-discovery')->discover(new \App\Models\Sensor([
                 'poller_type' => 'snmp',
-                'sensor_class' => 'dbm',
+                'sensor_class' => SensorEnum::Dbm,
                 'sensor_oid' => ".1.3.6.1.4.1.7483.2.2.7.3.1.4.1.2.$ifIndex.5",
                 'sensor_index' => "$ifIndex.5",
                 'sensor_type' => 'nokia-1830',

--- a/includes/discovery/sensors/dbm/nokia-isam.inc.php
+++ b/includes/discovery/sensors/dbm/nokia-isam.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 $multiplier = 1;
 $divisor = 1;
 foreach ($pre_cache['nokiaIsamSfpPort'] as $slotId => $slot) {
@@ -14,7 +16,7 @@ foreach ($pre_cache['nokiaIsamSfpPort'] as $slotId => $slot) {
             $limit = $port['sfpDiagRSSIRxPowerAlmHigh'] ?? -3;
             $warn_limit = $port['sfpDiagRSSIRxPowerWarnHigh'] ?? -5;
             $value = $port['sfpDiagRxPower'] / $divisor;
-            discover_sensor(null, 'dbm', $device, $oid, $portName . '-rx', 'nokia-isam', $descr, $divisor, $multiplier, $limit_low, $warn_limit_low, $warn_limit, $limit, $value, 'snmp');
+            discover_sensor(null, SensorEnum::Dbm, $device, $oid, $portName . '-rx', 'nokia-isam', $descr, $divisor, $multiplier, $limit_low, $warn_limit_low, $warn_limit, $limit, $value, 'snmp');
         }
         if (isset($port['sfpDiagTxPower']) && is_numeric($port['sfpDiagTxPower'])) {
             $oid = '.1.3.6.1.4.1.637.61.1.56.5.1.6.' . $slotId . '.' . $portId;
@@ -24,7 +26,7 @@ foreach ($pre_cache['nokiaIsamSfpPort'] as $slotId => $slot) {
             $limit = $port['sfpDiagRSSITxPowerAlmHigh'] ?? -3;
             $warn_limit = $port['sfpDiagRSSITxPowerWarnHigh'] ?? -4;
             $value = $port['sfpDiagTxPower'] / $divisor;
-            discover_sensor(null, 'dbm', $device, $oid, $portName . '-tx', 'nokia-isam', $descr, $divisor, $multiplier, $limit_low, $warn_limit_low, $warn_limit, $limit, $value, 'snmp');
+            discover_sensor(null, SensorEnum::Dbm, $device, $oid, $portName . '-tx', 'nokia-isam', $descr, $divisor, $multiplier, $limit_low, $warn_limit_low, $warn_limit, $limit, $value, 'snmp');
         }
     }
 }

--- a/includes/discovery/sensors/dbm/ocnos.inc.php
+++ b/includes/discovery/sensors/dbm/ocnos.inc.php
@@ -1,5 +1,6 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
 use LibreNMS\OS;
 
 if (empty($os)) {
@@ -21,7 +22,7 @@ if ($os instanceof \LibreNMS\OS\Ocnos) {
                 if (isset($channel_data['IPI-CMM-CHASSIS-MIB::cmmTransTxPowerSupported']) && $channel_data['IPI-CMM-CHASSIS-MIB::cmmTransTxPowerSupported'] == 'supported') {
                     app('sensor-discovery')->discover(new \App\Models\Sensor([
                         'poller_type' => 'snmp',
-                        'sensor_class' => 'dbm',
+                        'sensor_class' => SensorEnum::Dbm,
                         'sensor_oid' => ".1.3.6.1.4.1.36673.100.1.2.3.1.17.$cmmStackUnitIndex.$cmmTransIndex.$cmmTransChannelIndex",
                         'sensor_index' => "tx-$cmmStackUnitIndex.$cmmTransIndex.$cmmTransChannelIndex",
                         'sensor_type' => 'ocnos',
@@ -44,7 +45,7 @@ if ($os instanceof \LibreNMS\OS\Ocnos) {
                 if (isset($channel_data['IPI-CMM-CHASSIS-MIB::cmmTransRxPowerSupported']) && $channel_data['IPI-CMM-CHASSIS-MIB::cmmTransRxPowerSupported'] == 'supported') {
                     app('sensor-discovery')->discover(new \App\Models\Sensor([
                         'poller_type' => 'snmp',
-                        'sensor_class' => 'dbm',
+                        'sensor_class' => SensorEnum::Dbm,
                         'sensor_oid' => ".1.3.6.1.4.1.36673.100.1.2.3.1.22.$cmmStackUnitIndex.$cmmTransIndex.$cmmTransChannelIndex",
                         'sensor_index' => "rx-$cmmStackUnitIndex.$cmmTransIndex.$cmmTransChannelIndex",
                         'sensor_type' => 'ocnos',

--- a/includes/discovery/sensors/dbm/pbn.inc.php
+++ b/includes/discovery/sensors/dbm/pbn.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 /*
  * LibreNMS
  *
@@ -27,7 +29,7 @@ foreach ($pre_cache['pbn_oids'] as $index => $entry) {
         $value = $entry['rxPower'] / $divisor;
         $entPhysicalIndex = $index;
         $entPhysicalIndex_measured = 'ports';
-        discover_sensor(null, 'dbm', $device, $oid, 'rx-' . $index, 'pbn', $descr, $divisor, $multiplier, $limit_low, $warn_limit_low, $warn_limit, $limit, $value, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured);
+        discover_sensor(null, SensorEnum::Dbm, $device, $oid, 'rx-' . $index, 'pbn', $descr, $divisor, $multiplier, $limit_low, $warn_limit_low, $warn_limit, $limit, $value, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured);
     }
 
     if (is_numeric($entry['txPower']) && ($entry['txPower'] !== '-65535')) {
@@ -41,6 +43,6 @@ foreach ($pre_cache['pbn_oids'] as $index => $entry) {
         $value = $entry['txPower'] / $divisor;
         $entPhysicalIndex = $index;
         $entPhysicalIndex_measured = 'ports';
-        discover_sensor(null, 'dbm', $device, $oid, 'tx-' . $index, 'pbn', $descr, $divisor, $multiplier, $limit_low, $warn_limit_low, $warn_limit, $limit, $value, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured);
+        discover_sensor(null, SensorEnum::Dbm, $device, $oid, 'tx-' . $index, 'pbn', $descr, $divisor, $multiplier, $limit_low, $warn_limit_low, $warn_limit, $limit, $value, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured);
     }
 }

--- a/includes/discovery/sensors/dbm/procurve.inc.php
+++ b/includes/discovery/sensors/dbm/procurve.inc.php
@@ -1,5 +1,6 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
 use LibreNMS\Util\Rewrite;
 
 echo 'Procurve ';
@@ -16,7 +17,7 @@ foreach (SnmpQuery::cache()->walk('HP-ICF-TRANSCEIVER-MIB::hpicfXcvrInfoTable')-
         $entPhysicalIndex = $index;
         $entPhysicalIndex_measured = 'ports';
         $descr = Rewrite::shortenIfName($entry['HP-ICF-TRANSCEIVER-MIB::hpicfXcvrPortDesc']) . ' Rx Power';
-        discover_sensor(null, 'dbm', $device, $oid, 'hpicfXcvrRxPower.' . $index, 'procurve', $descr, $divisor, 1, $limit_low, $warn_limit_low, $warn_limit, $limit, $current, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured, group: 'transceiver');
+        discover_sensor(null, SensorEnum::Dbm, $device, $oid, 'hpicfXcvrRxPower.' . $index, 'procurve', $descr, $divisor, 1, $limit_low, $warn_limit_low, $warn_limit, $limit, $current, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured, group: 'transceiver');
     }
 
     if (is_numeric($entry['HP-ICF-TRANSCEIVER-MIB::hpicfXcvrTxPower']) && $entry['HP-ICF-TRANSCEIVER-MIB::hpicfXcvrTxPower'] != -99999999 && isset($entry['HP-ICF-TRANSCEIVER-MIB::hpicfXcvrDiagnosticsUpdate'])) {
@@ -29,6 +30,6 @@ foreach (SnmpQuery::cache()->walk('HP-ICF-TRANSCEIVER-MIB::hpicfXcvrInfoTable')-
         $entPhysicalIndex = $index;
         $entPhysicalIndex_measured = 'ports';
         $descr = Rewrite::shortenIfName($entry['HP-ICF-TRANSCEIVER-MIB::hpicfXcvrPortDesc']) . ' Tx Power';
-        discover_sensor(null, 'dbm', $device, $oid, 'hpicfXcvrTxPower.-' . $index, 'procurve', $descr, $divisor, 1, $limit_low, $warn_limit_low, $warn_limit, $limit, $current, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured, group: 'transceiver');
+        discover_sensor(null, SensorEnum::Dbm, $device, $oid, 'hpicfXcvrTxPower.-' . $index, 'procurve', $descr, $divisor, 1, $limit_low, $warn_limit_low, $warn_limit, $limit, $current, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured, group: 'transceiver');
     }
 }

--- a/includes/discovery/sensors/dbm/raisecom-ros.inc.php
+++ b/includes/discovery/sensors/dbm/raisecom-ros.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 echo 'Raisecom';
 
 $multiplier = 1;
@@ -19,7 +21,7 @@ foreach ($pre_cache['rosMgmtOpticalTransceiverDDMTable'] as $index => $data) {
             $entPhysicalIndex = $index;
             $entPhysicalIndex_measured = 'ports';
             if ($port['ifAdminStatus'] == 'up') {
-                discover_sensor(null, 'dbm', $device, $oid, 'tx-' . $index, $sensor_type, $descr, $divisor, $multiplier, $low_limit, $low_warn_limit, $warn_limit, $high_limit, $current, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured);
+                discover_sensor(null, SensorEnum::Dbm, $device, $oid, 'tx-' . $index, $sensor_type, $descr, $divisor, $multiplier, $low_limit, $low_warn_limit, $warn_limit, $high_limit, $current, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured);
             }
         }
         if (($key == 'rxPower') && is_numeric($value['rosMgmtOpticalTransceiverParameterValue']) && ($value['rosMgmtOpticalTransceiverDDMValidStatus'] != 0)) {
@@ -35,7 +37,7 @@ foreach ($pre_cache['rosMgmtOpticalTransceiverDDMTable'] as $index => $data) {
             $entPhysicalIndex = $index;
             $entPhysicalIndex_measured = 'ports';
             if ($port['ifAdminStatus'] == 'up') {
-                discover_sensor(null, 'dbm', $device, $oid, 'rx-' . $index, $sensor_type, $descr, $divisor, $multiplier, $low_limit, $low_warn_limit, $warn_limit, $high_limit, $current, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured);
+                discover_sensor(null, SensorEnum::Dbm, $device, $oid, 'rx-' . $index, $sensor_type, $descr, $divisor, $multiplier, $low_limit, $low_warn_limit, $warn_limit, $high_limit, $current, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured);
             }
         }
     }

--- a/includes/discovery/sensors/dbm/raisecom.inc.php
+++ b/includes/discovery/sensors/dbm/raisecom.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 echo 'Raisecom';
 
 $multiplier = 1;
@@ -19,7 +21,7 @@ foreach ($pre_cache['raisecomOpticalTransceiverDDMTable'] as $index => $data) {
             $entPhysicalIndex = $index;
             $entPhysicalIndex_measured = 'ports';
             if ($port['ifAdminStatus'] == 'up') {
-                discover_sensor(null, 'dbm', $device, $oid, 'tx-' . $index, $sensor_type, $descr, $divisor, $multiplier, $low_limit, $low_warn_limit, $warn_limit, $high_limit, $current, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured);
+                discover_sensor(null, SensorEnum::Dbm, $device, $oid, 'tx-' . $index, $sensor_type, $descr, $divisor, $multiplier, $low_limit, $low_warn_limit, $warn_limit, $high_limit, $current, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured);
             }
         }
         if (isset($value['raisecomOpticalTransceiverParameterValue'], $value['raisecomOpticalTransceiverDDMValidStatus']) && ($key == 'rxPower') && is_numeric($value['raisecomOpticalTransceiverParameterValue']) && ($value['raisecomOpticalTransceiverDDMValidStatus'] != 0)) {
@@ -35,7 +37,7 @@ foreach ($pre_cache['raisecomOpticalTransceiverDDMTable'] as $index => $data) {
             $entPhysicalIndex = $index;
             $entPhysicalIndex_measured = 'ports';
             if ($port['ifAdminStatus'] == 'up') {
-                discover_sensor(null, 'dbm', $device, $oid, 'rx-' . $index, $sensor_type, $descr, $divisor, $multiplier, $low_limit, $low_warn_limit, $warn_limit, $high_limit, $current, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured);
+                discover_sensor(null, SensorEnum::Dbm, $device, $oid, 'rx-' . $index, $sensor_type, $descr, $divisor, $multiplier, $low_limit, $low_warn_limit, $warn_limit, $high_limit, $current, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured);
             }
         }
     }

--- a/includes/discovery/sensors/dbm/wipipe.inc.php
+++ b/includes/discovery/sensors/dbm/wipipe.inc.php
@@ -29,7 +29,7 @@ foreach ($pre_cache['wipipe_oids'] as $index => $entry) {
         // Discover Sensor
         discover_sensor(
             null,
-            'dbm',
+            $sensor_class,
             $device,
             $oid,
             'mdmSignalStrength.' . $index,

--- a/includes/discovery/sensors/delay/infinera-groove.inc.php
+++ b/includes/discovery/sensors/delay/infinera-groove.inc.php
@@ -31,6 +31,6 @@ foreach ($pre_cache['infineragroove_portTable'] as $index => $data) {
         $oid = '.1.3.6.1.4.1.42229.1.2.4.1.19.1.1.22.' . $index;
         $value = $data['ochOsDGD'];
         $divisor = 1000000000000;
-        discover_sensor(null, 'delay', $device, $oid, 'ochOsOSNR.' . $index, 'infinera-groove', $descr, $divisor, '1', null, null, null, null, $value);
+        discover_sensor(null, \LibreNMS\Enum\Sensor::Delay, $device, $oid, 'ochOsOSNR.' . $index, 'infinera-groove', $descr, $divisor, '1', null, null, null, null, $value);
     }
 }

--- a/includes/discovery/sensors/entity-sensor.inc.php
+++ b/includes/discovery/sensors/entity-sensor.inc.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Str;
+use LibreNMS\Enum\Sensor as SensorEnum;
 
 echo ' ENTITY-SENSOR: ';
 echo 'Caching OIDs:';
@@ -40,15 +41,15 @@ if (! empty($entity_array)) {
 
 if (! empty($entity_oids)) {
     $entitysensor = [
-        'voltsDC' => 'voltage',
-        'voltsAC' => 'voltage',
-        'amperes' => 'current',
-        'watts' => 'power',
-        'hertz' => 'freq',
-        'percentRH' => 'humidity',
-        'rpm' => 'fanspeed',
-        'celsius' => 'temperature',
-        'dBm' => 'dbm',
+        'voltsDC' => SensorEnum::Voltage,
+        'voltsAC' => SensorEnum::Voltage,
+        'amperes' => SensorEnum::Current,
+        'watts' => SensorEnum::Power,
+        'hertz' => SensorEnum::Frequency,
+        'percentRH' => SensorEnum::Humidity,
+        'rpm' => SensorEnum::Fanspeed,
+        'celsius' => SensorEnum::Temperature,
+        'dBm' => SensorEnum::Dbm,
     ];
 
     foreach ($entity_oids as $index => $entry) {
@@ -71,7 +72,7 @@ if (! empty($entity_oids)) {
 
         // Fix for Cisco ASR920, 15.5(2)S
         if ($entry['entPhySensorType'] == 'other' && Str::contains($entity_array[$index]['entPhysicalName'], ['Rx Power Sensor', 'Tx Power Sensor'])) {
-            $entitysensor['other'] = 'dbm';
+            $entitysensor['other'] = SensorEnum::Dbm;
         }
         if (isset($entitysensor[$entry['entPhySensorType']]) && isset($entry['entPhySensorValue']) && is_numeric($entry['entPhySensorValue']) && is_numeric($index)) {
             $entPhysicalIndex = $index;
@@ -137,7 +138,7 @@ if (! empty($entity_oids)) {
             }
 
             $current = ($current * $multiplier / $divisor);
-            if ($type == 'temperature') {
+            if ($type === SensorEnum::Temperature) {
                 if ($current > '200') {
                     $valid_sensor = false;
                 }
@@ -146,13 +147,13 @@ if (! empty($entity_oids)) {
 
             // Fix for FortiSwitch - ALL FortiSwitches as of 14/2/2024 output fan speeds as percentages while entPhySensorType is RPM.
             if ($device['os'] == 'fortiswitch' && $entry['entPhySensorType'] == 'rpm') {
-                $type = 'percent';
+                $type = SensorEnum::Percent;
                 $divisor = 1;
                 $current *= 10;
             }
 
             if ($device['os'] == 'rittal-lcp') {
-                if ($type == 'voltage') {
+                if ($type === SensorEnum::Voltage) {
                     $divisor = 1000;
                 }
                 if ($descr == 'Temperature.Value') {
@@ -161,7 +162,7 @@ if (! empty($entity_oids)) {
                 if ($descr == 'System.Temperature.Value') {
                     $divisor = 1000;
                 }
-                if ($type == 'humidity' && $current == '0') {
+                if ($type === SensorEnum::Humidity && $current == '0') {
                     $valid_sensor = false;
                 }
             }
@@ -177,10 +178,10 @@ if (! empty($entity_oids)) {
                 $valid_sensor = false;
             }
 
-            if ($valid_sensor && dbFetchCell("SELECT COUNT(*) FROM `sensors` WHERE device_id = ? AND `sensor_class` = ? AND `sensor_type` = 'cisco-entity-sensor' AND `sensor_index` = ?", [$device['device_id'], $type, $index]) == '0') {
+            if ($valid_sensor && dbFetchCell("SELECT COUNT(*) FROM `sensors` WHERE device_id = ? AND `sensor_class` = ? AND `sensor_type` = 'cisco-entity-sensor' AND `sensor_index` = ?", [$device['device_id'], $type->value, $index]) == '0') {
                 // Check to make sure we've not already seen this sensor via cisco's entity sensor mib
-                if ($type == 'power' && $device['os'] == 'arista_eos' && preg_match('/DOM (R|T)x Power/i', (string) $descr)) {
-                    $type = 'dbm';
+                if ($type === SensorEnum::Power && $device['os'] == 'arista_eos' && preg_match('/DOM (R|T)x Power/i', (string) $descr)) {
+                    $type = SensorEnum::Dbm;
                     $current = round(10 * log10($entry['entPhySensorValue'] / 10000), 3);
                     $multiplier = 1;
                     $divisor = 1;

--- a/includes/discovery/sensors/fanspeed/apc.inc.php
+++ b/includes/discovery/sensors/fanspeed/apc.inc.php
@@ -29,6 +29,6 @@ foreach ($pre_cache['cooling_unit_analog'] as $index => $data) {
     $scale = $data['coolingUnitStatusAnalogScale'] ?? null;
     $value = $data['coolingUnitStatusAnalogValue'] ?? null;
     if (preg_match('/Fan Speed/', (string) $descr) && $data['coolingUnitStatusAnalogUnits'] == '%' && $value >= 0) {
-        discover_sensor(null, 'fanspeed', $device, $cur_oid, $cur_oid, 'apc', $descr, $scale, 1, null, null, null, null, $value);
+        discover_sensor(null, \LibreNMS\Enum\Sensor::Fanspeed, $device, $cur_oid, $cur_oid, 'apc', $descr, $scale, 1, null, null, null, null, $value);
     }
 }

--- a/includes/discovery/sensors/fanspeed/areca.inc.php
+++ b/includes/discovery/sensors/fanspeed/areca.inc.php
@@ -16,6 +16,6 @@ foreach (explode("\n", (string) $oids) as $data) {
         $oid = '.1.3.6.1.4.1.18928.1.2.2.1.9.1.3.' . $index;
         $current = snmp_get($device, $oid, '-Oqv', '');
 
-        discover_sensor(null, 'fanspeed', $device, $oid, $index, 'areca', trim($descr, '"'), '1', '1', null, null, null, null, $current);
+        discover_sensor(null, \LibreNMS\Enum\Sensor::Fanspeed, $device, $oid, $index, 'areca', trim($descr, '"'), '1', '1', null, null, null, null, $current);
     }
 }

--- a/includes/discovery/sensors/fanspeed/benuos.inc.php
+++ b/includes/discovery/sensors/fanspeed/benuos.inc.php
@@ -14,6 +14,6 @@ for ($index = 4; $index <= 9; $index++) { //Benu Fans are index 4 thru 9
     $sensor_oid = ".1.3.6.1.4.1.39406.1.1.1.4.1.1.5.1.$index";
     $descr = $data["1.$index"]['benuSensorName'] ?? null;
     $current = $data["1.$index"]['benuSensorValue'] ?? null;
-    discover_sensor(null, 'fanspeed', $device, $sensor_oid, $sensor_index, 'benuos', $descr, '1', '1', null, null, null, null, $current);
+    discover_sensor(null, \LibreNMS\Enum\Sensor::Fanspeed, $device, $sensor_oid, $sensor_index, 'benuos', $descr, '1', '1', null, null, null, null, $current);
     $sensor_index++;
 }//end loop

--- a/includes/discovery/sensors/fanspeed/dell.inc.php
+++ b/includes/discovery/sensors/fanspeed/dell.inc.php
@@ -23,7 +23,7 @@ if (is_array($temp)) {
         (isset($temp[$index]['coolingDeviceUpperNonCriticalThreshold'])) ? $warnlimit = $temp[$index]['coolingDeviceUpperNonCriticalThreshold'] : $warnlimit = null;
         (isset($temp[$index]['coolingDeviceUpperCriticalThreshold'])) ? $limit = $temp[$index]['coolingDeviceUpperCriticalThreshold'] : $limit = null;
 
-        discover_sensor(null, 'fanspeed', $device, $cur_oid . $index, $index, 'dell', $descr, '0', '1', $lowlimit, $low_warn_limit, $warnlimit, $limit, $value, 'snmp', $index);
+        discover_sensor(null, \LibreNMS\Enum\Sensor::Fanspeed, $device, $cur_oid . $index, $index, 'dell', $descr, '0', '1', $lowlimit, $low_warn_limit, $warnlimit, $limit, $value, 'snmp', $index);
 
         unset(
             $descr,

--- a/includes/discovery/sensors/fanspeed/edgecos.inc.php
+++ b/includes/discovery/sensors/fanspeed/edgecos.inc.php
@@ -23,4 +23,4 @@
  * @copyright  2026 Frederik Kriewitz
  * @author     Frederik Kriewitz <frederik@kriewitz.eu>
  */
-$os->discoverFanSensors(['fanspeed']);
+$os->discoverFanSensors([\LibreNMS\Enum\Sensor::Fanspeed]);

--- a/includes/discovery/sensors/fanspeed/eltex-olt.inc.php
+++ b/includes/discovery/sensors/fanspeed/eltex-olt.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 /**
  * eltex-olt.inc.php
  *
@@ -36,7 +38,7 @@ if (isset($tmp_eltex['.1.3.6.1.4.1.35265.1.22.1.10.6.0'])) {
         $descr = 'Fan 0';
         $divisor = 1;
         $fanspeed = $tmp_eltex[$oid];
-        discover_sensor(null, 'fanspeed', $device, $oid, $index, $type, $descr, $divisor, '1', $min_eltex, null, null, $max_eltex, $fanspeed);
+        discover_sensor(null, SensorEnum::Fanspeed, $device, $oid, $index, $type, $descr, $divisor, '1', $min_eltex, null, null, $max_eltex, $fanspeed);
     }
 }
 
@@ -48,7 +50,7 @@ if (isset($tmp_eltex['.1.3.6.1.4.1.35265.1.22.1.10.8.0'])) {
         $descr = 'Fan 1';
         $divisor = 1;
         $fanspeed = $tmp_eltex[$oid];
-        discover_sensor(null, 'fanspeed', $device, $oid, $index, $type, $descr, $divisor, '1', $min_eltex, null, null, $max_eltex, $fanspeed);
+        discover_sensor(null, SensorEnum::Fanspeed, $device, $oid, $index, $type, $descr, $divisor, '1', $min_eltex, null, null, $max_eltex, $fanspeed);
     }
 }
 

--- a/includes/discovery/sensors/fanspeed/equallogic.inc.php
+++ b/includes/discovery/sensors/fanspeed/equallogic.inc.php
@@ -33,7 +33,7 @@ if (! empty($oids)) {
             $index = (100 + $index);
 
             if ($extra[$keys[0]]['eqlMemberHealthDetailsFanCurrentState'] != 'unknown') {
-                discover_sensor(null, 'fanspeed', $device, $oid, $index, 'snmp', $descr, 1, 1, $low_limit, $low_warn, $high_limit, $high_warn, $temperature);
+                discover_sensor(null, \LibreNMS\Enum\Sensor::Fanspeed, $device, $oid, $index, 'snmp', $descr, 1, 1, $low_limit, $low_warn, $high_limit, $high_warn, $temperature);
             }
         }//end if
     }//end foreach

--- a/includes/discovery/sensors/fanspeed/f5.inc.php
+++ b/includes/discovery/sensors/fanspeed/f5.inc.php
@@ -20,7 +20,7 @@ if ($oids) {
             $oid = '.1.3.6.1.4.1.3375.2.1.3.2.1.2.1.3.' . $index;
             $fanspeed /= $divisor;
             if ($fanspeed >= 0) {
-                discover_sensor(null, 'fanspeed', $device, $oid, $index, $type, $descr, $divisor, '1', null, null, null, null, $fanspeed);
+                discover_sensor(null, \LibreNMS\Enum\Sensor::Fanspeed, $device, $oid, $index, $type, $descr, $divisor, '1', null, null, null, null, $fanspeed);
             }
         }
     }

--- a/includes/discovery/sensors/fanspeed/nos.inc.php
+++ b/includes/discovery/sensors/fanspeed/nos.inc.php
@@ -27,7 +27,7 @@ if ($oids = snmp_walk($device, '.1.3.6.1.4.1.1588.2.1.1.1.1.22.1.2', '-Osqn')) {
             if (! strstr($descr, 'No') and ! strstr($value, 'No')) {
                 $descr = str_replace('"', '', $descr);
                 $descr = trim($descr);
-                discover_sensor(null, 'fanspeed', $device, $value_oid, $oididx, 'nos', $descr, '1', '1', null, null, '80', '100', $value);
+                discover_sensor(null, \LibreNMS\Enum\Sensor::Fanspeed, $device, $value_oid, $oididx, 'nos', $descr, '1', '1', null, null, '80', '100', $value);
             }
         }
     }

--- a/includes/discovery/sensors/fanspeed/onefs.inc.php
+++ b/includes/discovery/sensors/fanspeed/onefs.inc.php
@@ -31,7 +31,7 @@ foreach ($oids as $index => $entry) {
         $descr = $entry['fanDescription'];
         $oid = '.1.3.6.1.4.1.12124.2.53.1.4.' . $index;
         $current = $entry['fanSpeed'];
-        discover_sensor(null, 'fanspeed', $device, $oid, $index, 'onefs', $descr, '1', '1', 0, 0, 5000, 9000, $current);
+        discover_sensor(null, \LibreNMS\Enum\Sensor::Fanspeed, $device, $oid, $index, 'onefs', $descr, '1', '1', 0, 0, 5000, 9000, $current);
     }
 }
 

--- a/includes/discovery/sensors/fanspeed/quanta.inc.php
+++ b/includes/discovery/sensors/fanspeed/quanta.inc.php
@@ -23,6 +23,6 @@ foreach ($sensors_values as $index => $entry) {
     $descr = "Fan Speed $index:";
 
     if ($current_value > 0) {
-        discover_sensor(null, 'fanspeed', $device, "$numeric_oid_base.$index", $index, $sensor_type, $descr, 1, 1, null, null, null, null, $current_value);
+        discover_sensor(null, \LibreNMS\Enum\Sensor::Fanspeed, $device, "$numeric_oid_base.$index", $index, $sensor_type, $descr, 1, 1, null, null, null, null, $current_value);
     }
 }

--- a/includes/discovery/sensors/fanspeed/sgos.inc.php
+++ b/includes/discovery/sensors/fanspeed/sgos.inc.php
@@ -12,7 +12,7 @@ for ($index = 21; $index < 39; $index++) { //Proxy SG Fan OID end in 21-38
         $descr = snmp_get($device, $descr_oid, '-Oqv', 'BLUECOAT-SG-SENSOR-MIB');
         $current = snmp_get($device, $fan_oid, '-Oqv', 'BLUECOAT-SG-SENSOR-MIB');
         $divisor = '1';
-        discover_sensor(null, 'fanspeed', $device, $fan_oid, $fan_index, 'sgos', $descr, 1, '1', null, null, null, null, $current);
+        discover_sensor(null, \LibreNMS\Enum\Sensor::Fanspeed, $device, $fan_oid, $fan_index, 'sgos', $descr, 1, '1', null, null, null, null, $current);
     }
     $fan_index++;
 }//end for

--- a/includes/discovery/sensors/fanspeed/supermicro.inc.php
+++ b/includes/discovery/sensors/fanspeed/supermicro.inc.php
@@ -30,7 +30,7 @@ foreach (explode("\n", $oids) as $data) {
             $descr = str_replace(' Fan Speed', '', $descr);
             $descr = str_replace(' Speed', '', $descr);
             if ($monitor == 'true') {
-                discover_sensor(null, 'fanspeed', $device, $fan_oid, $index, 'supermicro', $descr, $divisor, '1', $low_limit, null, null, null, $current);
+                discover_sensor(null, \LibreNMS\Enum\Sensor::Fanspeed, $device, $fan_oid, $index, 'supermicro', $descr, $divisor, '1', $low_limit, null, null, null, $current);
             }
         }
     }//end if

--- a/includes/discovery/sensors/fanspeed/unix.inc.php
+++ b/includes/discovery/sensors/fanspeed/unix.inc.php
@@ -41,7 +41,7 @@ if (! empty($snmpData)) {
         $value = intval($lmData[$type . 'Value']) / $divisor;
         if (! empty($descr)) {
             $oid = Oid::of('LM-SENSORS-MIB::' . $type . 'Value.' . $index)->toNumeric();
-            discover_sensor(null, 'fanspeed', $device, $oid, $index, 'lmsensors', $descr, $divisor, 1, null, null, null, null, $value, 'snmp', null, null, null, 'lmsensors');
+            discover_sensor(null, \LibreNMS\Enum\Sensor::Fanspeed, $device, $oid, $index, 'lmsensors', $descr, $divisor, 1, null, null, null, null, $value, 'snmp', null, null, null, 'lmsensors');
         }
     }
 }

--- a/includes/discovery/sensors/frequency/apc.inc.php
+++ b/includes/discovery/sensors/frequency/apc.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 $oids = snmp_walk($device, '.1.3.6.1.4.1.318.1.1.8.5.3.2.1.4', '-OsqnU', '');
 d_echo($oids . "\n");
 
@@ -17,7 +19,7 @@ foreach (explode("\n", (string) $oids) as $data) {
         $index = $split_oid[count($split_oid) - 1];
         $oid = '.1.3.6.1.4.1.318.1.1.8.5.3.2.1.4.' . $index;
         $descr = 'Input Feed ' . chr(64 + $index);
-        discover_sensor(null, 'frequency', $device, $oid, "3.2.1.4.$index", $type, $descr, $divisor, '1', null, null, null, null, $current);
+        discover_sensor(null, SensorEnum::Frequency, $device, $oid, "3.2.1.4.$index", $type, $descr, $divisor, '1', null, null, null, null, $current);
     }
 }
 
@@ -42,7 +44,7 @@ foreach (explode("\n", (string) $oids) as $data) {
             $descr .= " $index";
         }
 
-        discover_sensor(null, 'frequency', $device, $oid, "4.2.1.4.$index", $type, $descr, $divisor, '1', null, null, null, null, $current);
+        discover_sensor(null, SensorEnum::Frequency, $device, $oid, "4.2.1.4.$index", $type, $descr, $divisor, '1', null, null, null, null, $current);
     }
 }
 
@@ -65,7 +67,7 @@ if ($oids) {
     [$oid,$current] = explode(' ', $oids);
     $type = 'apc';
     $descr = 'Input';
-    discover_sensor(null, 'frequency', $device, $oid, $index, $type, $descr, $divisor, '1', null, null, null, null, $current / $divisor);
+    discover_sensor(null, SensorEnum::Frequency, $device, $oid, $index, $type, $descr, $divisor, '1', null, null, null, null, $current / $divisor);
 }
 
 // upsHighPrecOutputFrequency
@@ -87,5 +89,5 @@ if ($oids) {
     [$oid,$current] = explode(' ', $oids);
     $type = 'apc';
     $descr = 'Output';
-    discover_sensor(null, 'frequency', $device, $oid, $index, $type, $descr, $divisor, '1', null, null, null, null, $current / $divisor);
+    discover_sensor(null, SensorEnum::Frequency, $device, $oid, $index, $type, $descr, $divisor, '1', null, null, null, null, $current / $divisor);
 }

--- a/includes/discovery/sensors/frequency/eaton-ats.inc.php
+++ b/includes/discovery/sensors/frequency/eaton-ats.inc.php
@@ -32,5 +32,5 @@ foreach ($oids as $volt_id => $data) {
     $divisor = 10;
     $current = $data['ats2InputFrequency'] / $divisor;
 
-    discover_sensor(null, 'frequency', $device, $volt_oid, $index, $type, $descr, $divisor, '1', null, null, null, null, $current);
+    discover_sensor(null, \LibreNMS\Enum\Sensor::Frequency, $device, $volt_oid, $index, $type, $descr, $divisor, '1', null, null, null, null, $current);
 }

--- a/includes/discovery/sensors/frequency/ipoman.inc.php
+++ b/includes/discovery/sensors/frequency/ipoman.inc.php
@@ -27,7 +27,7 @@ foreach ($oidsFreqIn as $index => $entry) {
     // FIXME: iPoMan 1201 also says it has 2 inlets, at least until firmware 1.06 - wtf?
     app('sensor-discovery')->discover(new \App\Models\Sensor([
         'poller_type' => 'snmp',
-        'sensor_class' => 'frequency',
+        'sensor_class' => \LibreNMS\Enum\Sensor::Frequency,
         'sensor_oid' => $oid,
         'sensor_index' => $index,
         'sensor_type' => 'ipoman',

--- a/includes/discovery/sensors/frequency/linux.inc.php
+++ b/includes/discovery/sensors/frequency/linux.inc.php
@@ -19,7 +19,7 @@ if (! empty($pre_cache['raspberry_pi_sensors'])) {
         }
         $value = current($pre_cache['raspberry_pi_sensors']['raspberry.' . $freq]);
         if (is_numeric($value)) {
-            discover_sensor(null, 'frequency', $device, $oid . $freq, $freq, $sensor_type, $descr, 1, 1, null, null, null, null, $value);
+            discover_sensor(null, \LibreNMS\Enum\Sensor::Frequency, $device, $oid . $freq, $freq, $sensor_type, $descr, 1, 1, null, null, null, null, $value);
         } else {
             break;
         }

--- a/includes/discovery/sensors/frequency/mgeups.inc.php
+++ b/includes/discovery/sensors/frequency/mgeups.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 echo 'MGE ';
 $oids = trim((string) snmp_walk($device, '.1.3.6.1.4.1.705.1.7.1', '-OsqnU'));
 d_echo($oids . "\n");
@@ -22,7 +24,7 @@ for ($i = 1; $i <= $numPhase; $i++) {
     $type = 'mge-ups';
     $divisor = 10;
     $index = $i;
-    discover_sensor(null, 'frequency', $device, $freq_oid, $index, $type, $descr, $divisor, '1', null, null, null, null, $current);
+    discover_sensor(null, SensorEnum::Frequency, $device, $freq_oid, $index, $type, $descr, $divisor, '1', null, null, null, null, $current);
 }
 
 $oids = trim((string) snmp_walk($device, '.1.3.6.1.4.1.705.1.6.1', '-OsqnU'));
@@ -46,5 +48,5 @@ for ($i = 1; $i <= $numPhase; $i++) {
     $type = 'mge-ups';
     $divisor = 10;
     $index = (100 + $i);
-    discover_sensor(null, 'frequency', $device, $freq_oid, $index, $type, $descr, $divisor, '1', null, null, null, null, $current);
+    discover_sensor(null, SensorEnum::Frequency, $device, $freq_oid, $index, $type, $descr, $divisor, '1', null, null, null, null, $current);
 }

--- a/includes/discovery/sensors/frequency/netagent2.inc.php
+++ b/includes/discovery/sensors/frequency/netagent2.inc.php
@@ -53,7 +53,7 @@ if ($in_phaseNum == '1') {
 
         discover_sensor(
             null,
-            'frequency',
+            $sensor_class,
             $device,
             $in_frequency_oid,
             $index,
@@ -85,7 +85,7 @@ if ($in_phaseNum == '1') {
 
         discover_sensor(
             null,
-            'frequency',
+            $sensor_class,
             $device,
             $out_frequency_oid,
             $index,
@@ -121,7 +121,7 @@ if ($in_phaseNum == '3') {
 
         discover_sensor(
             null,
-            'frequency',
+            $sensor_class,
             $device,
             $in_frequency_oid,
             $index,
@@ -153,7 +153,7 @@ if ($in_phaseNum == '3') {
 
         discover_sensor(
             null,
-            'frequency',
+            $sensor_class,
             $device,
             $in_frequency_oid,
             $index,
@@ -185,7 +185,7 @@ if ($in_phaseNum == '3') {
 
         discover_sensor(
             null,
-            'frequency',
+            $sensor_class,
             $device,
             $in_frequency_oid,
             $index,

--- a/includes/discovery/sensors/frequency/rfc1628.inc.php
+++ b/includes/discovery/sensors/frequency/rfc1628.inc.php
@@ -8,7 +8,7 @@ echo 'RFC1628 ';
 $input_freq = snmpwalk_group($device, 'upsInputFrequency', 'UPS-MIB');
 foreach ($input_freq as $index => $data) {
     $freq_oid = ".1.3.6.1.2.1.33.1.3.3.1.2.$index";
-    $divisor = get_device_divisor($device, $pre_cache['poweralert_serial'] ?? '', 'frequency', $freq_oid);
+    $divisor = get_device_divisor($device, $pre_cache['poweralert_serial'] ?? '', $sensor_class, $freq_oid);
     $descr = 'Input';
     if (count($input_freq) > 1) {
         $descr .= " Phase $index";
@@ -27,7 +27,7 @@ foreach ($input_freq as $index => $data) {
 
     discover_sensor(
         null,
-        'frequency',
+        $sensor_class,
         $device,
         $freq_oid,
         "3.2.0.$index",
@@ -46,11 +46,11 @@ foreach ($input_freq as $index => $data) {
 $output_freq = snmp_get($device, 'upsOutputFrequency.0', '-OqvU', 'UPS-MIB');
 if (is_numeric($output_freq)) {
     $freq_oid = '.1.3.6.1.2.1.33.1.4.2.0';
-    $divisor = get_device_divisor($device, $pre_cache['poweralert_serial'] ?? '', 'frequency', $freq_oid);
+    $divisor = get_device_divisor($device, $pre_cache['poweralert_serial'] ?? '', $sensor_class, $freq_oid);
 
     discover_sensor(
         null,
-        'frequency',
+        $sensor_class,
         $device,
         $freq_oid,
         '4.2.0',
@@ -69,11 +69,11 @@ if (is_numeric($output_freq)) {
 $bypass_freq = snmp_get($device, 'upsBypassFrequency.0', '-OqvU', 'UPS-MIB');
 if (is_numeric($bypass_freq)) {
     $freq_oid = '.1.3.6.1.2.1.33.1.5.1.0';
-    $divisor = get_device_divisor($device, $pre_cache['poweralert_serial'] ?? '', 'frequency', $freq_oid);
+    $divisor = get_device_divisor($device, $pre_cache['poweralert_serial'] ?? '', $sensor_class, $freq_oid);
 
     discover_sensor(
         null,
-        'frequency',
+        $sensor_class,
         $device,
         $freq_oid,
         '5.1.0',

--- a/includes/discovery/sensors/frequency/rs.inc.php
+++ b/includes/discovery/sensors/frequency/rs.inc.php
@@ -11,6 +11,6 @@ foreach ($oids as $id => $data) {
     $descr = (count($oids) > 1) ? 'Frequency ' . $id : 'Frequency';
     $type = 'rs';
     $current = $data['cmdExcFrequency'];
-    discover_sensor(null, 'frequency', $device, $num_oid, $index, $type, $descr, '1', '1', null, null, null, null, $current);
+    discover_sensor(null, \LibreNMS\Enum\Sensor::Frequency, $device, $num_oid, $index, $type, $descr, '1', '1', null, null, null, null, $current);
     $count++;
 }

--- a/includes/discovery/sensors/gw-eydfa.inc.php
+++ b/includes/discovery/sensors/gw-eydfa.inc.php
@@ -25,6 +25,7 @@
  */
 
 use Illuminate\Support\Facades\Log;
+use LibreNMS\Enum\Sensor as SensorEnum;
 
 $oids = snmp_walk($device, 'oaPumpTable', '-Osq', 'NSCRTV-HFCEMS-OPTICALAMPLIFIER-MIB');
 Log::debug($oids);
@@ -50,7 +51,7 @@ foreach (explode("\n", (string) $oids) as $data) {
             $high_warn = snmp_get($device, 'analogAlarmHI.13' . $num_oid, '-Ovq', 'NSCRTV-HFCEMS-PROPERTY-MIB') / $divisor;
             $high_limit = snmp_get($device, 'analogAlarmHIHI.13' . $num_oid, '-Ovq', 'NSCRTV-HFCEMS-PROPERTY-MIB') / $divisor;
         }
-        discover_sensor(null, 'current', $device, $num_oid, $sensor_index, 'gw-eydfa', $descr, $divisor, 1, $low_limit, $low_warn, $high_warn, $high_limit, $value);
+        discover_sensor(null, SensorEnum::Current, $device, $num_oid, $sensor_index, 'gw-eydfa', $descr, $divisor, 1, $low_limit, $low_warn, $high_warn, $high_limit, $value);
     }
     if ($split_oid[0] == 'oaPumpTEC' && $index == 1) { // Current - A
         $divisor = 100;
@@ -64,7 +65,7 @@ foreach (explode("\n", (string) $oids) as $data) {
             $high_limit = snmp_get($device, 'analogAlarmHIHI.13' . $num_oid, '-Ovq', 'NSCRTV-HFCEMS-PROPERTY-MIB') / $divisor;
         }
         $sensor_index = 'oaPumpTEC' . $index;
-        discover_sensor(null, 'current', $device, $num_oid, $sensor_index, 'gw-eydfa', $descr, $divisor, 1, $low_limit, $low_warn, $high_warn, $high_limit, $value);
+        discover_sensor(null, SensorEnum::Current, $device, $num_oid, $sensor_index, 'gw-eydfa', $descr, $divisor, 1, $low_limit, $low_warn, $high_warn, $high_limit, $value);
     }
     if ($split_oid[0] == 'oaPumpTemp' && $index == 1) { // Temperature - C
         $divisor = 10;
@@ -78,7 +79,7 @@ foreach (explode("\n", (string) $oids) as $data) {
             $high_limit = snmp_get($device, 'analogAlarmHIHI.13' . $num_oid, '-Ovq', 'NSCRTV-HFCEMS-PROPERTY-MIB') / $divisor;
         }
         $sensor_index = 'oaPumpTemp' . $index;
-        discover_sensor(null, 'temperature', $device, $num_oid, $sensor_index, 'gw-eydfa', $descr, $divisor, 1, $low_limit, $low_warn, $high_warn, $high_limit, $value);
+        discover_sensor(null, SensorEnum::Temperature, $device, $num_oid, $sensor_index, 'gw-eydfa', $descr, $divisor, 1, $low_limit, $low_warn, $high_warn, $high_limit, $value);
     }
     unset($oids, $split_oid, $index, $divisor, $descr, $low_limit, $low_warn, $high_warn, $sensor_index);
 }
@@ -107,7 +108,7 @@ foreach (explode("\n", $oids) as $data) {
         }
         $sensor_index = 'oaDCPowerVoltage' . $index;
         $value /= $divisor;
-        discover_sensor(null, 'voltage', $device, $num_oid, $sensor_index, 'gw-eydfa', $descr, $divisor, 1, $low_limit, $low_warn, $high_warn, $high_limit, $value);
+        discover_sensor(null, SensorEnum::Voltage, $device, $num_oid, $sensor_index, 'gw-eydfa', $descr, $divisor, 1, $low_limit, $low_warn, $high_warn, $high_limit, $value);
     }
 }
 
@@ -127,7 +128,7 @@ if (is_numeric($value)) {
     $high_limit = snmp_get($device, 'analogAlarmHIHI.12.1.3.6.1.4.1.17409.1.3.1.13.0', '-Ovq', 'NSCRTV-HFCEMS-PROPERTY-MIB');
 }
 $sensor_index = 'commonDeviceInternalTemperature.1';
-discover_sensor(null, 'temperature', $device, $num_oid, $sensor_index, 'gw-eydfa', $descr, 1, 1, $low_limit, $low_warn, $high_warn, $high_limit, $value);
+discover_sensor(null, SensorEnum::Temperature, $device, $num_oid, $sensor_index, 'gw-eydfa', $descr, 1, 1, $low_limit, $low_warn, $high_warn, $high_limit, $value);
 
 unset($num_oid, $value, $descr, $low_limit, $low_warn, $high_warn, $sensor_index);
 
@@ -147,7 +148,7 @@ if (is_numeric($value)) {
 }
 $value /= $divisor;
 $sensor_index = 'oaOutputOpticalPower.0';
-discover_sensor(null, 'dbm', $device, $num_oid, $sensor_index, 'gw-eydfa', $descr, $divisor, 1, $low_limit, $low_warn, $high_warn, $high_limit, $value);
+discover_sensor(null, SensorEnum::Dbm, $device, $num_oid, $sensor_index, 'gw-eydfa', $descr, $divisor, 1, $low_limit, $low_warn, $high_warn, $high_limit, $value);
 
 unset($num_oid, $value, $divisor, $descr, $low_limit, $low_warn, $high_warn, $sensor_index);
 
@@ -167,7 +168,7 @@ if (is_numeric($value)) {
 }
 $value /= $divisor;
 $sensor_index = 'oaInputOpticalPower.0';
-discover_sensor(null, 'dbm', $device, $num_oid, $sensor_index, 'gw-eydfa', $descr, $divisor, 1, $low_limit, $low_warn, $high_warn, $high_limit, $value);
+discover_sensor(null, SensorEnum::Dbm, $device, $num_oid, $sensor_index, 'gw-eydfa', $descr, $divisor, 1, $low_limit, $low_warn, $high_warn, $high_limit, $value);
 
 unset($num_oid, $value, $divisor, $descr, $low_limit, $low_warn, $high_warn, $sensor_index);
 
@@ -189,6 +190,6 @@ foreach ($oids as $oid) {
     $value = snmp_get($device, $oid, '-Ovq', 'NSCRTV-HFCEMS-PROPERTY-MIB');
     $descr = 'Power Supply ' . $n;
     $sensor_index = 'PowerSupplyState' . $n;
-    discover_sensor(null, 'state', $device, $oid, $sensor_index, $state_name, $descr, 1, 1, null, null, null, null, $value, 'snmp');
+    discover_sensor(null, SensorEnum::State, $device, $oid, $sensor_index, $state_name, $descr, 1, 1, null, null, null, null, $value, 'snmp');
     $n++;
 }

--- a/includes/discovery/sensors/humidity/aos-emu2.inc.php
+++ b/includes/discovery/sensors/humidity/aos-emu2.inc.php
@@ -43,7 +43,7 @@ foreach ($oids as $temp) {
 
         app('sensor-discovery')->discover(new \App\Models\Sensor([
             'poller_type' => 'snmp',
-            'sensor_class' => 'humidity',
+            'sensor_class' => \LibreNMS\Enum\Sensor::Humidity,
             'sensor_oid' => $oid,
             'sensor_index' => $index,
             'sensor_type' => 'aos-emu2',

--- a/includes/discovery/sensors/humidity/apc.inc.php
+++ b/includes/discovery/sensors/humidity/apc.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 // Environmental monitoring on UPSes etc
 // FIXME emConfigProbesTable may also be used? But not filled out on my device...
 $apc_env_data = snmpwalk_cache_oid($device, 'uioSensor', [], 'PowerNet-MIB', null, '-OQUse');
@@ -27,7 +29,7 @@ if ($apc_env_data) {
             if (count($split_index) == 2 && $split_index[1] == 1) {
                 $index = $split_index[0];
             }
-            discover_sensor(null, 'humidity', $device, $oid, $index, $sensorType, $descr, '1', '1', $low_limit, $low_warn_limit, $high_warn_limit, $high_limit, $current);
+            discover_sensor(null, SensorEnum::Humidity, $device, $oid, $index, $sensorType, $descr, '1', '1', $low_limit, $low_warn_limit, $high_warn_limit, $high_limit, $current);
         }
     }
 } else {
@@ -47,7 +49,7 @@ if ($apc_env_data) {
 
         if ($current > 0) {
             // Humidity = 0 -> Sensor not available
-            discover_sensor(null, 'humidity', $device, $oid, $index, $sensorType, $descr, '1', '1', $low_limit, $low_warn_limit, $high_warn_limit, $high_limit, $current);
+            discover_sensor(null, SensorEnum::Humidity, $device, $oid, $index, $sensorType, $descr, '1', '1', $low_limit, $low_warn_limit, $high_warn_limit, $high_limit, $current);
         }
     }
 }
@@ -66,7 +68,7 @@ foreach (array_keys($apc_env_data) as $index) {
         $high_limit = $apc_env_data[$index]['emsProbeStatusProbeMaxHumidityThresh'];
 
         if ($current > 0) {
-            discover_sensor(null, 'humidity', $device, $oid, $index, $sensorType, $descr, '1', '1', $low_limit, $low_warn_limit, $high_warn_limit, $high_limit, $current);
+            discover_sensor(null, SensorEnum::Humidity, $device, $oid, $index, $sensorType, $descr, '1', '1', $low_limit, $low_warn_limit, $high_warn_limit, $high_limit, $current);
         }
     }
 }
@@ -78,6 +80,6 @@ foreach ($pre_cache['mem_sensors_status'] as $index => $data) {
     $multiplier = 1;
     $value = $data['memSensorsHumidity'];
     if (is_numeric($value)) {
-        discover_sensor(null, 'humidity', $device, $cur_oid, 'memSensorsHumidity.' . $index, 'apc', $descr, $divisor, $multiplier, null, null, null, null, $value);
+        discover_sensor(null, SensorEnum::Humidity, $device, $cur_oid, 'memSensorsHumidity.' . $index, 'apc', $descr, $divisor, $multiplier, null, null, null, null, $value);
     }
 }

--- a/includes/discovery/sensors/humidity/geist-watchdog.inc.php
+++ b/includes/discovery/sensors/humidity/geist-watchdog.inc.php
@@ -30,5 +30,5 @@ $value = Number::cast(SnmpQuery::get('GEIST-MIB-V3::climateHumidity')->value());
 if ($value) {
     $current_oid = '.1.3.6.1.4.1.21239.2.2.1.7.1';
     $descr = 'Humidity';
-    discover_sensor(null, 'humidity', $device, $current_oid, 'climateHumidity', 'geist-watchdog', $descr, 1, 1, null, null, null, null, $value);
+    discover_sensor(null, \LibreNMS\Enum\Sensor::Humidity, $device, $current_oid, 'climateHumidity', 'geist-watchdog', $descr, 1, 1, null, null, null, null, $value);
 }

--- a/includes/discovery/sensors/humidity/ipoman.inc.php
+++ b/includes/discovery/sensors/humidity/ipoman.inc.php
@@ -23,7 +23,7 @@ if ($oidsEnv[0]['ipmEnvEmdStatusEmdType'] == 'eMD-HT') {
 
         app('sensor-discovery')->discover(new \App\Models\Sensor([
             'poller_type' => 'snmp',
-            'sensor_class' => 'humidity',
+            'sensor_class' => \LibreNMS\Enum\Sensor::Humidity,
             'sensor_oid' => $oid,
             'sensor_index' => 1,
             'sensor_type' => 'ipoman',

--- a/includes/discovery/sensors/humidity/liebert.inc.php
+++ b/includes/discovery/sensors/humidity/liebert.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 /**
  * liebert.inc.php
  *
@@ -44,7 +46,7 @@ foreach ($lib_data as $index => $data) {
 
     if (is_numeric($current)) {
         $descr = $data['lgpEnvHumidityDescrRel'];
-        discover_sensor(null, 'humidity', $device, $oid, $new_index, 'liebert', $descr, $divisor, 1, $low_limit, null, null, $high_limit, $current / $divisor);
+        discover_sensor(null, SensorEnum::Humidity, $device, $oid, $new_index, 'liebert', $descr, $divisor, 1, $low_limit, null, null, $high_limit, $current / $divisor);
     }
 }
 
@@ -64,7 +66,7 @@ if (is_numeric($return_humidity)) {
     $oid = '.1.3.6.1.4.1.476.1.42.3.4.2.1.2.0';
     $index = 'lgpEnvReturnAirHumidity.0';
     $descr = 'Return Air Humidity';
-    discover_sensor(null, 'humidity', $device, $oid, $index, 'liebert', $descr, $divisor, '1', null, null, null, null, $return_humidity);
+    discover_sensor(null, SensorEnum::Humidity, $device, $oid, $index, 'liebert', $descr, $divisor, '1', null, null, null, null, $return_humidity);
 }
 
 $supply_humidity = snmp_get($device, 'lgpEnvSupplyAirHumidity.0', '-Oqv');
@@ -72,5 +74,5 @@ if (is_numeric($supply_humidity)) {
     $oid = '.1.3.6.1.4.1.476.1.42.3.4.2.1.3.0';
     $index = 'lgpEnvSupplyAirHumidity.0';
     $descr = 'Supply Air Humidity';
-    discover_sensor(null, 'humidity', $device, $oid, $index, 'liebert', $descr, $divisor, '1', null, null, null, null, $supply_humidity);
+    discover_sensor(null, SensorEnum::Humidity, $device, $oid, $index, 'liebert', $descr, $divisor, '1', null, null, null, null, $supply_humidity);
 }

--- a/includes/discovery/sensors/humidity/mgeups.inc.php
+++ b/includes/discovery/sensors/humidity/mgeups.inc.php
@@ -52,6 +52,6 @@ foreach (array_keys($mge_env_data) as $index) {
     if ($current != 0) {
         // Humidity = 0 -> Sensor not available
         // FIXME true for MGE as wel as APC?
-        discover_sensor(null, 'humidity', $device, $oid, $index, $sensorType, $descr, '1', '1', $low_limit, $low_warn_limit, $high_warn_limit, $high_limit, $current);
+        discover_sensor(null, \LibreNMS\Enum\Sensor::Humidity, $device, $oid, $index, $sensorType, $descr, '1', '1', $low_limit, $low_warn_limit, $high_warn_limit, $high_limit, $current);
     }
 }//end foreach

--- a/includes/discovery/sensors/humidity/minkelsrms.inc.php
+++ b/includes/discovery/sensors/humidity/minkelsrms.inc.php
@@ -30,7 +30,7 @@ foreach (explode("\n", $oids) as $data) {
             $lowlimit = snmp_get($device, $lowlimit_oid, '-Oqv', '');
             $warnlowlimit = snmp_get($device, $warnlowlimit_oid, '-Oqv', '');
 
-            discover_sensor(null, 'humidity', $device, $oid, $index, 'akcp', $descr, '1', '1', $lowlimit, $warnlowlimit, $limit, $warnlimit, $humidity);
+            discover_sensor(null, \LibreNMS\Enum\Sensor::Humidity, $device, $oid, $index, 'akcp', $descr, '1', '1', $lowlimit, $warnlowlimit, $limit, $warnlimit, $humidity);
         }
     }
 }

--- a/includes/discovery/sensors/humidity/pcoweb.inc.php
+++ b/includes/discovery/sensors/humidity/pcoweb.inc.php
@@ -43,6 +43,6 @@ foreach ($humidities as $humidity) {
 
     if (is_numeric($current) && $current != 0) {
         $index = implode('.', array_slice(explode('.', $humidity['oid']), -5));
-        discover_sensor(null, 'humidity', $device, $humidity['oid'], $index, 'pcoweb', $humidity['descr'], $humidity['precision'], '1', $low_limit, null, null, $high_limit, $current);
+        discover_sensor(null, \LibreNMS\Enum\Sensor::Humidity, $device, $humidity['oid'], $index, 'pcoweb', $humidity['descr'], $humidity['precision'], '1', $low_limit, null, null, $high_limit, $current);
     }
 }

--- a/includes/discovery/sensors/humidity/raritan-pdu.inc.php
+++ b/includes/discovery/sensors/humidity/raritan-pdu.inc.php
@@ -41,7 +41,7 @@ foreach ($oids as $index => $sensor) {
         $limit_low_warn = $sensor['externalSensorLowerCriticalThreshold'] / $divisor;
         $offset++;
         if (is_numeric($hum_current) && $hum_current >= 0) {
-            discover_sensor(null, 'humidity', $device, $oid, $offset, 'raritan', $descr, $divisor, $multiplier, $limit_low, $limit_low_warn, $limit_high_warn, $limit_high, $hum_current);
+            discover_sensor(null, \LibreNMS\Enum\Sensor::Humidity, $device, $oid, $offset, 'raritan', $descr, $divisor, $multiplier, $limit_low, $limit_low_warn, $limit_high_warn, $limit_high, $hum_current);
         }
     }
 }

--- a/includes/discovery/sensors/humidity/sentry4.inc.php
+++ b/includes/discovery/sensors/humidity/sentry4.inc.php
@@ -32,6 +32,6 @@ foreach ($pre_cache['sentry4_humid'] as $index => $data) {
     $high_warn_limit = $data['st4HumidSensorHighWarning'];
     $current = $data['st4HumidSensorValue'];
     if ($current >= 0) {
-        discover_sensor(null, 'humidity', $device, $oid, "st4HumidSensorValue.$index", 'sentry4', $descr, 1, 1, $low_limit, $low_warn_limit, $high_warn_limit, $high_limit, $current);
+        discover_sensor(null, \LibreNMS\Enum\Sensor::Humidity, $device, $oid, "st4HumidSensorValue.$index", 'sentry4', $descr, 1, 1, $low_limit, $low_warn_limit, $high_warn_limit, $high_limit, $current);
     }
 }

--- a/includes/discovery/sensors/humidity/serverscheck.inc.php
+++ b/includes/discovery/sensors/humidity/serverscheck.inc.php
@@ -46,7 +46,7 @@ foreach ($pre_cache['serverscheck_control'] as $oid_name => $oid_value) {
             if (is_numeric($current)) {
                 $index = str_replace('.0', '', $oid_name);
                 $descr = $oid_value;
-                discover_sensor(null, 'humidity', $device, $serverscheck_oids[$tmp_oid], $index, 'serverscheck', $descr, 1, 1, null, null, null, null, $current);
+                discover_sensor(null, \LibreNMS\Enum\Sensor::Humidity, $device, $serverscheck_oids[$tmp_oid], $index, 'serverscheck', $descr, 1, 1, null, null, null, null, $current);
             }
         }
         $temp_x++;

--- a/includes/discovery/sensors/humidity/teracom.inc.php
+++ b/includes/discovery/sensors/humidity/teracom.inc.php
@@ -65,7 +65,7 @@ if (Arr::exists($teracom_devices, $device['hardware'])) {
             $low_limit = $t_data[1]['MINInt'];
             $current = $t_data[1]['Int'];
 
-            discover_sensor(null, 'humidity', $device, $oid, $index, 'teracom', $t_data['description'], $divisor, '1', $low_limit, null, null, $high_limit, $current);
+            discover_sensor(null, \LibreNMS\Enum\Sensor::Humidity, $device, $oid, $index, 'teracom', $t_data['description'], $divisor, '1', $low_limit, null, null, $high_limit, $current);
         }
     }
 }

--- a/includes/discovery/sensors/humidity/webmon.inc.php
+++ b/includes/discovery/sensors/humidity/webmon.inc.php
@@ -43,7 +43,7 @@ foreach ($prefixes as $prefix => $numOidPrefix) {
             $lowWarnLimit = $oid[$prefix . 'Thresh3'];
             $highLimit = $oid[$prefix . 'Thresh1'];
             $highWarnLimit = $oid[$prefix . 'Thresh2'];
-            discover_sensor(null, 'humidity', $device, $num_oid, $prefix . 'LiveRaw.' . $index, 'webmon', $descr, '1', '1', $lowLimit, $lowWarnLimit, $highWarnLimit, $highLimit, $value, 'snmp', null, null, null, $group);
+            discover_sensor(null, \LibreNMS\Enum\Sensor::Humidity, $device, $num_oid, $prefix . 'LiveRaw.' . $index, 'webmon', $descr, '1', '1', $lowLimit, $lowWarnLimit, $highWarnLimit, $highLimit, $value, 'snmp', null, null, null, $group);
         }
     }
 }

--- a/includes/discovery/sensors/humidity/websensor.inc.php
+++ b/includes/discovery/sensors/humidity/websensor.inc.php
@@ -30,5 +30,5 @@ if (is_numeric($pre_cache['websensor_valuesInt']['humInt.0'])) {
     $humidity = $pre_cache['websensor_valuesInt']['humInt.0'] / 10;
     $high_limit = $pre_cache['websensor_settings']['humHighInt.0'] / 10;
     $low_limit = $pre_cache['websensor_settings']['humLowInt.0'] / 10;
-    discover_sensor(null, 'humidity', $device, $humidity_oid, $humidity_index, 'websensor', $descr, '10', '1', $low_limit, null, null, $high_limit, $humidity);
+    discover_sensor(null, \LibreNMS\Enum\Sensor::Humidity, $device, $humidity_oid, $humidity_index, 'websensor', $descr, '10', '1', $low_limit, null, null, $high_limit, $humidity);
 }

--- a/includes/discovery/sensors/ipmi.inc.php
+++ b/includes/discovery/sensors/ipmi.inc.php
@@ -3,6 +3,7 @@
 use App\Facades\LibrenmsConfig;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
+use LibreNMS\Enum\Sensor as SensorEnum;
 
 // IPMI - We can discover this on poll!
 if ($ipmi['host'] = get_dev_attrib($device, 'ipmi_hostname')) {
@@ -56,10 +57,11 @@ if ($ipmi['host'] = get_dev_attrib($device, 'ipmi_hostname')) {
         [$desc,$current,$unit,$state,$low_nonrecoverable,$low_limit,$low_warn,$high_warn,$high_limit,$high_nonrecoverable] = $values;
 
         $index++;
-        if ($current != 'na' && LibrenmsConfig::has("ipmi_unit.$unit")) {
+        $sensorClass = SensorEnum::tryFrom(LibrenmsConfig::get("ipmi_unit.$unit", ''));
+        if ($current != 'na' && $sensorClass !== null) {
             discover_sensor(
                 null,
-                LibrenmsConfig::get("ipmi_unit.$unit"),
+                $sensorClass,
                 $device,
                 $desc,
                 $index,
@@ -81,9 +83,9 @@ if ($ipmi['host'] = get_dev_attrib($device, 'ipmi_hostname')) {
 }
 
 $sensorDiscovery = app('sensor-discovery');
-$sensorDiscovery->sync(sensor_class: 'voltage', poller_type: 'ipmi');
-$sensorDiscovery->sync(sensor_class: 'temperature', poller_type: 'ipmi');
-$sensorDiscovery->sync(sensor_class: 'fanspeed', poller_type: 'ipmi');
-$sensorDiscovery->sync(sensor_class: 'power', poller_type: 'ipmi');
-$sensorDiscovery->sync(sensor_class: 'current', poller_type: 'ipmi');
-$sensorDiscovery->sync(sensor_class: 'load', poller_type: 'ipmi');
+$sensorDiscovery->sync(sensor_class: SensorEnum::Voltage, poller_type: 'ipmi');
+$sensorDiscovery->sync(sensor_class: SensorEnum::Temperature, poller_type: 'ipmi');
+$sensorDiscovery->sync(sensor_class: SensorEnum::Fanspeed, poller_type: 'ipmi');
+$sensorDiscovery->sync(sensor_class: SensorEnum::Power, poller_type: 'ipmi');
+$sensorDiscovery->sync(sensor_class: SensorEnum::Current, poller_type: 'ipmi');
+$sensorDiscovery->sync(sensor_class: SensorEnum::Load, poller_type: 'ipmi');

--- a/includes/discovery/sensors/load/apc.inc.php
+++ b/includes/discovery/sensors/load/apc.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 echo 'APC Load ';
 
 $phasecount = $phasecount = $pre_cache['apcups_phase_count'];
@@ -13,7 +15,7 @@ if ($phasecount > 1) {
         $divisor = 1;
         $load = $data['upsPhaseOutputPercentLoad'];
         if ($load >= 0) {
-            discover_sensor(null, 'load', $device, $load_oid, $index, $type, $descr, $divisor, 1, null, null, null, null, $load);
+            discover_sensor(null, SensorEnum::Load, $device, $load_oid, $index, $type, $descr, $divisor, 1, null, null, null, null, $load);
         }
     }
     unset($oids);
@@ -47,7 +49,7 @@ if ($phasecount > 1) {
             if ($oids) {
                 echo $item['type'] . ' ' . $item['mib'] . ' UPS';
             }
-            discover_sensor(null, 'load', $device, $current_oid . '.' . $item['index'], $current_oid . '.' . $item['index'], $item['type'], $item['descr'], $item['divisor'], 1, null, null, null, null, $current);
+            discover_sensor(null, SensorEnum::Load, $device, $current_oid . '.' . $item['index'], $current_oid . '.' . $item['index'], $item['type'], $item['descr'], $item['divisor'], 1, null, null, null, null, $current);
         }
     }//end foreach
 }

--- a/includes/discovery/sensors/load/dhcpatriot.inc.php
+++ b/includes/discovery/sensors/load/dhcpatriot.inc.php
@@ -7,7 +7,7 @@
  *
 */
 
-$class = 'load';
+$class = $sensor_class;
 $multiplier = 100;
 $low_limit = null;
 $low_warn_limit = null;

--- a/includes/discovery/sensors/load/dsm.inc.php
+++ b/includes/discovery/sensors/load/dsm.inc.php
@@ -30,5 +30,5 @@ $ups_device_model = str_replace('"', '', snmp_get($device, $ups_device_model_oid
 $ups_load_oid = '.1.3.6.1.4.1.6574.4.2.12.1.0';
 $ups_load = snmp_get($device, $ups_load_oid, '-Oqv');
 if (is_numeric($ups_load)) {
-    discover_sensor(null, 'load', $device, $ups_load_oid, 0, 'snmp', $ups_device_manufacturer . ' ' . $ups_device_model . ' - UPS Load', '1', '1', 0, null, null, 100, intval($ups_load));
+    discover_sensor(null, \LibreNMS\Enum\Sensor::Load, $device, $ups_load_oid, 0, 'snmp', $ups_device_manufacturer . ' ' . $ups_device_model . ' - UPS Load', '1', '1', 0, null, null, 100, intval($ups_load));
 }

--- a/includes/discovery/sensors/load/infinera-groove.inc.php
+++ b/includes/discovery/sensors/load/infinera-groove.inc.php
@@ -29,7 +29,7 @@ foreach ($pre_cache['infineragroove_slotTable'] as $index => $data) {
         $descr = 'Chassis fan ' . $infinera_slot;
         $oid = '.1.3.6.1.4.1.42229.1.2.3.3.1.1.7.' . $index;
         $value = $data['cardFanSpeedRate'];
-        discover_sensor(null, 'load', $device, $oid, 'cardFanSpeedRate.' . $index, 'infinera-groove', $descr, null, '1', 0, 20, 80, 100, $value);
+        discover_sensor(null, \LibreNMS\Enum\Sensor::Load, $device, $oid, 'cardFanSpeedRate.' . $index, 'infinera-groove', $descr, null, '1', 0, 20, 80, 100, $value);
     }
 }
 

--- a/includes/discovery/sensors/load/netagent2.inc.php
+++ b/includes/discovery/sensors/load/netagent2.inc.php
@@ -50,7 +50,7 @@ if ($in_phaseNum == '1') {
 
         discover_sensor(
             null,
-            'load',
+            $sensor_class,
             $device,
             $load_oid,
             $index,
@@ -86,7 +86,7 @@ if ($in_phaseNum == '3') {
 
         discover_sensor(
             null,
-            'load',
+            $sensor_class,
             $device,
             $load_oid,
             $index,
@@ -118,7 +118,7 @@ if ($in_phaseNum == '3') {
 
         discover_sensor(
             null,
-            'load',
+            $sensor_class,
             $device,
             $load_oid,
             $index,
@@ -150,7 +150,7 @@ if ($in_phaseNum == '3') {
 
         discover_sensor(
             null,
-            'load',
+            $sensor_class,
             $device,
             $load_oid,
             $index,

--- a/includes/discovery/sensors/load/rfc1628.inc.php
+++ b/includes/discovery/sensors/load/rfc1628.inc.php
@@ -23,7 +23,7 @@ foreach ($load_data as $index => $data) {
         continue;
     }
 
-    $divisor = get_device_divisor($device, $pre_cache['poweralert_serial'] ?? 0, 'load', $load_oid);
+    $divisor = get_device_divisor($device, $pre_cache['poweralert_serial'] ?? 0, $sensor_class, $load_oid);
 
     if (count($load_data) > 1) {
         $descr .= " $index";
@@ -31,7 +31,7 @@ foreach ($load_data as $index => $data) {
 
     discover_sensor(
         null,
-        'load',
+        $sensor_class,
         $device,
         $load_oid,
         500 + $index,

--- a/includes/discovery/sensors/load/unix.inc.php
+++ b/includes/discovery/sensors/load/unix.inc.php
@@ -39,7 +39,7 @@ if (! empty($snmpData)) {
                 $oid = Oid::of('NET-SNMP-EXTEND-MIB::nsExtendOutLine."ups-nut".' . $index)->toNumeric();
                 discover_sensor(
                     null,
-                    'load',
+                    $sensor_class,
                     $device,
                     $oid,
                     $index,

--- a/includes/discovery/sensors/netscaler.inc.php
+++ b/includes/discovery/sensors/netscaler.inc.php
@@ -1,5 +1,6 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
 use LibreNMS\Util\Oid;
 
 echo ' NetScaler ';
@@ -19,15 +20,15 @@ foreach ($ns_sensor_array as $descr => $data) {
 
     $divisor = 1;
     if (str_contains((string) $descr, 'Temp')) {
-        $type = 'temperature';
+        $type = SensorEnum::Temperature;
     } elseif (str_contains((string) $descr, 'Fan')) {
-        $type = 'fanspeed';
+        $type = SensorEnum::Fanspeed;
     } elseif (str_contains((string) $descr, 'Volt')) {
         $divisor = 1000;
-        $type = 'voltage';
+        $type = SensorEnum::Voltage;
     } elseif (str_contains((string) $descr, 'Vtt')) {
         $divisor = 1000;
-        $type = 'voltage';
+        $type = SensorEnum::Voltage;
     }
 
     if (is_numeric($current) && isset($type)) {

--- a/includes/discovery/sensors/openbsd.inc.php
+++ b/includes/discovery/sensors/openbsd.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 echo ' OPENBSD-SENSORS-MIB: ';
 
 echo 'Caching OIDs:';
@@ -19,15 +21,15 @@ $oids = snmpwalk_cache_multi_oid($device, 'sensorType', $oids, 'OPENBSD-SENSORS-
 // illuminance(12), drive(13), timedelta(14), humidity(15), freq(16),
 // angle(17), distance(18), pressure(19), accel(20)
 
-$entitysensor['voltsdc'] = 'voltage';
-$entitysensor['voltsac'] = 'voltage';
-$entitysensor['fan'] = 'fanspeed';
+$entitysensor['voltsdc'] = SensorEnum::Voltage;
+$entitysensor['voltsac'] = SensorEnum::Voltage;
+$entitysensor['fan'] = SensorEnum::Fanspeed;
 
-$entitysensor['current'] = 'current';
-$entitysensor['power'] = 'power';
-$entitysensor['freq'] = 'freq';
-$entitysensor['humidity'] = 'humidity';
-$entitysensor['temperature'] = 'temperature';
+$entitysensor['current'] = SensorEnum::Current;
+$entitysensor['power'] = SensorEnum::Power;
+$entitysensor['freq'] = SensorEnum::Frequency;
+$entitysensor['humidity'] = SensorEnum::Humidity;
+$entitysensor['temperature'] = SensorEnum::Temperature;
 
 if (is_array($oids)) {
     foreach ($oids as $index => $entry) {
@@ -41,11 +43,11 @@ if (is_array($oids)) {
 
             $type = $entitysensor[$entry['sensorType']];
 
-            if ($type == 'voltage') {
+            if ($type === SensorEnum::Voltage) {
                 $descr = preg_replace('/ voltage/i', '', $descr);
             }
 
-            if ($type == 'temperature') {
+            if ($type === SensorEnum::Temperature) {
                 if ($current < -40 || $current > 200) {
                     $bogus = true;
                 }

--- a/includes/discovery/sensors/percent/enexus.inc.php
+++ b/includes/discovery/sensors/percent/enexus.inc.php
@@ -10,7 +10,7 @@ if (! empty($battery_test_result_table)) {
     $batteryQualityResult = $numeric_results[$last_index]['batteryTestResultQuality'];
     discover_sensor(
         null,
-        'percent',
+        $sensor_class,
         $device,
         '.1.3.6.1.4.1.12148.10.10.16.4.1.5',
         'batteryTestResultQuality',

--- a/includes/discovery/sensors/percent/fortigate.inc.php
+++ b/includes/discovery/sensors/percent/fortigate.inc.php
@@ -28,7 +28,7 @@ if (! empty($fgDhcpTables['fgDhcpLeaseUsage'])) {
 
             discover_sensor(
                 null,
-                'percent',
+                $sensor_class,
                 $device,
                 '.1.3.6.1.4.1.12356.101.23.2.1.1.2.' . $vdomID . '.' . $fgDhcpServerID,
                 'fgDhcpLeaseUsage.' . $vdomID . '.' . $fgDhcpServerID,

--- a/includes/discovery/sensors/percent/timos.inc.php
+++ b/includes/discovery/sensors/percent/timos.inc.php
@@ -55,7 +55,7 @@ foreach ($blockUsageData as $oid => $value) {
 
     discover_sensor(
         null,
-        'percent',
+        $sensor_class,
         $device,
         ".1.3.6.1.4.1.6527.3.1.2.65.1.4.4.1.2.$index",
         "tmnxNatPlLsnMemberBlockUsage.$index",

--- a/includes/discovery/sensors/power/apc.inc.php
+++ b/includes/discovery/sensors/power/apc.inc.php
@@ -29,6 +29,6 @@ foreach ($pre_cache['cooling_unit_analog'] as $index => $data) {
     $scale = $data['coolingUnitStatusAnalogScale'] ?? null;
     $value = $data['coolingUnitStatusAnalogValue'] ?? null;
     if (preg_match('/Cool/', (string) $descr) && $data['coolingUnitStatusAnalogUnits'] == 'kW' && $value >= 0) {
-        discover_sensor(null, 'power', $device, $cur_oid, $cur_oid, 'apc', $descr, $scale, 1, null, null, null, null, $value);
+        discover_sensor(null, \LibreNMS\Enum\Sensor::Power, $device, $cur_oid, $cur_oid, 'apc', $descr, $scale, 1, null, null, null, null, $value);
     }
 }

--- a/includes/discovery/sensors/power/ciscosb.inc.php
+++ b/includes/discovery/sensors/power/ciscosb.inc.php
@@ -28,7 +28,7 @@ foreach ($oids as $unit => $unitData) {
 
                 app('sensor-discovery')->discover(new \App\Models\Sensor([
                     'poller_type' => 'snmp',
-                    'sensor_class' => 'power',
+                    'sensor_class' => \LibreNMS\Enum\Sensor::Power,
                     'sensor_oid' => $oid,
                     'sensor_index' => $index,
                     'sensor_type' => 'ciscosb',

--- a/includes/discovery/sensors/power/dell-ups.inc.php
+++ b/includes/discovery/sensors/power/dell-ups.inc.php
@@ -16,5 +16,5 @@ $temp = snmp_get($device, 'physicalOutputPresentConsumption.0', '-Ovqe', 'DELL-S
 if (is_numeric($temp) && ! is_null($temp)) {
     $oid = '.1.3.6.1.4.1.674.10902.2.120.2.6.0';
     $descr = 'System Consumption';
-    discover_sensor(null, 'power', $device, $oid, '0', 'dell-ups', $descr, '1', '1', null, null, null, null, $temp);
+    discover_sensor(null, \LibreNMS\Enum\Sensor::Power, $device, $oid, '0', 'dell-ups', $descr, '1', '1', null, null, null, null, $temp);
 }

--- a/includes/discovery/sensors/power/dell.inc.php
+++ b/includes/discovery/sensors/power/dell.inc.php
@@ -36,7 +36,7 @@ foreach ((array) $temp as $index => $entry) {
         (isset($entry['amperageProbeUpperNonCriticalThreshold'])) ? $warnlimit = $entry['amperageProbeUpperNonCriticalThreshold'] / $divisor : $warnlimit = null;
         (isset($entry['amperageProbeUpperCriticalThreshold'])) ? $limit = $entry['amperageProbeUpperCriticalThreshold'] / $divisor : $limit = null;
 
-        discover_sensor(null, 'power', $device, $cur_oid . $index, $index, 'dell', $descr, $divisor, '1', $lowlimit, $low_warn_limit, $warnlimit, $limit, $value, 'snmp', $index);
+        discover_sensor(null, \LibreNMS\Enum\Sensor::Power, $device, $cur_oid . $index, $index, 'dell', $descr, $divisor, '1', $lowlimit, $low_warn_limit, $warnlimit, $limit, $value, 'snmp', $index);
     }
 
     unset(

--- a/includes/discovery/sensors/power/dsm.inc.php
+++ b/includes/discovery/sensors/power/dsm.inc.php
@@ -25,5 +25,5 @@ $ups_device_model = str_replace('"', '', snmp_get($device, $ups_device_model_oid
 $ups_real_power_nominal_oid = '.1.3.6.1.4.1.6574.4.2.21.2.0';
 $ups_real_power_nominal = snmp_get($device, $ups_real_power_nominal_oid, '-Oqv');
 if (is_numeric($ups_real_power_nominal)) {
-    discover_sensor(null, 'power', $device, $ups_real_power_nominal_oid, 'UPSRealPowerNominal', $ups_device_manufacturer . ' ' . $ups_device_model, 'UPS Real Power Nominal', '1', '1', null, null, null, null, $ups_real_power_nominal);
+    discover_sensor(null, \LibreNMS\Enum\Sensor::Power, $device, $ups_real_power_nominal_oid, 'UPSRealPowerNominal', $ups_device_manufacturer . ' ' . $ups_device_model, 'UPS Real Power Nominal', '1', '1', null, null, null, null, $ups_real_power_nominal);
 }

--- a/includes/discovery/sensors/power/eltex-mes23xx.inc.php
+++ b/includes/discovery/sensors/power/eltex-mes23xx.inc.php
@@ -42,7 +42,7 @@ foreach ($oids as $unit => $indexData) {
 
                 app('sensor-discovery')->discover(new \App\Models\Sensor([
                     'poller_type' => 'snmp',
-                    'sensor_class' => 'power',
+                    'sensor_class' => \LibreNMS\Enum\Sensor::Power,
                     'sensor_oid' => $oid,
                     'sensor_index' => 'Poe' . $index,
                     'sensor_type' => 'rlPethPsePortOutputPower',

--- a/includes/discovery/sensors/power/hpblmos.inc.php
+++ b/includes/discovery/sensors/power/hpblmos.inc.php
@@ -19,7 +19,7 @@ foreach (explode("\n", $psus) as $psu) {
             $descr = 'PSU ' . $current_id . ' output';
             $value = snmp_get($device, $current_oid, '-Oqv');
             $max_value = snmp_get($device, $psu_max_oid, '-Oqv');
-            discover_sensor(null, 'power', $device, $current_oid, $current_id, $sensor_type, $descr, 1, 1, null, null, null, $max_value, $value);
+            discover_sensor(null, \LibreNMS\Enum\Sensor::Power, $device, $current_oid, $current_id, $sensor_type, $descr, 1, 1, null, null, null, $max_value, $value);
         }
     }
 }

--- a/includes/discovery/sensors/power/raritan-pdu.inc.php
+++ b/includes/discovery/sensors/power/raritan-pdu.inc.php
@@ -20,7 +20,7 @@ if ($outlet_oids) {
             $outlet_descr = snmp_get($device, "outletLabel.$outletsuffix", '-Ovq', 'PDU-MIB');
             $outlet_power = snmp_get($device, "outletApparentPower.$outletsuffix", '-Ovq', 'PDU-MIB');
             if ($outlet_power >= 0) {
-                discover_sensor(null, 'power', $device, $outlet_oid, $outlet_insert_index, 'raritan', $outlet_descr, $divisor, $multiplier, null, null, null, null, $outlet_power);
+                discover_sensor(null, \LibreNMS\Enum\Sensor::Power, $device, $outlet_oid, $outlet_insert_index, 'raritan', $outlet_descr, $divisor, $multiplier, null, null, null, null, $outlet_power);
             }
         }
     }

--- a/includes/discovery/sensors/power/rfc1628.inc.php
+++ b/includes/discovery/sensors/power/rfc1628.inc.php
@@ -25,7 +25,7 @@ foreach ($output_power as $index => $data) {
 
     discover_sensor(
         null,
-        'power',
+        $sensor_class,
         $device,
         $pwr_oid,
         300 + $index,
@@ -62,7 +62,7 @@ foreach ($input_power as $index => $data) {
 
     discover_sensor(
         null,
-        'power',
+        $sensor_class,
         $device,
         $pwr_oid,
         100 + $index,
@@ -99,7 +99,7 @@ foreach ($bypass_power as $index => $data) {
 
     discover_sensor(
         null,
-        'power',
+        $sensor_class,
         $device,
         $pwr_oid,
         200 + $index,

--- a/includes/discovery/sensors/power/schleifenbauer.inc.php
+++ b/includes/discovery/sensors/power/schleifenbauer.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 echo 'Schleifenbauer ';
 
 foreach ($pre_cache['sdbMgmtCtrlDevUnitAddress'] as $sdbMgmtCtrlDevUnitAddress => $sdbDevIdIndex) {
@@ -12,7 +14,7 @@ foreach ($pre_cache['sdbMgmtCtrlDevUnitAddress'] as $sdbMgmtCtrlDevUnitAddress =
         // See includes/discovery/entity-physical/schleifenbauer.inc.php for an explanation why we set this as the entPhysicalIndex.
         $entPhysicalIndex = $sdbMgmtCtrlDevUnitAddress * 1000000 + 100000 + $sdbDevInIndex * 1000 + 130;
 
-        discover_sensor(null, 'power', $device, $power_oid, $serial_input, 'schleifenbauer', $descr, '1', '1', null, null, null, null, $sdbDevInPowerVoltAmpere, 'snmp', $entPhysicalIndex);
+        discover_sensor(null, SensorEnum::Power, $device, $power_oid, $serial_input, 'schleifenbauer', $descr, '1', '1', null, null, null, null, $sdbDevInPowerVoltAmpere, 'snmp', $entPhysicalIndex);
     }
 }
 
@@ -28,6 +30,6 @@ if (isset($pre_cache['sdbDevOutMtPowerVoltAmpere']) && is_array($pre_cache['sdbD
         // See includes/discovery/entity-physical/schleifenbauer.inc.php for an explanation why we set this as the entPhysicalIndex.
         $entPhysicalIndex = $sdbMgmtCtrlDevUnitAddress * 1000000 + 200000 + $sdbDevOutMtIndex * 1000 + 130;
 
-        discover_sensor(null, 'power', $device, $power_oid, $serial_input, 'schleifenbauer', $descr, '1', '1', null, null, null, null, $sdbDevOutMtPowerVoltAmpere, 'snmp', $entPhysicalIndex);
+        discover_sensor(null, SensorEnum::Power, $device, $power_oid, $serial_input, 'schleifenbauer', $descr, '1', '1', null, null, null, null, $sdbDevOutMtPowerVoltAmpere, 'snmp', $entPhysicalIndex);
     }
 }

--- a/includes/discovery/sensors/power/smartax.inc.php
+++ b/includes/discovery/sensors/power/smartax.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 /**
  * smartax.inc.php
  *
@@ -28,7 +30,7 @@ $power_frame_oid = '.1.3.6.1.4.1.2011.2.6.7.1.1.1.1.11.0';
 $power = snmp_get($device, $power_frame_oid, '-Ovq');
 $index = '0';
 
-discover_sensor(null, 'power', $device, $power_frame_oid, $index, 'smartax-total', 'Chassis Total', '1', '1', null, null, null, null, $power);
+discover_sensor(null, SensorEnum::Power, $device, $power_frame_oid, $index, 'smartax-total', 'Chassis Total', '1', '1', null, null, null, null, $power);
 
 $power_oid = '1.3.6.1.4.1.2011.2.6.7.1.1.2.1.11.0';
 $descr_oid = '1.3.6.1.4.1.2011.2.6.7.1.1.2.1.7.0';
@@ -43,5 +45,5 @@ foreach ($data as $index => $value) {
     $powerCurr = $value;
     $pow_oid = '.' . $power_oid . '.' . $index;
     $descr = $descr_data[$index];
-    discover_sensor(null, 'power', $device, $pow_oid, $index, 'smartax', $descr, '1', '1', null, null, null, null, $powerCurr);
+    discover_sensor(null, SensorEnum::Power, $device, $pow_oid, $index, 'smartax', $descr, '1', '1', null, null, null, null, $powerCurr);
 }

--- a/includes/discovery/sensors/power_consumed/ipoman.inc.php
+++ b/includes/discovery/sensors/power_consumed/ipoman.inc.php
@@ -22,7 +22,7 @@ foreach ($oidsPowOut as $index => $entry) {
 
     app('sensor-discovery')->discover(new \App\Models\Sensor([
         'poller_type' => 'snmp',
-        'sensor_class' => 'power_consumed',
+        'sensor_class' => \LibreNMS\Enum\Sensor::PowerConsumed,
         'sensor_oid' => $oid,
         'sensor_index' => $oid,
         'sensor_type' => 'ipoman',

--- a/includes/discovery/sensors/power_consumed/schleifenbauer.inc.php
+++ b/includes/discovery/sensors/power_consumed/schleifenbauer.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 echo 'Schleifenbauer ';
 
 foreach ($pre_cache['sdbMgmtCtrlDevUnitAddress'] ?? [] as $sdbMgmtCtrlDevUnitAddress => $sdbDevIdIndex) {
@@ -12,7 +14,7 @@ foreach ($pre_cache['sdbMgmtCtrlDevUnitAddress'] ?? [] as $sdbMgmtCtrlDevUnitAdd
         // See includes/discovery/entity-physical/schleifenbauer.inc.php for an explanation why we set this as the entPhysicalIndex.
         $entPhysicalIndex = $sdbMgmtCtrlDevUnitAddress * 1000000 + 100000 + $sdbDevInIndex * 1000 + 140;
 
-        discover_sensor(null, 'power_consumed', $device, $power_consumed_oid, $serial_input, 'schleifenbauer', $descr, '1', '1', '0', null, null, '16777215', $sdbDevInKWhTotal, 'snmp', $entPhysicalIndex);
+        discover_sensor(null, SensorEnum::PowerConsumed, $device, $power_consumed_oid, $serial_input, 'schleifenbauer', $descr, '1', '1', '0', null, null, '16777215', $sdbDevInKWhTotal, 'snmp', $entPhysicalIndex);
     }
 }
 
@@ -28,6 +30,6 @@ if (isset($pre_cache['sdbDevOutMtKWhTotal']) && is_array($pre_cache['sdbDevOutMt
         // See includes/discovery/entity-physical/schleifenbauer.inc.php for an explanation why we set this as the entPhysicalIndex.
         $entPhysicalIndex = $sdbMgmtCtrlDevUnitAddress * 1000000 + 200000 + $sdbDevOutMtIndex * 1000 + 140;
 
-        discover_sensor(null, 'power_consumed', $device, $power_consumed_oid, $serial_input, 'schleifenbauer', $descr, '1', '1', '0', null, null, '16777215', $sdbDevOutMtKWhTotal, 'snmp', $entPhysicalIndex);
+        discover_sensor(null, SensorEnum::PowerConsumed, $device, $power_consumed_oid, $serial_input, 'schleifenbauer', $descr, '1', '1', '0', null, null, '16777215', $sdbDevOutMtKWhTotal, 'snmp', $entPhysicalIndex);
     }
 }

--- a/includes/discovery/sensors/power_factor/schleifenbauer.inc.php
+++ b/includes/discovery/sensors/power_factor/schleifenbauer.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 echo 'Schleifenbauer ';
 $divisor = 10000;
 
@@ -14,7 +16,7 @@ foreach ($pre_cache['sdbMgmtCtrlDevUnitAddress'] as $sdbMgmtCtrlDevUnitAddress =
         // See includes/discovery/entity-physical/schleifenbauer.inc.php for an explanation why we set this as the entPhysicalIndex.
         $entPhysicalIndex = $sdbMgmtCtrlDevUnitAddress * 1000000 + 100000 + $sdbDevInIndex * 1000 + 150;
 
-        discover_sensor(null, 'power_factor', $device, $power_factor_oid, $serial_input, 'schleifenbauer', $descr, $divisor, '1', '0', null, null, '1', $power_factor, 'snmp', $entPhysicalIndex);
+        discover_sensor(null, SensorEnum::PowerFactor, $device, $power_factor_oid, $serial_input, 'schleifenbauer', $descr, $divisor, '1', '0', null, null, '1', $power_factor, 'snmp', $entPhysicalIndex);
     }
 }
 
@@ -31,6 +33,6 @@ if (isset($pre_cache['sdbDevOutMtPowerFactor']) && is_array($pre_cache['sdbDevOu
         // See includes/discovery/entity-physical/schleifenbauer.inc.php for an explanation why we set this as the entPhysicalIndex.
         $entPhysicalIndex = $sdbMgmtCtrlDevUnitAddress * 1000000 + 200000 + $sdbDevOutMtIndex * 1000 + 150;
 
-        discover_sensor(null, 'power_factor', $device, $power_factor_oid, $serial_input, 'schleifenbauer', $descr, $divisor, '1', '0', null, null, '1', $power_factor, 'snmp', $entPhysicalIndex);
+        discover_sensor(null, SensorEnum::PowerFactor, $device, $power_factor_oid, $serial_input, 'schleifenbauer', $descr, $divisor, '1', '0', null, null, '1', $power_factor, 'snmp', $entPhysicalIndex);
     }
 }

--- a/includes/discovery/sensors/rittal-cmc-iii-sensors.inc.php
+++ b/includes/discovery/sensors/rittal-cmc-iii-sensors.inc.php
@@ -24,6 +24,7 @@
  * @author    Denny Friebe <denny.friebe@icera-network.de>
  */
 
+use LibreNMS\Enum\Sensor as SensorEnum;
 use LibreNMS\Util\Number;
 use LibreNMS\Util\StringHelpers;
 
@@ -104,32 +105,32 @@ foreach ($cmc_iii_var_table as $index => $entry) {
 
             // encode string to ensure that degree sign may be used properly for unit comparison
             $unit = StringHelpers::inferEncoding($entry['cmcIIIVarUnit']);
-            $type = 'state';
+            $type = SensorEnum::State;
             $temperature_units = ['degree C', 'degree F', '°C', '°F'];
             if ($unit == 'mA') {
                 //In some cases we get a mA value. However, the cmcIIIVarScale is simply 1.
                 //Therefore, we must hardcode the divisor here to calculate the value into A.
-                $type = 'current';
+                $type = SensorEnum::Current;
                 $cmc_iii_sensors[$sensor_id]['divisor'] = 1000;
             } elseif ($unit == 'A') {
-                $type = 'current';
+                $type = SensorEnum::Current;
             } elseif ($unit == 'Wh' || $unit == 'VAh') {
                 $cmc_iii_sensors[$sensor_id]['divisor'] = 1000;
-                $type = 'power_consumed';
+                $type = SensorEnum::PowerConsumed;
             } elseif ($unit == 'kWh' || $unit == 'kVAh') {
-                $type = 'power_consumed';
+                $type = SensorEnum::PowerConsumed;
             } elseif ($unit == 'Hz') {
-                $type = 'frequency';
+                $type = SensorEnum::Frequency;
             } elseif (in_array($unit, $temperature_units)) {
-                $type = 'temperature';
+                $type = SensorEnum::Temperature;
             } elseif ($unit == 'l/min') {
-                $type = 'waterflow';
+                $type = SensorEnum::Waterflow;
             } elseif ($unit == 'V') {
-                $type = 'voltage';
+                $type = SensorEnum::Voltage;
             } elseif ($unit == 'W' || $unit == 'VA' || $unit == 'var') {
-                $type = 'power';
+                $type = SensorEnum::Power;
             } elseif ($unit == '%') {
-                $type = 'percent';
+                $type = SensorEnum::Percent;
             }
             $cmc_iii_sensors[$sensor_id]['type'] = $type;
             break;

--- a/includes/discovery/sensors/rpigpiomonitor.inc.php
+++ b/includes/discovery/sensors/rpigpiomonitor.inc.php
@@ -74,7 +74,13 @@ if (! empty($gpio_mon_data)) {
                 create_state_index($sensor_data['name'], $sensor_data['state_data']);
             }
 
-            discover_sensor(null, $sensor_data['type'], $device, $sensor_data['oid'], $sensor_id, $sensor_data['name'], $sensor_data['descr'], 1, 1, $sensor_data['low_limit'], $sensor_data['low_warn_limit'], $sensor_data['warn_limit'], $sensor_data['high_limit'], $sensor_data['value']);
+            $sensorClass = \LibreNMS\Enum\Sensor::tryFrom($sensor_data['type']);
+            if ($sensorClass === null) {
+                echo "[rpigpiomonitor] Unknown sensor type '{$sensor_data['type']}' for sensor '{$sensor_data['name']}', skipping.\n";
+                continue;
+            }
+
+            discover_sensor(null, $sensorClass, $device, $sensor_data['oid'], $sensor_id, $sensor_data['name'], $sensor_data['descr'], 1, 1, $sensor_data['low_limit'], $sensor_data['low_warn_limit'], $sensor_data['warn_limit'], $sensor_data['high_limit'], $sensor_data['value']);
         } else {
             echo "[rpigpiomonitor] An error occurred while reading a sensor! Please run 'rpigpiomonitor.php -validate' on the target device to verify the configuration.\n";
         }

--- a/includes/discovery/sensors/runtime/apc.inc.php
+++ b/includes/discovery/sensors/runtime/apc.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 $oids = snmp_get($device, '.1.3.6.1.4.1.318.1.1.1.2.2.3.0', '-OsqnUt', '');
 d_echo($oids . "\n");
 if ($oids) {
@@ -14,7 +16,7 @@ if ($oids) {
     $low_limit_warn = 10;
     $warn_limit = 2000;
     $high_limit = 3000;
-    discover_sensor(null, 'runtime', $device, $oid, $index, $type, $descr, $divisor, '1', $low_limit, $low_limit_warn, $warn_limit, $high_limit, $current);
+    discover_sensor(null, SensorEnum::Runtime, $device, $oid, $index, $type, $descr, $divisor, '1', $low_limit, $low_limit_warn, $warn_limit, $high_limit, $current);
 }
 
 // InRow IRRP100
@@ -37,7 +39,7 @@ if ($oids) {
     $descr = 'Filter';
     $sensorType = 'apc';
 
-    discover_sensor(null, 'runtime', $device, $cur_oid . $index, 'airIRRP100UnitRunHoursAirFilter.' . $index, $sensorType, $descr, '1', $multiplier, null, null, null, $service_interval, $current);
+    discover_sensor(null, SensorEnum::Runtime, $device, $cur_oid . $index, 'airIRRP100UnitRunHoursAirFilter.' . $index, $sensorType, $descr, '1', $multiplier, null, null, null, $service_interval, $current);
 
     // airIRRP100UnitRunHoursFan1
     $index = 0;
@@ -50,7 +52,7 @@ if ($oids) {
     $descr = 'Fan 1';
     $sensorType = 'apc';
 
-    discover_sensor(null, 'runtime', $device, $cur_oid . $index, 'airIRRP100UnitRunHoursFan1.' . $index, $sensorType, $descr, '1', $multiplier, null, null, null, $service_interval, $current);
+    discover_sensor(null, SensorEnum::Runtime, $device, $cur_oid . $index, 'airIRRP100UnitRunHoursFan1.' . $index, $sensorType, $descr, '1', $multiplier, null, null, null, $service_interval, $current);
 
     // airIRRP100UnitRunHoursFan2
     $index = 0;
@@ -63,7 +65,7 @@ if ($oids) {
     $descr = 'Fan 2';
     $sensorType = 'apc';
 
-    discover_sensor(null, 'runtime', $device, $cur_oid . $index, 'airIRRP100UnitRunHoursFan2.' . $index, $sensorType, $descr, '1', $multiplier, null, null, null, $service_interval, $current);
+    discover_sensor(null, SensorEnum::Runtime, $device, $cur_oid . $index, 'airIRRP100UnitRunHoursFan2.' . $index, $sensorType, $descr, '1', $multiplier, null, null, null, $service_interval, $current);
 
     // airIRRP100UnitRunHoursCompressor
     $index = 0;
@@ -76,5 +78,5 @@ if ($oids) {
     $descr = 'Compressor';
     $sensorType = 'apc';
 
-    discover_sensor(null, 'runtime', $device, $cur_oid . $index, 'airIRRP100UnitRunHoursCompressor.' . $index, $sensorType, $descr, '1', $multiplier, null, null, null, $service_interval, $current);
+    discover_sensor(null, SensorEnum::Runtime, $device, $cur_oid . $index, 'airIRRP100UnitRunHoursCompressor.' . $index, $sensorType, $descr, '1', $multiplier, null, null, null, $service_interval, $current);
 }

--- a/includes/discovery/sensors/runtime/enexus.inc.php
+++ b/includes/discovery/sensors/runtime/enexus.inc.php
@@ -10,7 +10,7 @@ if (! empty($battery_test_result_table)) {
     $batteryResultDuration = $numeric_results[$last_index]['batteryTestResultDuration'];
     discover_sensor(
         null,
-        'runtime',
+        $sensor_class,
         $device,
         '.1.3.6.1.4.1.12148.10.10.16.4.1.3',
         'batteryTestResultDuration',

--- a/includes/discovery/sensors/runtime/rfc1628.inc.php
+++ b/includes/discovery/sensors/runtime/rfc1628.inc.php
@@ -7,10 +7,10 @@ $secs_on_battery_oid = '.1.3.6.1.2.1.33.1.2.2.0';
 $secs_on_battery = snmp_get($device, $secs_on_battery_oid, '-Oqv');
 
 if (is_numeric($secs_on_battery)) {
-    $divisor = get_device_divisor($device, $pre_cache['poweralert_serial'] ?? '', 'runtime', $secs_on_battery_oid);
+    $divisor = get_device_divisor($device, $pre_cache['poweralert_serial'] ?? '', $sensor_class, $secs_on_battery_oid);
     discover_sensor(
         null,
-        'runtime',
+        $sensor_class,
         $device,
         $secs_on_battery_oid,
         100,
@@ -31,10 +31,10 @@ $est_battery_time_oid = '.1.3.6.1.2.1.33.1.2.3.0';
 $est_battery_time = snmp_get($device, $est_battery_time_oid, '-Ovq');
 
 if (is_numeric($est_battery_time)) {
-    $divisor = get_device_divisor($device, $pre_cache['poweralert_serial'] ?? '', 'runtime', $est_battery_time_oid);
+    $divisor = get_device_divisor($device, $pre_cache['poweralert_serial'] ?? '', $sensor_class, $est_battery_time_oid);
     discover_sensor(
         null,
-        'runtime',
+        $sensor_class,
         $device,
         $est_battery_time_oid,
         200,

--- a/includes/discovery/sensors/runtime/unix.inc.php
+++ b/includes/discovery/sensors/runtime/unix.inc.php
@@ -39,7 +39,7 @@ if (! empty($snmpData)) {
                 $oid = Oid::of('NET-SNMP-EXTEND-MIB::nsExtendOutLine."ups-nut".' . $index)->toNumeric();
                 discover_sensor(
                     null,
-                    'runtime',
+                    $sensor_class,
                     $device,
                     $oid,
                     $index,

--- a/includes/discovery/sensors/signal/cambium.inc.php
+++ b/includes/discovery/sensors/signal/cambium.inc.php
@@ -39,5 +39,5 @@ if (! empty($oids)) {
     $current /= $divisor;
     $index = $oid;
     $descr = 'Signal';
-    discover_sensor(null, 'signal', $device, $oid, $index, $type, $descr, $divisor, '1', null, null, null, null, $current);
+    discover_sensor(null, \LibreNMS\Enum\Sensor::Signal, $device, $oid, $index, $type, $descr, $divisor, '1', null, null, null, null, $current);
 }

--- a/includes/discovery/sensors/signal/canopy.inc.php
+++ b/includes/discovery/sensors/signal/canopy.inc.php
@@ -38,5 +38,5 @@ if (! empty($oids)) {
     $current /= $divisor;
     $index = $oid;
     $descr = 'Signal';
-    discover_sensor(null, 'signal', $device, $oid, $index, $type, $descr, $divisor, '1', null, null, null, null, $current);
+    discover_sensor(null, \LibreNMS\Enum\Sensor::Signal, $device, $oid, $index, $type, $descr, $divisor, '1', null, null, null, null, $current);
 }

--- a/includes/discovery/sensors/snr/arris-c4.inc.php
+++ b/includes/discovery/sensors/snr/arris-c4.inc.php
@@ -41,7 +41,7 @@ foreach ($oids as $index => $data) {
         if (preg_match('/.0$/', (string) $port?->ifName)) {
             app('sensor-discovery')->discover(new \App\Models\Sensor([
                 'poller_type' => 'snmp',
-                'sensor_class' => 'snr',
+                'sensor_class' => \LibreNMS\Enum\Sensor::Snr,
                 'sensor_oid' => $oid,
                 'sensor_index' => 'docsIfSigQSignalNoise.' . $index,
                 'sensor_type' => 'cmts',

--- a/includes/discovery/sensors/snr/ciscoepc.inc.php
+++ b/includes/discovery/sensors/snr/ciscoepc.inc.php
@@ -29,6 +29,6 @@ foreach ($pre_cache['ciscoepc_docsIfSignalQualityTable'] as $index => $data) {
         $oid = '.1.3.6.1.2.1.10.127.1.1.4.1.5.' . $index;
         $divisor = 10;
         $value = $data['docsIfSigQSignalNoise'];
-        discover_sensor(null, 'snr', $device, $oid, 'docsIfSigQSignalNoise.' . $index, 'ciscoepc', $descr, $divisor, '1', null, null, null, null, $value);
+        discover_sensor(null, \LibreNMS\Enum\Sensor::Snr, $device, $oid, 'docsIfSigQSignalNoise.' . $index, 'ciscoepc', $descr, $divisor, '1', null, null, null, null, $value);
     }
 }

--- a/includes/discovery/sensors/snr/infinera-groove.inc.php
+++ b/includes/discovery/sensors/snr/infinera-groove.inc.php
@@ -28,6 +28,6 @@ foreach ($pre_cache['infineragroove_portTable'] as $index => $data) {
         $descr = $data['portAlias'] . ' Optical SNR';
         $oid = '.1.3.6.1.4.1.42229.1.2.4.1.19.1.1.24.' . $index;
         $value = $data['ochOsOSNR'];
-        discover_sensor(null, 'snr', $device, $oid, 'ochOsOSNR.' . $index, 'infinera-groove', $descr, null, '1', null, null, null, null, $value);
+        discover_sensor(null, \LibreNMS\Enum\Sensor::Snr, $device, $oid, 'ochOsOSNR.' . $index, 'infinera-groove', $descr, null, '1', null, null, null, null, $value);
     }
 }

--- a/includes/discovery/sensors/snr/terra-sdi480.inc.php
+++ b/includes/discovery/sensors/snr/terra-sdi480.inc.php
@@ -23,6 +23,7 @@
  *
  * @author     Peca Nesovanovic <peca.nesovanovic@sattrakt.com>
  */
+
 $divisor = 10;
 $multiplier = 1;
 
@@ -44,7 +45,7 @@ if (is_array($oids)) {
 
             app('sensor-discovery')->discover(new \App\Models\Sensor([
                 'poller_type' => 'snmp',
-                'sensor_class' => 'snr',
+                'sensor_class' => \LibreNMS\Enum\Sensor::Snr,
                 'sensor_oid' => $oid,
                 'sensor_index' => $inputid,
                 'sensor_type' => $type,

--- a/includes/discovery/sensors/state/airos-af-ltu.inc.php
+++ b/includes/discovery/sensors/state/airos-af-ltu.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 /**
  * airos-af-ltu.inc.php
  *
@@ -45,8 +47,8 @@ foreach ($oids as $index => $entry) {
     create_state_index($rxrate_state_name, $rate_states);
 
     //Discover Sensors
-    discover_sensor(null, 'state', $device, '.1.3.6.1.4.1.41112.1.10.1.4.1.1.' . $index, 1, $txrate_state_name, 'TX Modulation Rate', '1', '1', null, null, null, null, $entry['afLTUStaTxRate']);
-    discover_sensor(null, 'state', $device, '.1.3.6.1.4.1.41112.1.10.1.4.1.2.' . $index, 2, $rxrate_state_name, 'RX Modulation Rate', '1', '1', null, null, null, null, $entry['afLTUStaRxRate']);
+    discover_sensor(null, SensorEnum::State, $device, '.1.3.6.1.4.1.41112.1.10.1.4.1.1.' . $index, 1, $txrate_state_name, 'TX Modulation Rate', '1', '1', null, null, null, null, $entry['afLTUStaTxRate']);
+    discover_sensor(null, SensorEnum::State, $device, '.1.3.6.1.4.1.41112.1.10.1.4.1.2.' . $index, 2, $rxrate_state_name, 'RX Modulation Rate', '1', '1', null, null, null, null, $entry['afLTUStaRxRate']);
     break;
 }
 

--- a/includes/discovery/sensors/state/airos-af60.inc.php
+++ b/includes/discovery/sensors/state/airos-af60.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 $oids = snmpwalk_cache_oid($device, 'af60StaTxMCS', [], 'UI-AF60-MIB', 'ubnt', '-OteQUsb'); //UBNT-AFLTU-MIB::afLTUStaTxRate
 $oids = snmpwalk_cache_oid($device, 'af60StaRxMCS', $oids, 'UI-AF60-MIB', 'ubnt', '-OteQUsb'); //UBNT-AFLTU-MIB::afLTUStaRxRate
 
@@ -24,8 +26,8 @@ foreach ($oids as $index => $entry) {
     create_state_index($rxmcs_state_name, $rate_states);
 
     //Discover Sensors
-    discover_sensor(null, 'state', $device, '.1.3.6.1.4.1.41112.1.11.1.3.1.5.' . $index, 1, $txmcs_state_name, 'TX MCS Rate', '1', '1', null, null, null, null, $entry['af60StaTxMCS']);
-    discover_sensor(null, 'state', $device, '.1.3.6.1.4.1.41112.1.11.1.3.1.6.' . $index, 2, $rxmcs_state_name, 'RX MCS Rate', '1', '1', null, null, null, null, $entry['af60StaRxMCS']);
+    discover_sensor(null, SensorEnum::State, $device, '.1.3.6.1.4.1.41112.1.11.1.3.1.5.' . $index, 1, $txmcs_state_name, 'TX MCS Rate', '1', '1', null, null, null, null, $entry['af60StaTxMCS']);
+    discover_sensor(null, SensorEnum::State, $device, '.1.3.6.1.4.1.41112.1.11.1.3.1.6.' . $index, 2, $rxmcs_state_name, 'RX MCS Rate', '1', '1', null, null, null, null, $entry['af60StaRxMCS']);
     break;
 }
 
@@ -55,7 +57,7 @@ foreach ($oids as $index => $entry) {
     create_state_index($activeLink_state_name, $rate_states);
 
     //Discover Sensors
-    discover_sensor(null, 'state', $device, '.1.3.6.1.4.1.41112.1.11.1.3.1.2.' . $index, 1, $activeLink_state_name, 'Active link', '1', '1', null, null, null, null, $entry['af60StaActiveLink']);
+    discover_sensor(null, SensorEnum::State, $device, '.1.3.6.1.4.1.41112.1.11.1.3.1.2.' . $index, 1, $activeLink_state_name, 'Active link', '1', '1', null, null, null, null, $entry['af60StaActiveLink']);
     break;
 }
 

--- a/includes/discovery/sensors/state/aos-emu2.inc.php
+++ b/includes/discovery/sensors/state/aos-emu2.inc.php
@@ -25,6 +25,8 @@
  * @author     Peca Nesovanovic <peca.nesovanovic@sattrakt.com>
  */
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 // Input Contact discovery
 $oids = SnmpQuery::walk([
     'PowerNet-MIB::emsInputContactStatusEntry',
@@ -54,7 +56,7 @@ foreach ($oids as $contact) {
 
     app('sensor-discovery')->discover(new \App\Models\Sensor([
         'poller_type' => 'snmp',
-        'sensor_class' => 'state',
+        'sensor_class' => SensorEnum::State,
         'sensor_oid' => $oid,
         'sensor_index' => $index,
         'sensor_type' => $state_name,
@@ -102,7 +104,7 @@ foreach ($oids as $relay) {
 
     app('sensor-discovery')->discover(new \App\Models\Sensor([
         'poller_type' => 'snmp',
-        'sensor_class' => 'state',
+        'sensor_class' => SensorEnum::State,
         'sensor_oid' => $oid,
         'sensor_index' => $index,
         'sensor_type' => $state_name,
@@ -150,7 +152,7 @@ foreach ($oids as $outlet) {
 
     app('sensor-discovery')->discover(new \App\Models\Sensor([
         'poller_type' => 'snmp',
-        'sensor_class' => 'state',
+        'sensor_class' => SensorEnum::State,
         'sensor_oid' => $oid,
         'sensor_index' => $index,
         'sensor_type' => $state_name,

--- a/includes/discovery/sensors/state/aos6.inc.php
+++ b/includes/discovery/sensors/state/aos6.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 $chas_oid = '.1.3.6.1.4.1.6486.800.1.1.1.1.1.1.1.2.'; // chasEntPhysOperStatus
 $stack_left = snmp_walk($device, 'chasFreeSlots', '-OQUse', 'ALCATEL-IND1-CHASSIS-MIB', 'nokia/aos6');
 $stack_role = snmp_walk($device, 'alaStackMgrChasRole', '-OQUse', 'ALCATEL-IND1-STACK-MANAGER-MIB', 'nokia/aos6');
@@ -25,7 +27,7 @@ foreach ($aos6_fan_oids as $index => $data) {
         ];
         if (! empty($current)) {
             create_state_index($state_name, $states);
-            discover_sensor(null, 'state', $device, $oid, $index, $state_name, $descr, 1, 1, null, null, null, null, $current);
+            discover_sensor(null, SensorEnum::State, $device, $oid, $index, $state_name, $descr, 1, 1, null, null, null, null, $current);
         }
     }
 }
@@ -49,7 +51,7 @@ if (($stack_left < $stacking) && ($stack_alone < $stacking_non)) {
                 ['value' => 2, 'generic' => 2, 'graph' => 1, 'descr' => 'Disconnected'],
             ];
             create_state_index($stack_state_namea, $states_stacka);
-            discover_sensor(null, 'state', $device, $oid_stackport_a, $stackindexa, $stack_state_namea, $descr_stacka, 1, 1, null, null, null, null, $current_stacka);
+            discover_sensor(null, SensorEnum::State, $device, $oid_stackport_a, $stackindexa, $stack_state_namea, $descr_stacka, 1, 1, null, null, null, null, $current_stacka);
         }
     }
 }
@@ -66,7 +68,7 @@ if (($stack_left < $stacking) && ($stack_alone < $stacking_non)) {
                 ['value' => 2, 'generic' => 2, 'graph' => 1, 'descr' => 'Disconnected'],
             ];
             create_state_index($stack_state_nameb, $states_stackb);
-            discover_sensor(null, 'state', $device, $oid_stackport_b, $stackindexb, $stack_state_nameb, $descr_stackb, 1, 1, null, null, null, null, $current_stackb);
+            discover_sensor(null, SensorEnum::State, $device, $oid_stackport_b, $stackindexb, $stack_state_nameb, $descr_stackb, 1, 1, null, null, null, null, $current_stackb);
         }
     }
 }

--- a/includes/discovery/sensors/state/apc.inc.php
+++ b/includes/discovery/sensors/state/apc.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 /*
  * LibreNMS
  *
@@ -26,7 +28,7 @@ if (is_numeric($temp)) {
 
     $descr = 'UPS Battery Replacement Status';
     //Discover Sensors
-    discover_sensor(null, 'state', $device, $cur_oid, $index, $state_name, $descr, 1, 1, null, null, null, null, $temp, 'snmp', $index);
+    discover_sensor(null, SensorEnum::State, $device, $cur_oid, $index, $state_name, $descr, 1, 1, null, null, null, null, $temp, 'snmp', $index);
 }
 
 $cooling_status = snmpwalk_cache_oid($device, 'coolingUnitStatusDiscreteEntry', [], 'PowerNet-MIB');
@@ -43,7 +45,7 @@ foreach ($cooling_status as $index => $data) {
     }
     create_state_index($state_name, $states);
 
-    discover_sensor(null, 'state', $device, $cur_oid, $cur_oid, 'apc', $state_name, 1, 1, null, null, null, null, $data['coolingUnitStatusDiscreteValueAsInteger']);
+    discover_sensor(null, SensorEnum::State, $device, $cur_oid, $cur_oid, 'apc', $state_name, 1, 1, null, null, null, null, $data['coolingUnitStatusDiscreteValueAsInteger']);
 }
 
 unset($cooling_status);
@@ -62,7 +64,7 @@ foreach ($cooling_unit as $index => $data) {
     }
     create_state_index($state_name, $states);
 
-    discover_sensor(null, 'state', $device, $cur_oid, $cur_oid, 'apc', $state_name, 1, 1, null, null, null, null, $data['coolingUnitExtendedDiscreteValueAsInteger']);
+    discover_sensor(null, SensorEnum::State, $device, $cur_oid, $cur_oid, 'apc', $state_name, 1, 1, null, null, null, null, $data['coolingUnitExtendedDiscreteValueAsInteger']);
 }
 
 unset($cooling_unit);
@@ -79,7 +81,7 @@ foreach ($relays as $index => $data) {
 
     $current = apc_relay_state($data['emsOutputRelayControlOutputRelayCommand']);
     if (is_numeric($current)) {
-        discover_sensor(null, 'state', $device, $cur_oid, $cur_oid, $state_name, $state_name, 1, 1, null, null, null, null, $current);
+        discover_sensor(null, SensorEnum::State, $device, $cur_oid, $cur_oid, $state_name, $state_name, 1, 1, null, null, null, null, $current);
     }
 }
 unset(
@@ -100,7 +102,7 @@ foreach ($switched as $index => $data) {
 
     $current = apc_relay_state($data['emsOutletControlOutletCommand']);
     if (is_numeric($current)) {
-        discover_sensor(null, 'state', $device, $cur_oid, $cur_oid, $state_name, $state_name, 1, 1, null, null, null, null, $current);
+        discover_sensor(null, SensorEnum::State, $device, $cur_oid, $cur_oid, $state_name, $state_name, 1, 1, null, null, null, null, $current);
     }
 }
 unset(
@@ -126,7 +128,7 @@ foreach ($pre_cache['mem_sensors_status'] as $index => $data) {
     $divisor = 1;
     $multiplier = 1;
     if (is_numeric($current)) {
-        discover_sensor(null, 'state', $device, $cur_oid, $state_name . '.' . $index, $state_name, $state_name, 1, 1, null, null, null, null, $current);
+        discover_sensor(null, SensorEnum::State, $device, $cur_oid, $state_name . '.' . $index, $state_name, $state_name, 1, 1, null, null, null, null, $current);
     }
 
     if ($data['memSensorsAlarmStatus']) {
@@ -145,7 +147,7 @@ foreach ($pre_cache['mem_sensors_status'] as $index => $data) {
     $divisor = 1;
     $multiplier = 1;
     if (is_numeric($current)) {
-        discover_sensor(null, 'state', $device, $cur_oid, $state_name . '.' . $index, $state_name, $state_name, 1, 1, null, null, null, null, $current);
+        discover_sensor(null, SensorEnum::State, $device, $cur_oid, $state_name . '.' . $index, $state_name, $state_name, 1, 1, null, null, null, null, $current);
     }
 }
 
@@ -183,7 +185,7 @@ if (isset($apcContactData['uioInputContactStatusTableSize']) && $apcContactData[
                 $index = $split_index[0];
             }
 
-            discover_sensor(null, 'state', $device, $cur_oid, $state_name . '.' . $index, $state_name, $state_name, 1, 1, null, null, null, null, $current);
+            discover_sensor(null, SensorEnum::State, $device, $cur_oid, $state_name . '.' . $index, $state_name, $state_name, 1, 1, null, null, null, null, $current);
         }
     }
 } else {
@@ -216,7 +218,7 @@ if (isset($apcContactData['uioInputContactStatusTableSize']) && $apcContactData[
             ];
             create_state_index($state_name, $states);
 
-            discover_sensor(null, 'state', $device, $cur_oid, $state_name . '.' . $index, $state_name, $state_name, 1, 1, null, null, null, null, $current);
+            discover_sensor(null, SensorEnum::State, $device, $cur_oid, $state_name . '.' . $index, $state_name, $state_name, 1, 1, null, null, null, null, $current);
         }
     }
 }

--- a/includes/discovery/sensors/state/axiscam.inc.php
+++ b/includes/discovery/sensors/state/axiscam.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 echo 'AXIS States';
 
 // Temp Sensor Status
@@ -23,7 +25,7 @@ if (isset($oids) && is_array($oids)) {
 
     foreach ($oids as $index => $entry) {
         //Discover Sensors
-        discover_sensor(null, 'state', $device, $cur_oid . $index, $index, $state_name, 'Temperature Sensor ' . $index, 1, 1, null, null, null, null, $entry['tempSensorStatus'], 'snmp', $index);
+        discover_sensor(null, SensorEnum::State, $device, $cur_oid . $index, $index, $state_name, 'Temperature Sensor ' . $index, 1, 1, null, null, null, null, $entry['tempSensorStatus'], 'snmp', $index);
     }
 }
 
@@ -42,7 +44,7 @@ if (is_array($oids)) {
 
     foreach ($oids as $index => $entry) {
         //Discover Sensors
-        discover_sensor(null, 'state', $device, $cur_oid . $index, $index, $state_name, 'Storage Status: ' . ($entry['storageName'] ?? null), 1, 1, null, null, null, null, $entry['storageDisruptionDetected'], 'snmp', $index);
+        discover_sensor(null, SensorEnum::State, $device, $cur_oid . $index, $index, $state_name, 'Storage Status: ' . ($entry['storageName'] ?? null), 1, 1, null, null, null, null, $entry['storageDisruptionDetected'], 'snmp', $index);
     }
 }
 

--- a/includes/discovery/sensors/state/boss.inc.php
+++ b/includes/discovery/sensors/state/boss.inc.php
@@ -53,7 +53,7 @@ if ($device['os'] === 'boss') {
                 $descr = "BOSS Unit $unit: $entry[s5ChasComDescr]";
             }
             //Discover Sensors
-            discover_sensor(null, 'state', $device, $cur_oid . $index, "s5ChasComOperState.$index", $state_name, $descr, 1, 1, null, null, null, null, $entry['s5ChasComOperState']);
+            discover_sensor(null, \LibreNMS\Enum\Sensor::State, $device, $cur_oid . $index, "s5ChasComOperState.$index", $state_name, $descr, 1, 1, null, null, null, null, $entry['s5ChasComOperState']);
             $temp_unit = $unit;
         }
     }

--- a/includes/discovery/sensors/state/cisco.inc.php
+++ b/includes/discovery/sensors/state/cisco.inc.php
@@ -228,7 +228,7 @@ foreach ($tables as $tablevalue) {
                     $repsegmentnumber++;
                     $descr = $tablevalue['descr'] . $repsegmentnumber;
                 }
-                discover_sensor(null, 'state', $device, $cur_oid . $index, $index, $state_name, trim((string) $descr), 1, 1, null, null, null, null, $entry[$state_name], 'snmp', $index, null, null, $state_group);
+                discover_sensor(null, \LibreNMS\Enum\Sensor::State, $device, $cur_oid . $index, $index, $state_name, trim((string) $descr), 1, 1, null, null, null, null, $entry[$state_name], 'snmp', $index, null, null, $state_group);
             }
         }
     }

--- a/includes/discovery/sensors/state/ciscosb.inc.php
+++ b/includes/discovery/sensors/state/ciscosb.inc.php
@@ -42,7 +42,7 @@ if (! empty($temp)) {
 
         if (Str::contains($descr, ['ethernet', 'Ethernet']) && $port?->ifOperStatus !== 'notPresent') {
             //Discover Sensors
-            discover_sensor(null, 'state', $device, $cur_oid . $index, $index, $state_name, $descr, 1, 1, null, null, null, null, $value, 'snmp', $index);
+            discover_sensor(null, \LibreNMS\Enum\Sensor::State, $device, $cur_oid . $index, $index, $state_name, $descr, 1, 1, null, null, null, null, $value, 'snmp', $index);
         }
     }
 }

--- a/includes/discovery/sensors/state/commander-plus.inc.php
+++ b/includes/discovery/sensors/state/commander-plus.inc.php
@@ -35,7 +35,7 @@ foreach ($state_table[0] as $state_name => $state_value) {
     create_state_index($state_name, $states);
 
     $descr = $state_name;
-    discover_sensor(null, 'state', $device, $start_oid . '.' . $x . '.0', $state_name, $state_name, $descr, 1, 1, null, null, null, null, $state_value, 'snmp');
+    discover_sensor(null, \LibreNMS\Enum\Sensor::State, $device, $start_oid . '.' . $x . '.0', $state_name, $state_name, $descr, 1, 1, null, null, null, null, $state_value, 'snmp');
     $x++;
 }
 

--- a/includes/discovery/sensors/state/ctm.inc.php
+++ b/includes/discovery/sensors/state/ctm.inc.php
@@ -75,7 +75,7 @@ foreach ($octetSetup as $entry) {
             $port_number = $index + 1;
             discover_sensor(
                 null,
-                'state',
+                $sensor_class,
                 $device,
                 $entry['num_oid'],
                 $port_number,

--- a/includes/discovery/sensors/state/cumulus.inc.php
+++ b/includes/discovery/sensors/state/cumulus.inc.php
@@ -46,6 +46,6 @@ if (is_array($temp)) {
         $oid = $base_oid . $index;
 
         // Discover Sensors
-        discover_sensor(null, 'state', $device, $oid, $index, $state_name, $descr, 1, 1, null, null, null, null, $sensor_value, 'snmp', $index);
+        discover_sensor(null, \LibreNMS\Enum\Sensor::State, $device, $oid, $index, $state_name, $descr, 1, 1, null, null, null, null, $sensor_value, 'snmp', $index);
     }
 }

--- a/includes/discovery/sensors/state/dell-powervault.inc.php
+++ b/includes/discovery/sensors/state/dell-powervault.inc.php
@@ -24,7 +24,7 @@ if (is_array($oids)) {
 
             create_state_index($descr, $states);
 
-            discover_sensor(null, 'state', $device, $cur_oid . $index, $index, 'dellme', $descr, '1', '1', null, null, null, null, $value);
+            discover_sensor(null, \LibreNMS\Enum\Sensor::State, $device, $cur_oid . $index, $index, 'dellme', $descr, '1', '1', null, null, null, null, $value);
         }
     }
 }

--- a/includes/discovery/sensors/state/dell.inc.php
+++ b/includes/discovery/sensors/state/dell.inc.php
@@ -118,7 +118,7 @@ foreach ($tables as [$table, $num_oid, $value_oid, $descr_oid, $mib, $mib_dir]) 
                     $descr = strip_tags((string) $entry[$descr_oid]); // Use clean as virtualDiskDeviceName is user defined
                 }
                 //Discover Sensors
-                discover_sensor(null, 'state', $device, $num_oid . $index, $index, $state_name, $descr, 1, 1, null, null, null, null, $entry[$value_oid], 'snmp', $index);
+                discover_sensor(null, \LibreNMS\Enum\Sensor::State, $device, $num_oid . $index, $index, $state_name, $descr, 1, 1, null, null, null, null, $entry[$value_oid], 'snmp', $index);
             }
         }
     }

--- a/includes/discovery/sensors/state/dhcpatriot.inc.php
+++ b/includes/discovery/sensors/state/dhcpatriot.inc.php
@@ -50,7 +50,7 @@ $oids = [
     ],
 ];
 
-$class = 'state';
+$class = $sensor_class;
 $type = 'dhcpatriotServiceStatus';
 $divisor = 1;
 $multiplier = 1;

--- a/includes/discovery/sensors/state/edgecos.inc.php
+++ b/includes/discovery/sensors/state/edgecos.inc.php
@@ -23,5 +23,5 @@
  * @copyright  2026 Frederik Kriewitz
  * @author     Frederik Kriewitz <frederik@kriewitz.eu>
  */
-$os->discoverFanSensors(['state']);
+$os->discoverFanSensors([\LibreNMS\Enum\Sensor::State]);
 $os->discoverPowerStatus();

--- a/includes/discovery/sensors/state/eltek-webpower.inc.php
+++ b/includes/discovery/sensors/state/eltek-webpower.inc.php
@@ -71,6 +71,6 @@ foreach ($count as &$countValue) {
         $num_oid = $symmetry_oid[$countValue - 1];
         $state = $state_numeric / $divisor;
         $descr = 'Battery banks symmetry ' . $countValue;
-        discover_sensor(null, 'state', $device, $num_oid, $index, $state_name, $descr, $divisor, '1', null, null, null, $limit, $state);
+        discover_sensor(null, \LibreNMS\Enum\Sensor::State, $device, $num_oid, $index, $state_name, $descr, $divisor, '1', null, null, null, $limit, $state);
     }
 }

--- a/includes/discovery/sensors/state/eltex-mes24xx.inc.php
+++ b/includes/discovery/sensors/state/eltex-mes24xx.inc.php
@@ -59,7 +59,7 @@ if (isset($eltexPhyTransceiverDiagnosticTable['lossOfSignal'])) {
 
         app('sensor-discovery')->discover(new \App\Models\Sensor([
             'poller_type' => 'snmp',
-            'sensor_class' => 'state',
+            'sensor_class' => \LibreNMS\Enum\Sensor::State,
             'sensor_oid' => $oid,
             'sensor_index' => 'SfpLoss' . $ifIndex,
             'sensor_type' => 'ELTEX-PHY-MIB',

--- a/includes/discovery/sensors/state/equallogic.inc.php
+++ b/includes/discovery/sensors/state/equallogic.inc.php
@@ -13,6 +13,7 @@
  */
 
 use Illuminate\Support\Facades\Log;
+use LibreNMS\Enum\Sensor as SensorEnum;
 use LibreNMS\Util\Number;
 
 $oids = snmp_walk($device, 'eqlMemberHealthStatus', '-OQne', 'EQLMEMBER-MIB', 'equallogic');
@@ -61,7 +62,7 @@ if (! empty($oids)) {
             $index = (int) Number::cast($num_index);
             $low_limit = 0.5;
             $high_limit = 2.5;
-            discover_sensor(null, 'state', $device, $oid, $index, $state_name, $descr, 1, 1, $low_limit, $low_limit, $high_limit, $high_limit, $current, 'snmp', $index);
+            discover_sensor(null, SensorEnum::State, $device, $oid, $index, $state_name, $descr, 1, 1, $low_limit, $low_limit, $high_limit, $high_limit, $current, 'snmp', $index);
         }
     }
 }
@@ -114,7 +115,7 @@ if (! empty($oids1)) {
                 $index = (100 + $index);
                 $low_limit = 0.5;
                 $high_limit = 1.5;
-                discover_sensor(null, 'state', $device, $oid, $index, $state_name, $descr, 1, 1, $low_limit, $low_limit, $high_limit, $high_limit, $pstatus, 'snmp', $index);
+                discover_sensor(null, SensorEnum::State, $device, $oid, $index, $state_name, $descr, 1, 1, $low_limit, $low_limit, $high_limit, $high_limit, $pstatus, 'snmp', $index);
             }
         }//end if
     }//end foreach
@@ -157,7 +158,7 @@ if (! empty($oids_disks)) {
                 $index = 'eqlDiskStatus.' . $disk_index;
                 $low_limit = 0.5;
                 $high_limit = 1.5;
-                discover_sensor(null, 'state', $device, $oid, $index, $state_name, "Disk $disk_index - $descr", 1, 1, $low_limit, $low_limit, $high_limit, $high_limit, $pstatus, 'snmp', $index);
+                discover_sensor(null, SensorEnum::State, $device, $oid, $index, $state_name, "Disk $disk_index - $descr", 1, 1, $low_limit, $low_limit, $high_limit, $high_limit, $pstatus, 'snmp', $index);
                 unset(
                     $index,
                     $low_limit,

--- a/includes/discovery/sensors/state/eurostor.inc.php
+++ b/includes/discovery/sensors/state/eurostor.inc.php
@@ -39,7 +39,7 @@ foreach ($walk as $mib => $num_oid) {
                     break;
                 }
             }
-            discover_sensor(null, 'state', $device, $num_oid . $index, $mib . $index, $state_name, $entry[$mib . 'Desc'], 1, 1, null, null, null, null, $stateLookupTable[$entry[$mib . 'State']], 'snmp', $mib . $index, null, null, $group);
+            discover_sensor(null, \LibreNMS\Enum\Sensor::State, $device, $num_oid . $index, $mib . $index, $state_name, $entry[$mib . 'Desc'], 1, 1, null, null, null, null, $stateLookupTable[$entry[$mib . 'State']], 'snmp', $mib . $index, null, null, $group);
         }
     }
 }

--- a/includes/discovery/sensors/state/exa.inc.php
+++ b/includes/discovery/sensors/state/exa.inc.php
@@ -17,7 +17,7 @@ foreach ($ponTable as $e7OltPonPortShelf => $ponShelf) {
 
                 app('sensor-discovery')->discover(new Sensor([
                     'poller_type' => 'snmp',
-                    'sensor_class' => 'state',
+                    'sensor_class' => \LibreNMS\Enum\Sensor::State,
                     'sensor_oid' => ".1.3.6.1.4.1.6321.1.2.2.2.1.6.2.1.4.$index",
                     'sensor_index' => 'ponStatus.' . $index,
                     'sensor_type' => 'E7-Calix-MIB::e7OltPonPortStatus',

--- a/includes/discovery/sensors/state/extendair.inc.php
+++ b/includes/discovery/sensors/state/extendair.inc.php
@@ -57,7 +57,7 @@ foreach ($sensors as $sensor) {
         create_state_index($state_name, $states);
 
         $descr = $sensor['descr'];
-        discover_sensor(null, 'state', $device, $cur_oid, $index, $state_name, $descr, 1, 1, null, null, null, null, $temp);
+        discover_sensor(null, \LibreNMS\Enum\Sensor::State, $device, $cur_oid, $index, $state_name, $descr, 1, 1, null, null, null, null, $temp);
     }
 }
 

--- a/includes/discovery/sensors/state/fortigate.inc.php
+++ b/includes/discovery/sensors/state/fortigate.inc.php
@@ -75,7 +75,7 @@ if ($systemMode == 'activePassive' || $systemMode == 'activeActive') {
 
         discover_sensor(
             null,
-            'state',
+            $sensor_class,
             $device,
             '.1.3.6.1.4.1.12356.101.13.2.1.1.12.' . $index,
             $index,

--- a/includes/discovery/sensors/state/fs-nmu.inc.php
+++ b/includes/discovery/sensors/state/fs-nmu.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 /**
  * fs-nmu.inc.php
  *
@@ -41,7 +43,7 @@ if (is_numeric($power1)) {
     create_state_index($state_name, $states);
 
     $descr = 'Power 1 State';
-    discover_sensor(null, 'state', $device, $oid_power1, $index, $state_name, $descr, 1, 1, null, null, null, null, $power1, 'snmp', $index);
+    discover_sensor(null, SensorEnum::State, $device, $oid_power1, $index, $state_name, $descr, 1, 1, null, null, null, null, $power1, 'snmp', $index);
 }
 
 // Power 2 State
@@ -54,7 +56,7 @@ if (is_numeric($power2)) {
     create_state_index($state_name, $states);
 
     $descr = 'Power 2 State';
-    discover_sensor(null, 'state', $device, $oid_power2, $index, $state_name, $descr, 1, 1, null, null, null, null, $power2, 'snmp', $index);
+    discover_sensor(null, SensorEnum::State, $device, $oid_power2, $index, $state_name, $descr, 1, 1, null, null, null, null, $power2, 'snmp', $index);
 }
 
 // Fan State
@@ -67,5 +69,5 @@ if (is_numeric($fan)) {
     create_state_index($state_name, $states);
 
     $descr = 'Fan State';
-    discover_sensor(null, 'state', $device, $oid_fan, $index, $state_name, $descr, 1, 1, null, null, null, null, $fan, 'snmp', $index);
+    discover_sensor(null, SensorEnum::State, $device, $oid_fan, $index, $state_name, $descr, 1, 1, null, null, null, null, $fan, 'snmp', $index);
 }

--- a/includes/discovery/sensors/state/grandstream-gxw.inc.php
+++ b/includes/discovery/sensors/state/grandstream-gxw.inc.php
@@ -51,7 +51,7 @@ if (is_array($statuses)) {
 
         discover_sensor(
             null,
-            'state',
+            $sensor_class,
             $device,
             $oid,
             $index,
@@ -99,7 +99,7 @@ if (is_array($statuses)) {
 
         discover_sensor(
             null,
-            'state',
+            $sensor_class,
             $device,
             $oid,
             $index,

--- a/includes/discovery/sensors/state/grandstream-ht.inc.php
+++ b/includes/discovery/sensors/state/grandstream-ht.inc.php
@@ -52,7 +52,7 @@ if (is_array($statuses)) {
 
         discover_sensor(
             null,
-            'state',
+            $sensor_class,
             $device,
             $oid,
             $state_index,
@@ -101,7 +101,7 @@ if (is_array($statuses)) {
 
         discover_sensor(
             null,
-            'state',
+            $sensor_class,
             $device,
             $oid,
             $state_index,

--- a/includes/discovery/sensors/state/hp.inc.php
+++ b/includes/discovery/sensors/state/hp.inc.php
@@ -62,7 +62,7 @@ foreach ($tables as $tablevalue) {
             //Discover Sensors
             discover_sensor(
                 null,
-                'state',
+                $sensor_class,
                 $device,
                 $num_oid . $index,
                 $index,

--- a/includes/discovery/sensors/state/hpblmos.inc.php
+++ b/includes/discovery/sensors/state/hpblmos.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 $fan_state_name = 'hpblmos_fanstate';
 $fan_state_descr = 'Fan ';
 $fans_oid = '.1.3.6.1.4.1.232.22.2.3.1.3.1.8';
@@ -26,7 +28,7 @@ foreach (explode("\n", $fans) as $fan) {
                 ];
                 create_state_index($state_name, $states);
             }
-            discover_sensor(null, 'state', $device, $current_oid, $current_id, $fan_state_name, $descr, 1, 1, null, null, null, null, $state, 'snmp', $current_id);
+            discover_sensor(null, SensorEnum::State, $device, $current_oid, $current_id, $fan_state_name, $descr, 1, 1, null, null, null, null, $state, 'snmp', $current_id);
         }
     }
 }
@@ -57,7 +59,7 @@ foreach (explode("\n", $psus) as $psu) {
                 ];
                 create_state_index($state_name, $states);
             }
-            discover_sensor(null, 'state', $device, $current_oid, $current_id, $psu_state_name, $descr, 1, 1, null, null, null, null, $state, 'snmp', $current_id);
+            discover_sensor(null, SensorEnum::State, $device, $current_oid, $current_id, $psu_state_name, $descr, 1, 1, null, null, null, null, $state, 'snmp', $current_id);
         }
     }
 }

--- a/includes/discovery/sensors/state/ict-pdu.inc.php
+++ b/includes/discovery/sensors/state/ict-pdu.inc.php
@@ -45,6 +45,6 @@ if (is_array($oids)) {
             $current_value = 2;
         }
 
-        discover_sensor(null, 'state', $device, $fuse_state_oid, $index, $state_name, $descr, 1, 1, null, null, null, null, $current_value, 'snmp', $index);
+        discover_sensor(null, \LibreNMS\Enum\Sensor::State, $device, $fuse_state_oid, $index, $state_name, $descr, 1, 1, null, null, null, null, $current_value, 'snmp', $index);
     }
 }

--- a/includes/discovery/sensors/state/infinera-groove.inc.php
+++ b/includes/discovery/sensors/state/infinera-groove.inc.php
@@ -39,6 +39,6 @@ foreach ($pre_cache['infineragroove_slotTable'] as $index => $data) {
     if (is_array($data) && isset($data['cardMode'])) {
         // discover sensors
         $descr = 'slot-' . str_replace('.', '/', $index) . ' (' . $data['slotActualCardType'] . ')';
-        discover_sensor(null, 'state', $device, $num_oid . $index, $index, $state_name, $descr, '1', '1', null, null, null, null, $data['cardMode'], 'snmp', $index);
+        discover_sensor(null, \LibreNMS\Enum\Sensor::State, $device, $num_oid . $index, $index, $state_name, $descr, '1', '1', null, null, null, null, $data['cardMode'], 'snmp', $index);
     }
 }

--- a/includes/discovery/sensors/state/innovaphone.inc.php
+++ b/includes/discovery/sensors/state/innovaphone.inc.php
@@ -36,6 +36,6 @@ if (! empty($oids)) {
         }
         $name = 'Interface ' . $ifname;
         //Discover Sensors
-        discover_sensor(null, 'state', $device, $num_oid . $index, $index, $state_name, $name, '1', '1', null, null, null, null, $entry['voiceIfState'], 'snmp', $index);
+        discover_sensor(null, \LibreNMS\Enum\Sensor::State, $device, $num_oid . $index, $index, $state_name, $name, '1', '1', null, null, null, null, $entry['voiceIfState'], 'snmp', $index);
     }
 }

--- a/includes/discovery/sensors/state/juniper-mss.inc.php
+++ b/includes/discovery/sensors/state/juniper-mss.inc.php
@@ -29,6 +29,6 @@ if (is_array($temp)) {
     foreach ($temp as $index => $entry) {
         $descr = $temp[$index]['trpzSysPowerSupplyDescr'];
         //Discover Sensors
-        discover_sensor(null, 'state', $device, $cur_oid . $index, $index, $state_name, $descr, 1, 1, null, null, null, null, $temp[$index]['trpzSysPowerSupplyStatus'], 'snmp', $index);
+        discover_sensor(null, \LibreNMS\Enum\Sensor::State, $device, $cur_oid . $index, $index, $state_name, $descr, 1, 1, null, null, null, null, $temp[$index]['trpzSysPowerSupplyStatus'], 'snmp', $index);
     }
 }

--- a/includes/discovery/sensors/state/linux.inc.php
+++ b/includes/discovery/sensors/state/linux.inc.php
@@ -36,7 +36,7 @@ if (! empty($pre_cache['raspberry_pi_sensors'])) {
             ];
             create_state_index($state_name, $states);
 
-            discover_sensor(null, 'state', $device, $oid . $codec, $codec, $state_name, $descr, 1, 1, null, null, null, null, $value, 'snmp', $codec);
+            discover_sensor(null, \LibreNMS\Enum\Sensor::State, $device, $oid . $codec, $codec, $state_name, $descr, 1, 1, null, null, null, null, $value, 'snmp', $codec);
         } else {
             break;
         }

--- a/includes/discovery/sensors/state/loop-telecom.inc.php
+++ b/includes/discovery/sensors/state/loop-telecom.inc.php
@@ -98,7 +98,7 @@ if (! empty($oids)) {
             $description = $index; //Set description equials to slot name. Ex. Slot-A or Slot-1
         }
 
-        discover_sensor(null, 'state', $device, $num_oid . $num_index, $index, $state_name, $description, '1', '1', null, null, null, null, $currentValue, 'snmp', null, null, null, 'Line cards');
+        discover_sensor(null, \LibreNMS\Enum\Sensor::State, $device, $num_oid . $num_index, $index, $state_name, $description, '1', '1', null, null, null, null, $currentValue, 'snmp', null, null, null, 'Line cards');
         $num_index += 1;
     }
 }

--- a/includes/discovery/sensors/state/netagent2.inc.php
+++ b/includes/discovery/sensors/state/netagent2.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 /**
  * netagent2.inc.php
  *
@@ -55,7 +57,7 @@ if (! empty($ups_state) || $ups_state == 0) {
     $state = $ups_state / $divisor;
     $descr = 'UPS state';
 
-    discover_sensor(null, 'state', $device, $ups_state_oid, $index, $state_name, $descr, $divisor, 1, $lowlimit, $lowwarnlimit, $warnlimit, $limit, $state);
+    discover_sensor(null, SensorEnum::State, $device, $ups_state_oid, $index, $state_name, $descr, $divisor, 1, $lowlimit, $lowwarnlimit, $warnlimit, $limit, $state);
 }
 
 // Detect type of UPS (Signle-Phase/3 Phase)
@@ -86,7 +88,7 @@ if ($in_phaseNum == '3') {
         $state = $ups_state / $divisor;
         $descr = 'In And Out';
 
-        discover_sensor(null, 'state', $device, $ups_state_oid, $index, $state_name, $descr, $divisor, 1, $lowlimit, $lowwarnlimit, $warnlimit, $limit, $state);
+        discover_sensor(null, SensorEnum::State, $device, $ups_state_oid, $index, $state_name, $descr, $divisor, 1, $lowlimit, $lowwarnlimit, $warnlimit, $limit, $state);
     }
 
     // Back Status
@@ -110,7 +112,7 @@ if ($in_phaseNum == '3') {
         $state = $ups_state / $divisor;
         $descr = 'Back Status';
 
-        discover_sensor(null, 'state', $device, $ups_state_oid, $index, $state_name, $descr, $divisor, 1, $lowlimit, $lowwarnlimit, $warnlimit, $limit, $state);
+        discover_sensor(null, SensorEnum::State, $device, $ups_state_oid, $index, $state_name, $descr, $divisor, 1, $lowlimit, $lowwarnlimit, $warnlimit, $limit, $state);
     }
 
     // Charge Status
@@ -135,7 +137,7 @@ if ($in_phaseNum == '3') {
         $state = $ups_state / $divisor;
         $descr = 'Charge Status';
 
-        discover_sensor(null, 'state', $device, $ups_state_oid, $index, $state_name, $descr, $divisor, 1, $lowlimit, $lowwarnlimit, $warnlimit, $limit, $state);
+        discover_sensor(null, SensorEnum::State, $device, $ups_state_oid, $index, $state_name, $descr, $divisor, 1, $lowlimit, $lowwarnlimit, $warnlimit, $limit, $state);
     }
 
     // Bypass braker status
@@ -159,7 +161,7 @@ if ($in_phaseNum == '3') {
         $state = $ups_state / $divisor;
         $descr = 'Breaker Status';
 
-        discover_sensor(null, 'state', $device, $ups_state_oid, $index, $state_name, $descr, $divisor, 1, $lowlimit, $lowwarnlimit, $warnlimit, $limit, $state);
+        discover_sensor(null, SensorEnum::State, $device, $ups_state_oid, $index, $state_name, $descr, $divisor, 1, $lowlimit, $lowwarnlimit, $warnlimit, $limit, $state);
     }
 
     // AC Status
@@ -183,7 +185,7 @@ if ($in_phaseNum == '3') {
         $state = $ups_state / $divisor;
         $descr = 'AC status';
 
-        discover_sensor(null, 'state', $device, $ups_state_oid, $index, $state_name, $descr, $divisor, 1, $lowlimit, $lowwarnlimit, $warnlimit, $limit, $state);
+        discover_sensor(null, SensorEnum::State, $device, $ups_state_oid, $index, $state_name, $descr, $divisor, 1, $lowlimit, $lowwarnlimit, $warnlimit, $limit, $state);
     }
 
     // Common State - Inverter active, Rectifier Operating
@@ -209,7 +211,7 @@ if ($in_phaseNum == '3') {
         $state = $ups_state / $divisor;
         $descr = 'Inverter Operating';
 
-        discover_sensor(null, 'state', $device, $ups_state_oid, $index, $state_name, $descr, $divisor, 1, $lowlimit, $lowwarnlimit, $warnlimit, $limit, $state);
+        discover_sensor(null, SensorEnum::State, $device, $ups_state_oid, $index, $state_name, $descr, $divisor, 1, $lowlimit, $lowwarnlimit, $warnlimit, $limit, $state);
     }
 
     // Rectifier Operating
@@ -229,7 +231,7 @@ if ($in_phaseNum == '3') {
         $state = $ups_state / $divisor;
         $descr = 'Rectifier Operating';
 
-        discover_sensor(null, 'state', $device, $ups_state_oid, $index, $state_name, $descr, $divisor, 1, $lowlimit, $lowwarnlimit, $warnlimit, $limit, $state);
+        discover_sensor(null, SensorEnum::State, $device, $ups_state_oid, $index, $state_name, $descr, $divisor, 1, $lowlimit, $lowwarnlimit, $warnlimit, $limit, $state);
     }
 
     // Switch Mode
@@ -253,7 +255,7 @@ if ($in_phaseNum == '3') {
         $state = $ups_state / $divisor;
         $descr = 'Switch Mode';
 
-        discover_sensor(null, 'state', $device, $ups_state_oid, $index, $state_name, $descr, $divisor, 1, $lowlimit, $lowwarnlimit, $warnlimit, $limit, $state);
+        discover_sensor(null, SensorEnum::State, $device, $ups_state_oid, $index, $state_name, $descr, $divisor, 1, $lowlimit, $lowwarnlimit, $warnlimit, $limit, $state);
     }
 
     // Common State - Rectifier Rotation Error, Bypass Status and Short Circuit
@@ -279,7 +281,7 @@ if ($in_phaseNum == '3') {
         $state = $ups_state / $divisor;
         $descr = 'Rectifier Rotation Error';
 
-        discover_sensor(null, 'state', $device, $ups_state_oid, $index, $state_name, $descr, $divisor, 1, $lowlimit, $lowwarnlimit, $warnlimit, $limit, $state);
+        discover_sensor(null, SensorEnum::State, $device, $ups_state_oid, $index, $state_name, $descr, $divisor, 1, $lowlimit, $lowwarnlimit, $warnlimit, $limit, $state);
     }
 
     // Bypass Status
@@ -299,7 +301,7 @@ if ($in_phaseNum == '3') {
         $state = $ups_state / $divisor;
         $descr = 'Bypass freq. fail';
 
-        discover_sensor(null, 'state', $device, $ups_state_oid, $index, $state_name, $descr, $divisor, 1, $lowlimit, $lowwarnlimit, $warnlimit, $limit, $state);
+        discover_sensor(null, SensorEnum::State, $device, $ups_state_oid, $index, $state_name, $descr, $divisor, 1, $lowlimit, $lowwarnlimit, $warnlimit, $limit, $state);
     }
 
     // Short Circuit
@@ -319,6 +321,6 @@ if ($in_phaseNum == '3') {
         $state = $ups_state / $divisor;
         $descr = 'Short Circuit';
 
-        discover_sensor(null, 'state', $device, $ups_state_oid, $index, $state_name, $descr, $divisor, 1, $lowlimit, $lowwarnlimit, $warnlimit, $limit, $state);
+        discover_sensor(null, SensorEnum::State, $device, $ups_state_oid, $index, $state_name, $descr, $divisor, 1, $lowlimit, $lowwarnlimit, $warnlimit, $limit, $state);
     }
 }

--- a/includes/discovery/sensors/state/nokia-isam.inc.php
+++ b/includes/discovery/sensors/state/nokia-isam.inc.php
@@ -55,7 +55,7 @@ foreach ($snmp_data['nokiaIsamEqpBoardTable'] as $index => $data) {
         }
 
         //Discover Sensors
-        discover_sensor(null, 'state', $device, $oid, $index, $state_name, $descr, 1, 1, null, null, null, null, $current, 'snmp', null, null, null, $group);
+        discover_sensor(null, \LibreNMS\Enum\Sensor::State, $device, $oid, $index, $state_name, $descr, 1, 1, null, null, null, null, $current, 'snmp', null, null, null, $group);
     }
 }
 

--- a/includes/discovery/sensors/state/nxos.inc.php
+++ b/includes/discovery/sensors/state/nxos.inc.php
@@ -46,6 +46,6 @@ if (is_array($fan_trays)) {
         ];
         create_state_index($state_name, $states);
 
-        discover_sensor(null, 'state', $device, $current_oid, $index, $state_name, $descr, 1, 1, null, null, null, null, $current_value);
+        discover_sensor(null, \LibreNMS\Enum\Sensor::State, $device, $current_oid, $index, $state_name, $descr, 1, 1, null, null, null, null, $current_value);
     }
 }

--- a/includes/discovery/sensors/state/pcoweb.inc.php
+++ b/includes/discovery/sensors/state/pcoweb.inc.php
@@ -26,5 +26,5 @@ foreach ($compressors as $compressor_oid) {
     $number = $split_oid[count($split_oid) - 2];
     $index = 'comp_' . $number;
     $descr = 'Compressor ' . $number;
-    discover_sensor(null, 'state', $device, $compressor_oid, $index, $type, $descr, $divisor, '1', null, null, null, null, $current);
+    discover_sensor(null, \LibreNMS\Enum\Sensor::State, $device, $compressor_oid, $index, $type, $descr, $divisor, '1', null, null, null, null, $current);
 }

--- a/includes/discovery/sensors/state/powervault.inc.php
+++ b/includes/discovery/sensors/state/powervault.inc.php
@@ -26,5 +26,5 @@ if (is_numeric($value)) {
     ];
     create_state_index($state_name, $states);
 
-    discover_sensor(null, 'state', $device, $oid, 1, $state_name, $descr, 1, 1);
+    discover_sensor(null, \LibreNMS\Enum\Sensor::State, $device, $oid, 1, $state_name, $descr, 1, 1);
 }

--- a/includes/discovery/sensors/state/printer.inc.php
+++ b/includes/discovery/sensors/state/printer.inc.php
@@ -21,7 +21,7 @@ if (is_numeric($state)) {
     $sensor_index = 0;
     discover_sensor(
         null,
-        'state',
+        $sensor_class,
         $device,
         '.1.3.6.1.2.1.25.3.2.1.5.1',
         $sensor_index,
@@ -86,7 +86,7 @@ if ($state) {
     $sensor_index = 0;
     discover_sensor(
         null,
-        'state',
+        $sensor_class,
         $device,
         '.1.3.6.1.2.1.25.3.5.1.2.1',
         $sensor_index,

--- a/includes/discovery/sensors/state/procurve.inc.php
+++ b/includes/discovery/sensors/state/procurve.inc.php
@@ -39,5 +39,5 @@ foreach (snmpwalk_cache_oid($device, 'hpicfSensorTable', [], 'HP-ICF-CHASSIS', n
     ];
     create_state_index($state_name, $states);
 
-    discover_sensor(null, 'state', $device, $state_oid . $index, $state_index, $state_name, $state_descr, '1', '1', null, null, null, null, $state);
+    discover_sensor(null, \LibreNMS\Enum\Sensor::State, $device, $state_oid . $index, $state_index, $state_name, $state_descr, '1', '1', null, null, null, null, $state);
 }

--- a/includes/discovery/sensors/state/quanta.inc.php
+++ b/includes/discovery/sensors/state/quanta.inc.php
@@ -43,7 +43,7 @@ foreach ($tables as $tablevalue) {
             $descr = $tablevalue[3] . $index;
             $oid_for_entry = $tablevalue[5] . '.' . $index;
 
-            discover_sensor(null, 'state', $device, $oid_for_entry, $index, $state_name, $descr, 1, 1, null, null, null, null, $entry[$cur_oid], 'snmp');
+            discover_sensor(null, \LibreNMS\Enum\Sensor::State, $device, $oid_for_entry, $index, $state_name, $descr, 1, 1, null, null, null, null, $entry[$cur_oid], 'snmp');
         }
     }
 }

--- a/includes/discovery/sensors/state/rfc1628.inc.php
+++ b/includes/discovery/sensors/state/rfc1628.inc.php
@@ -27,7 +27,7 @@ if (is_numeric($state)) {
     $sensor_index = 0;
     discover_sensor(
         null,
-        'state',
+        $sensor_class,
         $device,
         '.1.3.6.1.2.1.33.1.2.1.0',
         $sensor_index,
@@ -66,7 +66,7 @@ if (is_numeric($state)) {
     $sensor_index = 0;
     discover_sensor(
         null,
-        'state',
+        $sensor_class,
         $device,
         '.1.3.6.1.2.1.33.1.4.1.0',
         $sensor_index,
@@ -104,7 +104,7 @@ if (is_numeric($state)) {
     $sensor_index = 0;
     discover_sensor(
         null,
-        'state',
+        $sensor_class,
         $device,
         '.1.3.6.1.2.1.33.1.7.3.0',
         $sensor_index,

--- a/includes/discovery/sensors/state/serveriron.inc.php
+++ b/includes/discovery/sensors/state/serveriron.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 echo 'ServerIron States';
 
 // All those states are : (Value: 1 Other, 2 Normal, 3 failure) (Power Supply and Fans)
@@ -9,7 +11,7 @@ for ($i = 1; $i != 3; $i++) {
     $power_oid = '.1.3.6.1.4.1.1991.1.1.1.2.1.1.3.' . $i;
     $power_status = snmp_get($device, $power_oid, '-Oqv');
     if (! empty($power_status)) {
-        discover_sensor(null, 'state', $device, $power_oid, 'powerstatus' . $i, 'snmp', 'Power Supply ' . $i . ' Status', 1, 1, '1', null, null, '3', $power_status);
+        discover_sensor(null, SensorEnum::State, $device, $power_oid, 'powerstatus' . $i, 'snmp', 'Power Supply ' . $i . ' Status', 1, 1, '1', null, null, '3', $power_status);
     }
 }
 
@@ -18,6 +20,6 @@ for ($i = 1; $i != 7; $i++) {
     $fan_oid = '.1.3.6.1.4.1.1991.1.1.1.3.1.1.3.' . $i;
     $fan_status = snmp_get($device, $fan_oid, '-Oqv');
     if (! empty($fan_status)) {
-        discover_sensor(null, 'state', $device, $fan_oid, 'fanstatus' . $i, 'snmp', 'Fan ' . $i . ' Status', 1, 1, '1', null, null, '3', $fan_status);
+        discover_sensor(null, SensorEnum::State, $device, $fan_oid, 'fanstatus' . $i, 'snmp', 'Fan ' . $i . ' Status', 1, 1, '1', null, null, '3', $fan_status);
     }
 }

--- a/includes/discovery/sensors/state/serverscheck.inc.php
+++ b/includes/discovery/sensors/state/serverscheck.inc.php
@@ -53,7 +53,7 @@ foreach ($pre_cache['serverscheck_control'] as $oid_name => $oid_value) {
             ];
             create_state_index($state_name, $states);
 
-            discover_sensor(null, 'state', $device, $serverscheck_oids[$tmp_oid], $index, $state_name, $descr, 1, 1, null, null, null, null, 1);
+            discover_sensor(null, \LibreNMS\Enum\Sensor::State, $device, $serverscheck_oids[$tmp_oid], $index, $state_name, $descr, 1, 1, null, null, null, null, 1);
         }
     }
 }

--- a/includes/discovery/sensors/state/sitemonitor.inc.php
+++ b/includes/discovery/sensors/state/sitemonitor.inc.php
@@ -37,7 +37,7 @@ if ($switch) {
     $sensor_index = 3;
     discover_sensor(
         null,
-        'state',
+        $sensor_class,
         $device,
         '.1.3.6.1.4.1.32050.2.1.26.5.3',
         $sensor_index,

--- a/includes/discovery/sensors/state/sm-os.inc.php
+++ b/includes/discovery/sensors/state/sm-os.inc.php
@@ -35,7 +35,7 @@ foreach ($modulation as $link => $linkEntry) {
         if (isset($radioEntry['linkAcmRxModulation'])) {
             discover_sensor(
                 null,
-                'state',
+                $sensor_class,
                 $device,
                 ".1.3.6.1.4.1.3373.1103.80.17.1.6.$index",
                 "rx-$index",
@@ -46,7 +46,7 @@ foreach ($modulation as $link => $linkEntry) {
         if (isset($radioEntry['linkAcmTxModulation'])) {
             discover_sensor(
                 null,
-                'state',
+                $sensor_class,
                 $device,
                 ".1.3.6.1.4.1.3373.1103.80.17.1.7.$index",
                 "tx-$index",

--- a/includes/discovery/sensors/state/unix.inc.php
+++ b/includes/discovery/sensors/state/unix.inc.php
@@ -61,7 +61,7 @@ if (! empty($snmpData)) {
             create_state_index($state_name, $states);
 
             //Discover Sensors
-            discover_sensor(null, 'state', $device, $oid, $sensor_oid, $state_name, $descr, '1', '1', null, null, null, null, $value, 'snmp', null, null, null, 'ups-nut');
+            discover_sensor(null, \LibreNMS\Enum\Sensor::State, $device, $oid, $sensor_oid, $state_name, $descr, '1', '1', null, null, null, null, $value, 'snmp', null, null, null, 'ups-nut');
         }
     }
 }

--- a/includes/discovery/sensors/state/voss.inc.php
+++ b/includes/discovery/sensors/state/voss.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 /**
  * voss.inc.php
  *
@@ -41,7 +43,7 @@ if (is_array($voss_fan)) {
         ];
         create_state_index($state_name, $states);
 
-        discover_sensor(null, 'state', $device, $current_oid, "rcVossSystemFanInfoOperStatus.$tray_num.$fan_num", $state_name, $descr, 1, 1, null, null, 3, 3, $state);
+        discover_sensor(null, SensorEnum::State, $device, $current_oid, "rcVossSystemFanInfoOperStatus.$tray_num.$fan_num", $state_name, $descr, 1, 1, null, null, 3, 3, $state);
     }
 } elseif (is_array($fan)) {
     foreach ($fan as $oid => $array) {
@@ -60,7 +62,7 @@ if (is_array($voss_fan)) {
         ];
         create_state_index($state_name, $states);
 
-        discover_sensor(null, 'state', $device, $current_oid, "rcChasFanOperStatus.$index", $state_name, $descr, 1, 1, null, null, 3, 3, $state);
+        discover_sensor(null, SensorEnum::State, $device, $current_oid, "rcChasFanOperStatus.$index", $state_name, $descr, 1, 1, null, null, 3, 3, $state);
     }
 }
 
@@ -90,6 +92,6 @@ if (is_array($power_supply)) {
         ];
         create_state_index($state_name, $states);
 
-        discover_sensor(null, 'state', $device, $current_oid, "rcChasPowerSupplyOperStatus.$index", $state_name, $descr, 1, 1, null, null, 4, 4, $state);
+        discover_sensor(null, SensorEnum::State, $device, $current_oid, "rcChasPowerSupplyOperStatus.$index", $state_name, $descr, 1, 1, null, null, 4, 4, $state);
     }
 }

--- a/includes/discovery/sensors/state/wipipe.inc.php
+++ b/includes/discovery/sensors/state/wipipe.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 /*
  * Sensor State discovery module for the CradlePoint WiPipe Platform
  *
@@ -39,7 +41,7 @@ foreach ($pre_cache['wipipe_oids'] as $index => $entry) {
         $modemmdn = $entry['mdmMDN'];
         $descr = 'mdmStatus - ' . $modemdesc . ' - ' . $modemmdn;
         //Discover Sensors
-        discover_sensor(null, 'state', $device, $cur_oid . $index, $index, $state_name, $descr, 1, 1, null, null, null, null, $entry['mdmStatus'], 'snmp', $index);
+        discover_sensor(null, SensorEnum::State, $device, $cur_oid . $index, $index, $state_name, $descr, 1, 1, null, null, null, null, $entry['mdmStatus'], 'snmp', $index);
     }
 }
 // Device Firmware Upgrade Status
@@ -59,5 +61,5 @@ foreach ($upgradestatus as $index => $entry) {
 
     $descr = 'Firmware Upgrade Status';
     //Discover Sensors
-    discover_sensor(null, 'state', $device, $cur_oid . $index, $index, $state_name, $descr, 1, 1, null, null, null, null, $entry['devFWUpgradeStatus'], 'snmp', $index);
+    discover_sensor(null, SensorEnum::State, $device, $cur_oid . $index, $index, $state_name, $descr, 1, 1, null, null, null, null, $entry['devFWUpgradeStatus'], 'snmp', $index);
 }

--- a/includes/discovery/sensors/temperature/adva_fsp150.inc.php
+++ b/includes/discovery/sensors/temperature/adva_fsp150.inc.php
@@ -97,7 +97,7 @@ foreach (array_keys($pre_cache['adva_fsp150']) as $index) {
             d_echo($pre_cache['adva_fsp150']);
             discover_sensor(
                 null,
-                'temperature',
+                $sensor_class,
                 $device,
                 $oid,
                 $entry['sensor_name'] . $index,
@@ -130,7 +130,7 @@ foreach ($pre_cache['adva_fsp150_ports'] as $index => $entry) {
             $descr = ($pre_cache['adva_fsp150_ifName'][$entry['cmEthernetNetPortIfIndex']]['ifName'] ?? 'ifIndex ' . $entry['cmEthernetNetPortIfIndex']);
             discover_sensor(
                 null,
-                'temperature',
+                $sensor_class,
                 $device,
                 $oid,
                 'cmEthernetNetPortStatsTemp.' . $index,
@@ -159,7 +159,7 @@ foreach ($pre_cache['adva_fsp150_ports'] as $index => $entry) {
             $descr = ($pre_cache['adva_fsp150_ifName'][$entry['cmEthernetAccPortIfIndex']]['ifName'] ?? 'ifIndex ' . $entry['cmEthernetAccPortIfIndex']);
             discover_sensor(
                 null,
-                'temperature',
+                $sensor_class,
                 $device,
                 $oid,
                 'cmEthernetAccPortStatsTemp.' . $index,
@@ -188,7 +188,7 @@ foreach ($pre_cache['adva_fsp150_ports'] as $index => $entry) {
             $descr = ($pre_cache['adva_fsp150_ifName'][$entry['cmEthernetTrafficPortIfIndex']]['ifName'] ?? 'ifIndex ' . $entry['cmEthernetTrafficPortIfIndex']);
             discover_sensor(
                 null,
-                'temperature',
+                $sensor_class,
                 $device,
                 $oid,
                 'cmEthernetTrafficPortStatsTemp.' . $index,

--- a/includes/discovery/sensors/temperature/adva_fsp3kr7.inc.php
+++ b/includes/discovery/sensors/temperature/adva_fsp3kr7.inc.php
@@ -34,7 +34,7 @@ if (is_array($pre_cache['adva_fsp3kr7_Card'])) {
 
             discover_sensor(
                 null,
-                'temperature',
+                $sensor_class,
                 $device,
                 $oid,
                 'eqptPhysInstValueTemp' . $index,

--- a/includes/discovery/sensors/temperature/aen.inc.php
+++ b/includes/discovery/sensors/temperature/aen.inc.php
@@ -27,5 +27,5 @@ $valueoid = '.1.3.6.1.4.1.22420.1.1.12.1.2.1'; // acdDescTsCurrentTemp.1
 $value = snmp_get($device, $valueoid, '-Oqv');
 
 if (is_numeric($value)) {
-    discover_sensor(null, 'temperature', $device, $valueoid, 1, 'metronid', $descr, '1', '1', $low_limit, $low_warn_limit, $high_warn_limit, $high_limit, $value);
+    discover_sensor(null, \LibreNMS\Enum\Sensor::Temperature, $device, $valueoid, 1, 'metronid', $descr, '1', '1', $low_limit, $low_warn_limit, $high_warn_limit, $high_limit, $value);
 }

--- a/includes/discovery/sensors/temperature/akcp.inc.php
+++ b/includes/discovery/sensors/temperature/akcp.inc.php
@@ -18,7 +18,7 @@ foreach ($oids as $index => $entry) {
 
         discover_sensor(
             null,
-            'temperature',
+            $sensor_class,
             $device,
             $oid,
             $index,

--- a/includes/discovery/sensors/temperature/aos-emu2.inc.php
+++ b/includes/discovery/sensors/temperature/aos-emu2.inc.php
@@ -45,7 +45,7 @@ foreach ($oids as $temp) {
 
         app('sensor-discovery')->discover(new \App\Models\Sensor([
             'poller_type' => 'snmp',
-            'sensor_class' => 'temperature',
+            'sensor_class' => \LibreNMS\Enum\Sensor::Temperature,
             'sensor_oid' => $oid,
             'sensor_index' => $index,
             'sensor_type' => 'aos-emu2',

--- a/includes/discovery/sensors/temperature/aos.inc.php
+++ b/includes/discovery/sensors/temperature/aos.inc.php
@@ -6,5 +6,5 @@ $descr = '';
 $temperature = snmp_get($device, '.1.3.6.1.4.1.89.53.15.1.9.1', '-Oqv');
 if (is_numeric($temperature) && $temperature > '0') {
     $descr = 'Chassis Temperature';
-    discover_sensor(null, 'temperature', $device, '.1.3.6.1.4.1.89.53.15.1.9.1', '1', 'alcatel-device', $descr, '1', '1', null, null, null, null, $temperature);
+    discover_sensor(null, \LibreNMS\Enum\Sensor::Temperature, $device, '.1.3.6.1.4.1.89.53.15.1.9.1', '1', 'alcatel-device', $descr, '1', '1', null, null, null, null, $temperature);
 }

--- a/includes/discovery/sensors/temperature/aos6.inc.php
+++ b/includes/discovery/sensors/temperature/aos6.inc.php
@@ -12,6 +12,6 @@ foreach ($aos6_temp_oids as $index => $entry) {
         $warn_limit_low = '5';
         $descr = 'Chassis-' . ($index - 568) . ' Temperature';
 
-        discover_sensor(null, 'temperature', $device, $oid, $index, 'aos6', $descr, 1, 1, $limit_low, $warn_limit_low, $warn_limit, $limit, $value, 'snmp');
+        discover_sensor(null, \LibreNMS\Enum\Sensor::Temperature, $device, $oid, $index, 'aos6', $descr, 1, 1, $limit_low, $warn_limit_low, $warn_limit, $limit, $value, 'snmp');
     }
 }

--- a/includes/discovery/sensors/temperature/apc.inc.php
+++ b/includes/discovery/sensors/temperature/apc.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 // upsHighPrecBatteryTemperature
 $oids = snmp_get($device, '.1.3.6.1.4.1.318.1.1.1.2.3.2.0', '-OsqnU', '');
 d_echo($oids . "\n");
@@ -19,7 +21,7 @@ if ($oids) {
     $index = 0;
     $descr = 'Internal Temperature';
 
-    discover_sensor(null, 'temperature', $device, $oid, $index, $sensorType, $descr, $precision, '1', null, null, null, null, $current / $precision);
+    discover_sensor(null, SensorEnum::Temperature, $device, $oid, $index, $sensorType, $descr, $precision, '1', null, null, null, null, $current / $precision);
 }
 
 // Environmental monitoring on UPSes etc
@@ -49,7 +51,7 @@ if ($apc_env_data) {
             if (count($split_index) == 2 && $split_index[1] == 1) {
                 $index = $split_index[0];
             }
-            discover_sensor(null, 'temperature', $device, $oid, $index, $sensorType, $descr, 1, 1, $low_limit, $low_warn_limit, $high_warn_limit, $high_limit, $current);
+            discover_sensor(null, SensorEnum::Temperature, $device, $oid, $index, $sensorType, $descr, 1, 1, $low_limit, $low_warn_limit, $high_warn_limit, $high_limit, $current);
         }
     }
 } else {
@@ -72,7 +74,7 @@ if ($apc_env_data) {
 
             if ($current > 0) {
                 // Temperature = 0 -> Sensor not available
-                discover_sensor(null, 'temperature', $device, $oid, $index, $sensorType, $descr, 1, 1, $low_limit, $low_warn_limit, $high_warn_limit, $high_limit, $current);
+                discover_sensor(null, SensorEnum::Temperature, $device, $oid, $index, $sensorType, $descr, 1, 1, $low_limit, $low_warn_limit, $high_warn_limit, $high_limit, $current);
             }
         }
     }
@@ -91,7 +93,7 @@ foreach (array_keys($apc_env_data) as $index) {
         $high_warn_limit = $apc_env_data[$index]['emsProbeStatusProbeHighTempThresh'];
         $high_limit = $apc_env_data[$index]['emsProbeStatusProbeMaxTempThresh'];
 
-        discover_sensor(null, 'temperature', $device, $oid, $index, $sensorType, $descr, '1', '1', $low_limit, $low_warn_limit, $high_warn_limit, $high_limit, $current);
+        discover_sensor(null, SensorEnum::Temperature, $device, $oid, $index, $sensorType, $descr, '1', '1', $low_limit, $low_warn_limit, $high_warn_limit, $high_limit, $current);
     }
 }
 
@@ -111,7 +113,7 @@ if ($oids) {
         [$oid,$current] = explode(' ', $oids);
         $divisor = 10;
         $sensorType = substr($descr, 0, 2);
-        discover_sensor(null, 'temperature', $device, $oid, '0', $sensorType, $descr, $divisor, '1', null, null, null, null, $current);
+        discover_sensor(null, SensorEnum::Temperature, $device, $oid, '0', $sensorType, $descr, $divisor, '1', null, null, null, null, $current);
     }
 }
 
@@ -137,7 +139,7 @@ if ($oids !== false) {
         $descr = 'Supply Temperature';
     }
 
-    discover_sensor(null, 'temperature', $device, $oid, $index, $sensorType, $descr, $precision, '1', null, null, null, null, $current);
+    discover_sensor(null, SensorEnum::Temperature, $device, $oid, $index, $sensorType, $descr, $precision, '1', null, null, null, null, $current);
 }
 
 unset($oids);
@@ -159,7 +161,7 @@ if ($oids !== false) {
         $descr = 'Return Temperature';
     }
 
-    discover_sensor(null, 'temperature', $device, $oid, $index, $sensorType, $descr, $precision, '1', null, null, null, null, $current);
+    discover_sensor(null, SensorEnum::Temperature, $device, $oid, $index, $sensorType, $descr, $precision, '1', null, null, null, null, $current);
 }
 
 unset($oids);
@@ -180,7 +182,7 @@ if ($oids !== false) {
         $descr = 'Remote Temperature';
     }
 
-    discover_sensor(null, 'temperature', $device, $oid, $index, $sensorType, $descr, $precision, '1', null, null, null, null, $current);
+    discover_sensor(null, SensorEnum::Temperature, $device, $oid, $index, $sensorType, $descr, $precision, '1', null, null, null, null, $current);
 }
 
 $cooling_unit = snmpwalk_cache_oid($device, 'coolingUnitExtendedAnalogEntry', [], 'PowerNet-MIB');
@@ -190,7 +192,7 @@ foreach ($cooling_unit as $index => $data) {
     $scale = $data['coolingUnitExtendedAnalogScale'];
     $value = $data['coolingUnitExtendedAnalogValue'];
     if (preg_match('/Temperature/', (string) $descr) && $data['coolingUnitExtendedAnalogUnits'] == 'C' && $value >= 0) {
-        discover_sensor(null, 'temperature', $device, $cur_oid, $cur_oid, 'apc', $descr, $scale, 1, null, null, null, null, $value);
+        discover_sensor(null, SensorEnum::Temperature, $device, $cur_oid, $cur_oid, 'apc', $descr, $scale, 1, null, null, null, null, $value);
     }
 }
 
@@ -200,7 +202,7 @@ foreach ($pre_cache['cooling_unit_analog'] as $index => $data) {
     $scale = $data['coolingUnitStatusAnalogScale'] ?? null;
     $value = $data['coolingUnitStatusAnalogValue'] ?? null;
     if (preg_match('/Temperature/', (string) $descr) && $data['coolingUnitStatusAnalogUnits'] == 'C' && $value >= 0) {
-        discover_sensor(null, 'temperature', $device, $cur_oid, $cur_oid, 'apc', $descr, $scale, 1, null, null, null, null, $value);
+        discover_sensor(null, SensorEnum::Temperature, $device, $cur_oid, $cur_oid, 'apc', $descr, $scale, 1, null, null, null, null, $value);
     }
 }
 
@@ -215,6 +217,6 @@ foreach ($pre_cache['mem_sensors_status'] as $index => $data) {
         if ($pre_cache['memSensorsStatusSysTempUnits'] === 'fahrenheit') {
             $user_func = 'fahrenheit_to_celsius';
         }
-        discover_sensor(null, 'temperature', $device, $cur_oid, 'memSensorsTemperature.' . $index, 'apc', $descr, $divisor, $multiplier, null, null, null, null, $value, 'snmp', null, null, $user_func);
+        discover_sensor(null, SensorEnum::Temperature, $device, $cur_oid, 'memSensorsTemperature.' . $index, 'apc', $descr, $divisor, $multiplier, null, null, null, null, $value, 'snmp', null, null, $user_func);
     }
 }

--- a/includes/discovery/sensors/temperature/areca.inc.php
+++ b/includes/discovery/sensors/temperature/areca.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 $oids = snmp_walk($device, '.1.3.6.1.4.1.18928.1.1.2.14.1.2', '-Osqn', '');
 d_echo($oids . "\n");
 
@@ -18,7 +20,7 @@ foreach (explode("\n", $oids) as $data) {
         $temperature = snmp_get($device, $temperature_oid, '-Oqv', '');
         $descr = "Hard disk $temperature_id";
         if ($temperature != -128) { // -128 = not measured/present
-            discover_sensor(null, 'temperature', $device, $temperature_oid, Str::padLeft($temperature_id, 2, '0'), 'areca', $descr, '1', '1', null, null, null, null, $temperature);
+            discover_sensor(null, SensorEnum::Temperature, $device, $temperature_oid, Str::padLeft($temperature_id, 2, '0'), 'areca', $descr, '1', '1', null, null, null, null, $temperature);
         }
     }
 }
@@ -41,6 +43,6 @@ foreach (explode("\n", (string) $oids) as $data) {
         $oid = '.1.3.6.1.4.1.18928.1.2.2.1.10.1.3.' . $index;
         $current = snmp_get($device, $oid, '-Oqv', '');
 
-        discover_sensor(null, 'temperature', $device, $oid, $index, 'areca', trim($descr, '"'), '1', '1', null, null, null, null, $current);
+        discover_sensor(null, SensorEnum::Temperature, $device, $oid, $index, 'areca', trim($descr, '"'), '1', '1', null, null, null, null, $current);
     }
 }

--- a/includes/discovery/sensors/temperature/ats.inc.php
+++ b/includes/discovery/sensors/temperature/ats.inc.php
@@ -14,5 +14,5 @@ if (is_numeric($temperature['0']['atsMiscellaneousGroupAtsSystemTemperture'])) {
     $temperature['0']['high_warn'] = $temperature['0']['emdConfigTempHighSetPoint'] - 5;
     $temperature['0']['low_warn'] = $temperature['0']['emdConfigTempLowSetPoint'] + 5;
     $temperature['0']['oid'] = '.1.3.6.1.4.1.37662.1.2.2.1.1.5.1.0';
-    discover_sensor(null, 'temperature', $device, $temperature['0']['oid'], 'atsMiscellaneousGroupAtsSystemTemperture', 'ats', 'System', '1', '1', $temperature['0']['emdConfigTempLowSetPoint'], $temperature['0']['low_warn'], $temperature['0']['high_warn'], $temperature['0']['emdConfigTempHighSetPoint'], $temperature['0']['atsMiscellaneousGroupAtsSystemTemperture']);
+    discover_sensor(null, \LibreNMS\Enum\Sensor::Temperature, $device, $temperature['0']['oid'], 'atsMiscellaneousGroupAtsSystemTemperture', 'ats', 'System', '1', '1', $temperature['0']['emdConfigTempLowSetPoint'], $temperature['0']['low_warn'], $temperature['0']['high_warn'], $temperature['0']['emdConfigTempHighSetPoint'], $temperature['0']['atsMiscellaneousGroupAtsSystemTemperture']);
 }

--- a/includes/discovery/sensors/temperature/axiscam.inc.php
+++ b/includes/discovery/sensors/temperature/axiscam.inc.php
@@ -55,5 +55,5 @@ foreach (array_keys($oids) as $index) {
     $current = $oids[$index]['tempSensorValue'];
     $oid = $cur_oid . $index;
 
-    discover_sensor(null, 'temperature', $device, $oid, $index, 'axiscam', 'Temperature Sensor ' . $index, '1', '1', $low_limit, $low_warn_limit, $high_warn_limit, $high_limit, $current);
+    discover_sensor(null, \LibreNMS\Enum\Sensor::Temperature, $device, $oid, $index, 'axiscam', 'Temperature Sensor ' . $index, '1', '1', $low_limit, $low_warn_limit, $high_warn_limit, $high_limit, $current);
 }

--- a/includes/discovery/sensors/temperature/beagleboard.inc.php
+++ b/includes/discovery/sensors/temperature/beagleboard.inc.php
@@ -33,7 +33,7 @@ for ($temp = 0; $temp < 5; $temp++) {
     }
     if (is_numeric($value[$temp])) {
         // Need to scale down by 1000 (initial value, and added sensor). Scaling values are integer, but accepted approach seems to be setting as a string
-        discover_sensor(null, 'temperature', $device, $oid . '.' . ($temp + 1), $temp, $type, $descr, '1000', '1', null, null, null, null, $value[$temp] / 1000);
+        discover_sensor(null, \LibreNMS\Enum\Sensor::Temperature, $device, $oid . '.' . ($temp + 1), $temp, $type, $descr, '1000', '1', null, null, null, null, $value[$temp] / 1000);
     } else {
         break;
     }

--- a/includes/discovery/sensors/temperature/benuos.inc.php
+++ b/includes/discovery/sensors/temperature/benuos.inc.php
@@ -15,6 +15,6 @@ for ($index = 1; $index <= 3; $index++) { //Benu Temp Sensors are index 1 thru 3
     $sensor_oid = ".1.3.6.1.4.1.39406.1.1.1.4.1.1.5.1.$index";
     $descr = $data["1.$index"]['benuSensorName'] ?? null;
     $current = $data["1.$index"]['benuSensorValue'] ?? null;
-    discover_sensor(null, 'temperature', $device, $sensor_oid, $sensor_index, 'benuos', $descr, '1', '1', null, null, null, null, $current);
+    discover_sensor(null, \LibreNMS\Enum\Sensor::Temperature, $device, $sensor_oid, $sensor_index, 'benuos', $descr, '1', '1', null, null, null, null, $current);
     $sensor_index++;
 }//end loop

--- a/includes/discovery/sensors/temperature/binos.inc.php
+++ b/includes/discovery/sensors/temperature/binos.inc.php
@@ -27,6 +27,6 @@ if (str_contains((string) $device['sysObjectID'], '.1.3.6.1.4.1.738.1.5.100')) {
     $value = str_replace('"', '', $value);
 
     if (is_numeric($value)) {
-        discover_sensor(null, 'temperature', $device, $valueoid, 1, 'binos', $descr, '1', '1', $low_limit, $low_warn_limit, $high_warn_limit, $high_limit, $value);
+        discover_sensor(null, \LibreNMS\Enum\Sensor::Temperature, $device, $valueoid, 1, 'binos', $descr, '1', '1', $low_limit, $low_warn_limit, $high_warn_limit, $high_limit, $value);
     }
 }

--- a/includes/discovery/sensors/temperature/binox.inc.php
+++ b/includes/discovery/sensors/temperature/binox.inc.php
@@ -28,6 +28,6 @@ if (str_contains((string) $device['sysObjectID'], '.1.3.6.1.4.1.738.10.5.100')) 
     $value = str_replace('"', '', $value);
 
     if (is_numeric($value)) {
-        discover_sensor(null, 'temperature', $device, $valueoid, 1, 'binox', $descr, '1', '1', $low_limit, $low_warn_limit, $high_warn_limit, $high_limit, $value);
+        discover_sensor(null, \LibreNMS\Enum\Sensor::Temperature, $device, $valueoid, 1, 'binox', $descr, '1', '1', $low_limit, $low_warn_limit, $high_warn_limit, $high_limit, $value);
     }
 }

--- a/includes/discovery/sensors/temperature/boss.inc.php
+++ b/includes/discovery/sensors/temperature/boss.inc.php
@@ -15,5 +15,5 @@ foreach (explode("\n", (string) $temps) as $i => $t) {
     // Sensors are reported as 2 * value
     $divisor = 2;
     $val = (Number::cast($val) / $divisor);
-    discover_sensor(null, 'temperature', $device, $oid, Str::padLeft($i + 1, 2, '0'), 'avaya-ers', 'Unit ' . ($i + 1) . ' temperature', $divisor, 1, null, null, null, null, $val);
+    discover_sensor(null, \LibreNMS\Enum\Sensor::Temperature, $device, $oid, Str::padLeft($i + 1, 2, '0'), 'avaya-ers', 'Unit ' . ($i + 1) . ' temperature', $divisor, 1, null, null, null, null, $val);
 }

--- a/includes/discovery/sensors/temperature/calix.inc.php
+++ b/includes/discovery/sensors/temperature/calix.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 /*
  * LibreNMS Calix E5-1xx Temperature Discovery module
  *
@@ -30,7 +32,7 @@ if (strstr((string) $device['sysObjectID'], '.1.3.6.1.4.1.6321.1.2.3')) { // E5-
                 $descr = str_replace('"', '', $descr);
                 $current = $temperature;
 
-                discover_sensor(null, 'temperature', $device, $temperature_oid, $oid, 'calix', $descr, '1', '1', null, null, null, null, $current);
+                discover_sensor(null, SensorEnum::Temperature, $device, $temperature_oid, $oid, 'calix', $descr, '1', '1', null, null, null, null, $current);
             }
         }
     }
@@ -50,7 +52,7 @@ if (strstr((string) $device['sysObjectID'], '.1.3.6.1.4.1.6321.1.2.3')) { // E5-
                 $descr = str_replace('"', '', $descr);
                 $current = $temperature;
 
-                discover_sensor(null, 'temperature', $device, $temperature_oid, $oid, 'calix', $descr, '1', '1', null, null, null, null, $current);
+                discover_sensor(null, SensorEnum::Temperature, $device, $temperature_oid, $oid, 'calix', $descr, '1', '1', null, null, null, null, $current);
             }
         }
     }
@@ -70,7 +72,7 @@ if (strstr((string) $device['sysObjectID'], '.1.3.6.1.4.1.6321.1.2.3')) { // E5-
                 $descr = str_replace('"', '', $descr);
                 $current = $temperature;
 
-                discover_sensor(null, 'temperature', $device, $temperature_oid, $oid, 'calix', $descr, '1', '1', null, null, null, null, $current);
+                discover_sensor(null, SensorEnum::Temperature, $device, $temperature_oid, $oid, 'calix', $descr, '1', '1', null, null, null, null, $current);
             }
         }
     }
@@ -90,7 +92,7 @@ if (strstr((string) $device['sysObjectID'], '.1.3.6.1.4.1.6321.1.2.3')) { // E5-
                 $descr = str_replace('"', '', $descr);
                 $current = $temperature;
 
-                discover_sensor(null, 'temperature', $device, $temperature_oid, $oid, 'calix', $descr, '1', '1', null, null, null, null, $current);
+                discover_sensor(null, SensorEnum::Temperature, $device, $temperature_oid, $oid, 'calix', $descr, '1', '1', null, null, null, null, $current);
             }
         }
     }

--- a/includes/discovery/sensors/temperature/cisco.inc.php
+++ b/includes/discovery/sensors/temperature/cisco.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 /*
  * LibreNMS
  *
@@ -20,7 +22,7 @@ if (is_array($temp)) {
         }
         if ($temp[$index]['ciscoEnvMonTemperatureState'] != 'notPresent' && ! empty($temp[$index]['ciscoEnvMonTemperatureStatusDescr'])) {
             $descr = ucwords((string) $temp[$index]['ciscoEnvMonTemperatureStatusDescr']);
-            discover_sensor(null, 'temperature', $device, $cur_oid . $index, $index, 'cisco', $descr, '1', '1', null, null, null, $temp[$index]['ciscoEnvMonTemperatureThreshold'], $temp[$index]['ciscoEnvMonTemperatureStatusValue'], 'snmp', $index);
+            discover_sensor(null, SensorEnum::Temperature, $device, $cur_oid . $index, $index, 'cisco', $descr, '1', '1', null, null, null, $temp[$index]['ciscoEnvMonTemperatureThreshold'], $temp[$index]['ciscoEnvMonTemperatureStatusValue'], 'snmp', $index);
         }
     }
 }
@@ -30,6 +32,6 @@ if (is_array($temp)) {
     $cur_oid = '.1.3.6.1.4.1.9.9.661.1.1.1.12.';
     foreach ($temp as $index => $entry) {
         $descr = snmp_get($device, 'entPhysicalName.' . $index, '-Oqv', 'ENTITY-MIB');
-        discover_sensor(null, 'temperature', $device, $cur_oid . $index, $index, 'cisco', $descr, '1', '1', null, null, null, $temp[$index]['ciscoEnvMonTemperatureThreshold'] ?? null, $temp[$index]['c3gModemTemperature'], 'snmp', $index);
+        discover_sensor(null, SensorEnum::Temperature, $device, $cur_oid . $index, $index, 'cisco', $descr, '1', '1', null, null, null, $temp[$index]['ciscoEnvMonTemperatureThreshold'] ?? null, $temp[$index]['c3gModemTemperature'], 'snmp', $index);
     }
 }

--- a/includes/discovery/sensors/temperature/ciscosb.inc.php
+++ b/includes/discovery/sensors/temperature/ciscosb.inc.php
@@ -30,7 +30,7 @@ foreach ($oids as $index => $ciscosb_data) {
         if (is_numeric($temperature) && ($value['rlPhyTestTableTransceiverSupply'] != 0)) {
             app('sensor-discovery')->discover(new \App\Models\Sensor([
                 'poller_type' => 'snmp',
-                'sensor_class' => 'temperature',
+                'sensor_class' => \LibreNMS\Enum\Sensor::Temperature,
                 'sensor_oid' => $oid,
                 'sensor_index' => $index,
                 'sensor_type' => 'rlPhyTestTableTransceiverTemp',

--- a/includes/discovery/sensors/temperature/ciscowlc.inc.php
+++ b/includes/discovery/sensors/temperature/ciscowlc.inc.php
@@ -22,6 +22,6 @@ if (is_array($temp)) {
     foreach ($temp as $index => $entry) {
         $descr = 'Unit Temperature ' . $index;
         echo " $descr, ";
-        discover_sensor(null, 'temperature', $device, $cur_oid . $index, $index, 'wlc', $descr, '1', '1', null, $low[$index]['bsnTemperatureAlarmLowLimit'], $high[$index]['bsnTemperatureAlarmHighLimit'], null, $temp[$index]['bsnSensorTemperature'], 'snmp', $index);
+        discover_sensor(null, \LibreNMS\Enum\Sensor::Temperature, $device, $cur_oid . $index, $index, 'wlc', $descr, '1', '1', null, $low[$index]['bsnTemperatureAlarmLowLimit'], $high[$index]['bsnTemperatureAlarmHighLimit'], null, $temp[$index]['bsnSensorTemperature'], 'snmp', $index);
     }
 }

--- a/includes/discovery/sensors/temperature/commander-plus.inc.php
+++ b/includes/discovery/sensors/temperature/commander-plus.inc.php
@@ -28,4 +28,4 @@ $oid = '.1.3.6.1.4.1.18642.1.2.2.2.0';
 $descr = 'Battery temperature';
 $divisor = 1;
 $multiplier = 1;
-discover_sensor(null, 'temperature', $device, $oid, 'batteryTemperature', 'commander-plus', $descr, $divisor, $multiplier, null, null, null, null, $current);
+discover_sensor(null, \LibreNMS\Enum\Sensor::Temperature, $device, $oid, 'batteryTemperature', 'commander-plus', $descr, $divisor, $multiplier, null, null, null, null, $current);

--- a/includes/discovery/sensors/temperature/comware.inc.php
+++ b/includes/discovery/sensors/temperature/comware.inc.php
@@ -34,7 +34,7 @@ if (! empty($entphydata)) {
                 $cur_oid = '.1.3.6.1.4.1.25506.2.6.1.1.1.1.12.';
                 discover_sensor(
                     null,
-                    'temperature',
+                    $sensor_class,
                     $device,
                     $cur_oid . $tempindex,
                     'temp-' . $tempindex,
@@ -76,6 +76,6 @@ foreach ($hh3cTransceiverInfoTable as $index => $entry) {
         $entPhysicalIndex_measured = 'ports';
 
         $descr = $port->getShortLabel() . ' Module';
-        discover_sensor(null, 'temperature', $device, $oid, 'temp-trans-' . $index, 'comware', $descr, $divisor, $multiplier, $limit_low, $warn_limit_low, $warn_limit, $limit, $current, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured, group: 'transceiver');
+        discover_sensor(null, \LibreNMS\Enum\Sensor::Temperature, $device, $oid, 'temp-trans-' . $index, 'comware', $descr, $divisor, $multiplier, $limit_low, $warn_limit_low, $warn_limit, $limit, $current, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured, group: 'transceiver');
     }
 }

--- a/includes/discovery/sensors/temperature/dell-powervault.inc.php
+++ b/includes/discovery/sensors/temperature/dell-powervault.inc.php
@@ -19,7 +19,7 @@ if (is_array($oids)) {
             $descr = implode(':', $connUnitSensorMessage);
             app('sensor-discovery')->discover(new \App\Models\Sensor([
                 'poller_type' => 'snmp',
-                'sensor_class' => 'temperature',
+                'sensor_class' => \LibreNMS\Enum\Sensor::Temperature,
                 'sensor_oid' => $cur_oid . $index,
                 'sensor_index' => $index,
                 'sensor_type' => 'dellme',

--- a/includes/discovery/sensors/temperature/dell.inc.php
+++ b/includes/discovery/sensors/temperature/dell.inc.php
@@ -24,7 +24,7 @@ if (is_array($temp)) {
         (isset($temp[$index]['temperatureProbeUpperNonCriticalThreshold'])) ? $warnlimit = $temp[$index]['temperatureProbeUpperNonCriticalThreshold'] / $divisor : $warnlimit = null;
         (isset($temp[$index]['temperatureProbeUpperCriticalThreshold'])) ? $limit = $temp[$index]['temperatureProbeUpperCriticalThreshold'] / $divisor : $limit = null;
 
-        discover_sensor(null, 'temperature', $device, $cur_oid . $index, $index, 'dell', $descr, $divisor, '1', $lowlimit, $low_warn_limit, $warnlimit, $limit, $value, 'snmp', $index);
+        discover_sensor(null, \LibreNMS\Enum\Sensor::Temperature, $device, $cur_oid . $index, $index, 'dell', $descr, $divisor, '1', $lowlimit, $low_warn_limit, $warnlimit, $limit, $value, 'snmp', $index);
 
         unset(
             $descr,

--- a/includes/discovery/sensors/temperature/dhcpatriot.inc.php
+++ b/includes/discovery/sensors/temperature/dhcpatriot.inc.php
@@ -7,7 +7,7 @@
  *
 */
 
-$class = 'temperature';
+$class = $sensor_class;
 $oid = '.1.3.6.1.4.1.2021.50.3.101.1';
 $index = 1;
 $type = 'dhcpatriotTempCPU';

--- a/includes/discovery/sensors/temperature/dnos.inc.php
+++ b/includes/discovery/sensors/temperature/dnos.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 $temps = snmp_walk($device, '.1.3.6.1.4.1.674.10895.5000.2.6132.1.1.43.1.8.1.5', '-Osqn');
 //This will return at least 4 OIDs (multiplied by the number of switches if stacked)  and associated values for various temperatures
 
@@ -13,7 +15,7 @@ if (! empty($temps)) {
         if (str_ends_with($oid, '1')) {
             // This code will only pull CPU temp for each stack member, but there is no reason why the additional values couldn't be graphed
             $counter += 1;
-            discover_sensor(null, 'temperature', $device, $oid, $counter, 'dnos', 'Unit ' . $counter . ' CPU temperature', '1', '1', null, null, null, null, $val);
+            discover_sensor(null, SensorEnum::Temperature, $device, $oid, $counter, 'dnos', 'Unit ' . $counter . ' CPU temperature', '1', '1', null, null, null, null, $val);
         }
     }
 }
@@ -31,6 +33,6 @@ if (is_array($oids)) {
         $descr = 'Unit ' . $index . ' ' . $entry['chStackUnitSysType'];
         $oid = '.1.3.6.1.4.1.6027.3.10.1.2.2.1.14.' . $index;
         $current = $entry['chStackUnitTemp'];
-        discover_sensor(null, 'temperature', $device, $oid, $index, 'ftos-sseries', $descr, '1', '1', null, null, null, null, $current);
+        discover_sensor(null, SensorEnum::Temperature, $device, $oid, $index, 'ftos-sseries', $descr, '1', '1', null, null, null, null, $current);
     }
 }

--- a/includes/discovery/sensors/temperature/edgecos.inc.php
+++ b/includes/discovery/sensors/temperature/edgecos.inc.php
@@ -24,4 +24,4 @@
  * @author     Frederik Kriewitz <frederik@kriewitz.eu>
  */
 $os->discoverSwitchTemperatureSensors();
-$os->discoverTransceiverSensors(['temperature']);
+$os->discoverTransceiverSensors([\LibreNMS\Enum\Sensor::Temperature]);

--- a/includes/discovery/sensors/temperature/eltex-mes21xx.inc.php
+++ b/includes/discovery/sensors/temperature/eltex-mes21xx.inc.php
@@ -23,6 +23,7 @@
  *
  * @author     Peca Nesovanovic <peca.nesovanovic@sattrakt.com>
  */
+
 $divisor = 1;
 $multiplier = 1;
 
@@ -39,7 +40,7 @@ foreach ($oids as $ifIndex => $data) {
 
         app('sensor-discovery')->discover(new \App\Models\Sensor([
             'poller_type' => 'snmp',
-            'sensor_class' => 'temperature',
+            'sensor_class' => \LibreNMS\Enum\Sensor::Temperature,
             'sensor_oid' => $oid,
             'sensor_index' => 'SfpTemp' . $ifIndex,
             'sensor_type' => 'rlPhyTestTableTransceiverTemp',

--- a/includes/discovery/sensors/temperature/eltex-mes23xx.inc.php
+++ b/includes/discovery/sensors/temperature/eltex-mes23xx.inc.php
@@ -23,6 +23,7 @@
  *
  * @author     Peca Nesovanovic <peca.nesovanovic@sattrakt.com>
  */
+
 $divisor = 1;
 $multiplier = 1;
 
@@ -42,7 +43,7 @@ foreach ($oids as $ifIndex => $data) {
 
         app('sensor-discovery')->discover(new \App\Models\Sensor([
             'poller_type' => 'snmp',
-            'sensor_class' => 'temperature',
+            'sensor_class' => \LibreNMS\Enum\Sensor::Temperature,
             'sensor_oid' => $oid,
             'sensor_index' => 'SfpTemp' . $ifIndex,
             'sensor_type' => 'rlPhyTestTableTransceiverTemp',

--- a/includes/discovery/sensors/temperature/eltex-mes24xx.inc.php
+++ b/includes/discovery/sensors/temperature/eltex-mes24xx.inc.php
@@ -51,7 +51,7 @@ if (! empty($eltexPhyTransceiverDiagnosticTable['temperature'])) {
 
             app('sensor-discovery')->discover(new \App\Models\Sensor([
                 'poller_type' => 'snmp',
-                'sensor_class' => 'temperature',
+                'sensor_class' => \LibreNMS\Enum\Sensor::Temperature,
                 'sensor_oid' => $oid,
                 'sensor_index' => 'SfpTemp' . $ifIndex,
                 'sensor_type' => 'ELTEX-PHY-MIB',

--- a/includes/discovery/sensors/temperature/eltex-olt.inc.php
+++ b/includes/discovery/sensors/temperature/eltex-olt.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 /**
  * eltex-olt.inc.php
  *
@@ -32,7 +34,7 @@ if (isset($tmp_eltex['.1.3.6.1.4.1.35265.1.22.1.10.10.0']) && is_numeric($tmp_el
     $descr = 'Sensor 1 Temp';
     $divisor = 1;
     $current = $tmp_eltex[$oid];
-    discover_sensor(null, 'temperature', $device, $oid, $index, $type, $descr, $divisor, '1', null, null, null, null, $current);
+    discover_sensor(null, SensorEnum::Temperature, $device, $oid, $index, $type, $descr, $divisor, '1', null, null, null, null, $current);
 }
 
 if (isset($tmp_eltex['.1.3.6.1.4.1.35265.1.22.1.10.11.0']) && is_numeric($tmp_eltex['.1.3.6.1.4.1.35265.1.22.1.10.11.0'])) {
@@ -42,7 +44,7 @@ if (isset($tmp_eltex['.1.3.6.1.4.1.35265.1.22.1.10.11.0']) && is_numeric($tmp_el
     $descr = 'Sensor 2 Temp';
     $divisor = 1;
     $current = $tmp_eltex[$oid];
-    discover_sensor(null, 'temperature', $device, $oid, $index, $type, $descr, $divisor, '1', null, null, null, null, $current);
+    discover_sensor(null, SensorEnum::Temperature, $device, $oid, $index, $type, $descr, $divisor, '1', null, null, null, null, $current);
 }
 
 if (isset($tmp_eltex['.1.3.6.1.4.1.35265.1.22.1.10.12.0']) && is_numeric($tmp_eltex['.1.3.6.1.4.1.35265.1.22.1.10.12.0']) && $tmp_eltex['.1.3.6.1.4.1.35265.1.22.1.10.12.0'] != 65535) {
@@ -52,7 +54,7 @@ if (isset($tmp_eltex['.1.3.6.1.4.1.35265.1.22.1.10.12.0']) && is_numeric($tmp_el
     $descr = 'Sensor 1 External Temp';
     $divisor = 1;
     $current = $tmp_eltex[$oid];
-    discover_sensor(null, 'temperature', $device, $oid, $index, $type, $descr, $divisor, '1', null, null, null, null, $current);
+    discover_sensor(null, SensorEnum::Temperature, $device, $oid, $index, $type, $descr, $divisor, '1', null, null, null, null, $current);
 }
 
 if (isset($tmp_eltex['.1.3.6.1.4.1.35265.1.22.1.10.13.0']) && is_numeric($tmp_eltex['.1.3.6.1.4.1.35265.1.22.1.10.13.0']) && $tmp_eltex['.1.3.6.1.4.1.35265.1.22.1.10.13.0'] != 65535) {
@@ -62,7 +64,7 @@ if (isset($tmp_eltex['.1.3.6.1.4.1.35265.1.22.1.10.13.0']) && is_numeric($tmp_el
     $descr = 'Sensor 2 External Temp';
     $divisor = 1;
     $current = $tmp_eltex[$oid];
-    discover_sensor(null, 'temperature', $device, $oid, $index, $type, $descr, $divisor, '1', null, null, null, null, $current);
+    discover_sensor(null, SensorEnum::Temperature, $device, $oid, $index, $type, $descr, $divisor, '1', null, null, null, null, $current);
 }
 
 unset($tmp_eltex);

--- a/includes/discovery/sensors/temperature/equallogic.inc.php
+++ b/includes/discovery/sensors/temperature/equallogic.inc.php
@@ -39,7 +39,7 @@ if (! empty($oids)) {
             $index = (100 + $index);
 
             if ($extra[$keys[0]]['eqlMemberHealthDetailsTemperatureCurrentState'] != 'unknown') {
-                discover_sensor(null, 'temperature', $device, $oid, $index, 'snmp', $descr, 1, 1, $low_limit, $low_warn, $high_limit, $high_warn, $temperature);
+                discover_sensor(null, \LibreNMS\Enum\Sensor::Temperature, $device, $oid, $index, 'snmp', $descr, 1, 1, $low_limit, $low_warn, $high_limit, $high_warn, $temperature);
             }
         }//end if
     }//end foreach

--- a/includes/discovery/sensors/temperature/ericsson-ml.inc.php
+++ b/includes/discovery/sensors/temperature/ericsson-ml.inc.php
@@ -20,5 +20,5 @@ $divisor = 1;
 $temperature = (float) snmp_get($device, $oid, '-Oqv', 'PT-MONITOR-MIB');
 
 if ($temperature != 0.0) {
-    discover_sensor(null, 'temperature', $device, $oid, $index, $sensor_type, $descr, $divisor, 1, null, null, null, null, $temperature);
+    discover_sensor(null, \LibreNMS\Enum\Sensor::Temperature, $device, $oid, $index, $sensor_type, $descr, $divisor, 1, null, null, null, null, $temperature);
 }

--- a/includes/discovery/sensors/temperature/exa.inc.php
+++ b/includes/discovery/sensors/temperature/exa.inc.php
@@ -12,7 +12,7 @@ foreach ($ponTable as $e7OltPonPortShelf => $ponShelf) {
 
                 app('sensor-discovery')->discover(new \App\Models\Sensor([
                     'poller_type' => 'snmp',
-                    'sensor_class' => 'temperature',
+                    'sensor_class' => \LibreNMS\Enum\Sensor::Temperature,
                     'sensor_oid' => ".1.3.6.1.4.1.6321.1.2.2.2.1.6.2.1.5.$index",
                     'sensor_index' => $index,
                     'sensor_type' => 'transceiver',

--- a/includes/discovery/sensors/temperature/exos.inc.php
+++ b/includes/discovery/sensors/temperature/exos.inc.php
@@ -13,7 +13,7 @@ if (is_array($oids)) {
             [$value, $dump] = explode(' ', $temp_value[1]);
             app('sensor-discovery')->discover(new \App\Models\Sensor([
                 'poller_type' => 'snmp',
-                'sensor_class' => 'temperature',
+                'sensor_class' => \LibreNMS\Enum\Sensor::Temperature,
                 'sensor_oid' => '.1.3.6.1.3.94.1.8.1.6.' . $index,
                 'sensor_index' => $entry['connUnitSensorIndex'],
                 'sensor_type' => 'exos',

--- a/includes/discovery/sensors/temperature/extendair.inc.php
+++ b/includes/discovery/sensors/temperature/extendair.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 /**
  * extendair.inc.php
  *
@@ -28,7 +30,7 @@ $index = 0;
 $descr = 'Internal temp (far end radio)';
 $value = snmp_get($device, 'remCurrentTemp.0', '-Oqv', 'ExaltComProducts');
 if ($value) {
-    discover_sensor(null, 'temperature', $device, $oid, $index, 'extendair', $descr, '1', '1', null, null, null, null, $value);
+    discover_sensor(null, SensorEnum::Temperature, $device, $oid, $index, 'extendair', $descr, '1', '1', null, null, null, null, $value);
 }
 
 $oid = '.1.3.6.1.4.1.25651.1.2.4.2.3.1.3.0';
@@ -36,7 +38,7 @@ $index = 1;
 $descr = 'Internal temp (local radio)';
 $value = snmp_get($device, 'locCurrentTemp.0', '-Oqv', 'ExaltComProducts');
 if ($value) {
-    discover_sensor(null, 'temperature', $device, $oid, $index, 'extendair', $descr, '1', '1', null, null, null, null, $value);
+    discover_sensor(null, SensorEnum::Temperature, $device, $oid, $index, 'extendair', $descr, '1', '1', null, null, null, null, $value);
 }
 
 unset(

--- a/includes/discovery/sensors/temperature/f5.inc.php
+++ b/includes/discovery/sensors/temperature/f5.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 $f5_chassis = [];
 // Get the Chassis Temperature values
 //Pull the sysChassisTempTable table from the snmpwalk
@@ -14,7 +16,7 @@ if (is_array($f5_chassis)) {
         $sensorType = 'f5';
         $oid = '.1.3.6.1.4.1.3375.2.1.3.2.3.2.1.2.' . $index;
 
-        discover_sensor(null, 'temperature', $device, $oid, $index, $sensorType, $descr, '1', '1', null, null, null, null, $current);
+        discover_sensor(null, SensorEnum::Temperature, $device, $oid, $index, $sensorType, $descr, '1', '1', null, null, null, null, $current);
     }
 }
 
@@ -33,6 +35,6 @@ if (is_array($f5cpu)) {
         $sensorType = 'f5';
         $oid = '.1.3.6.1.4.1.3375.2.1.3.6.2.1.2.' . $index;
 
-        discover_sensor(null, 'temperature', $device, $oid, $index, $sensorType, $descr, '1', '1', null, null, null, null, $current);
+        discover_sensor(null, SensorEnum::Temperature, $device, $oid, $index, $sensorType, $descr, '1', '1', null, null, null, null, $current);
     }
 }

--- a/includes/discovery/sensors/temperature/fs-centec.inc.php
+++ b/includes/discovery/sensors/temperature/fs-centec.inc.php
@@ -12,7 +12,7 @@ foreach ($tempTable as $ifIndex => $current) {
         foreach (explode(',', (string) $current['FS-SWITCH-V2-MIB::temperCurrent']) as $channel => $value) {
             app('sensor-discovery')->discover(new \App\Models\Sensor([
                 'poller_type' => 'snmp',
-                'sensor_class' => 'temperature',
+                'sensor_class' => \LibreNMS\Enum\Sensor::Temperature,
                 'sensor_oid' => ".1.3.6.1.4.1.52642.1.37.1.10.2.1.5.$ifIndex",
                 'sensor_index' => "$ifIndex.$channel",
                 'sensor_type' => 'transceiver',

--- a/includes/discovery/sensors/temperature/ftos.inc.php
+++ b/includes/discovery/sensors/temperature/ftos.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 // Force10 S-Series
 // F10-S-SERIES-CHASSIS-MIB::chStackUnitTemp.1 = Gauge32: 47
 // F10-S-SERIES-CHASSIS-MIB::chStackUnitModelID.1 = STRING: S25-01-GE-24V
@@ -13,7 +15,7 @@ if (is_array($oids)) {
         $descr = 'Unit ' . $index . ' ' . $entry['chStackUnitSysType'];
         $oid = '.1.3.6.1.4.1.6027.3.10.1.2.2.1.14.' . $index;
         $current = $entry['chStackUnitTemp'];
-        discover_sensor(null, 'temperature', $device, $oid, $index, 'ftos-sseries', $descr, '1', '1', null, null, null, null, $current);
+        discover_sensor(null, SensorEnum::Temperature, $device, $oid, $index, 'ftos-sseries', $descr, '1', '1', null, null, null, null, $current);
     }
 }
 
@@ -23,7 +25,7 @@ if (is_array($oids)) {
         $entry['descr'] = 'Slot ' . $index;
         $entry['oid'] = '.1.3.6.1.4.1.6027.3.8.1.2.1.1.5.' . $index;
         $entry['current'] = $entry['chSysCardTemp'];
-        discover_sensor(null, 'temperature', $device, $entry['oid'], $index, 'ftos-cseries', $entry['descr'], '1', '1', null, null, null, null, $entry['current']);
+        discover_sensor(null, SensorEnum::Temperature, $device, $entry['oid'], $index, 'ftos-cseries', $entry['descr'], '1', '1', null, null, null, null, $entry['current']);
     }
 }
 
@@ -37,6 +39,6 @@ if (is_array($oids)) {
         $oid = '.1.3.6.1.4.1.6027.3.1.1.2.3.1.8.' . $index;
         $current = $entry['chSysCardUpperTemp'];
 
-        discover_sensor(null, 'temperature', $device, $oid, $index, 'ftos-eseries', $descr, '1', '1', null, null, null, null, $current);
+        discover_sensor(null, SensorEnum::Temperature, $device, $oid, $index, 'ftos-eseries', $descr, '1', '1', null, null, null, null, $current);
     }
 }

--- a/includes/discovery/sensors/temperature/geist-watchdog.inc.php
+++ b/includes/discovery/sensors/temperature/geist-watchdog.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 /**
  * geist-watchdog.inc.php
  *
@@ -27,14 +29,14 @@ $value = snmp_get($device, 'climateTempC', '-Oqv', 'GEIST-MIB-V3');
 if ($value) {
     $current_oid = '.1.3.6.1.4.1.21239.2.2.1.5.1';
     $descr = 'Temperature';
-    discover_sensor(null, 'temperature', $device, $current_oid, 'climateTempC', 'geist-watchdog', $descr, 1, 1, null, null, null, null, $value);
+    discover_sensor(null, SensorEnum::Temperature, $device, $current_oid, 'climateTempC', 'geist-watchdog', $descr, 1, 1, null, null, null, null, $value);
 }
 
 $value = snmp_get($device, 'climateTempF', '-Oqv', 'GEIST-MIB-V3');
 if ($value) {
     $current_oid = '.1.3.6.1.4.1.21239.2.2.1.6.1';
     $descr = 'Temperature';
-    discover_sensor(null, 'temperature', $device, $current_oid, 'climateTempF', 'geist-watchdog', $descr, 1, 1, null, null, null, null, $value, null, null, null, 'fahrenheit_to_celsius');
+    discover_sensor(null, SensorEnum::Temperature, $device, $current_oid, 'climateTempF', 'geist-watchdog', $descr, 1, 1, null, null, null, null, $value, null, null, null, 'fahrenheit_to_celsius');
 }
 
 $temp_table = snmpwalk_cache_oid($device, 'tempSensorTable', [], 'GEIST-MIB-V3');
@@ -44,7 +46,7 @@ foreach ($temp_table as $index => $temp_data) {
         $current_oid = '.1.3.6.1.4.1.21239.2.4.1.5.' . $index;
         $descr = $temp_data['tempSensorName'] . ': #' . $temp_data['tempSensorSerial'];
         $value = $temp_data['tempSensorTempC'];
-        discover_sensor(null, 'temperature', $device, $current_oid, $index, 'geist-watchdog', $descr, 1, 1, null, null, null, null, $value);
+        discover_sensor(null, SensorEnum::Temperature, $device, $current_oid, $index, 'geist-watchdog', $descr, 1, 1, null, null, null, null, $value);
     }
 }
 

--- a/includes/discovery/sensors/temperature/hpblmos.inc.php
+++ b/includes/discovery/sensors/temperature/hpblmos.inc.php
@@ -16,7 +16,7 @@ foreach (explode("\n", $temps) as $temp) {
             $current_oid = $sensor_value_oid . $current_id;
             $value = snmp_get($device, $current_oid, '-Oqve');
             if ($value > 0) {
-                discover_sensor(null, 'temperature', $device, $current_oid, $current_id, $sensor_type, $descr, 1, 1, null, null, null, null, $value);
+                discover_sensor(null, \LibreNMS\Enum\Sensor::Temperature, $device, $current_oid, $current_id, $sensor_type, $descr, 1, 1, null, null, null, null, $value);
             }
         }
     }

--- a/includes/discovery/sensors/temperature/hytera.inc.php
+++ b/includes/discovery/sensors/temperature/hytera.inc.php
@@ -18,6 +18,6 @@ foreach (explode("\n", (string) $oids) as $data) {
         $oid = '.1.3.6.1.4.1.40297.1.2.1.2.2.' . $index;
         $temperature = hytera_h2f(str_replace('"', '', snmp_get($device, $oid, '-Oqv')), 2);
 
-        discover_sensor(null, 'temperature', $device, $oid, $index, $type, $descr, $divisor, '1', 0, 0, 70, 75, $temperature);
+        discover_sensor(null, \LibreNMS\Enum\Sensor::Temperature, $device, $oid, $index, $type, $descr, $divisor, '1', 0, 0, 70, 75, $temperature);
     }
 }

--- a/includes/discovery/sensors/temperature/ibmnos.inc.php
+++ b/includes/discovery/sensors/temperature/ibmnos.inc.php
@@ -21,7 +21,7 @@ if (strstr((string) $device['sysDescr'], 'IBM Flex System Fabric')) {
             $divisor = '1';
             $multiplier = '1';
             $type = 'ibmnos';
-            discover_sensor(null, 'temperature', $device, $obj, $index, $type, $descr, $divisor, $multiplier, null, null, null, null, $current);
+            discover_sensor(null, \LibreNMS\Enum\Sensor::Temperature, $device, $obj, $index, $type, $descr, $divisor, $multiplier, null, null, null, null, $current);
         }
     }
 }

--- a/includes/discovery/sensors/temperature/ies.inc.php
+++ b/includes/discovery/sensors/temperature/ies.inc.php
@@ -14,6 +14,6 @@ if (is_array($oids)) {
         $oid = '.1.3.6.1.4.1.890.1.5.1.1.6.1.2.' . $index;
         $current = $entry['accessSwitchSysTempCurValue'];
         $divisor = '1';
-        discover_sensor(null, 'temperature', $device, $oid, $index, 'zyxel-ies', $descr, '1', '1', null, $entry['accessSwitchSysTempHighThresh'], null, null, $current);
+        discover_sensor(null, \LibreNMS\Enum\Sensor::Temperature, $device, $oid, $index, 'zyxel-ies', $descr, '1', '1', null, $entry['accessSwitchSysTempHighThresh'], null, null, $current);
     }
 }

--- a/includes/discovery/sensors/temperature/ifotec.inc.php
+++ b/includes/discovery/sensors/temperature/ifotec.inc.php
@@ -27,7 +27,7 @@ $index = 0;
 foreach ($pre_cache['ifoTemperatureTable'] ?? [] as $ifoSensor) {
     discover_sensor(
         null,
-        'temperature',
+        $sensor_class,
         $device,
         $ifoSensor['ifoTempValue']['oid'],
         $ifoSensor['ifoTempName']['value'], // each sensor id must be unique

--- a/includes/discovery/sensors/temperature/ipoman.inc.php
+++ b/includes/discovery/sensors/temperature/ipoman.inc.php
@@ -23,7 +23,7 @@ if ($oidsEnv[0]['ipmEnvEmdStatusEmdType'] != 'disabled') {
 
         app('sensor-discovery')->discover(new \App\Models\Sensor([
             'poller_type' => 'snmp',
-            'sensor_class' => 'temperature',
+            'sensor_class' => \LibreNMS\Enum\Sensor::Temperature,
             'sensor_oid' => $oid,
             'sensor_index' => 1,
             'sensor_type' => 'ipoman',

--- a/includes/discovery/sensors/temperature/junose.inc.php
+++ b/includes/discovery/sensors/temperature/junose.inc.php
@@ -13,7 +13,7 @@ if (is_array($oids)) {
             $oid = '.1.3.6.1.4.1.4874.2.2.2.1.9.4.1.3.' . $index;
             $current = $entry['juniSystemTempValue'];
 
-            discover_sensor(null, 'temperature', $device, $oid, $index, 'junose', $descr, '1', '1', null, null, null, null, $current);
+            discover_sensor(null, \LibreNMS\Enum\Sensor::Temperature, $device, $oid, $index, 'junose', $descr, '1', '1', null, null, null, null, $current);
         }
     }
 }

--- a/includes/discovery/sensors/temperature/lantronix-slc.inc.php
+++ b/includes/discovery/sensors/temperature/lantronix-slc.inc.php
@@ -27,5 +27,5 @@ $value = trim($value, 'Celsius');
 $value = trim($value, ' ');
 
 if (is_numeric($value)) {
-    discover_sensor(null, 'temperature', $device, $valueoid, 1, 'lantronix-slc', $descr, '1', '1', $low_limit, $low_warn_limit, $high_warn_limit, $high_limit, $value);
+    discover_sensor(null, \LibreNMS\Enum\Sensor::Temperature, $device, $valueoid, 1, 'lantronix-slc', $descr, '1', '1', $low_limit, $low_warn_limit, $high_warn_limit, $high_limit, $value);
 }

--- a/includes/discovery/sensors/temperature/liebert.inc.php
+++ b/includes/discovery/sensors/temperature/liebert.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 /**
  * liebert.inc.php
  *
@@ -43,7 +45,7 @@ foreach ($lib_data as $index => $data) {
     }
     if (is_numeric($current)) {
         $descr = $data['lgpEnvTemperatureDescrDegC'];
-        discover_sensor(null, 'temperature', $device, $oid, $new_index, 'liebert', $descr, $divisor, 1, $low_limit, null, null, $high_limit, $current / $divisor);
+        discover_sensor(null, SensorEnum::Temperature, $device, $oid, $new_index, 'liebert', $descr, $divisor, 1, $low_limit, null, null, $high_limit, $current / $divisor);
         unset($current);
     }
 }
@@ -65,7 +67,7 @@ if (is_numeric($return_temp)) {
     $index = 'lgpEnvReturnAirTemperature.0';
     $descr = 'Return Air Temp';
     $divisor = 1;
-    discover_sensor(null, 'temperature', $device, $oid, $index, 'liebert', $descr, $divisor, '1', null, null, null, null, $return_temp);
+    discover_sensor(null, SensorEnum::Temperature, $device, $oid, $index, 'liebert', $descr, $divisor, '1', null, null, null, null, $return_temp);
 }
 
 $supply_temp = snmp_get($device, 'lgpEnvSupplyAirTemperature.0', '-Oqv');
@@ -74,5 +76,5 @@ if (is_numeric($supply_temp)) {
     $index = 'lgpEnvSupplyAirTemperature.0';
     $descr = 'Supply Air Temp';
     $divisor = 1;
-    discover_sensor(null, 'temperature', $device, $oid, $index, 'liebert', $descr, $divisor, '1', null, null, null, null, $supply_temp);
+    discover_sensor(null, SensorEnum::Temperature, $device, $oid, $index, 'liebert', $descr, $divisor, '1', null, null, null, null, $supply_temp);
 }

--- a/includes/discovery/sensors/temperature/linux.inc.php
+++ b/includes/discovery/sensors/temperature/linux.inc.php
@@ -6,6 +6,7 @@
  */
 
 use Illuminate\Support\Str;
+use LibreNMS\Enum\Sensor as SensorEnum;
 
 $sensor_oid = '.1.3.6.1.4.1.8072.1.3.2.4.1.2.9.114.97.115.112.98.101.114.114.121.1';
 $value = snmp_get($device, $sensor_oid, '-Oqve');
@@ -13,7 +14,7 @@ $value = trim($value, '"');
 if (is_numeric($value)) {
     $sensor_type = 'raspberry_temp';
     $descr = 'CPU Temp';
-    discover_sensor(null, 'temperature', $device, $sensor_oid, 1, $sensor_type, $descr, 1, 1, null, null, null, null, $value);
+    discover_sensor(null, SensorEnum::Temperature, $device, $sensor_oid, 1, $sensor_type, $descr, 1, 1, null, null, null, null, $value);
 }
 
 if (Str::startsWith($device['sysObjectID'], '.1.3.6.1.4.1.232.')) {
@@ -37,7 +38,7 @@ if (Str::startsWith($device['sysObjectID'], '.1.3.6.1.4.1.232.')) {
             $threshold = snmp_get($device, $threshold_oid, '-Oqv', '');
 
             if (! empty($temperature)) {
-                discover_sensor(null, 'temperature', $device, $temperature_oid, $oid, 'hpilo', $descr, '1', '1', null, null, null, $threshold, $temperature);
+                discover_sensor(null, SensorEnum::Temperature, $device, $temperature_oid, $oid, 'hpilo', $descr, '1', '1', null, null, null, $threshold, $temperature);
             }
         }
     }
@@ -54,7 +55,7 @@ if (preg_match('/(Linux).+(ntc)/', (string) $device['sysDescr'])) {
     $index = '116.1';
     $value = snmp_get($device, $oid . $index, '-Oqv');
     if (is_numeric($value)) {
-        discover_sensor(null, 'temperature', $device, $oid . $index, $index, $sensor_type, $descr, '1', '1', $lowlimit, $lowwarnlimit, $warnlimit, $limit, $value);
+        discover_sensor(null, SensorEnum::Temperature, $device, $oid . $index, $index, $sensor_type, $descr, '1', '1', $lowlimit, $lowwarnlimit, $warnlimit, $limit, $value);
     }
 }
 

--- a/includes/discovery/sensors/temperature/mgeups.inc.php
+++ b/includes/discovery/sensors/temperature/mgeups.inc.php
@@ -49,5 +49,5 @@ foreach (array_keys($mge_env_data) as $index) {
 
     d_echo("low_limit : $low_limit\nlow_warn_limit : $low_warn_limit\nhigh_warn_limit : $high_warn_limit\nhigh_limit : $high_limit\n");
 
-    discover_sensor(null, 'temperature', $device, $oid, $index, $sensorType, $descr, '10', '1', $low_limit, $low_warn_limit, $high_warn_limit, $high_limit, $current / 10);
+    discover_sensor(null, \LibreNMS\Enum\Sensor::Temperature, $device, $oid, $index, $sensorType, $descr, '10', '1', $low_limit, $low_warn_limit, $high_warn_limit, $high_limit, $current / 10);
 }

--- a/includes/discovery/sensors/temperature/microsemipdsine.inc.php
+++ b/includes/discovery/sensors/temperature/microsemipdsine.inc.php
@@ -44,5 +44,5 @@ if (! empty($temperature_unit) && ! empty($temperature)) {
     $oid = '.1.3.6.1.4.1.7428.1.2.2.1.1.11.1';
     $current_value = $temperature / $divisor;
 
-    discover_sensor(null, 'temperature', $device, $oid, $index, $type, $descr, $divisor, '1', null, null, null, null, $current_value, 'snmp', null, null, $function);
+    discover_sensor(null, \LibreNMS\Enum\Sensor::Temperature, $device, $oid, $index, $type, $descr, $divisor, '1', null, null, null, null, $current_value, 'snmp', null, null, $function);
 }

--- a/includes/discovery/sensors/temperature/mimosa.inc.php
+++ b/includes/discovery/sensors/temperature/mimosa.inc.php
@@ -19,5 +19,5 @@ $descr = 'Internal Temp';
 $divisor = 10;
 $temperature = (snmp_get($device, $oid, '-Oqv') / $divisor);
 if (is_numeric($temperature)) {
-    discover_sensor(null, 'temperature', $device, $oid, $index, $sensor_type, $descr, $divisor, '1', '0', null, null, '65', $temperature);
+    discover_sensor(null, \LibreNMS\Enum\Sensor::Temperature, $device, $oid, $index, $sensor_type, $descr, $divisor, '1', '0', null, null, '65', $temperature);
 }

--- a/includes/discovery/sensors/temperature/minkelsrms.inc.php
+++ b/includes/discovery/sensors/temperature/minkelsrms.inc.php
@@ -30,7 +30,7 @@ foreach (explode("\n", $oids) as $data) {
             $limit = snmp_get($device, $limit_oid, '-Oqv', '');
             $lowlimit = snmp_get($device, $lowlimit_oid, '-Oqv', '');
 
-            discover_sensor(null, 'temperature', $device, $temperature_oid, $temperature_id, 'akcp', $descr, '1', '1', $lowlimit, $low_warn_limit, $warnlimit, $limit, $temperature);
+            discover_sensor(null, \LibreNMS\Enum\Sensor::Temperature, $device, $temperature_oid, $temperature_id, 'akcp', $descr, '1', '1', $lowlimit, $low_warn_limit, $warnlimit, $limit, $temperature);
         }
     }
 }

--- a/includes/discovery/sensors/temperature/netagent2.inc.php
+++ b/includes/discovery/sensors/temperature/netagent2.inc.php
@@ -39,7 +39,7 @@ if (! empty($ups_temperature) || $ups_temperature == 0) {
 
     discover_sensor(
         null,
-        'temperature',
+        $sensor_class,
         $device,
         $ups_temperature_oid,
         $index,

--- a/includes/discovery/sensors/temperature/netapp.inc.php
+++ b/includes/discovery/sensors/temperature/netapp.inc.php
@@ -26,7 +26,7 @@ if ($oids) {
             $temp_id = $temperature_id . '.' . $x;
             $descr = 'Temp Sensor';
             $x++;
-            discover_sensor(null, 'temperature', $device, $temperature_oid, $temp_id, 'netapp', $descr, '1', '1', $low_limit, $low_warn_limit, $warn_limit, $high_limit, $temperature);
+            discover_sensor(null, \LibreNMS\Enum\Sensor::Temperature, $device, $temperature_oid, $temp_id, 'netapp', $descr, '1', '1', $low_limit, $low_warn_limit, $warn_limit, $high_limit, $temperature);
         }
     }
 }

--- a/includes/discovery/sensors/temperature/nokia-1830.inc.php
+++ b/includes/discovery/sensors/temperature/nokia-1830.inc.php
@@ -20,7 +20,6 @@
 // *************************************************************
 // ***** Temperature Sensors for Nokia PSD
 // *************************************************************
-
 if (str_contains((string) $device['sysObjectID'], '.1.3.6.1.4.1.7483.1.3.1.12')) {
     d_echo('Nokia PSD DDM Temperature Sensors\n');
     $ifIndexToName = SnmpQuery::cache()->walk('IF-MIB::ifName')->pluck();
@@ -33,7 +32,7 @@ if (str_contains((string) $device['sysObjectID'], '.1.3.6.1.4.1.7483.1.3.1.12'))
             $divisor = 10;
             app('sensor-discovery')->discover(new \App\Models\Sensor([
                 'poller_type' => 'snmp',
-                'sensor_class' => 'temperature',
+                'sensor_class' => \LibreNMS\Enum\Sensor::Temperature,
                 'sensor_oid' => ".1.3.6.1.4.1.7483.2.2.7.3.1.4.1.2.$ifIndex.2",
                 'sensor_index' => "$ifIndex.2",
                 'sensor_type' => 'nokia-1830',

--- a/includes/discovery/sensors/temperature/nokia-isam.inc.php
+++ b/includes/discovery/sensors/temperature/nokia-isam.inc.php
@@ -13,7 +13,7 @@ foreach ($snmp_data['nokiaIsamSlotTemperature'] as $slotId => $slot) {
             $limit = $sensor['eqptBoardThermalSensorShutdownThresholdHigh'] ?? null;
             $warn_limit = $sensor['eqptBoardThermalSensorTcaThresholdHigh'] ?? null;
             $value = $sensor['eqptBoardThermalSensorActualTemperature'] / $divisor;
-            discover_sensor(null, 'temperature', $device, $oid, $slotName . '.' . $sensorId . '-temp', 'nokia-isam', $descr, $divisor, $multiplier, $limit_low, $warn_limit_low, $warn_limit, $limit, $value, 'snmp');
+            discover_sensor(null, \LibreNMS\Enum\Sensor::Temperature, $device, $oid, $slotName . '.' . $sensorId . '-temp', 'nokia-isam', $descr, $divisor, $multiplier, $limit_low, $warn_limit_low, $warn_limit, $limit, $value, 'snmp');
         }
     }
 }

--- a/includes/discovery/sensors/temperature/nos.inc.php
+++ b/includes/discovery/sensors/temperature/nos.inc.php
@@ -27,7 +27,7 @@ if ($oids = snmp_walk($device, '.1.3.6.1.4.1.1588.2.1.1.1.1.22.1.2', '-Osqn')) {
             if (! strstr($descr, 'No') and ! strstr($value, 'No')) {
                 $descr = str_replace('"', '', $descr);
                 $descr = trim($descr);
-                discover_sensor(null, 'temperature', $device, $value_oid, $oididx, 'nos', $descr, '1', '1', null, null, '80', '100', $value);
+                discover_sensor(null, \LibreNMS\Enum\Sensor::Temperature, $device, $value_oid, $oididx, 'nos', $descr, '1', '1', null, null, '80', '100', $value);
             }
         }
     }

--- a/includes/discovery/sensors/temperature/ocnos.inc.php
+++ b/includes/discovery/sensors/temperature/ocnos.inc.php
@@ -18,7 +18,7 @@ if ($os instanceof \LibreNMS\OS\Ocnos) {
                 if (isset($channel_data['IPI-CMM-CHASSIS-MIB::cmmTransTemperature']) && $channel_data['IPI-CMM-CHASSIS-MIB::cmmTransTemperature'] != '-100001') {
                     app('sensor-discovery')->discover(new \App\Models\Sensor([
                         'poller_type' => 'snmp',
-                        'sensor_class' => 'temperature',
+                        'sensor_class' => \LibreNMS\Enum\Sensor::Temperature,
                         'sensor_oid' => ".1.3.6.1.4.1.36673.100.1.2.3.1.2.$cmmStackUnitIndex.$cmmTransIndex.$cmmTransChannelIndex",
                         'sensor_index' => "$cmmStackUnitIndex.$cmmTransIndex",
                         'sensor_type' => 'transceiver',

--- a/includes/discovery/sensors/temperature/onefs.inc.php
+++ b/includes/discovery/sensors/temperature/onefs.inc.php
@@ -31,7 +31,7 @@ foreach ($oids as $index => $entry) {
         $descr = $entry['tempSensorDescription'];
         $oid = '.1.3.6.1.4.1.12124.2.54.1.4.' . $index;
         $current = $entry['tempSensorValue'];
-        discover_sensor(null, 'temperature', $device, $oid, $index, 'onefs', $descr, '1', '1', null, null, null, null, $current);
+        discover_sensor(null, \LibreNMS\Enum\Sensor::Temperature, $device, $oid, $index, 'onefs', $descr, '1', '1', null, null, null, null, $current);
     }
 }
 

--- a/includes/discovery/sensors/temperature/papouch-tme.inc.php
+++ b/includes/discovery/sensors/temperature/papouch-tme.inc.php
@@ -8,5 +8,5 @@ $temperature = (snmp_get($device, 'SNMPv2-SMI::enterprises.18248.1.1.1.0', '-Oqv
 if ($descr != '' && is_numeric($temperature) && $temperature > '0') {
     $temperature_oid = '.1.3.6.1.4.1.18248.1.1.1.0';
     $descr = trim(str_replace('"', '', $descr));
-    discover_sensor(null, 'temperature', $device, $temperature_oid, '1', 'papouch-tme', $descr, '10', '1', null, null, null, null, $temperature);
+    discover_sensor(null, \LibreNMS\Enum\Sensor::Temperature, $device, $temperature_oid, '1', 'papouch-tme', $descr, '10', '1', null, null, null, null, $temperature);
 }

--- a/includes/discovery/sensors/temperature/pbn.inc.php
+++ b/includes/discovery/sensors/temperature/pbn.inc.php
@@ -27,6 +27,6 @@ foreach ($pre_cache['pbn_oids'] as $index => $entry) {
         $value = $entry['temperature'] / $divisor;
         $entPhysicalIndex = $index;
         $entPhysicalIndex_measured = 'ports';
-        discover_sensor(null, 'temperature', $device, $oid, '' . $index, 'pbn', $descr, $divisor, $multiplier, $limit_low, $warn_limit_low, $warn_limit, $limit, $value, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured);
+        discover_sensor(null, \LibreNMS\Enum\Sensor::Temperature, $device, $oid, '' . $index, 'pbn', $descr, $divisor, $multiplier, $limit_low, $warn_limit_low, $warn_limit, $limit, $value, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured);
     }
 }

--- a/includes/discovery/sensors/temperature/pcoweb.inc.php
+++ b/includes/discovery/sensors/temperature/pcoweb.inc.php
@@ -121,6 +121,6 @@ foreach ($temperatures as $temperature) {
 
     if (is_numeric($current) && $current != 0) {
         $index = implode('.', array_slice(explode('.', $temperature['oid']), -5));
-        discover_sensor(null, 'temperature', $device, $temperature['oid'], $index, 'pcoweb', $temperature['descr'], $temperature['precision'], '1', $low_limit, null, null, $high_limit, $current);
+        discover_sensor(null, \LibreNMS\Enum\Sensor::Temperature, $device, $temperature['oid'], $index, 'pcoweb', $temperature['descr'], $temperature['precision'], '1', $low_limit, null, null, $high_limit, $current);
     }
 }

--- a/includes/discovery/sensors/temperature/powerconnect.inc.php
+++ b/includes/discovery/sensors/temperature/powerconnect.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 switch ($device['sysObjectID']) {
     /**
      * Operating Temperature: 0º C to 45º C
@@ -9,7 +11,7 @@ switch ($device['sysObjectID']) {
     case '.1.3.6.1.4.1.674.10895.3019': /* Dell Powerconnect 3548P */
     case '.1.3.6.1.4.1.674.10895.3028': /* Dell Powerconnect 2848 */
         $temperature = trim(snmp_get($device, '.1.3.6.1.4.1.89.53.15.1.9.1', '-Ovq'));
-        discover_sensor(null, 'temperature', $device, '.1.3.6.1.4.1.89.53.15.1.9.1', 0, 'powerconnect', 'Internal Temperature', '1', '1', '0', null, null, '45', $temperature);
+        discover_sensor(null, SensorEnum::Temperature, $device, '.1.3.6.1.4.1.89.53.15.1.9.1', 0, 'powerconnect', 'Internal Temperature', '1', '1', '0', null, null, '45', $temperature);
         break;
     default:
         /**
@@ -18,7 +20,7 @@ switch ($device['sysObjectID']) {
          */
         $temperature = snmp_get($device, 'boxServicesTempSensorTemperature.0', '-Ovq', 'FASTPATH-BOXSERVICES-PRIVATE-MIB');
         if (is_numeric($temperature)) {
-            discover_sensor(null, 'temperature', $device, '.1.3.6.1.4.1.674.10895.5000.2.6132.1.1.43.1.8.1.4.0', 0, 'powerconnect', 'Internal Temperature', '1', '1', '0', null, null, '45', $temperature);
+            discover_sensor(null, SensorEnum::Temperature, $device, '.1.3.6.1.4.1.674.10895.5000.2.6132.1.1.43.1.8.1.4.0', 0, 'powerconnect', 'Internal Temperature', '1', '1', '0', null, null, '45', $temperature);
         }
 }
 
@@ -38,7 +40,7 @@ foreach (explode("\n", (string) $temps) as $t) {
     if (str_ends_with($oid, '1')) {
         // This code will only pull CPU temp for each stack member, but there is no reason why the additional values couldn't be graphed
         $counter += 1;
-        discover_sensor(null, 'temperature', $device, $oid, $counter, 'dnos', 'Unit ' . $counter . ' CPU temperature', '1', '1', null, null, null, null, $val);
+        discover_sensor(null, SensorEnum::Temperature, $device, $oid, $counter, 'dnos', 'Unit ' . $counter . ' CPU temperature', '1', '1', null, null, null, null, $val);
     }
 }
 
@@ -55,6 +57,6 @@ if (is_array($oids)) {
         $descr = 'Unit ' . $index . ' ' . $entry['chStackUnitSysType'];
         $oid = '.1.3.6.1.4.1.6027.3.10.1.2.2.1.14.' . $index;
         $current = $entry['chStackUnitTemp'];
-        discover_sensor(null, 'temperature', $device, $oid, $index, 'ftos-sseries', $descr, '1', '1', null, null, null, null, $current);
+        discover_sensor(null, SensorEnum::Temperature, $device, $oid, $index, 'ftos-sseries', $descr, '1', '1', null, null, null, null, $current);
     }
 }

--- a/includes/discovery/sensors/temperature/procurve.inc.php
+++ b/includes/discovery/sensors/temperature/procurve.inc.php
@@ -16,6 +16,6 @@ foreach (SnmpQuery::cache()->walk('HP-ICF-TRANSCEIVER-MIB::hpicfXcvrInfoTable')-
         $entPhysicalIndex = $index;
         $entPhysicalIndex_measured = 'ports';
         $descr = Rewrite::shortenIfName($entry['HP-ICF-TRANSCEIVER-MIB::hpicfXcvrPortDesc']) . ' Temperature';
-        discover_sensor(null, 'temperature', $device, $oid, 'temp-trans-' . $index, 'procurve', $descr, $divisor, 1, $limit_low, $warn_limit_low, $warn_limit, $limit, $current, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured, group: 'transceiver');
+        discover_sensor(null, \LibreNMS\Enum\Sensor::Temperature, $device, $oid, 'temp-trans-' . $index, 'procurve', $descr, $divisor, 1, $limit_low, $warn_limit_low, $warn_limit, $limit, $current, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured, group: 'transceiver');
     }
 }

--- a/includes/discovery/sensors/temperature/quanta.inc.php
+++ b/includes/discovery/sensors/temperature/quanta.inc.php
@@ -22,6 +22,6 @@ foreach ($sensors_values as $index => $entry) {
     $descr = "Temperature $index:";
 
     if ($current_value > 0) {
-        discover_sensor(null, 'temperature', $device, "$numeric_oid_base.$index", $index, $sensor_type, $descr, 1, 1, null, null, null, null, $current_value);
+        discover_sensor(null, \LibreNMS\Enum\Sensor::Temperature, $device, "$numeric_oid_base.$index", $index, $sensor_type, $descr, 1, 1, null, null, null, null, $current_value);
     }
 }

--- a/includes/discovery/sensors/temperature/raisecom-ros.inc.php
+++ b/includes/discovery/sensors/temperature/raisecom-ros.inc.php
@@ -18,7 +18,7 @@ foreach ($pre_cache['rosMgmtOpticalTransceiverDDMTable'] as $index => $data) {
             $current = $value['rosMgmtOpticalTransceiverParameterValue'] / $divisor;
             $entPhysicalIndex = $index;
             $entPhysicalIndex_measured = 'ports';
-            discover_sensor(null, 'temperature', $device, $oid, 'tx-' . $index, $sensor_type, $descr, $divisor, $multiplier, $low_limit, $low_warn_limit, $warn_limit, $high_limit, $current, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured);
+            discover_sensor(null, \LibreNMS\Enum\Sensor::Temperature, $device, $oid, 'tx-' . $index, $sensor_type, $descr, $divisor, $multiplier, $low_limit, $low_warn_limit, $warn_limit, $high_limit, $current, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured);
         }
     }
 }

--- a/includes/discovery/sensors/temperature/raisecom.inc.php
+++ b/includes/discovery/sensors/temperature/raisecom.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 echo 'Raisecom';
 
 $multiplier = 1;
@@ -18,7 +20,7 @@ foreach ($pre_cache['raisecomOpticalTransceiverDDMTable'] as $index => $data) {
             $current = $value['raisecomOpticalTransceiverParameterValue'] / $divisor;
             $entPhysicalIndex = $index;
             $entPhysicalIndex_measured = 'ports';
-            discover_sensor(null, 'temperature', $device, $oid, 'tx-' . $index, $sensor_type, $descr, $divisor, $multiplier, $low_limit, $low_warn_limit, $warn_limit, $high_limit, $current, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured);
+            discover_sensor(null, SensorEnum::Temperature, $device, $oid, 'tx-' . $index, $sensor_type, $descr, $divisor, $multiplier, $low_limit, $low_warn_limit, $warn_limit, $high_limit, $current, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured);
         }
     }
 }
@@ -30,5 +32,5 @@ if (is_numeric($value)) {
     $low_limit = snmp_get($device, 'raisecomTemperatureThresholdLow.0', ['-OUvq', '-Pu'], 'RAISECOM-SYSTEM-MIB', 'raisecom');
     $high_limit = snmp_get($device, 'raisecomTemperatureThresholdHigh.0', ['-OUvq', '-Pu'], 'RAISECOM-SYSTEM-MIB', 'raisecom');
 
-    discover_sensor(null, 'temperature', $device, $oid, 0, 'raisecomTemperatureValue', $descr, '1', '1', $low_limit, null, null, $high_limit, $value);
+    discover_sensor(null, SensorEnum::Temperature, $device, $oid, 0, 'raisecomTemperatureValue', $descr, '1', '1', $low_limit, null, null, $high_limit, $value);
 }

--- a/includes/discovery/sensors/temperature/raritan-pdu.inc.php
+++ b/includes/discovery/sensors/temperature/raritan-pdu.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 /**
  * raritan-pdu.inc.php
  *
@@ -34,7 +36,7 @@ if (is_array($raritan_data) && ! empty($raritan_data)) {
     $warn_limit = $raritan_data['unitTempUpperWarning.0'];
     $high_limit = $raritan_data['unitTempUpperCritical.0'];
     $current = $raritan_data['unitCpuTemp.0'] / $divisor;
-    discover_sensor(null, 'temperature', $device, $oid, $tmp_index, 'raritan', $descr, $divisor, 1, $low_limit, $low_limit, $warn_limit, $high_limit, $current);
+    discover_sensor(null, SensorEnum::Temperature, $device, $oid, $tmp_index, 'raritan', $descr, $divisor, 1, $low_limit, $low_limit, $warn_limit, $high_limit, $current);
 }
 
 //Check for PDU MIB external Sensors
@@ -52,7 +54,7 @@ foreach ($oids as $index => $sensor) {
         $limit_low_warn = $sensor['externalSensorLowerCriticalThreshold'] / $divisor;
         $offset++;
         if (is_numeric($temp_current) && $temp_current >= 0) {
-            discover_sensor(null, 'temperature', $device, $oid, $offset, 'raritan', $descr, $divisor, 1, $limit_low, $limit_low_warn, $limit_high_warn, $limit_high, $temp_current);
+            discover_sensor(null, SensorEnum::Temperature, $device, $oid, $offset, 'raritan', $descr, $divisor, 1, $limit_low, $limit_low_warn, $limit_high_warn, $limit_high, $temp_current);
         }
     }
 }

--- a/includes/discovery/sensors/temperature/rfc1628.inc.php
+++ b/includes/discovery/sensors/temperature/rfc1628.inc.php
@@ -6,7 +6,7 @@ $battery_temp = snmp_get($device, 'upsBatteryTemperature.0', '-OqvU', 'UPS-MIB')
 if (is_numeric($battery_temp)) {
     discover_sensor(
         null,
-        'temperature',
+        $sensor_class,
         $device,
         '.1.3.6.1.2.1.33.1.2.7.0',
         0,

--- a/includes/discovery/sensors/temperature/sentry4.inc.php
+++ b/includes/discovery/sensors/temperature/sentry4.inc.php
@@ -39,6 +39,6 @@ foreach ($pre_cache['sentry4_temp'] as $index => $data) {
         $user_func = 'fahrenheit_to_celsius';
     }
     if (is_numeric($current) && $current >= 0) {
-        discover_sensor(null, 'temperature', $device, $oid, 'st4TempSensorValue' . $index, 'sentry4', $descr, $divisor, $multiplier, $low_limit, $low_warn_limit, $high_warn_limit, $high_limit, $current, 'snmp', null, null, $user_func);
+        discover_sensor(null, \LibreNMS\Enum\Sensor::Temperature, $device, $oid, 'st4TempSensorValue' . $index, 'sentry4', $descr, $divisor, $multiplier, $low_limit, $low_warn_limit, $high_warn_limit, $high_limit, $current, 'snmp', null, null, $user_func);
     }
 }

--- a/includes/discovery/sensors/temperature/seos.inc.php
+++ b/includes/discovery/sensors/temperature/seos.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 echo 'RBN-ENVMON-MIB ';
 
 $type = 'seos';
@@ -17,7 +19,7 @@ foreach (explode("\n", (string) $oids) as $data) {
         $temperature = snmp_get($device, $oid, '-Oqv');
         $descr = str_replace('"', '', $descr);
 
-        discover_sensor(null, 'temperature', $device, $oid, $insert_index, $type, $descr, 1, '1', null, null, null, null, $temperature);
+        discover_sensor(null, SensorEnum::Temperature, $device, $oid, $insert_index, $type, $descr, 1, '1', null, null, null, null, $temperature);
         $insert_index++;
     }
 }
@@ -34,7 +36,7 @@ foreach (explode("\n", (string) $oids) as $data) {
         $temperature = snmp_get($device, $oid, '-Oqv');
         $descr = str_replace('"', '', $descr);
 
-        discover_sensor(null, 'temperature', $device, $oid, $insert_index, $type, $descr, 1, '1', null, null, null, null, $temperature);
+        discover_sensor(null, SensorEnum::Temperature, $device, $oid, $insert_index, $type, $descr, 1, '1', null, null, null, null, $temperature);
         $insert_index++;
     }
 }

--- a/includes/discovery/sensors/temperature/serveriron.inc.php
+++ b/includes/discovery/sensors/temperature/serveriron.inc.php
@@ -24,5 +24,5 @@ if (is_numeric($value_high)) {
 
 if (is_numeric($value)) {
     $current = ($value / 2);
-    discover_sensor(null, 'temperature', $device, $oid, 1, 'serveriron-temp', $descr, '2', '1', null, null, $high_warn_limit, $high_limit, $current);
+    discover_sensor(null, \LibreNMS\Enum\Sensor::Temperature, $device, $oid, 1, 'serveriron-temp', $descr, '2', '1', null, null, $high_warn_limit, $high_limit, $current);
 }

--- a/includes/discovery/sensors/temperature/serverscheck.inc.php
+++ b/includes/discovery/sensors/temperature/serverscheck.inc.php
@@ -46,7 +46,7 @@ foreach ($pre_cache['serverscheck_control'] as $oid_name => $oid_value) {
             if (is_numeric($current)) {
                 $index = str_replace('.0', '', $oid_name);
                 $descr = $oid_value;
-                discover_sensor(null, 'temperature', $device, $serverscheck_oids[$tmp_oid], $index, 'serverscheck', $descr, 1, 1, null, null, null, null, $current);
+                discover_sensor(null, \LibreNMS\Enum\Sensor::Temperature, $device, $serverscheck_oids[$tmp_oid], $index, 'serverscheck', $descr, 1, 1, null, null, null, null, $current);
             }
         }
         $temp_x++;

--- a/includes/discovery/sensors/temperature/sgos.inc.php
+++ b/includes/discovery/sensors/temperature/sgos.inc.php
@@ -11,7 +11,7 @@ for ($index = 1; $index < 20; $index++) { //Proxy SG Temp OID end in 1-20
         $descr = snmp_get($device, $descr_oid, '-Oqv', 'BLUECOAT-SG-SENSOR-MIB');
         $current = snmp_get($device, $temp_oid, '-Oqv', 'BLUECOAT-SG-SENSOR-MIB');
         $divisor = '1';
-        discover_sensor(null, 'temperature', $device, $temp_oid, $temp_index, 'sgos', $descr, 1, '1', null, null, null, null, $current);
+        discover_sensor(null, \LibreNMS\Enum\Sensor::Temperature, $device, $temp_oid, $temp_index, 'sgos', $descr, 1, '1', null, null, null, null, $current);
     }
     $temp_index++;
 }

--- a/includes/discovery/sensors/temperature/sitemonitor.inc.php
+++ b/includes/discovery/sensors/temperature/sitemonitor.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 /**
  * sitemonitor.inc.php
  *
@@ -25,12 +27,12 @@
  */
 $oid = '.1.3.6.1.4.1.32050.2.1.27.5.0';
 $current = (snmp_get($device, $oid, '-Oqv') / 10);
-discover_sensor(null, 'temperature', $device, $oid, 0, 'sitemonitor', 'Temperature', 10, 1, null, null, null, null, $current);
+discover_sensor(null, SensorEnum::Temperature, $device, $oid, 0, 'sitemonitor', 'Temperature', 10, 1, null, null, null, null, $current);
 
 $oid = '.1.3.6.1.4.1.32050.2.1.27.5.5';
 $current = (snmp_get($device, $oid, '-Oqv') / 10);
-discover_sensor(null, 'temperature', $device, $oid, 5, 'sitemonitor', 'Relay on Above', 10, 1, null, null, null, null, $current);
+discover_sensor(null, SensorEnum::Temperature, $device, $oid, 5, 'sitemonitor', 'Relay on Above', 10, 1, null, null, null, null, $current);
 
 $oid = '.1.3.6.1.4.1.32050.2.1.27.5.6';
 $current = (snmp_get($device, $oid, '-Oqv') / 10);
-discover_sensor(null, 'temperature', $device, $oid, 6, 'sitemonitor', 'Relay on Below', 10, 1, null, null, null, null, $current);
+discover_sensor(null, SensorEnum::Temperature, $device, $oid, 6, 'sitemonitor', 'Relay on Below', 10, 1, null, null, null, null, $current);

--- a/includes/discovery/sensors/temperature/smartax.inc.php
+++ b/includes/discovery/sensors/temperature/smartax.inc.php
@@ -37,6 +37,6 @@ foreach ($data as $index => $value) {
         $tempCurr = $value;
         $temperature_oid = '.' . $temp_oid . '.' . $index;
         $descr = $descr_data[$index];
-        discover_sensor(null, 'temperature', $device, $temperature_oid, $index, 'smartax', $descr, '1', '1', null, null, null, null, $tempCurr);
+        discover_sensor(null, \LibreNMS\Enum\Sensor::Temperature, $device, $temperature_oid, $index, 'smartax', $descr, '1', '1', null, null, null, null, $tempCurr);
     }
 }

--- a/includes/discovery/sensors/temperature/sub10.inc.php
+++ b/includes/discovery/sensors/temperature/sub10.inc.php
@@ -25,4 +25,4 @@ foreach (explode("\n", (string) $threshes) as $thresh) {
 }
 
 // Create Sensor
-discover_sensor(null, 'temperature', $device, $oid, $oid, 'sub10', 'Modem', '1', '1', $thresholds[$indexes['low']], null, null, $thresholds[$indexes['high']], $current);
+discover_sensor(null, \LibreNMS\Enum\Sensor::Temperature, $device, $oid, $oid, 'sub10', 'Modem', '1', '1', $thresholds[$indexes['low']], null, null, $thresholds[$indexes['high']], $current);

--- a/includes/discovery/sensors/temperature/supermicro.inc.php
+++ b/includes/discovery/sensors/temperature/supermicro.inc.php
@@ -24,7 +24,7 @@ if ($oids) {
                 $monitor = snmp_get($device, $monitor_oid, '-Oqv', 'SUPERMICRO-HEALTH-MIB', 'supermicro');
                 if ($monitor == 'true') {
                     $descr = trim(str_ireplace('temperature', '', $descr));
-                    discover_sensor(null, 'temperature', $device, $temperature_oid, trim($index, '.'), 'supermicro', $descr, (int) $divisor, '1', null, null, null, $limit, $temperature);
+                    discover_sensor(null, \LibreNMS\Enum\Sensor::Temperature, $device, $temperature_oid, trim($index, '.'), 'supermicro', $descr, (int) $divisor, '1', null, null, null, $limit, $temperature);
                 }
             }
         }

--- a/includes/discovery/sensors/temperature/teracom.inc.php
+++ b/includes/discovery/sensors/temperature/teracom.inc.php
@@ -67,7 +67,7 @@ if (Arr::exists($teracom_devices, $device['hardware'])) {
             $current = $t_data[1]['Int'];
             $temp_func = ($teracom_temp_value == 1) ? 'fahrenheit_to_celsius' : null;
 
-            discover_sensor(null, 'temperature', $device, $oid, $index, 'teracom', $t_data['description'], $divisor, '1', $low_limit, null, null, $high_limit, $current, 'snmp', null, null, $temp_func);
+            discover_sensor(null, \LibreNMS\Enum\Sensor::Temperature, $device, $oid, $index, 'teracom', $t_data['description'], $divisor, '1', $low_limit, null, null, $high_limit, $current, 'snmp', null, null, $temp_func);
         }
     }
 }

--- a/includes/discovery/sensors/temperature/terra.inc.php
+++ b/includes/discovery/sensors/temperature/terra.inc.php
@@ -10,7 +10,7 @@ if ($device['os'] === 'terra') {
         if (str_contains((string) $device['sysDescr'], $row[0])) {
             $temperature = snmp_get($device, $row[1], '-Oqv');
             if (is_numeric($temperature)) {
-                discover_sensor(null, 'temperature', $device, $row[1], '0', $row[0], 'Internal Temperature', 1, 1, null, null, null, null, $temperature);
+                discover_sensor(null, \LibreNMS\Enum\Sensor::Temperature, $device, $row[1], '0', $row[0], 'Internal Temperature', 1, 1, null, null, null, null, $temperature);
             }
         }
     }

--- a/includes/discovery/sensors/temperature/tpdin.inc.php
+++ b/includes/discovery/sensors/temperature/tpdin.inc.php
@@ -40,7 +40,7 @@ $tpdin_oids = [
 
 foreach ($tpdin_oids as $data) {
     if ($data['current'] > 0) {
-        discover_sensor(null, 'temperature', $device, $data['oid'], $data['index'], $device['os'], $data['descr'], 10, '1', null, null, null, null, $data['current']);
+        discover_sensor(null, \LibreNMS\Enum\Sensor::Temperature, $device, $data['oid'], $data['index'], $device['os'], $data['descr'], 10, '1', null, null, null, null, $data['current']);
     }
 }
 

--- a/includes/discovery/sensors/temperature/unix.inc.php
+++ b/includes/discovery/sensors/temperature/unix.inc.php
@@ -41,7 +41,7 @@ if (! empty($snmpData)) {
         $value = intval($lmData[$type . 'Value']) / $divisor;
         if (! empty($descr)) {
             $oid = Oid::of('LM-SENSORS-MIB::' . $type . 'Value.' . $index)->toNumeric();
-            discover_sensor(null, 'temperature', $device, $oid, $index, 'lmsensors', $descr, $divisor, 1, null, null, null, null, $value, 'snmp', null, null, null, 'lmsensors');
+            discover_sensor(null, \LibreNMS\Enum\Sensor::Temperature, $device, $oid, $index, 'lmsensors', $descr, $divisor, 1, null, null, null, null, $value, 'snmp', null, null, null, 'lmsensors');
         }
     }
 }
@@ -60,7 +60,7 @@ if (! empty($snmpData)) {
                 $oid = Oid::of('NET-SNMP-EXTEND-MIB::nsExtendOutLine."ups-nut".' . $index)->toNumeric();
                 discover_sensor(
                     null,
-                    'temperature',
+                    $sensor_class,
                     $device,
                     $oid,
                     $index,

--- a/includes/discovery/sensors/temperature/voss.inc.php
+++ b/includes/discovery/sensors/temperature/voss.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 /**
  * voss.inc.php
  *
@@ -20,7 +22,7 @@ if (is_array($rcChasFan)) {
         $value = $rcChasFan[$index]['rcChasFanAmbientTemperature'];
         $var1 = 'rcChasFanAmbientTemperature';
         $oid = '.1.3.6.1.4.1.2272.1.4.7.1.1.3.' . $index;
-        discover_sensor(null, 'temperature', $device, $oid, "$var1.$index", 'avaya-vsp', $descr, '1', '1', null, null, null, null, $value);
+        discover_sensor(null, SensorEnum::Temperature, $device, $oid, "$var1.$index", 'avaya-vsp', $descr, '1', '1', null, null, null, null, $value);
     }
 }
 
@@ -31,7 +33,7 @@ $oid = '.1.3.6.1.4.1.2272.1.212.1.0';
 $descr = 'VOSS CPU temperature';
 $value = snmp_get($device, $index, '-OvqU', 'RAPID-CITY');
 if (is_numeric($value) && $value != 0) {
-    discover_sensor(null, 'temperature', $device, $oid, $index, 'avaya-vsp', $descr, '1', '1', null, null, null, null, $value);
+    discover_sensor(null, SensorEnum::Temperature, $device, $oid, $index, 'avaya-vsp', $descr, '1', '1', null, null, null, null, $value);
 }
 
 $index = 'rcSingleCpSystemMacTemperature.0';
@@ -39,7 +41,7 @@ $oid = '.1.3.6.1.4.1.2272.1.212.2.0';
 $descr = 'VOSS MAC temperature';
 $value = snmp_get($device, $index, '-OvqU', 'RAPID-CITY');
 if (is_numeric($value) && $value != 0) {
-    discover_sensor(null, 'temperature', $device, $oid, $index, 'avaya-vsp', $descr, '1', '1', null, null, null, null, $value);
+    discover_sensor(null, SensorEnum::Temperature, $device, $oid, $index, 'avaya-vsp', $descr, '1', '1', null, null, null, null, $value);
 }
 
 $index = 'rcSingleCpSystemPhy1Temperature.0';
@@ -47,7 +49,7 @@ $oid = '.1.3.6.1.4.1.2272.1.212.3.0';
 $descr = 'VOSS PHY1 temperature';
 $value = snmp_get($device, $index, '-OvqU', 'RAPID-CITY');
 if (is_numeric($value) && $value != 0) {
-    discover_sensor(null, 'temperature', $device, $oid, $index, 'avaya-vsp', $descr, '1', '1', null, null, null, null, $value);
+    discover_sensor(null, SensorEnum::Temperature, $device, $oid, $index, 'avaya-vsp', $descr, '1', '1', null, null, null, null, $value);
 }
 
 $index = 'rcSingleCpSystemPhy2Temperature.0';
@@ -56,7 +58,7 @@ $descr = 'VOSS PHY2 temperature';
 $value = snmp_get($device, $index, '-OvqU', 'RAPID-CITY');
 d_echo("VOSS $descr: $value\n");
 if (is_numeric($value) && $value != 0) {
-    discover_sensor(null, 'temperature', $device, $oid, $index, 'avaya-vsp', $descr, '1', '1', null, null, null, null, $value);
+    discover_sensor(null, SensorEnum::Temperature, $device, $oid, $index, 'avaya-vsp', $descr, '1', '1', null, null, null, null, $value);
 }
 
 $index = 'rcSingleCpSystemMac2Temperature.0';
@@ -65,5 +67,5 @@ $descr = 'VOSS MAC2 temperature';
 $value = snmp_get($device, $index, '-OvqU', 'RAPID-CITY');
 d_echo("VOSS $descr: $value\n");
 if (is_numeric($value) && $value != 0) {
-    discover_sensor(null, 'temperature', $device, $oid, $index, 'avaya-vsp', $descr, '1', '1', null, null, null, null, $value);
+    discover_sensor(null, SensorEnum::Temperature, $device, $oid, $index, 'avaya-vsp', $descr, '1', '1', null, null, null, null, $value);
 }

--- a/includes/discovery/sensors/temperature/webmon.inc.php
+++ b/includes/discovery/sensors/temperature/webmon.inc.php
@@ -52,7 +52,7 @@ foreach ($prefixes as $prefix => $numOidPrefix) {
                 $highLimit = fahrenheit_to_celsius($highLimit);
                 $highWarnLimit = fahrenheit_to_celsius($highWarnLimit);
             }
-            discover_sensor(null, 'temperature', $device, $num_oid, $prefix . 'LiveRaw.' . $index, 'webmon', $descr, '1', '1', $lowLimit, $lowWarnLimit, $highWarnLimit, $highLimit, $value, 'snmp', null, null, $user_function, $group);
+            discover_sensor(null, \LibreNMS\Enum\Sensor::Temperature, $device, $num_oid, $prefix . 'LiveRaw.' . $index, 'webmon', $descr, '1', '1', $lowLimit, $lowWarnLimit, $highWarnLimit, $highLimit, $value, 'snmp', null, null, $user_function, $group);
         }
     }
 }

--- a/includes/discovery/sensors/temperature/websensor.inc.php
+++ b/includes/discovery/sensors/temperature/websensor.inc.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Str;
+use LibreNMS\Enum\Sensor as SensorEnum;
 
 $regexp = '/
     \.1\.3\.6\.1\.4\.1\.22626\.1\.5\.2\.
@@ -45,7 +46,7 @@ if ($oids) {
             $limit = trim($sensor['limit_high'], ' "');
             $temperature = $sensor['temp_intval'];
 
-            discover_sensor(null, 'temperature', $device, $temperature_oid, $temperature_id, 'cometsystem-p85xx', $descr, '10', '1', $lowlimit, null, null, $limit, $temperature);
+            discover_sensor(null, SensorEnum::Temperature, $device, $temperature_oid, $temperature_id, 'cometsystem-p85xx', $descr, '10', '1', $lowlimit, null, null, $limit, $temperature);
         }
     }
 }
@@ -64,5 +65,5 @@ if (is_numeric($pre_cache['websensor_valuesInt']['tempInt.0'])) {
     $temperature = $pre_cache['websensor_valuesInt']['tempInt.0'] / 10;
     $high_limit = $pre_cache['websensor_settings']['tempHighInt.0'] / 10;
     $low_limit = $pre_cache['websensor_settings']['tempLowInt.0'] / 10;
-    discover_sensor(null, 'temperature', $device, $temperature_oid, $temperature_index, 'websensor', $descr, '10', '1', $low_limit, null, null, $high_limit, $temperature, 'snmp', null, null, $user_func);
+    discover_sensor(null, SensorEnum::Temperature, $device, $temperature_oid, $temperature_index, 'websensor', $descr, '10', '1', $low_limit, null, null, $high_limit, $temperature, 'snmp', null, null, $user_func);
 }

--- a/includes/discovery/sensors/temperature/zxdsl.inc.php
+++ b/includes/discovery/sensors/temperature/zxdsl.inc.php
@@ -16,7 +16,7 @@ $value = str_replace('"', '', $value);
 if (is_numeric($value)) {
     discover_sensor(
         null,
-        'temperature',
+        $sensor_class,
         $device,
         $valueoid,
         0,

--- a/includes/discovery/sensors/tv_signal/terra-sdi480.inc.php
+++ b/includes/discovery/sensors/tv_signal/terra-sdi480.inc.php
@@ -23,6 +23,7 @@
  *
  * @author     Peca Nesovanovic <peca.nesovanovic@sattrakt.com>
  */
+
 $divisor = 10000;
 $multiplier = 1;
 
@@ -44,7 +45,7 @@ if (is_array($oids)) {
 
             app('sensor-discovery')->discover(new \App\Models\Sensor([
                 'poller_type' => 'snmp',
-                'sensor_class' => 'tv_signal',
+                'sensor_class' => \LibreNMS\Enum\Sensor::TvSignal,
                 'sensor_oid' => $oid,
                 'sensor_index' => $inputid,
                 'sensor_type' => $type,

--- a/includes/discovery/sensors/voltage/adva_fsp150.inc.php
+++ b/includes/discovery/sensors/voltage/adva_fsp150.inc.php
@@ -97,7 +97,7 @@ foreach (array_keys($pre_cache['adva_fsp150']) as $index) {
 
             discover_sensor(
                 null,
-                'voltage',
+                $sensor_class,
                 $device,
                 $oid,
                 $entry['sensor_name'] . $index,

--- a/includes/discovery/sensors/voltage/adva_fsp3kr7.inc.php
+++ b/includes/discovery/sensors/voltage/adva_fsp3kr7.inc.php
@@ -34,7 +34,7 @@ if (is_array($pre_cache['adva_fsp3kr7_Card'])) {
 
             discover_sensor(
                 null,
-                'voltage',
+                $sensor_class,
                 $device,
                 $oid,
                 'eqptPhysInstValuePsuVoltInp' . $index,

--- a/includes/discovery/sensors/voltage/apc.inc.php
+++ b/includes/discovery/sensors/voltage/apc.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 // Battery Bus Voltage
 
 // upsHighPrecBatteryActualVoltage
@@ -21,7 +23,7 @@ if ($oids) {
     [$oid,$current] = explode(' ', $oids);
     $type = 'apc';
     $descr = 'Battery Bus';
-    discover_sensor(null, 'voltage', $device, $oid, $index, $type, $descr, $divisor, '1', null, null, null, null, $current / $divisor);
+    discover_sensor(null, SensorEnum::Voltage, $device, $oid, $index, $type, $descr, $divisor, '1', null, null, null, null, $current / $divisor);
 }
 unset($oids);
 
@@ -41,7 +43,7 @@ if ($phasecount > 2) {
         $divisor = 1;
         $voltage = $data['upsPhaseOutputVoltage'] / $divisor;
         if ($voltage >= 0) {
-            discover_sensor(null, 'voltage', $device, $voltage_oid, $index, $type, $descr, $divisor, 1, null, null, null, null, $voltage);
+            discover_sensor(null, SensorEnum::Voltage, $device, $voltage_oid, $index, $type, $descr, $divisor, 1, null, null, null, null, $voltage);
         }
     }
     unset($index);
@@ -54,10 +56,10 @@ if ($phasecount > 2) {
         $in_index = '3.1.3.' . $index;
         if (substr((string) $index, 0, 1) == 2 && $data['upsPhaseInputVoltage'] != -1) {
             $descr = 'Phase ' . substr((string) $index, -1) . ' Bypass Input';
-            discover_sensor(null, 'voltage', $device, $voltage_oid, $in_index, $type, $descr, $divisor, 0, null, null, null, null, $voltage);
+            discover_sensor(null, SensorEnum::Voltage, $device, $voltage_oid, $in_index, $type, $descr, $divisor, 0, null, null, null, null, $voltage);
         } elseif (substr((string) $index, 0, 1) == 1) {
             $descr = 'Phase ' . substr((string) $index, -1) . ' Input';
-            discover_sensor(null, 'voltage', $device, $voltage_oid, $in_index, $type, $descr, $divisor, 0, null, null, null, null, $voltage);
+            discover_sensor(null, SensorEnum::Voltage, $device, $voltage_oid, $in_index, $type, $descr, $divisor, 0, null, null, null, null, $voltage);
         }
     }
 } else {
@@ -75,7 +77,7 @@ if ($phasecount > 2) {
                 $index = $split_oid[count($split_oid) - 3];
                 $oid = '.1.3.6.1.4.1.318.1.1.8.5.3.3.1.3.' . $index . '.1.1';
                 $descr = 'Input Feed ' . chr(64 + $index);
-                discover_sensor(null, 'voltage', $device, $oid, "3.3.1.3.$index", $type, $descr, $divisor, '1', null, null, null, null, $current);
+                discover_sensor(null, SensorEnum::Voltage, $device, $oid, "3.3.1.3.$index", $type, $descr, $divisor, '1', null, null, null, null, $current);
             }
         }
     }
@@ -96,7 +98,7 @@ if ($phasecount > 2) {
                 if (count(explode("\n", (string) $oids)) > 1) {
                     $descr .= " $index";
                 }
-                discover_sensor(null, 'voltage', $device, $oid, "4.3.1.3.$index", $type, $descr, $divisor, '1', null, null, null, null, $current);
+                discover_sensor(null, SensorEnum::Voltage, $device, $oid, "4.3.1.3.$index", $type, $descr, $divisor, '1', null, null, null, null, $current);
             }
         }
     }
@@ -117,7 +119,7 @@ if ($phasecount > 2) {
         [$oid,$current] = explode(' ', $oids);
         $type = 'apc';
         $descr = 'Input';
-        discover_sensor(null, 'voltage', $device, $oid, $index, $type, $descr, $divisor, '1', null, null, null, null, $current / $divisor);
+        discover_sensor(null, SensorEnum::Voltage, $device, $oid, $index, $type, $descr, $divisor, '1', null, null, null, null, $current / $divisor);
     }
     // upsHighPrecOutputVoltage
     $oids = snmp_get($device, '.1.3.6.1.4.1.318.1.1.1.4.3.1.0', '-OsqnU');
@@ -136,7 +138,7 @@ if ($phasecount > 2) {
         [$oid,$current] = explode(' ', $oids);
         $type = 'apc';
         $descr = 'Output';
-        discover_sensor(null, 'voltage', $device, $oid, $index, $type, $descr, $divisor, '1', null, null, null, null, $current / $divisor);
+        discover_sensor(null, SensorEnum::Voltage, $device, $oid, $index, $type, $descr, $divisor, '1', null, null, null, null, $current / $divisor);
     }
     // rPDUIdentDeviceLinetoLineVoltage
     $oids = snmp_get($device, '.1.3.6.1.4.1.318.1.1.12.1.15.0', '-OsqnU');
@@ -149,7 +151,7 @@ if ($phasecount > 2) {
             $type = 'apc';
             $index = '1';
             $descr = 'Input';
-            discover_sensor(null, 'voltage', $device, $oid, $index, $type, $descr, $divisor, '1', null, null, null, null, $current);
+            discover_sensor(null, SensorEnum::Voltage, $device, $oid, $index, $type, $descr, $divisor, '1', null, null, null, null, $current);
         }
     }
     // rPDU2PhaseStatusVoltage
@@ -163,7 +165,7 @@ if ($phasecount > 2) {
             $type = 'apc';
             $index = '1';
             $descr = 'Input';
-            discover_sensor(null, 'voltage', $device, $oid, $index, $type, $descr, $divisor, '1', null, null, null, null, $current);
+            discover_sensor(null, SensorEnum::Voltage, $device, $oid, $index, $type, $descr, $divisor, '1', null, null, null, null, $current);
         }
     }
 }

--- a/includes/discovery/sensors/voltage/areca.inc.php
+++ b/includes/discovery/sensors/voltage/areca.inc.php
@@ -18,7 +18,7 @@ if ($oids) {
             $current = (snmp_get($device, $oid, '-Oqv', '') / $divisor);
             if (trim($descr, '"') != 'Battery Status') {
                 // Battery Status is charge percentage, or 255 when no BBU
-                discover_sensor(null, 'voltage', $device, $oid, $index, $type, trim($descr, '"'), $divisor, '1', null, null, null, null, $current);
+                discover_sensor(null, \LibreNMS\Enum\Sensor::Voltage, $device, $oid, $index, $type, trim($descr, '"'), $divisor, '1', null, null, null, null, $current);
             }
         }
     }

--- a/includes/discovery/sensors/voltage/benuos.inc.php
+++ b/includes/discovery/sensors/voltage/benuos.inc.php
@@ -15,6 +15,6 @@ for ($index = 10; $index <= 11; $index++) { //Benu Voltage Sensors are index 10 
     $sensor_oid = ".1.3.6.1.4.1.39406.1.1.1.4.1.1.5.1.$index";
     $descr = $data["1.$index"]['benuSensorName'] ?? null;
     $current = $data["1.$index"]['benuSensorValue'] ?? null;
-    discover_sensor(null, 'voltage', $device, $sensor_oid, $sensor_index, 'benuos', $descr, '1', '1', null, null, null, null, $current);
+    discover_sensor(null, \LibreNMS\Enum\Sensor::Voltage, $device, $sensor_oid, $sensor_index, 'benuos', $descr, '1', '1', null, null, null, null, $current);
     $sensor_index++;
 }//end loop

--- a/includes/discovery/sensors/voltage/ciscosb.inc.php
+++ b/includes/discovery/sensors/voltage/ciscosb.inc.php
@@ -30,7 +30,7 @@ foreach ($oids as $index => $ciscosb_data) {
         if (is_numeric($voltage) && ($value['rlPhyTestTableTransceiverTemp'] != 0)) {
             app('sensor-discovery')->discover(new \App\Models\Sensor([
                 'poller_type' => 'snmp',
-                'sensor_class' => 'voltage',
+                'sensor_class' => \LibreNMS\Enum\Sensor::Voltage,
                 'sensor_oid' => $oid,
                 'sensor_index' => $index,
                 'sensor_type' => 'rlPhyTestTableTransceiverSupply',

--- a/includes/discovery/sensors/voltage/commander-plus.inc.php
+++ b/includes/discovery/sensors/voltage/commander-plus.inc.php
@@ -30,4 +30,4 @@ $multiplier = 1;
 $limit_low = 24;
 $limit = 57;
 $current = snmp_get($device, 'rectifierFloatVoltage.0', '-Oqv', 'CCPOWER-MIB');
-discover_sensor(null, 'voltage', $device, $oid, 'rectifierFloatVoltage', 'commander-plus', $descr, $divisor, $multiplier, $limit_low, null, null, $limit, $current);
+discover_sensor(null, \LibreNMS\Enum\Sensor::Voltage, $device, $oid, 'rectifierFloatVoltage', 'commander-plus', $descr, $divisor, $multiplier, $limit_low, null, null, $limit, $current);

--- a/includes/discovery/sensors/voltage/comware.inc.php
+++ b/includes/discovery/sensors/voltage/comware.inc.php
@@ -35,6 +35,6 @@ foreach ($hh3cTransceiverInfoTable as $index => $entry) {
         $entPhysicalIndex_measured = 'ports';
 
         $descr = $port->getShortLabel() . ' Supply Voltage';
-        discover_sensor(null, 'voltage', $device, $oid, 'volt-' . $index, 'comware', $descr, $divisor, $multiplier, $limit_low, $warn_limit_low, $warn_limit, $limit, $current, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured, group: 'transceiver');
+        discover_sensor(null, \LibreNMS\Enum\Sensor::Voltage, $device, $oid, 'volt-' . $index, 'comware', $descr, $divisor, $multiplier, $limit_low, $warn_limit_low, $warn_limit, $limit, $current, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured, group: 'transceiver');
     }
 }

--- a/includes/discovery/sensors/voltage/dell-powervault.inc.php
+++ b/includes/discovery/sensors/voltage/dell-powervault.inc.php
@@ -19,7 +19,7 @@ if (is_array($oids)) {
             $descr = implode(':', $connUnitSensorMessage);
             app('sensor-discovery')->discover(new \App\Models\Sensor([
                 'poller_type' => 'snmp',
-                'sensor_class' => 'voltage',
+                'sensor_class' => \LibreNMS\Enum\Sensor::Voltage,
                 'sensor_oid' => $cur_oid . $index,
                 'sensor_index' => $index,
                 'sensor_type' => 'dellme',

--- a/includes/discovery/sensors/voltage/dell.inc.php
+++ b/includes/discovery/sensors/voltage/dell.inc.php
@@ -36,7 +36,7 @@ foreach ((array) $temp as $index => $entry) {
         (isset($entry['voltageProbeUpperNonCriticalThreshold'])) ? $warnlimit = $entry['voltageProbeUpperNonCriticalThreshold'] / $divisor : $warnlimit = null;
         (isset($entry['voltageProbeUpperCriticalThreshold'])) ? $limit = $entry['voltageProbeUpperCriticalThreshold'] / $divisor : $limit = null;
 
-        discover_sensor(null, 'voltage', $device, $cur_oid . $index, $index, 'dell', $descr, $divisor, '1', $lowlimit, $low_warn_limit, $warnlimit, $limit, $value, 'snmp', $index);
+        discover_sensor(null, \LibreNMS\Enum\Sensor::Voltage, $device, $cur_oid . $index, $index, 'dell', $descr, $divisor, '1', $lowlimit, $low_warn_limit, $warnlimit, $limit, $value, 'snmp', $index);
     }
 
     unset(

--- a/includes/discovery/sensors/voltage/dsm.inc.php
+++ b/includes/discovery/sensors/voltage/dsm.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 /*
  * LibreNMS
  *
@@ -25,26 +27,26 @@ $ups_device_model = str_replace('"', '', snmp_get($device, $ups_device_model_oid
 $ups_input_voltage_oid = '.1.3.6.1.4.1.6574.4.4.1.1.0';
 $ups_input_voltage = snmp_get($device, $ups_input_voltage_oid, '-Oqv');
 if (is_numeric($ups_input_voltage)) {
-    discover_sensor(null, 'voltage', $device, $ups_input_voltage_oid, 'UPSInputVoltageValue', $ups_device_manufacturer . ' ' . $ups_device_model, 'UPS Input Voltage Value', '1', '1', null, null, null, null, $ups_input_voltage);
+    discover_sensor(null, SensorEnum::Voltage, $device, $ups_input_voltage_oid, 'UPSInputVoltageValue', $ups_device_manufacturer . ' ' . $ups_device_model, 'UPS Input Voltage Value', '1', '1', null, null, null, null, $ups_input_voltage);
 }
 
 // UPS Input Voltage Nominal, example return : SNMPv2-SMI::enterprises.6574.4.4.1.4.0 = Opaque: Float: 230.000000
 $ups_input_voltage_nominal_oid = '.1.3.6.1.4.1.6574.4.4.1.4.0';
 $ups_input_voltage_nominal = snmp_get($device, $ups_input_voltage_nominal_oid, '-Oqv');
 if (is_numeric($ups_input_voltage_nominal)) {
-    discover_sensor(null, 'voltage', $device, $ups_input_voltage_nominal_oid, 'UPSInputVoltageNominal', $ups_device_manufacturer . ' ' . $ups_device_model, 'UPS Input Voltage Nominal', '1', '1', null, null, null, null, $ups_input_voltage_nominal);
+    discover_sensor(null, SensorEnum::Voltage, $device, $ups_input_voltage_nominal_oid, 'UPSInputVoltageNominal', $ups_device_manufacturer . ' ' . $ups_device_model, 'UPS Input Voltage Nominal', '1', '1', null, null, null, null, $ups_input_voltage_nominal);
 }
 
 // UPS Battery Voltage Value, example return : SNMPv2-SMI::enterprises.6574.4.3.2.1.0 = Opaque: Float: 27.000000
 $ups_battery_voltage_oid = '.1.3.6.1.4.1.6574.4.3.2.1.0';
 $ups_battery_voltage = snmp_get($device, $ups_battery_voltage_oid, '-Oqv');
 if (is_numeric($ups_battery_voltage)) {
-    discover_sensor(null, 'voltage', $device, $ups_battery_voltage_oid, 'UPSBatteryVoltage', $ups_device_manufacturer . ' ' . $ups_device_model, 'UPS Battery Voltage', '1', '1', null, null, null, null, $ups_battery_voltage);
+    discover_sensor(null, SensorEnum::Voltage, $device, $ups_battery_voltage_oid, 'UPSBatteryVoltage', $ups_device_manufacturer . ' ' . $ups_device_model, 'UPS Battery Voltage', '1', '1', null, null, null, null, $ups_battery_voltage);
 }
 
 // UPS Battery Voltage Nominal, example return : SNMPv2-SMI::enterprises.6574.4.3.2.2.0 = Opaque: Float: 24.000000
 $ups_battery_voltage_nominal_oid = '.1.3.6.1.4.1.6574.4.3.2.2.0';
 $ups_battery_voltage_nominal = snmp_get($device, $ups_battery_voltage_nominal_oid, '-Oqv');
 if (is_numeric($ups_battery_voltage_nominal)) {
-    discover_sensor(null, 'voltage', $device, $ups_battery_voltage_nominal_oid, 'SystemStatus', $ups_device_manufacturer . ' ' . $ups_device_model, 'UPS Battery Voltage Nominal', '1', '1', null, null, null, null, $ups_battery_voltage_nominal);
+    discover_sensor(null, SensorEnum::Voltage, $device, $ups_battery_voltage_nominal_oid, 'SystemStatus', $ups_device_manufacturer . ' ' . $ups_device_model, 'UPS Battery Voltage Nominal', '1', '1', null, null, null, null, $ups_battery_voltage_nominal);
 }

--- a/includes/discovery/sensors/voltage/eaton-ats.inc.php
+++ b/includes/discovery/sensors/voltage/eaton-ats.inc.php
@@ -33,5 +33,5 @@ foreach ($oids as $volt_id => $data) {
     $divisor = 10;
     $current = $data['ats2InputVoltage'] / $divisor;
 
-    discover_sensor(null, 'voltage', $device, $volt_oid, $index, $type, $descr, $divisor, '1', null, null, null, null, $current);
+    discover_sensor(null, \LibreNMS\Enum\Sensor::Voltage, $device, $volt_oid, $index, $type, $descr, $divisor, '1', null, null, null, null, $current);
 }

--- a/includes/discovery/sensors/voltage/edgecos.inc.php
+++ b/includes/discovery/sensors/voltage/edgecos.inc.php
@@ -23,4 +23,4 @@
  * @copyright  2026 Frederik Kriewitz
  * @author     Frederik Kriewitz <frederik@kriewitz.eu>
  */
-$os->discoverTransceiverSensors(['voltage']);
+$os->discoverTransceiverSensors([\LibreNMS\Enum\Sensor::Voltage]);

--- a/includes/discovery/sensors/voltage/eltex-mes21xx.inc.php
+++ b/includes/discovery/sensors/voltage/eltex-mes21xx.inc.php
@@ -23,6 +23,7 @@
  *
  * @author     Peca Nesovanovic <peca.nesovanovic@sattrakt.com>
  */
+
 $divisor = 1000000;
 $multiplier = 1;
 
@@ -39,7 +40,7 @@ foreach ($oids as $ifIndex => $data) {
 
         app('sensor-discovery')->discover(new \App\Models\Sensor([
             'poller_type' => 'snmp',
-            'sensor_class' => 'voltage',
+            'sensor_class' => \LibreNMS\Enum\Sensor::Voltage,
             'sensor_oid' => $oid,
             'sensor_index' => 'SfpVolt' . $ifIndex,
             'sensor_type' => 'rlPhyTestTableTransceiverSupply',

--- a/includes/discovery/sensors/voltage/eltex-mes23xx.inc.php
+++ b/includes/discovery/sensors/voltage/eltex-mes23xx.inc.php
@@ -23,6 +23,7 @@
  *
  * @author     Peca Nesovanovic <peca.nesovanovic@sattrakt.com>
  */
+
 $divisor = 1000000;
 $multiplier = 1;
 
@@ -42,7 +43,7 @@ foreach ($oids as $ifIndex => $data) {
 
         app('sensor-discovery')->discover(new \App\Models\Sensor([
             'poller_type' => 'snmp',
-            'sensor_class' => 'voltage',
+            'sensor_class' => \LibreNMS\Enum\Sensor::Voltage,
             'sensor_oid' => $oid,
             'sensor_index' => 'SfpVolt' . $ifIndex,
             'sensor_type' => 'rlPhyTestTableTransceiverSupply',

--- a/includes/discovery/sensors/voltage/eltex-mes24xx.inc.php
+++ b/includes/discovery/sensors/voltage/eltex-mes24xx.inc.php
@@ -52,7 +52,7 @@ if (! empty($eltexPhyTransceiverDiagnosticTable['supplyVoltage'])) {
 
             app('sensor-discovery')->discover(new \App\Models\Sensor([
                 'poller_type' => 'snmp',
-                'sensor_class' => 'voltage',
+                'sensor_class' => \LibreNMS\Enum\Sensor::Voltage,
                 'sensor_oid' => $oid,
                 'sensor_index' => 'SfpVolt' . $ifIndex,
                 'sensor_type' => 'ELTEX-PHY-MIB',

--- a/includes/discovery/sensors/voltage/exa.inc.php
+++ b/includes/discovery/sensors/voltage/exa.inc.php
@@ -12,7 +12,7 @@ foreach ($ponTable as $e7OltPonPortShelf => $ponShelf) {
 
                 app('sensor-discovery')->discover(new \App\Models\Sensor([
                     'poller_type' => 'snmp',
-                    'sensor_class' => 'voltage',
+                    'sensor_class' => \LibreNMS\Enum\Sensor::Voltage,
                     'sensor_oid' => ".1.3.6.1.4.1.6321.1.2.2.2.1.6.2.1.9.$index",
                     'sensor_index' => $index,
                     'sensor_type' => 'exa',

--- a/includes/discovery/sensors/voltage/exos.inc.php
+++ b/includes/discovery/sensors/voltage/exos.inc.php
@@ -13,7 +13,7 @@ if (is_array($oids)) {
             $value = str_replace('V', '', $temp_value[1]);
             app('sensor-discovery')->discover(new \App\Models\Sensor([
                 'poller_type' => 'snmp',
-                'sensor_class' => 'voltage',
+                'sensor_class' => \LibreNMS\Enum\Sensor::Voltage,
                 'sensor_oid' => '.1.3.6.1.3.94.1.8.1.6.' . $index,
                 'sensor_index' => $entry['connUnitSensorIndex'],
                 'sensor_type' => 'exos',

--- a/includes/discovery/sensors/voltage/fs-centec.inc.php
+++ b/includes/discovery/sensors/voltage/fs-centec.inc.php
@@ -12,7 +12,7 @@ foreach ($voltageTable as $ifIndex => $current) {
         foreach (explode(',', (string) $current['FS-SWITCH-V2-MIB::voltageCurrent']) as $channel => $value) {
             app('sensor-discovery')->discover(new \App\Models\Sensor([
                 'poller_type' => 'snmp',
-                'sensor_class' => 'voltage',
+                'sensor_class' => \LibreNMS\Enum\Sensor::Voltage,
                 'sensor_oid' => ".1.3.6.1.4.1.52642.1.37.1.10.3.1.5.$ifIndex",
                 'sensor_index' => "$ifIndex.$channel",
                 'sensor_type' => 'fs-centec',

--- a/includes/discovery/sensors/voltage/fs-net-pdu.inc.php
+++ b/includes/discovery/sensors/voltage/fs-net-pdu.inc.php
@@ -26,5 +26,5 @@
 $oid = '.1.3.6.1.4.1.30966.10.3.2.1.0';
 $voltage = snmp_get($device, $oid, '-Oqv');
 if ($voltage > 0) {
-    discover_sensor(null, 'voltage', $device, $oid, 0, 'PDU L1', 'Voltage', 1, 1, null, null, null, null, $voltage);
+    discover_sensor(null, \LibreNMS\Enum\Sensor::Voltage, $device, $oid, 0, 'PDU L1', 'Voltage', 1, 1, null, null, null, null, $voltage);
 }

--- a/includes/discovery/sensors/voltage/gamatronicups.inc.php
+++ b/includes/discovery/sensors/voltage/gamatronicups.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 for ($i = 1; $i <= 3; $i++) {
     $volt_oid = ".1.3.6.1.4.1.6050.5.4.1.1.2.$i";
     $descr = "Input Phase $i";
@@ -10,7 +12,7 @@ for ($i = 1; $i <= 3; $i++) {
     $lowlimit = 0;
     $limit = null;
 
-    discover_sensor(null, 'voltage', $device, $volt_oid, $index, $type, $descr, $divisor, '1', null, null, null, null, $volt);
+    discover_sensor(null, SensorEnum::Voltage, $device, $volt_oid, $index, $type, $descr, $divisor, '1', null, null, null, null, $volt);
 }
 
 for ($i = 1; $i <= 3; $i++) {
@@ -23,5 +25,5 @@ for ($i = 1; $i <= 3; $i++) {
     $lowlimit = 0;
     $limit = null;
 
-    discover_sensor(null, 'voltage', $device, $volt_oid, $index, $type, $descr, $divisor, '1', null, null, null, null, $volt);
+    discover_sensor(null, SensorEnum::Voltage, $device, $volt_oid, $index, $type, $descr, $divisor, '1', null, null, null, null, $volt);
 }

--- a/includes/discovery/sensors/voltage/geist-watchdog.inc.php
+++ b/includes/discovery/sensors/voltage/geist-watchdog.inc.php
@@ -27,5 +27,5 @@ $value = snmp_get($device, 'climateVolts', '-Oqv', 'GEIST-MIB-V3');
 $current_oid = '.1.3.6.1.4.1.21239.2.2.1.14.1';
 $descr = 'Voltage';
 if (is_numeric($value)) {
-    discover_sensor(null, 'voltage', $device, $current_oid, 'climateVolts', 'geist-watchdog', $descr, 1, 1, null, null, null, null, $value);
+    discover_sensor(null, \LibreNMS\Enum\Sensor::Voltage, $device, $current_oid, 'climateVolts', 'geist-watchdog', $descr, 1, 1, null, null, null, null, $value);
 }

--- a/includes/discovery/sensors/voltage/hytera.inc.php
+++ b/includes/discovery/sensors/voltage/hytera.inc.php
@@ -17,7 +17,7 @@ if ($oids !== false) {
             $descr = 'Voltage ' . $index;
             $oid = '.1.3.6.1.4.1.40297.1.2.1.2.1.' . $index;
             $voltage = hytera_h2f(str_replace('"', '', snmp_get($device, $oid, '-OUqnv', '')), 2);
-            discover_sensor(null, 'voltage', $device, $oid, $index, $type, $descr, $divisor, '1', 11.00, 11.5, 14.5, 15, $voltage);
+            discover_sensor(null, \LibreNMS\Enum\Sensor::Voltage, $device, $oid, $index, $type, $descr, $divisor, '1', 11.00, 11.5, 14.5, 15, $voltage);
         }
     }
 }

--- a/includes/discovery/sensors/voltage/ict-pdu.inc.php
+++ b/includes/discovery/sensors/voltage/ict-pdu.inc.php
@@ -35,5 +35,5 @@ if (! empty($systemVoltage)) {
     $type = 'ict-pdu';
     $current_value = $systemVoltage / $divisor;
 
-    discover_sensor(null, 'voltage', $device, $oid, $index, $type, $descr, $divisor, '1', null, null, null, null, $current_value);
+    discover_sensor(null, \LibreNMS\Enum\Sensor::Voltage, $device, $oid, $index, $type, $descr, $divisor, '1', null, null, null, null, $current_value);
 }

--- a/includes/discovery/sensors/voltage/ict-psu.inc.php
+++ b/includes/discovery/sensors/voltage/ict-psu.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 /**
  * ict-psu.inc.php
  *
@@ -36,7 +38,7 @@ if (! empty($inputVoltage)) {
     $type = 'ict-psu';
     $currentValue = $inputVoltage / $divisor;
     echo "got in\n";
-    discover_sensor(null, 'voltage', $device, $oid, $index, $type, $descr, $divisor, '1', null, null, null, null, $currentValue);
+    discover_sensor(null, SensorEnum::Voltage, $device, $oid, $index, $type, $descr, $divisor, '1', null, null, null, null, $currentValue);
 }
 
 // Output Voltage
@@ -51,5 +53,5 @@ if (! empty($outputVoltage)) {
     $type = 'ict-psu';
     $currentValue = $outputVoltage / $divisor;
 
-    discover_sensor(null, 'voltage', $device, $oid, $index, $type, $descr, $divisor, '1', null, null, null, null, $currentValue);
+    discover_sensor(null, SensorEnum::Voltage, $device, $oid, $index, $type, $descr, $divisor, '1', null, null, null, null, $currentValue);
 }

--- a/includes/discovery/sensors/voltage/ipoman.inc.php
+++ b/includes/discovery/sensors/voltage/ipoman.inc.php
@@ -27,7 +27,7 @@ foreach ($oidsVoltIn as $index => $entry) {
     // FIXME: iPoMan 1201 also says it has 2 inlets, at least until firmware 1.06 - wtf?
     app('sensor-discovery')->discover(new \App\Models\Sensor([
         'poller_type' => 'snmp',
-        'sensor_class' => 'voltage',
+        'sensor_class' => \LibreNMS\Enum\Sensor::Voltage,
         'sensor_oid' => $oid,
         'sensor_index' => $index,
         'sensor_type' => 'ipoman',

--- a/includes/discovery/sensors/voltage/linux.inc.php
+++ b/includes/discovery/sensors/voltage/linux.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 /*
  * voltages for raspberry pi
  * requires snmp extend agent script from librenms-agent
@@ -24,7 +26,7 @@ if (! empty($pre_cache['raspberry_pi_sensors'])) {
         }
         $value = current($pre_cache['raspberry_pi_sensors']['raspberry.' . $volt]);
         if (is_numeric($value)) {
-            discover_sensor(null, 'voltage', $device, $oid . $volt, $volt, $sensor_type, $descr, '1', '1', null, null, null, null, $value);
+            discover_sensor(null, SensorEnum::Voltage, $device, $oid . $volt, $volt, $sensor_type, $descr, '1', '1', null, null, null, null, $value);
         } else {
             break;
         }
@@ -62,7 +64,7 @@ foreach (explode("\n", $oids) as $data) {
             $descr = trim(str_ireplace('Voltage', '', $descr));
 
             if ($monitor == 'true') {
-                discover_sensor(null, 'voltage', $device, $volt_oid, $index, $type, $descr, $divisor, '1', $lowlimit, null, null, $limit, $current);
+                discover_sensor(null, SensorEnum::Voltage, $device, $volt_oid, $index, $type, $descr, $divisor, '1', $lowlimit, null, null, $limit, $current);
             }
         }
     }//end if
@@ -79,13 +81,13 @@ if (preg_match('/(Linux).+(ntc)/', (string) $device['sysDescr'])) {
     $index = '116.2';
     $value = snmp_get($device, $oid . $index, '-Oqv');
     if (is_numeric($value)) {
-        discover_sensor(null, 'voltage', $device, $oid . $index, $index, $sensor_type, $descr, '1', '1', $lowlimit, $lowwarnlimit, $warnlimit, $limit, $value);
+        discover_sensor(null, SensorEnum::Voltage, $device, $oid . $index, $index, $sensor_type, $descr, '1', '1', $lowlimit, $lowwarnlimit, $warnlimit, $limit, $value);
     }
     $descr = 'VBUS voltage';
     $index = '116.4';
     $value = snmp_get($device, $oid . $index, '-Oqv');
     if (is_numeric($value)) {
-        discover_sensor(null, 'voltage', $device, $oid . $index, $index, $sensor_type, $descr, '1', '1', $lowlimit, $lowwarnlimit, $warnlimit, $limit, $value);
+        discover_sensor(null, SensorEnum::Voltage, $device, $oid . $index, $index, $sensor_type, $descr, '1', '1', $lowlimit, $lowwarnlimit, $warnlimit, $limit, $value);
     }
     $lowlimit = 2.75;
     $lowwarnlimit = 2.8;
@@ -95,6 +97,6 @@ if (preg_match('/(Linux).+(ntc)/', (string) $device['sysDescr'])) {
     $index = '116.6';
     $value = snmp_get($device, $oid . $index, '-Oqv');
     if (is_numeric($value)) {
-        discover_sensor(null, 'voltage', $device, $oid . $index, $index, $sensor_type, $descr, '1', '1', $lowlimit, $lowwarnlimit, $warnlimit, $limit, $value);
+        discover_sensor(null, SensorEnum::Voltage, $device, $oid . $index, $index, $sensor_type, $descr, '1', '1', $lowlimit, $lowwarnlimit, $warnlimit, $limit, $value);
     }
 }

--- a/includes/discovery/sensors/voltage/mgeups.inc.php
+++ b/includes/discovery/sensors/voltage/mgeups.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 echo 'MGE ';
 $oids = trim((string) snmp_walk($device, 'mgoutputVoltage', '-OsqnU', 'MG-SNMP-UPS-MIB'));
 d_echo($oids . "\n");
@@ -23,7 +25,7 @@ for ($i = 1; $i <= $numPhase; $i++) {
     $divisor = 10;
     $index = $i;
 
-    discover_sensor(null, 'voltage', $device, $volt_oid, $index, $type, $descr, $divisor, '1', null, null, null, null, $current);
+    discover_sensor(null, SensorEnum::Voltage, $device, $volt_oid, $index, $type, $descr, $divisor, '1', null, null, null, null, $current);
 }
 
 $oids = trim((string) snmp_walk($device, 'mgeinputVoltage', '-OsqnU', 'MG-SNMP-UPS-MIB'));
@@ -48,5 +50,5 @@ for ($i = 1; $i <= $numPhase; $i++) {
     $divisor = 10;
     $index = (100 + $i);
 
-    discover_sensor(null, 'voltage', $device, $volt_oid, $index, $type, $descr, $divisor, '1', null, null, null, null, $current);
+    discover_sensor(null, SensorEnum::Voltage, $device, $volt_oid, $index, $type, $descr, $divisor, '1', null, null, null, null, $current);
 }

--- a/includes/discovery/sensors/voltage/microsemipdsine.inc.php
+++ b/includes/discovery/sensors/voltage/microsemipdsine.inc.php
@@ -36,5 +36,5 @@ if (! empty($mainVoltage)) {
     $oid = '.1.3.6.1.4.1.7428.1.2.2.1.1.2.1';
     $current_value = $mainVoltage / $divisor;
 
-    discover_sensor(null, 'voltage', $device, $oid, $index, $type, $descr, $divisor, '1', null, null, null, null, $current_value);
+    discover_sensor(null, \LibreNMS\Enum\Sensor::Voltage, $device, $oid, $index, $type, $descr, $divisor, '1', null, null, null, null, $current_value);
 }

--- a/includes/discovery/sensors/voltage/netagent2.inc.php
+++ b/includes/discovery/sensors/voltage/netagent2.inc.php
@@ -77,7 +77,7 @@ if ($in_phaseNum == '1') {
 
         discover_sensor(
             null,
-            'voltage',
+            $sensor_class,
             $device,
             $in_voltage_oid,
             $index,
@@ -108,7 +108,7 @@ if ($in_phaseNum == '3') {
 
         discover_sensor(
             null,
-            'voltage',
+            $sensor_class,
             $device,
             $in_voltage1_oid,
             $index,
@@ -136,7 +136,7 @@ if ($in_phaseNum == '3') {
 
         discover_sensor(
             null,
-            'voltage',
+            $sensor_class,
             $device,
             $in_voltage2_oid,
             $index,
@@ -164,7 +164,7 @@ if ($in_phaseNum == '3') {
 
         discover_sensor(
             null,
-            'voltage',
+            $sensor_class,
             $device,
             $in_voltage3_oid,
             $index,
@@ -195,7 +195,7 @@ if ($in_phaseNum == '1') {
 
         discover_sensor(
             null,
-            'voltage',
+            $sensor_class,
             $device,
             $out_voltage_oid,
             $index,
@@ -227,7 +227,7 @@ if ($out_phaseNum == '3') {
 
         discover_sensor(
             null,
-            'voltage',
+            $sensor_class,
             $device,
             $out_voltage1_oid,
             $index,
@@ -255,7 +255,7 @@ if ($out_phaseNum == '3') {
 
         discover_sensor(
             null,
-            'voltage',
+            $sensor_class,
             $device,
             $out_voltage2_oid,
             $index,
@@ -283,7 +283,7 @@ if ($out_phaseNum == '3') {
 
         discover_sensor(
             null,
-            'voltage',
+            $sensor_class,
             $device,
             $out_voltage3_oid,
             $index,
@@ -315,7 +315,7 @@ if ($out_phaseNum == '3') {
 
         discover_sensor(
             null,
-            'voltage',
+            $sensor_class,
             $device,
             $bypass_voltage1_oid,
             $index,
@@ -343,7 +343,7 @@ if ($out_phaseNum == '3') {
 
         discover_sensor(
             null,
-            'voltage',
+            $sensor_class,
             $device,
             $bypass_voltage2_oid,
             $index,
@@ -371,7 +371,7 @@ if ($out_phaseNum == '3') {
 
         discover_sensor(
             null,
-            'voltage',
+            $sensor_class,
             $device,
             $bypass_voltage3_oid,
             $index,
@@ -419,7 +419,7 @@ if (! empty($battery_voltage1) || $battery_voltage1 == 0) {
 
     discover_sensor(
         null,
-        'voltage',
+        $sensor_class,
         $device,
         $battery_voltage1_oid,
         $index,

--- a/includes/discovery/sensors/voltage/nokia-1830.inc.php
+++ b/includes/discovery/sensors/voltage/nokia-1830.inc.php
@@ -20,7 +20,6 @@
 // *************************************************************
 // ***** Voltage Sensors for Nokia PSD
 // *************************************************************
-
 if (str_contains((string) $device['sysObjectID'], '.1.3.6.1.4.1.7483.1.3.1.12')) {
     d_echo('Nokia PSD DDM Voltage Sensors\n');
     $ifIndexToName = SnmpQuery::cache()->walk('IF-MIB::ifName')->pluck();
@@ -33,7 +32,7 @@ if (str_contains((string) $device['sysObjectID'], '.1.3.6.1.4.1.7483.1.3.1.12'))
             $divisor = 10000;
             app('sensor-discovery')->discover(new \App\Models\Sensor([
                 'poller_type' => 'snmp',
-                'sensor_class' => 'voltage',
+                'sensor_class' => \LibreNMS\Enum\Sensor::Voltage,
                 'sensor_oid' => ".1.3.6.1.4.1.7483.2.2.7.3.1.4.1.2.$ifIndex.1",
                 'sensor_index' => "$ifIndex.1",
                 'sensor_type' => 'nokia-1830',

--- a/includes/discovery/sensors/voltage/ocnos.inc.php
+++ b/includes/discovery/sensors/voltage/ocnos.inc.php
@@ -18,7 +18,7 @@ if ($os instanceof \LibreNMS\OS\Ocnos) {
                 if (isset($channel_data['IPI-CMM-CHASSIS-MIB::cmmTransVoltage']) && $channel_data['IPI-CMM-CHASSIS-MIB::cmmTransVoltage'] != '-100001') {
                     app('sensor-discovery')->discover(new \App\Models\Sensor([
                         'poller_type' => 'snmp',
-                        'sensor_class' => 'voltage',
+                        'sensor_class' => \LibreNMS\Enum\Sensor::Voltage,
                         'sensor_oid' => ".1.3.6.1.4.1.36673.100.1.2.3.1.7.$cmmStackUnitIndex.$cmmTransIndex.$cmmTransChannelIndex",
                         'sensor_index' => "$cmmStackUnitIndex.$cmmTransIndex",
                         'sensor_type' => 'ocnos',

--- a/includes/discovery/sensors/voltage/onefs.inc.php
+++ b/includes/discovery/sensors/voltage/onefs.inc.php
@@ -31,7 +31,7 @@ foreach ($oids as $index => $entry) {
         $descr = $entry['powerSensorDescription'];
         $oid = '.1.3.6.1.4.1.12124.2.55.1.4.' . $index;
         $current = $entry['powerSensorValue'];
-        discover_sensor(null, 'voltage', $device, $oid, $index, 'onefs', $descr, '1', '1', null, null, null, null, $current);
+        discover_sensor(null, \LibreNMS\Enum\Sensor::Voltage, $device, $oid, $index, 'onefs', $descr, '1', '1', null, null, null, null, $current);
     }
 }
 

--- a/includes/discovery/sensors/voltage/pbn.inc.php
+++ b/includes/discovery/sensors/voltage/pbn.inc.php
@@ -27,6 +27,6 @@ foreach ($pre_cache['pbn_oids'] as $index => $entry) {
         $value = $entry['voltage'] / $divisor;
         $entPhysicalIndex = $index;
         $entPhysicalIndex_measured = 'ports';
-        discover_sensor(null, 'voltage', $device, $oid, '' . $index, 'pbn', $descr, $divisor, $multiplier, $limit_low, $warn_limit_low, $warn_limit, $limit, $value, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured);
+        discover_sensor(null, \LibreNMS\Enum\Sensor::Voltage, $device, $oid, '' . $index, 'pbn', $descr, $divisor, $multiplier, $limit_low, $warn_limit_low, $warn_limit, $limit, $value, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured);
     }
 }

--- a/includes/discovery/sensors/voltage/procurve.inc.php
+++ b/includes/discovery/sensors/voltage/procurve.inc.php
@@ -17,6 +17,6 @@ foreach (SnmpQuery::cache()->walk('HP-ICF-TRANSCEIVER-MIB::hpicfXcvrInfoTable')-
         $entPhysicalIndex = $index;
         $entPhysicalIndex_measured = 'ports';
         $descr = Rewrite::shortenIfName($entry['HP-ICF-TRANSCEIVER-MIB::hpicfXcvrPortDesc']) . ' Voltage';
-        discover_sensor(null, 'voltage', $device, $oid, 'hpicfXcvrVoltage.' . $index, 'procurve', $descr, $divisor, 1, $limit_low, $warn_limit_low, $warn_limit, $limit, $current, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured, group: 'transceiver');
+        discover_sensor(null, \LibreNMS\Enum\Sensor::Voltage, $device, $oid, 'hpicfXcvrVoltage.' . $index, 'procurve', $descr, $divisor, 1, $limit_low, $warn_limit_low, $warn_limit, $limit, $current, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured, group: 'transceiver');
     }
 }

--- a/includes/discovery/sensors/voltage/raritan-pdu.inc.php
+++ b/includes/discovery/sensors/voltage/raritan-pdu.inc.php
@@ -35,6 +35,6 @@ foreach ($pre_cache['raritan_inletTable'] as $index => $raritan_data) {
         $warn_limit = $raritan_data['inletVoltageLowerWarning'] / $divisor;
         $high_limit = $raritan_data['inletVoltageLowerCritical'] / $divisor;
         $current = $pre_cache['raritan_inletPoleTable'][$index][$x]['inletPoleVoltage'] / $divisor;
-        discover_sensor(null, 'voltage', $device, $oid, $tmp_index, 'raritan', $descr, $divisor, 1, $low_limit, $low_limit, $warn_limit, $high_limit, $current);
+        discover_sensor(null, \LibreNMS\Enum\Sensor::Voltage, $device, $oid, $tmp_index, 'raritan', $descr, $divisor, 1, $low_limit, $low_limit, $warn_limit, $high_limit, $current);
     }
 }

--- a/includes/discovery/sensors/voltage/rfc1628.inc.php
+++ b/includes/discovery/sensors/voltage/rfc1628.inc.php
@@ -8,11 +8,11 @@ echo 'RFC1628 ';
 $battery_volts = snmp_get($device, 'upsBatteryVoltage.0', '-OqvU', 'UPS-MIB');
 if (is_numeric($battery_volts)) {
     $volt_oid = '.1.3.6.1.2.1.33.1.2.5.0';
-    $divisor = get_device_divisor($device, $pre_cache['poweralert_serial'] ?? 0, 'voltage', $volt_oid);
+    $divisor = get_device_divisor($device, $pre_cache['poweralert_serial'] ?? 0, $sensor_class, $volt_oid);
 
     discover_sensor(
         null,
-        'voltage',
+        $sensor_class,
         $device,
         $volt_oid,
         '1.2.5.0',
@@ -31,7 +31,7 @@ if (is_numeric($battery_volts)) {
 $output_volts = snmpwalk_group($device, 'upsOutputVoltage', 'UPS-MIB');
 foreach ($output_volts as $index => $data) {
     $volt_oid = ".1.3.6.1.2.1.33.1.4.4.1.2.$index";
-    $divisor = get_device_divisor($device, $pre_cache['poweralert_serial'] ?? 0, 'voltage', $volt_oid);
+    $divisor = get_device_divisor($device, $pre_cache['poweralert_serial'] ?? 0, $sensor_class, $volt_oid);
     $descr = 'Output';
     if (count($output_volts) > 1) {
         $descr .= " Phase $index";
@@ -52,7 +52,7 @@ foreach ($output_volts as $index => $data) {
 
     discover_sensor(
         null,
-        'voltage',
+        $sensor_class,
         $device,
         $volt_oid,
         $index,
@@ -71,7 +71,7 @@ foreach ($output_volts as $index => $data) {
 $input_volts = snmpwalk_group($device, 'upsInputVoltage', 'UPS-MIB');
 foreach ($input_volts as $index => $data) {
     $volt_oid = ".1.3.6.1.2.1.33.1.3.3.1.3.$index";
-    $divisor = get_device_divisor($device, $pre_cache['poweralert_serial'] ?? 0, 'voltage', $volt_oid);
+    $divisor = get_device_divisor($device, $pre_cache['poweralert_serial'] ?? 0, $sensor_class, $volt_oid);
     $descr = 'Input';
     if (count($input_volts) > 1) {
         $descr .= " Phase $index";
@@ -91,7 +91,7 @@ foreach ($input_volts as $index => $data) {
 
     discover_sensor(
         null,
-        'voltage',
+        $sensor_class,
         $device,
         $volt_oid,
         100 + $index,
@@ -110,7 +110,7 @@ foreach ($input_volts as $index => $data) {
 $bypass_volts = snmpwalk_group($device, 'upsBypassVoltage', 'UPS-MIB');
 foreach ($bypass_volts as $index => $data) {
     $volt_oid = ".1.3.6.1.2.1.33.1.5.3.1.2.$index";
-    $divisor = get_device_divisor($device, $pre_cache['poweralert_serial'] ?? 0, 'voltage', $volt_oid);
+    $divisor = get_device_divisor($device, $pre_cache['poweralert_serial'] ?? 0, $sensor_class, $volt_oid);
     $descr = 'Bypass';
     if (count($bypass_volts) > 1) {
         $descr .= " Phase $index";
@@ -129,7 +129,7 @@ foreach ($bypass_volts as $index => $data) {
 
     discover_sensor(
         null,
-        'voltage',
+        $sensor_class,
         $device,
         $volt_oid,
         200 + $index,

--- a/includes/discovery/sensors/voltage/schleifenbauer.inc.php
+++ b/includes/discovery/sensors/voltage/schleifenbauer.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 echo 'Schleifenbauer ';
 $divisor = 100;
 
@@ -14,7 +16,7 @@ foreach ($pre_cache['sdbMgmtCtrlDevUnitAddress'] ?? [] as $sdbMgmtCtrlDevUnitAdd
         // See includes/discovery/entity-physical/schleifenbauer.inc.php for an explanation why we set this as the entPhysicalIndex.
         $entPhysicalIndex = $sdbMgmtCtrlDevUnitAddress * 1000000 + 100000 + $sdbDevInIndex * 1000 + 110;
 
-        discover_sensor(null, 'voltage', $device, $voltage_oid, $serial_input, 'schleifenbauer', $descr, $divisor, '1', null, null, null, null, $voltage, 'snmp', $entPhysicalIndex);
+        discover_sensor(null, SensorEnum::Voltage, $device, $voltage_oid, $serial_input, 'schleifenbauer', $descr, $divisor, '1', null, null, null, null, $voltage, 'snmp', $entPhysicalIndex);
     }
 }
 
@@ -30,6 +32,6 @@ if (isset($pre_cache['sdbDevOutMtActualVoltage']) && is_array($pre_cache['sdbDev
         // See includes/discovery/entity-physical/schleifenbauer.inc.php for an explanation why we set this as the entPhysicalIndex.
         $entPhysicalIndex = $sdbMgmtCtrlDevUnitAddress * 1000000 + 200000 + $sdbDevOutMtIndex * 1000 + 110;
 
-        discover_sensor(null, 'voltage', $device, $voltage_oid, $serial_input, 'schleifenbauer', $descr, $divisor, '1', null, null, null, null, $voltage, 'snmp', $entPhysicalIndex);
+        discover_sensor(null, SensorEnum::Voltage, $device, $voltage_oid, $serial_input, 'schleifenbauer', $descr, $divisor, '1', null, null, null, null, $voltage, 'snmp', $entPhysicalIndex);
     }
 }

--- a/includes/discovery/sensors/voltage/sitemonitor.inc.php
+++ b/includes/discovery/sensors/voltage/sitemonitor.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Enum\Sensor as SensorEnum;
+
 /**
  * sitemonitor.inc.php
  *
@@ -25,12 +27,12 @@
  */
 $oid = '.1.3.6.1.4.1.32050.2.1.27.5.1';
 $current = (snmp_get($device, $oid, '-Oqv') / 10);
-discover_sensor(null, 'voltage', $device, $oid, 1, 'sitemonitor', 'Shunt Input', 10, 1, null, null, null, null, $current);
+discover_sensor(null, SensorEnum::Voltage, $device, $oid, 1, 'sitemonitor', 'Shunt Input', 10, 1, null, null, null, null, $current);
 
 $oid = '.1.3.6.1.4.1.32050.2.1.27.5.2';
 $current = (snmp_get($device, $oid, '-Oqv') / 10);
-discover_sensor(null, 'voltage', $device, $oid, 2, 'sitemonitor', 'Power 1', 10, 1, null, null, null, null, $current);
+discover_sensor(null, SensorEnum::Voltage, $device, $oid, 2, 'sitemonitor', 'Power 1', 10, 1, null, null, null, null, $current);
 
 $oid = '.1.3.6.1.4.1.32050.2.1.27.5.3';
 $current = (snmp_get($device, $oid, '-Oqv') / 10);
-discover_sensor(null, 'voltage', $device, $oid, 3, 'sitemonitor', 'Power 2', 10, 1, null, null, null, null, $current);
+discover_sensor(null, SensorEnum::Voltage, $device, $oid, 3, 'sitemonitor', 'Power 2', 10, 1, null, null, null, null, $current);

--- a/includes/discovery/sensors/voltage/terra.inc.php
+++ b/includes/discovery/sensors/voltage/terra.inc.php
@@ -10,7 +10,7 @@ if ($device['os'] === 'terra') {
         if (str_contains((string) $device['sysDescr'], $row[0])) {
             $c = snmp_get($device, $row[1], '-Oqv') / 10;
             if (is_numeric($c)) {
-                discover_sensor(null, 'voltage', $device, $row[1], 0, $row[0], 'Supply voltage', 10, 1, null, null, null, null, $c);
+                discover_sensor(null, \LibreNMS\Enum\Sensor::Voltage, $device, $row[1], 0, $row[0], 'Supply voltage', 10, 1, null, null, null, null, $c);
             }
         }
     }

--- a/includes/discovery/sensors/voltage/tpdin.inc.php
+++ b/includes/discovery/sensors/voltage/tpdin.inc.php
@@ -52,7 +52,7 @@ $tpdin_oids = [
 
 foreach ($tpdin_oids as $data) {
     if ($data['current'] > 0) {
-        discover_sensor(null, 'voltage', $device, $data['oid'], $data['index'], $device['os'], $data['descr'], 10, '1', null, null, null, null, $data['current']);
+        discover_sensor(null, \LibreNMS\Enum\Sensor::Voltage, $device, $data['oid'], $data['index'], $device['os'], $data['descr'], 10, '1', null, null, null, null, $data['current']);
     }
 }
 


### PR DESCRIPTION
## Summary
- Replace raw string sensor class arguments (e.g., `'temperature'`, `'voltage'`) with `SensorEnum` instances in all ~337 discovery sensor include files
- Type-hint `discover_sensor()`, `discovery_process()`, `get_device_divisor()`, and `sensors()` functions to accept `SensorEnum`
- Use `tryFrom()` for external data sources (IPMI config, rpigpiomonitor agent) to safely handle unknown sensor types
- Split out from #18998 to reduce PR size

## Test plan
- [ ] Run sensor discovery on a device with SNMP-based sensors
- [ ] Run sensor discovery on a device with IPMI sensors  
- [ ] Verify rpigpiomonitor sensor discovery handles unknown types gracefully
- [ ] Verify YAML-based dynamic sensor discovery still works
- [ ] Run existing sensor unit tests