### PR TITLE
WIP: add new application for systemd-timesyncd

### DIFF
--- a/LibreNMS/Util/StringHelpers.php
+++ b/LibreNMS/Util/StringHelpers.php
@@ -69,6 +69,7 @@ class StringHelpers
             'sdfsinfo' => 'SDFS info',
             'smart' => 'SMART',
             'ss' => 'Socket Statistics',
+            'systemd-timesyncd' => 'Systemd-Timesyncd',
             'ups-apcups' => 'UPS apcups',
             'ups-nut' => 'UPS nut',
             'zfs' => 'ZFS',

--- a/doc/Extensions/Applications.md
+++ b/doc/Extensions/Applications.md
@@ -143,6 +143,7 @@ Currently supported applications as are below.
 - redis
 - seafile
 - supervisord
+- systemd-timesyncd
 - ups-apcups
 - zfs
 

--- a/doc/Extensions/Applications/Systemd-Timesyncd.md
+++ b/doc/Extensions/Applications/Systemd-Timesyncd.md
@@ -1,0 +1,31 @@
+# Systemd-Timesyncd
+
+A shell script that gets stats from `systemd-timesyncd` using `timedatectl`.
+
+## SNMP Extend
+
+1. Download the script onto the desired host.
+
+    ```bash
+    wget https://raw.githubusercontent.com/librenms/librenms-agent/master/snmp/systemd-timesyncd -O /etc/snmp/systemd-timesyncd
+    ```
+
+2. Make the script executable
+
+    ```bash
+    chmod +x /etc/snmp/systemd-timesyncd
+    ```
+
+3. Edit your snmpd.conf file (usually /etc/snmp/snmpd.conf) and add:
+
+    ```bash
+    extend systemd-timesyncd /etc/snmp/systemd-timesyncd
+    ```
+
+4. Restart snmpd on your host
+
+    ```bash
+    systemctl restart snmpd.service
+    ```
+
+    The application should be auto-discovered as described at the top of the page. If it is not, please follow the steps set out under `SNMP Extend` heading top of page.

--- a/includes/html/graphs/application/systemd-timesyncd_freq.inc.php
+++ b/includes/html/graphs/application/systemd-timesyncd_freq.inc.php
@@ -1,0 +1,7 @@
+<?php
+
+$ds = 'frequency';
+$unit_text = 'Frequency [ppm]';
+$rrd_filename = Rrd::name($device['hostname'], ['app', 'systemd-timesyncd', $app->app_id]);
+
+require 'includes/html/graphs/generic_stats.inc.php';

--- a/includes/html/graphs/application/systemd-timesyncd_stats.inc.php
+++ b/includes/html/graphs/application/systemd-timesyncd_stats.inc.php
@@ -1,0 +1,29 @@
+<?php
+
+require 'includes/html/graphs/common.inc.php';
+
+$colours = 'mixed';
+$nototal = (($width < 224) ? 1 : 0);
+$unit_text = 'Milliseconds';
+$rrd_filename = Rrd::name($device['hostname'], ['app', 'systemd-timesyncd', $app->app_id]);
+$array = [
+    'offset' => ['descr' => 'Offset'],
+    'jitter' => ['descr' => 'Jitter'],
+    'delay' => ['descr' => 'Delay'],
+];
+
+$i = 0;
+
+if (Rrd::checkRrdExists($rrd_filename)) {
+    foreach ($array as $ds => $var) {
+        $rrd_list[$i]['filename'] = $rrd_filename;
+        $rrd_list[$i]['descr'] = $var['descr'];
+        $rrd_list[$i]['ds'] = $ds;
+        $rrd_list[$i]['colour'] = \App\Facades\LibrenmsConfig::get("graph_colours.$colours.$i");
+        $i++;
+    }
+} else {
+    throw new \LibreNMS\Exceptions\RrdGraphException("No Data file $rrd_filename");
+}
+
+require 'includes/html/graphs/generic_multi_line.inc.php';

--- a/includes/html/pages/apps.inc.php
+++ b/includes/html/pages/apps.inc.php
@@ -108,6 +108,10 @@ $graphs['ntp-client'] = [
     'stats',
     'freq',
 ];
