### PR TITLE
Fix unhandled Oxidized ConnectionException causing CRITICAL crash on device config tab

### DIFF
--- a/app/ApiClients/Oxidized.php
+++ b/app/ApiClients/Oxidized.php
@@ -27,6 +27,8 @@
 namespace App\ApiClients;
 
 use App\Facades\LibrenmsConfig;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Support\Facades\Log;
 
 class Oxidized extends BaseApi
 {
@@ -45,7 +47,11 @@ class Oxidized extends BaseApi
     public function reloadNodes(): void
     {
         if ($this->enabled && LibrenmsConfig::get('oxidized.reload_nodes') === true) {
-            $this->getClient()->get('/reload.json');
+            try {
+                $this->getClient()->get('/reload.json');
+            } catch (ConnectionException $e) {
+                Log::warning('Oxidized is not reachable: ' . $e->getMessage());
+            }
         }
     }
 
@@ -58,9 +64,13 @@ class Oxidized extends BaseApi
             // Work around https://github.com/rack/rack/issues/337
             $msg = str_replace('%', '', $msg);
 
-            return $this->getClient()
-                ->put("/node/next/$hostname", ['user' => $username, 'msg' => $msg])
-                ->successful();
+            try {
+                return $this->getClient()
+                    ->put("/node/next/$hostname", ['user' => $username, 'msg' => $msg])
+                    ->successful();
+            } catch (ConnectionException $e) {
+                Log::warning('Oxidized is not reachable: ' . $e->getMessage());
+            }
         }
 
         return false;
@@ -70,9 +80,15 @@ class Oxidized extends BaseApi
     public function getContent(string $uri): string
     {
         if ($this->enabled) {
-            return $this->getClient()->get($uri);
-        } else {
-            return '';
+            try {
+                return $this->getClient()->get($uri);
+            } catch (ConnectionException $e) {
+                Log::warning('Oxidized is not reachable: ' . $e->getMessage());
+
+                return '';
+            }
         }
+
+        return '';
     }
 }

--- a/includes/html/pages/device/showconfig.inc.php
+++ b/includes/html/pages/device/showconfig.inc.php
@@ -335,7 +335,7 @@ if (Gate::allows('showConfig', DeviceCache::getPrimary())) {
             echo '</div>';
         } else {
             echo '<br />';
-            print_error("We couldn't retrieve the device information from Oxidized");
+            print_error(__('device.oxidized.connection_error', ['url' => htmlspecialchars((string) LibrenmsConfig::get('oxidized.url'))]));
             if (isset($response) && preg_match('#<title>(.*)</title>#', $response, $error_matches)) {
                 print_error(strip_tags($error_matches[1]));
             }

--- a/includes/html/pages/device/showconfig.inc.php
+++ b/includes/html/pages/device/showconfig.inc.php
@@ -335,7 +335,7 @@ if (Gate::allows('showConfig', DeviceCache::getPrimary())) {
             echo '</div>';
         } else {
             echo '<br />';
-            print_error(__('device.oxidized.connection_error', ['url' => htmlspecialchars((string) LibrenmsConfig::get('oxidized.url'))]));
+            print_error(__('device.oxidized.connection_error'));
             if (isset($response) && preg_match('#<title>(.*)</title>#', $response, $error_matches)) {
                 print_error(strip_tags($error_matches[1]));
             }

--- a/lang/en/device.php
+++ b/lang/en/device.php
@@ -71,4 +71,8 @@ return [
 
         'rediscover_error' => 'An error occurred setting this device to be rediscovered',
     ],
+
+    'oxidized' => [
+        'connection_error' => "We couldn't retrieve the device information from Oxidized. Please verify the Oxidized service is running and reachable at: :url",
+    ],
 ];

--- a/lang/en/device.php
+++ b/lang/en/device.php
@@ -73,6 +73,6 @@ return [
     ],
 
     'oxidized' => [
-        'connection_error' => "We couldn't retrieve the device information from Oxidized. Please verify the Oxidized service is running and reachable at: :url",
+        'connection_error' => "We couldn't retrieve the device information from Oxidized",
     ],
 ];

