### PR TITLE
Introduce multi-thread support to bill poller

### DIFF
--- a/LibreNMS/queuemanager.py
+++ b/LibreNMS/queuemanager.py
@@ -340,6 +340,15 @@ class BillingQueueManager(TimedQueueManager):
             "calculate_billing_timer",
         )
 
+    def start(self):
+        """
+        Start billing worker threads
+        """
+        workers = self.get_poller_config().workers
+        logger.debug("Starting {} workers for {}".format(workers, self.type))
+        for i in range(workers):
+            self.spawn_worker("{}-{}".format(self.type.title(), i + 1), 0)
+
     def start_dispatch(self):
         """
         Start the dispatch timer, this is not called automatically on init
@@ -358,17 +367,29 @@ class BillingQueueManager(TimedQueueManager):
         self.post_work("calculate", 0)
 
     def do_dispatch(self):
-        self.post_work("poll", 0)
+        db = LibreNMS.DB(self.config)
+        cursor = db.query("SELECT `bill_id` FROM `bills` ORDER BY `bill_id`")
+        for row in cursor.fetchall():
+            self.post_work(str(row[0]), 0)
 
     def do_work(self, run_type, group):
-        if run_type == "poll":
-            logger.info("Polling billing")
-            args = ("-d", "-f") if self.config.debug else ("-f",)
-            exit_code, output = LibreNMS.call_script("poll-billing.php", args)
-        else:  # run_type == 'calculate'
+        if run_type == "calculate":
             logger.info("Calculating billing")
             args = ("-d", "-f") if self.config.debug else ("-f",)
             exit_code, output = LibreNMS.call_script("billing-calculate.php", args)
+        else:
+            logger.info("Polling billing for bill_id %s", run_type)
+            args = (
+                (
+                    "-d",
+                    "-f",
+                    "-b",
+                    str(run_type),
+                )
+                if self.config.debug
+                else ("-f", "-b", str(run_type))
+            )
+            exit_code, output = LibreNMS.call_script("poll-billing.php", args)
 
         if exit_code != 0:
             logger.warning(

--- a/LibreNMS/service.py
+++ b/LibreNMS/service.py
@@ -169,6 +169,9 @@ class ServiceConfig(DBConfig):
             if config.get("schedule_type").get("billing", "legacy") == "legacy"
             else config.get("schedule_type").get("billing", "legacy") == "dispatcher"
         )
+        self.billing.workers = config.get(
+            "service_billing_workers", ServiceConfig.billing.workers
+        )
         self.billing.frequency = config.get(
             "service_billing_frequency", ServiceConfig.billing.frequency
         )
@@ -524,7 +527,11 @@ class Service:
                     else "disabled"
                 ),
                 "enabled" if self.config.alerting.enabled else "disabled",
-                "enabled" if self.config.billing.enabled else "disabled",
+                (
+                    self.config.billing.workers
+                    if self.config.billing.enabled
+                    else "disabled"
+                ),
                 "enabled" if self.config.ping.enabled else "disabled",
             )
         )

--- a/resources/definitions/config_definitions.json
+++ b/resources/definitions/config_definitions.json
@@ -193,7 +193,7 @@
                 "critical": "Critical"
             }
         },
-        "alert_rule.default_operation_steps_to": {
+        "alert_rule.max_alerts": {
             "default": 1,
             "units": "count",
             "group": "alerting",
@@ -201,7 +201,7 @@
             "order": 1,
             "type": "integer"
         },
-        "alert_rule.default_operation_start_in": {
+        "alert_rule.delay": {
             "default": 1,
             "units": "minutes",
             "group": "alerting",
@@ -209,7 +209,7 @@
             "order": 2,
             "type": "integer"
         },
-        "alert_rule.default_operation_step_duration": {
+        "alert_rule.interval": {
             "default": 5,
             "units": "minutes",
             "group": "alerting",
@@ -217,7 +217,7 @@
             "order": 3,
             "type": "integer"
         },
-        "alert_rule.default_operation_notifications_suppressed": {
+        "alert_rule.mute_alerts": {
             "default": false,
             "type": "boolean",
             "group": "alerting",
@@ -2272,7 +2272,7 @@
         "enable_ports_etherlike": {
             "group": "webui",
             "section": "device",
-            "order": 23,
+            "order": 22,
             "default": false,
             "type": "boolean"
         },
@@ -6308,17 +6308,6 @@
                 "fdb": "FDB"
             }
         },
-        "ports_ipv4_neighbours": {
-            "default": "subnet",
-            "type": "select",
-            "group": "webui",
-            "section": "device",
-            "order": 22,
-            "options":{
-                "subnet": "Subnet",
-                "arp": "ARP"
-            }
-        },
         "ports_purge": {
             "group": "system",
             "section": "cleanup",
@@ -6734,11 +6723,19 @@
             "type": "integer",
             "units": "Seconds"
         },
+         "service_billing_workers": {
+            "default": 2,
+            "group": "poller",
+            "section": "dispatcherservice",
+            "order": 16,
+            "type": "integer",
+            "units": "Workers"
+        },
         "service_billing_frequency": {
             "default": 300,
             "group": "poller",
             "section": "dispatcherservice",
-            "order": 16,
+            "order": 17,
             "type": "integer",
             "units": "Seconds"
         },
@@ -6746,7 +6743,7 @@
             "default": 60,
             "group": "poller",
             "section": "dispatcherservice",
-            "order": 17,
+            "order": 18,
             "type": "integer",
             "units": "Seconds"
         },
@@ -7018,13 +7015,6 @@
             "group": "external",
             "section": "binaries",
             "order": 12,
-            "type": "executable"
-        },
-        "snmptrap": {
-            "default": "/usr/bin/snmptrap",
-            "group": "external",
-            "section": "binaries",
-            "order": 13,
             "type": "executable"
         },
         "sso.create_users": {
@@ -7375,20 +7365,6 @@
             "order": 2,
             "type": "boolean"
         },
-        "webui.availability_bar.threshold_good": {
-            "default": 99,
-            "group": "webui",
-            "section": "availability-bar",
-            "order": 1,
-            "type": "integer"
-        },
-        "webui.availability_bar.threshold_medium": {
-            "default": 95,
-            "group": "webui",
-            "section": "availability-bar",
-            "order": 2,
-            "type": "integer"
-        },
         "webui.custom_css": {
             "default": [],
             "group": "webui",
@@ -7451,40 +7427,6 @@
         "xirrus_disable_stations": {
             "default": false,
             "type": "boolean"
-        },
-        "ssl_certificates.auto_discover": {
-            "default": false,
-            "group": "apps",
-            "section": "ssl-certificates",
-            "order": 0,
-            "type": "boolean"
-        },
-        "ssl_certificates.skip_hosts": {
-            "default": [],
-            "group": "apps",
-            "section": "ssl-certificates",
-            "order": 1,
-            "type": "array",
-            "validate": {
-                "value": "array",
-                "value.*": "string"
-            }
-        },
-        "ssl_certificates.days_until_expiry_warning": {
-            "default": 30,
-            "group": "apps",
-            "section": "ssl-certificates",
-            "order": 2,
-            "type": "integer",
-            "units": "days"
-        },
-        "ssl_certificates.days_until_expiry_danger": {
-            "default": 0,
-            "group": "apps",
-            "section": "ssl-certificates",
-            "order": 3,
-            "type": "integer",
-            "units": "days"
         },
         "smokeping.integration": {
             "default": false,


### PR DESCRIPTION
Add support for parallel threads to billing poller.

The cron entry would look something like this:

`*/5  *    * * *   librenms    /opt/librenms/lnms poller:billing --threads 4 >> /dev/null 2>&1`

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
