### PR TITLE
Fix service check_mssql_health using incorrect variable

### DIFF
--- a/includes/services/check_mssql_health.inc.php
+++ b/includes/services/check_mssql_health.inc.php
@@ -5,6 +5,6 @@ $check_cmd = \App\Facades\LibrenmsConfig::get('nagios_plugins') . '/check_mssql_
 if ($service['service_ip']) {
     $check_cmd .= $service['service_ip'];
 } else {
-    $check_cmd .= $service['server'];
+    $check_cmd .= $service['hostname'];
 }
 $check_cmd .= ' ' . $service['service_param'];


### PR DESCRIPTION
$service['server'] isn't resolving to the hostname of the device being checked, so I changed this to $service['hostname']

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
