### PR TITLE
Alert operations mute

### DIFF
--- a/LibreNMS/Alert/AlertUtil.php
+++ b/LibreNMS/Alert/AlertUtil.php
@@ -126,7 +126,6 @@ class AlertUtil
             return;
         }
 
-        // Operation-level suppression: treat this as a muted rule (RunAlerts already supports rextra['mute']).
         if ((bool) ($ruleRow->alertOperation?->notifications_suppressed ?? false)) {
             $rextra['mute'] = true;
 

--- a/LibreNMS/Alert/AlertUtil.php
+++ b/LibreNMS/Alert/AlertUtil.php
@@ -126,6 +126,12 @@ class AlertUtil
             return;
         }
 
+        if ((bool) $op->notifications_suppressed) {
+            $rextra['mute'] = true;
+
+            return;
+        }
+
         $rextra['delay'] = $notificationCount === 0 ? (int) $op->start_in_seconds : 0;
         $stepDur = (int) $op->step_duration_seconds;
         $rextra['interval'] = $stepDur > 0 ? $stepDur : $defaultStep;

--- a/LibreNMS/Alert/AlertUtil.php
+++ b/LibreNMS/Alert/AlertUtil.php
@@ -91,7 +91,7 @@ class AlertUtil
         unset($rextra['_stop_notifications']);
 
         $ruleRow = AlertRule::query()
-            ->with('alertOperation:id,default_operation_step_duration_seconds')
+            ->with('alertOperation:id,default_operation_step_duration_seconds,notifications_suppressed')
             ->whereKey($ruleId)
             ->first(['id', 'alert_operation_id']);
         if ($ruleRow === null || $ruleRow->alert_operation_id === null) {
@@ -126,7 +126,8 @@ class AlertUtil
             return;
         }
 
-        if ((bool) $op->notifications_suppressed) {
+        // Operation-level suppression: treat this as a muted rule (RunAlerts already supports rextra['mute']).
+        if ((bool) ($ruleRow->alertOperation?->notifications_suppressed ?? false)) {
             $rextra['mute'] = true;
 
             return;

--- a/LibreNMS/Alert/AlertUtil.php
+++ b/LibreNMS/Alert/AlertUtil.php
@@ -126,7 +126,7 @@ class AlertUtil
             return;
         }
 
-        if ((bool) ($ruleRow->alertOperation?->notifications_suppressed ?? false)) {
+        if ($ruleRow->alertOperation === null || (bool) $ruleRow->alertOperation->notifications_suppressed) {
             $rextra['mute'] = true;
 
             return;

--- a/app/Http/Controllers/AlertOperationController.php
+++ b/app/Http/Controllers/AlertOperationController.php
@@ -42,9 +42,13 @@ class AlertOperationController extends Controller
             'segments.transportGroups:alert_transport_groups.transport_group_id,transport_group_name',
         ]);
 
+        $defaultSuppressed = $alertOperation->segments->contains(static fn ($s) => (bool) $s->notifications_suppressed);
+
         return response()->json([
             'status' => 'ok',
-            'operation' => $alertOperation->toApiArray(),
+            'operation' => array_merge($alertOperation->toApiArray(), [
+                'default_notifications_suppressed' => $defaultSuppressed,
+            ]),
         ]);
     }
 
@@ -115,6 +119,7 @@ class AlertOperationController extends Controller
     private function syncSegments(AlertOperation $op, AlertOperationRequest $request): void
     {
         $rows = $request->validated('segments');
+        $defaultSuppressed = (bool) $request->validated('default_notifications_suppressed', false);
         $op->segments()->delete();
 
         foreach (array_values($rows) as $idx => $row) {
@@ -129,7 +134,7 @@ class AlertOperationController extends Controller
                 'escalation_step_to' => $to,
                 'start_in_seconds' => max(0, (int) ($row['start_in_seconds'] ?? 0)),
                 'step_duration_seconds' => max(0, (int) ($row['step_duration_seconds'] ?? 0)),
-                'notifications_suppressed' => false,
+                'notifications_suppressed' => $defaultSuppressed,
             ]);
 
             $transportsRaw = $row['transports'] ?? [];

--- a/app/Http/Controllers/AlertOperationController.php
+++ b/app/Http/Controllers/AlertOperationController.php
@@ -126,6 +126,7 @@ class AlertOperationController extends Controller
             $from = max(1, (int) ($row['escalation_step_from'] ?? 1));
             $toRaw = $row['escalation_step_to'] ?? null;
             $to = ($toRaw === '' || $toRaw === null) ? null : max($from, (int) $toRaw);
