### PR TITLE
Remove options method from SnmpQuery interface

### DIFF
--- a/LibreNMS/Data/Source/NetSnmpQuery.php
+++ b/LibreNMS/Data/Source/NetSnmpQuery.php
@@ -243,20 +243,53 @@ class NetSnmpQuery implements SnmpQueryInterface
     }
 
     /**
-     * Set option(s) for net-snmp command line. Overrides the default options.
-     * Some options may break parsing, but you can manually parse the raw output if needed.
-     * This will override other options set such as setting numeric.
-     * Calling with null will reset to the default options (-OQXUte).
-     * Try to avoid setting options this way to keep the API generic.
-     *
-     * @param  array|string|null  $options
-     * @return $this
+     * Default timeticks output
      */
-    public function options($options = []): SnmpQueryInterface
+    public function defaultTimeticks(): SnmpQueryInterface
     {
-        $this->options = $options !== null
-            ? Arr::wrap($options)
-            : [self::DEFAULT_FLAGS];
+        // remove -Ot from the default flags
+        if (isset($this->options[0]) && Str::contains($this->options[0], 't')) {
+            $this->options[0] = str_replace('t', '', $this->options[0]);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Enable printing units
+     */
+    public function printUnits(): SnmpQueryInterface
+    {
+        // remove -OU from the default flags
+        if (isset($this->options[0]) && Str::contains($this->options[0], 'U')) {
+            $this->options[0] = str_replace('U', '', $this->options[0]);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Disable extended index output
+     */
+    public function noExtendedIndex(): SnmpQueryInterface
+    {
+        // remove -OX from the default flags
+        if (isset($this->options[0]) && Str::contains($this->options[0], 'X')) {
+            $this->options[0] = str_replace('X', '', $this->options[0]);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Disable quick print output
+     */
+    public function noQuickPrint(): SnmpQueryInterface
+    {
+        // remove -OQ from the default flags
+        if (isset($this->options[0]) && Str::contains($this->options[0], 'Q')) {
+            $this->options[0] = str_replace('Q', '', $this->options[0]);
+        }
 
         return $this;
     }

--- a/LibreNMS/Data/Source/NetSnmpQuery.php
+++ b/LibreNMS/Data/Source/NetSnmpQuery.php
@@ -230,6 +230,16 @@ class NetSnmpQuery implements SnmpQueryInterface
     }
 
     /**
+     * RandomLookup
+     */
+    public function randomLookup(): SnmpQueryInterface
+    {
+        $this->options = array_merge($this->options, ['-IR']);
+
+        return $this;
+    }
+
+    /**
      * Output enum values as strings instead of values. This could affect index output.
      */
     public function enumStrings(): SnmpQueryInterface

--- a/LibreNMS/Data/Source/NetSnmpQuery.php
+++ b/LibreNMS/Data/Source/NetSnmpQuery.php
@@ -230,16 +230,6 @@ class NetSnmpQuery implements SnmpQueryInterface
     }
 
     /**
-     * RandomLookup
-     */
-    public function randomLookup(): SnmpQueryInterface
-    {
-        $this->options = array_merge($this->options, ['-IR']);
-
-        return $this;
-    }
-
-    /**
      * Output enum values as strings instead of values. This could affect index output.
      */
     public function enumStrings(): SnmpQueryInterface

--- a/LibreNMS/Data/Source/NetSnmpQuery.php
+++ b/LibreNMS/Data/Source/NetSnmpQuery.php
@@ -41,7 +41,7 @@ use LibreNMS\Util\Rewrite;
 use Log;
 use Symfony\Component\Process\Process;
 
-class NetSnmpQuery implements SnmpQueryInterface
+class NetSnmpQuery extends SnmpQueryBase implements SnmpQueryInterface
 {
     private const DEFAULT_FLAGS = '-OQXUte';
 

--- a/LibreNMS/Data/Source/SnmpQueryBase.php
+++ b/LibreNMS/Data/Source/SnmpQueryBase.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * SnmpQueryBase.php
+ *
+ * -Description-
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @package    LibreNMS
+ * @link       http://librenms.org
+ * @copyright  2026 Steven Wilton
+ * @author     Steven Wilton <swilton@fluentit.au>
+ */
+
+namespace LibreNMS\Data\Source;
+
+use App\Models\Device;
+
+class SnmpQueryBase
+{
+    /**
+     * Parse SNMP options
+     */
+    public function parseOptions(array $options): SnmpQueryInterface
+    {
+        foreach ($options as $option) {
+            $this->parseOption($option);
+        }
+
+        return $this;
+    }
+
+    private function parseOption(string $option): SnmpQueryInterface
+    {
+        return match ($option) {
+            'noExtendedIndex' => $this->noExtendedIndex(),
+            'enumStrings' => $this->enumStrings(),
+            default => throw new \Exception("parseOption() does not recognise $option as a valid SNMP option"),
+        };
+    }
+}

--- a/LibreNMS/Data/Source/SnmpQueryInterface.php
+++ b/LibreNMS/Data/Source/SnmpQueryInterface.php
@@ -98,6 +98,11 @@ interface SnmpQueryInterface
     public function hideMib(): SnmpQueryInterface;
 
     /**
+     * Enable "random lookup" for MIBs
+     */
+    public function randomLookup(): SnmpQueryInterface;
+
+    /**
      * Output enum values as strings instead of values. This could affect index output.
      */
     public function enumStrings(): SnmpQueryInterface;

--- a/LibreNMS/Data/Source/SnmpQueryInterface.php
+++ b/LibreNMS/Data/Source/SnmpQueryInterface.php
@@ -98,11 +98,6 @@ interface SnmpQueryInterface
     public function hideMib(): SnmpQueryInterface;
 
     /**
-     * Enable "random lookup" for MIBs
-     */
-    public function randomLookup(): SnmpQueryInterface;
-
-    /**
      * Output enum values as strings instead of values. This could affect index output.
      */
     public function enumStrings(): SnmpQueryInterface;

--- a/LibreNMS/Data/Source/SnmpQueryInterface.php
+++ b/LibreNMS/Data/Source/SnmpQueryInterface.php
@@ -103,15 +103,24 @@ interface SnmpQueryInterface
     public function enumStrings(): SnmpQueryInterface;
 
     /**
-     * Set option(s) for net-snmp command line.
-     * Some options may break parsing, but you can manually parse the raw output if needed.
-     * This will override other options set such as setting numeric.  Call with no options to reset to default.
-     * Try to avoid setting options this way to keep the API generic.
-     *
-     * @param  array|string|null  $options
-     * @return $this
+     * Default timeticks output
      */
-    public function options($options = []): SnmpQueryInterface;
+    public function defaultTimeticks(): SnmpQueryInterface;
+
+    /**
+     * Enable printing units
+     */
+    public function printUnits(): SnmpQueryInterface;
+
+    /**
+     * Disable extended index output
+     */
+    public function noExtendedIndex(): SnmpQueryInterface;
+
+    /**
+     * Disable quick print output
+     */
+    public function noQuickPrint(): SnmpQueryInterface;
 
     /**
      * snmpget an OID

--- a/LibreNMS/Data/Source/SnmpQueryInterface.php
+++ b/LibreNMS/Data/Source/SnmpQueryInterface.php
@@ -154,4 +154,9 @@ interface SnmpQueryInterface
      * Call numeric method prior output numeric OID.
      */
     public function translate(string $oid): string;
+
+    /**
+     * Parse SNMP options
+     */
+    public function parseOptions(array $options): SnmpQueryInterface;
 }

--- a/LibreNMS/Discovery/YamlDiscoveryDefinition.php
+++ b/LibreNMS/Discovery/YamlDiscoveryDefinition.php
@@ -117,7 +117,10 @@ class YamlDiscoveryDefinition
             $snmp_data = [];
             if (! empty($numeric_oids)) {
                 $snmpQuery = SnmpQuery::numeric();
-                if (isset($yamlItem['snmp_flags'])) {
+                if (isset($yamlItem['snmp_options'])) {
+                    $snmpQuery = $snmpQuery->parseOptions($yamlItem['snmp_options']);
+                } elseif (isset($yamlItem['snmp_flags'])) {
+                    // TODO: Remove once everything is converted to snmp_options
                     $snmpQuery->options($yamlItem['snmp_flags']);
                 }
                 $snmp_data = $snmpQuery->get($numeric_oids)->values();
@@ -126,7 +129,10 @@ class YamlDiscoveryDefinition
 
             if (! empty($oids)) {
                 $snmpQuery = SnmpQuery::enumStrings()->numericIndex();
-                if (isset($yamlItem['snmp_flags'])) {
+                if (isset($yamlItem['snmp_options'])) {
+                    $snmpQuery = $snmpQuery->parseOptions($yamlItem['snmp_options']);
+                } elseif (isset($yamlItem['snmp_flags'])) {
+                    // TODO: Remove once everything is converted to snmp_options
                     $snmpQuery->options($yamlItem['snmp_flags']);
                 }
                 $response = $snmpQuery->walk($oids);
@@ -186,7 +192,10 @@ class YamlDiscoveryDefinition
 
         $query = SnmpQuery::enumStrings()->numericIndex();
 
-        if (isset($data['snmp_flags'])) {
+        if (isset($yamlItem['snmp_options'])) {
+            $query = $query->parseOptions($yamlItem['snmp_options']);
+        } elseif (isset($data['snmp_flags'])) {
+            // TODO: Remove once everything is converted to snmp_options
             $query->options($data['snmp_flags']);
         }
 

--- a/LibreNMS/Modules/Core.php
+++ b/LibreNMS/Modules/Core.php
@@ -240,7 +240,6 @@ class Core implements Module
                 }
             } elseif ($key == 'snmpget') {
                 $get_value = SnmpQuery::device($device)
-                    ->options($value['options'] ?? null)
                     ->mibDir($value['mib_dir'] ?? $mibdir)
                     ->get($value['oid'])
                     ->value();
@@ -249,7 +248,6 @@ class Core implements Module
                 }
             } elseif ($key == 'snmpwalk') {
                 $walk_value = SnmpQuery::device($device)
-                    ->options($value['options'] ?? null)
                     ->mibDir($value['mib_dir'] ?? $mibdir)
                     ->walk($value['oid'])
                     ->raw;

--- a/LibreNMS/Util/ModuleTestHelper.php
+++ b/LibreNMS/Util/ModuleTestHelper.php
@@ -152,11 +152,11 @@ class ModuleTestHelper
                 $this->qPrint(' ' . $oid_data['oid']);
 
                 if ($oid_data['method'] == 'walk') {
-                    $data = \SnmpQuery::context($context)->numericIndex()->numeric()->noQuickPrint()->noExtendedIndex()->defaultTimeticks()->mib($oid_data['mib'])->mibDir($oid_data['mibdir'] ?? null)->walk($oid_data['oid']);
+                    $data = \SnmpQuery::context($context)->numericIndex()->numeric()->noQuickPrint()->noExtendedIndex()->defaultTimeticks()->mibs([$oid_data['mib']])->mibDir($oid_data['mibdir'] ?? null)->walk($oid_data['oid']);
                 } elseif ($oid_data['method'] == 'get') {
-                    $data = \SnmpQuery::context($context)->numericIndex()->numeric()->noQuickPrint()->noExtendedIndex()->defaultTimeticks()->mib($oid_data['mib'])->mibDir($oid_data['mibdir'] ?? null)->get($oid_data['oid']);
+                    $data = \SnmpQuery::context($context)->numericIndex()->numeric()->noQuickPrint()->noExtendedIndex()->defaultTimeticks()->mibs([$oid_data['mib']])->mibDir($oid_data['mibdir'] ?? null)->get($oid_data['oid']);
                 } elseif ($oid_data['method'] == 'getnext') {
-                    $data = \SnmpQuery::context($context)->numericIndex()->numeric()->noQuickPrint()->noExtendedIndex()->defaultTimeticks()->mib($oid_data['mib'])->mibDir($oid_data['mibdir'] ?? null)->next($oid_data['oid']);
+                    $data = \SnmpQuery::context($context)->numericIndex()->numeric()->noQuickPrint()->noExtendedIndex()->defaultTimeticks()->mibs([$oid_data['mib']])->mibDir($oid_data['mibdir'] ?? null)->next($oid_data['oid']);
                 }
 
                 if (isset($data) && $data->getExitCode() === 0) {

--- a/LibreNMS/Util/ModuleTestHelper.php
+++ b/LibreNMS/Util/ModuleTestHelper.php
@@ -151,13 +151,12 @@ class ModuleTestHelper
             foreach ($context_oids as $oid_data) {
                 $this->qPrint(' ' . $oid_data['oid']);
 
-                $snmp_options = ['-OUneb', '-Ih', '-m', '+' . $oid_data['mib']];
                 if ($oid_data['method'] == 'walk') {
-                    $data = \SnmpQuery::options($snmp_options)->context($context)->mibDir($oid_data['mibdir'] ?? null)->walk($oid_data['oid']);
+                    $data = \SnmpQuery::context($context)->numericIndex()->numeric()->noQuickPrint()->noExtendedIndex()->defaultTimeticks()->mib($oid_data['mib'])->mibDir($oid_data['mibdir'] ?? null)->walk($oid_data['oid']);
                 } elseif ($oid_data['method'] == 'get') {
-                    $data = \SnmpQuery::options($snmp_options)->context($context)->mibDir($oid_data['mibdir'] ?? null)->get($oid_data['oid']);
+                    $data = \SnmpQuery::context($context)->numericIndex()->numeric()->noQuickPrint()->noExtendedIndex()->defaultTimeticks()->mib($oid_data['mib'])->mibDir($oid_data['mibdir'] ?? null)->get($oid_data['oid']);
                 } elseif ($oid_data['method'] == 'getnext') {
-                    $data = \SnmpQuery::options($snmp_options)->context($context)->mibDir($oid_data['mibdir'] ?? null)->next($oid_data['oid']);
+                    $data = \SnmpQuery::context($context)->numericIndex()->numeric()->noQuickPrint()->noExtendedIndex()->defaultTimeticks()->mib($oid_data['mib'])->mibDir($oid_data['mibdir'] ?? null)->next($oid_data['oid']);
                 }
 
                 if (isset($data) && $data->getExitCode() === 0) {

--- a/includes/discovery/sensors/pre-cache/infinera-groove.inc.php
+++ b/includes/discovery/sensors/pre-cache/infinera-groove.inc.php
@@ -27,16 +27,16 @@ if (! isset($pre_cache['infineragroove_portTable']) || ! is_array($pre_cache['in
     echo 'Caching OIDs:';
     $pre_cache['infineragroove_portTable'] = [];
     echo ' portTable';
-    $portTable = SnmpQuery::options('-OQ')->numericIndex()->hideMib()->walk('CORIANT-GROOVE-MIB::portTable')->valuesByIndex();
+    $portTable = SnmpQuery::printUnits()->noExtendedIndex()->defaultTimeticks()->enumStrings()->numericIndex()->hideMib()->walk('CORIANT-GROOVE-MIB::portTable')->valuesByIndex();
     $pre_cache['infineragroove_portTable'] = array_merge_recursive($pre_cache['infineragroove_portTable'], $portTable);
     echo ' OchOsTable';
-    $OchOsTable = SnmpQuery::options('-OQ')->numericIndex()->hideMib()->walk('CORIANT-GROOVE-MIB::ochOsTable')->valuesByIndex();
+    $OchOsTable = SnmpQuery::printUnits()->noExtendedIndex()->defaultTimeticks()->enumStrings()->numericIndex()->hideMib()->walk('CORIANT-GROOVE-MIB::ochOsTable')->valuesByIndex();
     $pre_cache['infineragroove_portTable'] = array_merge_recursive($pre_cache['infineragroove_portTable'], $OchOsTable);
     echo ' bitErrorRatePostFecTable';
-    $bitErrorRatePostFecTable = SnmpQuery::options('-OQ')->numericIndex()->hideMib()->walk('CORIANT-GROOVE-MIB::bitErrorRatePostFecTable')->valuesByIndex();
+    $bitErrorRatePostFecTable = SnmpQuery::printUnits()->noExtendedIndex()->defaultTimeticks()->enumStrings()->numericIndex()->hideMib()->walk('CORIANT-GROOVE-MIB::bitErrorRatePostFecTable')->valuesByIndex();
     $pre_cache['infineragroove_portTable'] = array_merge_recursive($pre_cache['infineragroove_portTable'], $bitErrorRatePostFecTable);
     echo ' bitErrorRatePreFecTable';
-    $bitErrorRatePreFecTable = SnmpQuery::options('-OQ')->numericIndex()->hideMib()->walk('CORIANT-GROOVE-MIB::bitErrorRatePreFecTable')->valuesByIndex();
+    $bitErrorRatePreFecTable = SnmpQuery::printUnits()->noExtendedIndex()->defaultTimeticks()->enumStrings()->numericIndex()->hideMib()->walk('CORIANT-GROOVE-MIB::bitErrorRatePreFecTable')->valuesByIndex();
     $pre_cache['infineragroove_portTable'] = array_merge_recursive($pre_cache['infineragroove_portTable'], $bitErrorRatePreFecTable);
 }
 
@@ -56,9 +56,9 @@ foreach (array_keys($pre_cache['infineragroove_portTable']) as $index) {
 if (! isset($pre_cache['infineragroove_slotTable']) || ! is_array($pre_cache['infineragroove_slotTable'])) {
     $pre_cache['infineragroove_slotTable'] = [];
     echo ' slotTable';
-    $slotTable = SnmpQuery::options('-OQ')->numericIndex()->hideMib()->walk('CORIANT-GROOVE-MIB::slotTable')->valuesByIndex();
+    $slotTable = SnmpQuery::printUnits()->noExtendedIndex()->defaultTimeticks()->enumStrings()->numericIndex()->hideMib()->walk('CORIANT-GROOVE-MIB::slotTable')->valuesByIndex();
     $pre_cache['infineragroove_slotTable'] = array_merge_recursive($pre_cache['infineragroove_slotTable'], $slotTable);
     echo ' cardTable';
-    $cardTable = SnmpQuery::options('-OQ')->numericIndex()->hideMib()->walk('CORIANT-GROOVE-MIB::cardTable')->valuesByIndex();
+    $cardTable = SnmpQuery::printUnits()->noExtendedIndex()->defaultTimeticks()->enumStrings()->numericIndex()->hideMib()->walk('CORIANT-GROOVE-MIB::cardTable')->valuesByIndex();
     $pre_cache['infineragroove_slotTable'] = array_merge_recursive($pre_cache['infineragroove_slotTable'], $cardTable);
 }

--- a/includes/polling/ports/os/nokia-isam.inc.php
+++ b/includes/polling/ports/os/nokia-isam.inc.php
@@ -36,13 +36,12 @@ $hc_test = array_slice($port_stats, 0, 1);
 
 // If the device doesn't have ifXentry data, fetch ifEntry instead.
 if (! is_numeric($hc_test[0]['ifHCInOctets'] ?? null) || ! is_numeric($hc_test[0]['ifHighSpeed'] ?? null)) {
-    $ifEntrySnmpFlags = ['-OQUst'];
-    SnmpQuery::options($ifEntrySnmpFlags)->context('ihub')->hideMib()->walk(['IF-MIB::ifEntry'])->table(1, $port_stats);
+    SnmpQuery::context('ihub')->noExtendedIndex()->enumStrings()->hideMib()->walk(['IF-MIB::ifEntry'])->table(1, $port_stats);
 } else {
     // For devices with ifXentry data, only specific ifEntry keys are fetched to reduce SNMP load
     foreach ($ifmib_oids as $oid) {
         echo "$oid ";
-        SnmpQuery::options('-OQUst')->context('ihub')->hideMib()->walk(['IF-MIB::' . $oid])->table(1, $port_stats);
+        SnmpQuery::context('ihub')->noExtendedIndex()->enumStrings()->hideMib()->walk(['IF-MIB::' . $oid])->table(1, $port_stats);
     }
 }
 

--- a/resources/definitions/os_discovery/hpe-ilo.yaml
+++ b/resources/definitions/os_discovery/hpe-ilo.yaml
@@ -44,7 +44,8 @@ modules:
                     oid: CPQHLTH-MIB::cpqHeTemperatureTable
                     value: CPQHLTH-MIB::cpqHeTemperatureCelsius
                     num_oid: '.1.3.6.1.4.1.232.6.2.6.8.1.4.{{ $index }}'
-                    snmp_flags: '-OtQUSab'
+                    snmp_options: ['enumStrings', 'noExtendedIndex']
+                    snmp_flags: ['-OQUt']
                     index: 'cpqHeTemperatureCelsius.{{ $index }}'
                     descr: CPQHLTH-MIB::cpqHeTemperatureLocale
                     high_limit: '90' #cpqHeTemperatureThreshold

--- a/resources/definitions/schema/discovery_schema.json
+++ b/resources/definitions/schema/discovery_schema.json
@@ -167,6 +167,11 @@
                                     "warn_percent": {
                                         "type": "string"
                                     },
+                                    "snmp_options": {
+                                        "type": [
+                                            "array"
+                                        ]
+                                    },
                                     "snmp_flags": {
                                         "type": [
                                             "string",
@@ -271,6 +276,11 @@
                                             },
                                             "skip_values": {
                                                 "$ref": "#/$defs/skip_values"
+                                            },
+                                            "snmp_options": {
+                                                "type": [
+                                                    "array"
+                                                ]
                                             },
                                             "snmp_flags": {
                                                 "type": [
@@ -427,6 +437,11 @@
             "type": "object",
             "properties": {
                 "oids": {"$ref": "#/$defs/oids"},
+                "snmp_options": {
+                    "type": [
+                        "array"
+                    ]
+                },
                 "snmp_flags": {
                     "type": [
                         "string",
@@ -451,6 +466,11 @@
                         "type": "object",
                         "properties": {
                             "oid": {"$ref": "#/$defs/oids"},
+                            "snmp_options": {
+                                "type": [
+                                    "array"
+                                ]
+                            },
                             "snmp_flags": {
                                 "type": [
                                     "string",
@@ -519,6 +539,11 @@
                             },
                             "skip_values": {
                                 "$ref": "#/$defs/skip_values"
+                            },
+                            "snmp_options": {
+                                "type": [
+                                    "array"
+                                ]
                             },
                             "snmp_flags": {
                                 "type": [

--- a/tests/Mocks/SnmpQueryMock.php
+++ b/tests/Mocks/SnmpQueryMock.php
@@ -47,7 +47,6 @@ class SnmpQueryMock implements SnmpQueryInterface
     private array $mibs = [];
     private bool $numeric = false;
     private bool $hideMib = false;
-    private array $options = [];
     private bool $abort = false;
 
     public function __construct()
@@ -179,8 +178,6 @@ class SnmpQueryMock implements SnmpQueryInterface
 
     public function options($options = []): SnmpQueryInterface
     {
-        $this->options = $options === null ? [] : Arr::wrap($options);
-
         return $this;
     }
 

--- a/tests/Mocks/SnmpQueryMock.php
+++ b/tests/Mocks/SnmpQueryMock.php
@@ -384,7 +384,7 @@ class SnmpQueryMock implements SnmpQueryInterface
             throw new Exception('Could not translate oid: ' . $oid . PHP_EOL);
         }
 
-        return ltrim($number, '.');
+        return ltrim((string) $number, '.');
     }
 
     private function community(): string

--- a/tests/Mocks/SnmpQueryMock.php
+++ b/tests/Mocks/SnmpQueryMock.php
@@ -376,7 +376,7 @@ class SnmpQueryMock implements SnmpQueryInterface
 
         $number = NetSnmpQuery::make()->mibDir($this->mibDir)
             ->mibs($this->mibs)
-            ->randomLookup()->numeric()->translate($oid);
+            ->numeric()->translate($oid);
 
         if (empty($number)) {
             throw new Exception('Could not translate oid: ' . $oid . PHP_EOL);

--- a/tests/Mocks/SnmpQueryMock.php
+++ b/tests/Mocks/SnmpQueryMock.php
@@ -374,11 +374,9 @@ class SnmpQueryMock implements SnmpQueryInterface
             return ltrim($oid, '.');
         }
 
-        $options = ['-IR'];
-
         $number = NetSnmpQuery::make()->mibDir($this->mibDir)
             ->mibs($this->mibs)
-            ->options(array_merge($options, $this->options))->numeric()->translate($oid);
+            ->randomLookup()->numeric()->translate($oid);
 
         if (empty($number)) {
             throw new Exception('Could not translate oid: ' . $oid . PHP_EOL);

--- a/tests/Mocks/SnmpQueryMock.php
+++ b/tests/Mocks/SnmpQueryMock.php
@@ -89,19 +89,18 @@ class SnmpQueryMock implements SnmpQueryInterface
     public function translate(string $oid): string
     {
         // call real snmptranslate
-        $options = $this->options;
+        $snmp = NetSnmpQuery::make()
+            ->mibDir($this->mibDir)
+            ->mibs($this->mibs);
+
         if ($this->numeric) {
-            $options[] = '-On';
+            $snmp = $snmp->numeric();
         }
         if ($this->hideMib) {
-            $options[] = '-Os';
+            $snmp = $snmp->hideMib();
         }
 
-        return NetSnmpQuery::make()
-            ->mibDir($this->mibDir)
-            ->mibs($this->mibs)
-            ->options($options)
-            ->translate($oid);
+        return $snmp->translate($oid);
     }
 
     public function abortOnFailure(): SnmpQueryInterface
@@ -142,6 +141,38 @@ class SnmpQueryMock implements SnmpQueryInterface
     {
         // TODO: Implement enumStrings() method, no idea how
         Log::error('enumStrings not implemented in SnmpQueryMock');
+
+        return $this;
+    }
+
+    public function defaultTimeticks(): SnmpQueryInterface
+    {
+        // TODO: Implement defaultTimeticks() method, no idea how
+        Log::error('defaultTimeticks not implemented in SnmpQueryMock');
+
+        return $this;
+    }
+
+    public function noExtendedIndex(): SnmpQueryInterface
+    {
+        // TODO: Implement noExtendedIndex() method, no idea how
+        Log::error('noExtendedIndex not implemented in SnmpQueryMock');
+
+        return $this;
+    }
+
+    public function noQuickPrint(): SnmpQueryInterface
+    {
+        // TODO: Implement noQuickPrint() method, no idea how
+        Log::error('noQuickPrint not implemented in SnmpQueryMock');
+
+        return $this;
+    }
+
+    public function printUnits(): SnmpQueryInterface
+    {
+        // TODO: Implement printUnits() method, no idea how
+        Log::error('printUnits not implemented in SnmpQueryMock');
 
         return $this;
     }


### PR DESCRIPTION
The options method in the SnmpQuery interface is quite specific to the NetSnmp implementation.  This PR removes the options method and adds new methods to remove specific default options one at a time.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.

