### PR TITLE
Added defaults to some OSPFv3 fields missing from Arista

### DIFF
--- a/LibreNMS/Modules/Ospfv3.php
+++ b/LibreNMS/Modules/Ospfv3.php
@@ -397,7 +397,7 @@ class Ospfv3 implements Module
 
     public function fetchAndFillNeighbor(Ospfv3Nbr $nbr): void
     {
-        $ospf_nbr= SnmpQuery::context($nbr->context_name)
+        $ospf_nbr = SnmpQuery::context($nbr->context_name)
             ->hideMib()->enumStrings()->get([
                 "OSPFV3-MIB::ospfv3NbrAddressType.$nbr->ospfv3NbrIfIndex.$nbr->ospfv3NbrIfInstId.$nbr->ospfv3NbrRtrId",
                 "OSPFV3-MIB::ospfv3NbrOptions.$nbr->ospfv3NbrIfIndex.$nbr->ospfv3NbrIfInstId.$nbr->ospfv3NbrRtrId",

--- a/LibreNMS/Modules/Ospfv3.php
+++ b/LibreNMS/Modules/Ospfv3.php
@@ -385,7 +385,11 @@ class Ospfv3 implements Module
                 "OSPFV3-MIB::ospfv3IfTEDisabled.$port->ospfv3IfIndex.$port->ospfv3IfInstId",
             ])->valuesByIndex()["$port->ospfv3IfIndex.$port->ospfv3IfInstId"] ?? [];
 
-        $ospf_port['ospfv3IfBackupDesignatedRouter'] ??= '';  // missing on some devices
+        // Missing on some devices
+        $ospf_port['ospfv3IfRtrPriority'] ??= 1;
+        $ospf_port['ospfv3IfDesignatedRouter'] ??= '';
+        $ospf_port['ospfv3IfDemand'] ??= '';
+        $ospf_port['ospfv3IfBackupDesignatedRouter'] ??= '';
 
         $port->fill($ospf_port);
         $port->port_id = (int) PortCache::getIdFromIfIndex($port->ospfv3IfIndex, $port->device_id); // this was skipped in initial poll
@@ -393,7 +397,7 @@ class Ospfv3 implements Module
 
     public function fetchAndFillNeighbor(Ospfv3Nbr $nbr): void
     {
-        $nbr->fill(SnmpQuery::context($nbr->context_name)
+        $ospf_nbr= SnmpQuery::context($nbr->context_name)
             ->hideMib()->enumStrings()->get([
                 "OSPFV3-MIB::ospfv3NbrAddressType.$nbr->ospfv3NbrIfIndex.$nbr->ospfv3NbrIfInstId.$nbr->ospfv3NbrRtrId",
                 "OSPFV3-MIB::ospfv3NbrOptions.$nbr->ospfv3NbrIfIndex.$nbr->ospfv3NbrIfInstId.$nbr->ospfv3NbrRtrId",
@@ -405,8 +409,12 @@ class Ospfv3 implements Module
                 "OSPFV3-MIB::ospfv3NbrRestartHelperStatus.$nbr->ospfv3NbrIfIndex.$nbr->ospfv3NbrIfInstId.$nbr->ospfv3NbrRtrId",
                 "OSPFV3-MIB::ospfv3NbrRestartHelperAge.$nbr->ospfv3NbrIfIndex.$nbr->ospfv3NbrIfInstId.$nbr->ospfv3NbrRtrId",
                 "OSPFV3-MIB::ospfv3NbrRestartHelperExitReason.$nbr->ospfv3NbrIfIndex.$nbr->ospfv3NbrIfInstId.$nbr->ospfv3NbrRtrId",
-            ])->valuesByIndex()["$nbr->ospfv3NbrIfIndex.$nbr->ospfv3NbrIfInstId.$nbr->ospfv3NbrRtrId"] ?? []);
+            ])->valuesByIndex()["$nbr->ospfv3NbrIfIndex.$nbr->ospfv3NbrIfInstId.$nbr->ospfv3NbrRtrId"] ?? [];
 
+        // Missing on some devices
+        $ospf_nbr['ospfv3NbrHelloSuppressed'] ??= '';
+
+        $nbr->fill($ospf_nbr);
         $nbr->port_id = PortCache::getIdFromIp($nbr->ospfv3NbrAddress, $nbr->context_name); // this was skipped in initial poll
     }
 }


### PR DESCRIPTION
Looks like not all OIDs are returned for OSPV3-MIB from Arista devices:

```
ospfv3IfRtrPriority[2001200][0] = No Such Instance currently exists at this OID
ospfv3IfTransitDelay[2001200][0] = 1
ospfv3IfRetransInterval[2001200][0] = 5
ospfv3IfHelloInterval[2001200][0] = 10
ospfv3IfRtrDeadInterval[2001200][0] = 40
ospfv3IfPollInterval[2001200][0] = No Such Instance currently exists at this OID
ospfv3IfDesignatedRouter[2001200][0] = No Such Instance currently exists at this OID
ospfv3IfBackupDesignatedRouter[2001200][0] = No Such Instance currently exists at this OID
ospfv3IfEvents[2001200][0] = 1
ospfv3IfDemand[2001200][0] = No Such Object available on this agent at this OID
ospfv3IfLinkScopeLsaCount[2001200][0] = 2
ospfv3IfLinkLsaCksumSum[2001200][0] = No Such Object available on this agent at this OID
ospfv3IfLinkLSASuppression[2001200][0] = No Such Object available on this agent at this OID
ospfv3IfDemandNbrProbe[2001200][0] = No Such Object available on this agent at this OID
ospfv3IfDemandNbrProbeRetransLimit[2001200][0] = No Such Object available on this agent at this OID
ospfv3IfDemandNbrProbeInterval[2001200][0] = No Such Object available on this agent at this OID
ospfv3IfTEDisabled[2001200][0] = No Such Object available on this agent at this OID
```

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