+            $suppressed = array_key_exists('notifications_suppressed', $row) ? (bool) $row['notifications_suppressed'] : $defaultSuppressed;
 
             $seg = $op->segments()->create([
                 'position' => (int) ($row['position'] ?? $idx),
@@ -134,7 +135,7 @@ class AlertOperationController extends Controller
                 'escalation_step_to' => $to,
                 'start_in_seconds' => max(0, (int) ($row['start_in_seconds'] ?? 0)),
                 'step_duration_seconds' => max(0, (int) ($row['step_duration_seconds'] ?? 0)),
-                'notifications_suppressed' => $defaultSuppressed,
+                'notifications_suppressed' => $suppressed,
             ]);
 
             $transportsRaw = $row['transports'] ?? [];

--- a/app/Http/Controllers/AlertOperationController.php
+++ b/app/Http/Controllers/AlertOperationController.php
@@ -42,13 +42,9 @@ class AlertOperationController extends Controller
             'segments.transportGroups:alert_transport_groups.transport_group_id,transport_group_name',
         ]);
 
-        $defaultSuppressed = $alertOperation->segments->contains(static fn ($s) => (bool) $s->notifications_suppressed);
-
         return response()->json([
             'status' => 'ok',
-            'operation' => array_merge($alertOperation->toApiArray(), [
-                'default_notifications_suppressed' => $defaultSuppressed,
-            ]),
+            'operation' => $alertOperation->toApiArray(),
         ]);
     }
 
@@ -61,6 +57,7 @@ class AlertOperationController extends Controller
             $op = new AlertOperation;
             $op->name = $validated['name'];
             $op->default_operation_step_duration_seconds = $validated['default_operation_step_duration_seconds'] ?? null;
+            $op->notifications_suppressed = (bool) ($validated['notifications_suppressed'] ?? false);
             $op->save();
             $this->syncSegments($op, $request);
 
@@ -85,6 +82,7 @@ class AlertOperationController extends Controller
             $validated = $request->validated();
             $alertOperation->name = $validated['name'];
             $alertOperation->default_operation_step_duration_seconds = $validated['default_operation_step_duration_seconds'] ?? null;
+            $alertOperation->notifications_suppressed = (bool) ($validated['notifications_suppressed'] ?? false);
             $alertOperation->save();
             $this->syncSegments($alertOperation, $request);
 
@@ -119,14 +117,12 @@ class AlertOperationController extends Controller
     private function syncSegments(AlertOperation $op, AlertOperationRequest $request): void
     {
         $rows = $request->validated('segments');
-        $defaultSuppressed = (bool) $request->validated('default_notifications_suppressed', false);
         $op->segments()->delete();
 
         foreach (array_values($rows) as $idx => $row) {
             $from = max(1, (int) ($row['escalation_step_from'] ?? 1));
             $toRaw = $row['escalation_step_to'] ?? null;
             $to = ($toRaw === '' || $toRaw === null) ? null : max($from, (int) $toRaw);
-            $suppressed = array_key_exists('notifications_suppressed', $row) ? (bool) $row['notifications_suppressed'] : $defaultSuppressed;
 
             $seg = $op->segments()->create([
                 'position' => (int) ($row['position'] ?? $idx),
@@ -135,7 +131,6 @@ class AlertOperationController extends Controller
                 'escalation_step_to' => $to,
                 'start_in_seconds' => max(0, (int) ($row['start_in_seconds'] ?? 0)),
                 'step_duration_seconds' => max(0, (int) ($row['step_duration_seconds'] ?? 0)),
-                'notifications_suppressed' => $suppressed,
             ]);
 
             $transportsRaw = $row['transports'] ?? [];

--- a/app/Http/Controllers/AlertRuleController.php
+++ b/app/Http/Controllers/AlertRuleController.php
@@ -167,11 +167,12 @@ class AlertRuleController extends Controller
             }
         }
 
-        // extra json (no delay/interval/count/mute — those live on operations)
+        // extra json (rule-level toggles)
         $extra = $request->safe([
             'invert',
             'acknowledgement',
             'recovery',
+            'mute',
         ]);
         $extra['options'] = ['override_query' => $overrideQuery];
         $alertRule->extra = array_merge($alertRule->extra ?? [], $extra);

--- a/app/Http/Controllers/AlertRuleController.php
+++ b/app/Http/Controllers/AlertRuleController.php
@@ -167,7 +167,6 @@ class AlertRuleController extends Controller
             }
         }
 
