### PR TITLE
epmp: add radio overview and subscriber summary panels

### DIFF
--- a/includes/html/pages/device/overview.inc.php
+++ b/includes/html/pages/device/overview.inc.php
@@ -18,6 +18,7 @@ require 'includes/html/dev-overview-data.inc.php';
 require 'overview/maps.inc.php';
 require 'includes/html/dev-groups-overview-data.inc.php';
 require 'overview/puppet_agent.inc.php';
+require 'overview/wireless-subscribers.inc.php';
 
 echo LibreNMS\Plugins::call('device_overview_container', [$device]);
 foreach (PluginManager::call(DeviceOverviewHook::class, ['device' => DeviceCache::getPrimary()]) as $view) {

--- a/includes/html/pages/device/overview/epmp-radio.inc.php
+++ b/includes/html/pages/device/overview/epmp-radio.inc.php
@@ -1,0 +1,127 @@
+<?php
+
+use App\Facades\LibrenmsConfig;
+use LibreNMS\Enum\Sensor;
+use LibreNMS\Util\Html;
+use LibreNMS\Util\Rewrite;
+use LibreNMS\Util\Url;
+
+if (! function_exists('librenms_epmp_radio_tx_power_sensor')) {
+    function librenms_epmp_radio_tx_power_sensor()
+    {
+        return DeviceCache::getPrimary()->sensors
+            ->where('sensor_class', Sensor::Dbm->value)
+            ->first(fn ($sensor) => $sensor->group === 'Radio' && $sensor->sensor_descr === 'TX Power');
+    }
+}
+
+if (! function_exists('librenms_epmp_radio_state_sensors')) {
+    function librenms_epmp_radio_state_sensors()
+    {
+        return DeviceCache::getPrimary()->sensors
+            ->where('sensor_class', Sensor::State->value)
+            ->where('group', 'Radio')
+            ->sortBy('sensor_descr')
+            ->values();
+    }
+}
+
+if (! function_exists('librenms_epmp_radio_antenna_gain')) {
+    function librenms_epmp_radio_antenna_gain()
+    {
+        $value = DeviceCache::getPrimary()->getAttrib('epmp_radio_antenna_gain_dbi');
+
+        return is_numeric($value) ? $value : null;
+    }
+}
+
+if (! function_exists('librenms_epmp_has_radio_overview_rows')) {
+    function librenms_epmp_has_radio_overview_rows(): bool
+    {
+        return librenms_epmp_radio_tx_power_sensor() !== null
+            || librenms_epmp_radio_state_sensors()->isNotEmpty()
+            || librenms_epmp_radio_antenna_gain() !== null;
+    }
+}
+
+if (! function_exists('librenms_epmp_render_sensor_overview_row')) {
+    function librenms_epmp_render_sensor_overview_row(array $device, $sensor, Sensor $sensor_class): void
+    {
+        $graph_array = [
+            'height' => '100',
+            'width' => '210',
+            'to' => LibrenmsConfig::get('time.now'),
+            'id' => $sensor->sensor_id,
+            'type' => 'sensor_' . $sensor_class->value,
+            'from' => LibrenmsConfig::get('time.day'),
+            'legend' => 'no',
+        ];
+
+        $link_array = $graph_array;
+        $link_array['page'] = 'graphs';
+        unset($link_array['height'], $link_array['width'], $link_array['legend']);
+        $link = Url::generate($link_array);
+
+        if ($sensor->poller_type == 'ipmi') {
+            $sensor_descr = substr((string) ipmiSensorName($device['hardware'], $sensor->sensor_descr), 0, 48);
+        } else {
+            $sensor_descr = substr((string) $sensor->sensor_descr, 0, 48);
+        }
+
+        $overlib_content = '<div class=overlib><span class=overlib-text>' . $device['hostname'] . ' - ' . $sensor_descr . '</span><br />';
+        foreach (['day', 'week', 'month', 'year'] as $period) {
+            $graph_array['from'] = LibrenmsConfig::get("time.$period");
+            $overlib_content .= str_replace('"', "\'", Url::graphTag($graph_array));
+        }
+        $overlib_content .= '</div>';
+
+        $graph_array['width'] = 80;
+        $graph_array['height'] = 20;
+        $graph_array['bg'] = 'ffffff00';
+        $graph_array['from'] = LibrenmsConfig::get('time.day');
+        $sensor_minigraph = Url::lazyGraphTag($graph_array);
+        $sensor_current = Html::severityToLabel($sensor->currentStatus(), $sensor->formatValue());
+
+        echo '<tr><td><div style="display: grid; grid-gap: 10px; grid-template-columns: 3fr 1fr 1fr;">
+            <div>' . Url::overlibLink($link, Rewrite::shortenIfName($sensor_descr), $overlib_content, $sensor_class->value) . '</div>
+            <div>' . Url::overlibLink($link, $sensor_minigraph, $overlib_content, $sensor_class->value) . '</div>
+            <div>' . Url::overlibLink($link, $sensor_current, $overlib_content, $sensor_class->value) . '</div>
+            </div></td></tr>';
+    }
+}
+
+if (! function_exists('librenms_epmp_render_metadata_overview_row')) {
+    function librenms_epmp_render_metadata_overview_row(string $label, string $value): void
+    {
+        echo '<tr><td><div style="display: grid; grid-gap: 10px; grid-template-columns: 3fr 1fr 1fr;">
+            <div>' . htmlspecialchars($label, ENT_QUOTES) . '</div>
+            <div></div>
+            <div>' . htmlspecialchars($value, ENT_QUOTES) . '</div>
+            </div></td></tr>';
+    }
+}
+
+if (! function_exists('librenms_epmp_render_radio_overview_rows')) {
+    function librenms_epmp_render_radio_overview_rows(array $device): void
+    {
+        if (! librenms_epmp_has_radio_overview_rows()) {
+            return;
+        }
+
+        echo "<tr><td colspan='3'><strong>Radio</strong></td></tr>";
+
+        $tx_power = librenms_epmp_radio_tx_power_sensor();
+        if ($tx_power) {
+            librenms_epmp_render_sensor_overview_row($device, $tx_power, Sensor::Dbm);
+        }
+
+        $antenna_gain = librenms_epmp_radio_antenna_gain();
+        if ($antenna_gain !== null) {
+            librenms_epmp_render_metadata_overview_row('Antenna Gain', $antenna_gain . ' dBi');
+        }
+
+        foreach (librenms_epmp_radio_state_sensors() as $sensor) {
+            librenms_epmp_render_sensor_overview_row($device, $sensor, Sensor::State);
+        }
+    }
+}

--- a/includes/html/pages/device/overview/generic/sensor.inc.php
+++ b/includes/html/pages/device/overview/generic/sensor.inc.php
@@ -2,12 +2,24 @@
 
 use LibreNMS\Util\Html;
 
+require_once 'includes/html/pages/device/overview/epmp-radio.inc.php';
+
 $sensors = DeviceCache::getPrimary()->sensors->where('sensor_class', $sensor_class->value)->where('group', '!=', 'transceiver')->sortBy([
     ['group', 'asc'],
     ['sensor_descr', 'asc'],
 ]); // cache all sensors on device and exclude transceivers
 
-if ($sensors->isNotEmpty()) {
+$is_epmp = ($device['os'] ?? null) === 'epmp';
+
+if ($is_epmp && $sensor_class === \LibreNMS\Enum\Sensor::State) {
+    $sensors = $sensors->reject(fn ($sensor) => $sensor->group === 'Radio')->values();
+} elseif ($is_epmp && $sensor_class === \LibreNMS\Enum\Sensor::Dbm) {
+    $sensors = $sensors->reject(fn ($sensor) => $sensor->group === 'Radio' && $sensor->sensor_descr === 'TX Power')->values();
+}
+
+$render_epmp_radio_rows = $is_epmp && $sensor_class === \LibreNMS\Enum\Sensor::State && librenms_epmp_has_radio_overview_rows();
+
+if ($sensors->isNotEmpty() || $render_epmp_radio_rows) {
     $sensor_fa_icon = 'fa-' . $sensor_class->icon();
 
     echo '
@@ -18,6 +30,11 @@ if ($sensors->isNotEmpty()) {
     echo '<a href="device/device=' . $device['device_id'] . '/tab=health/metric=' . $sensor_class->value . '/"><i class="fa ' . $sensor_fa_icon . ' fa-lg icon-theme" aria-hidden="true"></i><strong> ' . $sensor_class->label() . '</strong></a>';
     echo '      </div>
         <table class="table table-hover table-condensed table-striped">';
+
+    if ($render_epmp_radio_rows) {
+        librenms_epmp_render_radio_overview_rows($device);
+    }
+
     $group = '';
     foreach ($sensors as $sensor) {
         if ($group != $sensor->group) {

--- a/includes/html/pages/device/overview/wireless-subscribers.inc.php
+++ b/includes/html/pages/device/overview/wireless-subscribers.inc.php
@@ -1,0 +1,6 @@
+<?php
+
+require_once 'includes/html/pages/device/wireless-summary.inc.php';
+
+$subscriber_summary = librenms_wireless_subscriber_summary((int) $device['device_id']);
+librenms_render_wireless_subscriber_summary($subscriber_summary);

--- a/includes/html/pages/device/wireless-summary.inc.php
+++ b/includes/html/pages/device/wireless-summary.inc.php
@@ -1,0 +1,199 @@
+<?php
+
+use App\Models\WirelessSensor;
+use LibreNMS\Util\Number;
+use LibreNMS\Util\Url;
+
+if (! function_exists('librenms_wireless_subscriber_summary')) {
+    function librenms_wireless_subscriber_summary(int $deviceId): array
+    {
+        static $cache = [];
+
+        if (isset($cache[$deviceId])) {
+            return $cache[$deviceId];
+        }
+
+        $all_wireless_sensors = WirelessSensor::where('device_id', $deviceId)
+            ->where('sensor_deleted', 0)
+            ->orderBy('sensor_class')
+            ->orderBy('sensor_index')
+            ->orderBy('sensor_descr')
+            ->get()
+            ->toArray();
+
+        $subscriber_column_map = [
+            'distance' => ['label' => 'Distance', 'order' => 10],
+            'tx_rate' => ['label' => 'TX Rate', 'order' => 20],
+            'rx_rate' => ['label' => 'RX Rate', 'order' => 30],
+            'ul_rssi' => ['label' => 'UL RSSI', 'order' => 40],
+            'dl_rssi' => ['label' => 'DL RSSI', 'order' => 50],
+            'rssi' => ['label' => 'RSSI', 'order' => 60],
+            'ul_snr' => ['label' => 'UL SNR', 'order' => 70],
+            'dl_snr' => ['label' => 'DL SNR', 'order' => 80],
+            'ul_mcs' => ['label' => 'UL MCS', 'order' => 90],
+            'dl_mcs' => ['label' => 'DL MCS', 'order' => 100],
+            'snr' => ['label' => 'SNR', 'order' => 110],
+            'quality' => ['label' => 'Quality', 'order' => 120],
+            'capacity' => ['label' => 'Capacity', 'order' => 130],
+        ];
+
+        $subscriber_rows = [];
+        $subscriber_columns = [];
+
+        foreach ($all_wireless_sensors as $sensor) {
+            if (in_array($sensor['sensor_class'], ['clients', 'frequency', 'ap-count', 'channel', 'cell'], true)) {
+                continue;
+            }
+
+            $index = (string) ($sensor['sensor_index'] ?? '');
+            if ($index === '') {
+                continue;
+            }
+
+            $type = strtolower((string) ($sensor['sensor_type'] ?? ''));
+            $descr = trim((string) ($sensor['sensor_descr'] ?? ''));
+            $lower_descr = strtolower($descr);
+
+            $direction = null;
+            if (str_contains($type, '-ul') || str_contains($lower_descr, ' ul ')) {
+                $direction = 'ul';
+            } elseif (str_contains($type, '-dl') || str_contains($lower_descr, ' dl ')) {
+                $direction = 'dl';
+            } elseif (str_contains($type, '-tx') || str_starts_with($lower_descr, 'tx ')) {
+                $direction = 'tx';
+            } elseif (str_contains($type, '-rx') || str_starts_with($lower_descr, 'rx ')) {
+                $direction = 'rx';
+            }
+
+            $column_key = match ($sensor['sensor_class']) {
+                'distance' => 'distance',
+                'quality' => 'quality',
+                'capacity' => 'capacity',
+                'rate' => $direction === 'tx' ? 'tx_rate' : ($direction === 'rx' ? 'rx_rate' : 'rate'),
+                'mcs' => $direction === 'ul' ? 'ul_mcs' : ($direction === 'dl' ? 'dl_mcs' : 'mcs'),
+                'rssi' => $direction === 'ul' ? 'ul_rssi' : ($direction === 'dl' ? 'dl_rssi' : 'rssi'),
+                'snr' => $direction === 'ul' ? 'ul_snr' : ($direction === 'dl' ? 'dl_snr' : 'snr'),
+                default => null,
+            };
+
+            if ($column_key === null || ! isset($subscriber_column_map[$column_key])) {
+                continue;
+            }
+
+            $label = $descr;
+            if (preg_match('/^(RX|TX|SNR|Sta)\s+\((.+)\)$/i', $descr, $matches)) {
+                $label = trim($matches[2]);
+            } else {
+                $label = trim((string) preg_replace([
+                    '/\s+(UL|DL)\s+RSSI$/i',
+                    '/\s+(UL|DL)\s+SNR$/i',
+                    '/\s+(UL|DL)\s+MCS$/i',
+                    '/\s+(RX|TX)\s+Rate$/i',
+                    '/\s+Tx\s+Quality$/i',
+                    '/\s+Tx\s+Capacity$/i',
+                    '/\s+Distance$/i',
+                ], '', $descr));
+            }
+
+            $subscriber_rows[$index] ??= ['label' => 'Subscriber ' . $index, 'values' => []];
+            if ($label !== '' && ($subscriber_rows[$index]['label'] === 'Subscriber ' . $index || strlen($label) > strlen($subscriber_rows[$index]['label']))) {
+                $subscriber_rows[$index]['label'] = $label;
+            }
+
+            $current = $sensor['sensor_current'];
+            $formatted_value = match ($sensor['sensor_class']) {
+                'distance' => $current === null || $current === '' ? '' : Number::formatSi((float) $current * 1000, 3, 0, 'm'),
+                'rate' => $current === null || $current === '' ? '' : Number::formatSi((float) $current, 3, 0, 'bps'),
+                'mcs' => $current === null || $current === '' ? '' : (string) ((int) $current),
+                'rssi' => $current === null || $current === '' ? '' : ((int) $current) . ' dBm',
+                'snr' => $current === null || $current === '' ? '' : ((int) $current) . ' dB',
+                'quality', 'capacity' => $current === null || $current === '' ? '' : ((int) $current) . '%',
+                default => (string) $current,
+            };
+
+            $subscriber_rows[$index]['values'][$column_key] = [
+                'text' => $formatted_value,
+                'html' => $formatted_value,
+            ];
+
+            if ($formatted_value !== '' && ! empty($sensor['sensor_id'])) {
+                $graph_type = 'wireless_' . $sensor['sensor_class'];
+                $graph_title = addslashes(htmlentities($label . ' - ' . $subscriber_column_map[$column_key]['label']));
+                $content = '<div class=list-large>' . $graph_title . '</div>';
+                $content .= "<div style='width: 850px'>";
+
+                foreach ([
+                    \Carbon\Carbon::now()->subDay()->timestamp,
+                    \Carbon\Carbon::now()->subWeek()->timestamp,
+                    \Carbon\Carbon::now()->subMonth()->timestamp,
+                    \Carbon\Carbon::now()->subYear()->timestamp,
+                ] as $from) {
+                    $content .= \LibreNMS\Util\Url::graphTag([
+                        'type' => $graph_type,
+                        'legend' => 'yes',
+                        'height' => 100,
+                        'width' => 340,
+                        'to' => \Carbon\Carbon::now()->timestamp,
+                        'from' => $from,
+                        'id' => $sensor['sensor_id'],
+                    ]);
+                }
+
+                $content .= '</div>';
+
+                $subscriber_rows[$index]['values'][$column_key]['html'] = Url::overlibLink(
+                    Url::deviceUrl($deviceId, ['tab' => 'wireless', 'metric' => $sensor['sensor_class']]),
+                    $formatted_value,
+                    $content
+                );
+            }
+
+            $subscriber_columns[$column_key] = $subscriber_column_map[$column_key];
+        }
+
+        uasort($subscriber_rows, static fn ($left, $right) => strnatcasecmp($left['label'], $right['label']));
+        uasort($subscriber_columns, static fn ($left, $right) => $left['order'] <=> $right['order']);
+
+        return $cache[$deviceId] = [
+            'rows' => $subscriber_rows,
+            'columns' => $subscriber_columns,
+            'has_data' => ! empty($subscriber_rows) && ! empty($subscriber_columns),
+        ];
+    }
+}
+
+if (! function_exists('librenms_render_wireless_subscriber_summary')) {
+    function librenms_render_wireless_subscriber_summary(array $summary, string $title = 'Subscribers'): void
+    {
+        if (empty($summary['has_data'])) {
+            return;
+        }
+
+        echo '<div class="panel panel-default">';
+        echo '<div class="panel-heading"><h3 class="panel-title">' . htmlspecialchars($title) . '</h3></div>';
+        echo '<div class="table-responsive">';
+        echo '<table class="table table-hover table-condensed table-striped">';
+        echo '<thead><tr><th>Subscriber</th>';
+
+        foreach ($summary['columns'] as $column) {
+            echo '<th>' . htmlspecialchars((string) $column['label']) . '</th>';
+        }
+
+        echo '</tr></thead><tbody>';
+
+        foreach ($summary['rows'] as $row) {
+            echo '<tr>';
+            echo '<td>' . htmlspecialchars((string) $row['label']) . '</td>';
+
+            foreach (array_keys($summary['columns']) as $column_key) {
+                $value = $row['values'][$column_key] ?? ['text' => '', 'html' => ''];
+                echo '<td>' . ($value['html'] ?: htmlspecialchars((string) $value['text'])) . '</td>';
+            }
+
+            echo '</tr>';
+        }
+
+        echo '</tbody></table>';
+        echo '</div></div>';
+    }
+}

--- a/includes/html/pages/device/wireless.inc.php
+++ b/includes/html/pages/device/wireless.inc.php
@@ -4,13 +4,18 @@ use App\Models\WirelessSensor;
 use LibreNMS\Enum\WirelessSensorType;
 use LibreNMS\Util\Number;
 
-// this determines the order of the tabs
-$db_classes = WirelessSensor::where('device_id', $device['device_id'])
-    ->distinct()
-    ->pluck('sensor_class')
-    ->map(fn (WirelessSensorType $class) => $class->value)
-    ->all();
+require_once 'includes/html/pages/device/wireless-summary.inc.php';
+
+$all_wireless_sensors = WirelessSensor::where('device_id', $device['device_id'])
+    ->where('sensor_deleted', 0)
+    ->orderBy('sensor_class')
+    ->orderBy('sensor_index')
+    ->orderBy('sensor_descr')
+    ->get()
+    ->toArray();
+$db_classes = array_values(array_unique(array_map(static fn ($sensor) => $sensor['sensor_class'], $all_wireless_sensors)));
 $sensor_classes = array_intersect(WirelessSensorType::values(), $db_classes);
+$subscriber_summary = librenms_wireless_subscriber_summary((int) $device['device_id']);
 
 $wireless_link_array = [
     'page' => 'device',
@@ -31,6 +36,12 @@ echo '<span' . ($vars['metric'] == 'overview' ? ' class="pagemenu-selected"' : '
 echo generate_link('Overview', $wireless_link_array, ['metric' => 'overview']);
 echo '</span>';
 
+if (! empty($subscriber_summary['has_data'])) {
+    echo ' | <span' . ($vars['metric'] == 'subscribers' ? ' class="pagemenu-selected"' : '') . '>';
+    echo generate_link('Subscribers', $wireless_link_array, ['metric' => 'subscribers']);
+    echo '</span>';
+}
+
 foreach ($sensor_classes as $type) {
     echo ' | <span';
     if ($vars['metric'] == $type) {
@@ -46,6 +57,8 @@ foreach ($sensor_classes as $type) {
 print_optionbar_end();
 
 if ($vars['metric'] == 'overview') {
+    librenms_render_wireless_subscriber_summary($subscriber_summary);
+
     foreach ($sensor_classes as $type) {
         $text = __("wireless.$type.long");
         $unit = __("wireless.$type.unit");
@@ -58,6 +71,8 @@ if ($vars['metric'] == 'overview') {
 
         include \App\Facades\LibrenmsConfig::get('install_dir') . '/includes/html/print-device-graph.php';
     }
+} elseif ($vars['metric'] == 'subscribers') {
+    librenms_render_wireless_subscriber_summary($subscriber_summary);
 } elseif (WirelessSensorType::tryFrom($vars['metric'])) {
     $unit = __('wireless.' . $vars['metric'] . '.unit');
     $factor = 1;


### PR DESCRIPTION
Adds device overview and wireless tab panels for ePMP Access Points.

- Radio overview panel showing frequency, channel width, GPS sync status, and connected client count
- Subscriber summary table on the wireless tab with per-subscriber RSSI, SNR, MCS, distance, and quality
- Generic sensor overview partial for reuse with wireless sensor types

Note: this PR has a soft dependency on #19462 (the data these panels display comes from the sensors discovered in that PR). The panels degrade gracefully if the data isn't present.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.