### PR TITLE
Replace dbBulkInsert() with Eloquent

### DIFF
--- a/includes/dbFacile.php
+++ b/includes/dbFacile.php
@@ -56,49 +56,6 @@ function dbInsert($data, $table): ?int
 }//end dbInsert()
 
 /**
- * Passed an array and a table name, it attempts to insert the data into the table.
- * $data is an array (rows) of key value pairs.  keys are fields.  Rows need to have same fields.
- * Check for boolean false to determine whether insert failed
- *
- * @param  array  $data
- * @param  string  $table
- * @return bool
- *
- * @deprecated Please use Eloquent instead; https://laravel.com/docs/eloquent#inserting-and-updating-models
- * @see https://laravel.com/docs/eloquent#inserting-and-updating-models
- */
-function dbBulkInsert($data, $table)
-{
-    // check that data isn't an empty array
-    if (empty($data)) {
-        return false;
-    }
-
-    // make sure we have fields to insert
-    $fields = array_keys(reset($data));
-    if (empty($fields)) {
-        return false;
-    }
-
-    // Break into managable chunks to prevent situations where insert
-    // fails due to prepared statement having too many placeholders.
-    $data_chunks = array_chunk($data, 10000, true);
-
-    foreach ($data_chunks as $data_chunk) {
-        try {
-            $result = Eloquent::DB()->table($table)->insert((array) $data_chunk);
-
-            return $result;
-        } catch (PDOException $pdoe) {
-            // FIXME query?
-            dbHandleException(new QueryException('dbFacile', "Bulk insert $table", $data_chunk, $pdoe));
-        }
-    }
-
-    return false;
-}//end dbBulkInsert()
-
-/**
  * Passed an array, table name, WHERE clause, and placeholder parameters, it attempts to update a record.
  * Returns the number of affected rows
  *

--- a/includes/discovery/entity-state.inc.php
+++ b/includes/discovery/entity-state.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Models\EntityState;
+
 /**
  * entity-state.inc.php
  *
@@ -85,7 +87,9 @@ if (! empty($entPhysical)) {
     }
 
     if (! empty($state_data)) {
-        dbBulkInsert($state_data, 'entityState');
+        foreach (array_chunk($state_data, 1000) as $chunk) {
+            EntityState::insert($chunk);
+        }
     }
 
     if (! empty($db_states)) {

--- a/includes/html/forms/transport-groups.inc.php
+++ b/includes/html/forms/transport-groups.inc.php
@@ -26,6 +26,7 @@
 
 use App\Models\AlertTransport;
 use App\Models\AlertTransportGroup;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Gate;
 
 header('Content-type: application/json');
@@ -86,7 +87,7 @@ if (empty($name)) {
             ];
         }
         if (! empty($insert)) {
-            dbBulkInsert($insert, 'transport_group_transport');
+            DB::table('transport_group_transport')->insert($insert);
         }
 
         // Remove old transport group members

--- a/includes/polling/unix-agent.inc.php
+++ b/includes/polling/unix-agent.inc.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Models\Process;
 use Illuminate\Support\Facades\Cache;
 use LibreNMS\RRD\RrdDefinition;
 
@@ -119,7 +120,9 @@ if ($device['os_group'] == 'unix' || $device['os'] == 'windows') {
                 }
             }
             if (count($data) > 0) {
-                dbBulkInsert($data, 'processes');
+                foreach (array_chunk($data, 1000) as $chunk) {
+                    Process::insert($chunk);
+                }
             }
             echo "\n";
         }
@@ -143,7 +146,9 @@ if ($device['os_group'] == 'unix' || $device['os'] == 'windows') {
                 }
             }
             if (count($data) > 0) {
-                dbBulkInsert($data, 'processes');
+                foreach (array_chunk($data, 1000) as $chunk) {
+                    Process::insert($chunk);
+                }
             }
             echo "\n";
         }

--- a/phpstan-baseline-deprecated.neon
+++ b/phpstan-baseline-deprecated.neon
@@ -2036,15 +2036,6 @@ parameters:
 
 		-
 			message: '''
-				#^Call to deprecated function dbBulkInsert\(\)\:
-				Please use Eloquent instead; https\://laravel\.com/docs/eloquent\#inserting\-and\-updating\-models$#
-			'''
-			identifier: function.deprecated
-			count: 1
-			path: includes/discovery/entity-state.inc.php
-
-		-
-			message: '''
 				#^Call to deprecated function dbDelete\(\)\:
 				Please use Eloquent instead; https\://laravel\.com/docs/eloquent\#deleting\-models$#
 			'''
@@ -5276,15 +5267,6 @@ parameters:
 
 		-
 			message: '''
-				#^Call to deprecated function dbBulkInsert\(\)\:
-				Please use Eloquent instead; https\://laravel\.com/docs/eloquent\#inserting\-and\-updating\-models$#
-			'''
-			identifier: function.deprecated
-			count: 1
-			path: includes/html/forms/alert-rules.inc.php
-
-		-
-			message: '''
 				#^Call to deprecated function dbDelete\(\)\:
 				Please use Eloquent instead; https\://laravel\.com/docs/eloquent\#deleting\-models$#
 			'''
@@ -5813,15 +5795,6 @@ parameters:
 			identifier: function.deprecated
 			count: 1
 			path: includes/html/forms/token-item-remove.inc.php
-
-		-
-			message: '''
-				#^Call to deprecated function dbBulkInsert\(\)\:
-				Please use Eloquent instead; https\://laravel\.com/docs/eloquent\#inserting\-and\-updating\-models$#
-			'''
-			identifier: function.deprecated
-			count: 1
-			path: includes/html/forms/transport-groups.inc.php
 
 		-
 			message: '''
@@ -9071,15 +9044,6 @@ parameters:
 			identifier: function.deprecated
 			count: 1
 			path: includes/polling/ucd-mib.inc.php
-
-		-
-			message: '''
-				#^Call to deprecated function dbBulkInsert\(\)\:
-				Please use Eloquent instead; https\://laravel\.com/docs/eloquent\#inserting\-and\-updating\-models$#
-			'''
-			identifier: function.deprecated
-			count: 2
-			path: includes/polling/unix-agent.inc.php
 
 		-
 			message: '''


### PR DESCRIPTION
Convert all dbBulkInsert() call sites to use Eloquent model::insert() or DB::table()->insert() with array_chunk(1000) to stay within MySQL's placeholder limit.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
