### PR TITLE
fix(fs-ruijie): correct fsSystemElectricalSourceIsNormal state mappings

### DIFF
--- a/resources/definitions/os_discovery/fs-ruijie.yaml
+++ b/resources/definitions/os_discovery/fs-ruijie.yaml
@@ -100,13 +100,14 @@ modules:
                     value: FS-SYSTEM-MIB::fsSystemElectricalSourceIsNormal
                     num_oid: '.1.3.6.1.4.1.52642.1.1.10.2.1.1.18.1.2.{{ $index }}'
                     descr: '{{ FS-SYSTEM-MIB::fsSystemElectricalSourceName }}'
+                    state_name: 'fsSystemElectricalSourceIsNormal'
                     states:
-                        - { value: 1, generic: 3, graph: 0, descr: 'Unknown' }
-                        - { value: 2, generic: 0, graph: 0, descr: 'Green' }
-                        - { value: 3, generic: 1, graph: 0, descr: 'Yellow' }
-                        - { value: 4, generic: 2, graph: 0, descr: 'Not present' }
-                        - { value: 5, generic: 0, graph: 0, descr: 'Normal' }
-                        - { value: 6, generic: 2, graph: 0, descr: 'Abnormal' }
+                        - { value: 1, generic: 2, graph: 1, descr: 'noexist' }
+                        - { value: 2, generic: 2, graph: 1, descr: 'existnopower' }
+                        - { value: 3, generic: 1, graph: 1, descr: 'existreadypower' }
+                        - { value: 4, generic: 0, graph: 1, descr: 'normal' }
+                        - { value: 5, generic: 2, graph: 1, descr: 'powerbutabnormal' }
+                        - { value: 6, generic: 3, graph: 1, descr: 'unknow' }
                 -
                     oid: FS-SYSTEM-MIB::fsSystemFanIsNormalTable
                     value: FS-SYSTEM-MIB::fsSystemFanIsNormal

--- a/tests/data/fs-ruijie_s3410.json
+++ b/tests/data/fs-ruijie_s3410.json
@@ -7,13 +7,13 @@
                     "sysObjectID": ".1.3.6.1.4.1.52642.1.1.10.1.797",
                     "sysDescr": "FS Campus Switch PoE (S3410-24TS-P) By FS.COM Inc",
                     "sysContact": null,
-                    "hardware": "S3410-24TS-P",
                     "version": "S3410_FSOS 11.4(1)B74T3",
-                    "serial": "G1SC2NX000612",
+                    "hardware": "S3410-24TS-P",
                     "features": null,
                     "location": "Examplestreet,",
                     "os": "fs-ruijie",
                     "type": "network",
+                    "serial": "G1SC2NX000612",
                     "icon": "fs.svg"
                 }
             ]
