### PR TITLE
Cleanup unused functions

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -230,17 +230,6 @@ function convert_delay($delay)
     return Time::durationToSeconds($delay);
 }
 
-function fix_integer_value($value)
-{
-    if ($value < 0) {
-        $return = 4294967296 + $value;
-    } else {
-        $return = $value;
-    }
-
-    return $return;
-}
-
 /**
  * Checks if the $hostname provided exists in the DB already
  */

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -19,53 +19,6 @@ use Illuminate\Support\Str;
 use LibreNMS\Enum\Severity;
 use LibreNMS\Util\Time;
 
-/**
- * Parse cli discovery or poller modules and set config for this run
- *
- * @param  string  $type  discovery or poller
- * @param  array  $options  get_opts array (only m key is checked)
- * @return bool
- */
-function parse_modules($type, $options)
-{
-    $override = false;
-
-    if (! empty($options['m'])) {
-        // get all modules in the correct order and disable all
-        $modules = array_map(fn ($v) => false, LibrenmsConfig::get("{$type}_modules", []));
-
-        foreach (explode(',', (string) $options['m']) as $module) {
-            // parse submodules (only supported by some modules)
-            if (Str::contains($module, '/')) {
-                [$module, $submodule] = explode('/', $module, 2);
-                $existing_submodules = LibrenmsConfig::get("{$type}_submodules.$module", []);
-                $existing_submodules[] = $submodule;
-                LibrenmsConfig::set("{$type}_submodules.$module", $existing_submodules);
-            }
-
-            $dir = $type == 'poller' ? 'polling' : $type;
-            if (is_file("includes/$dir/$module.inc.php")) {
-                $modules[$module] = true; // enable module
-                $override = true;
-            }
-        }
-
-        // filter disabled modules and set in global config
-        LibrenmsConfig::set("{$type}_modules", array_filter($modules));
-
-        // display selected modules
-        $modules = array_map(function ($module) use ($type) {
-            $submodules = LibrenmsConfig::get("{$type}_submodules.$module");
-
-            return $module . ($submodules ? '(' . implode(',', $submodules) . ')' : '');
-        }, array_keys(LibrenmsConfig::get("{$type}_modules", [])));
-
-        Log::debug('Override ' . $type . ' modules: ' . implode(', ', $modules));
-    }
-
-    return $override;
-}
-
 function renamehost($id, $new, $source = 'console')
 {
     $host = DeviceCache::get((int) $id)->hostname;

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -523,27 +523,6 @@ function lock_and_purge_query($table, $sql, $msg)
 }
 
 /**
- * Check if disk is valid to poll.
- * Settings: bad_disk_regexp
- *
- * @param  array  $disk
- * @param  array  $device
- * @return bool
- */
-function is_disk_valid($disk, $device)
-{
-    foreach (LibrenmsConfig::getCombined($device['os'], 'bad_disk_regexp') as $bir) {
-        if (preg_match($bir . 'i', (string) $disk['diskIODevice'])) {
-            Log::debug('Ignored Disk: ' . $disk['diskIODevice'] . ' (matched: ' . $bir . ')');
-
-            return false;
-        }
-    }
-
-    return true;
-}
-
-/**
  * Take a BGP error code and subcode to return a string representation of it
  *
  * @params int code

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -230,14 +230,6 @@ function convert_delay($delay)
     return Time::durationToSeconds($delay);
 }
 
-function normalize_snmp_ip_address($data)
-{
-    // $data is received from snmpwalk, can be ipv4 xxx.xxx.xxx.xxx or ipv6 xx:xx:...:xx (16 chunks)
-    // ipv4 is returned unchanged, ipv6 is returned with one ':' removed out of two, like
-    //  xxxx:xxxx:...:xxxx (8 chuncks)
-    return preg_replace('/([0-9a-fA-F]{2}):([0-9a-fA-F]{2})/', '\1\2', explode('%', (string) $data, 2)[0]);
-}
-
 function fix_integer_value($value)
 {
     if ($value < 0) {

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -231,18 +231,6 @@ function convert_delay($delay)
 }
 
 /**
- * Checks if the $hostname provided exists in the DB already
- */
-function host_exists(string $hostname, ?string $sysName = null): bool
-{
-    return Device::where('hostname', $hostname)
-        ->when(! empty($sysName), function ($query) use ($sysName): void {
-            $query->when(! LibrenmsConfig::get('allow_duplicate_sysName'), fn ($q) => $q->orWhere('sysName', $sysName))
-                  ->when(! empty(LibrenmsConfig::get('mydomain')), fn ($q) => $q->orWhere('sysName', rtrim((string) $sysName, '.') . '.' . LibrenmsConfig::get('mydomain')));
-        })->exists();
-}
-
-/**
  * Create a new state index.  Update translations if $states is given.
  *
  * For for backward compatibility:

--- a/includes/html/functions.inc.php
+++ b/includes/html/functions.inc.php
@@ -391,31 +391,6 @@ function print_optionbar_end()
         ';
 }//end print_optionbar_end()
 
-/**
- * Get the recursive file size and count for a directory
- *
- * @param  string  $path
- * @return array [size, file count]
- */
-function foldersize($path)
-{
-    $total_size = 0;
-    $total_files = 0;
-
-    foreach (glob(rtrim($path, '/') . '/*', GLOB_NOSORT) as $item) {
-        if (is_dir($item)) {
-            [$folder_size, $file_count] = foldersize($item);
-            $total_size += $folder_size;
-            $total_files += $file_count;
-        } else {
-            $total_size += filesize($item);
-            $total_files++;
-        }
-    }
-
-    return [$total_size, $total_files];
-}
-
 function generate_ap_link($args, $text = null, $type = null)
 {
     $args = cleanPort($args);

--- a/includes/html/functions.inc.php
+++ b/includes/html/functions.inc.php
@@ -479,17 +479,6 @@ function generate_pagination($count, $limit, $page, $links = 2)
     return $return;
 }//end generate_pagination()
 