+$graphs['systemd-timesyncd'] = [
+    'stats',
+    'freq',
+];
 $graphs['ntp-server'] = [
     'stats',
     'freq',

--- a/includes/html/pages/device/apps/systemd-timesyncd.inc.php
+++ b/includes/html/pages/device/apps/systemd-timesyncd.inc.php
@@ -1,0 +1,26 @@
+<?php
+
+$graphs = [
+    'systemd-timesyncd_stats' => 'Timesyncd - Statistics',
+    'systemd-timesyncd_freq' => 'Timesyncd - Frequency',
+];
+
+foreach ($graphs as $key => $text) {
+    $graph_type = $key;
+    $graph_array['height'] = '100';
+    $graph_array['width'] = '215';
+    $graph_array['to'] = \App\Facades\LibrenmsConfig::get('time.now');
+    $graph_array['id'] = $app['app_id'];
+    $graph_array['type'] = 'application_' . $key;
+
+    echo '<div class="panel panel-default">
+    <div class="panel-heading">
+        <h3 class="panel-title">' . $text . '</h3>
+    </div>
+    <div class="panel-body">
+    <div class="row">';
+    include 'includes/html/print-graphrow.inc.php';
+    echo '</div>';
+    echo '</div>';
+    echo '</div>';
+}

--- a/includes/polling/applications/systemd-timesyncd.inc.php
+++ b/includes/polling/applications/systemd-timesyncd.inc.php
@@ -1,0 +1,47 @@
+<?php
+
+use LibreNMS\Exceptions\JsonAppException;
+use LibreNMS\Exceptions\JsonAppParsingFailedException;
+use LibreNMS\RRD\RrdDefinition;
+
+$name = 'systemd-timesyncd';
+
+try {
+    $timesyncd = json_app_get($device, $name);
+} catch (JsonAppParsingFailedException $e) {
+    // Legacy script, build compatible array
+    $legacy = $e->getOutput();
+
+    $timesyncd = [
+        'data' => [],
+    ];
+    [$timesyncd['data']['offset'], $timesyncd['data']['frequency'], $timesyncd['data']['jitter'],
+        $timesyncd['data']['delay']] = explode("\n", (string) $legacy);
+} catch (JsonAppException $e) {
+    echo PHP_EOL . $name . ':' . $e->getCode() . ':' . $e->getMessage() . PHP_EOL;
+    update_application($app, $e->getCode() . ':' . $e->getMessage(), []); // Set empty metrics and error message
+
+    return;
+}
+
+$rrd_def = RrdDefinition::make()
+    ->addDataset('offset', 'GAUGE', -1000, 1000)
+    ->addDataset('frequency', 'GAUGE', -1000, 1000)
+    ->addDataset('jitter', 'GAUGE', -1000, 1000)
+    ->addDataset('delay', 'GAUGE', -1000, 1000);
+
+$fields = [
+    'offset' => $timesyncd['data']['offset'],
+    'frequency' => $timesyncd['data']['frequency'],
+    'jitter' => $timesyncd['data']['jitter'],
+    'delay' => $timesyncd['data']['delay'],
+];
+
+$tags = [
+    'name' => $name,
+    'app_id' => $app->app_id,
+    'rrd_name' => ['app', $name, $app->app_id],
+    'rrd_def' => $rrd_def,
+];
+app('Datastore')->put($device, 'app', $tags, $fields);
+update_application($app, 'OK', $fields);

--- a/tests/data/linux_systemd-timesyncd.json
+++ b/tests/data/linux_systemd-timesyncd.json
@@ -1,0 +1,79 @@
+{
+    "applications": {
+        "discovery": {
+            "applications": [
+                {
+                    "app_type": "systemd-timesyncd",
+                    "app_state": "UNKNOWN",
+                    "discovered": 1,
+                    "app_state_prev": null,
+                    "app_status": "",
+                    "app_instance": "",
+                    "data": null,
+                    "deleted_at": null
+                }
+            ]
+        },
+        "poller": {
+            "applications": [
+                {
+                    "app_type": "systemd-timesyncd",
+                    "app_state": "OK",
+                    "discovered": 1,
+                    "app_state_prev": "UNKNOWN",
+                    "app_status": "",
+                    "app_instance": "",
+                    "data": null,
+                    "deleted_at": null
+                }
+            ],
+            "application_metrics": [
+                {
+                    "metric": "frequency",
+                    "value": 2.074,
+                    "value_prev": null,
+                    "app_type": "systemd-timesyncd"
+                },
+                {
+                    "metric": "jitter",
+                    "value": 11.589,
+                    "value_prev": null,
+                    "app_type": "systemd-timesyncd"
+                },
+                {
+                    "metric": "delay",
+                    "value": 58.021,
+                    "value_prev": null,
+                    "app_type": "systemd-timesyncd"
+                },
+                {
+                    "metric": "offset",
+                    "value": 23.889,
+                    "value_prev": null,
+                    "app_type": "systemd-timesyncd"
+                }
+            ]
+        }
+    },
+    "os": {
+        "discovery": {
+            "devices": [
+                {
+                    "sysName": "<private>",
+                    "sysObjectID": ".1.3.6.1.4.1.8072.3.2.10",
+                    "sysDescr": "Linux server 3.10.0-693.5.2.el7.x86_64 #1 SMP Fri Oct 20 20:32:50 UTC 2017 x86_64",
+                    "sysContact": "<private>",
+                    "version": "3.10.0-693.5.2.el7.x86_64",
+                    "hardware": "Generic x86 64-bit",
+                    "features": null,
+                    "location": "<private>",
+                    "os": "linux",
+                    "type": "server",
+                    "serial": null,
+                    "icon": "linux.svg"
+                }
+            ]
+        },
+        "poller": "matches discovery"
+    }
+}


### PR DESCRIPTION
As Debian13 uses `systemd-timesyncd` and not `ntpd` as default, a new application that could do what `ntp-client` did was needed. This does that.

It uses `timedatectl timesync-status` to get status.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