--- a/tests/Unit/OxidizedApiClientTest.php
+++ b/tests/Unit/OxidizedApiClientTest.php
@@ -1,0 +1,116 @@
+<?php
+
+/**
+ * OxidizedApiClientTest.php
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * @link       https://www.librenms.org
+ *
+ * @copyright  2024 LibreNMS
+ */
+
+namespace LibreNMS\Tests\Unit;
+
+use App\ApiClients\Oxidized;
+use App\Facades\LibrenmsConfig;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use LibreNMS\Tests\TestCase;
+
+final class OxidizedApiClientTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        LibrenmsConfig::set('oxidized.enabled', true);
+        LibrenmsConfig::set('oxidized.url', 'http://oxidized:8888');
+    }
+
+    public function testGetContentReturnsEmptyStringOnConnectionException(): void
+    {
+        Http::fake(function () {
+            throw new ConnectionException('cURL error 7: Failed to connect');
+        });
+
+        Log::shouldReceive('warning')
+            ->once()
+            ->withArgs(fn ($msg) => str_contains($msg, 'Oxidized is not reachable'));
+
+        $client = new Oxidized();
+        $result = $client->getContent('/node/show/192.168.10.241?format=json');
+
+        $this->assertSame('', $result, 'getContent() should return empty string when Oxidized is unreachable');
+    }
+
+    public function testGetContentReturnsEmptyStringWhenDisabled(): void
+    {
+        LibrenmsConfig::set('oxidized.enabled', false);
+
+        Http::fake(['*' => Http::response('{"name":"router"}', 200)]);
+
+        $client = new Oxidized();
+        $result = $client->getContent('/node/show/router?format=json');
+
+        $this->assertSame('', $result, 'getContent() should return empty string when Oxidized is disabled');
+        Http::assertNothingSent();
+    }
+
+    public function testGetContentReturnsBodyOnSuccess(): void
+    {
+        $body = '{"name":"router","ip":"192.168.10.241","model":"ios"}';
+        Http::fake(['*' => Http::response($body, 200)]);
+
+        $client = new Oxidized();
+        $result = $client->getContent('/node/show/router?format=json');
+
+        $this->assertSame($body, $result, 'getContent() should return the response body on success');
+    }
+
+    public function testUpdateNodeReturnsFalseOnConnectionException(): void
+    {
+        Http::fake(function () {
+            throw new ConnectionException('cURL error 7: Failed to connect');
+        });
+
+        Log::shouldReceive('warning')
+            ->once()
+            ->withArgs(fn ($msg) => str_contains($msg, 'Oxidized is not reachable'));
+
+        $client = new Oxidized();
+        $result = $client->updateNode('router', 'config changed', 'admin');
+
+        $this->assertFalse($result, 'updateNode() should return false when Oxidized is unreachable');
+    }
+
+    public function testReloadNodesDoesNotThrowOnConnectionException(): void
+    {
+        LibrenmsConfig::set('oxidized.reload_nodes', true);
+
+        Http::fake(function () {
+            throw new ConnectionException('cURL error 7: Failed to connect');
+        });
+
+        Log::shouldReceive('warning')
+            ->once()
+            ->withArgs(fn ($msg) => str_contains($msg, 'Oxidized is not reachable'));
+
+        $client = new Oxidized();
+
+        // Should not throw
+        $this->expectNotToPerformAssertions();
+        $client->reloadNodes();
+    }
+}

