### PR TITLE
Fix: mistyped variable name breaking custom OID

### DIFF
--- a/includes/html/forms/customoid.inc.php
+++ b/includes/html/forms/customoid.inc.php
@@ -15,7 +15,7 @@ $status = 'error';
 $message = '';
 
 $device_id = $_POST['device_id'];
-$id = $_POST['ccustomoid_id'];
+$id = $_POST['customoid_id'];
 $action = $_POST['action'];
 $name = strip_tags((string) $_POST['name']);
 $oid = strip_tags((string) $_POST['oid']);


### PR DESCRIPTION
…e custom OID facility.

Attempting to add a customer OID to a device was failing. Log file librenms.log was showing an error referring to "multiple OIDs" when I had submitted only one. Troubleshooting led me to the file ~/includes/html/forms/customoid.inc.php where, on line 18, the variable **ccustomoid_id** was found. This variable appeared nowhere else that I could find, so I change my local file so this variable became **customoid_id** and this fixed the custom OID failures. See https://community.librenms.org/t/possible-bug-custom-oid/27285

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
