### PR TITLE
Stop creating rrd directories when using network rrdcached 1.5.5 and above

### DIFF
--- a/app/Jobs/PollDevice.php
+++ b/app/Jobs/PollDevice.php
@@ -185,7 +185,9 @@ EOH, $this->device->hostname, $os_group ? " ($os_group)" : '', $this->device->de
     private function initRrdDirectory(): void
     {
         $host_rrd = \Rrd::name($this->device->hostname, '', '');
-        if (LibrenmsConfig::get('rrd.enable', true) && ! is_dir($host_rrd)) {
+        if (LibrenmsConfig::get('rrd.enable', true) &&
+            ! is_dir($host_rrd) &&
+            (version_compare(LibrenmsConfig::get('rrdtool_version','1.4'), '1.5.5', '<') || str_contains(LibrenmsConfig::get('rrdcached', false), 'unix:'))) {
             try {
                 mkdir($host_rrd);
                 Log::info("Created directory : $host_rrd");


### PR DESCRIPTION
It's late so this could be crazy.

However I've noticed on a distributed poller, when rrdcached becomes unavailable for whatever reason, the rrd files are created locally which can consume a large amount of disk space that may not be allocated as they are just pollers.

This was a quick stab at trying to stop that by:

If rrd.enable is true
if the directory doesn't exist already
if the rrdtool version is less than one that supports remote file creation (1.5.5) OR if the rrdcached config contains unix: meaning it's a local socket rather than network.

If those all match then we will create the directory as normal, otherwise we leave rrdcached to create it.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