-        // extra json (rule-level toggles)
         $extra = $request->safe([
             'invert',
             'acknowledgement',

--- a/app/Http/Requests/AlertOperationRequest.php
+++ b/app/Http/Requests/AlertOperationRequest.php
@@ -43,6 +43,7 @@ class AlertOperationRequest extends FormRequest
             'segments.*.escalation_step_to' => ['nullable', 'integer', 'min:1'],
             'segments.*.start_in_seconds' => ['required', 'integer', 'min:0'],
             'segments.*.step_duration_seconds' => ['required', 'integer', 'min:0'],
+            'segments.*.notifications_suppressed' => ['sometimes', 'boolean'],
             'segments.*.transports' => ['required', 'array', 'min:1'],
             'segments.*.transports.*' => ['nullable'],
         ];

--- a/app/Http/Requests/AlertOperationRequest.php
+++ b/app/Http/Requests/AlertOperationRequest.php
@@ -36,14 +36,13 @@ class AlertOperationRequest extends FormRequest
         return [
             'name' => ['required', 'string', 'max:255'],
             'default_operation_step_duration_seconds' => ['nullable', 'integer', 'min:0'],
-            'default_notifications_suppressed' => ['sometimes', 'boolean'],
+            'notifications_suppressed' => ['sometimes', 'boolean'],
             'segments' => ['required', 'array', 'min:1'],
             'segments.*.position' => ['sometimes', 'integer', 'min:0', 'max:65535'],
             'segments.*.escalation_step_from' => ['required', 'integer', 'min:1'],
             'segments.*.escalation_step_to' => ['nullable', 'integer', 'min:1'],
             'segments.*.start_in_seconds' => ['required', 'integer', 'min:0'],
             'segments.*.step_duration_seconds' => ['required', 'integer', 'min:0'],
-            'segments.*.notifications_suppressed' => ['sometimes', 'boolean'],
             'segments.*.transports' => ['required', 'array', 'min:1'],
             'segments.*.transports.*' => ['nullable'],
         ];

--- a/app/Http/Requests/AlertOperationRequest.php
+++ b/app/Http/Requests/AlertOperationRequest.php
@@ -36,6 +36,7 @@ class AlertOperationRequest extends FormRequest
         return [
             'name' => ['required', 'string', 'max:255'],
             'default_operation_step_duration_seconds' => ['nullable', 'integer', 'min:0'],
+            'default_notifications_suppressed' => ['sometimes', 'boolean'],
             'segments' => ['required', 'array', 'min:1'],
             'segments.*.position' => ['sometimes', 'integer', 'min:0', 'max:65535'],
             'segments.*.escalation_step_from' => ['required', 'integer', 'min:1'],

--- a/app/Http/Requests/AlertRuleRequest.php
+++ b/app/Http/Requests/AlertRuleRequest.php
@@ -58,6 +58,7 @@ class AlertRuleRequest extends FormRequest
 
             'invert' => ['sometimes', 'boolean'],
             'recovery' => ['sometimes', 'boolean'],
+            'mute' => ['sometimes', 'boolean'],
             'acknowledgement' => ['sometimes', 'boolean'],
             'invert_map' => ['sometimes', 'boolean'],
 
@@ -82,7 +83,7 @@ class AlertRuleRequest extends FormRequest
         ]);
 
         // Convert checkbox values ('on' string) to boolean
