### PR TITLE
Cleanup get_sensor_rrd

### DIFF
--- a/includes/common.php
+++ b/includes/common.php
@@ -130,11 +130,6 @@ function print_message($text)
     }
 }
 
-function get_sensor_rrd($device, $sensor)
-{
-    return Rrd::name($device['hostname'], get_sensor_rrd_name($device, $sensor));
-}
-
 function get_sensor_rrd_name($device, $sensor)
 {
     // For IPMI, sensors tend to change order, and there is no index, so we prefer to use the description as key here.

--- a/includes/html/graphs/device/sensor.inc.php
+++ b/includes/html/graphs/device/sensor.inc.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Facades\Rrd;
 use App\Models\Sensor;
 use LibreNMS\Exceptions\RrdGraphException;
 
@@ -30,7 +31,7 @@ foreach ($sensors as $index => $sensor) {
     };
 
     $sensor_descr_fixed = \LibreNMS\Data\Store\Rrd::fixedSafeDescr($sensor->sensor_descr, 12);
-    $rrd_filename = get_sensor_rrd($device, $sensor);
+    $rrd_filename = Rrd::name($device['hostname'], get_sensor_rrd_name($device, $sensor));
     $field = 'sensor' . $sensor->sensor_id;
     $rrd_options[] = "DEF:$field=$rrd_filename:sensor:AVERAGE";
 

--- a/includes/html/graphs/multisensor/graph.inc.php
+++ b/includes/html/graphs/multisensor/graph.inc.php
@@ -13,6 +13,7 @@
  * All sensors must be of the same class (e.g., all power, all temperature).
  */
 
+use App\Facades\Rrd;
 use LibreNMS\Exceptions\RrdGraphException;
 
 require 'includes/html/graphs/common.inc.php';
@@ -93,7 +94,7 @@ $aggr_fields = '';  // For building aggregate CDEF
 
 foreach ($sensors as $sensor) {
     $device = device_by_id_cache($sensor->device_id);
-    $rrd_filename = get_sensor_rrd($device, $sensor);
+    $rrd_filename = Rrd::name($device['hostname'], get_sensor_rrd_name($device, $sensor));
 
     if (! Rrd::checkRrdExists($rrd_filename)) {
         continue;

--- a/includes/html/graphs/sensor/auth.inc.php
+++ b/includes/html/graphs/sensor/auth.inc.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Facades\Rrd;
 use App\Models\Sensor;
 
 if (is_numeric($vars['id'])) {
@@ -8,7 +9,7 @@ if (is_numeric($vars['id'])) {
     if ($auth || device_permitted($sensor->device_id)) {
         $device = device_by_id_cache($sensor->device_id);
 
-        $rrd_filename = get_sensor_rrd($device, $sensor);
+        $rrd_filename = Rrd::name($device['hostname'], get_sensor_rrd_name($device, $sensor));
 
         $title = generate_device_link($device);
         $title .= ' :: Sensor :: ' . htmlentities((string) $sensor->sensor_descr);


### PR DESCRIPTION
To clean up the next set of deprecated functions, I need to take small steps, which are easy to review.
I don't like to create big problems for others, since they don't have unit tests etc..

Removes
- `get_sensor_rrd()`

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
