### PR TITLE
Add "last changed" column to oxidized overview table

### DIFF
--- a/includes/html/functions.inc.php
+++ b/includes/html/functions.inc.php
@@ -828,7 +828,6 @@ function eventlog_severity($eventlog_severity)
     };
 } // end eventlog_severity
 
-
 /**
  * Convert a UTC timestamp to local timezone.
  *
@@ -851,7 +850,6 @@ function format_oxidize_timestamp($time)
         return $time;
     }
 }
-
 
 function get_oxidized_nodes_list()
 {

--- a/includes/html/functions.inc.php
+++ b/includes/html/functions.inc.php
@@ -838,31 +838,40 @@ function get_oxidized_nodes_list()
 
     $data = json_decode(file_get_contents(LibrenmsConfig::get('oxidized.url') . '/nodes?format=json', false, $context), true);
 
+    function format_oxidize_timestamp($time) 
+    {
+        try {
+            // Convert UTC time string to local timezone set
+            $utc_time = $time;
+            $utc_date = new DateTime($utc_time, new DateTimeZone('UTC'));
+            $local_timezone = new DateTimeZone(date_default_timezone_get());
+            $local_date = $utc_date->setTimezone($local_timezone);
+
+            // Generate local time string
+            return $local_date->format('Y-m-d H:i:s T');
+        } catch (Exception) {
+            // Just display the current value
+            return $time;
+        }
+
+    }
     foreach ($data as $object) {
         $device = DeviceCache::getByHostname($object['name']);
         if (! device_permitted($device->device_id)) {
             //user cannot see this device, so let's skip it.
             continue;
         }
-        try {
-            // Convert UTC time string to local timezone set
-            $utc_time = $object['time'];
-            $utc_date = new DateTime($utc_time, new DateTimeZone('UTC'));
-            $local_timezone = new DateTimeZone(date_default_timezone_get());
-            $local_date = $utc_date->setTimezone($local_timezone);
-
-            // Generate local time string
-            $formatted_local_time = $local_date->format('Y-m-d H:i:s T');
-        } catch (Exception) {
-            // Just display the current value of $object['time'];
-            $formatted_local_time = $object['time'];
+        $extra_columns = "";
+        if (LibrenmsConfig::get('oxidized.features.versioning') === true) {
+          $extra_columns .= '<td>' . format_oxidize_timestamp($object["mtime"]) . '</td>';
         }
         echo '<tr>
         <td>' . $device->device_id . '</td>
         <td>' . $object['name'] . '</td>
         <td>' . $device->sysName . '</td>
         <td>' . $object['status'] . '</td>
-        <td>' . $formatted_local_time . '</td>
+        <td>' . format_oxidize_timestamp($object["time"]) . '</td>
+        ' . $extra_columns . '
         <td>' . $object['model'] . '</td>
         <td>' . $object['group'] . '</td>
         <td></td>

--- a/includes/html/functions.inc.php
+++ b/includes/html/functions.inc.php
@@ -828,6 +828,31 @@ function eventlog_severity($eventlog_severity)
     };
 } // end eventlog_severity
 
+
+/**
+ * Convert a UTC timestamp to local timezone.
+ *
+ * @param  string  $time  UTC time string
+ * @return string Formatted local time with timezone abbreviation, or original value on error
+ */
+function format_oxidize_timestamp($time)
+{
+    try {
+        // Convert UTC time string to local timezone set
+        $utc_time = $time;
+        $utc_date = new DateTime($utc_time, new DateTimeZone('UTC'));
+        $local_timezone = new DateTimeZone(date_default_timezone_get());
+        $local_date = $utc_date->setTimezone($local_timezone);
+
+        // Generate local time string
+        return $local_date->format('Y-m-d H:i:s T');
+    } catch (Exception) {
+        // Just display the current value
+        return $time;
+    }
+}
+
+
 function get_oxidized_nodes_list()
 {
     $context = stream_context_create([
@@ -838,39 +863,22 @@ function get_oxidized_nodes_list()
 
     $data = json_decode(file_get_contents(LibrenmsConfig::get('oxidized.url') . '/nodes?format=json', false, $context), true);
 
-    function format_oxidize_timestamp($time) 
-    {
-        try {
-            // Convert UTC time string to local timezone set
-            $utc_time = $time;
-            $utc_date = new DateTime($utc_time, new DateTimeZone('UTC'));
-            $local_timezone = new DateTimeZone(date_default_timezone_get());
-            $local_date = $utc_date->setTimezone($local_timezone);
-
-            // Generate local time string
-            return $local_date->format('Y-m-d H:i:s T');
-        } catch (Exception) {
-            // Just display the current value
-            return $time;
-        }
-
-    }
     foreach ($data as $object) {
         $device = DeviceCache::getByHostname($object['name']);
         if (! device_permitted($device->device_id)) {
             //user cannot see this device, so let's skip it.
             continue;
         }
-        $extra_columns = "";
+        $extra_columns = '';
         if (LibrenmsConfig::get('oxidized.features.versioning') === true) {
-          $extra_columns .= '<td>' . format_oxidize_timestamp($object["mtime"]) . '</td>';
+            $extra_columns .= '<td>' . format_oxidize_timestamp($object['mtime']) . '</td>';
         }
         echo '<tr>
         <td>' . $device->device_id . '</td>
         <td>' . $object['name'] . '</td>
         <td>' . $device->sysName . '</td>
         <td>' . $object['status'] . '</td>
-        <td>' . format_oxidize_timestamp($object["time"]) . '</td>
+        <td>' . format_oxidize_timestamp($object['time']) . '</td>
         ' . $extra_columns . '
         <td>' . $object['model'] . '</td>
         <td>' . $object['group'] . '</td>

--- a/includes/html/pages/oxidized.inc.php
+++ b/includes/html/pages/oxidized.inc.php
@@ -35,6 +35,9 @@ $no_refresh = true;
                                 <th data-column-id="sysname" data-visible="false">SysName</th>
                                 <th data-column-id="last_status" data-formatter="status">Last Status</th>
                                 <th data-column-id="last_update">Last Update</th>
+                                <?php if (LibrenmsConfig::get('oxidized.features.versioning') === true) { ?>
+                                  <th data-column-id="last_change">Last Change</th>
+                                <?php } ?>
                                 <th data-column-id="model">Model</th>
                                 <th data-column-id="group">Group</th>
                                 <th data-column-id="actions" data-formatter="actions">Actions</th>


### PR DESCRIPTION
This PR adds a last changed column to the oxidized overview table. The column shows `mtime` as returned by oxidized-web. The column only shows when versioning is enabled. 

<img width="1883" height="399" alt="oxidized screenshot" src="https://github.com/user-attachments/assets/5a99c057-6d12-4c90-bbe5-38e42a64c37b" />


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
