### PR TITLE
Fix poller modules perf graph error when a module has no override

### DIFF
--- a/includes/html/graphs/device/poller_modules_perf.inc.php
+++ b/includes/html/graphs/device/poller_modules_perf.inc.php
@@ -29,7 +29,7 @@ require 'includes/html/graphs/common.inc.php';
 
 foreach ($modules as $module => $module_status) {
     $rrd_filename = Rrd::name($device->hostname, ['poller-perf', $module]);
-    if ($attribs['poll_' . $module] || ($module_status && ! isset($attribs['poll_' . $module])) ||
+    if ((isset($attribs['poll_' . $module]) && $attribs['poll_' . $module]) || ($module_status && ! isset($attribs['poll_' . $module])) ||
         (LibrenmsConfig::getOsSetting($device->os, 'poller_modules.' . $module) && ! isset($attribs['poll_' . $module]))) {
         if (Rrd::checkRrdExists($rrd_filename)) {
             $ds['ds'] = 'poller';


### PR DESCRIPTION
Like with PR#19489, I noticed another graph wasn't drawing while in debug mode. If a module wasn't in the array, the graph failed to draw. Added a check to see if the module existed in the array first, matching the other two conditions.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
