### PR TITLE
fix(ServiceTemplate): correct services() relationship

### DIFF
--- a/app/Http/Controllers/ServiceTemplateController.php
+++ b/app/Http/Controllers/ServiceTemplateController.php
@@ -5,7 +5,6 @@ namespace App\Http\Controllers;
 use App\Http\Interfaces\ToastInterface;
 use App\Models\Device;
 use App\Models\DeviceGroup;
-use App\Models\Service;
 use App\Models\ServiceTemplate;
 use Illuminate\Http\Request;
 use Illuminate\Validation\Rule;
@@ -330,7 +329,7 @@ class ServiceTemplateController extends Controller
 
         // remove any remaining services no longer in the correct device group
         foreach (Device::notInServiceTemplate($template->id)->notInDeviceGroup($template->groups->pluck('id'))->pluck('device_id') as $device_id) {
-            Service::where('device_id', $device_id)->where('service_template_id', $template->id)->delete();
+            $template->services()->where('device_id', $device_id)->delete();
         }
         $msg = __('All Service Templates have been applied');
 
@@ -390,7 +389,7 @@ class ServiceTemplateController extends Controller
 
         // remove if this template no longer applies
         foreach (Device::notInServiceTemplate($template->id)->notInDeviceGroup($template->groups->pluck('id'))->where('device_id', $device_id)->pluck('device_id') as $device_id) {
-            Service::where('device_id', $device_id)->where('service_template_id', $template->id)->delete();
+            $template->services()->where('device_id', $device_id)->delete();
         }
     }
 
@@ -404,7 +403,7 @@ class ServiceTemplateController extends Controller
     {
         $this->authorize('update', ServiceTemplate::class);
 
-        Service::where('service_template_id', $template->id)->delete();
+        $template->services()->delete();
 
         $msg = __('All Service Templates have been applied');
 
@@ -419,7 +418,7 @@ class ServiceTemplateController extends Controller
      */
     public function destroy(ServiceTemplate $template)
     {
-        Service::where('service_template_id', $template->id)->delete();
+        $template->services()->delete();
         $template->delete();
 
         $msg = __('Service Template :name deleted, Services removed', ['name' => htmlentities($template->name)]);

--- a/app/Models/ServiceTemplate.php
+++ b/app/Models/ServiceTemplate.php
@@ -28,6 +28,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use LibreNMS\Alerting\QueryBuilderFluentParser;
 use Log;
 
@@ -94,7 +95,7 @@ class ServiceTemplate extends BaseModel
     /**
      * Update devices included in this template (dynamic only)
      */
-    public function updateDevices()
+    public function updateDevices(): void
     {
         if ($this->type == 'dynamic') {
             $this->devices()->sync(QueryBuilderFluentParser::fromJson($this->rules)->toQuery()
@@ -106,7 +107,7 @@ class ServiceTemplate extends BaseModel
      * Update the device template groups for the given device or device_id
      *
      * @param  Device|int  $device
-     * @return array
+     * @return array{attached: array<int>, detached: array<int>, updated: array<int>}
      */
     public static function updateServiceTemplatesForDevice($device)
     {
@@ -152,7 +153,7 @@ class ServiceTemplate extends BaseModel
      * Update the device template groups for the given device group or device_group_id
      *
      * @param  DeviceGroup|int  $deviceGroup
-     * @return array
+     * @return array{attached: array<int>, detached: array<int>, updated: array<int>}
      */
     public static function updateServiceTemplatesForDeviceGroup($deviceGroup)
     {
@@ -192,16 +193,16 @@ class ServiceTemplate extends BaseModel
 
     // ---- Query Scopes ----
 
+    /** @param  Builder<ServiceTemplate>  $query
+     *  @return Builder<ServiceTemplate> */
     public function scopeHasAccess(Builder $query, User $user): Builder
     {
         return $query;
     }
 
-    /**
-     * @param  Builder  $query
-     * @return Builder
-     */
-    public function scopeIsDisabled($query)
+    /** @param  Builder<ServiceTemplate>  $query
+     *  @return Builder<ServiceTemplate> */
+    public function scopeIsDisabled(Builder $query): Builder
     {
         return $query->where('disabled', 1);
     }
@@ -216,11 +217,11 @@ class ServiceTemplate extends BaseModel
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany<\App\Models\Service, $this>
+     * @return HasMany<Service, $this>
      */
-    public function services(): BelongsToMany
+    public function services(): HasMany
     {
-        return $this->belongsToMany(Service::class, 'service_templates_device', 'service_template_id', 'device_id');
+        return $this->hasMany(Service::class, 'service_template_id');
     }
 
     /**


### PR DESCRIPTION
The services() relationship was using belongsToMany through the service_templates_device pivot table with device_id as the foreign key, which joined on the wrong column and returned incorrect results. Services already have a service_template_id column, so this is a simple hasMany relationship.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
