### PR TITLE
Fix ambiguous transport_id column in transport-groups query

### DIFF
--- a/includes/html/forms/transport-groups.inc.php
+++ b/includes/html/forms/transport-groups.inc.php
@@ -71,7 +71,7 @@ if (empty($name)) {
     if (is_numeric($group_id) && $group_id > 0) {
         $db_members = AlertTransportGroup::find($group_id)
             ->transports()
-            ->pluck('transport_id')
+            ->pluck('alert_transports.transport_id')
             ->all();
 
         // Compare arrays to get added and removed transports


### PR DESCRIPTION
### Summary

`transport-groups.inc.php` throws a fatal SQL error when loading an existing transport group, due to an ambiguous column reference in a JOIN query.

It prevent creating a new transport group linked with any transport, or modify an existing transport group.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply 19294`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.

### Error

```
SQLSTATE[23000]: Integrity constraint violation: 1052 Column 'transport_id' in SELECT is ambiguous
SQL: select `transport_id` from `alert_transports`
     inner join `transport_group_transport`
     on `alert_transports`.`transport_id` = `transport_group_transport`.`transport_id`
     where `transport_group_transport`.`transport_group_id` = 5
```

### Root cause

At line 74, `->pluck('transport_id')` generates an unqualified `SELECT transport_id` over a JOIN between `alert_transports` and `transport_group_transport`. Both tables have a `transport_id` column, making the reference ambiguous. Strict MySQL/MariaDB versions reject this with an integrity constraint violation rather than silently resolving it.

### Fix

Qualify the column with its table name so MySQL can unambiguously resolve it.

```diff
--- a/includes/html/forms/transport-groups.inc.php
+++ b/includes/html/forms/transport-groups.inc.php
@@ -74 +74 @@
-            ->pluck('transport_id')
+            ->pluck('alert_transports.transport_id')
```

### Testing

- Open an existing transport group in the LibreNMS UI → members load correctly ✅
- Save an existing transport group → no SQL error ✅
- Create a new transport group → unaffected code path, works as before ✅

### Notes

This likely worked on older MySQL versions which silently resolved ambiguous column references in favour of the left-side table. Strict mode enforcement in newer MySQL/MariaDB versions surfaces the error.