### PR TITLE
Fix undefined variable $port in aos6 FDB table discovery

### DIFF
--- a/includes/discovery/fdb-table/aos6.inc.php
+++ b/includes/discovery/fdb-table/aos6.inc.php
@@ -49,8 +49,8 @@ if (! empty($fdbPort_table)) {
     // Build dot1dBasePort to port_id dictionary
     $portid_dict = [];
     $dot1dBasePortIfIndex = snmpwalk_group($device, 'dot1dBasePortIfIndex', 'BRIDGE-MIB');
-    foreach ($dot1dBasePortIfIndex as $data) {
-        $portid_dict[$port['ifIndex']] = PortCache::getIdFromIfIndex($data['dot1dBasePortIfIndex'], $device['device_id']);
+    foreach ($dot1dBasePortIfIndex as $portLocal => $data) {
+        $portid_dict[$portLocal] = PortCache::getIdFromIfIndex($data['dot1dBasePortIfIndex'], $device['device_id']);
     }
     // Collect data and populate $insert
     foreach ($fdbPort_table as $vlan => $data) {


### PR DESCRIPTION
## Summary

- The `foreach` loop over `dot1dBasePortIfIndex` was missing the key variable and used undefined `$port['ifIndex']` as the dictionary index
- Changed to `foreach (... as $portLocal => $data)` with `$portid_dict[$portLocal]`, matching the established pattern in `bridge.inc.php` and `arubaos.inc.php`

This was not just a warning — it meant the port ID dictionary was never populated correctly, so AOS6 FDB entries were silently dropped.

Fixes #19246