### PR TITLE
Improve IPv4 discovery detection for out of order OIDs

### DIFF
--- a/LibreNMS/Modules/Ipv4Addresses.php
+++ b/LibreNMS/Modules/Ipv4Addresses.php
@@ -192,7 +192,7 @@ class Ipv4Addresses implements Module
     {
         $ips = new Collection;
         foreach ($device->getVrfContexts() as $context_name) {
-            $ips = $ips->merge(SnmpQuery::context($context_name)->hideMib()->enumStrings()->walk(
+            $ips = $ips->merge(SnmpQuery::context($context_name)->allowUnordered()->hideMib()->enumStrings()->walk(
                 ['IP-MIB::ipAdEntAddr', 'IP-MIB::ipAdEntIfIndex', 'IP-MIB::ipAdEntNetMask'])
             ->mapTable(function ($data, $ipAddr = '') use ($context_name, $device) {
                 //on some devices, ipAddr is broken, so use ipAdEntAddr as primary

--- a/tests/data/timos_7750-bgp.json
+++ b/tests/data/timos_7750-bgp.json
@@ -47886,5 +47886,88 @@
                 }
             ]
         }
+    },
+    "ipv4-addresses": {
+        "discovery": {
+            "ipv4_addresses": [
+                {
+                    "ipv4_address": "192.0.2.112",
+                    "ipv4_prefixlen": 32,
+                    "context_name": "",
+                    "ipv4_network": null,
+                    "ifIndex": 24
+                },
+                {
+                    "ipv4_address": "192.168.119.100",
+                    "ipv4_prefixlen": 31,
+                    "context_name": "",
+                    "ipv4_network": "192.168.119.100/31",
+                    "ifIndex": 5
+                },
+                {
+                    "ipv4_address": "192.168.119.116",
+                    "ipv4_prefixlen": 31,
+                    "context_name": "",
+                    "ipv4_network": "192.168.119.116/31",
+                    "ifIndex": 3
+                },
+                {
+                    "ipv4_address": "192.168.119.123",
+                    "ipv4_prefixlen": 31,
+                    "context_name": "",
+                    "ipv4_network": "192.168.119.122/31",
+                    "ifIndex": 21
+                },
+                {
+                    "ipv4_address": "192.168.119.124",
+                    "ipv4_prefixlen": 31,
+                    "context_name": "",
+                    "ipv4_network": "192.168.119.124/31",
+                    "ifIndex": 22
+                },
+                {
+                    "ipv4_address": "192.168.119.6",
+                    "ipv4_prefixlen": 32,
+                    "context_name": "",
+                    "ipv4_network": null,
+                    "ifIndex": 1
+                },
+                {
+                    "ipv4_address": "192.168.124.157",
+                    "ipv4_prefixlen": 30,
+                    "context_name": "",
+                    "ipv4_network": "192.168.124.156/30",
+                    "ifIndex": 16
+                },
+                {
+                    "ipv4_address": "192.168.124.217",
+                    "ipv4_prefixlen": 30,
+                    "context_name": "",
+                    "ipv4_network": "192.168.124.216/30",
+                    "ifIndex": 10
+                },
+                {
+                    "ipv4_address": "192.168.125.134",
+                    "ipv4_prefixlen": 31,
+                    "context_name": "",
+                    "ipv4_network": "192.168.125.134/31",
+                    "ifIndex": 23
+                },
+                {
+                    "ipv4_address": "192.168.125.45",
+                    "ipv4_prefixlen": 30,
+                    "context_name": "",
+                    "ipv4_network": "192.168.125.44/30",
+                    "ifIndex": 4
+                },
+                {
+                    "ipv4_address": "192.169.90.34",
+                    "ipv4_prefixlen": 31,
+                    "context_name": "",
+                    "ipv4_network": "192.169.90.34/31",
+                    "ifIndex": 12
+                }
+            ]
+        }
     }
 }


### PR DESCRIPTION
While working on the php-snmp implementation I discovered that there are a few snmprec files with the IPv4 OIDs in the wrong order, which I assume is the order returned from the devices.

This PR allows the IPv4 discovery to process unordered IPv4 address OIDs.

The issue was discovered while testing php-snmp as an alternative for net-snmp for doing SNMP queries because the 2 implementations returned different results while discovering IPv4 addresses. 

The only concern is if there are devices with a SNMP implementation that has an endless loop while walking the IPv4 OID tree.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
