### PR TITLE
Remove explicit setting of SnmpQuery options to defaults in Zyxelnwa

### DIFF
--- a/LibreNMS/OS/Zyxelnwa.php
+++ b/LibreNMS/OS/Zyxelnwa.php
@@ -37,7 +37,7 @@ class Zyxelnwa extends Zyxel implements OSDiscovery, WirelessClientsDiscovery, W
             $sensors[] = new WirelessSensor(WirelessSensorType::Clients, $this->getDeviceId(), $base_oid . $index, 'zyxelnwa', $index, $radio, $row['ZYXEL-ES-WIRELESS::wlanStationCount']);
         }
 
-        $total = \SnmpQuery::options(['-OQXUte', '-Pu'])->get('ZYXEL-ES-WIRELESS::wlanTotalStationCount.0')->value();
+        $total = \SnmpQuery::get('ZYXEL-ES-WIRELESS::wlanTotalStationCount.0')->value();
         if ($total !== '') {
             $sensors[] = new WirelessSensor(WirelessSensorType::Clients, $this->getDeviceId(), '.1.3.6.1.4.1.890.1.15.3.5.15.0', 'zyxelnwa', 'total', 'Total', (int) $total);
         }
@@ -76,8 +76,7 @@ class Zyxelnwa extends Zyxel implements OSDiscovery, WirelessClientsDiscovery, W
 
     private function getWlanRadioTable()
     {
-        return \SnmpQuery::options(['-OQXUte', '-Pu']) // ignore underscores
-            ->cache()
+        return \SnmpQuery::cache()
             ->walk('ZYXEL-ES-WIRELESS::wlanRadioTable')
             ->table(1);
     }


### PR DESCRIPTION
The Zyxelnwa OS explicitly sets the SnmpQuery options to the same default options as NetSnmpQuery already uses.  This PR removes the unnecessary call to the options() function.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
