### PR TITLE
UI: Quality of life improvement for disk I/O health filters

### DIFF
--- a/LibreNMS/Util/DiskIoFilter.php
+++ b/LibreNMS/Util/DiskIoFilter.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace LibreNMS\Util;
+
+final class DiskIoFilter
+{
+    public static function normalizeSelection(?string $view, ?string $subtype): array
+    {
+        if (! in_array((string) $view, ['physical', 'logical', 'all'], true)) {
+            $view = 'physical';
+        }
+
+        if ($view === 'all') {
+            return ['view' => 'all', 'subtype' => 'all'];
+        }
+
+        if (! in_array((string) $subtype, self::subtypesFor($view), true)) {
+            $subtype = 'all';
+        }
+
+        return ['view' => $view, 'subtype' => $subtype];
+    }
+
+    public static function subtypesFor(string $view): array
+    {
+        return match ($view) {
+            'physical' => ['all', 'sd_family', 'nvme', 'mmcblk', 'other'],
+            'logical' => ['all', 'partitions', 'dm', 'md', 'loop', 'other'],
+            default => ['all'],
+        };
+    }
+
+    public static function classify(string $diskName): array
+    {
+        if (preg_match('/^dm-\d+$/i', $diskName)) {
+            return ['view' => 'logical', 'subtype' => 'dm'];
+        }
+
+        if (preg_match('/^loop\d+$/i', $diskName)) {
+            return ['view' => 'logical', 'subtype' => 'loop'];
+        }
+
+        if (preg_match('/^md\d+$/i', $diskName)) {
+            return ['view' => 'logical', 'subtype' => 'md'];
+        }
+
+        if (preg_match('/^(sd[a-z]+\d+|hd[a-z]+\d+|vd[a-z]+\d+|xvd[a-z]+\d+)$/i', $diskName)
+            || preg_match('/^nvme\d+n\d+p\d+$/i', $diskName)
+            || preg_match('/^mmcblk\d+p\d+$/i', $diskName)
+            || preg_match('/^md\d+p\d+$/i', $diskName)) {
+            return ['view' => 'logical', 'subtype' => 'partitions'];
+        }
+
+        if (preg_match('/^(sd[a-z]+|hd[a-z]+|vd[a-z]+|xvd[a-z]+)$/i', $diskName)) {
+            return ['view' => 'physical', 'subtype' => 'sd_family'];
+        }
+
+        if (preg_match('/^nvme\d+n\d+$/i', $diskName)) {
+            return ['view' => 'physical', 'subtype' => 'nvme'];
+        }
+
+        if (preg_match('/^mmcblk\d+$/i', $diskName)) {
+            return ['view' => 'physical', 'subtype' => 'mmcblk'];
+        }
+
+        return ['view' => 'physical', 'subtype' => 'other'];
+    }
+
+    public static function matches(array $diskType, string $selectedView, string $selectedSubtype): bool
+    {
+        if ($selectedView !== 'all' && $diskType['view'] !== $selectedView) {
+            return false;
+        }
+
+        return $selectedView === 'all' || $selectedSubtype === 'all' || $diskType['subtype'] === $selectedSubtype;
+    }
+}

--- a/includes/html/pages/device/health/diskio.inc.php
+++ b/includes/html/pages/device/health/diskio.inc.php
@@ -6,10 +6,9 @@ $diskioViews = [
     'all' => 'All Drives',
 ];
 
