### PR TITLE
Show device sysname on device table always if it differs from displayname

### DIFF
--- a/app/Models/Device.php
+++ b/app/Models/Device.php
@@ -216,15 +216,11 @@ class Device extends BaseModel
     }
 
     /**
-     * Returns the device name if not already displayed
+     * Returns the device sysName if it differs from diplayname
      */
     public function name(): string
     {
-        $display = $this->displayName();
-
-        if (! Str::contains($display, $this->hostname)) {
-            return (string) $this->hostname;
-        } elseif (! Str::contains($display, $this->sysName)) {
+        if ($this->displayName() != $this->sysName) {
             return (string) $this->sysName;
         }
 


### PR DESCRIPTION
Show device sysName on Device tables if it differs from the configured displayname. The old logic failed to display the sysnames if they did not overlap.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
