### PR TITLE
Validate utf8mb4_uca1400_ai_ci

### DIFF
--- a/LibreNMS/Validations/Database/CheckSchemaCollation.php
+++ b/LibreNMS/Validations/Database/CheckSchemaCollation.php
@@ -44,7 +44,7 @@ class CheckSchemaCollation implements Validation, ValidationFixer
         $db_collation_sql = "SELECT DEFAULT_CHARACTER_SET_NAME, DEFAULT_COLLATION_NAME
             FROM information_schema.SCHEMATA S
             WHERE schema_name = '$db_name' AND
-            ( DEFAULT_CHARACTER_SET_NAME != 'utf8mb4' OR DEFAULT_COLLATION_NAME != 'utf8mb4_unicode_ci')";
+            ( DEFAULT_CHARACTER_SET_NAME != 'utf8mb4' OR DEFAULT_COLLATION_NAME != 'utf8mb4_unicode_ci' OR DEFAULT_COLLATION_NAME != 'utf8mb4_uca1400_ai_ci')";
         $collation = Eloquent::DB()->selectOne($db_collation_sql);
         if (empty($collation) !== true) {
             return ValidationResult::fail(


### PR DESCRIPTION
Since MariaDB 11.4.2 (so that includes 11.8.6 used in Debian 13) the default collation is now utf8mb4_uca1400_ai_ci and that is fully backwards compatible with utf8mb4 as far as I've researched.  There should be no reason for it not to validate when using this default collation.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
