### PR TITLE
Remove overflow-y scroll from styles

### DIFF
--- a/html/css/styles.css
+++ b/html/css/styles.css
@@ -8,7 +8,6 @@ body {
   color: #555;
   font-size: 10pt;
   line-height: 20px;
-  overflow-y: scroll;
 }
 
 .pagemenu-selected {


### PR DESCRIPTION
Show the vertical scrollbar only when required.

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Screenshots:

<details><summary>Before:</summary>

<img width="1188" height="582" alt="image" src="https://github.com/user-attachments/assets/0a0164ec-edfe-4980-9467-3e4d5ee71a23" />

<img width="1188" height="556" alt="image" src="https://github.com/user-attachments/assets/7b29a96b-46c3-4689-a68f-dac7b9471496" /></details>

<details><summary>After:</summary>

<img width="1188" height="582" alt="9f061f29-0c94-42eb-81b5-6c816a0e169d" src="https://github.com/user-attachments/assets/3965ee60-f312-49f0-aa60-583b9332da43" />

<img width="1188" height="422" alt="3be6e73f-e91a-41cf-9926-b2d91a2b5d73" src="https://github.com/user-attachments/assets/62382938-60fa-4a93-8396-49233c494850" />

<img width="1188" height="556" alt="ap-reuniao1 ¦ LibreNMS (1)" src="https://github.com/user-attachments/assets/b2295b67-d617-4054-a9ee-c33bd410601b" /></details>

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
