### PR TITLE
Add alert rules for Windows resources, Zebra printer traps, and Dell DRAC sensors

### DIFF
--- a/resources/definitions/alert_rules.json
+++ b/resources/definitions/alert_rules.json
@@ -876,6 +876,26 @@
     "builder": {"condition":"AND","rules":[{"id":"devices.os","field":"devices.os","type":"string","input":"text","operator":"equal","value":"drac"},{"id":"sensors.sensor_class","field":"sensors.sensor_class","type":"string","input":"text","operator":"equal","value":"state"},{"id":"sensors.sensor_type","field":"sensors.sensor_type","type":"string","input":"text","operator":"equal","value":"virtualDiskState"},{"id":"sensors.sensor_current","field":"sensors.sensor_current","type":"string","input":"text","operator":"equal","value":"4"}],"valid":true}
   },
   {
+    "name": "Dell DRAC power supply status critical",
+    "severity": "critical",
+    "builder": {"condition":"AND","rules":[{"id":"devices.os","field":"devices.os","type":"string","input":"text","operator":"equal","value":"drac"},{"id":"sensors.sensor_class","field":"sensors.sensor_class","type":"string","input":"text","operator":"equal","value":"state"},{"id":"sensors.sensor_type","field":"sensors.sensor_type","type":"string","input":"text","operator":"equal","value":"powerSupplyStatus"},{"id":"sensors.sensor_current","field":"sensors.sensor_current","type":"string","input":"text","operator":"regex","value":"[5-6]"}],"valid":true}
+  },
+  {
+    "name": "Dell DRAC power supply status warning",
+    "severity": "warning",
+    "builder": {"condition":"AND","rules":[{"id":"devices.os","field":"devices.os","type":"string","input":"text","operator":"equal","value":"drac"},{"id":"sensors.sensor_class","field":"sensors.sensor_class","type":"string","input":"text","operator":"equal","value":"state"},{"id":"sensors.sensor_type","field":"sensors.sensor_type","type":"string","input":"text","operator":"equal","value":"powerSupplyStatus"},{"id":"sensors.sensor_current","field":"sensors.sensor_current","type":"string","input":"text","operator":"equal","value":"4"}],"valid":true}
+  },
+  {
+    "name": "Dell DRAC RAID controller state critical",
+    "severity": "critical",
+    "builder": {"condition":"AND","rules":[{"id":"devices.os","field":"devices.os","type":"string","input":"text","operator":"equal","value":"drac"},{"id":"sensors.sensor_class","field":"sensors.sensor_class","type":"string","input":"text","operator":"equal","value":"state"},{"id":"sensors.sensor_type","field":"sensors.sensor_type","type":"string","input":"text","operator":"equal","value":"controllerState"},{"id":"sensors.sensor_current","field":"sensors.sensor_current","type":"string","input":"text","operator":"regex","value":"[2,6]"}],"valid":true}
+  },
+  {
+    "name": "Dell DRAC RAID controller state warning",
+    "severity": "warning",
+    "builder": {"condition":"AND","rules":[{"id":"devices.os","field":"devices.os","type":"string","input":"text","operator":"equal","value":"drac"},{"id":"sensors.sensor_class","field":"sensors.sensor_class","type":"string","input":"text","operator":"equal","value":"state"},{"id":"sensors.sensor_type","field":"sensors.sensor_type","type":"string","input":"text","operator":"equal","value":"controllerState"},{"id":"sensors.sensor_current","field":"sensors.sensor_current","type":"string","input":"text","operator":"equal","value":"4"}],"valid":true}
+  },
+  {
     "name": "Dell OME-M blade status critical",
     "severity": "critical",
     "builder": {"condition":"AND","rules":[{"id":"devices.os","field":"devices.os","type":"string","input":"text","operator":"equal","value":"dell-ome-m"},{"id":"sensors.sensor_class","field":"sensors.sensor_class","type":"string","input":"text","operator":"equal","value":"state"},{"id":"sensors.sensor_type","field":"sensors.sensor_type","type":"string","input":"text","operator":"equal","value":"dmmBladeCurrStatus"},{"id":"sensors.sensor_current","field":"sensors.sensor_current","type":"string","input":"text","operator":"regex","value":"[5-6]"}],"valid":true}
@@ -1034,5 +1054,45 @@
     "name": "Expiring SSL Certificates",
     "severity": "warning",
     "builder": {"condition":"AND","rules":[{"id":"ssl_certificates.days_until_expiry","field":"ssl_certificates.days_until_expiry","type":"integer","input":"text","operator":"less","value":"14"},{"id":"ssl_certificates.disabled","field":"ssl_certificates.disabled","type":"integer","input":"text","operator":"equal","value":"0"}],"valid":true}
+  },
+  {
+    "name": "Windows High CPU Usage, >= 90%",
+    "severity": "warning",
+    "builder": {"condition":"AND","rules":[{"id":"processors.processor_usage","field":"processors.processor_usage","type":"string","input":"text","operator":"greater_or_equal","value":"90"},{"id":"devices.os","field":"devices.os","type":"string","input":"text","operator":"equal","value":"windows"},{"id":"macros.device_up","field":"macros.device_up","type":"integer","input":"radio","operator":"equal","value":"1"}],"valid":true}
+  },
+  {
+    "name": "Windows High CPU Usage, >= 95%",
+    "severity": "critical",
+    "builder": {"condition":"AND","rules":[{"id":"processors.processor_usage","field":"processors.processor_usage","type":"string","input":"text","operator":"greater_or_equal","value":"95"},{"id":"devices.os","field":"devices.os","type":"string","input":"text","operator":"equal","value":"windows"},{"id":"macros.device_up","field":"macros.device_up","type":"integer","input":"radio","operator":"equal","value":"1"}],"valid":true}
+  },
+  {
+    "name": "Windows High Memory Usage, >= 90% in use",
+    "severity": "warning",
+    "builder": {"condition":"AND","rules":[{"id":"mempools.mempool_class","field":"mempools.mempool_class","type":"string","input":"text","operator":"equal","value":"system"},{"id":"mempools.mempool_perc","field":"mempools.mempool_perc","type":"string","input":"number","operator":"greater_or_equal","value":"90"},{"id":"devices.os","field":"devices.os","type":"string","input":"text","operator":"equal","value":"windows"}],"valid":true}
+  },
+  {
+    "name": "Windows High Memory Usage, >= 95% in use",
+    "severity": "critical",
+    "builder": {"condition":"AND","rules":[{"id":"mempools.mempool_class","field":"mempools.mempool_class","type":"string","input":"text","operator":"equal","value":"system"},{"id":"mempools.mempool_perc","field":"mempools.mempool_perc","type":"string","input":"number","operator":"greater_or_equal","value":"95"},{"id":"devices.os","field":"devices.os","type":"string","input":"text","operator":"equal","value":"windows"}],"valid":true}
+  },
+  {
+    "name": "Windows Disk Usage, >= 90% and < 95% in use",
+    "severity": "warning",
+    "builder": {"condition":"AND","rules":[{"id":"storage.storage_perc","field":"storage.storage_perc","type":"string","input":"text","operator":"greater_or_equal","value":"90"},{"id":"storage.storage_perc","field":"storage.storage_perc","type":"string","input":"text","operator":"less","value":"95"},{"id":"devices.os","field":"devices.os","type":"string","input":"text","operator":"equal","value":"windows"},{"id":"macros.device_up","field":"macros.device_up","type":"integer","input":"radio","operator":"equal","value":"1"}],"valid":true}
+  },
+  {
+    "name": "Windows Disk Usage, >= 95% in use",
+    "severity": "critical",
+    "builder": {"condition":"AND","rules":[{"id":"storage.storage_perc","field":"storage.storage_perc","type":"string","input":"text","operator":"greater_or_equal","value":"95"},{"id":"devices.os","field":"devices.os","type":"string","input":"text","operator":"equal","value":"windows"},{"id":"macros.device_up","field":"macros.device_up","type":"integer","input":"radio","operator":"equal","value":"1"}],"valid":true}
+  },
+  {
+    "name": "Zebra Printer Trap: Warning",
+    "severity": "warning",
+    "builder": {"condition":"AND","rules":[{"id":"eventlog.type","field":"eventlog.type","type":"string","input":"text","operator":"equal","value":"trap"},{"id":"eventlog.severity","field":"eventlog.severity","type":"string","input":"text","operator":"equal","value":"4"},{"id":"devices.os","field":"devices.os","type":"string","input":"text","operator":"equal","value":"zebra"},{"id":"eventlog.datetime","field":"eventlog.datetime","type":"datetime","input":"text","operator":"greater_or_equal","value":"`DATE_SUB(NOW(),INTERVAL 30 SECOND)`"}],"valid":true}
+  },
+  {
+    "name": "Zebra Printer Trap: Critical",
+    "severity": "critical",
+    "builder": {"condition":"AND","rules":[{"id":"eventlog.type","field":"eventlog.type","type":"string","input":"text","operator":"equal","value":"trap"},{"id":"eventlog.severity","field":"eventlog.severity","type":"string","input":"text","operator":"equal","value":"5"},{"id":"devices.os","field":"devices.os","type":"string","input":"text","operator":"equal","value":"zebra"},{"id":"eventlog.datetime","field":"eventlog.datetime","type":"datetime","input":"text","operator":"greater_or_equal","value":"`DATE_SUB(NOW(),INTERVAL 30 SECOND)`"}],"valid":true}
   }
 ]