-function get_client_ip()
-{
-    if (isset($_SERVER['HTTP_X_FORWARDED_FOR'])) {
-        $client_ip = $_SERVER['HTTP_X_FORWARDED_FOR'];
-    } else {
-        $client_ip = $_SERVER['REMOTE_ADDR'];
-    }
-
-    return $client_ip;
-}//end get_client_ip()
-
 function clean_bootgrid($string)
 {
     $output = str_replace(["\r", "\n"], '', $string);

--- a/includes/rewrites.php
+++ b/includes/rewrites.php
@@ -93,17 +93,6 @@ function cleanPort($interface, $device = null)
     return $interface;
 }
 
-function rewrite_generic_hardware($hardware)
-{
-    $rewrite_GenericHW = [
-        ' Computer Corporation' => '',
-        ' Corporation' => '',
-        ' Inc.' => '',
-    ];
-
-    return str_replace(array_keys($rewrite_GenericHW), array_values($rewrite_GenericHW), $hardware);
-}
-
 function short_hrDeviceDescr($dev)
 {
     $rewrite_hrDevice = [

--- a/includes/rewrites.php
+++ b/includes/rewrites.php
@@ -123,11 +123,6 @@ function short_port_descr($desc)
     return $desc;
 }
 
-function rewrite_adslLineType($adslLineType)
-{
-    return \LibreNMS\Util\Rewrite::dslLineType($adslLineType);
-}
-
 function ipmiSensorName($hardwareId, $sensorIpmi)
 {
     $ipmiSensorsNames = [


### PR DESCRIPTION
I think this are deprecated functions which can be removed. They are all untested so I am not 100% sure. With grep I haven't found them in the rest of the project. I also think non of them are YAML helper functions:

- `foldersize()`
- `get_client_ip()`
- `parse_modules()`
- `is_disk_valid()`
- `normalize_snmp_ip_address()`
- `fix_integer_value()`
- `host_exists()`
- `rewrite_generic_hardware()`
- `rewrite_adslLineType()`

More will follow in separate PRs.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