--- a/tests/Unit/OxidizedApiClientTest.php
+++ b/tests/Unit/OxidizedApiClientTest.php
@@ -41,13 +41,13 @@ final class OxidizedApiClientTest extends TestCase
 
     public function testGetContentReturnsEmptyStringOnConnectionException(): void
     {
-        Http::fake(function () {
+        Http::fake(function (): void {
             throw new ConnectionException('cURL error 7: Failed to connect');
         });
 
         Log::shouldReceive('warning')
             ->once()
-            ->withArgs(fn ($msg) => str_contains($msg, 'Oxidized is not reachable'));
+            ->withArgs(fn ($msg) => str_contains((string) $msg, 'Oxidized is not reachable'));
 
         $client = new Oxidized();
         $result = $client->getContent('/node/show/192.168.10.241?format=json');
@@ -81,13 +81,13 @@ final class OxidizedApiClientTest extends TestCase
 
     public function testUpdateNodeReturnsFalseOnConnectionException(): void
     {
-        Http::fake(function () {
+        Http::fake(function (): void {
             throw new ConnectionException('cURL error 7: Failed to connect');
         });
 
         Log::shouldReceive('warning')
             ->once()
-            ->withArgs(fn ($msg) => str_contains($msg, 'Oxidized is not reachable'));
+            ->withArgs(fn ($msg) => str_contains((string) $msg, 'Oxidized is not reachable'));
 
         $client = new Oxidized();
         $result = $client->updateNode('router', 'config changed', 'admin');
@@ -99,13 +99,13 @@ final class OxidizedApiClientTest extends TestCase
     {
         LibrenmsConfig::set('oxidized.reload_nodes', true);
 
-        Http::fake(function () {
+        Http::fake(function (): void {
             throw new ConnectionException('cURL error 7: Failed to connect');
         });
 
         Log::shouldReceive('warning')
             ->once()
-            ->withArgs(fn ($msg) => str_contains($msg, 'Oxidized is not reachable'));
+            ->withArgs(fn ($msg) => str_contains((string) $msg, 'Oxidized is not reachable'));
 
         $client = new Oxidized();
 

--- a/tests/Unit/OxidizedApiClientTest.php
+++ b/tests/Unit/OxidizedApiClientTest.php
@@ -52,7 +52,7 @@ final class OxidizedApiClientTest extends TestCase
         $client = new Oxidized();
         $result = $client->getContent('/node/show/192.168.10.241?format=json');
 
-        $this->assertSame('', $result, 'getContent() should return empty string when Oxidized is unreachable');
+        $this->assertSame('', $result, 'getContent() should return an empty string when Oxidized is unreachable');
     }
 
     public function testGetContentReturnsEmptyStringWhenDisabled(): void
@@ -64,7 +64,7 @@ final class OxidizedApiClientTest extends TestCase
         $client = new Oxidized();
         $result = $client->getContent('/node/show/router?format=json');
 
-        $this->assertSame('', $result, 'getContent() should return empty string when Oxidized is disabled');
+        $this->assertSame('', $result, 'getContent() should return an empty string when Oxidized is disabled');
         Http::assertNothingSent();
     }
 
@@ -110,7 +110,6 @@ final class OxidizedApiClientTest extends TestCase
         $client = new Oxidized();
 
         // Should not throw
-        $this->expectNotToPerformAssertions();
         $client->reloadNodes();
     }
 }


### PR DESCRIPTION
#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Description

When Oxidized integration is enabled but the service is unreachable, `App\ApiClients\Oxidized::getContent()` propagates a `ConnectionException` all the way to the HTTP kernel, producing a CRITICAL log entry and a crash page instead of a graceful error.

#### Changes

- **`app/ApiClients/Oxidized.php`** — wrap `getContent()`, `updateNode()`, and `reloadNodes()` in `try/catch (ConnectionException)`. Failures are logged at `warning` level; methods return safe defaults (`''` / `false`).

- **`lang/en/device.php`** — add `oxidized.connection_error` translation key so the message is localizable. Other locales with a `device.php` fall back to English until translated.

- **`includes/html/pages/device/showconfig.inc.php`** — replace hardcoded error string with `__('device.oxidized.connection_error')`.

- **`tests/Unit/OxidizedApiClientTest.php`** *(new)* — unit tests covering: `ConnectionException` → empty string, disabled → empty string (no HTTP call made), success → body returned, `updateNode` on error → `false`, `reloadNodes` on error → no throw.

```php
// Before: unhandled, bubbles to kernel as CRITICAL
return $this->getClient()->get($uri);

// After: caught, logged, safe default returned
try {
    return $this->getClient()->get($uri);
} catch (ConnectionException $e) {
    Log::warning('Oxidized is not reachable: ' . $e->getMessage());
    return '';
}
```

#### Screenshots

**Before**: 
<img width="1920" height="295" alt="image" src="https://github.com/user-attachments/assets/abe13e92-b9b4-40af-a057-5443d7231a2a" />

**After**: 
<img width="999" height="159" alt="image" src="https://github.com/user-attachments/assets/0bb91ac1-7930-4c54-aefb-864b68e5460d" />

#### Logs

**Before**:

```php
[2026-04-13T19:05:42][CRITICAL] Exception: Illuminate\Http\Client\ConnectionException cURL error 7: Failed to connect to oxidized port 8888 after 3 ms: Could not connect to server (see https://curl.haxx.se/libcurl/c/libcurl-errors.html) for http://oxidized:8888/node/show/192.168.10.241?format=json @ /opt/librenms/vendor/laravel/framework/src/Illuminate/Http/Client/PendingRequest.php:1787
#0 /opt/librenms/vendor/laravel/framework/src/Illuminate/Http/Client/PendingRequest.php(1067): Illuminate\Http\Client\PendingRequest->marshalConnectionException()
#1 /opt/librenms/vendor/laravel/framework/src/Illuminate/Support/helpers.php(329): Illuminate\Http\Client\PendingRequest->Illuminate\Http\Client\{closure}()
#2 /opt/librenms/vendor/laravel/framework/src/Illuminate/Http/Client/PendingRequest.php(1027): retry()
#3 /opt/librenms/vendor/laravel/framework/src/Illuminate/Http/Client/PendingRequest.php(847): Illuminate\Http\Client\PendingRequest->send()
#4 /opt/librenms/app/ApiClients/Oxidized.php(73): Illuminate\Http\Client\PendingRequest->get()
#5 /opt/librenms/includes/html/pages/device/showconfig.inc.php(187): App\ApiClients\Oxidized->getContent()
#6 /opt/librenms/app/Http/Controllers/DeviceController.php(76): include('...')
#7 /opt/librenms/app/Http/Controllers/DeviceController.php(57): App\Http\Controllers\DeviceController->renderLegacyTab()
#8 /opt/librenms/vendor/laravel/framework/src/Illuminate/Routing/ControllerDispatcher.php(46): App\Http\Controllers\DeviceController->index()
#9 /opt/librenms/vendor/laravel/framework/src/Illuminate/Routing/Route.php(265): Illuminate\Routing\ControllerDispatcher->dispatch()
#10 /opt/librenms/vendor/laravel/framework/src/Illuminate/Routing/Route.php(211): Illuminate\Routing\Route->runController()
#11 /opt/librenms/vendor/laravel/framework/src/Illuminate/Routing/Router.php(822): Illuminate\Routing\Route->run()
#12 /opt/librenms/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(180): Illuminate\Routing\Router->Illuminate\Routing\{closure}()
#13 /opt/librenms/app/Http/Middleware/LoadUserPreferences.php(46): Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}()
#14 /opt/librenms/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(219): App\Http\Middleware\LoadUserPreferences->handle()
#15 /opt/librenms/app/Http/Middleware/VerifyTwoFactor.php(41): Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}()
#16 /opt/librenms/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(219): App\Http\Middleware\VerifyTwoFactor->handle()
#17 /opt/librenms/app/Http/Middleware/VerifyUserEnabled.php(28): Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}()
#18 /opt/librenms/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(219): App\Http\Middleware\VerifyUserEnabled->handle()
#19 /opt/librenms/app/Http/Middleware/CheckInstalled.php(64): Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}()
#20 /opt/librenms/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(219): App\Http\Middleware\CheckInstalled->handle()
#21 /o...
```

**Now**:

```
[2026-04-13T19:31:21][WARNING] Oxidized is not reachable: cURL error 7: Failed to connect to oxidized port 8888 after 1 ms: Could not connect to server (see https://curl.haxx.se/libcurl/c/libcurl-errors.html) for http://oxidized:8888/node/show/192.168.10.241?format=json
```

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
