### PR TITLE
Socialite decouples token attribute lookup from OAuth scopes

### DIFF
--- a/app/Http/Controllers/Auth/SocialiteController.php
+++ b/app/Http/Controllers/Auth/SocialiteController.php
@@ -170,7 +170,7 @@ class SocialiteController extends Controller
         $scopeValues = $claimField !== null
             ? Arr::wrap($attributes[$claimField] ?? [])
             : collect($attributes)
-                ->filter(fn($values, $name) => collect($scopes)->contains(fn($scope) => str_contains((string) $name, (string) $scope)))
+                ->filter(fn ($values, $name) => collect($scopes)->contains(fn ($scope) => str_contains((string) $name, (string) $scope)))
                 ->flatten()
                 ->all();
 

--- a/app/Http/Controllers/Auth/SocialiteController.php
+++ b/app/Http/Controllers/Auth/SocialiteController.php
@@ -160,55 +160,32 @@ class SocialiteController extends Controller
         $scopes = LibrenmsConfig::get('auth.socialite.scopes');
         $claims = LibrenmsConfig::get('auth.socialite.claims');
 
-        if (is_array($scopes) &&
-            $this->socialite_user instanceof \Laravel\Socialite\AbstractUser &&
-            ! empty($claims)
-        ) {
-            $roles = [];
-            $attributes = $this->socialite_user->getRaw();
-
-            if (is_object(current($attributes)) && method_exists(current($attributes), 'getName') && method_exists(current($attributes), 'getAllAttributeValues')) {
-                $parsed_attributes = [];
-                foreach ($attributes as $attribute_object) {
-                    $attribute_name = $attribute_object->getName();
-                    $attribute_values = $attribute_object->getAllAttributeValues();
-                    $parsed_attributes[$attribute_name] = $attribute_values;
-                }
-                $attributes = $parsed_attributes;
-            }
-
-            // claim_field decouples token attribute lookup from OAuth scopes.
-            // Some providers (e.g. Microsoft) deliver role information under a
-            // claim field such as 'roles' that is not a valid OAuth scope name.
-            // Adding it to scopes causes the IdP to reject the authorization
-            // request. Set claim_field per provider to specify which token field
-            // to read without changing the scopes sent to the IdP.
-            $claimField = LibrenmsConfig::get("auth.socialite.configs.$provider.claim_field");
-
-            if ($claimField !== null) {
-                foreach (Arr::wrap($attributes[$claimField] ?? []) as $scope_data) {
-                    $roles = array_merge($roles, $claims[$scope_data]['roles'] ?? []);
-                }
-            } else {
-                foreach ($scopes as $scope) {
-                    foreach ($attributes as $attribute_name => $attribute_values) {
-                        if (str_contains((string) $attribute_name, (string) $scope)) {
-                            foreach (Arr::wrap($attributes[$attribute_name] ?? []) as $scope_data) {
-                                $roles = array_merge($roles, $claims[$scope_data]['roles'] ?? []);
-                            }
-                        }
-                    }
-                }
-            }
-
-            if (count($roles) > 0) {
-                $user->syncRoles(array_unique($roles));
-
-                return true;
-            }
+        if (! is_array($scopes) || ! $this->socialite_user instanceof \Laravel\Socialite\AbstractUser || empty($claims)) {
+            return false;
         }
 
-        return false;
+        $attributes = $this->normalizeAttributes($this->socialite_user->getRaw());
+
+        $claimField = LibrenmsConfig::get("auth.socialite.configs.$provider.claim_field");
+        $scopeValues = $claimField !== null
+            ? Arr::wrap($attributes[$claimField] ?? [])
+            : collect($attributes)
+                ->filter(fn($values, $name) => collect($scopes)->contains(fn($scope) => str_contains((string) $name, (string) $scope)))
+                ->flatten()
+                ->all();
+
+        $roles = [];
+        foreach ($scopeValues as $value) {
+            $roles = array_merge($roles, $claims[$value]['roles'] ?? []);
+        }
+
+        if (empty($roles)) {
+            return false;
+        }
+
+        $user->syncRoles(array_unique($roles));
+
+        return true;
     }
 
     private function pairUser(string $provider): RedirectResponse

--- a/app/Http/Controllers/Auth/SocialiteController.php
+++ b/app/Http/Controllers/Auth/SocialiteController.php
@@ -188,6 +188,20 @@ class SocialiteController extends Controller
         return true;
     }
 
