### PR TITLE
Handle null last_polled and last_discovered values

### DIFF
--- a/resources/views/device/edit/device.blade.php
+++ b/resources/views/device/edit/device.blade.php
@@ -219,7 +219,7 @@
                 @if($rrd_num)
                 {{ __('device.edit.size_on_disk') }}: <b>{{ $rrd_size }}</b> in <b>{{ $rrd_num }}</b> {{ __('device.edit.rrd_files') }} |
                 @endif
-                {{ __('device.edit.last_polled') }}: <b>{{ $device-> last_polled ? \LibreNMS\Util\Time::format($device->last_polled, 'byminute') : $device-> last_polled }}</b>
+                {{ __('device.edit.last_polled') }}: <b>{{ $device->last_polled ? \LibreNMS\Util\Time::format($device->last_polled, 'byminute') : $device->last_polled }}</b>
                 @if($device->last_discovered)
                     | {{ __('device.edit.last_discovered') }}: <b>{{ $device->last_discovered ? \LibreNMS\Util\Time::format($device->last_discovered, 'byminute') : $device->last_discovered }}</b>
                 @endif

--- a/resources/views/device/edit/device.blade.php
+++ b/resources/views/device/edit/device.blade.php
@@ -219,9 +219,9 @@
                 @if($rrd_num)
                 {{ __('device.edit.size_on_disk') }}: <b>{{ $rrd_size }}</b> in <b>{{ $rrd_num }}</b> {{ __('device.edit.rrd_files') }} |
                 @endif
-                {{ __('device.edit.last_polled') }}: <b>{{ \LibreNMS\Util\Time::format($device->last_polled, 'byminute') }}</b>
+                {{ __('device.edit.last_polled') }}: <b>{{ $device-> last_polled ? \LibreNMS\Util\Time::format($device->last_polled, 'byminute') : $device-> last_polled }}</b>
                 @if($device->last_discovered)
-                    | {{ __('device.edit.last_discovered') }}: <b>{{ \LibreNMS\Util\Time::format($device->last_discovered, 'byminute') }}</b>
+                    | {{ __('device.edit.last_discovered') }}: <b>{{ $device->last_discovered ? \LibreNMS\Util\Time::format($device->last_discovered, 'byminute') : $device->last_discovered }}</b>
                 @endif
             </div>
         </div>


### PR DESCRIPTION
This fixes #19436 where if `last_polled` or `last_discovered` were null, it would cause the blade rendering to crash. 
Usually this happens when you just added a device and go and edit it before the first discovery/poll happens (within a minute or so)

Although I am unsure if this is the right way to fix it, maybe it's better to omit the "Last discovered" and "Last polled" texts if they are null, dunno. 

I tested this by adding a new device and go to the configuration page, and I no longer crash, and the timestamps show up formatted if the user preferences are set that way.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
