### PR TITLE
docs(borgbackup): improve setup docs and add systemd timer

### DIFF
--- a/doc/Extensions/Applications/BorgBackup.md
+++ b/doc/Extensions/Applications/BorgBackup.md
@@ -1,87 +1,162 @@
-## BorgBackup
+# BorgBackup
 
-### SNMP Extend
+Monitor Borg repositories via a LibreNMS JSON SNMP extend.
 
-1. Copy the shell script to the desired host.
+The script uses `borg info <repo> --json` to collect stats and writes cached output files for `snmpd` to read.
 
-```bash
-wget https://raw.githubusercontent.com/librenms/librenms-agent/master/snmp/borgbackup -O /etc/snmp/borgbackup
-```
+## SNMP Extend
 
-2. Make the script executable
+1. Download the Perl script onto the host.
 
-```bash
-chmod +x /etc/snmp/borgbackup
-```
-
-3. Install depends.
-
-=== "FreeBSD"
     ```bash
-    pkg install p5-Config-Tiny p5-JSON p5-File-Slurp p5-MIME-Base64 p5-String-ShellQuote
+    wget https://raw.githubusercontent.com/librenms/librenms-agent/master/snmp/borgbackup -O /etc/snmp/borgbackup
     ```
 
-=== "Debian/Ubuntu"
+2. Make the script executable.
+
     ```bash
-    apt-get install libconfig-tiny-perl libjson-perl libfile-slurp-perl libmime-base64-perl libstring-shellquote-perl
+    chmod +x /etc/snmp/borgbackup
     ```
 
-=== "Generic"
+3. Install dependencies.
+
+    === "FreeBSD"
+        ```bash
+        pkg install p5-Config-Tiny p5-JSON p5-File-Slurp p5-MIME-Base64 p5-String-ShellQuote
+        ```
+
+    === "Debian/Ubuntu"
+        ```bash
+        apt-get install libconfig-tiny-perl libjson-perl libfile-slurp-perl libmime-base64-perl libstring-shellquote-perl
+        ```
+
+    === "Generic"
+        ```bash
+        cpanm Config::Tiny File::Slurp JSON MIME::Base64 String::ShellQuote
+        ```
+
+4. Create a config file.
+
+    Default config path is `/usr/local/etc/borgbackup_extend.ini` (override with `-c`).
+
+5. Run it periodically (writes output files, then SNMP only reads them).
+
+    Default output dir is `/var/cache/borgbackup_extend` (override with `-o`).
+
+    === "cron"
+        
+        Add to `/etc/cron.d/librenms-borgbackup-extend`:
+
+        ```bash
+        */5 * * * * /etc/snmp/borgbackup -c /usr/local/etc/borgbackup_extend.ini -o /var/cache/borgbackup_extend >/dev/null 2>&1
+        ```
+
+    === "systemd"
+        Create a dedicated user (adjust as needed):
+
+        === "Debian/Ubuntu"
+            ```bash 
+            adduser --system --group --home /var/lib/borgbackup --shell /usr/sbin/nologin borgbackup
+            ```
+
+        === "RHEL/CentOS"
+            ```bash
+            groupadd --system borgbackup 2>/dev/null || true
+            useradd --system --gid borgbackup --home-dir /var/lib/borgbackup --shell /usr/sbin/nologin borgbackup
+            ```
+
+        `/etc/systemd/system/borgbackup-extend.service`
+
+        ```ini
+        [Unit]
+        Description=LibreNMS BorgBackup SNMP extend cache
+
+        [Service]
+        Type=oneshot
+        # Run as a user that can read the borg repo(s)
+        User=borgbackup
+        Group=borgbackup
+        ExecStart=/etc/snmp/borgbackup -c /usr/local/etc/borgbackup_extend.ini -o /var/cache/borgbackup_extend
+        ```
+
+        `/etc/systemd/system/borgbackup-extend.timer`
+
+        ```ini
+        [Unit]
+        Description=Run LibreNMS BorgBackup extend every 5 minutes
+
+        [Timer]
+        OnBootSec=2min
+        OnUnitActiveSec=5min
+        Persistent=true
+
+        [Install]
+        WantedBy=timers.target
+        ```
+
+        Enable the timer:
+
+        ```bash
+        systemctl daemon-reload
+        systemctl enable --now borgbackup-extend.timer
+        ```
+
+        Adjust `User=`/`Group=` and ensure `/var/cache/borgbackup_extend` is writable by that user and readable by `snmpd`.
+
+6. Add the following to `snmpd.conf`.
+
     ```bash
-    cpanm Config::Tiny File::Slurp JSON MIME::Base64 String::ShellQuote
+    extend borgbackup /bin/cat /var/cache/borgbackup_extend/extend_return
     ```
 