-        $this->merge(collect(['invert', 'recovery', 'acknowledgement', 'invert_map', 'override_query'])
+        $this->merge(collect(['invert', 'recovery', 'mute', 'acknowledgement', 'invert_map', 'override_query'])
             ->mapWithKeys(fn ($field) => [$field => match ($this->input($field)) {
                 'on', '1', 1, true => true,
                 default => false

--- a/app/Models/AlertOperation.php
+++ b/app/Models/AlertOperation.php
@@ -13,6 +13,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  * @property int $id
  * @property string $name
  * @property int|null $default_operation_step_duration_seconds
+ * @property bool $notifications_suppressed
  */
 class AlertOperation extends BaseModel
 {
@@ -21,10 +22,12 @@ class AlertOperation extends BaseModel
     protected $fillable = [
         'name',
         'default_operation_step_duration_seconds',
+        'notifications_suppressed',
     ];
 
     protected $casts = [
         'default_operation_step_duration_seconds' => 'integer',
+        'notifications_suppressed' => 'boolean',
     ];
 
     /**
@@ -59,6 +62,7 @@ class AlertOperation extends BaseModel
             'id' => $this->id,
             'name' => $this->name,
             'default_operation_step_duration_seconds' => $this->default_operation_step_duration_seconds,
+            'notifications_suppressed' => (bool) $this->notifications_suppressed,
             'segments' => $this->segments->map(static fn (AlertOperationSegment $s) => $s->toApiArray())->values()->all(),
         ];
     }

--- a/app/Models/AlertOperationSegment.php
+++ b/app/Models/AlertOperationSegment.php
@@ -16,7 +16,6 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
  * @property int|null $escalation_step_to
  * @property int $start_in_seconds
  * @property int $step_duration_seconds
- * @property bool $notifications_suppressed
  */
 class AlertOperationSegment extends BaseModel
 {
@@ -32,12 +31,9 @@ class AlertOperationSegment extends BaseModel
         'escalation_step_to',
         'start_in_seconds',
         'step_duration_seconds',
-        'notifications_suppressed',
     ];
 
-    protected $casts = [
-        'notifications_suppressed' => 'boolean',
-    ];
+    protected $casts = [];
 
     /**
      * @return BelongsTo<AlertOperation, $this>
@@ -99,7 +95,6 @@ class AlertOperationSegment extends BaseModel
             'escalation_step_to' => $this->escalation_step_to,
             'start_in_seconds' => $this->start_in_seconds,
             'step_duration_seconds' => $this->step_duration_seconds,
-            'notifications_suppressed' => (bool) $this->notifications_suppressed,
             'transports' => $transports,
         ];
     }

--- a/app/Models/AlertOperationSegment.php
+++ b/app/Models/AlertOperationSegment.php
@@ -99,6 +99,7 @@ class AlertOperationSegment extends BaseModel
             'escalation_step_to' => $this->escalation_step_to,
             'start_in_seconds' => $this->start_in_seconds,
             'step_duration_seconds' => $this->step_duration_seconds,
+            'notifications_suppressed' => (bool) $this->notifications_suppressed,
             'transports' => $transports,
         ];
     }

--- a/database/migrations/2026_04_25_000000_move_operation_mute_to_operations_table.php
+++ b/database/migrations/2026_04_25_000000_move_operation_mute_to_operations_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('alert_operations', function (Blueprint $table): void {
+            $table->boolean('notifications_suppressed')->default(false)->after('default_operation_step_duration_seconds');
+        });
+
+        Schema::table('alert_operation_segments', function (Blueprint $table): void {
+            $table->dropColumn('notifications_suppressed');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('alert_operation_segments', function (Blueprint $table): void {
+            $table->boolean('notifications_suppressed')->default(false);
+        });
+
+        Schema::table('alert_operations', function (Blueprint $table): void {
+            $table->dropColumn('notifications_suppressed');
+        });
+    }
+};
+

--- a/database/migrations/2026_04_25_154814_move_operation_mute_to_operations_table.php
+++ b/database/migrations/2026_04_25_154814_move_operation_mute_to_operations_table.php
@@ -28,4 +28,3 @@ return new class extends Migration
         });
     }
 };
-

--- a/database/migrations/2026_04_25_154814_move_operation_mute_to_operations_table.php
+++ b/database/migrations/2026_04_25_154814_move_operation_mute_to_operations_table.php
@@ -2,7 +2,6 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration

--- a/doc/Alerting/Rules.md
+++ b/doc/Alerting/Rules.md
@@ -51,17 +51,19 @@ Here are some of the other options available when adding an alerting rule:
 
 - Rule name: The name associated with the rule.
 - Severity: How "important" the rule is.
-- Max alerts: The maximum number of alerts sent for the event.  `-1` means unlimited.
-- Delay: The amount of time in seconds to wait after a rule is matched
-  before sending an alert out transport.
-- Interval: The interval of time in seconds between alerts for an
-  event until Max alert is reached.
-- Mute alerts: Disables sending alert rule through alert
-  transport. But will still show the alert in the Web UI.
 - Invert match: Invert the matching rule (ie. alert on items that
   _don't match the rule).
+- Mute alerts: Disables sending alert rule through alert
+  transport. But will still show the alert in the Web UI.
 - Recovery alerts: This will disable the recovery notification from
   being sent if turned off.
+- Acknowledgement alerts: This will disable the acknowledgement notifications
+  from being sent if turned off.
+- Operations: Select the alert operation you want to associate to this alert rule.
+- Match devices, groups and location list: Associate this alert rule to only these devices.
+- All devices except in list: Invert the association to a device based on the Match selection.
+- Procedure URL: [Rules.md#Procedure](See Procedure).
+- Notes: Add any notes about this rule, this informtion will also be passed to the alert notifications.
 
 ## Advanced
 

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -1684,6 +1684,7 @@ function api_assign_rule_alert_operation_from_legacy_api(int $ruleId, array $ope
         $to = ($toRaw === '' || $toRaw === null) ? null : max($from, (int) $toRaw);
         $startIn = max(0, (int) ($operation['start_in_seconds'] ?? 0));
         $stepDuration = max(0, (int) ($operation['step_duration_seconds'] ?? 0));
+        $suppressed = filter_var($operation['notifications_suppressed'] ?? false, FILTER_VALIDATE_BOOLEAN);
 
         $seg = $op->segments()->create([
             'position' => (int) ($operation['position'] ?? $idx),
@@ -1692,7 +1693,7 @@ function api_assign_rule_alert_operation_from_legacy_api(int $ruleId, array $ope
             'escalation_step_to' => $to,
             'start_in_seconds' => $startIn,
             'step_duration_seconds' => $stepDuration,
-            'notifications_suppressed' => false,
+            'notifications_suppressed' => $suppressed,
         ]);
 
         [$single, $group] = api_parse_transport_targets((array) ($operation['transports'] ?? []));

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -1651,7 +1651,7 @@ function api_default_transport_targets(): array
  *
  * @param  array<int, array<string, mixed>>  $operations
  */
-function api_assign_rule_alert_operation_from_legacy_api(int $ruleId, array $operations, string $ruleName, ?int $defaultStepSeconds = null): void
+function api_assign_rule_alert_operation_from_legacy_api(int $ruleId, array $operations, string $ruleName, ?int $defaultStepSeconds = null, bool $notificationsSuppressed = false): void
 {
     $rule = \App\Models\AlertRule::find($ruleId);
     if (! $rule) {
@@ -1670,6 +1670,7 @@ function api_assign_rule_alert_operation_from_legacy_api(int $ruleId, array $ope
     $op = \App\Models\AlertOperation::create([
         'name' => $name,
         'default_operation_step_duration_seconds' => $defaultStepSeconds !== null ? max(0, $defaultStepSeconds) : null,
+        'notifications_suppressed' => $notificationsSuppressed,
     ]);
 
     $anyTransports = false;
@@ -1684,8 +1685,6 @@ function api_assign_rule_alert_operation_from_legacy_api(int $ruleId, array $ope
         $to = ($toRaw === '' || $toRaw === null) ? null : max($from, (int) $toRaw);
         $startIn = max(0, (int) ($operation['start_in_seconds'] ?? 0));
         $stepDuration = max(0, (int) ($operation['step_duration_seconds'] ?? 0));
-        $suppressed = filter_var($operation['notifications_suppressed'] ?? false, FILTER_VALIDATE_BOOLEAN);
-
         $seg = $op->segments()->create([
             'position' => (int) ($operation['position'] ?? $idx),
             'operation_phase' => $phase,
@@ -1693,7 +1692,6 @@ function api_assign_rule_alert_operation_from_legacy_api(int $ruleId, array $ope
             'escalation_step_to' => $to,
             'start_in_seconds' => $startIn,
             'step_duration_seconds' => $stepDuration,
-            'notifications_suppressed' => $suppressed,
         ]);
 
         [$single, $group] = api_parse_transport_targets((array) ($operation['transports'] ?? []));
@@ -1818,6 +1816,10 @@ function add_edit_rule(Illuminate\Http\Request $request)
 
     // New operation-based API fields
     $operations = $data['operations'] ?? null;
+    $operationNotificationsSuppressed = filter_var(
+        $data['operation_notifications_suppressed'] ?? false,
+        FILTER_VALIDATE_BOOLEAN
+    );
     $defaultOperationStepDuration = array_key_exists('default_operation_step_duration', $data)
         ? Time::durationToSeconds((string) $data['default_operation_step_duration'])
         : null;
@@ -1909,7 +1911,7 @@ function add_edit_rule(Illuminate\Http\Request $request)
 
     if (! array_key_exists('alert_operation_id', $data) && is_array($operations)) {
         try {
-            api_assign_rule_alert_operation_from_legacy_api((int) $rule_id, $operations, $name, $defaultOperationStepDuration);
+            api_assign_rule_alert_operation_from_legacy_api((int) $rule_id, $operations, $name, $defaultOperationStepDuration, $operationNotificationsSuppressed);
         } catch (\InvalidArgumentException $e) {
             return api_error(400, $e->getMessage());
         } catch (\Throwable) {

--- a/includes/html/modal/new_alert_rule.inc.php
+++ b/includes/html/modal/new_alert_rule.inc.php
@@ -89,6 +89,10 @@ $default_invert_map = LibrenmsConfig::get('alert_rule.invert_map');
                                     <div class='col-sm-2' title="Alert when this rule doesn't match.">
                                         <input type='checkbox' name='invert' id='invert'>
                                     </div>
+                                    <label for='mute' class='col-sm-3 col-md-3 control-label' title="Suppress all notifications for this rule (alerts still appear in the Web UI)." style="vertical-align: top;">Mute alerts </label>
+                                    <div class='col-sm-2' title="Suppress all notifications for this rule (alerts still appear in the Web UI).">
+                                        <input type='checkbox' name='mute' id='mute'>
+                                    </div>
                                 </div>
                                 <div class="form-group form-inline">
                                     <label for='recovery' class='col-sm-3 col-md-2 control-label' title="Issue recovery alerts.">Recovery alerts </label>
@@ -326,6 +330,7 @@ $default_invert_map = LibrenmsConfig::get('alert_rule.invert_map');
                 $severity.val($severity.find("option[selected]").val());
                 $("#invert").bootstrapSwitch('state', <?=$default_invert_rule_match?>);
                 $("#recovery").bootstrapSwitch('state', <?=$default_recovery_alerts?>);
+                $("#mute").bootstrapSwitch('state', false);
                 $("#acknowledgement").bootstrapSwitch('state', <?=$default_acknowledgement_alerts?>);
                 $("#override_query").bootstrapSwitch('state', false);
                 $("#invert_map").bootstrapSwitch('state', <?=$default_invert_map?>);
@@ -392,6 +397,7 @@ $default_invert_map = LibrenmsConfig::get('alert_rule.invert_map');
                     extra.options.override_query = false;
                 }
                 $("[name='recovery']").bootstrapSwitch('state', extra.recovery);
+                $("[name='mute']").bootstrapSwitch('state', !!extra.mute);
                 $("[name='acknowledgement']").bootstrapSwitch('state', extra.acknowledgement);
 
                 if (rule.invert_map == 1) {

--- a/includes/html/print-alert-rules.php
+++ b/includes/html/print-alert-rules.php
@@ -158,6 +158,12 @@ $full_query .= ' ORDER BY name ASC';
 $rule_list = dbFetchRows($full_query, $param);
 $opIdsAll = array_unique(array_filter(array_map(intval(...), array_column($rule_list, 'alert_operation_id'))));
 $opDefaults = $opIdsAll === [] ? [] : \App\Models\AlertOperation::query()->whereIn('id', $opIdsAll)->pluck('default_operation_step_duration_seconds', 'id')->all();
+$opMuted = $opIdsAll === [] ? [] : \App\Models\AlertOperation::query()
+    ->whereIn('id', $opIdsAll)
+    ->where('notifications_suppressed', true)
+    ->pluck('id')
+    ->flip()
+    ->all();
 $count = count($rule_list);
 
 if (isset($_POST['page_number']) && $_POST['page_number'] > 0 && $_POST['page_number'] <= $count) {
@@ -428,8 +434,12 @@ foreach ($rule_list as $rule) {
     $status_popover = 'top';
 
     echo "<td><a href=" . url('alerts/rule_id='.$rule['id']) ."><span data-toggle='popover' data-placement='$status_popover' data-content='$status_msg' id='alert-rule-" . $rule['id'] . "' class='fa fa-fw fa-2x fa-" . $ico . ' text-' . $col . "'></span></a>";
-    if (isset($rule_extra['mute']) && $rule_extra['mute'] === true) {
+    $ruleMuted = isset($rule_extra['mute']) && $rule_extra['mute'] === true;
+    if ($ruleMuted) {
         echo "<div data-toggle='popover' data-content='Alerts for " . htmlentities($rule['name'] ?? '') . " are muted' class='fa fa-fw fa-2x fa-volume-off text-primary' aria-hidden='true'></div>";
+    }
+    if (! $ruleMuted && ! empty($rule['alert_operation_id']) && isset($opMuted[(int) $rule['alert_operation_id']])) {
+        echo "<div data-toggle='popover' data-content='Operation notifications are suppressed for " . htmlentities($rule['name'] ?? '') . "' class='fa fa-fw fa-2x fa-volume-off text-info' aria-hidden='true'></div>";
     }
     if (isset($sub['state']) && $sub['state'] == AlertState::ACKNOWLEDGED) {
         echo "<div data-toggle='popover' data-content='Some Alerts for " . htmlentities($rule['name'] ?? '') . " are acknowledged' class='fa fa-fw fa-2x fa-sticky-note text-info' aria-hidden='true'></div>";

--- a/resources/definitions/schema/db_schema.yaml
+++ b/resources/definitions/schema/db_schema.yaml
@@ -77,6 +77,7 @@ alert_operations:
     - { Field: id, Type: 'int unsigned', 'Null': false, Extra: auto_increment }
     - { Field: name, Type: varchar(255), 'Null': false, Extra: '' }
     - { Field: default_operation_step_duration_seconds, Type: 'int unsigned', 'Null': true, Extra: '' }
+    - { Field: notifications_suppressed, Type: tinyint, 'Null': false, Extra: '', Default: '0' }
   Indexes:
     PRIMARY: { Name: PRIMARY, Columns: [id], Unique: true, Type: BTREE }
 alert_operation_segments:
@@ -89,7 +90,6 @@ alert_operation_segments:
     - { Field: escalation_step_to, Type: 'int unsigned', 'Null': true, Extra: '' }
     - { Field: start_in_seconds, Type: 'int unsigned', 'Null': false, Extra: '', Default: '0' }
     - { Field: step_duration_seconds, Type: 'int unsigned', 'Null': false, Extra: '', Default: '0' }
-    - { Field: notifications_suppressed, Type: tinyint, 'Null': false, Extra: '', Default: '0' }
   Indexes:
     PRIMARY: { Name: PRIMARY, Columns: [id], Unique: true, Type: BTREE }
     alert_operation_segments_alert_operation_id_index: { Name: alert_operation_segments_alert_operation_id_index, Columns: [alert_operation_id], Unique: false, Type: BTREE }

--- a/resources/views/alert/operations/index.blade.php
+++ b/resources/views/alert/operations/index.blade.php
@@ -22,6 +22,7 @@
                 <tr>
                     <th>{{ __('Name') }}</th>
                     <th>{{ __('Default step (s)') }}</th>
+                    <th>{{ __('Muted') }}</th>
                     <th>{{ __('Segments') }}</th>
                     <th>{{ __('Transports') }}</th>
                     <th>{{ __('Used by rules') }}</th>
@@ -64,6 +65,13 @@
                     <tr id="alert-operation-{{ (int) $op->id }}">
                         <td>{{ $op->name }}</td>
                         <td><small>{{ $op->default_operation_step_duration_seconds !== null ? (int) $op->default_operation_step_duration_seconds : '—' }}</small></td>
+                        <td>
+                            @if($op->notifications_suppressed)
+                                <span class="text-info" title="{{ __('Notifications suppressed') }}"><i class="fa fa-volume-off"></i></span>
+                            @else
+                                <span class="text-muted">—</span>
+                            @endif
+                        </td>
                         <td><small>{!! $segStr !!}</small></td>
                         <td class="col-sm-3"><small>{!! $tpStr !!}</small></td>
                         <td>{{ (int) $op->alert_rules_count }}</td>

--- a/resources/views/alert/operations/modal.blade.php
+++ b/resources/views/alert/operations/modal.blade.php
@@ -19,7 +19,17 @@
                     <div class="form-group">
                         <label class="col-sm-3 control-label" title="{{ __('Used when a segment step duration is 0 (repeat interval). Leave empty to use the global default from settings.') }}">{{ __('Default step duration') }}</label>
                         <div class="col-sm-9">
-                            <input type="number" class="form-control" name="default_operation_step_duration_seconds" id="ao_default_step_duration" min="0" step="1" placeholder="">
+                            <div class="row">
+                                <div class="col-sm-6">
+                                    <input type="number" class="form-control" name="default_operation_step_duration_seconds" id="ao_default_step_duration" min="0" step="1" placeholder="">
+                                </div>
+                                <div class="col-sm-6 text-right" style="padding-top:6px;">
+                                    <label style="font-weight:600; margin:0;">
+                                        {{ __('Suppress notifications') }}
+                                    </label>
+                                    <input type="checkbox" id="ao_default_notifications_suppressed" value="1" data-size="small">
+                                </div>
+                            </div>
                             <p class="help-block">{{ __('Seconds. When a segment’s step duration is 0, this value is the repeat interval. Leave empty to use the global default from settings.') }}</p>
                         </div>
                     </div>

--- a/resources/views/alert/operations/modal.blade.php
+++ b/resources/views/alert/operations/modal.blade.php
@@ -30,7 +30,6 @@
                                     <input type="checkbox" id="ao_default_notifications_suppressed" value="1" data-size="small">
                                 </div>
                             </div>
-                            <p class="help-block">{{ __('Seconds. When a segment’s step duration is 0, this value is the repeat interval. Leave empty to use the global default from settings.') }}</p>
                         </div>
                     </div>
                     <div class="form-group">

--- a/resources/views/alert/operations/scripts.blade.php
+++ b/resources/views/alert/operations/scripts.blade.php
@@ -83,9 +83,9 @@ $(function () {
                 $('#ao_default_step_duration').val(
                     o.default_operation_step_duration_seconds != null ? o.default_operation_step_duration_seconds : ''
                 );
-                if (typeof o.default_notifications_suppressed !== 'undefined') {
+                if (typeof o.notifications_suppressed !== 'undefined') {
                     initAoSuppressSwitch();
-                    $aoSuppress.bootstrapSwitch('state', !!o.default_notifications_suppressed);
+                    $aoSuppress.bootstrapSwitch('state', !!o.notifications_suppressed);
                 }
                 if (o.segments && o.segments.length) {
                     $.each(o.segments, function (i, s) {
@@ -136,7 +136,7 @@ $(function () {
         var body = {
             name: $('#ao_name').val(),
             default_operation_step_duration_seconds: (dsRaw === '' || dsRaw === null) ? null : parseInt(dsRaw, 10),
-            default_notifications_suppressed: ($aoSuppress.bootstrapSwitch('state') ? 1 : 0),
+            notifications_suppressed: ($aoSuppress.bootstrapSwitch('state') ? 1 : 0),
             segments: segments,
             _token: '{{ csrf_token() }}'
         };

--- a/resources/views/alert/operations/scripts.blade.php
+++ b/resources/views/alert/operations/scripts.blade.php
@@ -1,5 +1,19 @@
 <script>
 $(function () {
+    var defaultSuppress = @json((bool) \App\Facades\LibrenmsConfig::get('alert_rule.default_operation_notifications_suppressed', false));
+    var $aoSuppress = $('#ao_default_notifications_suppressed');
+
+    function initAoSuppressSwitch() {
+        if (! $aoSuppress.length) {
+            return;
+        }
+        if ($aoSuppress.data('bootstrap-switch-initialized')) {
+            return;
+        }
+        $aoSuppress.bootstrapSwitch();
+        $aoSuppress.data('bootstrap-switch-initialized', true);
+    }
+
     function initAoSegmentTransports($sel) {
         $sel.select2({
             width: '100%',
@@ -57,6 +71,8 @@ $(function () {
         $('#alert-operation-form-error').hide().text('');
         $('#ao_operation_id').val(opId || '');
         $('#ao-segments-table tbody.ao-segment-group').remove();
+        initAoSuppressSwitch();
+        $aoSuppress.bootstrapSwitch('state', !!defaultSuppress);
         if (opId) {
             $.get('{{ url('alert-operation') }}/' + opId, function (res) {
                 if (res.status !== 'ok' || !res.operation) {
@@ -67,6 +83,10 @@ $(function () {
                 $('#ao_default_step_duration').val(
                     o.default_operation_step_duration_seconds != null ? o.default_operation_step_duration_seconds : ''
                 );
+                if (typeof o.default_notifications_suppressed !== 'undefined') {
+                    initAoSuppressSwitch();
+                    $aoSuppress.bootstrapSwitch('state', !!o.default_notifications_suppressed);
+                }
                 if (o.segments && o.segments.length) {
                     $.each(o.segments, function (i, s) {
                         addAoSegmentRow(s);
@@ -116,6 +136,7 @@ $(function () {
         var body = {
             name: $('#ao_name').val(),
             default_operation_step_duration_seconds: (dsRaw === '' || dsRaw === null) ? null : parseInt(dsRaw, 10),
+            default_notifications_suppressed: ($aoSuppress.bootstrapSwitch('state') ? 1 : 0),
             segments: segments,
             _token: '{{ csrf_token() }}'
         };


### PR DESCRIPTION
This adds the mute option back to alert rules and also adds in a mute option to the alert operations.

Updated the UI to visually show when rules are set be muted and if it's a rule or operation setting.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
