### PR TITLE
Fix dynamic service templates not applied during device discovery

### DIFF
--- a/app/Http/Controllers/ServiceTemplateController.php
+++ b/app/Http/Controllers/ServiceTemplateController.php
@@ -305,6 +305,9 @@ class ServiceTemplateController extends Controller
     public function applyDeviceAll(int $device_id): void
     {
         foreach (ServiceTemplate::all() as $template) {
+            if ($template->type == 'dynamic') {
+                $template->updateDevices();
+            }
             $this->applyDevice($template, $device_id);
         }
     }


### PR DESCRIPTION
  ## Summary
  - Dynamic service templates are not automatically applied to newly
    discovered devices during the discovery process
  - The `applyDeviceAll()` method (called from `Services::discover()`)
    never calls `updateDevices()` to refresh the pivot table before
    checking device membership, causing new devices to be silently skipped
  - The UI "Apply" button (`apply()` method) already handles this
    correctly — this fix aligns the discovery path with the same behavior

  ## Steps to reproduce
  1. Create a dynamic service template with a rule (e.g. `os in iosxr,iosxe`)
  2. Enable `discover_services_templates`
  3. Add a new device matching the rule
  4. Wait for discovery to run
  5. No service is created — manual "Apply" from the UI is required

  ## Fix
  Call `updateDevices()` for dynamic templates in `applyDeviceAll()`
  before calling `applyDevice()`, so the pivot table is up to date
  when the device membership check runs.

  ## Test plan
  - [ ] Add a device matching a dynamic service template rule
  - [ ] Run discovery (`lnms device:discover <hostname>`)
  - [ ] Verify the service is automatically created without manual "Apply"
  - [ ] Verify existing static and device-group templates still work


When a new device is discovered, applyDeviceAll() iterates all service templates and calls applyDevice() for each. However, for dynamic templates, updateDevices() was never called to refresh the pivot table before checking device membership. This caused new devices matching dynamic rules to be silently skipped.

The apply() method (used by the UI "Apply" button) already calls updateDevices() before processing. This fix adds the same call in the discovery path (applyDeviceAll), ensuring dynamic templates are consistently applied to newly discovered devices.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
