### PR TITLE
Fix sensors include path

### DIFF
--- a/includes/html/pages/device/health/airflow.inc.php
+++ b/includes/html/pages/device/health/airflow.inc.php
@@ -25,4 +25,4 @@
  */
 $class = \LibreNMS\Enum\Sensor::Airflow;
 
-require 'sensors.inc.php';
+require 'includes/html/pages/device/health/sensors.inc.php';

--- a/includes/html/pages/device/health/ber.inc.php
+++ b/includes/html/pages/device/health/ber.inc.php
@@ -2,4 +2,4 @@
 
 $class = \LibreNMS\Enum\Sensor::Ber;
 
-require 'sensors.inc.php';
+require 'includes/html/pages/device/health/sensors.inc.php';

--- a/includes/html/pages/device/health/bitrate.inc.php
+++ b/includes/html/pages/device/health/bitrate.inc.php
@@ -25,4 +25,4 @@
  */
 $class = \LibreNMS\Enum\Sensor::Bitrate;
 
-require 'sensors.inc.php';
+require 'includes/html/pages/device/health/sensors.inc.php';

--- a/includes/html/pages/device/health/charge.inc.php
+++ b/includes/html/pages/device/health/charge.inc.php
@@ -2,4 +2,4 @@
 
 $class = \LibreNMS\Enum\Sensor::Charge;
 
-require 'sensors.inc.php';
+require 'includes/html/pages/device/health/sensors.inc.php';

--- a/includes/html/pages/device/health/chromatic_dispersion.inc.php
+++ b/includes/html/pages/device/health/chromatic_dispersion.inc.php
@@ -2,4 +2,4 @@
 
 $class = \LibreNMS\Enum\Sensor::ChromaticDispersion;
 
-require 'sensors.inc.php';
+require 'includes/html/pages/device/health/sensors.inc.php';

--- a/includes/html/pages/device/health/cooling.inc.php
+++ b/includes/html/pages/device/health/cooling.inc.php
@@ -2,4 +2,4 @@
 
 $class = \LibreNMS\Enum\Sensor::Cooling;
 
-require 'sensors.inc.php';
+require 'includes/html/pages/device/health/sensors.inc.php';

--- a/includes/html/pages/device/health/count.inc.php
+++ b/includes/html/pages/device/health/count.inc.php
@@ -2,4 +2,4 @@
 
 $class = \LibreNMS\Enum\Sensor::Count;
 
-require 'sensors.inc.php';
+require 'includes/html/pages/device/health/sensors.inc.php';

--- a/includes/html/pages/device/health/current.inc.php
+++ b/includes/html/pages/device/health/current.inc.php
@@ -2,4 +2,4 @@
 
 $class = \LibreNMS\Enum\Sensor::Current;
 
-require 'sensors.inc.php';
+require 'includes/html/pages/device/health/sensors.inc.php';

--- a/includes/html/pages/device/health/dbm.inc.php
+++ b/includes/html/pages/device/health/dbm.inc.php
@@ -2,4 +2,4 @@
 
 $class = \LibreNMS\Enum\Sensor::Dbm;
 
-require 'sensors.inc.php';
+require 'includes/html/pages/device/health/sensors.inc.php';

--- a/includes/html/pages/device/health/delay.inc.php
+++ b/includes/html/pages/device/health/delay.inc.php
@@ -2,4 +2,4 @@
 
 $class = \LibreNMS\Enum\Sensor::Delay;
 
-require 'sensors.inc.php';
+require 'includes/html/pages/device/health/sensors.inc.php';

--- a/includes/html/pages/device/health/eer.inc.php
+++ b/includes/html/pages/device/health/eer.inc.php
@@ -2,4 +2,4 @@
 
 $class = \LibreNMS\Enum\Sensor::Eer;
 
-require 'sensors.inc.php';
+require 'includes/html/pages/device/health/sensors.inc.php';

--- a/includes/html/pages/device/health/fanspeed.inc.php
+++ b/includes/html/pages/device/health/fanspeed.inc.php
@@ -2,4 +2,4 @@
 
 $class = \LibreNMS\Enum\Sensor::Fanspeed;
 
-require 'sensors.inc.php';
+require 'includes/html/pages/device/health/sensors.inc.php';

--- a/includes/html/pages/device/health/frequency.inc.php
+++ b/includes/html/pages/device/health/frequency.inc.php
@@ -2,4 +2,4 @@
 
 $class = \LibreNMS\Enum\Sensor::Frequency;
 
-require 'sensors.inc.php';
+require 'includes/html/pages/device/health/sensors.inc.php';

--- a/includes/html/pages/device/health/humidity.inc.php
+++ b/includes/html/pages/device/health/humidity.inc.php
@@ -2,4 +2,4 @@
 
 $class = \LibreNMS\Enum\Sensor::Humidity;
 
-require 'sensors.inc.php';
+require 'includes/html/pages/device/health/sensors.inc.php';

--- a/includes/html/pages/device/health/load.inc.php
+++ b/includes/html/pages/device/health/load.inc.php
@@ -2,4 +2,4 @@
 
 $class = \LibreNMS\Enum\Sensor::Load;
 
-require 'sensors.inc.php';
+require 'includes/html/pages/device/health/sensors.inc.php';

--- a/includes/html/pages/device/health/loss.inc.php
+++ b/includes/html/pages/device/health/loss.inc.php
@@ -2,4 +2,4 @@
 
 $class = \LibreNMS\Enum\Sensor::Loss;
 
-require 'sensors.inc.php';
+require 'includes/html/pages/device/health/sensors.inc.php';

