### PR TITLE
Improved stack port descriptions

### DIFF
--- a/includes/discovery/sensors/state/cisco.inc.php
+++ b/includes/discovery/sensors/state/cisco.inc.php
@@ -42,6 +42,19 @@ $swrolenumber = 0;
 $swstatenumber = 0;
 $repsegmentnumber = 0;
 
+$stack_ports = SnmpQuery::walk('CISCO-STACKWISE-MIB::cswStackPortOperStatus')->valuesByIndex();
+	$stack_port_indexes = array_keys($stack_ports);
+		sort($stack_port_indexes);
+	$stack_map = [];
+	foreach ($stack_port_indexes as $i => $idx) {
+		$switch_num = intval($i / 2) + 1;
+		$port_num = ($i % 2) + 1;
+		$stack_map[$idx] = [
+			'switch' => $switch_num,
+			'port' => $port_num,
+		];
+	}
+
 foreach ($tables as $tablevalue) {
     //Some switches on 15.x expose this information regardless if they are stacked or not, we try to mitigate that by doing the following.
     if (in_array($tablevalue['oid'], ['CISCO-STACKWISE-MIB::cswGlobals', 'CISCO-STACKWISE-MIB::cswSwitchRole', 'CISCO-STACKWISE-MIB::cswSwitchState', 'CISCO-STACKWISE-MIB::cswStackPortOperStatus']) && $redundant_data == 'false' && count($role_data) <= 1) {
@@ -217,8 +230,9 @@ foreach ($tables as $tablevalue) {
                     $swstatenumber++;
                     $descr = $tablevalue['descr'] . $swstatenumber;
                 } elseif ($state_name == 'cswStackPortOperStatus') {
-                    $port = PortCache::getByIfIndex($index, $device['device_id']);
-                    $descr = $tablevalue['descr'] . $port?->ifDescr;
+                    $switch_num = $stack_map[$index]['switch'] ?? '?';
+                    $port_num   = $stack_map[$index]['port'] ?? '?';
+                    $descr = 'Stack Port - Switch #' . $switch_num . ' Port ' . $port_num;
                 } elseif ($state_name == 'cefcFRUPowerOperStatus') {
                     $descr = SnmpQuery::get('ENTITY-MIB::entPhysicalName.' . $index)->value();
                 } elseif ($state_name == 'c3gModemStatus' || $state_name == 'c3gGsmCurrentBand' || $state_name == 'c3gGsmPacketService' || $state_name == 'c3gGsmCurrentRoamingStatus' || $state_name == 'c3gGsmSimStatus') {


### PR DESCRIPTION
Improved stack port descriptions
from the constant
"Stack Port Status - "
to
"Stack Port - Switch #{switch number} Port {port number}"

Tested on Cisco 3850, 9200, and 9300 in stacks of 2 to a maximum of 8 switches.

Before view
<img width="1061" height="290" alt="image" src="https://github.com/user-attachments/assets/bf607709-c741-4d7d-9d3e-f02a35799b54" />

After view
<img width="1056" height="293" alt="image" src="https://github.com/user-attachments/assets/26fffa71-4228-4957-aa36-a56a44e7cc28" />

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
