### PR TITLE
Add API endpoints for Scheduled maintenance

### DIFF
--- a/doc/API/Alerts.md
+++ b/doc/API/Alerts.md
@@ -341,6 +341,168 @@ Output:
 }
 ```
 
+## Scheduled maintenance
+
+### `list_scheduled_maintenance`
+
+List all scheduled maintenances.
+
+Route: `/api/v0/alerts/scheduled_maintenance`
+
+Input: None
+
+Example:
+
+```curl
+curl -H 'X-Auth-Token: YOURAPITOKENHERE' https://foo.example/api/v0/alerts/scheduled_maintenance
+```
+
+Output:
+
+```json
+{
+  "status": "ok",
+  "schedule": [
+    {
+      "schedule_id": 1,
+      "title": "Planned maintenance",
+      "notes": "Monthly maintenance window",
+      "recurring": 0,
+      "start": "2026-03-17 00:00:00",
+      "end": "2026-03-17 06:00:00",
+      "start_recurring_dt": "2026-03-17",
+      "start_recurring_hr": "00:00",
+      "end_recurring_dt": "2026-03-17",
+      "end_recurring_hr": "06:00",
+      "recurring_day": ["Mo"],
+      "status": 1,
+      "devices": [1, 2],
+      "device_groups": [1],
+      "locations": []
+    }
+  ],
+  "count": 1
+}
+```
+
+### `get_scheduled_maintenance`
+
+Get details of a specific alert maintenance schedule.
+
+Route: `/api/v0/alerts/scheduled_maintenance/:id`
+
+- id is the scheduled maintenance id, obtainable from [`list_scheduled_maintenance`](#list_scheduled_maintenance).
+
+Input:
+
+  -
+
+Example:
+
+```curl
+curl -H 'X-Auth-Token: YOURAPITOKENHERE' https://foo.example/api/v0/alerts/scheduled_maintenance/1
+```
+
+Output:
+
+```json
+{
+  "status": "ok",
+  "schedule": {
+    "schedule_id": 1,
+    "title": "Planned maintenance",
+    "notes": "Monthly maintenance window",
+    "recurring": 0,
+    "start": "2026-03-17 00:00:00",
+    "end": "2026-03-17 06:00:00",
+    "start_recurring_dt": "2026-03-17",
+    "start_recurring_hr": "00:00",
+    "end_recurring_dt": "2026-03-17",
+    "end_recurring_hr": "06:00",
+    "recurring_day": ["Mo"],
+    "status": 1,
+    "devices": [1, 2],
+    "device_groups": [1],
+    "locations": []
+  }
+}
+```
+
+### `add_scheduled_maintenance`
+
+Create a new scheduled maintenance.
+
+Route: `/api/v0/alerts/scheduled_maintenance`
+
+Input (JSON):
+
+- title: (Required) Title of the maintenance schedule.
+- notes: Optional notes for this maintenance schedule.
+- behavior: Optional integer controlling maintenance behavior (`1`, `2`, or `3`).
+- recurring: Whether this is a recurring schedule (boolean, default `false`).
+- **When `recurring` is `false`** (non-recurring):
+  - start: (Required) Start datetime in `Y-m-d H:i:s` format.
+  - end: (Required) End datetime in `Y-m-d H:i:s` format. Must be after `start`.
+- **When `recurring` is `true`**:
+  - start_recurring_dt: (Required) Start date in `Y-m-d` format.
+  - start_recurring_hr: (Required) Start time in `H:i` format.
+  - end_recurring_hr: (Required) End time in `H:i` format. May be before `start_recurring_hr` to span midnight.
+  - end_recurring_dt: Optional end date in `Y-m-d` format (no end date if omitted).
+  - recurring_day: Optional array of day abbreviations. Valid values: `Mo`, `Tu`, `We`, `Th`, `Fr`, `Sa`, `Su`.
+- **Targets** (at least one is required):
+  - devices: Array of device IDs.
+  - device_groups: Array of device group IDs.
+  - locations: Array of location IDs.
+
+Example (non-recurring):
+
+```curl
+curl -X POST -d '{"title":"Planned maintenance","notes":"Monthly maintenance window","devices":[1,2],"start":"2026-03-17 00:00:00","end":"2026-03-17 06:00:00"}' -H 'X-Auth-Token: YOURAPITOKENHERE' https://foo.example/api/v0/alerts/scheduled_maintenance
+```
+
+Example (recurring):
+
+```curl
+curl -X POST -d '{"title":"Weekly maintenance","recurring":true,"start_recurring_dt":"2026-03-17","start_recurring_hr":"22:00","end_recurring_hr":"06:00","recurring_day":["Mo","Tu","We","Th","Fr"],"device_groups":[1]}' -H 'X-Auth-Token: YOURAPITOKENHERE' https://foo.example/api/v0/alerts/scheduled_maintenance
+```
+
+Output:
+
+```json
+{
+  "status": "ok",
+  "message": "Scheduled maintenance created",
+  "schedule_id": 1
+}
+```
+
+### `delete_scheduled_maintenance`
+
+Delete an alert maintenance schedule.
+
+Route: `/api/v0/alerts/scheduled_maintenance/:id`
+
+- id is the scheduled maintenance id, obtainable from [`list_scheduled_maintenance`](#list_scheduled_maintenance).
+
+Input:
+
+  -
+
+Example:
+
+```curl
+curl -X DELETE -H 'X-Auth-Token: YOURAPITOKENHERE' https://foo.example/api/v0/alerts/scheduled_maintenance/1
+```
+
+Output:
+
+```json
+{
+  "status": "ok",
+  "message": "Scheduled maintenance deleted"
+}
+```
+
 ## Alert templates
 
 ### `get_alert_template`

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -15,6 +15,7 @@
 use App\Actions\Device\ValidateDeviceAndCreate;
 use App\Facades\DeviceCache;
 use App\Facades\LibrenmsConfig;
+use App\Models\AlertSchedule;
 use App\Models\AlertTemplate;
 use App\Models\AlertTemplateMap;
 use App\Models\Availability;
@@ -1533,6 +1534,136 @@ function add_edit_alert_template(Illuminate\Http\Request $request)
     }
 
     return response()->json($response, 200, [], JSON_PRETTY_PRINT);
+}
+
+function list_scheduled_maintenance(): JsonResponse
+{
+    $maintenceSchedules = AlertSchedule::all();
+    $alertSchedules = [];
+    foreach ($maintenceSchedules as $maintenceSchedule) {
+        $alertSchedule = $maintenceSchedule->attributesToArray();
+        $alertSchedule['devices'] = $maintenceSchedule->devices->pluck('device_id')->toArray();
+        $alertSchedule['device_groups'] = $maintenceSchedule->deviceGroups->pluck('id')->toArray();
+        $alertSchedule['locations'] = $maintenceSchedule->locations->pluck('id')->toArray();
+        array_push($alertSchedules, $alertSchedule);
+    }
+
+    return api_success($alertSchedules, 'schedule');
+}
+
+function get_scheduled_maintenance(Illuminate\Http\Request $request): JsonResponse
+{
+    $id = $request->route('id');
+
+    $maintenceSchedule = AlertSchedule::find($id);
+
+    if (! $maintenceSchedule) {
+        return api_error(404, 'Scheduled maintenance not found');
+    }
+
+    if (! $maintenceSchedule->recurring) {
+        $maintenceSchedule
+            ->makeHidden('start_recurring_dt')
+            ->makeHidden('start_recurring_hr')
+            ->makeHidden('end_recurring_dt')
+            ->makeHidden('end_recurring_hr')
+            ->makeHidden('recurring_day');
+    }
+
+    $alertSchedule = $maintenceSchedule->attributesToArray();
+    $alertSchedule['devices'] = $maintenceSchedule->devices->pluck('device_id')->toArray();
+    $alertSchedule['device_groups'] = $maintenceSchedule->deviceGroups->pluck('id')->toArray();
+    $alertSchedule['locations'] = $maintenceSchedule->locations->pluck('id')->toArray();
+
+    return api_success($alertSchedule, 'schedule');
+}
+
+function add_scheduled_maintenance(Illuminate\Http\Request $request): JsonResponse
+{
+    $data = json_decode($request->getContent(), true);
+    if (json_last_error() || ! is_array($data)) {
+        return api_error(400, "We couldn't parse the provided json. " . json_last_error_msg());
+    }
+
+    $rules = [
+        'title' => 'required|string',
+        'notes' => 'nullable|string',
+        'behavior' => 'nullable|integer|in:1,2,3',
+        'recurring' => 'boolean',
+        'start' => 'required_if:recurring,0|nullable|date_format:Y-m-d H:i:s',
+        'end' => 'required_if:recurring,0|nullable|date_format:Y-m-d H:i:s|after:start',
+        'start_recurring_dt' => 'required_if:recurring,1|nullable|date_format:Y-m-d',
+        'start_recurring_hr' => 'required_if:recurring,1|nullable|date_format:H:i',
+        'end_recurring_hr' => 'required_if:recurring,1|nullable|date_format:H:i',
+        'end_recurring_dt' => 'required_if:recurring,1|nullable|date_format:Y-m-d|after_or_equal:start_recurring_dt',
+        'recurring_day' => 'required_if:recurring,1|nullable|array',
+        'recurring_day.*' => 'in:Mo,Tu,We,Th,Fr,Sa,Su',
+        'devices' => 'nullable|array',
+        'devices.*' => 'integer',
+        'device_groups' => 'nullable|array',
+        'device_groups.*' => 'integer',
+        'locations' => 'nullable|array',
+        'locations.*' => 'integer',
+    ];
+
+    $v = Validator::make($data, $rules);
+    if ($v->fails()) {
+        return api_error(422, $v->messages());
+    }
+
+    $recurring = (bool) ($data['recurring'] ?? false);
+
+    if (empty($data['devices']) && empty($data['device_groups']) && empty($data['locations'])) {
+        return api_error(422, 'At least one device, device_group, or location is required');
+    }
+
+    $alertSchedule = new AlertSchedule($v->safe()->only(['title', 'notes', 'recurring', 'behavior']));
+
+    if ($recurring) {
+        $alertSchedule->start_recurring_dt = $data['start_recurring_dt'];
+        $alertSchedule->start_recurring_hr = $data['start_recurring_hr'];
+        $alertSchedule->end_recurring_dt = $data['end_recurring_dt'];
+        $alertSchedule->end_recurring_hr = $data['end_recurring_hr'];
+        if (! empty($data['recurring_day'])) {
+            $day_map = ['Mo' => 1, 'Tu' => 2, 'We' => 3, 'Th' => 4, 'Fr' => 5, 'Sa' => 6, 'Su' => 7];
+            $alertSchedule->recurring_day = array_map(fn ($d) => $day_map[$d], $data['recurring_day']);
+        }
+    } else {
+        $alertSchedule->start = \Carbon\Carbon::createFromFormat('Y-m-d H:i:s', $data['start']);
+        $alertSchedule->end = \Carbon\Carbon::createFromFormat('Y-m-d H:i:s', $data['end']);
+    }
+
+    $alertSchedule->save();
+
+    $alertSchedule->devices()->sync($data['devices'] ?? []);
+    $alertSchedule->deviceGroups()->sync($data['device_groups'] ?? []);
+    $alertSchedule->locations()->sync($data['locations'] ?? []);
+
+    return api_success(
+        $alertSchedule->schedule_id,
+        'schedule_id',
+        'Scheduled maintenance created',
+        201,
+    );
+}
+
+function delete_scheduled_maintenance(Illuminate\Http\Request $request): JsonResponse
+{
+    $scheduleId = $request->route('id');
+
+    $alertSchedule = AlertSchedule::find($scheduleId);
+
+    if (! $alertSchedule) {
+        return api_error(404, 'Scheduled maintenance not found');
+    }
+
+    $deleted = $alertSchedule->delete();
+
+    if (! $deleted) {
+        return api_error(500, 'Scheduled maintenance could not be removed');
+    }
+
+    return api_success_noresult(200, 'Scheduled maintenance removed');
 }
 
 /**

--- a/routes/api.php
+++ b/routes/api.php
@@ -35,6 +35,8 @@ Route::prefix('v0')->group(function (): void {
         Route::get('port_groups/{name}', [App\Api\Controllers\LegacyApiController::class, 'get_ports_by_group'])->name('get_ports_by_group');
         Route::get('portgroups/multiport/bits/{id}', [App\Api\Controllers\LegacyApiController::class, 'get_graph_by_portgroup'])->name('get_graph_by_portgroup_multiport_bits');
         Route::get('portgroups/{group}', [App\Api\Controllers\LegacyApiController::class, 'get_graph_by_portgroup'])->name('get_graph_by_portgroup');
+        Route::get('alerts/scheduled_maintenance', [\App\Api\Controllers\LegacyApiController::class, 'list_scheduled_maintenance'])->name('list_scheduled_maintenance');
+        Route::get('alerts/scheduled_maintenance/{id}', [\App\Api\Controllers\LegacyApiController::class, 'get_scheduled_maintenance'])->name('get_scheduled_maintenance');
         Route::get('alerts/{id}', [App\Api\Controllers\LegacyApiController::class, 'list_alerts'])->name('get_alert');
         Route::get('alerts', [App\Api\Controllers\LegacyApiController::class, 'list_alerts'])->name('list_alerts');
         Route::get('rules/{id}', [App\Api\Controllers\LegacyApiController::class, 'list_alert_rules'])->name('get_alert_rule');
@@ -86,6 +88,8 @@ Route::prefix('v0')->group(function (): void {
         Route::delete('bills/{bill_id}', [App\Api\Controllers\LegacyApiController::class, 'delete_bill'])->name('delete_bill');
         Route::put('alerts/{id}', [App\Api\Controllers\LegacyApiController::class, 'ack_alert'])->name('ack_alert');
         Route::put('alerts/unmute/{id}', [App\Api\Controllers\LegacyApiController::class, 'unmute_alert'])->name('unmute_alert');
+        Route::post('alerts/scheduled_maintenance', [\App\Api\Controllers\LegacyApiController::class, 'add_scheduled_maintenance'])->name('add_scheduled_maintenance');
+        Route::delete('alerts/scheduled_maintenance/{id}', [\App\Api\Controllers\LegacyApiController::class, 'delete_scheduled_maintenance'])->name('delete_scheduled_maintenance');
         Route::post('alert_templates', [App\Api\Controllers\LegacyApiController::class, 'add_edit_alert_template'])->name('add_alert_template');
         Route::put('alert_templates', [App\Api\Controllers\LegacyApiController::class, 'add_edit_alert_template'])->name('edit_alert_template');
         // Route::delete('alert_templates/{id}', [App\Api\Controllers\LegacyApiController::class, 'delete_alert_template'])->name('delete_alert_template');


### PR DESCRIPTION
Provides API endpoints to create, view and delete scheduled maintenances

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.

