### PR TITLE
fix(drac): show temperature and power graphs in device overview

### DIFF
--- a/resources/definitions/os_detection/drac.yaml
+++ b/resources/definitions/os_detection/drac.yaml
@@ -3,6 +3,9 @@ text: 'Dell DRAC'
 icon: dell
 type: management
 mib_dir: dell
+over:
+    - { graph: device_temperature, text: 'Temperature' }
+    - { graph: device_power, text: 'Power' }
 discovery:
     -
         sysObjectID:


### PR DESCRIPTION
iDRAC management cards do not expose CPU or memory utilisation OIDs, so the default Processor/Memory overview graphs render as broken images. Override with temperature and power sensor graphs that iDRAC actually collects.

This is a follow up to https://github.com/librenms/librenms/pull/19403 only without the override to the CPU/Memory at collection level. 

This puts the idrac overview page inline with the supermicro impi overview page

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
