### PR TITLE
SNMP Trap Handler: Extend German SNMP trap translations for Zebra printers

### DIFF
--- a/LibreNMS/Snmptrap/Handlers/ZebraPrinterAlert.php
+++ b/LibreNMS/Snmptrap/Handlers/ZebraPrinterAlert.php
@@ -61,7 +61,7 @@ class ZebraPrinterAlert implements SnmptrapHandler
             return Severity::Info;
         }
 
-        if (preg_match('/PQ JOB COMPLETED|LABEL READY|POWER ON|COLD START|RIBBON IN|Druckauftr Fertg/', $message)) {
+        if (preg_match('/PQ JOB COMPLETED|LABEL READY|POWER ON|COLD START|RIBBON IN|Druckauftr Fertg|Eingeschaltet|KALTSTART/', $message)) {
             return Severity::Ok;
         }
 

--- a/tests/Feature/SnmpTraps/ZebraPrinterTrapTest.php
+++ b/tests/Feature/SnmpTraps/ZebraPrinterTrapTest.php
@@ -741,6 +741,36 @@ TRAP,
         );
     }
 
+    public function testZebraPrinterEingeschaltet(): void
+    {
+        $this->assertTrapLogsMessage(<<<'TRAP'
+{{ hostname }}
+UDP: [{{ ip }}]:44298->[192.168.5.5]:162
+DISMAN-EVENT-MIB::sysUpTimeInstance 19:3:47:23.13
+SNMPv2-MIB::snmpTrapOID.0 ZEBRA-QL-MIB::zebra.1.0.1
+ESI-MIB::psOutput.7 MELDUNG: Eingeschaltet
+TRAP,
+            'MELDUNG: Eingeschaltet',
+            'Failed to handle ZEBRA-QL-MIB::zebra.1.0.1 Eingeschaltet',
+            [Severity::Ok, 'printer'],
+        );
+    }
+
+    public function testZebraPrinterKaltstart(): void
+    {
+        $this->assertTrapLogsMessage(<<<'TRAP'
+{{ hostname }}
+UDP: [{{ ip }}]:44298->[192.168.5.5]:162
+DISMAN-EVENT-MIB::sysUpTimeInstance 19:3:47:23.13
+SNMPv2-MIB::snmpTrapOID.0 ZEBRA-QL-MIB::zebra.1.0.1
+ESI-MIB::psOutput.7 MELDUNG: KALTSTART
+TRAP,
+            'MELDUNG: KALTSTART',
+            'Failed to handle ZEBRA-QL-MIB::zebra.1.0.1 KALTSTART',
+            [Severity::Ok, 'printer'],
+        );
+    }
+
     public function testZebraPrinterAlertCleared(): void
     {
         $this->assertTrapLogsMessage(<<<'TRAP'


### PR DESCRIPTION
Introduced Eingeschaltet and KALTSTART as German equivalents of POWER ON and COLD START in the ZebraPrinterAlert severity mapping, including test coverage.

Unfortunately, I can only add these as I come across them. Zebra doesn't appear to provide a complete list of translations, and the fact that some translations in the firmware are incorrect makes it even more difficult.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
