### PR TITLE
Fix undefined array key 0 in commander-plus sensor state

### DIFF
--- a/includes/discovery/sensors/state/commander-plus.inc.php
+++ b/includes/discovery/sensors/state/commander-plus.inc.php
@@ -26,7 +26,7 @@
 $start_oid = '.1.3.6.1.4.1.18642.1.2.4';
 $state_table = snmpwalk_cache_oid($device, '.1.3.6.1.4.1.18642.1.2.4', [], 'CCPOWER-MIB');
 $x = 1;
-foreach ($state_table[0] as $state_name => $state_value) {
+foreach ($state_table[0] ?? [] as $state_name => $state_value) {
     //Create State Translation
     $states = [
         ['value' => 1, 'generic' => 2, 'graph' => 1, 'descr' => 'inactive'],


### PR DESCRIPTION
## Summary

- Use null coalescing (`??`) on `$state_table[0]` to default to empty array when the SNMP walk returns no data

Fixes #19252

## Test plan

- [ ] Run sensor state discovery against a Commander Plus device and confirm no `Undefined array key 0` errors