-4. Set it up in cron.
+7. Restart `snmpd` and wait for the device to rediscover (or rediscover it manually).
 
-``` bash
-*/5 * * * /etc/snmp/borgbackup 2> /dev/null > /dev/null
-```
+## Notes
 
-5. Configure it. See further down below or `/etc/snmp/borgbackup --help`.
+- Run the periodic job (cron/systemd) as a user that can access the Borg repo(s); `snmpd` only needs read access to the output dir.
+- `repo=` must be a local filesystem path to the repo directory (the script reads `$repo/nonce` and `$repo/lock.exclusive`).
+- The script writes two files under the output dir: `extend_return` (used by SNMP) and `pretty` (human-readable JSON for debugging).
+- `extend_return` may be plain JSON or gzip+base64 compressed JSON (the script auto-selects the smaller format).
+- Caching to files avoids running `borg info ...` as `snmpd` and avoids long runtimes (lock timeouts can cause slow polls on large repos).
 
-6. Add the following to the SNMPD config.
+## Flags
 
-```bash
-extend borgbackup /bin/cat /var/cache/borgbackup_extend/extend_return
-```
+- `-c <path>`: config file (default: `/usr/local/etc/borgbackup_extend.ini`)
+- `-o <path>`: output directory (default: `/var/cache/borgbackup_extend`)
+- `-h|--help`: help
+- `-v|--version`: version
 
-7. Restart SNMPD and wait for the device to rediscover or tell it to
-   manually.
+## Config
 