@@ -24,13 +24,13 @@
         "discovery": {
             "processors": [
                 {
-                    "processor_descr": "CPU 0",
-                    "processor_usage": 8,
                     "entPhysicalIndex": 0,
                     "hrDeviceIndex": 0,
-                    "processor_type": "fs-ruijie",
                     "processor_oid": ".1.3.6.1.4.1.52642.1.1.10.2.36.1.1.3.0",
                     "processor_index": "0",
+                    "processor_type": "fs-ruijie",
+                    "processor_usage": 8,
+                    "processor_descr": "CPU 0",
                     "processor_precision": 1,
                     "processor_perc_warn": 75
                 }
@@ -336,45 +336,45 @@
                 },
                 {
                     "state_name": "FS-SYSTEM-MIB::fsSystemElectricalSourceIsNormalTable",
-                    "state_descr": "Unknown",
-                    "state_draw_graph": 0,
+                    "state_descr": "noexist",
+                    "state_draw_graph": 1,
                     "state_value": 1,
-                    "state_generic_value": 3
+                    "state_generic_value": 2
                 },
                 {
                     "state_name": "FS-SYSTEM-MIB::fsSystemElectricalSourceIsNormalTable",
-                    "state_descr": "Green",
-                    "state_draw_graph": 0,
+                    "state_descr": "existnopower",
+                    "state_draw_graph": 1,
                     "state_value": 2,
-                    "state_generic_value": 0
+                    "state_generic_value": 2
                 },
                 {
                     "state_name": "FS-SYSTEM-MIB::fsSystemElectricalSourceIsNormalTable",
-                    "state_descr": "Yellow",
-                    "state_draw_graph": 0,
+                    "state_descr": "existreadypower",
+                    "state_draw_graph": 1,
                     "state_value": 3,
                     "state_generic_value": 1
                 },
                 {
                     "state_name": "FS-SYSTEM-MIB::fsSystemElectricalSourceIsNormalTable",
-                    "state_descr": "Not present",
-                    "state_draw_graph": 0,
+                    "state_descr": "normal",
+                    "state_draw_graph": 1,
                     "state_value": 4,
-                    "state_generic_value": 2
-                },
-                {
-                    "state_name": "FS-SYSTEM-MIB::fsSystemElectricalSourceIsNormalTable",
-                    "state_descr": "Normal",
-                    "state_draw_graph": 0,
-                    "state_value": 5,
                     "state_generic_value": 0
                 },
                 {
                     "state_name": "FS-SYSTEM-MIB::fsSystemElectricalSourceIsNormalTable",
-                    "state_descr": "Abnormal",
-                    "state_draw_graph": 0,
-                    "state_value": 6,
+                    "state_descr": "powerbutabnormal",
+                    "state_draw_graph": 1,
+                    "state_value": 5,
                     "state_generic_value": 2
+                },
+                {
+                    "state_name": "FS-SYSTEM-MIB::fsSystemElectricalSourceIsNormalTable",
+                    "state_descr": "unknow",
+                    "state_draw_graph": 1,
+                    "state_value": 6,
+                    "state_generic_value": 3
                 },
                 {
                     "state_name": "FS-SYSTEM-MIB::fsSystemFanIsNormalTable",

--- a/tests/data/fs-ruijie_s3410.json
+++ b/tests/data/fs-ruijie_s3410.json
@@ -147,56 +147,6 @@
                     "sensor_deleted": 0,
                     "sensor_class": "state",
                     "poller_type": "snmp",
-                    "sensor_oid": ".1.3.6.1.4.1.52642.1.1.10.2.1.1.18.1.2.1",
-                    "sensor_index": "1",
-                    "sensor_type": "FS-SYSTEM-MIB::fsSystemElectricalSourceIsNormalTable",
-                    "sensor_descr": "Power supply 1",
-                    "group": null,
-                    "sensor_divisor": 1,
-                    "sensor_multiplier": 1,
-                    "sensor_current": 5,
-                    "sensor_limit": null,
-                    "sensor_limit_warn": null,
-                    "sensor_limit_low": null,
-                    "sensor_limit_low_warn": null,
-                    "sensor_alert": 1,
-                    "sensor_custom": "No",
-                    "entPhysicalIndex": null,
-                    "entPhysicalIndex_measured": null,
-                    "sensor_prev": null,
-                    "user_func": null,
-                    "rrd_type": "GAUGE",
-                    "state_name": "FS-SYSTEM-MIB::fsSystemElectricalSourceIsNormalTable"
-                },
-                {
-                    "sensor_deleted": 0,
-                    "sensor_class": "state",
-                    "poller_type": "snmp",
-                    "sensor_oid": ".1.3.6.1.4.1.52642.1.1.10.2.1.1.18.1.2.2",
-                    "sensor_index": "2",
-                    "sensor_type": "FS-SYSTEM-MIB::fsSystemElectricalSourceIsNormalTable",
-                    "sensor_descr": "Power supply 2",
-                    "group": null,
-                    "sensor_divisor": 1,
-                    "sensor_multiplier": 1,
-                    "sensor_current": 4,
-                    "sensor_limit": null,
-                    "sensor_limit_warn": null,
-                    "sensor_limit_low": null,
-                    "sensor_limit_low_warn": null,
-                    "sensor_alert": 1,
-                    "sensor_custom": "No",
-                    "entPhysicalIndex": null,
-                    "entPhysicalIndex_measured": null,
-                    "sensor_prev": null,
-                    "user_func": null,
-                    "rrd_type": "GAUGE",
-                    "state_name": "FS-SYSTEM-MIB::fsSystemElectricalSourceIsNormalTable"
-                },
-                {
-                    "sensor_deleted": 0,
-                    "sensor_class": "state",
-                    "poller_type": "snmp",
                     "sensor_oid": ".1.3.6.1.4.1.52642.1.1.10.2.1.1.21.1.2.1",
                     "sensor_index": "1",
                     "sensor_type": "FS-SYSTEM-MIB::fsSystemFanIsNormalTable",
@@ -242,6 +192,56 @@
                     "user_func": null,
                     "rrd_type": "GAUGE",
                     "state_name": "FS-SYSTEM-MIB::fsSystemFanIsNormalTable"
+                },
+                {
+                    "sensor_deleted": 0,
+                    "sensor_class": "state",
+                    "poller_type": "snmp",
+                    "sensor_oid": ".1.3.6.1.4.1.52642.1.1.10.2.1.1.18.1.2.1",
+                    "sensor_index": "1",
+                    "sensor_type": "fsSystemElectricalSourceIsNormal",
+                    "sensor_descr": "Power supply 1",
+                    "group": null,
+                    "sensor_divisor": 1,
+                    "sensor_multiplier": 1,
+                    "sensor_current": 5,
+                    "sensor_limit": null,
+                    "sensor_limit_warn": null,
+                    "sensor_limit_low": null,
+                    "sensor_limit_low_warn": null,
+                    "sensor_alert": 1,
+                    "sensor_custom": "No",
+                    "entPhysicalIndex": null,
+                    "entPhysicalIndex_measured": null,
+                    "sensor_prev": null,
+                    "user_func": null,
+                    "rrd_type": "GAUGE",
+                    "state_name": "fsSystemElectricalSourceIsNormal"
+                },
+                {
+                    "sensor_deleted": 0,
+                    "sensor_class": "state",
+                    "poller_type": "snmp",
+                    "sensor_oid": ".1.3.6.1.4.1.52642.1.1.10.2.1.1.18.1.2.2",
+                    "sensor_index": "2",
+                    "sensor_type": "fsSystemElectricalSourceIsNormal",
+                    "sensor_descr": "Power supply 2",
+                    "group": null,
+                    "sensor_divisor": 1,
+                    "sensor_multiplier": 1,
+                    "sensor_current": 4,
+                    "sensor_limit": null,
+                    "sensor_limit_warn": null,
+                    "sensor_limit_low": null,
+                    "sensor_limit_low_warn": null,
+                    "sensor_alert": 1,
+                    "sensor_custom": "No",
+                    "entPhysicalIndex": null,
+                    "entPhysicalIndex_measured": null,
+                    "sensor_prev": null,
+                    "user_func": null,
+                    "rrd_type": "GAUGE",
+                    "state_name": "fsSystemElectricalSourceIsNormal"
                 },
                 {
                     "sensor_deleted": 0,
@@ -335,48 +335,6 @@
                     "state_generic_value": 3
                 },
                 {
-                    "state_name": "FS-SYSTEM-MIB::fsSystemElectricalSourceIsNormalTable",
-                    "state_descr": "noexist",
-                    "state_draw_graph": 1,
-                    "state_value": 1,
-                    "state_generic_value": 2
-                },
-                {
-                    "state_name": "FS-SYSTEM-MIB::fsSystemElectricalSourceIsNormalTable",
-                    "state_descr": "existnopower",
-                    "state_draw_graph": 1,
-                    "state_value": 2,
-                    "state_generic_value": 2
-                },
-                {
-                    "state_name": "FS-SYSTEM-MIB::fsSystemElectricalSourceIsNormalTable",
-                    "state_descr": "existreadypower",
-                    "state_draw_graph": 1,
-                    "state_value": 3,
-                    "state_generic_value": 1
-                },
-                {
-                    "state_name": "FS-SYSTEM-MIB::fsSystemElectricalSourceIsNormalTable",
-                    "state_descr": "normal",
-                    "state_draw_graph": 1,
-                    "state_value": 4,
-                    "state_generic_value": 0
-                },
-                {
-                    "state_name": "FS-SYSTEM-MIB::fsSystemElectricalSourceIsNormalTable",
-                    "state_descr": "powerbutabnormal",
-                    "state_draw_graph": 1,
-                    "state_value": 5,
-                    "state_generic_value": 2
-                },
-                {
-                    "state_name": "FS-SYSTEM-MIB::fsSystemElectricalSourceIsNormalTable",
-                    "state_descr": "unknow",
-                    "state_draw_graph": 1,
-                    "state_value": 6,
-                    "state_generic_value": 3
-                },
-                {
                     "state_name": "FS-SYSTEM-MIB::fsSystemFanIsNormalTable",
                     "state_descr": "Unknown",
                     "state_draw_graph": 0,
@@ -410,9 +368,76 @@
                     "state_draw_graph": 0,
                     "state_value": 5,
                     "state_generic_value": 2
+                },
+                {
+                    "state_name": "fsSystemElectricalSourceIsNormal",
+                    "state_descr": "noexist",
+                    "state_draw_graph": 1,
+                    "state_value": 1,
+                    "state_generic_value": 2
+                },
+                {
+                    "state_name": "fsSystemElectricalSourceIsNormal",
+                    "state_descr": "existnopower",
+                    "state_draw_graph": 1,
+                    "state_value": 2,
+                    "state_generic_value": 2
+                },
+                {
+                    "state_name": "fsSystemElectricalSourceIsNormal",
+                    "state_descr": "existreadypower",
+                    "state_draw_graph": 1,
+                    "state_value": 3,
+                    "state_generic_value": 1
+                },
+                {
+                    "state_name": "fsSystemElectricalSourceIsNormal",
+                    "state_descr": "normal",
+                    "state_draw_graph": 1,
+                    "state_value": 4,
+                    "state_generic_value": 0
+                },
+                {
+                    "state_name": "fsSystemElectricalSourceIsNormal",
+                    "state_descr": "powerbutabnormal",
+                    "state_draw_graph": 1,
+                    "state_value": 5,
+                    "state_generic_value": 2
+                },
+                {
+                    "state_name": "fsSystemElectricalSourceIsNormal",
+                    "state_descr": "unknow",
+                    "state_draw_graph": 1,
+                    "state_value": 6,
+                    "state_generic_value": 3
                 }
             ]
         },
         "poller": "matches discovery"
+    },
+    "transceivers": {
+        "discovery": {
+            "transceivers": [
+                {
+                    "index": "25",
+                    "entity_physical_index": 25,
+                    "type": null,
+                    "vendor": null,
+                    "oui": null,
+                    "model": null,
+                    "revision": null,
+                    "serial": "VT2544000590",
+                    "date": null,
+                    "ddm": null,
+                    "encoding": null,
+                    "cable": null,
+                    "distance": null,
+                    "wavelength": null,
+                    "connector": null,
+                    "channels": 1,
+                    "ifIndex": null
+                }
+            ]
+        }
     }
 }


### PR DESCRIPTION
State values for PSU monitoring were incorrectly mapped causing healthy power supplies reporting value 4 (normal per FS-SYSTEM-MIB) to trigger critical alerts labeled 'Not present'.

Corrected mappings to match FS-SYSTEM-MIB::fsSystemElectricalSourceIsNormal:
- 1: noexist (critical)
- 2: existnopower (critical)
- 3: existreadypower (warning)
- 4: normal (ok)
- 5: powerbutabnormal (critical)
- 6: unknow (unknown)

Also added missing state_name field.
Tested on FS S5860-48XMG-U (fs-ruijie OS).

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ x ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
