### PR TITLE
api: add wireless sensors endpoint

### DIFF
--- a/app/Models/WirelessSensor.php
+++ b/app/Models/WirelessSensor.php
@@ -27,6 +27,7 @@
 namespace App\Models;
 
 use App\Facades\LibrenmsConfig;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Support\Arr;
 use LibreNMS\Enum\WirelessSensorType;
 use LibreNMS\Interfaces\Models\Keyable;
@@ -34,6 +35,8 @@ use LibreNMS\Util\Number;
 
 class WirelessSensor extends SensorModel implements Keyable
 {
+    use HasFactory;
+
     const CREATED_AT = null;
     const UPDATED_AT = 'lastupdate';
     protected $primaryKey = 'sensor_id';

--- a/database/factories/WirelessSensorFactory.php
+++ b/database/factories/WirelessSensorFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use LibreNMS\Enum\WirelessSensorType;
+
+/** @extends Factory<\App\Models\WirelessSensor> */
+class WirelessSensorFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'sensor_class' => $this->faker->randomElement(WirelessSensorType::values()),
+            'sensor_index' => (string) $this->faker->randomDigit(),
+            'sensor_type' => 'generic',
+            'sensor_current' => $this->faker->randomDigit(),
+            'sensor_oids' => ['value' => '.1.3.6.1.4.1.17713.21.1.2.30.1.4.1'],
+        ];
+    }
+}

