### PR TITLE
Fix hardcoded font color in device inventory tab for dark mode

### DIFF
--- a/includes/html/pages/device/entphysical.inc.php
+++ b/includes/html/pages/device/entphysical.inc.php
@@ -112,7 +112,7 @@ function printEntPhysical($device, $ent, $level, $class)
         }
 
         if ($ent['entPhysicalSerialNum']) {
-            echo " <br /><span style='color: #000099;'>Serial No. " . $ent['entPhysicalSerialNum'] . '</span> ';
+            echo " <br /><span class='text-info'>Serial No. " . $ent['entPhysicalSerialNum'] . '</span> ';
         }
 
         // Display sensors values with their descr, as we have more than one attached to this entPhysical
@@ -121,7 +121,7 @@ function printEntPhysical($device, $ent, $level, $class)
             foreach ($sensors as $sensor) {
                 $disp_name = str_replace([$ent['entPhysicalDescr'], $ent['entPhysicalName']], ['', ''], $sensor->sensor_descr);
                 echo "<a href='graphs/id=" . $sensor->sensor_id . '/type=sensor_' . $sensor->sensor_class . "/' onmouseover=\"return overlib('<img src=\'graph.php?id=" . $sensor->sensor_id . '&amp;type=sensor_' . $sensor->sensor_class . '&amp;from=-2d&amp;to=now&amp;width=400&amp;height=150&amp;a=' . $ent['entPhysical_id'] . "\'><img src=\'graph.php?id=" . $sensor->sensor_id . '&amp;type=sensor_' . $sensor->sensor_class . '&amp;from=-2w&amp;to=now&amp;width=400&amp;height=150&amp;a=' . $ent['entPhysical_id'] . "\'>', LEFT,FGCOLOR,'#e5e5e5', BGCOLOR, '#c0c0c0', BORDER, 5, CELLPAD, 4, CAPCOLOR, '#050505');\" onmouseout=\"return nd();\">";
-                echo "<span style='color: #000099;'>" . $disp_name . ' ' . $sensor->sensor_class . '</span>';
+                echo "<span class='text-info'>" . $disp_name . ' ' . $sensor->sensor_class . '</span>';
                 echo ' ';
                 echo Html::severityToLabel($sensor->currentStatus(), $sensor->formatValue());
                 echo '</a><br>';


### PR DESCRIPTION
Replace inline `style=color:` `#000099` with Bootstrap's text-info class in entphysical.inc.php. The dark navy blue `#000099` was unreadable in dark mode; text-info adapts correctly via tw_dark.css dark mode overrides.

Fixes #19284

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

<img width="1316" height="529" alt="image" src="https://github.com/user-attachments/assets/e0a82ff5-8f45-4bfd-989e-8638cd540607" />

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