--- a/resources/definitions/alert_rules.json
+++ b/resources/definitions/alert_rules.json
@@ -878,22 +878,22 @@
   {
     "name": "Dell DRAC power supply status critical",
     "severity": "critical",
-    "builder": {"condition":"AND","rules":[{"id":"devices.os","field":"devices.os","type":"string","input":"text","operator":"equal","value":"drac"},{"id":"sensors.sensor_class","field":"sensors.sensor_class","type":"string","input":"text","operator":"equal","value":"state"},{"id":"sensors.sensor_type","field":"sensors.sensor_type","type":"string","input":"text","operator":"equal","value":"powerSupplyStatus"},{"id":"sensors.sensor_current","field":"sensors.sensor_current","type":"string","input":"text","operator":"regex","value":"[5-6]"}],"valid":true}
+    "builder": {"condition":"AND","rules":[{"id":"devices.os","field":"devices.os","type":"string","input":"text","operator":"equal","value":"drac"},{"id":"sensors.sensor_class","field":"sensors.sensor_class","type":"string","input":"text","operator":"equal","value":"state"},{"id":"sensors.sensor_type","field":"sensors.sensor_type","type":"string","input":"text","operator":"equal","value":"powerSupplyStatus"},{"id":"sensors.sensor_current","field":"sensors.sensor_current","type":"string","input":"text","operator":"regex","value":"[5-6]"},{"id":"macros.device_up","field":"macros.device_up","type":"integer","input":"radio","operator":"equal","value":"1"}],"valid":true}
   },
   {
     "name": "Dell DRAC power supply status warning",
     "severity": "warning",
-    "builder": {"condition":"AND","rules":[{"id":"devices.os","field":"devices.os","type":"string","input":"text","operator":"equal","value":"drac"},{"id":"sensors.sensor_class","field":"sensors.sensor_class","type":"string","input":"text","operator":"equal","value":"state"},{"id":"sensors.sensor_type","field":"sensors.sensor_type","type":"string","input":"text","operator":"equal","value":"powerSupplyStatus"},{"id":"sensors.sensor_current","field":"sensors.sensor_current","type":"string","input":"text","operator":"equal","value":"4"}],"valid":true}
+    "builder": {"condition":"AND","rules":[{"id":"devices.os","field":"devices.os","type":"string","input":"text","operator":"equal","value":"drac"},{"id":"sensors.sensor_class","field":"sensors.sensor_class","type":"string","input":"text","operator":"equal","value":"state"},{"id":"sensors.sensor_type","field":"sensors.sensor_type","type":"string","input":"text","operator":"equal","value":"powerSupplyStatus"},{"id":"sensors.sensor_current","field":"sensors.sensor_current","type":"string","input":"text","operator":"equal","value":"4"},{"id":"macros.device_up","field":"macros.device_up","type":"integer","input":"radio","operator":"equal","value":"1"}],"valid":true}
   },
   {
     "name": "Dell DRAC RAID controller state critical",
     "severity": "critical",
-    "builder": {"condition":"AND","rules":[{"id":"devices.os","field":"devices.os","type":"string","input":"text","operator":"equal","value":"drac"},{"id":"sensors.sensor_class","field":"sensors.sensor_class","type":"string","input":"text","operator":"equal","value":"state"},{"id":"sensors.sensor_type","field":"sensors.sensor_type","type":"string","input":"text","operator":"equal","value":"controllerState"},{"id":"sensors.sensor_current","field":"sensors.sensor_current","type":"string","input":"text","operator":"regex","value":"[2,6]"}],"valid":true}
+    "builder": {"condition":"AND","rules":[{"id":"devices.os","field":"devices.os","type":"string","input":"text","operator":"equal","value":"drac"},{"id":"sensors.sensor_class","field":"sensors.sensor_class","type":"string","input":"text","operator":"equal","value":"state"},{"id":"sensors.sensor_type","field":"sensors.sensor_type","type":"string","input":"text","operator":"equal","value":"controllerState"},{"id":"sensors.sensor_current","field":"sensors.sensor_current","type":"string","input":"text","operator":"regex","value":"[2,6]"},{"id":"macros.device_up","field":"macros.device_up","type":"integer","input":"radio","operator":"equal","value":"1"}],"valid":true}
   },
   {
     "name": "Dell DRAC RAID controller state warning",
     "severity": "warning",
-    "builder": {"condition":"AND","rules":[{"id":"devices.os","field":"devices.os","type":"string","input":"text","operator":"equal","value":"drac"},{"id":"sensors.sensor_class","field":"sensors.sensor_class","type":"string","input":"text","operator":"equal","value":"state"},{"id":"sensors.sensor_type","field":"sensors.sensor_type","type":"string","input":"text","operator":"equal","value":"controllerState"},{"id":"sensors.sensor_current","field":"sensors.sensor_current","type":"string","input":"text","operator":"equal","value":"4"}],"valid":true}
+    "builder": {"condition":"AND","rules":[{"id":"devices.os","field":"devices.os","type":"string","input":"text","operator":"equal","value":"drac"},{"id":"sensors.sensor_class","field":"sensors.sensor_class","type":"string","input":"text","operator":"equal","value":"state"},{"id":"sensors.sensor_type","field":"sensors.sensor_type","type":"string","input":"text","operator":"equal","value":"controllerState"},{"id":"sensors.sensor_current","field":"sensors.sensor_current","type":"string","input":"text","operator":"equal","value":"4"},{"id":"macros.device_up","field":"macros.device_up","type":"integer","input":"radio","operator":"equal","value":"1"}],"valid":true}
   },
   {
     "name": "Dell OME-M blade status critical",
@@ -1068,12 +1068,12 @@
   {
     "name": "Windows High Memory Usage, >= 90% in use",
     "severity": "warning",
-    "builder": {"condition":"AND","rules":[{"id":"mempools.mempool_class","field":"mempools.mempool_class","type":"string","input":"text","operator":"equal","value":"system"},{"id":"mempools.mempool_perc","field":"mempools.mempool_perc","type":"string","input":"number","operator":"greater_or_equal","value":"90"},{"id":"devices.os","field":"devices.os","type":"string","input":"text","operator":"equal","value":"windows"}],"valid":true}
+    "builder": {"condition":"AND","rules":[{"id":"mempools.mempool_class","field":"mempools.mempool_class","type":"string","input":"text","operator":"equal","value":"system"},{"id":"mempools.mempool_perc","field":"mempools.mempool_perc","type":"string","input":"number","operator":"greater_or_equal","value":"90"},{"id":"devices.os","field":"devices.os","type":"string","input":"text","operator":"equal","value":"windows"},{"id":"macros.device_up","field":"macros.device_up","type":"integer","input":"radio","operator":"equal","value":"1"}],"valid":true}
   },
   {
     "name": "Windows High Memory Usage, >= 95% in use",
     "severity": "critical",
-    "builder": {"condition":"AND","rules":[{"id":"mempools.mempool_class","field":"mempools.mempool_class","type":"string","input":"text","operator":"equal","value":"system"},{"id":"mempools.mempool_perc","field":"mempools.mempool_perc","type":"string","input":"number","operator":"greater_or_equal","value":"95"},{"id":"devices.os","field":"devices.os","type":"string","input":"text","operator":"equal","value":"windows"}],"valid":true}
+    "builder": {"condition":"AND","rules":[{"id":"mempools.mempool_class","field":"mempools.mempool_class","type":"string","input":"text","operator":"equal","value":"system"},{"id":"mempools.mempool_perc","field":"mempools.mempool_perc","type":"string","input":"number","operator":"greater_or_equal","value":"95"},{"id":"devices.os","field":"devices.os","type":"string","input":"text","operator":"equal","value":"windows"},{"id":"macros.device_up","field":"macros.device_up","type":"integer","input":"radio","operator":"equal","value":"1"}],"valid":true}
   },
   {
     "name": "Windows Disk Usage, >= 90% and < 95% in use",
@@ -1088,11 +1088,11 @@
   {
     "name": "Zebra Printer Trap: Warning",
     "severity": "warning",
-    "builder": {"condition":"AND","rules":[{"id":"eventlog.type","field":"eventlog.type","type":"string","input":"text","operator":"equal","value":"trap"},{"id":"eventlog.severity","field":"eventlog.severity","type":"string","input":"text","operator":"equal","value":"4"},{"id":"devices.os","field":"devices.os","type":"string","input":"text","operator":"equal","value":"zebra"},{"id":"eventlog.datetime","field":"eventlog.datetime","type":"datetime","input":"text","operator":"greater_or_equal","value":"`DATE_SUB(NOW(),INTERVAL 5 MINUTE)`"}],"valid":true}
+    "builder": {"condition":"AND","rules":[{"id":"eventlog.type","field":"eventlog.type","type":"string","input":"text","operator":"equal","value":"trap"},{"id":"eventlog.severity","field":"eventlog.severity","type":"string","input":"text","operator":"equal","value":"4"},{"id":"devices.os","field":"devices.os","type":"string","input":"text","operator":"equal","value":"zebra"},{"id":"eventlog.datetime","field":"eventlog.datetime","type":"datetime","input":"text","operator":"greater_or_equal","value":"`DATE_SUB(NOW(),INTERVAL 5 MINUTE)`"},{"id":"macros.device_up","field":"macros.device_up","type":"integer","input":"radio","operator":"equal","value":"1"}],"valid":true}
   },
   {
     "name": "Zebra Printer Trap: Critical",
     "severity": "critical",
-    "builder": {"condition":"AND","rules":[{"id":"eventlog.type","field":"eventlog.type","type":"string","input":"text","operator":"equal","value":"trap"},{"id":"eventlog.severity","field":"eventlog.severity","type":"string","input":"text","operator":"equal","value":"5"},{"id":"devices.os","field":"devices.os","type":"string","input":"text","operator":"equal","value":"zebra"},{"id":"eventlog.datetime","field":"eventlog.datetime","type":"datetime","input":"text","operator":"greater_or_equal","value":"`DATE_SUB(NOW(),INTERVAL 5 MINUTE)`"}],"valid":true}
+    "builder": {"condition":"AND","rules":[{"id":"eventlog.type","field":"eventlog.type","type":"string","input":"text","operator":"equal","value":"trap"},{"id":"eventlog.severity","field":"eventlog.severity","type":"string","input":"text","operator":"equal","value":"5"},{"id":"devices.os","field":"devices.os","type":"string","input":"text","operator":"equal","value":"zebra"},{"id":"eventlog.datetime","field":"eventlog.datetime","type":"datetime","input":"text","operator":"greater_or_equal","value":"`DATE_SUB(NOW(),INTERVAL 5 MINUTE)`"},{"id":"macros.device_up","field":"macros.device_up","type":"integer","input":"radio","operator":"equal","value":"1"}],"valid":true}
   }
 ]

--- a/resources/definitions/alert_rules.json
+++ b/resources/definitions/alert_rules.json
@@ -1088,11 +1088,11 @@
   {
     "name": "Zebra Printer Trap: Warning",
     "severity": "warning",
-    "builder": {"condition":"AND","rules":[{"id":"eventlog.type","field":"eventlog.type","type":"string","input":"text","operator":"equal","value":"trap"},{"id":"eventlog.severity","field":"eventlog.severity","type":"string","input":"text","operator":"equal","value":"4"},{"id":"devices.os","field":"devices.os","type":"string","input":"text","operator":"equal","value":"zebra"},{"id":"eventlog.datetime","field":"eventlog.datetime","type":"datetime","input":"text","operator":"greater_or_equal","value":"`DATE_SUB(NOW(),INTERVAL 30 SECOND)`"}],"valid":true}
+    "builder": {"condition":"AND","rules":[{"id":"eventlog.type","field":"eventlog.type","type":"string","input":"text","operator":"equal","value":"trap"},{"id":"eventlog.severity","field":"eventlog.severity","type":"string","input":"text","operator":"equal","value":"4"},{"id":"devices.os","field":"devices.os","type":"string","input":"text","operator":"equal","value":"zebra"},{"id":"eventlog.datetime","field":"eventlog.datetime","type":"datetime","input":"text","operator":"greater_or_equal","value":"`DATE_SUB(NOW(),INTERVAL 5 MINUTE)`"}],"valid":true}
   },
   {
     "name": "Zebra Printer Trap: Critical",
     "severity": "critical",
-    "builder": {"condition":"AND","rules":[{"id":"eventlog.type","field":"eventlog.type","type":"string","input":"text","operator":"equal","value":"trap"},{"id":"eventlog.severity","field":"eventlog.severity","type":"string","input":"text","operator":"equal","value":"5"},{"id":"devices.os","field":"devices.os","type":"string","input":"text","operator":"equal","value":"zebra"},{"id":"eventlog.datetime","field":"eventlog.datetime","type":"datetime","input":"text","operator":"greater_or_equal","value":"`DATE_SUB(NOW(),INTERVAL 30 SECOND)`"}],"valid":true}
+    "builder": {"condition":"AND","rules":[{"id":"eventlog.type","field":"eventlog.type","type":"string","input":"text","operator":"equal","value":"trap"},{"id":"eventlog.severity","field":"eventlog.severity","type":"string","input":"text","operator":"equal","value":"5"},{"id":"devices.os","field":"devices.os","type":"string","input":"text","operator":"equal","value":"zebra"},{"id":"eventlog.datetime","field":"eventlog.datetime","type":"datetime","input":"text","operator":"greater_or_equal","value":"`DATE_SUB(NOW(),INTERVAL 5 MINUTE)`"}],"valid":true}
   }
 ]


### PR DESCRIPTION
Add collection alert rules for:
- Windows CPU, memory, and disk usage at warning (90%) and critical (95%) thresholds
- Zebra printer SNMP trap alerts for warning and critical severity
- Dell DRAC power supply status and RAID controller state

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