--- a/includes/html/pages/device/health/percent.inc.php
+++ b/includes/html/pages/device/health/percent.inc.php
@@ -2,4 +2,4 @@
 
 $class = \LibreNMS\Enum\Sensor::Percent;
 
-require 'sensors.inc.php';
+require 'includes/html/pages/device/health/sensors.inc.php';

--- a/includes/html/pages/device/health/power.inc.php
+++ b/includes/html/pages/device/health/power.inc.php
@@ -2,4 +2,4 @@
 
 $class = \LibreNMS\Enum\Sensor::Power;
 
-require 'sensors.inc.php';
+require 'includes/html/pages/device/health/sensors.inc.php';

--- a/includes/html/pages/device/health/power_consumed.inc.php
+++ b/includes/html/pages/device/health/power_consumed.inc.php
@@ -2,4 +2,4 @@
 
 $class = \LibreNMS\Enum\Sensor::PowerConsumed;
 
-require 'sensors.inc.php';
+require 'includes/html/pages/device/health/sensors.inc.php';

--- a/includes/html/pages/device/health/power_factor.inc.php
+++ b/includes/html/pages/device/health/power_factor.inc.php
@@ -2,4 +2,4 @@
 
 $class = \LibreNMS\Enum\Sensor::PowerFactor;
 
-require 'sensors.inc.php';
+require 'includes/html/pages/device/health/sensors.inc.php';

--- a/includes/html/pages/device/health/pressure.inc.php
+++ b/includes/html/pages/device/health/pressure.inc.php
@@ -2,4 +2,4 @@
 
 $class = \LibreNMS\Enum\Sensor::Pressure;
 
-require 'sensors.inc.php';
+require 'includes/html/pages/device/health/sensors.inc.php';

--- a/includes/html/pages/device/health/quality_factor.inc.php
+++ b/includes/html/pages/device/health/quality_factor.inc.php
@@ -2,4 +2,4 @@
 
 $class = \LibreNMS\Enum\Sensor::QualityFactor;
 
-require 'sensors.inc.php';
+require 'includes/html/pages/device/health/sensors.inc.php';

--- a/includes/html/pages/device/health/runtime.inc.php
+++ b/includes/html/pages/device/health/runtime.inc.php
@@ -2,4 +2,4 @@
 
 $class = \LibreNMS\Enum\Sensor::Runtime;
 
-require 'sensors.inc.php';
+require 'includes/html/pages/device/health/sensors.inc.php';

--- a/includes/html/pages/device/health/signal.inc.php
+++ b/includes/html/pages/device/health/signal.inc.php
@@ -2,4 +2,4 @@
 
 $class = \LibreNMS\Enum\Sensor::Signal;
 
-require 'sensors.inc.php';
+require 'includes/html/pages/device/health/sensors.inc.php';

--- a/includes/html/pages/device/health/signal_loss.inc.php
+++ b/includes/html/pages/device/health/signal_loss.inc.php
@@ -2,4 +2,4 @@
 
 $class = \LibreNMS\Enum\Sensor::SignalLoss;
 
-require 'sensors.inc.php';
+require 'includes/html/pages/device/health/sensors.inc.php';

--- a/includes/html/pages/device/health/snr.inc.php
+++ b/includes/html/pages/device/health/snr.inc.php
@@ -2,4 +2,4 @@
 
 $class = \LibreNMS\Enum\Sensor::Snr;
 
-require 'sensors.inc.php';
+require 'includes/html/pages/device/health/sensors.inc.php';

--- a/includes/html/pages/device/health/state.inc.php
+++ b/includes/html/pages/device/health/state.inc.php
@@ -2,4 +2,4 @@
 
 $class = \LibreNMS\Enum\Sensor::State;
 
-require 'sensors.inc.php';
+require 'includes/html/pages/device/health/sensors.inc.php';

--- a/includes/html/pages/device/health/temperature.inc.php
+++ b/includes/html/pages/device/health/temperature.inc.php
@@ -2,4 +2,4 @@
 
 $class = \LibreNMS\Enum\Sensor::Temperature;
 
-require 'sensors.inc.php';
+require 'includes/html/pages/device/health/sensors.inc.php';

--- a/includes/html/pages/device/health/tv_signal.inc.php
+++ b/includes/html/pages/device/health/tv_signal.inc.php
@@ -4,4 +4,4 @@ $class = \LibreNMS\Enum\Sensor::TvSignal;
 
 $graph_type = 'sensor_signal';
 
-require 'sensors.inc.php';
+require 'includes/html/pages/device/health/sensors.inc.php';

--- a/includes/html/pages/device/health/voltage.inc.php
+++ b/includes/html/pages/device/health/voltage.inc.php
@@ -2,4 +2,4 @@
 
 $class = \LibreNMS\Enum\Sensor::Voltage;
 
-require 'sensors.inc.php';
+require 'includes/html/pages/device/health/sensors.inc.php';

--- a/includes/html/pages/device/health/waterflow.inc.php
+++ b/includes/html/pages/device/health/waterflow.inc.php
@@ -2,4 +2,4 @@
 
 $class = \LibreNMS\Enum\Sensor::Waterflow;
 
-require 'sensors.inc.php';
+require 'includes/html/pages/device/health/sensors.inc.php';


### PR DESCRIPTION
Clicking the "Sensors" headline in the device overview results in an error because `sensors.inc.php` is included via a relative path, which no longer resolves correctly.

It happens when you navigate to the device overview page. Click on the "Sensors" headline.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
