### PR TITLE
Updated graph background when dark mode used

### DIFF
--- a/resources/definitions/config_definitions.json
+++ b/resources/definitions/config_definitions.json
@@ -6548,7 +6548,7 @@
             "type": "text"
         },
         "rrdgraph_def_text_dark": {
-            "default": "-c BACK#EEEEEE00 -c SHADEA#EEEEEE00 -c SHADEB#EEEEEE00 -c CANVAS#FFFFFF00 -c GRID#292929 -c MGRID#2f343e -c FRAME#5e5e5e -c ARROW#5e5e5e",
+            "default": "-c BACK#2e3338 -c SHADEA#EEEEEE00 -c SHADEB#EEEEEE00 -c CANVAS#FFFFFF00 -c GRID#292929 -c MGRID#2f343e -c FRAME#5e5e5e -c ARROW#5e5e5e",
             "type": "text"
         },
         "rrdgraph_def_text_color": {


### PR DESCRIPTION
Was transparent before hand so when you open the graphs in a tab on their own it produces unreadable text as it's also white.

I considered changing the text colour but not sure that's as good.

<img width="1236" height="350" alt="image" src="https://github.com/user-attachments/assets/303af0a6-ebcd-4a34-8126-72f7e39f3346" />
<img width="777" height="398" alt="image" src="https://github.com/user-attachments/assets/241ab5c5-26f1-4118-b8a3-84a44e2cf89e" />
<img width="792" height="377" alt="image" src="https://github.com/user-attachments/assets/2fdfb97d-5538-4306-97f1-0f7cf86c065b" />



DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
