### PR TITLE
Fix bridge FDB discovery TypeError when dot1dBasePort is an array (#19248)

### DIFF
--- a/includes/discovery/fdb-table/bridge.inc.php
+++ b/includes/discovery/fdb-table/bridge.inc.php
@@ -77,7 +77,25 @@ if (! empty($fdbPort_table)) {
         // device VLANs table should catch anything invalid.
         $vlan = $vlan_fdb_dict[$vlanIndex] ?? $vlanIndex;
 
-        foreach ($data[$data_oid] ?? [] as $mac => $dot1dBasePort) {
+        // Some SNMP agents (arubaos-cx, comtrol) prepend a length byte to
+        // MacAddress indexes, encoding 7 bytes instead of 6.  With -OX the
+        // last octet spills out of the bracket into a nested array level:
+        //   dot1dTpFdbPort[6:0:a:f7:ec:d1].97 = 10
+        //   → key '6:0:a:f7:ec:d1', value ['97' => '10']
+        // Strip the length prefix, append the spilled octet (decimal → hex).
+        $fdb_entries = $data[$data_oid] ?? [];
+        foreach ($fdb_entries as $mac => $dot1dBasePort) {
+            if (is_array($dot1dBasePort)) {
+                unset($fdb_entries[$mac]);
+                $octets = explode(':', (string) $mac);
+                array_shift($octets); // drop length prefix byte
+                foreach ($dot1dBasePort as $spilled_octet => $port) {
+                    $fdb_entries[implode(':', [...$octets, dechex((int) $spilled_octet)])] = $port;
+                }
+            }
+        }
+
+        foreach ($fdb_entries as $mac => $dot1dBasePort) {
             if ($dot1dBasePort == 0) {
                 Log::debug("No port known for $mac\n");
                 continue;


### PR DESCRIPTION
Some SNMP agents (arubaos-cx, comtrol) prepend a length byte to MacAddress indexes in dot1dTpFdbPort / dot1qTpFdbPort.  The MIB defines the index as OCTET STRING SIZE 6, but these agents encode 7 bytes: 0x06 (length) + 6 MAC octets.  With snmpwalk -OX this renders as e.g.:

  dot1dTpFdbPort[6:0:a:f7:ec:d1].97 = 10

snmpwalk_group treats the bracketed portion as one key and the trailing ".97" (the last MAC octet in decimal) spills into an extra array level, causing a TypeError when the array is used as an array offset.

Reconstruct the real 6-byte MAC by stripping the length prefix and appending each spilled decimal octet (converted to hex), matching the approach used for ArpTable in #19278.

Fixes #19248

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.

