### PR TITLE
Update collation checks logic to use NOT IN and add utf8mb4_uca1400_a…

### DIFF
--- a/LibreNMS/Validations/Database/CheckSchemaCollation.php
+++ b/LibreNMS/Validations/Database/CheckSchemaCollation.php
@@ -44,7 +44,7 @@ class CheckSchemaCollation implements Validation, ValidationFixer
         $db_collation_sql = "SELECT DEFAULT_CHARACTER_SET_NAME, DEFAULT_COLLATION_NAME
             FROM information_schema.SCHEMATA S
             WHERE schema_name = '$db_name' AND
-            ( DEFAULT_CHARACTER_SET_NAME != 'utf8mb4' OR DEFAULT_COLLATION_NAME != 'utf8mb4_unicode_ci' OR DEFAULT_COLLATION_NAME != 'utf8mb4_uca1400_ai_ci')";
+            ( DEFAULT_CHARACTER_SET_NAME != 'utf8mb4' OR DEFAULT_COLLATION_NAME NOT IN ('utf8mb4_unicode_ci', 'utf8mb4_uca1400_ai_ci'))";
         $collation = Eloquent::DB()->selectOne($db_collation_sql);
         if (empty($collation) !== true) {
             return ValidationResult::fail(
@@ -56,7 +56,7 @@ class CheckSchemaCollation implements Validation, ValidationFixer
         $table_collation_sql = "SELECT T.TABLE_NAME, C.CHARACTER_SET_NAME, C.COLLATION_NAME
             FROM information_schema.TABLES AS T, information_schema.COLLATION_CHARACTER_SET_APPLICABILITY AS C
             WHERE C.collation_name = T.table_collation AND T.table_schema = '$db_name' AND
-             ( C.CHARACTER_SET_NAME != 'utf8mb4' OR C.COLLATION_NAME != 'utf8mb4_unicode_ci' );";
+             ( C.CHARACTER_SET_NAME != 'utf8mb4' OR C.COLLATION_NAME NOT IN ('utf8mb4_unicode_ci', 'utf8mb4_uca1400_ai_ci'));";
         $collation_tables = Eloquent::DB()->select($table_collation_sql);
         if (empty($collation_tables) !== true) {
             return ValidationResult::fail('MySQL tables collation is wrong: ')
@@ -67,7 +67,7 @@ class CheckSchemaCollation implements Validation, ValidationFixer
 
         $column_collation_sql = "SELECT TABLE_NAME, COLUMN_NAME, CHARACTER_SET_NAME, COLLATION_NAME
             FROM information_schema.COLUMNS  WHERE TABLE_SCHEMA = '$db_name' AND
-            ( CHARACTER_SET_NAME != 'utf8mb4' OR COLLATION_NAME != 'utf8mb4_unicode_ci' );";
+            ( CHARACTER_SET_NAME != 'utf8mb4' OR  COLLATION_NAME NOT IN ('utf8mb4_unicode_ci', 'utf8mb4_uca1400_ai_ci');";
         $collation_columns = Eloquent::DB()->select($column_collation_sql);
         if (empty($collation_columns) !== true) {
             return ValidationResult::fail('MySQL column collation is wrong: ')

--- a/LibreNMS/Validations/Database/CheckSchemaCollation.php
+++ b/LibreNMS/Validations/Database/CheckSchemaCollation.php
@@ -67,7 +67,7 @@ class CheckSchemaCollation implements Validation, ValidationFixer
 
         $column_collation_sql = "SELECT TABLE_NAME, COLUMN_NAME, CHARACTER_SET_NAME, COLLATION_NAME
             FROM information_schema.COLUMNS  WHERE TABLE_SCHEMA = '$db_name' AND
-            ( CHARACTER_SET_NAME != 'utf8mb4' OR  COLLATION_NAME NOT IN ('utf8mb4_unicode_ci', 'utf8mb4_uca1400_ai_ci');";
+            ( CHARACTER_SET_NAME != 'utf8mb4' OR  COLLATION_NAME NOT IN ('utf8mb4_unicode_ci', 'utf8mb4_uca1400_ai_ci'));";
         $collation_columns = Eloquent::DB()->select($column_collation_sql);
         if (empty($collation_columns) !== true) {
             return ValidationResult::fail('MySQL column collation is wrong: ')


### PR DESCRIPTION
…i_ci everywhere not just in initial check

Updated logic so validate.php returns cleanly when collation is updated appropriately

Please give a short description what your pull request is for

Fix issue #19439

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
