### PR TITLE
Add beforeSave hook for SettingsHook to transform settings on save

### DIFF
--- a/app/Http/Controllers/PluginSettingsController.php
+++ b/app/Http/Controllers/PluginSettingsController.php
@@ -30,12 +30,25 @@ class PluginSettingsController extends Controller
         return view('plugins.settings', $data);
     }
 
-    public function update(Request $request, Plugin $plugin): \Illuminate\Http\RedirectResponse
+    public function update(Request $request, \App\Plugins\PluginManager $manager, Plugin $plugin): \Illuminate\Http\RedirectResponse
     {
-        $plugin->fill($this->validate($request, [
+        $validated = $this->validate($request, [
             'plugin_active' => 'in:0,1',
             'settings' => 'array',
-        ]));
+        ]);
+
+        if (isset($validated['settings'])) {
+            // Let the plugin's SettingsHook transform the submitted
+            // settings (e.g. preserve secrets the form intentionally
+            // omits) before the wholesale replace below.
+            $validated['settings'] = $manager->applyBeforeSave(
+                $plugin->plugin_name,
+                $validated['settings'],
+                (array) $plugin->settings,
+            );
+        }
+
+        $plugin->fill($validated);
 
         if ($plugin->isDirty('plugin_active') && $plugin->plugin_active == 1) {
             // enabling plugin delete notifications assuming they are fixed

--- a/app/Plugins/Hooks/SettingsHook.php
+++ b/app/Plugins/Hooks/SettingsHook.php
@@ -46,6 +46,31 @@ abstract class SettingsHook implements \LibreNMS\Interfaces\Plugins\Hooks\Settin
         ];
     }
 
