### PR TITLE
Add manufacturing date support for Huawei VRP transceivers

### DIFF
--- a/LibreNMS/OS/Vrp.php
+++ b/LibreNMS/OS/Vrp.php
@@ -137,7 +137,7 @@ class Vrp extends OS implements
             }
 
             // Parse hex string format: "07 DF 05 0D 00 00 00 00"
-            $bytes = array_map('hexdec', explode(' ', trim($hexDate)));
+            $bytes = array_map(hexdec(...), explode(' ', trim((string) $hexDate)));
 
             // Skip all-zero dates or invalid data
             if (count($bytes) < 4 || ($bytes[0] === 0 && $bytes[1] === 0)) {


### PR DESCRIPTION
- Add separate SNMP walks for manufacturing date OIDs
- Support both hwOpticalModuleInfoTable and hwOpticalModuleExtInfoTable
- Parse Huawei hex date format (OCTET STRING) to YYYY-MM-DD
- Handle both 8-byte and 11-byte date formats
- Preserve numeric array keys using + operator

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
