### PR TITLE
Add graylog.match-any-address configuration option

### DIFF
--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -1137,6 +1137,10 @@ return [
                     'help' => 'Changes the default field to query graylog API.',
                 ],
             ],
+            'match-any-address' => [
+                'description' => 'Match any address',
+                'help' => 'This is used to match any address of a device to the source of a graylog log message, by default, only the primary address is used',
+            ],
         ],
         'html' => [
             'device' => [

--- a/resources/definitions/config_definitions.json
+++ b/resources/definitions/config_definitions.json
@@ -4502,6 +4502,13 @@
             "section": "graylog",
             "order": 10
         },
+        "graylog.match-any-address": {
+            "default": false,
+            "type": "boolean",
+            "group": "external",
+            "section": "graylog",
+            "order": 11
+        },
         "group": {
             "type": "text",
             "default": "librenms"


### PR DESCRIPTION
Please give a short description what your pull request is for
Address graylog.match-any-address config not existing but being valid and in documentation. 
resolve issue #19444

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
