### PR TITLE
Enable Larastan noUnnecessaryEnumerableToArrayCalls rule and fix violations

### DIFF
--- a/LibreNMS/Validations/Poller/CheckDispatcherService.php
+++ b/LibreNMS/Validations/Poller/CheckDispatcherService.php
@@ -73,7 +73,7 @@ class CheckDispatcherService implements \LibreNMS\Interfaces\Validation
 
             if ($inactive->isNotEmpty()) {
                 return ValidationResult::fail(trans('validation.validations.poller.CheckDispatcherService.nodes_down'))
-                    ->setList('Inactive Nodes', $inactive->toArray());
+                    ->setList('Inactive Nodes', $inactive->all());
             }
 
             // all ok

--- a/app/Console/Commands/Traits/CompletesConfigArgument.php
+++ b/app/Console/Commands/Traits/CompletesConfigArgument.php
@@ -37,7 +37,7 @@ trait CompletesConfigArgument
     public function completeArgument($name, $value, $previous)
     {
         if ($name == 'setting') {
-            return (new DynamicConfig())->all()->keys()->filter(fn ($setting) => Str::startsWith($setting, $value))->toArray();
+            return (new DynamicConfig())->all()->keys()->filter(fn ($setting) => Str::startsWith($setting, $value))->all();
         } elseif ($name == 'value') {
             $config = (new DynamicConfig())->get($previous);
 

--- a/app/Http/Requests/AlertRuleRequest.php
+++ b/app/Http/Requests/AlertRuleRequest.php
@@ -91,7 +91,7 @@ class AlertRuleRequest extends FormRequest
             ->mapWithKeys(fn ($field) => [$field => match ($this->input($field)) {
                 'on', '1', 1, true => true,
                 default => false
-            }])->toArray());
+            }])->all());
 
         // Ensure maps/transports are arrays if present as empty string
         foreach (['maps', 'transports'] as $key) {

--- a/app/Listeners/MarkNotificationsRead.php
+++ b/app/Listeners/MarkNotificationsRead.php
@@ -37,7 +37,7 @@ class MarkNotificationsRead
                 'user_id' => $user->user_id,
                 'key' => 'read',
                 'value' => 1,
-            ])->toArray());
+            ])->all());
 
         \Log::info('Marked all notifications as read for user ' . $user->username);
     }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -34,6 +34,7 @@ parameters:
     checkInternalClassCaseSensitivity: true
 
     checkModelProperties: true
+    noUnnecessaryEnumerableToArrayCalls: true
 
     ignoreErrors:
         - '#Unsafe usage of new static#'


### PR DESCRIPTION
This rule checks for unnecessary calls Enumerable::toArray() that could have used all() instead. The toArray() method recursively converts all Arrayable items in the Enumerable to an array and if none of the items are Arrayable, it is unnecessary map call.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
