### PR TITLE
Fix  for TP-Link Jetsream LLDP Neighbor Adds by IP

### DIFF
--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -253,6 +253,11 @@ if (($device['os'] == 'routeros') && version_compare($device['version'], '7.7', 
                 $remote_device_id = discover_new_device($remote_device_name, $device, 'LLDP', $port);
             }
 
+            // If we received an IP from the LLDP neighbor, and IP discovery is enabled, add the device by IP.
+            if (! $remote_device_id && $remote_device_ip && LibrenmsConfig::get('discovery_by_ip', false)) {
+                $remote_device_id = discover_new_device($remote_device_ip, $device, 'LLDP', $port);
+            }
+
             if ($port?->exists && $remote_device_name && $remote_port_descr) {
                 discover_link(
                     $port->port_id, //our port id from database


### PR DESCRIPTION
TP-Link's Jetstream LLDP data requires special handling. The existing code will only add by hostname if it passes validity checks. Adding a secondary check to add LLDP neighbors by IP if necessary.

The lnms dev:check command also made some style changes by removing some leading backslashes.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [-] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [-] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
