### PR TITLE
Remove del_dev_attrib

### DIFF
--- a/includes/common.php
+++ b/includes/common.php
@@ -205,11 +205,6 @@ function get_dev_attrib($device, $attrib_type)
     return DeviceCache::get((int) $device['device_id'])->getAttrib($attrib_type);
 }
 
-function del_dev_attrib($device, $attrib_type)
-{
-    return DeviceCache::get((int) $device['device_id'])->forgetAttrib($attrib_type);
-}
-
 /**
  * Output using console color if possible
  * https://github.com/pear/Console_Color2/blob/master/examples/documentation

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -1271,7 +1271,7 @@ function update_port_description(Illuminate\Http\Request $request)
     if ($description == 'repoll') {
         // No description provided, clear description
         $device->forgetAttrib('ifName:' . $port->ifName);
-        Eventlog::log("$ifName Port ifAlias cleared via API", $port->device_id, 'interface', Severity::Notice, $port->port_id);
+        Eventlog::log("$port->ifName Port ifAlias cleared via API", $port->device_id, 'interface', Severity::Notice, $port->port_id);
 
         return api_success_noresult(200, 'Port description cleared.');
     } else {

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -1248,9 +1248,12 @@ function update_port_description(Illuminate\Http\Request $request)
         ->where([
             'port_id' => $port_id,
         ])->first();
+
     if (empty($port)) {
         return api_error(400, 'Invalid port ID.');
     }
+
+    $device = DeviceCache::get($port->device_id);
 
     $data = json_decode($request->getContent(), true);
     $field = 'description';
@@ -1265,19 +1268,16 @@ function update_port_description(Illuminate\Http\Request $request)
     $port->ifAlias = $description;
     $port->save();
 
-    $ifName = $port->ifName;
-    $device = $port->device_id;
-
     if ($description == 'repoll') {
         // No description provided, clear description
-        del_dev_attrib($port, 'ifName:' . $ifName); // "port" object has required device_id
-        Eventlog::log("$ifName Port ifAlias cleared via API", $device, 'interface', Severity::Notice, $port_id);
+        $device->forgetAttrib('ifName:' . $port->ifName);
+        Eventlog::log("$ifName Port ifAlias cleared via API", $port->device_id, 'interface', Severity::Notice, $port->port_id);
 
         return api_success_noresult(200, 'Port description cleared.');
     } else {
         // Prevent poller from overwriting new description
-        set_dev_attrib($port, 'ifName:' . $ifName, 1); // see above
-        Eventlog::log("$ifName Port ifAlias set via API: $description", $device, 'interface', Severity::Notice, $port_id);
+        $device->setAttrib('ifName:' . $port->ifName, 1);
+        Eventlog::log("$port->ifName Port ifAlias set via API: $description", $port->device_id, 'interface', Severity::Notice, $port->port_id);
 
         return api_success_noresult(200, 'Port description updated.');
     }

--- a/includes/html/forms/override-config.inc.php
+++ b/includes/html/forms/override-config.inc.php
@@ -12,6 +12,7 @@
  * the source code distribution for details.
 */
 
+use App\Facades\DeviceCache;
 use App\Models\Device;
 use Illuminate\Support\Facades\Gate;
 
