### PR TITLE
Breaking: Change default APP_TRUSTED_PROXIES to 127.0.0.1

### DIFF
--- a/config/trustedproxy.php
+++ b/config/trustedproxy.php
@@ -25,7 +25,7 @@ return [
      * of your proxy (e.g. if using ELB or similar).
      *
      */
-    'proxies' => LibreNMS\Util\EnvHelper::parseArray('APP_TRUSTED_PROXIES', '*', ['', '*', '**']),
+    'proxies' => LibreNMS\Util\EnvHelper::parseArray('APP_TRUSTED_PROXIES', '127.0.0.1', ['', '*', '**']),
 
     /*
      * To trust one or more specific proxies that connect

--- a/doc/Support/Environment-Variables.md
+++ b/doc/Support/Environment-Variables.md
@@ -20,7 +20,10 @@ DB_SOCKET=
 
 A comma separated list of trusted reverse proxy IPs or CIDR.
 
-For legacy reasons the default is `'*'`, which means any proxy is allowed.
+The default value is '127.0.0.1', which only allows reverse proxies on the localhost.
+
+These options should be avoided for security reasons.
+`'*'` means trust any proxie
 `'**'` means trust any proxy up the chain.
 
 ```dotenv

--- a/misc/notifications.rss
+++ b/misc/notifications.rss
@@ -32,10 +32,5 @@
     <description>As part of the continued effort to improve LibreNMS, it's code base and associated files, we will be migrating the yaml files used for OS detection and support. Please see https://community.librenms.org/t/os-definitions-and-discovery-file-relocation/27646 for further information.</description>
     <pubDate>Wed, 16 Apr 2025 22:00:00 +0000</pubDate>
   </item>
-  <item>
-    <title>Trusted Proxies default change</title>
-    <description>In order to improve the default security of LibreNMS. The default trusted proxies (APP_TRUSTED_PROXIES) will be changed to 127.0.0.1 from * on the 6th of May, 2026 and the 26.5 release.  If you use reverse proxeis, update your APP_TRUSTED_PROXIES setting to include your reverse proxy IPs to avoid any issues with the change is applied.</description>
-    <pubDate>Sun, 26 Apr 2026 22:00:00 +0000</pubDate>
-  </item>
 </channel>
 </rss>

--- a/misc/notifications.rss
+++ b/misc/notifications.rss
@@ -32,5 +32,10 @@
     <description>As part of the continued effort to improve LibreNMS, it's code base and associated files, we will be migrating the yaml files used for OS detection and support. Please see https://community.librenms.org/t/os-definitions-and-discovery-file-relocation/27646 for further information.</description>
     <pubDate>Wed, 16 Apr 2025 22:00:00 +0000</pubDate>
   </item>
+  <item>
+    <title>Trusted Proxies default change</title>
+    <description>In order to improve the default security of LibreNMS. The default trusted proxies (APP_TRUSTED_PROXIES) will be changed to 127.0.0.1 from * on the 6th of May, 2026 and the 26.5 release.  If you use reverse proxeis, update your APP_TRUSTED_PROXIES setting to include your reverse proxy IPs to avoid any issues with the change is applied.</description>
+    <pubDate>Sun, 26 Apr 2026 22:00:00 +0000</pubDate>
+  </item>
 </channel>
 </rss>


### PR DESCRIPTION
This will affect users using reverse proxies on other hosts unless they are already setting APP_TRUSTED_PROXIES (as recommended by the documentation)

Please update your APP_TRUSTED_PROXIES setting if you are using a reverse proxy before May 5th, 2026 for the daily release and the 26.5 monthly release to avoid interruptions.



#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
