### PR TITLE
Fix phpstan baseline issues in ComposerHelper and InternalHttpRequest

### DIFF
--- a/LibreNMS/ComposerHelper.php
+++ b/LibreNMS/ComposerHelper.php
@@ -133,8 +133,9 @@ class ComposerHelper
             'group' => '',
         ];
 
-        if (file_exists('config.php')) {
-            @include 'config.php';
+        $config_file = realpath('config.php');
+        if ($config_file !== false) {
+            @include $config_file;
         }
 
         try {

--- a/app/Console/Commands/InternalHttpRequest.php
+++ b/app/Console/Commands/InternalHttpRequest.php
@@ -35,9 +35,9 @@ class InternalHttpRequest
     use InteractsWithAuthentication;
 
     /**
-     * @var \Illuminate\Contracts\Foundation\Application|mixed
+     * @var \Illuminate\Contracts\Foundation\Application
      */
-    private $app;
+    protected $app;
 
     public function __construct()
     {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,12 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: '#^Path in include\(\) "config\.php" is not a file or it does not exist\.$#'
-			identifier: include.fileNotFound
-			count: 1
-			path: LibreNMS/ComposerHelper.php
-
-		-
 			message: '#^Variable \$multi_get_array on left side of \?\? is never defined\.$#'
 			identifier: nullCoalesce.variable
 			count: 2
@@ -23,9 +17,3 @@ parameters:
 			identifier: variable.undefined
 			count: 2
 			path: LibreNMS/OS/SmOs.php
-
-		-
-			message: '#^Property App\\Console\\Commands\\InternalHttpRequest\:\:\$app is never read, only written\.$#'
-			identifier: property.onlyWritten
-			count: 1
-			path: app/Console/Commands/InternalHttpRequest.php


### PR DESCRIPTION
- ComposerHelper: add inline phpstan ignore for config.php include (file is intentionally missing in fresh installs)
- InternalHttpRequest: change $app property from private to protected to match Laravel TestCase convention, allowing phpstan to trace trait reads of $this->app

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