@@ -38,7 +39,7 @@ if (empty($device['device_id'])) {
     if ($state == true) {
         set_dev_attrib($device, $attrib, $state);
     } else {
-        del_dev_attrib($device, $attrib);
+        DeviceCache::get((int) $device['device_id'])->forgetAttrib($attrib);
     }
     $status = 'ok';
     $message = 'Config has been updated';

--- a/includes/html/forms/update-ifalias.inc.php
+++ b/includes/html/forms/update-ifalias.inc.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Facades\DeviceCache;
 use App\Models\Eventlog;
 use App\Models\Port;
 use LibreNMS\Enum\Severity;
@@ -34,13 +35,13 @@ if (! empty($ifName) && is_numeric($port_id)) {
         // Set to repoll so we avoid using ifDescr on port poll
     }
     if (Port::where('port_id', $port_id)->update(['ifAlias' => $descr]) > 0) {
-        $device = device_by_id_cache($device_id);
+        $device = DeviceCache::get($device_id);
         if ($descr === 'repoll') {
-            del_dev_attrib($device, 'ifName:' . $ifName);
-            Eventlog::log("$ifName Port ifAlias cleared manually", $device['device_id'], 'interface', Severity::Notice, $port_id);
+            $device->forgetAttrib('ifName:' . $ifName);
+            Eventlog::log("$ifName Port ifAlias cleared manually", $device->device_id, 'interface', Severity::Notice, $port_id);
         } else {
-            set_dev_attrib($device, 'ifName:' . $ifName, 1);
-            Eventlog::log("$ifName Port ifAlias set manually: $descr", $device['device_id'], 'interface', Severity::Notice, $port_id);
+            $device->setAttrib('ifName:' . $ifName, 1);
+            Eventlog::log("$ifName Port ifAlias set manually: $descr", $device->device_id, 'interface', Severity::Notice, $port_id);
         }
         $status = 'ok';
     } else {

--- a/includes/html/pages/device/edit/ipmi.inc.php
+++ b/includes/html/pages/device/edit/ipmi.inc.php
@@ -3,7 +3,8 @@
 use Illuminate\Support\Facades\Gate;
 
 if ($_POST['editing']) {
-    if (Gate::allows('update', DeviceCache::getPrimary())) {
+    $device=DeviceCache::getPrimary();
+    if (Gate::allows('update', $device)) {
         $ipmi_hostname = $_POST['ipmi_hostname'];
         $ipmi_port = (int) $_POST['ipmi_port'];
         $ipmi_username = $_POST['ipmi_username'];
@@ -13,45 +14,45 @@ if ($_POST['editing']) {
         $ipmi_timeout = $_POST['ipmi_timeout'];
 
         if ($ipmi_hostname != '') {
-            set_dev_attrib($device, 'ipmi_hostname', $ipmi_hostname);
+            $device->setAttrib('ipmi_hostname', $ipmi_hostname);
         } else {
-            del_dev_attrib($device, 'ipmi_hostname');
+            $device->forgetAttrib('ipmi_hostname');
         }
 
         if ($ipmi_port != 0) {
-            set_dev_attrib($device, 'ipmi_port', $ipmi_port);
+            $device->setAttrib('ipmi_port', $ipmi_port);
         } else {
-            set_dev_attrib($device, 'ipmi_port', '623'); // Default port
+            $device->setAttrib('ipmi_port', 623); // Default port
         }
 
         if ($ipmi_username != '') {
-            set_dev_attrib($device, 'ipmi_username', $ipmi_username);
+            $device->setAttrib('ipmi_username', $ipmi_username);
         } else {
-            del_dev_attrib($device, 'ipmi_username');
+            $device->forgetAttrib('ipmi_username');
         }
 
         if ($ipmi_password != '') {
-            set_dev_attrib($device, 'ipmi_password', $ipmi_password);
+            $device->setAttrib('ipmi_password', $ipmi_password);
         } else {
-            del_dev_attrib($device, 'ipmi_password');
+            $device->forgetAttrib('ipmi_password');
         }
 
         if ($ipmi_kg_key != '') {
-            set_dev_attrib($device, 'ipmi_kg_key', $ipmi_kg_key);
+            $device->setAttrib('ipmi_kg_key', $ipmi_kg_key);
         } else {
-            del_dev_attrib($device, 'ipmi_kg_key');
+            $device->forgetAttrib('ipmi_kg_key');
         }
 
         if ($ipmi_ciphersuite != '') {
-            set_dev_attrib($device, 'ipmi_ciphersuite', $ipmi_ciphersuite);
+            $device->setAttrib('ipmi_ciphersuite', $ipmi_ciphersuite);
         } else {
-            del_dev_attrib($device, 'ipmi_ciphersuite');
+            $device->forgetAttrib('ipmi_ciphersuite');
         }
 
         if ($ipmi_timeout != '') {
-            set_dev_attrib($device, 'ipmi_timeout', $ipmi_timeout);
+            $device->setAttrib('ipmi_timeout', $ipmi_timeout);
         } else {
-            del_dev_attrib($device, 'ipmi_timeout');
+            $device->forgetAttrib('ipmi_timeout');
         }
 
         $update_message = 'Device IPMI data updated.';

--- a/includes/html/pages/device/edit/ipmi.inc.php
+++ b/includes/html/pages/device/edit/ipmi.inc.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Facades\DeviceCache;
 use Illuminate\Support\Facades\Gate;
 
 if ($_POST['editing']) {

--- a/includes/html/pages/device/edit/snmp.inc.php
+++ b/includes/html/pages/device/edit/snmp.inc.php
@@ -63,7 +63,6 @@ if (isset($_POST['editing'])) {
             // update devices_attribs table
 
             // note:
-            // set_dev_attrib and del_dev_attrib *only* return (bool)
             // setAttrib() returns true if it was set and false if it was not (e.g. it didn't change)
             // forgetAttrib() returns true if it was deleted and false if it was not (e.g. it didn't exist)
             // Symfony throws FatalThrowableError on error


### PR DESCRIPTION
`del_dev_attrib($device, $attrib_type)` => `DeviceCache::get( $device['device_id'])->forgetAttrib($attrib_type)`

I will start by removing the first of the three 'get, set, del_dev_attib' functions. I am not sure if there will be any side effects, so I am splitting the process into multiple steps.

It's untested!


Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
