### PR TITLE
Fix IPv4 address parsing error from malformed SNMP data (#19259)

### DIFF
--- a/LibreNMS/Modules/Ipv4Addresses.php
+++ b/LibreNMS/Modules/Ipv4Addresses.php
@@ -199,6 +199,10 @@ class Ipv4Addresses implements Module
                 $entAddr = $data['ipAdEntAddr'] ?? '';
                 $addr = (preg_match('/(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/', (string) $entAddr, $tmp)) ? $entAddr : $ipAddr;
 
+                if (! IPv4::isValid($addr)) {
+                    return null;
+                }
+
                 return new Ipv4Address([
                     'port_id' => PortCache::getIdFromIfIndex($data['ipAdEntIfIndex'] ?? 0, $device),
                     'ipv4_address' => $addr,


### PR DESCRIPTION
ats.snmprec contains a ipAddrTable index with ".0" for example

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
