### PR TITLE
Fix the new SSL page to show HTML on the days until expiry column

### DIFF
--- a/app/Http/Controllers/Table/SslCertificateController.php
+++ b/app/Http/Controllers/Table/SslCertificateController.php
@@ -63,12 +63,12 @@ class SslCertificateController extends TableController
 
         $daysUntilExpiry = $sslCertificate->days_until_expiry;
         $daysDisplay = $daysUntilExpiry !== null
-            ? (string) $daysUntilExpiry . ' ' . __('days')
+            ? (string) e($daysUntilExpiry) . ' ' . __('days')
             : '—';
         if ($daysUntilExpiry !== null && $daysUntilExpiry <= $daysDanger) {
-            $daysDisplay = '<span class="text-danger">' . $daysUntilExpiry . ' ' . __('days') . '</span>';
+            $daysDisplay = '<span class="text-danger">' . e($daysUntilExpiry) . ' ' . __('days') . '</span>';
         } elseif ($daysUntilExpiry !== null && $daysUntilExpiry <= $daysWarning) {
-            $daysDisplay = '<span class="text-warning">' . $daysUntilExpiry . ' ' . __('days') . '</span>';
+            $daysDisplay = '<span class="text-warning">' . e($daysUntilExpiry) . ' ' . __('days') . '</span>';
         }
 
         return [
@@ -78,7 +78,7 @@ class SslCertificateController extends TableController
             'subject' => e($sslCertificate->subject),
             'issuer' => e($sslCertificate->issuer),
             'valid_to' => e($validTo),
-            'days_until_expiry' => e($daysDisplay),
+            'days_until_expiry' => $daysDisplay,
             'last_checked_at' => $sslCertificate->last_checked_at !== null ? e($sslCertificate->last_checked_at->format('Y-m-d H:i')) : null,
             'device_id' => $sslCertificate->device_id,
             'device' => $deviceLink,


### PR DESCRIPTION
Currently the days until expiry column on the new SSL Certificates page shows the HTML span tags, this corrects that issue by changing where we run htmlentities on the content.

Before Patch
<img width="390" height="136" alt="chrome_CX4PFLayMm" src="https://github.com/user-attachments/assets/6aa8ab64-9269-437c-b777-c54c8b34fb8e" />

After Patch
<img width="221" height="159" alt="fixed" src="https://github.com/user-attachments/assets/9e82e2fe-8332-4d1e-806d-cf127f4c7b81" />


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
