### PR TITLE
Fix undefined array key 1 in avtech sensor pre-cache

### DIFF
--- a/includes/discovery/sensors/pre-cache/avtech.inc.php
+++ b/includes/discovery/sensors/pre-cache/avtech.inc.php
@@ -39,7 +39,10 @@ $virtual_tables = [
 
 $data = trim((string) snmp_walk($device, '.1.3.6.1.4.1.20916.1', '-OQn'));
 foreach (explode(PHP_EOL, $data) as $line) {
-    [$oid, $value] = explode(' =', $line);
+    if (! str_contains($line, ' =')) {
+        continue;
+    }
+    [$oid, $value] = explode(' =', $line, 2);
     $value = trim($value);
 
     $processed = false;


### PR DESCRIPTION
## Summary

- Skip SNMP walk output lines that don't contain the ` =` delimiter
- Limit `explode()` to 2 parts to correctly handle values that contain ` =`

Fixes #19250

## Test plan

- [ ] Run sensor discovery against an AVTECH device and confirm no `Undefined array key 1` errors