### PR TITLE
Fix: Set safe working directory for CLI commands to prevent posix_spawn permission errors

### DIFF
--- a/app/Console/Commands/DeviceDiscover.php
+++ b/app/Console/Commands/DeviceDiscover.php
@@ -57,6 +57,12 @@ class DeviceDiscover extends LnmsCommand
 
     public function handle(MeasurementManager $measurements): int
     {
+        // Save current working directory (CWD)
+        $originalCwd = getcwd();
+
+        // Force the change to the secure root of LibreNMS (e.g., /opt/librenms)
+        @chdir(base_path());
+
         try {
             $this->handleDebug();
 
@@ -78,6 +84,11 @@ class DeviceDiscover extends LnmsCommand
             return $processor->processResults($measurements, $this->getOutput());
         } catch (QueryException $e) {
             return $this->handleQueryException($e);
+        } finally {
+            // Regardless of success or failure, it returns the original CWD
+            if ($originalCwd) {
+                @chdir($originalCwd);
+            }
         }
     }
 }

--- a/app/Console/Commands/DeviceDiscover.php
+++ b/app/Console/Commands/DeviceDiscover.php
@@ -57,12 +57,6 @@ class DeviceDiscover extends LnmsCommand
 
     public function handle(MeasurementManager $measurements): int
     {
-        // Save current working directory (CWD)
-        $originalCwd = getcwd();
-
-        // Force the change to the secure root of LibreNMS (e.g., /opt/librenms)
-        @chdir(base_path());
-
         try {
             $this->handleDebug();
 
@@ -84,11 +78,6 @@ class DeviceDiscover extends LnmsCommand
             return $processor->processResults($measurements, $this->getOutput());
         } catch (QueryException $e) {
             return $this->handleQueryException($e);
-        } finally {
-            // Regardless of success or failure, it returns the original CWD
-            if ($originalCwd) {
-                @chdir($originalCwd);
-            }
         }
     }
 }

--- a/app/Console/LnmsCommand.php
+++ b/app/Console/LnmsCommand.php
@@ -179,7 +179,7 @@ abstract class LnmsCommand extends Command
     {
         $originalCwd = getcwd();
         @chdir(base_path());
-    
+
         try {
             return parent::execute($input, $output);
         } finally {

--- a/app/Console/LnmsCommand.php
+++ b/app/Console/LnmsCommand.php
@@ -175,6 +175,20 @@ abstract class LnmsCommand extends Command
         };
     }
 
+    public function execute(\Symfony\Component\Console\Input\InputInterface $input, \Symfony\Component\Console\Output\OutputInterface $output): int
+    {
+        $originalCwd = getcwd();
+        @chdir(base_path());
+    
+        try {
+            return parent::execute($input, $output);
+        } finally {
+            if ($originalCwd) {
+                @chdir($originalCwd);
+            }
+        }
+    }
+
     private function getCallable(string $type, string $name): ?callable
     {
         if (empty($this->{'option' . $type}[$name])) {


### PR DESCRIPTION
Save and restore the original working directory in handle method.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Description

When system administrators execute CLI commands (like `lnms device:discover`) using `sudo -H -u librenms` from a restricted directory (e.g., their personal `/home/user` folder), the underlying processes fail with a **Permission denied** error.

This happens because the PHP process inherits the caller's Current Working Directory (CWD). When LibreNMS attempts to spawn external system binaries (such as `python3` or `fping`) via the Symfony `Process` component, the kernel blocks the execution because the `librenms` user lacks execute/read permissions in the inherited home directory.

Since external commands are instantiated across dozens of legacy modules and includes (which do not explicitly define a `$cwd` when creating a `new Process`), fixing this globally at the CLI entry point is the most robust approach.

#### Steps to Reproduce

Running `sudo -H -u librenms lnms device:discover <ip> -vvv` from a restricted directory like `/home/user` yields the following fatal exceptions:

```
[FPING] '/usr/sbin/fping' '-e' '-q' '-c' '3' '-p' '500' '-t' '500' '-O' '0' '192.168.10.253'
Working directory: /home/zabbix-proxy
Error: proc_open(): posix_spawn() failed: Permission denied @ /opt/librenms/vendor/symfony/process/Process.php:387
[Symfony\Component\Process\Exception\ProcessStartFailedException]  
The command "'/usr/sbin/fping' '-e' '-q' '-c' '3' '-p' '500' '-t' '500' '-O' '0' '192.168.10.253'" failed.
```

#### Solution

This PR modifies the `handle()` methods in `DeviceDiscover.php` and `DevicePoll.php` (and/or their base execution traits) to safely sandbox the CWD during execution.

1. We capture the user's original CWD using `getcwd()`.
1. We enforce the LibreNMS root directory using `@chdir(base_path())` right before the heavy lifting (`PerDeviceProcess`) begins. This ensures any downstream Symfony Process or `exec()` call defaults to a safe, fully-permissioned directory.
1. We wrap the execution in a `try...finally` block.
1. In the `finally` block, we restore the original CWD (`@chdir($originalCwd)`). This respects the sysadmin's terminal state, preventing the CLI from unexpectedly "teleporting" them to `/opt/librenms` after the command finishes.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