-#### Config
-
-The config file is a ini file and handled by
+The config file is an INI file and handled by
 [Config::Tiny](https://metacpan.org/pod/Config::Tiny).
 
+Keys:
+
+- `mode`: `single` or `multi` (default: `single`)
+- `repo`: filesystem path to the Borg repo directory
+- `passphrase`: passphrase for the repo
+- `passcommand`: passcommand for the repo
+
+If `passphrase` and `passcommand` are both specified, `passcommand` is used.
+
+!!! note
+    Unencrypted repositories: the current script requires either `passphrase` or `passcommand` to be set, even if `borg info` works without credentials. If you use an unencrypted repo, set `passphrase` to a something (example: `passphrase=0`).
+
+### Single repo example
+
+All variables are in the root section:
+
 ```ini
-- mode :: single or multi, for if this is a single repo or for
-        multiple repos.
-    - Default :: single
-
-- repo :: Directory for the borg backup repo.
-    - Default :: undef
-
-- passphrase :: Passphrase for the borg backup repo.
-    - Default :: undef
-
-- passcommand :: Passcommand for the borg backup repo.
-    - Default :: undef
-```
-
-For single repos all those variables are in the root section of the config,
-so lets the repo is at '/backup/borg' with a passphrase of '1234abc'.
-
-```bash
 repo=/backup/borg
-repo=1234abc
+passphrase=1234abc
 ```
 
-For multi, each section outside of the root represents a repo. So if
-there is '/backup/borg1' with a passphrase of 'foobar' and
-'/backup/derp' with a passcommand of 'pass show backup' it would be
-like below.
+### Multi repo example
 
-```bash
+Each section outside of the root represents a repo:
+
+```ini
 mode=multi
 
 [borg1]
@@ -93,22 +168,53 @@ repo=/backup/derp
 passcommand=pass show backup
 ```
 
-If 'passphrase' and 'passcommand' are both specified, then passcommand
-is used.
+## Metrics
 
-#### Metrics
-
-The metrics are all from `.data.totals` in the extend return.
+Totals are from `.data.totals` in the extend return.
 
 | Value                    | Type    | Description                                               |
 |--------------------------|---------|-----------------------------------------------------------|
 | errored                  | repos   | Total number of repos that info could not be fetched for. |
-| locked                   | repos   | Total number of locked repos                              |
+| locked                   | repos   | Total number of locked repos.                             |
 | locked_for               | seconds | Longest time any repo has been locked.                    |
-| time_since_last_modified | seconds | Largest time - mtime for the repo nonce                   |
-| total_chunks             | chunks  | Total number of chunks                                    |
+| time_since_last_modified | seconds | Largest `time - mtime($repo/nonce)` across repos.         |
+| total_chunks             | chunks  | Total number of chunks.                                   |
 | total_csize              | bytes   | Total compressed size of all archives in all repos.       |
-| total_size               | byes    | Total uncompressed size of all archives in all repos.     |
-| total_unique_chunks      | chunks  | Total number of unique chuckes in all repos.              |
-| unique_csize             | bytes   | Total deduplicated size of all archives in all repos.     |
-| unique_size              | chunks  | Total number of chunks in all repos.                      |
+| total_size               | bytes   | Total uncompressed size of all archives in all repos.     |
+| total_unique_chunks      | chunks  | Total number of unique chunks in all repos.               |
+| unique_csize             | bytes   | Total deduplicated compressed size in all repos.          |
+| unique_size              | bytes   | Total deduplicated uncompressed size in all repos.        |
+
+Per-repo values are under `.data.repos.<name>` (in `single` mode the repo key is `single`).
+
+| Value                    | Type    | Description                                  |
+|--------------------------|---------|----------------------------------------------|
+| error                    | string  | Error returned when fetching info (if any).  |
+| locked                   | 0/1     | Repo is locked.                              |
+| locked_for               | seconds | Time since `lock.exclusive` creation.        |
+| time_since_last_modified | seconds | `time - mtime($repo/nonce)`.                 |
+| total_chunks             | chunks  | Repo total chunks.                           |
+| total_csize              | bytes   | Repo total compressed size.                  |
+| total_size               | bytes   | Repo total uncompressed size.                |
+| total_unique_chunks      | chunks  | Repo unique chunk count.                     |
+| unique_csize             | bytes   | Repo deduplicated compressed size.           |
+| unique_size              | bytes   | Repo deduplicated uncompressed size.         |
+
+## JSON Return
+
+The extend output follows the LibreNMS JSON SNMP extend format:
+`https://docs.librenms.org/Developing/Application-Notes/#librenms-json-snmp-extends`
+
+Top-level keys:
+
+- `version`: JSON extend version (currently `1`)
+- `error`: exit/error code (also used as the script exit status)
+- `errorString`: error details (when `error != 0`)
+- `data`: payload (includes `mode`, `totals`, and `repos`)
+
+Common error codes:
+
+- `1`: failed reading config file
+- `2`: `mode` is not `single` or `multi`
+- `3`: neither `passphrase` nor `passcommand` defined
+- `4`: `repo` is not defined


### PR DESCRIPTION
Updates BorgBackup application docs to match the current extend script behavior:
- Clarify config/flags and output caching (extend_return/pretty)
- Add systemd timer alternative (and dedicated user example) alongside cron
- Expand metrics + JSON return details and note unencrypted repo behavior
Commands to create it (only include the doc change)

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ X ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ NA ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ NA ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.