--- a/doc/API/Devices.md
+++ b/doc/API/Devices.md
@@ -458,6 +458,84 @@ Output:
 }
 ```
 
+### `get_device_wireless_sensors`
+
+Get the wireless sensors recorded for a device. Returns rows from the
+`wireless_sensors` table, optionally filtered by sensor class and projected
+to a chosen subset of columns.
+
+Route: `/api/v0/devices/:hostname/wireless-sensors`
+
+- hostname can be either the device hostname or id
+
+Input:
+
+- class (optional): filter rows by `sensor_class`. Must be one of the
+  wireless sensor types (`clients`, `rssi`, `snr`, `mcs`, `frequency`,
+  `capacity`, `distance`, `quality`, etc.).
+- columns (optional): comma-separated list of `wireless_sensors` columns to
+  return. Defaults to all columns.
+
+Example:
+
+```curl
+curl -H 'X-Auth-Token: YOURAPITOKENHERE' https://foo.example/api/v0/devices/localhost/wireless-sensors
+```
+
+Output:
+
+```json
+{
+    "status": "ok",
+    "wireless_sensors": [
+        {
+            "sensor_id": 5132,
+            "sensor_deleted": 0,
+            "sensor_class": "rssi",
+            "device_id": 42,
+            "sensor_index": "1",
+            "sensor_type": "epmp-ap-ul",
+            "sensor_descr": "Subscriber-1 (10.0.0.11) [aa:bb:cc:dd:ee:f1] UL RSSI",
+            "sensor_divisor": 1,
+            "sensor_multiplier": 1,
+            "sensor_current": -54,
+            "sensor_prev": -54,
+            "sensor_limit": null,
+            "sensor_limit_warn": null,
+            "sensor_limit_low": null,
+            "sensor_limit_low_warn": null,
+            "sensor_alert": 1,
+            "sensor_custom": "No",
+            "sensor_oids": "[\".1.3.6.1.4.1.17713.21.1.2.30.1.4.1\"]"
+        }
+    ],
+    "count": 1
+}
+```
+
+Example filtered by class and selecting a subset of columns:
+
+```curl
+curl -H 'X-Auth-Token: YOURAPITOKENHERE' https://foo.example/api/v0/devices/localhost/wireless-sensors?class=rssi&columns=sensor_id,sensor_index,sensor_descr,sensor_current
+```
+
+Output:
+
+```json
+{
+    "status": "ok",
+    "wireless_sensors": [
+        {
+            "sensor_id": 5132,
+            "sensor_index": "1",
+            "sensor_descr": "Subscriber-1 (10.0.0.11) [aa:bb:cc:dd:ee:f1] UL RSSI",
+            "sensor_current": -54
+        }
+    ],
+    "count": 1
+}
+```
+
 ### `get_health_graph`
 
 Get a particular health class graph for a device, if you provide a

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -48,6 +48,7 @@ use App\Models\ServiceTemplate;
 use App\Models\UserPref;
 use App\Models\Vlan;
 use App\Models\Vrf;
+use App\Models\WirelessSensor;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -1157,6 +1158,64 @@ function get_device_ports(Illuminate\Http\Request $request): JsonResponse
     }
 
     return api_success($ports, 'ports');
+}
+
+function get_device_wireless_sensors(Illuminate\Http\Request $request): JsonResponse
+{
+    $device = DeviceCache::get($request->route('hostname'));
+    $class = $request->input('class');
+
+    if ($class && ! in_array($class, \LibreNMS\Enum\WirelessSensorType::values(), true)) {
+        return api_error(400, "Invalid wireless sensor class '$class'");
+    }
+
+    $columns = validate_column_list($request->input('columns'), 'wireless_sensors', [
+        'sensor_id',
+        'sensor_deleted',
+        'sensor_class',
+        'device_id',
+        'sensor_index',
+        'sensor_type',
+        'sensor_descr',
+        'sensor_divisor',
+        'sensor_multiplier',
+        'sensor_aggregator',
+        'sensor_current',
+        'sensor_prev',
+        'sensor_limit',
+        'sensor_limit_warn',
+        'sensor_limit_low',
+        'sensor_limit_low_warn',
+        'sensor_alert',
+        'sensor_custom',
+        'entPhysicalIndex',
+        'entPhysicalIndex_measured',
+        'lastupdate',
+        'sensor_oids',
+        'access_point_id',
+        'rrd_type',
+    ]);
+
+    $wireless_sensors = WirelessSensor::query()
+        ->hasAccess(Auth::user())
+        ->where('sensor_deleted', 0)
+        ->where('device_id', $device->device_id)
+        ->when($class, fn ($q) => $q->where('sensor_class', $class))
+        ->select($columns)
+        ->orderBy('sensor_class')
+        ->orderBy('sensor_index')
+        ->orderBy('sensor_descr')
+        ->get();
+
+    if ($wireless_sensors->isEmpty()) {
+        $message = $class
+            ? "No wireless sensors found for class '$class'"
+            : 'No wireless sensors found';
+
+        return api_error(404, $message);
+    }
+
+    return api_success($wireless_sensors, 'wireless_sensors', count: $wireless_sensors->count());
 }
 
 function get_device_ip_addresses(Illuminate\Http\Request $request)

--- a/routes/api.php
+++ b/routes/api.php
@@ -130,6 +130,7 @@ Route::prefix('v0')->group(function (): void {
         Route::get('{hostname}/nac', [App\Api\Controllers\LegacyApiController::class, 'get_nac'])->name('get_nac');
         Route::get('{hostname}/health/{type?}/{sensor_id?}', [App\Api\Controllers\LegacyApiController::class, 'list_available_health_graphs'])->name('list_available_health_graphs');
         Route::get('{hostname}/wireless/{type?}/{sensor_id?}', [App\Api\Controllers\LegacyApiController::class, 'list_available_wireless_graphs'])->name('list_available_wireless_graphs');
+        Route::get('{hostname}/wireless-sensors', [App\Api\Controllers\LegacyApiController::class, 'get_device_wireless_sensors'])->name('get_device_wireless_sensors');
         Route::get('{hostname}/ports', [App\Api\Controllers\LegacyApiController::class, 'get_device_ports'])->name('get_device_ports');
         Route::get('{hostname}/ip', [App\Api\Controllers\LegacyApiController::class, 'get_device_ip_addresses'])->name('get_ip_addresses');
         Route::get('{hostname}/port_stack', [App\Api\Controllers\LegacyApiController::class, 'get_port_stack'])->name('get_port_stack');

--- a/tests/BasicApiTest.php
+++ b/tests/BasicApiTest.php
@@ -59,19 +59,19 @@ final class BasicApiTest extends DBTestCase
         $token = ApiToken::generateToken($user);
         $device = Device::factory()->create();
 
-        $rssi = $this->makeWirelessSensor($device, [
+        $rssi = WirelessSensor::factory()->for($device)->create([
             'sensor_class' => 'rssi',
             'sensor_index' => '1.1',
             'sensor_descr' => 'Subscriber 1 UL RSSI',
             'sensor_current' => -62,
         ]);
-        $this->makeWirelessSensor($device, [
+        WirelessSensor::factory()->for($device)->create([
             'sensor_class' => 'snr',
             'sensor_index' => '1.2',
             'sensor_descr' => 'Subscriber 1 UL SNR',
             'sensor_current' => 31,
         ]);
-        $this->makeWirelessSensor($device, [
+        WirelessSensor::factory()->for($device)->create([
             'sensor_class' => 'rssi',
             'sensor_index' => '1.3',
             'sensor_descr' => 'Deleted Sensor',
@@ -98,13 +98,13 @@ final class BasicApiTest extends DBTestCase
         $token = ApiToken::generateToken($user);
         $device = Device::factory()->create();
 
-        $rssi = $this->makeWirelessSensor($device, [
+        $rssi = WirelessSensor::factory()->for($device)->create([
             'sensor_class' => 'rssi',
             'sensor_index' => '2.1',
             'sensor_descr' => 'Subscriber 2 UL RSSI',
             'sensor_current' => -55,
         ]);
-        $this->makeWirelessSensor($device, [
+        WirelessSensor::factory()->for($device)->create([
             'sensor_class' => 'snr',
             'sensor_index' => '2.2',
             'sensor_descr' => 'Subscriber 2 UL SNR',
@@ -150,35 +150,5 @@ final class BasicApiTest extends DBTestCase
                 'status' => 'error',
                 'message' => "Invalid wireless sensor class 'bogus'",
             ]);
-    }
-
-    private function makeWirelessSensor(Device $device, array $attributes = []): WirelessSensor
-    {
-        $sensor = new WirelessSensor();
-        $sensor->device_id = $device->device_id;
-        $sensor->sensor_deleted = $attributes['sensor_deleted'] ?? 0;
-        $sensor->sensor_class = $attributes['sensor_class'] ?? 'rssi';
-        $sensor->sensor_index = $attributes['sensor_index'] ?? '1';
-        $sensor->sensor_type = $attributes['sensor_type'] ?? 'generic';
-        $sensor->sensor_descr = $attributes['sensor_descr'] ?? 'Wireless Sensor';
-        $sensor->sensor_divisor = $attributes['sensor_divisor'] ?? 1;
-        $sensor->sensor_multiplier = $attributes['sensor_multiplier'] ?? 1;
-        $sensor->sensor_aggregator = $attributes['sensor_aggregator'] ?? 'sum';
-        $sensor->sensor_current = $attributes['sensor_current'] ?? 0;
-        $sensor->sensor_prev = $attributes['sensor_prev'] ?? null;
-        $sensor->sensor_limit = $attributes['sensor_limit'] ?? null;
-        $sensor->sensor_limit_warn = $attributes['sensor_limit_warn'] ?? null;
-        $sensor->sensor_limit_low = $attributes['sensor_limit_low'] ?? null;
-        $sensor->sensor_limit_low_warn = $attributes['sensor_limit_low_warn'] ?? null;
-        $sensor->sensor_alert = $attributes['sensor_alert'] ?? 1;
-        $sensor->sensor_custom = $attributes['sensor_custom'] ?? 'No';
-        $sensor->entPhysicalIndex = $attributes['entPhysicalIndex'] ?? null;
-        $sensor->entPhysicalIndex_measured = $attributes['entPhysicalIndex_measured'] ?? null;
-        $sensor->sensor_oids = $attributes['sensor_oids'] ?? ['value' => '.1.3.6.1.4.1.17713.21.1.2.30.1.4.1'];
-        $sensor->access_point_id = $attributes['access_point_id'] ?? null;
-        $sensor->rrd_type = $attributes['rrd_type'] ?? 'GAUGE';
-        $sensor->save();
-
-        return $sensor;
     }
 }

--- a/tests/BasicApiTest.php
+++ b/tests/BasicApiTest.php
@@ -29,6 +29,7 @@ namespace LibreNMS\Tests;
 use App\Models\ApiToken;
 use App\Models\Device;
 use App\Models\User;
+use App\Models\WirelessSensor;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 
 final class BasicApiTest extends DBTestCase
@@ -49,5 +50,135 @@ final class BasicApiTest extends DBTestCase
                 'devices' => [$device->toArray()],
                 'count' => 1,
             ]);
+    }
+
+    public function testGetDeviceWirelessSensors(): void
+    {
+        /** @var User $user */
+        $user = User::factory()->admin()->create();
+        $token = ApiToken::generateToken($user);
+        $device = Device::factory()->create();
+
+        $rssi = $this->makeWirelessSensor($device, [
+            'sensor_class' => 'rssi',
+            'sensor_index' => '1.1',
+            'sensor_descr' => 'Subscriber 1 UL RSSI',
+            'sensor_current' => -62,
+        ]);
+        $this->makeWirelessSensor($device, [
+            'sensor_class' => 'snr',
+            'sensor_index' => '1.2',
+            'sensor_descr' => 'Subscriber 1 UL SNR',
+            'sensor_current' => 31,
+        ]);
+        $this->makeWirelessSensor($device, [
+            'sensor_class' => 'rssi',
+            'sensor_index' => '1.3',
+            'sensor_descr' => 'Deleted Sensor',
+            'sensor_current' => 7,
+            'sensor_deleted' => 1,
+        ]);
+
+        $response = $this->json('GET', "/api/v0/devices/{$device->device_id}/wireless-sensors", [], ['X-Auth-Token' => $token->token_hash]);
+
+        $response->assertStatus(200)
+            ->assertJsonPath('status', 'ok')
+            ->assertJsonPath('count', 2)
+            ->assertJsonCount(2, 'wireless_sensors');
+
+        $this->assertSame($rssi->sensor_id, $response->json('wireless_sensors.0.sensor_id'));
+        $this->assertSame('rssi', $response->json('wireless_sensors.0.sensor_class'));
+        $this->assertSame('snr', $response->json('wireless_sensors.1.sensor_class'));
+    }
+
+    public function testGetDeviceWirelessSensorsSupportsFilteringAndColumns(): void
+    {
+        /** @var User $user */
+        $user = User::factory()->admin()->create();
+        $token = ApiToken::generateToken($user);
+        $device = Device::factory()->create();
+
+        $rssi = $this->makeWirelessSensor($device, [
+            'sensor_class' => 'rssi',
+            'sensor_index' => '2.1',
+            'sensor_descr' => 'Subscriber 2 UL RSSI',
+            'sensor_current' => -55,
+        ]);
+        $this->makeWirelessSensor($device, [
+            'sensor_class' => 'snr',
+            'sensor_index' => '2.2',
+            'sensor_descr' => 'Subscriber 2 UL SNR',
+            'sensor_current' => 31,
+        ]);
+
+        $response = $this->json(
+            'GET',
+            "/api/v0/devices/{$device->device_id}/wireless-sensors?class=rssi&columns=sensor_id,sensor_class,sensor_descr,sensor_current,lastupdate",
+            [],
+            ['X-Auth-Token' => $token->token_hash]
+        );
+
+        $response->assertStatus(200)
+            ->assertJsonPath('status', 'ok')
+            ->assertJsonPath('count', 1)
+            ->assertJsonCount(1, 'wireless_sensors');
+
+        $row = $response->json('wireless_sensors.0');
+
+        $this->assertSame($rssi->sensor_id, $row['sensor_id']);
+        $this->assertSame('rssi', $row['sensor_class']);
+        $this->assertSame('Subscriber 2 UL RSSI', $row['sensor_descr']);
+        $this->assertEquals(-55, $row['sensor_current']);
+        $this->assertArrayHasKey('lastupdate', $row);
+        $this->assertArrayNotHasKey('sensor_type', $row);
+    }
+
+    public function testGetDeviceWirelessSensorsRejectsInvalidClass(): void
+    {
+        /** @var User $user */
+        $user = User::factory()->admin()->create();
+        $token = ApiToken::generateToken($user);
+        $device = Device::factory()->create();
+
+        $this->json(
+            'GET',
+            "/api/v0/devices/{$device->device_id}/wireless-sensors?class=bogus",
+            [],
+            ['X-Auth-Token' => $token->token_hash]
+        )->assertStatus(400)
+            ->assertJson([
+                'status' => 'error',
+                'message' => "Invalid wireless sensor class 'bogus'",
+            ]);
+    }
+
+    private function makeWirelessSensor(Device $device, array $attributes = []): WirelessSensor
+    {
+        $sensor = new WirelessSensor();
+        $sensor->device_id = $device->device_id;
+        $sensor->sensor_deleted = $attributes['sensor_deleted'] ?? 0;
+        $sensor->sensor_class = $attributes['sensor_class'] ?? 'rssi';
+        $sensor->sensor_index = $attributes['sensor_index'] ?? '1';
+        $sensor->sensor_type = $attributes['sensor_type'] ?? 'generic';
+        $sensor->sensor_descr = $attributes['sensor_descr'] ?? 'Wireless Sensor';
+        $sensor->sensor_divisor = $attributes['sensor_divisor'] ?? 1;
+        $sensor->sensor_multiplier = $attributes['sensor_multiplier'] ?? 1;
+        $sensor->sensor_aggregator = $attributes['sensor_aggregator'] ?? 'sum';
+        $sensor->sensor_current = $attributes['sensor_current'] ?? 0;
+        $sensor->sensor_prev = $attributes['sensor_prev'] ?? null;
+        $sensor->sensor_limit = $attributes['sensor_limit'] ?? null;
+        $sensor->sensor_limit_warn = $attributes['sensor_limit_warn'] ?? null;
+        $sensor->sensor_limit_low = $attributes['sensor_limit_low'] ?? null;
+        $sensor->sensor_limit_low_warn = $attributes['sensor_limit_low_warn'] ?? null;
+        $sensor->sensor_alert = $attributes['sensor_alert'] ?? 1;
+        $sensor->sensor_custom = $attributes['sensor_custom'] ?? 'No';
+        $sensor->entPhysicalIndex = $attributes['entPhysicalIndex'] ?? null;
+        $sensor->entPhysicalIndex_measured = $attributes['entPhysicalIndex_measured'] ?? null;
+        $sensor->sensor_oids = $attributes['sensor_oids'] ?? ['value' => '.1.3.6.1.4.1.17713.21.1.2.30.1.4.1'];
+        $sensor->access_point_id = $attributes['access_point_id'] ?? null;
+        $sensor->rrd_type = $attributes['rrd_type'] ?? 'GAUGE';
+        $sensor->save();
+
+        return $sensor;
     }
 }


### PR DESCRIPTION
Adds a new API endpoint `GET /api/v0/devices/{hostname}/wireless-sensors` that returns wireless sensor data for a device, similar to how the existing ports endpoint works.

Supports optional `class` parameter to filter by sensor type, and `columns` parameter to select specific fields. Validates the class parameter against WirelessSensorType and returns 400 for invalid values. Deleted sensors are excluded by default.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.