### PR TITLE
Discover Cisco UCS devices as NX-OS instead of UCOS (Unified Communications)

### DIFF
--- a/resources/definitions/os_detection/nxos.yaml
+++ b/resources/definitions/os_detection/nxos.yaml
@@ -30,7 +30,3 @@ discovery:
         sysDescr:
             - NX-OS(tm)
             - Cisco NX-OS
-        sysDescr_except:
-            - Cisco NX-OS(tm) ucs # exclude UCS, and indentify as "UCOS" OS
-        sysObjectID_except:
-            - .1.3.6.1.4.1.9.12.3.1.3.1062 # exclude UCS, and indentify as "UCOS" OS

--- a/resources/definitions/os_detection/ucos.yaml
+++ b/resources/definitions/os_detection/ucos.yaml
@@ -25,8 +25,6 @@ discovery:
     -
         sysObjectID:
             - .1.3.6.1.4.1.9.1.1348
-            - .1.3.6.1.4.1.9.12.3.1.3.1062
     -
         sysDescr:
             - 'Software:UCOS'
-            - 'Cisco NX-OS(tm) ucs'


### PR DESCRIPTION
Cisco UCS Fabric Interconnect devices are using NX-OS as their operating system, and hence share a lot of common MIBs with them.
Currently, Cisco UCS devices are wrongly being discovered as UCOS (Unified Communications Operating System), which is used for Cisco Unified Communications Manager, not at all for UCS (Unified Computing System). The confusion likely came from the fact that these 2 names and acronyms are close.

This PR instead makes Cisco UCS devices be discovered as regular NX-OS devices, which works quite well. It allows all their network interfaces to be discovered properly, including vEthernet & vFC virtual interfaces.