### PR TITLE
Capture more complete debug logs when running tests

### DIFF
--- a/LibreNMS/Util/ModuleTestHelper.php
+++ b/LibreNMS/Util/ModuleTestHelper.php
@@ -608,9 +608,7 @@ class ModuleTestHelper
         if ($this->quiet) {
             Debug::setOnly($save_debug);
             Debug::setVerbose($save_vedbug);
-            if (! $save_debug) {
-                Debug::disableCliDebugOutput();
-            }
+            Debug::disableCliDebugOutput();
         } else {
             ob_flush();
         }
@@ -642,9 +640,7 @@ class ModuleTestHelper
         if ($this->quiet) {
             Debug::setOnly($save_debug);
             Debug::setVerbose($save_vedbug);
-            if (! $save_debug) {
-                Debug::disableCliDebugOutput();
-            }
+            Debug::disableCliDebugOutput();
         } else {
             ob_flush();
         }

--- a/LibreNMS/Util/ModuleTestHelper.php
+++ b/LibreNMS/Util/ModuleTestHelper.php
@@ -597,6 +597,7 @@ class ModuleTestHelper
         if ($this->quiet) {
             Debug::setOnly();
             Debug::setVerbose();
+            Debug::enableCliDebugOutput();
         }
         ob_start();
         Log::setDefaultDriver('stdout');
@@ -607,6 +608,9 @@ class ModuleTestHelper
         if ($this->quiet) {
             Debug::setOnly($save_debug);
             Debug::setVerbose($save_vedbug);
+            if (! $save_debug) {
+                Debug::disableCliDebugOutput();
+            }
         } else {
             ob_flush();
         }
@@ -627,6 +631,7 @@ class ModuleTestHelper
         if ($this->quiet) {
             Debug::setOnly();
             Debug::setVerbose();
+            Debug::enableCliDebugOutput();
         }
         ob_start();
         Log::setDefaultDriver('stdout');
@@ -637,6 +642,9 @@ class ModuleTestHelper
         if ($this->quiet) {
             Debug::setOnly($save_debug);
             Debug::setVerbose($save_vedbug);
+            if (! $save_debug) {
+                Debug::disableCliDebugOutput();
+            }
         } else {
             ob_flush();
         }

--- a/tests/OSDiscoveryTest.php
+++ b/tests/OSDiscoveryTest.php
@@ -28,6 +28,7 @@ namespace LibreNMS\Tests;
 
 use App\Facades\LibrenmsConfig;
 use App\Models\Device;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use LibreNMS\Data\Source\NetSnmpQuery;
 use LibreNMS\Modules\Core;
@@ -142,14 +143,20 @@ final class OSDiscoveryTest extends TestCase
         $start = microtime(true);
 
         $community = $filename ?: $expected_os;
+        $log_driver = Log::getDefaultDriver();
+
         Debug::set();
         Debug::setVerbose();
+        Debug::enableCliDebugOutput();
         ob_start();
+        Log::setDefaultDriver('stdout');
         $os = Core::detectOS($this->genDevice($community));
         $output = ob_get_contents();
+        Log::setDefaultDriver($log_driver);
         ob_end_clean();
         Debug::set(false);
         Debug::setVerbose(false);
+        Debug::disableCliDebugOutput();
 
         $this->assertLessThan(10, microtime(true) - $start, "OS $expected_os took longer than 10s to detect");
         $this->assertEquals($expected_os, $os, "Test file: $community.snmprec\n$output");


### PR DESCRIPTION
When tests fail, the SNMP output was not being captured because they are logged as Log::debug() and the Laravel logging level was not being set correctly.

This PR fixes this by calling Debug::enableCliDebugOutput() and Debug::disableCliDebugOutput() before and after the discovery and polling modules to ensure the Log::debug() messages are also captured

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.

