### PR TITLE
Fix for device dependency host to respect global display name template

### DIFF
--- a/app/Http/Controllers/Device/EditDeviceController.php
+++ b/app/Http/Controllers/Device/EditDeviceController.php
@@ -78,7 +78,7 @@ class EditDeviceController
             'static_groups' => $static_groups,
             'types' => $types,
             'default_type' => LibrenmsConfig::getOsSetting($device->os, 'type'),
-            'parents' => $device->parents->mapWithKeys(fn ($parent) => [$parent->device_id => $parent->displayName()]),
+            'parents' => $device->parents()->select(['devices.device_id', 'hostname', 'sysName', 'ip', 'overwrite_ip', 'display'])->get()->mapWithKeys(fn ($parent) => [$parent->device_id => $parent->displayName()]),
             'poller_groups' => PollerGroup::orderBy('group_name')->pluck('group_name', 'id'),
             'default_poller_group' => LibrenmsConfig::get('distributed_poller_group'),
             'override_sysContact_bool' => $device->getAttrib('override_sysContact_bool'),

--- a/app/Http/Controllers/Device/EditDeviceController.php
+++ b/app/Http/Controllers/Device/EditDeviceController.php
@@ -78,7 +78,7 @@ class EditDeviceController
             'static_groups' => $static_groups,
             'types' => $types,
             'default_type' => LibrenmsConfig::getOsSetting($device->os, 'type'),
-            'parents' => $device->parents()->pluck('hostname', 'device_id'),
+            'parents' => $device->parents->mapWithKeys(fn ($parent) => [$parent->device_id => $parent->displayName()]),
             'poller_groups' => PollerGroup::orderBy('group_name')->pluck('group_name', 'id'),
             'default_poller_group' => LibrenmsConfig::get('distributed_poller_group'),
             'override_sysContact_bool' => $device->getAttrib('override_sysContact_bool'),

--- a/resources/views/device/edit/device.blade.php
+++ b/resources/views/device/edit/device.blade.php
@@ -136,8 +136,8 @@
                 <label for="parent_id" class="col-sm-2 control-label">{{ __('device.edit.depends_on') }}</label>
                 <div class="col-sm-6">
                     <select multiple name="parent_id[]" id="parent_id" class="form-control" style="width: 100%">
-                        @foreach ($parents as $parent_id => $parent_hostname)
-                            <option value="{{  $parent_id }}" selected>{{ $parent_hostname }}</option>
+                        @foreach ($parents as $parent_id => $parent_display)
+                            <option value="{{ $parent_id }}" selected>{{ $parent_display }}</option>
                         @endforeach
                     </select>
                 </div>


### PR DESCRIPTION
This change fixes a discrepancy with the way hosts are displayed in a device's dependency field. The current code uses hostname instead of displayName, which doesn't respect the global display name template setting. When an environment uses sysName as part of the display name template, the host or target in a device's dependency input field appears as an IP address only.

<img width="403" height="149" alt="image" src="https://github.com/user-attachments/assets/becda169-3e47-41d1-b918-c191c46ec1c3" />


<img width="437" height="198" alt="image" src="https://github.com/user-attachments/assets/98da2d2c-809b-4d8e-bf08-45d9575ac787" />


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [-] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
