### PR TITLE
Oxidized - hostname VS sysName VS displayName

### DIFF
--- a/includes/html/pages/oxidized.inc.php
+++ b/includes/html/pages/oxidized.inc.php
@@ -32,7 +32,7 @@ $no_refresh = true;
                             <tr>
                                 <th data-column-id="id" data-visible="false">ID</th>
                                 <th data-column-id="hostname" data-formatter="hostname" data-order="asc">Hostname</th>
-                                <th data-column-id="sysname" data-visible="false">SysName</th>
+                                <th data-column-id="sysname">SysName</th>
                                 <th data-column-id="last_status" data-formatter="status">Last Status</th>
                                 <th data-column-id="last_update">Last Update</th>
                                 <th data-column-id="model">Model</th>


### PR DESCRIPTION
Display sysname by default to avoid having to enable it every time in the dropdown menu

Please give a short description what your pull request is for

Default view on oxidized page hides the sysname, making it difficult to differentiate devices in the list unless you know specific IP addresses and meaning you need to enable the column every time you load the page. This change just enables the column by default

Before:
<img width="1676" height="360" alt="image" src="https://github.com/user-attachments/assets/6ca61d9e-2f86-4456-9c4c-adf2beeb8795" />
After(redacted):
<img width="1669" height="316" alt="image" src="https://github.com/user-attachments/assets/94b1beba-7fbd-4a5a-8be2-852957fc3d6a" />



#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.

