### PR TITLE
Update SNMPv3 auth/priv example in docs

### DIFF
--- a/doc/Support/SNMP-Configuration-Examples.md
+++ b/doc/Support/SNMP-Configuration-Examples.md
@@ -435,15 +435,39 @@ chmod +x /usr/bin/distro
 
 ### Linux (snmpd v3)
 
-Go to /etc/snmp/snmpd.conf
+#### Stop the snmpd service
 
-Open the file in vi or nano /etc/snmp/snmpd.conf and add the following
+##### CentOS 6 / Red hat 6
+
+```bash
+service snmpd stop
+```
+
+##### CentOS 7 / Red hat 7
+
+```bash
+systemctl stop snmpd
+```
+
+##### Ubuntu
+
+```bash
+service snmpd stop
+```
+
+Go to /var/lib/snmp/snmpd.conf
+
+Open the file in vi or nano /var/lib/snmp/snmpd.conf and add the following
 line to create SNMPV3 User (replace username and passwords with your
 own):
 
 ```bash
 createUser authPrivUser SHA "authPassword" AES "privPassword"
 ```
+
+This line will be removed and processed into an equivalent line starting with usmUser once the service is started again.
+
+Go to /etc/snmp/snmpd.conf
 
 Make sure the agent listens to all interfaces by adding the following
 line inside snmpd.conf:


### PR DESCRIPTION
See... https://net-snmp.sourceforge.io/docs/man/snmpd.examples.html

" Remember that these createUser directives should be defined in the /var/net-snmp/snmpd.conf file, rather than the usual location. "

Whilst **yes** placing createUser into /etc/snmp/snmpd.conf will also convert this into usmUser in /var/lib/snmp/snmpd.conf  --  the problems with that are... a) it's not how Net-SNMP Agent project recommends you do it... b) it'll leave your authPass and/or privPass in plain text in that config file... potentially re-attempting to run createUser every time the service starts.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
