### PR TITLE
Fix undefined array key in awplus NTP discovery

### DIFF
--- a/includes/discovery/ntp/awplus.inc.php
+++ b/includes/discovery/ntp/awplus.inc.php
@@ -18,7 +18,7 @@ $component = new LibreNMS\Component();
 $components = $component->getComponents($device['device_id'], ['type' => $module]);
 
 // We only care about our device id.
-$components = $components[$device['device_id']];
+$components = $components[$device['device_id']] ?? [];
 
 // Begin our master array, all other values will be processed into this array.
 $tblComponents = [];


### PR DESCRIPTION
## Summary

- Use null coalescing (`??`) when accessing `$components[$device['device_id']]`, defaulting to empty array when no NTP components exist yet for the device

Fixes #19251

## Test plan

- [ ] Run NTP discovery against an AWPlus device with no existing NTP components and confirm no `Undefined array key` errors