-$selectedDiskioView = $vars['diskio_view'] ?? 'physical';
-if (! array_key_exists((string) $selectedDiskioView, $diskioViews)) {
-    $selectedDiskioView = 'physical';
-}
+$selection = \LibreNMS\Util\DiskIoFilter::normalizeSelection($vars['diskio_view'] ?? null, $vars['diskio_subtype'] ?? null);
+$selectedDiskioView = $selection['view'];
+$selectedDiskioSubtype = $selection['subtype'];
 
 $diskioSubtypes = [
     'physical' => [
@@ -28,11 +27,6 @@ $diskioSubtypes = [
         'other' => 'Other Logical',
     ],
 ];
-
-$selectedDiskioSubtype = $vars['diskio_subtype'] ?? 'all';
-if (! isset($diskioSubtypes[$selectedDiskioView][$selectedDiskioSubtype])) {
-    $selectedDiskioSubtype = 'all';
-}
 
 $diskioLinkArray = [
     'page' => 'device',
@@ -110,51 +104,11 @@ if (isset($subtypeDescriptions[$selectedDiskioView][$selectedDiskioSubtype])) {
 }
 echo '</div>';
 
-$diskType = static function (string $diskName): array {
-    if (preg_match('/^dm-\d+$/i', $diskName)) {
-        return ['view' => 'logical', 'subtype' => 'dm'];
-    }
-
-    if (preg_match('/^loop\d+$/i', $diskName)) {
-        return ['view' => 'logical', 'subtype' => 'loop'];
-    }
-
-    if (preg_match('/^md\d+$/i', $diskName)) {
-        return ['view' => 'logical', 'subtype' => 'md'];
-    }
-
-    if (preg_match('/^(sd[a-z]+\d+|hd[a-z]+\d+|vd[a-z]+\d+|xvd[a-z]+\d+)$/i', $diskName)
-        || preg_match('/^nvme\d+n\d+p\d+$/i', $diskName)
-        || preg_match('/^mmcblk\d+p\d+$/i', $diskName)
-        || preg_match('/^md\d+p\d+$/i', $diskName)) {
-        return ['view' => 'logical', 'subtype' => 'partitions'];
-    }
-
-    if (preg_match('/^(sd[a-z]+|hd[a-z]+|vd[a-z]+|xvd[a-z]+)$/i', $diskName)) {
-        return ['view' => 'physical', 'subtype' => 'sd_family'];
-    }
-
-    if (preg_match('/^nvme\d+n\d+$/i', $diskName)) {
-        return ['view' => 'physical', 'subtype' => 'nvme'];
-    }
-
-    if (preg_match('/^mmcblk\d+$/i', $diskName)) {
-        return ['view' => 'physical', 'subtype' => 'mmcblk'];
-    }
-
-    return ['view' => 'physical', 'subtype' => 'other'];
-};
-
 $row = 1;
 
 foreach (dbFetchRows('SELECT * FROM `ucd_diskio` WHERE device_id = ? ORDER BY diskio_descr', [$device['device_id']]) as $drive) {
-    $driveType = $diskType($drive['diskio_descr']);
-
-    if ($selectedDiskioView !== 'all' && $driveType['view'] !== $selectedDiskioView) {
-        continue;
-    }
-
-    if ($selectedDiskioView !== 'all' && $selectedDiskioSubtype !== 'all' && $driveType['subtype'] !== $selectedDiskioSubtype) {
+    $driveType = \LibreNMS\Util\DiskIoFilter::classify($drive['diskio_descr']);
+    if (! \LibreNMS\Util\DiskIoFilter::matches($driveType, $selectedDiskioView, $selectedDiskioSubtype)) {
         continue;
     }
 

--- a/tests/Unit/Util/DiskIoFilterTest.php
+++ b/tests/Unit/Util/DiskIoFilterTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace LibreNMS\Tests\Unit\Util;
+
+use LibreNMS\Tests\TestCase;
+use LibreNMS\Util\DiskIoFilter;
+
+final class DiskIoFilterTest extends TestCase
+{
+    public function testNormalizeSelectionDefaultsToPhysical(): void
+    {
+        $selection = DiskIoFilter::normalizeSelection(null, null);
+
+        $this->assertSame('physical', $selection['view']);
+        $this->assertSame('all', $selection['subtype']);
+    }
+
+    public function testNormalizeSelectionForcesAllSubtypeOnAllView(): void
+    {
+        $selection = DiskIoFilter::normalizeSelection('all', 'nvme');
+
+        $this->assertSame('all', $selection['view']);
+        $this->assertSame('all', $selection['subtype']);
+    }
+
+    public function testNormalizeSelectionFallsBackForInvalidSubtype(): void
+    {
+        $selection = DiskIoFilter::normalizeSelection('logical', 'nvme');
+
+        $this->assertSame('logical', $selection['view']);
+        $this->assertSame('all', $selection['subtype']);
+    }
+
+    public function testClassifyPhysicalDrives(): void
+    {
+        $this->assertSame(['view' => 'physical', 'subtype' => 'sd_family'], DiskIoFilter::classify('sda'));
+        $this->assertSame(['view' => 'physical', 'subtype' => 'nvme'], DiskIoFilter::classify('nvme0n1'));
+        $this->assertSame(['view' => 'physical', 'subtype' => 'mmcblk'], DiskIoFilter::classify('mmcblk0'));
+    }
+
+    public function testClassifyLogicalDrives(): void
+    {
+        $this->assertSame(['view' => 'logical', 'subtype' => 'partitions'], DiskIoFilter::classify('sda1'));
+        $this->assertSame(['view' => 'logical', 'subtype' => 'partitions'], DiskIoFilter::classify('nvme0n1p1'));
+        $this->assertSame(['view' => 'logical', 'subtype' => 'partitions'], DiskIoFilter::classify('md0p1'));
+        $this->assertSame(['view' => 'logical', 'subtype' => 'dm'], DiskIoFilter::classify('dm-0'));
+        $this->assertSame(['view' => 'logical', 'subtype' => 'md'], DiskIoFilter::classify('md0'));
+        $this->assertSame(['view' => 'logical', 'subtype' => 'loop'], DiskIoFilter::classify('loop0'));
+    }
+
+    public function testMatchesRespectsViewAndSubtypeFilters(): void
+    {
+        $diskType = ['view' => 'physical', 'subtype' => 'nvme'];
+
+        $this->assertTrue(DiskIoFilter::matches($diskType, 'all', 'all'));
+        $this->assertTrue(DiskIoFilter::matches($diskType, 'physical', 'all'));
+        $this->assertTrue(DiskIoFilter::matches($diskType, 'physical', 'nvme'));
+        $this->assertFalse(DiskIoFilter::matches($diskType, 'logical', 'all'));
+        $this->assertFalse(DiskIoFilter::matches($diskType, 'physical', 'sd_family'));
+    }
+}


### PR DESCRIPTION
hi 

I’ve found the disk I/O page on Linux devices increasingly hard to navigate as the number of disks and device types grows. In most cases, I really just want to start with the physical disks, but today everything is mixed together, which makes it harder to get a quick overview.

I also felt that filtering wasn’t very intuitive, especially when different device types are shown together.

My main goal here was to make the page feel more structured and intentional. Instead of showing everything at once, I wanted the primary views to  guide how the data is explored.

<img width="1787" height="473" alt="Screenshot 2026-03-25 at 18-09-40 server2 LibreNMS" src="https://github.com/user-attachments/assets/742b4fd6-09c1-4b43-be9c-dc091c6ff0a7" />


## Summary
- add Linux-focused disk I/O navigation on device health pages with default `Physical Drives` view, plus `Logical Drives` and `All Drives`
- add subtype filtering for the active view only, with user-friendly labels and inline definitions for drive categories
- extract disk classification/filter logic to `LibreNMS\Util\DiskIoFilter` and add unit tests for URL selection normalization and device-name matching 


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [X] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.

