### PR TITLE
Fix undefined array key 1 in adva_fsp150 sensor pre-cache

### DIFF
--- a/includes/discovery/sensors/pre-cache/adva_fsp150.inc.php
+++ b/includes/discovery/sensors/pre-cache/adva_fsp150.inc.php
@@ -23,7 +23,7 @@ $pre_cache['adva_erp'] = snmpwalk_cache_multi_oid($device, 'f3ErpConfigObjects',
 $pre_cache['adva_fsp150_perfs'] = [];
 $pre_cache['adva_fsp150_ports'] = [];
 
-$neType = $pre_cache['adva_fsp150'][1]['neType'];
+$neType = $pre_cache['adva_fsp150'][1]['neType'] ?? null;
 $pre_cache['adva_fsp150_ifName'] = snmpwalk_cache_multi_oid($device, 'ifName', [], 'IF-MIB', null, '-OQUbs');
 
 if ($neType == 'ccxg116pro' || $neType == 'ccxg116proH' || $neType == 'ccxg120pro' || $neType == 'aggregation') {


### PR DESCRIPTION
## Summary

- Use null coalescing operator (`??`) when accessing `$pre_cache['adva_fsp150'][1]['neType']` to avoid `ErrorException` when the SNMP walk returns no data for `cmEntityObjects`
- When `neType` is unknown, the else branch (default device handling) still runs rather than skipping discovery entirely

Fixes #19244

## Test plan

- [ ] Run discovery against an ADVA FSP150 device and confirm no `Undefined array key 1` errors in the log
- [ ] Run discovery against a device where the `cmEntityObjects` SNMP walk returns empty results and confirm the else branch handles it gracefully