### PR TITLE
Fix ArpTable TypeError when Mac::parse() receives array instead of string

### DIFF
--- a/LibreNMS/Modules/ArpTable.php
+++ b/LibreNMS/Modules/ArpTable.php
@@ -118,13 +118,15 @@ class ArpTable implements Module
                 );
 
                 foreach ($port_arp as $ip => $raw_mac) {
-                    // Some SNMP agents encode IpAddress indexes with an extra prefix byte,
-                    // causing table() to produce nested arrays instead of flat ip => mac entries.
-                    // Flatten by appending the spilled octet to $ip and taking the mac value.
+                    // Some SNMP agents add an extra prefix byte to IpAddress indexes, so instead of:
+                    //   '1.2.3.4' => 'aa:bb:cc:dd:ee:ff'
+                    // table() returns:
+                    //   '0.1.2.3' => [ '4' => 'aa:bb:cc:dd:ee:ff' ]
+                    // Reconstruct the correct IP by dropping the prefix octet and appending the spilled one.
                     if (is_array($raw_mac)) {
-                        $parts = explode('.', ltrim((string) $ip, '.'));
-                        array_shift($parts);
-                        $ip = implode('.', $parts) . '.' . ltrim((string) array_key_first($raw_mac), '.');
+                        $octets = explode('.', ltrim((string) $ip, '.'));
+                        $spilled_octet = ltrim((string) array_key_first($raw_mac), '.');
+                        $ip = implode('.', array_slice($octets, 1)) . '.' . $spilled_octet;
                         $raw_mac = array_values($raw_mac)[0];
                     }
 


### PR DESCRIPTION
Some SNMP agents encode IpAddress indexes with an extra prefix byte,
causing SnmpResponse::table() to produce nested arrays. This resulted
in Mac::parse() receiving an array instead of a string.

Try reconstruct the IP by stripping the prefix byte and appending
the spilled last octet, then let existing validation handle the rest.

Fixes #19255

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
