### PR TITLE
Improve visibility of and/or selector in alert rule builder

### DIFF
--- a/html/css/styles.css
+++ b/html/css/styles.css
@@ -2611,8 +2611,8 @@ label {
 }
 
 .rules-group-header .btn-primary {
-  background-color: #ac2925;
-  border-color: #761c19;
+  background-color: #337ab7;
+  border-color: #1175cc;
 }
 
 .rules-group-header .active {

--- a/html/css/styles.css
+++ b/html/css/styles.css
@@ -2609,3 +2609,11 @@ label {
   right: auto;
   left: 1px;
 }
+
+.rules-group-header .btn-primary {
+  background-color: rgb(178, 32, 32);
+}
+
+.rules-group-header .active {
+  background-color: rgb(0, 128, 0);
+}

--- a/html/css/styles.css
+++ b/html/css/styles.css
@@ -2611,9 +2611,9 @@ label {
 }
 
 .rules-group-header .btn-primary {
-  background-color: rgb(178, 32, 32);
+  background-color: #ac2925;
 }
 
 .rules-group-header .active {
-  background-color: rgb(0, 128, 0);
+  background-color: #5cb85c;
 }

--- a/html/css/styles.css
+++ b/html/css/styles.css
@@ -2612,8 +2612,10 @@ label {
 
 .rules-group-header .btn-primary {
   background-color: #ac2925;
+  border-color: #761c19;
 }
 
 .rules-group-header .active {
   background-color: #5cb85c;
+  border-color: #4cae4c;
 }

--- a/html/css/styles.css
+++ b/html/css/styles.css
@@ -2611,8 +2611,8 @@ label {
 }
 
 .rules-group-header .btn-primary {
-  background-color: #337ab7;
-  border-color: #1175cc;
+  background-color: #424548;
+  border-color: #1f2022;
 }
 
 .rules-group-header .active {

--- a/resources/views/layouts/librenmsv1.blade.php
+++ b/resources/views/layouts/librenmsv1.blade.php
@@ -41,7 +41,7 @@
     <link href="{{ asset('css/select2.min.css') }}" rel="stylesheet">
     <link href="{{ asset('css/select2-bootstrap.min.css') }}" rel="stylesheet">
     <link href="{{ asset('css/query-builder.default.min.css') }}" rel="stylesheet">
-    <link href="{{ asset(LibrenmsConfig::get('stylesheet', 'css/styles.css')) }}?ver=02132026" rel="stylesheet">
+    <link href="{{ asset(LibrenmsConfig::get('stylesheet', 'css/styles.css')) }}?ver=04212026" rel="stylesheet">
     <link href="{{ asset('css/tw_dark.css?ver=19112025') }}" rel="stylesheet">
     @if(!in_array(session('applied_site_style', 'light'), ['light', 'dark']))
     <link href="{{ asset('css/' . session('applied_site_style') . '.css?ver=732417643') }}" rel="stylesheet">


### PR DESCRIPTION
Hard to see if AND or OR is active with old colours. No way to overwrite them when initialising the library so had to do this.

Old

<img width="995" height="274" alt="image" src="https://github.com/user-attachments/assets/83e6e6fb-9536-4213-9107-75517b879e5a" />


New

<img width="1009" height="319" alt="image" src="https://github.com/user-attachments/assets/d95a0106-06ce-4c6c-acfc-baa36d5e6a92" />


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