+    /**
+     * Transform submitted settings before they are persisted.
+     *
+     * Called by PluginSettingsController with the settings submitted from
+     * the form and the settings currently stored for the plugin. The
+     * returned array is what actually gets written to the database.
+     *
+     * Useful for preserving fields the form intentionally omits — most
+     * commonly secrets (API keys, passwords, OAuth tokens) that should
+     * not round-trip through the rendered HTML but also should not be
+     * cleared when the admin saves unrelated changes without re-entering
+     * them.
+     *
+     * The default implementation is a pass-through so existing plugins
+     * keep their historical "wholesale replace" save behavior.
+     *
+     * @param  array  $incoming  settings submitted via the form
+     * @param  array  $current  settings currently stored for this plugin
+     * @return array settings to persist
+     */
+    public function beforeSave(array $incoming, array $current): array
+    {
+        return $incoming;
+    }
+
     final public function handle(string $pluginName, array $settings, Application $app): array
     {
         return array_merge([

--- a/app/Plugins/PluginManager.php
+++ b/app/Plugins/PluginManager.php
@@ -131,6 +131,37 @@ class PluginManager implements PluginManagerInterface
     }
 
     /**
+     * Dispatch beforeSave to the plugin's SettingsHook, allowing the
+     * plugin to merge or transform submitted settings with the
+     * currently-stored settings before they are persisted. Used by
+     * PluginSettingsController::update before the wholesale replace.
+     *
+     * Returns $incoming unchanged if the plugin has no settings hook, if
+     * the registered hook doesn't extend the abstract SettingsHook (and
+     * therefore has no beforeSave default), or if the hook's authorize()
+     * check denies the current user — matching the authorization
+     * semantics the GET path already uses.
+     *
+     * @param  string  $pluginName
+     * @param  array  $incoming  settings submitted from the form
+     * @param  array  $current  settings currently stored for the plugin
+     * @return array settings to persist
+     */
+    public function applyBeforeSave(string $pluginName, array $incoming, array $current): array
+    {
+        $hookType = \LibreNMS\Interfaces\Plugins\Hooks\SettingsHook::class;
+
+        foreach ($this->hooksFor($hookType, [], $pluginName) as $hook) {
+            $instance = $hook['instance'];
+            if ($instance instanceof Hooks\SettingsHook) {
+                return $instance->beforeSave($incoming, $current);
+            }
+        }
+
+        return $incoming;
+    }
+
+    /**
      * Get the settings stored in the database for a plugin.
      * One plugin shares the settings across all hooks
      *

--- a/tests/Unit/Plugins/Fixtures/DirectInterfaceSettingsHook.php
+++ b/tests/Unit/Plugins/Fixtures/DirectInterfaceSettingsHook.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * DirectInterfaceSettingsHook.php
+ *
+ * Test fixture: a plugin that implements the SettingsHook interface
+ * directly (i.e. without extending the abstract class). Used to
+ * verify that PluginManager::applyBeforeSave() skips hooks that have
+ * no beforeSave() method rather than throwing a method-not-found
+ * error.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @link       https://www.librenms.org
+ */
+
+namespace LibreNMS\Tests\Unit\Plugins\Fixtures;
+
+use App\Models\User;
+use LibreNMS\Interfaces\Plugins\Hooks\SettingsHook;
+
+final class DirectInterfaceSettingsHook implements SettingsHook
+{
+    public function authorize(User $user): bool
+    {
+        return true;
+    }
+}

--- a/tests/Unit/Plugins/Fixtures/MergingSettingsHook.php
+++ b/tests/Unit/Plugins/Fixtures/MergingSettingsHook.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * MergingSettingsHook.php
+ *
+ * Test fixture: a SettingsHook whose beforeSave() returns a marker
+ * payload built from the incoming and current arrays. Used to verify
+ * PluginManager::applyBeforeSave() actually dispatches to the right
+ * instance and passes both arguments through.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @link       https://www.librenms.org
+ */
+
+namespace LibreNMS\Tests\Unit\Plugins\Fixtures;
+
+use App\Plugins\Hooks\SettingsHook;
+
+final class MergingSettingsHook extends SettingsHook
+{
+    public function beforeSave(array $incoming, array $current): array
+    {
+        return [
+            'merged' => true,
+            'from_incoming' => $incoming['key'],
+            'from_current' => $current['key'],
+        ];
+    }
+}

--- a/tests/Unit/Plugins/Fixtures/PassthroughSettingsHook.php
+++ b/tests/Unit/Plugins/Fixtures/PassthroughSettingsHook.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * PassthroughSettingsHook.php
+ *
+ * Test fixture: a SettingsHook that relies entirely on the abstract
+ * class's default beforeSave() pass-through behavior.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @link       https://www.librenms.org
+ */
+
+namespace LibreNMS\Tests\Unit\Plugins\Fixtures;
+
+use App\Plugins\Hooks\SettingsHook;
+
+final class PassthroughSettingsHook extends SettingsHook
+{
+}

--- a/tests/Unit/Plugins/Fixtures/PreservingSettingsHook.php
+++ b/tests/Unit/Plugins/Fixtures/PreservingSettingsHook.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * PreservingSettingsHook.php
+ *
+ * Test fixture: a SettingsHook that preserves the stored api_key when
+ * the form submits it blank. Demonstrates the canonical "don't clear
+ * the secret if the admin didn't touch the field" use case.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @link       https://www.librenms.org
+ */
+
+namespace LibreNMS\Tests\Unit\Plugins\Fixtures;
+
+use App\Plugins\Hooks\SettingsHook;
+
+final class PreservingSettingsHook extends SettingsHook
+{
+    public function beforeSave(array $incoming, array $current): array
+    {
+        if (empty($incoming['api_key']) && ! empty($current['api_key'])) {
+            $incoming['api_key'] = $current['api_key'];
+        }
+
+        return $incoming;
+    }
+}

--- a/tests/Unit/Plugins/SettingsHookBeforeSaveTest.php
+++ b/tests/Unit/Plugins/SettingsHookBeforeSaveTest.php
@@ -1,0 +1,139 @@
+<?php
+
+/*
+ * SettingsHookBeforeSaveTest.php
+ *
+ * Unit tests for SettingsHook::beforeSave() and
+ * PluginManager::applyBeforeSave().
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * @link       https://www.librenms.org
+ */
+
+namespace LibreNMS\Tests\Unit\Plugins;
+
+use App\Plugins\PluginManager;
+use Illuminate\Support\Collection;
+use LibreNMS\Tests\TestCase;
+
+final class SettingsHookBeforeSaveTest extends TestCase
+{
+    /**
+     * Build a PluginManager with its hooksFor() method stubbed so tests
+     * can inject hook instances directly without touching the database
+     * or the real plugin registration path.
+     */
+    private function managerWithHooks(array $hooks): PluginManager
+    {
+        $manager = $this->getMockBuilder(PluginManager::class)
+            ->onlyMethods(['hooksFor'])
+            ->getMock();
+
+        $manager->method('hooksFor')
+            ->willReturn(new Collection($hooks));
+
+        return $manager;
+    }
+
+    // ──────────────────────────────────────────────
+    // Abstract class default
+    // ──────────────────────────────────────────────
+
+    public function testAbstractDefaultReturnsIncomingUnchanged(): void
+    {
+        $hook = new Fixtures\PassthroughSettingsHook();
+
+        $incoming = ['api_url' => 'https://example.com', 'api_key' => ''];
+        $current = ['api_url' => 'https://example.com', 'api_key' => 'sk-secret'];
+
+        $this->assertSame($incoming, $hook->beforeSave($incoming, $current));
+    }
+
+    public function testPluginCanPreserveSecretWhenFormFieldIsBlank(): void
+    {
+        $hook = new Fixtures\PreservingSettingsHook();
+
+        $incoming = ['api_url' => 'https://example.com', 'api_key' => ''];
+        $current = ['api_url' => 'https://other.com', 'api_key' => 'sk-secret'];
+
+        $result = $hook->beforeSave($incoming, $current);
+
+        $this->assertSame('https://example.com', $result['api_url'], 'non-secret fields follow the incoming form');
+        $this->assertSame('sk-secret', $result['api_key'], 'blank secret is replaced with the stored value');
+    }
+
+    public function testPluginCanClearSecretByNotOverridingDefault(): void
+    {
+        // Default pass-through means a blank field DOES clear the stored
+        // value — this is the historical behavior and should not regress
+        // for plugins that don't opt in to beforeSave().
+        $hook = new Fixtures\PassthroughSettingsHook();
+
+        $incoming = ['api_key' => ''];
+        $current = ['api_key' => 'sk-secret'];
+
+        $result = $hook->beforeSave($incoming, $current);
+
+        $this->assertSame('', $result['api_key']);
+    }
+
+    // ──────────────────────────────────────────────
+    // PluginManager::applyBeforeSave dispatch
+    // ──────────────────────────────────────────────
+
+    public function testApplyBeforeSaveReturnsIncomingWhenNoHookRegistered(): void
+    {
+        $manager = $this->managerWithHooks([]);
+
+        $incoming = ['key' => 'new'];
+        $current = ['key' => 'old'];
+
+        $this->assertSame($incoming, $manager->applyBeforeSave('SomePlugin', $incoming, $current));
+    }
+
+    public function testApplyBeforeSaveDispatchesToAbstractHook(): void
+    {
+        $hook = new Fixtures\MergingSettingsHook();
+
+        $manager = $this->managerWithHooks([
+            ['plugin_name' => 'TestPlugin', 'instance' => $hook],
+        ]);
+
+        $result = $manager->applyBeforeSave('TestPlugin', ['key' => 'new'], ['key' => 'old']);
+
+        $this->assertSame([
+            'merged' => true,
+            'from_incoming' => 'new',
+            'from_current' => 'old',
+        ], $result);
+    }
+
+    public function testApplyBeforeSaveSkipsHooksThatDoNotExtendAbstractClass(): void
+    {
+        // A plugin that implements the interface directly (without
+        // extending the abstract class) has no beforeSave default, so
+        // the dispatcher should skip it and return $incoming unchanged.
+        $hook = new Fixtures\DirectInterfaceSettingsHook();
+
+        $manager = $this->managerWithHooks([
+            ['plugin_name' => 'DirectPlugin', 'instance' => $hook],
+        ]);
+
+        $incoming = ['key' => 'new'];
+        $current = ['key' => 'old'];
+
+        $this->assertSame($incoming, $manager->applyBeforeSave('DirectPlugin', $incoming, $current));
+    }
+}


### PR DESCRIPTION
## Summary

Add a `beforeSave(array $incoming, array $current): array` hook on the abstract `SettingsHook` class so plugins can transform submitted settings before they're persisted. The default implementation is a pass-through, so existing plugins are unaffected.

## Motivation

`PluginSettingsController::update` currently does a wholesale replace of `$plugin->settings` with whatever the form submits. This forces any plugin with sensitive fields — API keys, passwords, OAuth tokens — into one of two bad choices:

1. Echo the stored secret back into the form as a `value="…"` attribute so it round-trips on save. This leaks the secret to anyone who can view the settings page HTML.
2. Leave the field blank and force admins to re-enter the secret on every save. Workable but easy to forget, and "admin hit save and the API key is gone" is a real footgun.

Neither is good. The `beforeSave` hook lets a plugin inspect both the submitted form data and the currently-stored settings and return the merged result to persist. Typical use case:

```php
public function beforeSave(array $incoming, array $current): array
{
    if (empty($incoming['api_key']) && ! empty($current['api_key'])) {
        $incoming['api_key'] = $current['api_key'];
    }

    return $incoming;
}
```

## Scope

- `app/Plugins/Hooks/SettingsHook.php` — add `beforeSave()` with pass-through default implementation
- `app/Plugins/PluginManager.php` — add `applyBeforeSave()` dispatcher that finds the plugin's SettingsHook and calls `beforeSave()` on it
- `app/Http/Controllers/PluginSettingsController.php` — call the dispatcher in `update()` before `$plugin->fill()`
- `tests/Unit/Plugins/SettingsHookBeforeSaveTest.php` — 6 unit tests covering the default pass-through, a plugin overriding to preserve a secret, a plugin choosing not to override, the no-hook-registered path, and the "plugin implements interface directly without the abstract class" edge case

No changes to the `librenms/plugin-interfaces` composer package — the interface stays empty, so BC is preserved for third-party plugins that implement it directly.

## Backwards compatibility

- Plugins extending the existing abstract `SettingsHook` get the default pass-through behavior automatically — identical to today's "wholesale replace" semantics.
- Plugins implementing the `LibreNMS\Interfaces\Plugins\Hooks\SettingsHook` interface directly (without the abstract class) are unaffected — the dispatcher checks `instanceof App\Plugins\Hooks\SettingsHook` before calling `beforeSave`.
- No database changes, no config changes, no composer changes.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/) — `./lnms dev:check` (lint + PHPStan deprecated + PHPStan main + style) runs clean on this branch.
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it. — **Not applicable**: no UI changes, the settings form is unchanged; this only adds a server-side hook that plugins can opt into.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/). — **Not applicable**: no discovery, polling, or YAML changes.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.