### PR TITLE
Fix undefined array key in arubaos FDB discovery

### DIFF
--- a/includes/discovery/fdb-table/arubaos.inc.php
+++ b/includes/discovery/fdb-table/arubaos.inc.php
@@ -73,10 +73,7 @@ if (! empty($fdbPort_table)) {
                 continue;
             }
 
-            $port_id = $portid_dict[$dot1dBasePort];
-            if ($port_id === null) {
-                $port_id = 0;
-            }
+            $port_id = $portid_dict[$dot1dBasePort] ?? 0;
             $vlan_id = $vlans_dict[$vlan] ?? 0;
 
             $insert[$vlan_id][$mac_address]['port_id'] = $port_id;


### PR DESCRIPTION
## Summary

- Use null coalescing (`??`) to default to `0` when `$dot1dBasePort` is not found in `$portid_dict`, replacing the separate null check

Fixes #19249

## Test plan

- [ ] Run FDB table discovery against an ArubaOS device and confirm no `Undefined array key` errors