### PR TITLE
Fix: Prevent git diff errors in CiHelper when .git directory is missing

### DIFF
--- a/LibreNMS/Util/CiHelper.php
+++ b/LibreNMS/Util/CiHelper.php
@@ -453,8 +453,14 @@ class CiHelper
             return;
         }
         $base_dir = base_path();
-        $changed_files = trim(getenv('FILES')) ?:
-            exec("cd $base_dir && git diff --diff-filter=d --name-only master | tr '\n' ' '|sed 's/,*$//g'");
+        $changed_files = trim(getenv('FILES'));
+        if (empty($changed_files)) {
+            if (!is_dir($base_dir . '/.git')) {                                                                                                                
+                echo "Warning: Skipping git-based file detection: .git/ directory not found\n";
+            } else {
+                $changed_files = exec("cd $base_dir && git diff --diff-filter=d --name-only master | tr '\n' ' '|sed 's/,*$//g'");
+            }
+        }
 
         $this->flags['full'] = empty($changed_files); // don't disable full if already set
         $files = $changed_files ? explode(' ', $changed_files) : [];


### PR DESCRIPTION
Currently, when running `./lnms dev:check` in environments that do not contain a full git clone (such as lightweight Docker containers optimized for testing or CI pipelines that only download specific directories via sparse-checkout or tarballs), the `CiHelper` script attempts to run `git diff`. This can lead to unexpected behavior or silent failures when the Git engine is unavailable.

### Changes Made
Updated `detectChangedFiles()` in `LibreNMS/Util/CiHelper.php` to explicitly check for the existence of the `.git` directory before attempting to execute Git commands. 
* If `.git` is missing, it skips the command, outputs a clear warning (`Warning: Skipping git-based file detection: .git/ directory not found`), and gracefully falls back to the `full` checks mode.
* The logic for the `FILES` environment variable and existing fallbacks remains intact.

### How to Test
1. Set up a LibreNMS environment (or Docker container) and remove or rename the `.git` directory (`mv .git .git_backup`).
2. Run `sudo -u librenms ./lnms dev:check`.
3. Verify that the script outputs the warning and proceeds with the full checks instead of failing on the `exec(git diff...)` command.
4. Restore the `.git` directory and verify the script behaves normally, detecting changed files.

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
