### PR TITLE
Fix: GBK-encoded interface names appearing as garbled text in port polling

### DIFF
--- a/LibreNMS/Util/StringHelpers.php
+++ b/LibreNMS/Util/StringHelpers.php
@@ -107,18 +107,18 @@ class StringHelpers
             return (string) $converted;
         }
 
-        foreach (['GB18030', 'GBK', 'GB2312'] as $encoding) {
-            if (($converted = @iconv($encoding, 'UTF-8', $string)) !== false) {
-                return (string) $converted;
-            }
-        }
-
         if ($charset !== 'Windows-1252' && ($converted = @iconv('Windows-1252', 'UTF-8', $string)) !== false) {
             return (string) $converted;
         }
 
         if ($charset !== 'CP850' && ($converted = @iconv('CP850', 'UTF-8', $string)) !== false) {
             return (string) $converted;
+        }
+
+        foreach (['GB18030', 'GBK', 'GB2312'] as $encoding) {
+            if (($converted = @iconv($encoding, 'UTF-8', $string)) !== false) {
+                return (string) $converted;
+            }
         }
 
         \Log::debug('Failed to convert string: ' . $string);

--- a/LibreNMS/Util/StringHelpers.php
+++ b/LibreNMS/Util/StringHelpers.php
@@ -107,6 +107,12 @@ class StringHelpers
             return (string) $converted;
         }
 
+        foreach (['GB18030', 'GBK', 'GB2312'] as $encoding) {
+            if (($converted = @iconv($encoding, 'UTF-8', $string)) !== false) {
+                return (string) $converted;
+            }
+        }
+
         if ($charset !== 'Windows-1252' && ($converted = @iconv('Windows-1252', 'UTF-8', $string)) !== false) {
             return (string) $converted;
         }

--- a/includes/discovery/ports.inc.php
+++ b/includes/discovery/ports.inc.php
@@ -126,6 +126,8 @@ $default_port_group = LibrenmsConfig::get('default_port_group');
 foreach ($port_stats as $ifIndex => $snmp_data) {
     $snmp_data['ifIndex'] = $ifIndex; // Store ifIndex in port entry
     $snmp_data['ifAlias'] = StringHelpers::inferEncoding($snmp_data['ifAlias'] ?? null);
+    $snmp_data['ifName'] = StringHelpers::inferEncoding($snmp_data['ifName'] ?? null);
+    $snmp_data['ifDescr'] = StringHelpers::inferEncoding($snmp_data['ifDescr'] ?? null);
 
     // Get port_id according to port_association_mode used for this device
     $port_id = get_port_id($ports_mapped, $snmp_data, $port_association_mode);

--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -587,6 +587,9 @@ foreach ($ports as $port) {
             $this_port['ifName'] = $matches[1];
         }
 
+        $this_port['ifName'] = StringHelpers::inferEncoding($this_port['ifName'] ?? null);
+        $this_port['ifDescr'] = StringHelpers::inferEncoding($this_port['ifDescr'] ?? null);
+
         $polled_period = max($polled - $port['poll_time'], 1);
 
         $port['update'] = [];

--- a/tests/Unit/Util/StringHelperTest.php
+++ b/tests/Unit/Util/StringHelperTest.php
@@ -45,6 +45,7 @@ final class StringHelperTest extends TestCase
 
         $this->assertEquals('Øverbyvegen', StringHelpers::inferEncoding(base64_decode('w5h2ZXJieXZlZ2Vu')));
         $this->assertEquals('Øverbyvegen', StringHelpers::inferEncoding(base64_decode('2HZlcmJ5dmVnZW4=')));
+        $this->assertEquals('教科网IPv4', StringHelpers::inferEncoding(base64_decode('vcy/xs34SVB2NA==')));
 
         config(['app.charset' => 'Shift_JIS']);
         $this->assertEquals('コンサート', StringHelpers::inferEncoding(base64_decode('g1KDk4NUgVuDZw==')));


### PR DESCRIPTION
Fixes character encoding issues where GBK-encoded interface names would show up as mojibake, such as ½Ì¿ÆÍøIPv4 instead of the correct Chinese characters
<img width="2128" height="616" alt="image" src="https://github.com/user-attachments/assets/f8f86463-3287-48dd-aeab-ebbd510a5217" />
#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [ x ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ x ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ x ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.