### PR TITLE
Fix missing translations for SSL Certificates and Alert Map application settings

### DIFF
--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -32,6 +32,7 @@ return [
             'powerdns-recursor' => ['name' => 'PowerDNS Recursor'],
             'oslv_monitor' => ['name' => 'OSLV Monitor'],
             'sneck' => ['name' => 'Sneck'],
+            'ssl-certificates' => ['name' => 'SSL Certificates'],
         ],
         'auth' => [
             'general' => ['name' => 'General Authentication Settings'],
@@ -2278,6 +2279,14 @@ return [
             'skip_hosts' => [
                 'description' => 'Skip Hosts',
                 'help' => 'Skip hosts from SSL certificate discovery',
+            ],
+            'days_until_expiry_warning' => [
+                'description' => 'Warning (days)',
+                'help' => 'Number of days until certificate expiry to trigger a warning',
+            ],
+            'days_until_expiry_danger' => [
+                'description' => 'Danger (days)',
+                'help' => 'Number of days until certificate expiry to trigger a danger alert',
             ],
         ],
         'sso' => [

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -112,6 +112,7 @@ return [
             'front-page' => ['name' => 'Front Page Settings'],
             'menu' => ['name' => 'Menu Settings'],
             'scheduled-maintenance' => ['name' => 'Scheduled Maintenance'],
+            'alert-map' => ['name' => 'Alert Map Settings'],
         ],
     ],
     'settings' => [
@@ -2414,6 +2415,22 @@ return [
             'scheduled_maintenance_default_behavior' => [
                 'description' => 'Default Behaviour',
                 'help' => 'When managing scheduled maintenances, this will be the default option for the Behavior option.',
+            ],
+            'alert_map_compact' => [
+                'description' => 'Alert map compact view',
+                'help' => 'Alert map view with small indicators',
+            ],
+            'alert_map_sort_status' => [
+                'description' => 'Sort by status',
+                'help' => 'Sort alerts by status',
+            ],
+            'alert_map_use_device_groups' => [
+                'description' => 'Use device groups filter',
+                'help' => 'Enable usage of device groups filter',
+            ],
+            'alert_map_box_size' => [
+                'description' => 'Alert box width',
+                'help' => 'Input desired tile width in pixels for box size in full view',
             ],
             'availability_map_box_size' => [
                 'description' => 'Availability box width',


### PR DESCRIPTION
The SSL Certificates section in Global Settings > Applications and Alert Map was displaying raw translation keys instead of proper labels. Added the missing section name and setting descriptions to the English language file.

sudo -u librenms /opt/librenms/lnms translation:generate is required for testing the PR

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
