### PR TITLE
Add ability to show single graph for Port Group

### DIFF
--- a/includes/html/pages/iftype.inc.php
+++ b/includes/html/pages/iftype.inc.php
@@ -1,8 +1,16 @@
 <table class="table table-condensed table-hover table-striped">
 <?php
 
+use App\Models\PortGroup;
+
 $types_array = explode(',', strip_tags((string) $vars['type']));
-$ports = get_ports_from_type($types_array);
+$port_group = $vars['group'] ? PortGroup::find($vars['group'])
+                                        ->ports()
+                                        ->join('devices', 'ports.device_id', 'devices.device_id')
+                                        ->select('devices.*', 'ports.*')
+                                        ->get()
+                                        ->toArray() : null;
+$ports = $port_group ?? get_ports_from_type($types_array);
 
 $if_list = implode(',', array_map(fn ($port) => $port['port_id'], $ports));
 

--- a/includes/html/pages/ports.inc.php
+++ b/includes/html/pages/ports.inc.php
@@ -61,6 +61,9 @@ foreach ($menu_options as $option => $text) {
     }
     $sep = ' | ';
 }
+if (isset($vars['group']) && $vars['group']) {
+    $displayLists .= ' | <a href="' . url('iftype/group=' . $vars['group']) . '"><i class="fa fa-chart-area fa-fw fa-lg"></i></a>';
+}
 
 $displayLists .= '<div style="float: right;">';
 $displayLists .= '<a href="' . \LibreNMS\Util\Url::generate($vars) . '" title="Update the browser URL to reflect the search criteria.">Update URL</a> | ';


### PR DESCRIPTION
This is what the image looks like to get to the page. Any suggestions on improving that is welcome.

<img width="811" height="73" alt="image" src="https://github.com/user-attachments/assets/3cd092c6-a30a-4d83-9608-06449776b3b4" />

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
