### PR TITLE
Fix query builder filter dropdown not matching partial table names when searching

### DIFF
--- a/includes/html/modal/new_alert_rule.inc.php
+++ b/includes/html/modal/new_alert_rule.inc.php
@@ -187,7 +187,31 @@ $default_invert_map = LibrenmsConfig::get('alert_rule.invert_map');
                 $(this).select2({
                     dropdownParent: $("#create-alert"),
                     dropdownAutoWidth : true,
-                    width: 'auto'
+                    width: 'auto',
+                    matcher: function (params, data) {
+                        if ($.trim(params.term) === '') {
+                            return data;
+                        }
+                        if (typeof data.text === 'undefined') {
+                            return null;
+                        }
+                        // match each dot-separated segment as a prefix so "device.os" matches "devices.os"
+                        var termParts = params.term.toLowerCase().split('.');
+                        var textParts = data.text.toLowerCase().split('.');
+                        if (termParts.length > textParts.length) {
+                            return null;
+                        }
+                        for (var i = 0; i < termParts.length; i++) {
+                            if (textParts[i].indexOf(termParts[i]) !== 0) {
+                                // also allow a plain substring match on the full text
+                                if (data.text.toLowerCase().indexOf(params.term.toLowerCase()) > -1) {
+                                    return data;
+                                }
+                                return null;
+                            }
+                        }
+                        return data;
+                    }
                 });
             });
         }).on('ruleToSQL.queryBuilder.filter', function (e, rule) {

--- a/resources/views/device-group/form.blade.php
+++ b/resources/views/device-group/form.blade.php
@@ -62,7 +62,29 @@
         $("[name$='_filter']").each(function () {
             $(this).select2({
                 dropdownAutoWidth: true,
-                width: 'auto'
+                width: 'auto',
+                matcher: function (params, data) {
+                    if ($.trim(params.term) === '') {
+                        return data;
+                    }
+                    if (typeof data.text === 'undefined') {
+                        return null;
+                    }
+                    var termParts = params.term.toLowerCase().split('.');
+                    var textParts = data.text.toLowerCase().split('.');
+                    if (termParts.length > textParts.length) {
+                        return null;
+                    }
+                    for (var i = 0; i < termParts.length; i++) {
+                        if (textParts[i].indexOf(termParts[i]) !== 0) {
+                            if (data.text.toLowerCase().indexOf(params.term.toLowerCase()) > -1) {
+                                return data;
+                            }
+                            return null;
+                        }
+                    }
+                    return data;
+                }
             });
         });
     }).on('ruleToSQL.queryBuilder.filter', function (e, rule) {

--- a/resources/views/service-template/form.blade.php
+++ b/resources/views/service-template/form.blade.php
@@ -134,7 +134,29 @@
         $("[name$='_filter']").each(function () {
             $(this).select2({
                 dropdownAutoWidth: true,
-                width: 'auto'
+                width: 'auto',
+                matcher: function (params, data) {
+                    if ($.trim(params.term) === '') {
+                        return data;
+                    }
+                    if (typeof data.text === 'undefined') {
+                        return null;
+                    }
+                    var termParts = params.term.toLowerCase().split('.');
+                    var textParts = data.text.toLowerCase().split('.');
+                    if (termParts.length > textParts.length) {
+                        return null;
+                    }
+                    for (var i = 0; i < termParts.length; i++) {
+                        if (textParts[i].indexOf(termParts[i]) !== 0) {
+                            if (data.text.toLowerCase().indexOf(params.term.toLowerCase()) > -1) {
+                                return data;
+                            }
+                            return null;
+                        }
+                    }
+                    return data;
+                }
             });
         });
     }).on('ruleToSQL.queryBuilder.filter', function (e, rule) {


### PR DESCRIPTION
The Select2 dropdown in the query builder rule filter uses a default substring matcher. Filter options use "table.column" format (e.g. "devices.os"), but typing "device.os" would not match because the default indexOf check fails "device.os" is not a substring of "devices.os" due to the trailing 's' before the dot.

Replace the default Select2 matcher with a custom one that splits the search term and option text on dots and matches each segment as a prefix. This way "device.os" matches "devices.os" because "device" is a prefix of "devices" and "os" matches "os". A plain substring fallback is also retained for non-dotted searches.

Applied the fix to all three query builder instances:
- Alert rule builder (new_alert_rule.inc.php)
- Device group builder (device-group/form.blade.php)
- Service template builder (service-template/form.blade.php)

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
