### PR TITLE
Add ability to change snmp is up check oid per os

### DIFF
--- a/LibreNMS/Modules/Core.php
+++ b/LibreNMS/Modules/Core.php
@@ -57,7 +57,16 @@ class Core implements Module
 
     public function shouldDiscover(OS $os, ModuleStatus $status): bool
     {
-        return ! $os->getDevice()->snmp_disable && $os->getDevice()->status;
+        if ($os->getDevice()->snmp_disable) {
+            return false;
+        }
+
+        if ($os->getDevice()->status) {
+            return true;
+        }
+
+        // this check allows for detection of OS that don't return sysObjectID
+        return $os->getDevice()->status_reason === 'snmp' && $os->getDevice()->os === 'generic';
     }
 
     public function discover(OS $os): void

--- a/LibreNMS/Modules/Core.php
+++ b/LibreNMS/Modules/Core.php
@@ -57,16 +57,18 @@ class Core implements Module
 
     public function shouldDiscover(OS $os, ModuleStatus $status): bool
     {
-        if ($os->getDevice()->snmp_disable) {
+        $device = $os->getDevice();
+
+        if ($device->snmp_disable) {
             return false;
         }
 
-        if ($os->getDevice()->status) {
+        if ($device->status) {
             return true;
         }
 
         // this check allows for detection of OS that don't return sysObjectID
-        return $os->getDevice()->status_reason === 'snmp' && $os->getDevice()->os === 'generic';
+        return $device->sysObjectID === null && $device->status_reason === 'snmp' && $device->os === 'generic';
     }
 
     public function discover(OS $os): void

--- a/app/Actions/Device/DeviceIsSnmpable.php
+++ b/app/Actions/Device/DeviceIsSnmpable.php
@@ -2,6 +2,7 @@
 
 namespace App\Actions\Device;
 
+use App\Facades\LibrenmsConfig;
 use App\Models\Device;
 use SnmpQuery;
 
@@ -9,7 +10,8 @@ class DeviceIsSnmpable
 {
     public function execute(Device $device): bool
     {
-        $response = SnmpQuery::device($device)->get('SNMPv2-MIB::sysObjectID.0');
+        $oid = LibrenmsConfig::getOsSetting($device->os, 'snmp.check_oid', 'SNMPv2-MIB::sysObjectID.0');
+        $response = SnmpQuery::device($device)->get($oid);
 
         return $response->getExitCode() === 0 || $response->isValid();
     }

--- a/resources/definitions/os_detection/exeltech-xfersw.yaml
+++ b/resources/definitions/os_detection/exeltech-xfersw.yaml
@@ -5,7 +5,9 @@ discovery:
     -   sysObjectID_regex: '/^$/'
         snmpget:
             oid: '.1.3.6.1.4.1.30320.1.0.0.1.0'
-            op: '!=='
-            value: ''
+            op: 'regex'
+            value: '/^\d+$/'
 icon: exeltech
 mib_dir: exeltech
+snmp:
+    check_oid: '.1.3.6.1.4.1.30320.1.0.0.1.0'

--- a/resources/definitions/os_detection/hikvision-cam.yaml
+++ b/resources/definitions/os_detection/hikvision-cam.yaml
@@ -12,3 +12,5 @@ discovery:
             oid: .1.3.6.1.4.1.39165.1.1.0
             op: contains
             value: '-'
+snmp:
+    check_oid: .1.3.6.1.4.1.39165.1.1.0

--- a/resources/definitions/os_detection/supercap.yaml
+++ b/resources/definitions/os_detection/supercap.yaml
@@ -15,3 +15,5 @@ discovery:
             oid: SUPERCAPBATTERY-MIB::BMS01-AmbientTemperature
             op: 'regex'
             value: '/^\d+$/'
+snmp:
+    check_oid: SUPERCAPBATTERY-MIB::BMS01-AmbientTemperature

--- a/resources/definitions/schema/os_schema.json
+++ b/resources/definitions/schema/os_schema.json
@@ -412,7 +412,8 @@
             "max_repeaters": {
                 "type": "integer",
                 "minimum": 1
-            }
+            },
+            "check_oid": {"$ref": "oid_types.json#/$defs/oid"}
         },
         "additionalProperties": false
     },


### PR DESCRIPTION
This does require two discoveries (first one sets the OS, second uses correct snmp.check_oid)
When adding a device, this probably still requires a force add...

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
