### PR TITLE
Fix: Use localized timezone for Last Polled and Last Discovered in Device Edit view

### DIFF
--- a/resources/views/device/edit/device.blade.php
+++ b/resources/views/device/edit/device.blade.php
@@ -219,9 +219,9 @@
                 @if($rrd_num)
                 {{ __('device.edit.size_on_disk') }}: <b>{{ $rrd_size }}</b> in <b>{{ $rrd_num }}</b> {{ __('device.edit.rrd_files') }} |
                 @endif
-                {{ __('device.edit.last_polled') }}: <b>{{ $device->last_polled }}</b>
+                {{ __('device.edit.last_polled') }}: <b>{{ \LibreNMS\Util\Time::format($device->last_polled, 'byminute') }}</b>
                 @if($device->last_discovered)
-                    | {{ __('device.edit.last_discovered') }}: <b>{{ $device->last_discovered }}</b>
+                    | {{ __('device.edit.last_discovered') }}: <b>{{ \LibreNMS\Util\Time::format($device->last_discovered, 'byminute') }}</b>
                 @endif
             </div>
         </div>


### PR DESCRIPTION
Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Description

This PR fixes a timezone inconsistency in the "Edit Device" view (URL: `/device/1/edit`). Currently, the timestamps for **Last Polled** and **Last Discovered** are being displayed as raw strings directly from the database model.

When a user sets a specific timezone in their **User Preferences**, these specific fields in the Device Edit footer do not respect that setting. They often default to UTC or a generic format, causing confusion for users in different time zones (e.g., showing a polling time 3 hours ahead/behind the actual local time).

Directly echoing `$device->last_polled` bypasses the Carbon/Time localization layer. Wrapping it in `\LibreNMS\Util\Time::format()` is the standard approach used in other parts of the application, such as the Device Overview page.

#### Screenshots

Before:

<img width="890" height="65" alt="2026-04-10 14_36_55-Greenshot" src="https://github.com/user-attachments/assets/a919d8df-5a51-4249-91d0-7c0c029fa907" />

After:

<img width="826" height="56" alt="2026-04-10 14_39_51-Greenshot" src="https://github.com/user-attachments/assets/5cb49f3d-eb9b-4d27-9cbf-19b08dd613cd" />

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
