### PR TITLE
Fix Junos Optic Temperature Discovery

### DIFF
--- a/resources/definitions/os_discovery/junos.yaml
+++ b/resources/definitions/os_discovery/junos.yaml
@@ -212,7 +212,7 @@ modules:
                     oid: JUNIPER-DOM-MIB::jnxDomCurrentTable
                     value: JUNIPER-DOM-MIB::jnxDomCurrentModuleTemperature
                     num_oid: '.1.3.6.1.4.1.2636.3.60.1.1.1.1.8.{{ $index }}'
-                    descr: '{{ IF-MIB::ifDescr }} Temperature'
+                    descr: '{{ IF-MIB::ifDescr }} Module Temperature'
                     skip_values: 0
                     low_limit: JUNIPER-DOM-MIB::jnxDomCurrentModuleTemperatureLowAlarmThreshold
                     low_warn_limit: JUNIPER-DOM-MIB::jnxDomCurrentModuleTemperatureLowWarningThreshold
@@ -228,7 +228,8 @@ modules:
                     num_oid: '.1.3.6.1.4.1.2636.3.71.1.2.1.1.39.{{ $index }}'
                     entPhysicalIndex: '{{ $index }}'
                     entPhysicalIndex_measured: 'ports'
-                    descr: '{{ IF-MIB::ifDescr }} Temperature'
+                    divisor: 10
+                    descr: '{{ IF-MIB::ifDescr }} Laser Temperature'
                     index: 'jnxPMCurTemperature.{{ $index }}'
                     group: transceiver
         current:


### PR DESCRIPTION
Coherent optics have a temperature sensor on the module and the transmit laser. For Junos, the current discovery outputs in Celsius while the device returns an integer value in .1 Celsius (JUNIPER-IFOPTICS-MIB::jnxPMCurTemperature), which is correct per the MIB.

This change adds a divisor value of 10 so that the recorded value is in Celsius. 

It also updates the graph heading for this OID to read '{{ IF-MIB::ifDescr }} Laser Temperature', and the graph heading for the module temperature (JUNIPER-DOM-MIB::jnxDomCurrentModuleTemperature) to '{{ IF-MIB::ifDescr }} Module Temperature' to make them distinct.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
