### PR TITLE
Fix undefined array key in adva_fsp3kr7 sensor pre-cache

### DIFF
--- a/includes/discovery/sensors/pre-cache/adva_fsp3kr7.inc.php
+++ b/includes/discovery/sensors/pre-cache/adva_fsp3kr7.inc.php
@@ -18,7 +18,7 @@
  **/
 
 // FSP3000 R7 Series
-$pre_cache['adva_fsp3kr7'] = snmpwalk_cache_multi_oid($device, 'pmSnapshotCurrentEntry', $pre_cache['adva_fsp3kr7'], 'ADVA-FSPR7-MIB', null, '-OQUbs');
+$pre_cache['adva_fsp3kr7'] = snmpwalk_cache_multi_oid($device, 'pmSnapshotCurrentEntry', [], 'ADVA-FSPR7-MIB', null, '-OQUbs');
 $pre_cache['adva_fsp3kr7'] = snmpwalk_cache_multi_oid($device, 'entityFacilityOneIndex', $pre_cache['adva_fsp3kr7'], 'ADVA-FSPR7-MIB', null, '-OQUbs');
 $pre_cache['adva_fsp3kr7'] = snmpwalk_cache_multi_oid($device, 'entityDcnOneIndex', $pre_cache['adva_fsp3kr7'], 'ADVA-FSPR7-MIB', null, '-OQUbs');
 $pre_cache['adva_fsp3kr7'] = snmpwalk_cache_multi_oid($device, 'entityOpticalMuxOneIndex', $pre_cache['adva_fsp3kr7'], 'ADVA-FSPR7-MIB', null, '-OQUbs');
@@ -33,7 +33,7 @@ $pre_cache['adva_fsp3kr7'] = snmpwalk_cache_multi_oid($device, 'plugTransmitChan
 $pre_cache['adva_fsp3kr7'] = snmpwalk_cache_multi_oid($device, 'plugFiberType', $pre_cache['adva_fsp3kr7'], 'ADVA-FSPR7-MIB', null, '-OQUbs');
 $pre_cache['adva_fsp3kr7'] = snmpwalk_cache_multi_oid($device, 'plugReach', $pre_cache['adva_fsp3kr7'], 'ADVA-FSPR7-MIB', null, '-OQUbs');
 
-$pre_cache['adva_fsp3kr7_Card'] = snmpwalk_cache_multi_oid($device, 'entityEqptAidString', $pre_cache['adva_fsp3kr7_Card'], 'ADVA-FSPR7-MIB', null, '-OQUbs');
+$pre_cache['adva_fsp3kr7_Card'] = snmpwalk_cache_multi_oid($device, 'entityEqptAidString', [], 'ADVA-FSPR7-MIB', null, '-OQUbs');
 $pre_cache['adva_fsp3kr7_Card'] = snmpwalk_cache_multi_oid($device, 'eqptPhysInstValueEntry', $pre_cache['adva_fsp3kr7_Card'], 'ADVA-FSPR7-PM-MIB', null, '-OQUbs');
 $pre_cache['adva_fsp3kr7_Card'] = snmpwalk_cache_multi_oid($device, 'optMuxPhysInstValueTable', $pre_cache['adva_fsp3kr7_Card'], 'ADVA-FSPR7-PM-MIB', null, '-OQUbs');
 $pre_cache['adva_fsp3kr7_Card'] = snmpwalk_cache_multi_oid($device, 'entityMtosiSlotsAidString', $pre_cache['adva_fsp3kr7_Card'], 'ADVA-FSPR7-PM-MIB', null, '-OQUbs');


### PR DESCRIPTION
## Summary

- Initialize `$pre_cache['adva_fsp3kr7']` and `$pre_cache['adva_fsp3kr7_Card']` to empty arrays before first use as `snmpwalk_cache_multi_oid()` input, avoiding `ErrorException` when the keys don't already exist in `$pre_cache`

Fixes #19245

## Test plan

- [ ] Run discovery against an ADVA FSP3000 R7 device and confirm no `Undefined array key "adva_fsp3kr7"` errors in the log