### PR TITLE
Fix undefined variable $oids in MEF discovery

### DIFF
--- a/includes/discovery/mef.inc.php
+++ b/includes/discovery/mef.inc.php
@@ -17,7 +17,7 @@ $mef_list = [];
  * Fetch information about MEF Links.
  */
 
-$oids = snmpwalk_cache_multi_oid($device, 'MefServiceEvcCfgEntry', $oids, 'MEF-UNI-EVC-MIB');
+$oids = snmpwalk_cache_multi_oid($device, 'MefServiceEvcCfgEntry', [], 'MEF-UNI-EVC-MIB');
 
 echo 'MEF : ';
 foreach ($oids as $index => $entry) {


### PR DESCRIPTION
Pass an empty array instead of the undefined $oids variable as the third argument to snmpwalk_cache_multi_oid().

Fixes #19254

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
