### PR TITLE
Prevent blank windows or tabs when opening SSH/Telnet

### DIFF
--- a/app/Http/Controllers/Table/DeviceController.php
+++ b/app/Http/Controllers/Table/DeviceController.php
@@ -306,6 +306,7 @@ class DeviceController extends TableController
             'title' => 'Telnet to ' . $device->hostname,
             'href' => 'telnet://' . $device->hostname,
             'icon' => 'fa-terminal',
+            'external' => false,
         ];
 
         $ssh_href = 'ssh://' . $device->hostname;
@@ -319,6 +320,7 @@ class DeviceController extends TableController
             'title' => 'SSH to ' . $device->hostname,
             'href' => $ssh_href,
             'icon' => 'fa-lock',
+            'external' => false,
         ];
 
         $actions[$row][] = [

--- a/app/View/Components/Device/PageLinks.php
+++ b/app/View/Components/Device/PageLinks.php
@@ -130,7 +130,7 @@ class PageLinks extends Component
             'icon' => 'fa-lock',
             'url' => $ssh_url,
             'title' => __('SSH'),
-            'external' => true,
+            'external' => false,
         ];
 
         // Telnet
@@ -139,7 +139,7 @@ class PageLinks extends Component
             'icon' => 'fa-terminal',
             'url' => 'telnet://' . $device->hostname . $telnet_port,
             'title' => __('Telnet'),
-            'external' => true,
+            'external' => false,
         ];
 
         if (Gate::allows('debug', \App\Models\Device::class)) {


### PR DESCRIPTION
All of the SSH and Telnet links currently render with target="_blank" hardcoded. Some browsers will open a blank tab in addition to passing the ssh:// and telnet:// information through to the helper app. By adding a toggle in Settings > Web UI > Device Settings, users can disable that behavior. In my testing, when no window or tab is opened, the current device or device list page does not change, as there's no HTML to render. The browser simply hands off the URL to the helper app.

The commands can be called by lnms through html.device.ssh_external or html.device.telnet_external. This change will default them to enabled, with a fallback if they somehow get unset.

I did adjust the order of another definition, html.device.primary_link, moving it further down in the UI, since they're all three related.

<img width="1243" height="439" alt="image" src="https://github.com/user-attachments/assets/ba45f3aa-71ce-4e7a-894d-27f08b7587f9" />

<img width="1328" height="468" alt="image" src="https://github.com/user-attachments/assets/c85ee03e-787d-41b1-a001-211220752fa9" />



DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [-] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
