### PR TITLE
Local snmpsim fix

### DIFF
--- a/LibreNMS/Util/Snmpsim.php
+++ b/LibreNMS/Util/Snmpsim.php
@@ -38,7 +38,7 @@ class Snmpsim extends Process
         public readonly int $port = 1161,
         public readonly ?string $log_method = null)
     {
-        $this->snmprec_dir = base_path('tests/snmpsim');
+        $this->snmprec_dir = 'tests/snmpsim';
 
         $cmd = [
             $this->getVenvPath('bin/snmpsim-command-responder-lite'),


### PR DESCRIPTION
If you try to run `lnms dev:check ci --os 'ciscosb'` locally it fails with the following error:
```
$ lnms dev:check ci --os 'ciscosb'
Only checking os: ciscosb
Running unit check...
PHPUnit 11.5.55 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.4.16
Configuration: /opt/librenms/phpunit.xml

F

Time: 00:03.439, Memory: 170.50 MB

OS Discovery
 ✘ OS detection with ciscosb
   ┐
   ├ Test file: ciscosb_cbs350-4x.snmprec
   ├
   ├ Failed asserting that two strings are equal.
   ┊ ---·Expected
   ┊ +++·Actual
   ┊ @@ @@
   ┊ -'ciscosb'
   ┊ +'generic'
   │
   │ /opt/librenms/tests/OSDiscoveryTest.php:155
   │ /opt/librenms/tests/OSDiscoveryTest.php:116
   ┴

FAILURES!
Tests: 1, Assertions: 34, Failures: 1.
failed (8.41s)
```

The Github tests succeed, and I tracked this down to the use of a relative path when snmpsim is Github compared to the absolute path on the local tests.  The use of a relative path is safe because the tests give the following error if you try to run them outside the LibreNMS root directory:
```
lnms dev:check ci --os 'ciscosb'
Running composer install to install developer dependencies.
sh: 1: scripts/composer_wrapper.php: not found

Running installing deps with composer failed.
 You should try running './scripts/composer_wrapper.php install' by hand
You can find more info at https://docs.librenms.org/Developing/Validating-Code/
```

After the PR is applied the output looks like this:
```
$ lnms dev:check ci --os 'ciscosb'
Only checking os: ciscosb
Running unit check...
PHPUnit 11.5.55 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.4.16
Configuration: /opt/librenms/phpunit.xml

...........................                                       27 / 27 (100%)

Time: 01:05.572, Memory: 228.50 MB

OS Discovery
 ✔ OS detection with ciscosb

OS Modules
 ✔ OS data is valid with ciscosb
 ✔ OS data is valid with ciscosb_c1200
 ✔ OS data is valid with ciscosb_cbs250-24p-4x-v3
 ✔ OS data is valid with ciscosb_cbs350-4x
 ✔ OS data is valid with ciscosb_cbs350
 ✔ OS data is valid with ciscosb_esw540-8p
 ✔ OS data is valid with ciscosb_sg350-10
 ✔ OS data is valid with ciscosb_sg350x-24p
 ✔ OS data is valid with ciscosb_sg350x-48
 ✔ OS data is valid with ciscosb_sg550x-24
 ✔ OS data is valid with ciscosb_sg550x-8f8t
 ✔ OS data is valid with ciscosb_sge
 ✔ OS data is valid with ciscosb_sx550x-24f
 ✔ OS with ciscosb
 ✔ OS with ciscosb_c1200
 ✔ OS with ciscosb_cbs250-24p-4x-v3
 ✔ OS with ciscosb_cbs350-4x
 ✔ OS with ciscosb_cbs350
 ✔ OS with ciscosb_esw540-8p
 ✔ OS with ciscosb_sg350-10
 ✔ OS with ciscosb_sg350x-24p
 ✔ OS with ciscosb_sg350x-48
 ✔ OS with ciscosb_sg550x-24
 ✔ OS with ciscosb_sg550x-8f8t
 ✔ OS with ciscosb_sge
 ✔ OS with ciscosb_sx550x-24f

OK (27 tests, 96 assertions)
success (70.52s)
```

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.