+    private function normalizeAttributes(array $attributes): array
+    {
+        if (! empty($attributes) && is_object(current($attributes)) && method_exists(current($attributes), 'getName') && method_exists(current($attributes), 'getAllAttributeValues')) {
+            $parsed_attributes = [];
+            foreach ($attributes as $attribute_object) {
+                $parsed_attributes[$attribute_object->getName()] = $attribute_object->getAllAttributeValues();
+            }
+
+            return $parsed_attributes;
+        }
+
+        return $attributes;
+    }
+    
     private function pairUser(string $provider): RedirectResponse
     {
         $user = Auth::user();

--- a/app/Http/Controllers/Auth/SocialiteController.php
+++ b/app/Http/Controllers/Auth/SocialiteController.php
@@ -190,16 +190,12 @@ class SocialiteController extends Controller
 
     private function normalizeAttributes(array $attributes): array
     {
-        if (! empty($attributes) && is_object(current($attributes)) && method_exists(current($attributes), 'getName') && method_exists(current($attributes), 'getAllAttributeValues')) {
-            $parsed_attributes = [];
-            foreach ($attributes as $attribute_object) {
-                $parsed_attributes[$attribute_object->getName()] = $attribute_object->getAllAttributeValues();
-            }
-
-            return $parsed_attributes;
+        $first = current($attributes);
+        if (! is_object($first) || ! method_exists($first, 'getName') || ! method_exists($first, 'getAllAttributeValues')) {
+            return $attributes;
         }
 
-        return $attributes;
+        return collect($attributes)->keyBy->getName()->map->getAllAttributeValues()->all();
     }
 
     private function pairUser(string $provider): RedirectResponse

--- a/app/Http/Controllers/Auth/SocialiteController.php
+++ b/app/Http/Controllers/Auth/SocialiteController.php
@@ -183,7 +183,6 @@ class SocialiteController extends Controller
             // Adding it to scopes causes the IdP to reject the authorization
             // request. Set claim_field per provider to specify which token field
             // to read without changing the scopes sent to the IdP.
-            // Falls back to scopes-based lookup when not set (existing behaviour).
             $claimField = LibrenmsConfig::get("auth.socialite.configs.$provider.claim_field");
 
             if ($claimField !== null) {

--- a/app/Http/Controllers/Auth/SocialiteController.php
+++ b/app/Http/Controllers/Auth/SocialiteController.php
@@ -177,11 +177,26 @@ class SocialiteController extends Controller
                 $attributes = $parsed_attributes;
             }
 
-            foreach ($scopes as $scope) {
-                foreach ($attributes as $attribute_name => $attribute_values) {
-                    if (str_contains((string) $attribute_name, (string) $scope)) {
-                        foreach (Arr::wrap($attributes[$attribute_name] ?? []) as $scope_data) {
-                            $roles = array_merge($roles, $claims[$scope_data]['roles'] ?? []);
+            // claim_field decouples token attribute lookup from OAuth scopes.
+            // Some providers (e.g. Microsoft) deliver role information under a
+            // claim field such as 'roles' that is not a valid OAuth scope name.
+            // Adding it to scopes causes the IdP to reject the authorization
+            // request. Set claim_field per provider to specify which token field
+            // to read without changing the scopes sent to the IdP.
+            // Falls back to scopes-based lookup when not set (existing behaviour).
+            $claimField = LibrenmsConfig::get("auth.socialite.configs.$provider.claim_field");
+
+            if ($claimField !== null) {
+                foreach (Arr::wrap($attributes[$claimField] ?? []) as $scope_data) {
+                    $roles = array_merge($roles, $claims[$scope_data]['roles'] ?? []);
+                }
+            } else {
+                foreach ($scopes as $scope) {
+                    foreach ($attributes as $attribute_name => $attribute_values) {
+                        if (str_contains((string) $attribute_name, (string) $scope)) {
+                            foreach (Arr::wrap($attributes[$attribute_name] ?? []) as $scope_data) {
+                                $roles = array_merge($roles, $claims[$scope_data]['roles'] ?? []);
+                            }
                         }
                     }
                 }

--- a/app/Http/Controllers/Auth/SocialiteController.php
+++ b/app/Http/Controllers/Auth/SocialiteController.php
@@ -201,7 +201,7 @@ class SocialiteController extends Controller
 
         return $attributes;
     }
-    
+
     private function pairUser(string $provider): RedirectResponse
     {
         $user = Auth::user();

--- a/doc/Extensions/OAuth-SAML.md
+++ b/doc/Extensions/OAuth-SAML.md
@@ -318,7 +318,25 @@ Then setup mappings from the returned claim arrays to the User levels you want
     lnms config:set auth.socialite.claims.RETURN_FROM_CLAIM.roles '["admin"]'
     lnms config:set auth.socialite.claims.OTHER_RETURN_FROM_CLAIM.roles '["global-read","cleaner"]'
     ```
+## Claim Field (advanced)
 
+Some providers deliver role or group membership under a token claim field that
+is **not** a valid OAuth scope name.  Microsoft is a common example: app-role
+assignments arrive in the `roles` claim, but adding `roles` to
+`auth.socialite.scopes` causes Microsoft to return:
+
+```
+AADSTS650053: The application asked for scope 'roles' that doesn't exist
+```
+
+The `claim_field` option solves this by separating *what is requested from the
+IdP* (scopes) from *what key is read in the returned token* (claim_field).  It
+is configured per provider under `auth.socialite.configs.<provider>.claim_field`
+and accepts an array of strings.
+
+```bash
+lnms config:set auth.socialite.configs.microsoft.claim_field roles
+```
 
 ## SAML2 Example
 


### PR DESCRIPTION
Please give a short description what your pull request is for

Fixes role mapping for providers (notably Microsoft) that deliver role 
information under a claim field that is not a valid OAuth scope name.

Previously, setRolesFromClaim() used auth.socialite.scopes for both:
  1. Requesting scopes from the IdP in the authorize URL
  2. Matching token attribute keys for role lookups

Microsoft delivers app-role assignments in a 'roles' claim. Adding 'roles'
to scopes causes AADSTS650053. The two concerns are now decoupled.

New optional config key (per provider):
  `auth.socialite.configs.<provider>.claim_field`

When set, claim_field is used for attribute lookup instead of scopes.
Scopes continue to be sent to the IdP unchanged.
Falls back to scopes when not set

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
