### PR TITLE
Added QoS data associated with ports

### DIFF
--- a/resources/views/device/tabs/qos.blade.php
+++ b/resources/views/device/tabs/qos.blade.php
@@ -2,6 +2,6 @@
 
 @section('content')
     <x-device.page :device="$device">
-        <x-qos :qosItems="$device->qos->whereNull('port_id')" :show="$data['show']" />
+        <x-qos :qosItems="$device->qos" :show="$data['show']" />
     </x-device.page>
 @endsection


### PR DESCRIPTION
So QoS data associated with a port isn't shown on the device -> qos page, instead you had to go to the specific port -> qos.

I've added all QoS to the Device -> QoS as it seems to make more sense.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
