### PR TITLE
Cleanup ifclass

### DIFF
--- a/includes/common.php
+++ b/includes/common.php
@@ -157,15 +157,6 @@ function get_port_by_id($port_id): array|false
     return false;
 }
 
-function ifclass($ifOperStatus, $ifAdminStatus)
-{
-    // fake a port model
-    return \LibreNMS\Util\Url::portLinkDisplayClass((object) [
-        'ifOperStatus' => $ifOperStatus instanceof \LibreNMS\Enum\IfOperStatus ? $ifOperStatus : \LibreNMS\Enum\IfOperStatus::tryFrom($ifOperStatus),
-        'ifAdminStatus' => $ifAdminStatus instanceof \LibreNMS\Enum\IfOperStatus ? $ifAdminStatus : \LibreNMS\Enum\IfOperStatus::tryFrom($ifAdminStatus),
-    ]);
-}
-
 function device_by_id_cache($device_id)
 {
     return DeviceCache::get((int) $device_id)->toArray();

--- a/includes/html/functions.inc.php
+++ b/includes/html/functions.inc.php
@@ -18,6 +18,7 @@ use App\Models\Device;
 use App\Models\Port;
 use Illuminate\Support\Facades\Gate;
 use LibreNMS\Enum\ImageFormat;
+use LibreNMS\Util\Clean;
 use LibreNMS\Util\Number;
 use LibreNMS\Util\Rewrite;
 use LibreNMS\Util\Url;
@@ -230,38 +231,22 @@ function generate_port_link($port, $text = null, $type = null, $overlib = 1, $si
     if (is_null($port)) {
         return (string) $text;
     }
-    $graph_array = [];
+
+    if(is_array($port)) {
+        $port = PortCache::get((int) ($port['port_id'] ?? 0));
+    }
+
 
     if (! $text) {
-        $text = Rewrite::normalizeIfName($port['label'] ?? $port['ifName']);
+        $text = $port->getLabel();
     }
 
-    if ($type) {
-        $port['graph_type'] = $type;
-    }
-
-    if (! isset($port['graph_type'])) {
-        $port['graph_type'] = 'port_bits';
-    }
-
-    // fake a port model in midterm refractor the hole function
-    $class = Url::portLinkDisplayClass((object) [
-        'ifOperStatus' => $port['ifOperStatus'] instanceof \LibreNMS\Enum\IfOperStatus ? $port['ifOperStatus'] : \LibreNMS\Enum\IfOperStatus::tryFrom($port['ifOperStatus']),
-        'ifAdminStatus' => $port['ifAdminStatus'] instanceof \LibreNMS\Enum\IfOperStatus ? $port['ifAdminStatus'] : \LibreNMS\Enum\IfOperStatus::tryFrom($port['ifAdminStatus']),
-    ]);
-    if (! isset($port['hostname'])) {
-        $port = array_merge($port, device_by_id_cache($port['device_id']));
-    }
-
-    if (! isset($port['label'])) {
-        $port = cleanPort($port);
-    }
-
-    $content = '<div class=list-large>' . ($port['hostname'] ?? '') . ' - ' . Rewrite::normalizeIfName(addslashes(\LibreNMS\Util\Clean::html($port['label'], []))) . '</div>';
-    $content .= addslashes(\LibreNMS\Util\Clean::html($port['ifAlias'], [])) . '<br />';
-
+    $content = '<div class=list-large>' . ($port->device?->hostname ?? '') . ' - ' . Rewrite::normalizeIfName(addslashes(\LibreNMS\Util\Clean::html($port->getLabel(), []))) . '</div>';
+    $content .= addslashes(Clean::html($port->ifAlias, [])) . '<br />';
     $content .= "<div style=\'width: 850px\'>";
-    $graph_array['type'] = $port['graph_type'];
+
+    $graph_array = [];
+    $graph_array['type'] = $port->type ?? 'port_bits';
     $graph_array['legend'] = 'yes';
     $graph_array['height'] = '100';
     $graph_array['width'] = '340';
@@ -280,12 +265,12 @@ function generate_port_link($port, $text = null, $type = null, $overlib = 1, $si
 
     $content .= '</div>';
 
-    $url = generate_port_url($port);
+    $url = Url::portUrl($port);
 
     if ($overlib == 0) {
         return $content;
-    } elseif (port_permitted($port['port_id'], $port['device_id'])) {
-        return Url::overlibLink($url, $text, $content, $class);
+    } elseif (port_permitted($port->port_id, $port->device_id)) {
+        return Url::overlibLink($url, $text, $content, Url::portLinkDisplayClass($port));
     } else {
         return Rewrite::normalizeIfName($text);
     }

--- a/includes/html/functions.inc.php
+++ b/includes/html/functions.inc.php
@@ -233,7 +233,7 @@ function generate_port_link($port, $text = null, $type = null, $overlib = 1, $si
     }
 
     if(is_array($port)) {
-        $port = PortCache::get((int) ($port['port_id'] ?? 0));
+        $port = PortCache::get((int) $port['port_id']);
     }
 
 

--- a/includes/html/functions.inc.php
+++ b/includes/html/functions.inc.php
@@ -247,7 +247,7 @@ function generate_port_link($port, $text = null, $type = null, $overlib = 1, $si
         'width' => '340',
         'to' => LibrenmsConfig::get('time.now'),
         'from' => LibrenmsConfig::get('time.day'),
-        'id' => $port->port_id
+        'id' => $port->port_id,
     ];
     $content .= Url::graphTag($graph_array);
     if ($single_graph == 0) {
@@ -266,7 +266,7 @@ function generate_port_link($port, $text = null, $type = null, $overlib = 1, $si
     if ($overlib == 0) {
         return $content;
     } elseif (port_permitted($port->port_id, $port->device_id)) {
-        return Url::overlibLink($url, ($text ?? $port->getLabel()), $content, Url::portLinkDisplayClass($port));
+        return Url::overlibLink($url, $text ?? $port->getLabel(), $content, Url::portLinkDisplayClass($port));
     } else {
         return Rewrite::normalizeIfName($text ?? $port->getLabel());
     }

--- a/includes/html/functions.inc.php
+++ b/includes/html/functions.inc.php
@@ -236,22 +236,19 @@ function generate_port_link($port, $text = null, $type = null, $overlib = 1, $si
         $port = PortCache::get((int) $port['port_id']);
     }
 
-    if (! $text) {
-        $text = $port->getLabel();
-    }
-
     $content = '<div class=list-large>' . ($port->device?->hostname ?? '') . ' - ' . Rewrite::normalizeIfName(addslashes(\LibreNMS\Util\Clean::html($port->getLabel(), []))) . '</div>';
     $content .= addslashes(Clean::html($port->ifAlias, [])) . '<br />';
     $content .= "<div style=\'width: 850px\'>";
 
-    $graph_array = [];
-    $graph_array['type'] = $type ?? $port->type ?? 'port_bits';
-    $graph_array['legend'] = 'yes';
-    $graph_array['height'] = '100';
-    $graph_array['width'] = '340';
-    $graph_array['to'] = LibrenmsConfig::get('time.now');
-    $graph_array['from'] = LibrenmsConfig::get('time.day');
-    $graph_array['id'] = $port->port_id;
+    $graph_array = [
+        'type' => $type ?? 'port_bits',
+        'legend' => 'yes',
+        'height' => '100',
+        'width' => '340',
+        'to' => LibrenmsConfig::get('time.now'),
+        'from' => LibrenmsConfig::get('time.day'),
+        'id' => $port->port_id
+    ];
     $content .= Url::graphTag($graph_array);
     if ($single_graph == 0) {
         $graph_array['from'] = LibrenmsConfig::get('time.week');
@@ -269,9 +266,9 @@ function generate_port_link($port, $text = null, $type = null, $overlib = 1, $si
     if ($overlib == 0) {
         return $content;
     } elseif (port_permitted($port->port_id, $port->device_id)) {
-        return Url::overlibLink($url, $text, $content, Url::portLinkDisplayClass($port));
+        return Url::overlibLink($url, ($text ?? $port->getLabel()), $content, Url::portLinkDisplayClass($port));
     } else {
-        return Rewrite::normalizeIfName($text);
+        return Rewrite::normalizeIfName($text ?? $port->getLabel());
     }
 }//end generate_port_link()
 

--- a/includes/html/functions.inc.php
+++ b/includes/html/functions.inc.php
@@ -232,10 +232,9 @@ function generate_port_link($port, $text = null, $type = null, $overlib = 1, $si
         return (string) $text;
     }
 
-    if(is_array($port)) {
+    if (is_array($port)) {
         $port = PortCache::get((int) $port['port_id']);
     }
-
 
     if (! $text) {
         $text = $port->getLabel();
@@ -246,13 +245,13 @@ function generate_port_link($port, $text = null, $type = null, $overlib = 1, $si
     $content .= "<div style=\'width: 850px\'>";
 
     $graph_array = [];
-    $graph_array['type'] = $port->type ?? 'port_bits';
+    $graph_array['type'] = $type ?? $port->type ?? 'port_bits';
     $graph_array['legend'] = 'yes';
     $graph_array['height'] = '100';
     $graph_array['width'] = '340';
     $graph_array['to'] = LibrenmsConfig::get('time.now');
     $graph_array['from'] = LibrenmsConfig::get('time.day');
-    $graph_array['id'] = $port['port_id'];
+    $graph_array['id'] = $port->port_id;
     $content .= Url::graphTag($graph_array);
     if ($single_graph == 0) {
         $graph_array['from'] = LibrenmsConfig::get('time.week');

--- a/includes/html/functions.inc.php
+++ b/includes/html/functions.inc.php
@@ -244,8 +244,11 @@ function generate_port_link($port, $text = null, $type = null, $overlib = 1, $si
         $port['graph_type'] = 'port_bits';
     }
 
-    $class = ifclass($port['ifOperStatus'], $port['ifAdminStatus']);
-
+    // fake a port model in midterm refractor the hole function
+    $class = Url::portLinkDisplayClass((object) [
+        'ifOperStatus' => $port['ifOperStatus'] instanceof \LibreNMS\Enum\IfOperStatus ? $port['ifOperStatus'] : \LibreNMS\Enum\IfOperStatus::tryFrom($port['ifOperStatus']),
+        'ifAdminStatus' => $port['ifAdminStatus'] instanceof \LibreNMS\Enum\IfOperStatus ? $port['ifAdminStatus'] : \LibreNMS\Enum\IfOperStatus::tryFrom($port['ifAdminStatus']),
+    ]);
     if (! isset($port['hostname'])) {
         $port = array_merge($port, device_by_id_cache($port['device_id']));
     }

--- a/includes/html/pages/iftype.inc.php
+++ b/includes/html/pages/iftype.inc.php
@@ -38,7 +38,6 @@ if ($if_list) {
         unset($class);
         $port['ifAlias'] = str_ireplace($port['type'] . ': ', '', $port['ifAlias']);
         $port['ifAlias'] = str_ireplace('[PNI]', 'Private', $port['ifAlias']);
-        $ifclass = ifclass($port['ifOperStatus'], $port['ifAdminStatus']);
 
         echo "<tr class='iftype'>
             <td><span class=list-large>" . generate_port_link($port, $port['port_descr_descr']) . "</span><br />


### PR DESCRIPTION
Removes:
 - `ifclass()`

Refractor `generate_port_link()` internal using Port::class to get rid of this helper function.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
