### PR TITLE
Fix wireless_rate graph missing $unit_long

### DIFF
--- a/includes/html/graphs/device/wireless_rate.inc.php
+++ b/includes/html/graphs/device/wireless_rate.inc.php
@@ -1,8 +1,7 @@
 <?php
 
 $scale_min = '0';
-
 $class = 'rate';
 $unit = 'bps';
-
+$unit_long = 'Bitrate';
 require 'includes/html/graphs/device/wireless-sensor.inc.php';


### PR DESCRIPTION
Noticed that the wireless rate graph wasn't drawing on my dev server while working on PR#17334. Logging showed an undefined variable, but only while in debug mode. Tested by swapping in and out of debug, before and after applying the fix, to check the graph rendered properly. Added $unit_long to match other wrappers.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
