### PR TITLE
Fix "Custom OID" modal positioning in Device Edit page

### DIFF
--- a/html/css/styles.css
+++ b/html/css/styles.css
@@ -1319,12 +1319,20 @@ tr.search:nth-child(odd) {
 nav.navbar-sticky-top {
   position: sticky;
   top: 0;
-  z-index: 1100;
+  z-index: 1030;
   border-bottom-width: 2px;
   border-left-width: 0;
   border-top-width: 0;
   border-right-width: 0;
   border-radius: 0;
+}
+
+/* Ensure Bootstrap modals and backdrops appear above the sticky navbar */
+.modal-backdrop {
+  z-index: 1040;
+}
+.modal {
+  z-index: 1050;
 }
 
 .navbar-brand {

--- a/html/css/styles.css
+++ b/html/css/styles.css
@@ -8,7 +8,6 @@ body {
   color: #555;
   font-size: 10pt;
   line-height: 20px;
-  overflow-y: scroll;
 }
 
 .pagemenu-selected {

--- a/html/js/boot.js
+++ b/html/js/boot.js
@@ -28,19 +28,6 @@ $.ajaxSetup({
         { 'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content') }
 });
 
-// Compensate Bootstrap 3 modal scrollbar padding on the sticky navbar.
-// Bootstrap 3 adds padding-right to <body> to prevent layout shift when the
-// scrollbar disappears, but it does not handle position:sticky navbars.
-// This mirrors the behaviour Bootstrap 4+ applies to .fixed-top elements.
-$(document).on('show.bs.modal', '.modal', function () {
-    if (document.body.clientWidth < window.innerWidth) {
-        var scrollbarWidth = window.innerWidth - document.body.clientWidth;
-        $('nav.navbar-sticky-top').css('padding-right', scrollbarWidth);
-    }
-}).on('hidden.bs.modal', '.modal', function () {
-    $('nav.navbar-sticky-top').css('padding-right', '');
-});
-
 // toastr style to match php toasts
 toastr.options = {
     toastClass: 'tw:border-current tw:relative tw:pl-20 tw:py-4 tw:pr-2 tw:bg-white! tw:dark:bg-dark-gray-300! tw:opacity-80 tw:hover:opacity-100 tw:rounded-md tw:shadow-lg tw:hover:shadow-xl tw:border-l-8 tw:border-t-0.5 tw:border-r-0.5 tw:border-b-0.5 tw:mt-2 tw:cursor-pointer',

--- a/html/js/boot.js
+++ b/html/js/boot.js
@@ -28,6 +28,19 @@ $.ajaxSetup({
         { 'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content') }
 });
 
+// Compensate Bootstrap 3 modal scrollbar padding on the sticky navbar.
+// Bootstrap 3 adds padding-right to <body> to prevent layout shift when the
+// scrollbar disappears, but it does not handle position:sticky navbars.
+// This mirrors the behaviour Bootstrap 4+ applies to .fixed-top elements.
+$(document).on('show.bs.modal', '.modal', function () {
+    if (document.body.clientWidth < window.innerWidth) {
+        var scrollbarWidth = window.innerWidth - document.body.clientWidth;
+        $('nav.navbar-sticky-top').css('padding-right', scrollbarWidth);
+    }
+}).on('hidden.bs.modal', '.modal', function () {
+    $('nav.navbar-sticky-top').css('padding-right', '');
+});
+
 // toastr style to match php toasts
 toastr.options = {
     toastClass: 'tw:border-current tw:relative tw:pl-20 tw:py-4 tw:pr-2 tw:bg-white! tw:dark:bg-dark-gray-300! tw:opacity-80 tw:hover:opacity-100 tw:rounded-md tw:shadow-lg tw:hover:shadow-xl tw:border-l-8 tw:border-t-0.5 tw:border-r-0.5 tw:border-b-0.5 tw:mt-2 tw:cursor-pointer',

--- a/includes/html/print-customoid.php
+++ b/includes/html/print-customoid.php
@@ -125,9 +125,9 @@ echo '</table>
 
 <script>
 
-$("[data-toggle='modal'], [data-toggle='popover']").popover({
+$("[data-toggle='popover']").popover({
     trigger: 'hover',
-        'placement': 'top'
+    'placement': 'top'
 });
 
 function updateResults(rows) {

--- a/includes/html/print-customoid.php
+++ b/includes/html/print-customoid.php
@@ -127,7 +127,7 @@ echo '</table>
 
 $("[data-toggle='popover']").popover({
     trigger: 'hover',
-    'placement': 'top'
+    placement: 'top'
 });
 
 function updateResults(rows) {


### PR DESCRIPTION
This PR addresses several UI glitches related to Bootstrap Modals and Popovers on pages with the sticky navigation bar. Previously, opening a modal or interacting with modal trigger buttons would cause unintended behaviors, such as glitchy tooltips, the navigation bar overlapping the modal backdrop, and the entire page shifting left/right due to scrollbar compensation.

#### Changes

This PR implements three specific UI fixes:

* **Fixed Popover/Modal Event Conflict (`print-customoid.php`):** Updated the jQuery selector to only initialize `.popover()` on `[data-toggle='popover']` elements. Previously, the selector also targeted `[data-toggle='modal']`, which caused Bootstrap's popover script to interfere with buttons designed only to open modals. The original jQuery selector used a comma, which acts like an "OR". It was selecting both modal buttons AND popover buttons, and applying the `.popover()` initialization to all of them.
* **Fixed Z-Index Overlap (`styles.css`):** Removed `overflow-y: scroll` from `body` (show the vertical scrollbar only when needed). Adjusted the `z-index` of `nav.navbar-sticky-top` from `1100` down to `1030`. Standard Bootstrap modals usually have a `z-index` of `1050`. This meant that if you opened a modal, the sticky navigation bar would awkwardly float on top of the darkened background and the modal window itself. Added explicit `z-index` values for `.modal-backdrop` (`1040`) and `.modal` (`1050`) to ensure modals always render visually on top of the sticky navbar.

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Screenshots

<details><summary>Before</summary>

<img width="1188" height="582" alt="image" src="https://github.com/user-attachments/assets/0a0164ec-edfe-4980-9467-3e4d5ee71a23" />

<img width="1920" height="911" alt="image" src="https://github.com/user-attachments/assets/f5adc956-2c64-4d2e-becf-3480682bf845" />

<img width="1188" height="556" alt="image" src="https://github.com/user-attachments/assets/7b29a96b-46c3-4689-a68f-dac7b9471496" /></details>

<details><summary>After</summary>

<img width="1188" height="582" alt="9f061f29-0c94-42eb-81b5-6c816a0e169d" src="https://github.com/user-attachments/assets/3965ee60-f312-49f0-aa60-583b9332da43" />

<img width="1188" height="422" alt="3be6e73f-e91a-41cf-9926-b2d91a2b5d73" src="https://github.com/user-attachments/assets/62382938-60fa-4a93-8396-49233c494850" />

<img width="1188" height="556" alt="ap-reuniao1 ¦ LibreNMS (1)" src="https://github.com/user-attachments/assets/b2295b67-d617-4054-a9ee-c33bd410601b" /></details>

#### How To Test

1. Navigate to the **Device Edit > Custom OID** page (`/device/device=1/tab=edit/section=customoid`).
2. Click the [**+ Add New OID**] button to open the modal.
3. Verify the page does **not** shift horizontally when the background scrollbar disappears.
4. Verify the sticky navigation bar (navbar) remains strictly *behind* the darkened modal backdrop and the modal window itself.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
