### PR TITLE
Fix Areca OS: isHex() receives null when serial is not set

### DIFF
--- a/LibreNMS/OS/Areca.php
+++ b/LibreNMS/OS/Areca.php
@@ -38,7 +38,7 @@ class Areca extends OS implements OSDiscovery
         parent::discoverOS($device); //yaml
 
         // Sometimes firmware outputs serial as hex-string
-        if (! empty($device->serial) && StringHelpers::isHex($device->serial, ' ')) {
+        if (StringHelpers::isHex((string) $device->serial, ' ')) {
             $device->serial = StringHelpers::hexToAscii($device->serial, ' ');
         }
     }

--- a/LibreNMS/OS/Areca.php
+++ b/LibreNMS/OS/Areca.php
@@ -38,7 +38,7 @@ class Areca extends OS implements OSDiscovery
         parent::discoverOS($device); //yaml
 
         // Sometimes firmware outputs serial as hex-string
-        if (StringHelpers::isHex($device->serial, ' ')) {
+        if (! empty($device->serial) && StringHelpers::isHex($device->serial, ' ')) {
             $device->serial = StringHelpers::hexToAscii($device->serial, ' ');
         }
     }


### PR DESCRIPTION
## Summary

- Guard `StringHelpers::isHex()` call with `empty()` check on `$device->serial` to avoid `TypeError` when SNMP returns no serial value

Fixes #19247

## Test plan

- [ ] Run discovery against an Areca device with no serial and confirm no TypeError
- [ ] Run discovery against an Areca device with a hex serial and confirm it's still converted correctly