### PR TITLE
Move Builder docblock to type hints and resolve PHPStan type errors

### DIFF
--- a/app/Models/Alert.php
+++ b/app/Models/Alert.php
@@ -48,11 +48,17 @@ class Alert extends Model
 
     // ---- Query scopes ----
 
+    /**
+     * Scope a query to only include active alerts.
+     */
     public function scopeActive(Builder $query): Builder
     {
         return $query->where('state', AlertState::ACTIVE);
     }
 
+    /**
+     * Scope a query to only include acknowledged alerts.
+     */
     public function scopeAcknowledged(Builder $query): Builder
     {
         return $query->where('state', AlertState::ACKNOWLEDGED);

--- a/app/Models/Alert.php
+++ b/app/Models/Alert.php
@@ -48,31 +48,19 @@ class Alert extends Model
 
     // ---- Query scopes ----
 
-    /**
-     * Only select active alerts
-     *
-     * @param  Builder  $query
-     * @return Builder
-     */
-    public function scopeActive($query)
+    public function scopeActive(Builder $query): Builder
     {
-        return $query->where('state', '=', AlertState::ACTIVE);
+        return $query->where('state', AlertState::ACTIVE);
     }
 
-    /**
-     * Only select active alerts
-     *
-     * @param  Builder  $query
-     * @return Builder
-     */
-    public function scopeAcknowledged($query)
+    public function scopeAcknowledged(Builder $query): Builder
     {
-        return $query->where('state', '=', AlertState::ACKNOWLEDGED);
+        return $query->where('state', AlertState::ACKNOWLEDGED);
     }
 
     // ---- Define Relationships ----
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo<\App\Models\Device, $this>
+     * @return BelongsTo<Device, $this>
      */
     public function device(): BelongsTo
     {
@@ -80,7 +68,7 @@ class Alert extends Model
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo<\App\Models\AlertRule, $this>
+     * @return BelongsTo<AlertRule, $this>
      */
     public function rule(): BelongsTo
     {
@@ -88,7 +76,7 @@ class Alert extends Model
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany<\App\Models\User, $this>
+     * @return BelongsToMany<User, $this>
      */
     public function users(): BelongsToMany
     {

--- a/app/Models/AlertRule.php
+++ b/app/Models/AlertRule.php
@@ -85,11 +85,17 @@ class AlertRule extends BaseModel
 
     // ---- Query scopes ----
 
+    /**
+     * Scope a query to only include enabled alert rules.
+     */
     public function scopeEnabled(Builder $query): Builder
     {
         return $query->where('alert_rules.disabled', 0);
     }
 
+    /**
+     * Scope a query to only include active alert rules (enabled and with active alerts).
+     */
     public function scopeIsActive(Builder $query): Builder
     {
         $this->scopeEnabled($query);
@@ -98,6 +104,9 @@ class AlertRule extends BaseModel
             ->whereNotIn('alerts.state', [AlertState::CLEAR, AlertState::ACKNOWLEDGED, AlertState::RECOVERED]);
     }
 
+    /**
+     * Scope a query to only include alert rules the user has access to.
+     */
     public function scopeHasAccess(Builder $query, User $user): Builder
     {
         if (Gate::allows('viewAll', AlertRule::class)) {

--- a/app/Models/AlertRule.php
+++ b/app/Models/AlertRule.php
@@ -85,37 +85,20 @@ class AlertRule extends BaseModel
 
     // ---- Query scopes ----
 
-    /**
-     * @param  Builder<AlertRule>  $query
-     * @return Builder
-     */
-    public function scopeEnabled($query)
+    public function scopeEnabled(Builder $query): Builder
     {
         return $query->where('alert_rules.disabled', 0);
     }
 
-    /**
-     * Scope for only alert rules that are currently in alarm
-     *
-     * @param  Builder<AlertRule>  $query
-     * @return Builder
-     */
-    public function scopeIsActive($query)
+    public function scopeIsActive(Builder $query): Builder
     {
-        return $query->enabled()
-            ->join('alerts', 'alerts.rule_id', 'alert_rules.id')
+        $this->scopeEnabled($query);
+
+        return $query->join('alerts', 'alerts.rule_id', 'alert_rules.id')
             ->whereNotIn('alerts.state', [AlertState::CLEAR, AlertState::ACKNOWLEDGED, AlertState::RECOVERED]);
     }
 
-    /**
-     * Scope to filter rules for devices permitted to user
-     * (do not use for admin and global read-only users)
-     *
-     * @param  Builder<AlertRule>  $query
-     * @param  User  $user
-     * @return mixed
-     */
-    public function scopeHasAccess($query, User $user)
+    public function scopeHasAccess(Builder $query, User $user): Builder
     {
         if (Gate::allows('viewAll', AlertRule::class)) {
             return $query;
@@ -131,7 +114,7 @@ class AlertRule extends BaseModel
     // ---- Define Relationships ----
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany<\App\Models\Alert, $this>
+     * @return HasMany<Alert, $this>
      */
     public function alerts(): HasMany
     {
@@ -139,7 +122,7 @@ class AlertRule extends BaseModel
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany<\App\Models\AlertLog, $this>
+     * @return HasMany<AlertLog, $this>
      */
     public function logs(): HasMany
     {
@@ -147,7 +130,7 @@ class AlertRule extends BaseModel
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany<\App\Models\AlertTemplateMap, $this>
+     * @return HasMany<AlertTemplateMap, $this>
      */
     public function templateMaps(): HasMany
     {
@@ -155,7 +138,7 @@ class AlertRule extends BaseModel
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany<\App\Models\Device, $this>
+     * @return BelongsToMany<Device, $this>
      */
     public function devices(): BelongsToMany
     {
@@ -163,7 +146,7 @@ class AlertRule extends BaseModel
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany<\App\Models\DeviceGroup, $this>
+     * @return BelongsToMany<DeviceGroup, $this>
      */
     public function groups(): BelongsToMany
     {
@@ -171,7 +154,7 @@ class AlertRule extends BaseModel
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany<\App\Models\Location, $this>
+     * @return BelongsToMany<Location, $this>
      */
     public function locations(): BelongsToMany
     {

--- a/app/Models/AlertSchedule.php
+++ b/app/Models/AlertSchedule.php
@@ -174,6 +174,9 @@ class AlertSchedule extends Model
 
     // ---- Query scopes ----
 
+    /**
+     * Scope a query to only include active alert schedules.
+     */
     public function scopeIsActive(Builder $query): Builder
     {
         return $query->where(function ($query): void {

--- a/app/Models/AlertSchedule.php
+++ b/app/Models/AlertSchedule.php
@@ -29,6 +29,7 @@ namespace App\Models;
 use Carbon\Carbon;
 use Carbon\CarbonImmutable;
 use Date;
+use Illuminate\Contracts\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
@@ -174,7 +175,7 @@ class AlertSchedule extends Model
 
     // ---- Query scopes ----
 
-    public function scopeIsActive($query)
+    public function scopeIsActive(Builder $query): Builder
     {
         return $query->where(function ($query): void {
             $now = CarbonImmutable::now('UTC');
@@ -189,12 +190,12 @@ class AlertSchedule extends Model
                             ->where(function ($query) use ($now): void {
                                 $query->where(function ($query) use ($now): void {
                                     // normal, inside one day
-                                    $query->whereTime('start', '<', DB::raw('time(`end`)'))
+                                    $query->whereRaw('time(`start`) < time(`end`)')
                                         ->whereTime('start', '<=', $now->toTimeString())
                                         ->whereTime('end', '>', $now->toTimeString());
                                 })->orWhere(function ($query) use ($now): void {
                                     // outside, spans days
-                                    $query->whereTime('start', '>', DB::raw('time(`end`)'))
+                                    $query->whereRaw('time(`start`) > time(`end`)')
                                         ->where(function ($query) use ($now): void {
                                             $query->whereTime('start', '<=', $now->toTimeString())
                                                 ->orWhereTime('end', '>', $now->toTimeString());
@@ -213,7 +214,7 @@ class AlertSchedule extends Model
 
     // ---- Define Relationships ----
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\MorphToMany<\App\Models\Device, $this>
+     * @return MorphToMany<Device, $this>
      */
     public function devices(): MorphToMany
     {
@@ -221,7 +222,7 @@ class AlertSchedule extends Model
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\MorphToMany<\App\Models\DeviceGroup, $this>
+     * @return MorphToMany<DeviceGroup, $this>
      */
     public function deviceGroups(): MorphToMany
     {
@@ -229,7 +230,7 @@ class AlertSchedule extends Model
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\MorphToMany<\App\Models\Location, $this>
+     * @return MorphToMany<Location, $this>
      */
     public function locations(): MorphToMany
     {

--- a/app/Models/AlertSchedule.php
+++ b/app/Models/AlertSchedule.php
@@ -33,7 +33,6 @@ use Illuminate\Contracts\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use LibreNMS\Enum\AlertScheduleStatus;
 use LibreNMS\Enum\MaintenanceBehavior;

--- a/app/Models/ApiToken.php
+++ b/app/Models/ApiToken.php
@@ -112,6 +112,9 @@ class ApiToken extends BaseModel
 
     // ---- Query scopes ----
 
+    /**
+     * Scope a query to only include enabled tokens.
+     */
     public function scopeIsEnabled(Builder $query): Builder
     {
         return $query->where('disabled', 0);

--- a/app/Models/ApiToken.php
+++ b/app/Models/ApiToken.php
@@ -26,6 +26,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class ApiToken extends BaseModel
@@ -111,14 +112,14 @@ class ApiToken extends BaseModel
 
     // ---- Query scopes ----
 
-    public function scopeIsEnabled($query)
+    public function scopeIsEnabled(Builder $query): Builder
     {
         return $query->where('disabled', 0);
     }
 
     // ---- Define Relationships ----
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo<\App\Models\User, $this>
+     * @return BelongsTo<User, $this>
      */
     public function user(): BelongsTo
     {

--- a/app/Models/Config.php
+++ b/app/Models/Config.php
@@ -26,6 +26,8 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Builder;
+
 class Config extends BaseModel
 {
     public $timestamps = false;
@@ -60,7 +62,7 @@ class Config extends BaseModel
 
     // ---- Query Scopes ----
 
-    public function scopeWithChildren($query, $name)
+    public function scopeWithChildren(Builder $query, string $name): Builder
     {
         return $query->where('config_name', $name)
             ->orWhere('config_name', 'like', "$name.%");

--- a/app/Models/Config.php
+++ b/app/Models/Config.php
@@ -62,6 +62,9 @@ class Config extends BaseModel
 
     // ---- Query Scopes ----
 
+    /**
+     * Scope a query to include the config with the given name and all of its children.
+     */
     public function scopeWithChildren(Builder $query, string $name): Builder
     {
         return $query->where('config_name', $name)

--- a/app/Models/CustomMapNode.php
+++ b/app/Models/CustomMapNode.php
@@ -26,6 +26,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -42,13 +43,13 @@ class CustomMapNode extends BaseModel
                 ->whereRelation('device', fn ($q) => $q->isDown())->exists();
     }
 
-    public function scopeHasAccess($query, User $user)
+    public function scopeHasAccess(Builder $query, User $user): Builder
     {
         return $this->hasDeviceAccess($query, $user);
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo<\App\Models\CustomMap, $this>
+     * @return BelongsTo<CustomMap, $this>
      */
     public function map(): BelongsTo
     {
@@ -56,7 +57,7 @@ class CustomMapNode extends BaseModel
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo<\App\Models\Device, $this>
+     * @return BelongsTo<Device, $this>
      */
     public function device(): BelongsTo
     {
@@ -64,7 +65,7 @@ class CustomMapNode extends BaseModel
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo<\App\Models\CustomMap, $this>
+     * @return BelongsTo<CustomMap, $this>
      */
     public function linked_map(): BelongsTo
     {
@@ -72,7 +73,7 @@ class CustomMapNode extends BaseModel
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo<\App\Models\CustomMapNodeImage, $this>
+     * @return BelongsTo<CustomMapNodeImage, $this>
      */
     public function nodeimage(): BelongsTo
     {
@@ -80,7 +81,7 @@ class CustomMapNode extends BaseModel
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany<\App\Models\CustomMapEdge, $this>
+     * @return HasMany<CustomMapEdge, $this>
      */
     public function edges1(): HasMany
     {
@@ -88,7 +89,7 @@ class CustomMapNode extends BaseModel
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany<\App\Models\CustomMapEdge, $this>
+     * @return HasMany<CustomMapEdge, $this>
      */
     public function edges2(): HasMany
     {

--- a/app/Models/CustomMapNode.php
+++ b/app/Models/CustomMapNode.php
@@ -43,6 +43,9 @@ class CustomMapNode extends BaseModel
                 ->whereRelation('device', fn ($q) => $q->isDown())->exists();
     }
 
+    /**
+     * Scope a query to only include nodes that the given user has access to.
+     */
     public function scopeHasAccess(Builder $query, User $user): Builder
     {
         return $this->hasDeviceAccess($query, $user);

--- a/app/Models/Device.php
+++ b/app/Models/Device.php
@@ -532,6 +532,9 @@ class Device extends BaseModel
 
     // ---- Query scopes ----
 
+    /**
+     * Scope a query to only include devices that are up and not ignored or disabled.
+     */
     public function scopeIsUp(Builder $query): Builder
     {
         return $query->where([
@@ -542,6 +545,9 @@ class Device extends BaseModel
         ]);
     }
 
+    /**
+     * Scope a query to only include devices that are not ignored or disabled, regardless of status.
+     */
     public function scopeIsActive(Builder $query): Builder
     {
         return $query->where([
@@ -550,6 +556,9 @@ class Device extends BaseModel
         ]);
     }
 
+    /**
+     * Scope a query to only include devices that are down and not ignored or disabled.
+     */
     public function scopeIsDown(Builder $query): Builder
     {
         return $query->where([
@@ -559,6 +568,9 @@ class Device extends BaseModel
         ]);
     }
 
+    /**
+     * Scope a query to only include devices that are ignored (regardless of status) but not disabled.
+     */
     public function scopeIsIgnored(Builder $query): Builder
     {
         return $query->where([
@@ -567,6 +579,9 @@ class Device extends BaseModel
         ]);
     }
 
+    /**
+     * Scope a query to only include devices that are not ignored (regardless of status) and not disabled.
+     */
     public function scopeNotIgnored(Builder $query): Builder
     {
         return $query->where([
@@ -574,6 +589,10 @@ class Device extends BaseModel
         ]);
     }
 
+
+    /**
+     * Scope a query to only include devices that are disabled (regardless of status or ignore).
+     */
     public function scopeIsDisabled(Builder $query): Builder
     {
         return $query->where([
@@ -581,6 +600,9 @@ class Device extends BaseModel
         ]);
     }
 
+    /**
+     * Scope a query to only include devices that are disabled for notifications (regardless of status or ignore).
+     */
     public function scopeIsDisableNotify(Builder $query): Builder
     {
         return $query->where([
@@ -588,6 +610,9 @@ class Device extends BaseModel
         ]);
     }
 
+    /**
+    * Scope a query to only include devices that are not disabled for notifications and not disabled (regardless of status or ignore).
+    */
     public function scopeIsNotDisabled(Builder $query): Builder
     {
         return $query->where([
@@ -596,6 +621,9 @@ class Device extends BaseModel
         ]);
     }
 
+    /**
+    * Scope a query to only include devices that have a specific attribute disabled (attribute value is null or not 'true').
+    */
     public function scopeWhereAttributeDisabled(Builder $query, string $attribute): Builder
     {
         return $query->leftJoin('devices_attribs', function (JoinClause $query) use ($attribute): void {
@@ -607,6 +635,9 @@ class Device extends BaseModel
         });
     }
 
+    /**
+     * Scope a query to only include devices with uptime greater than 0 and matching the given uptime condition.
+     */
     public function scopeWhereUptime(Builder $query, $uptime, $modifier = '<'): Builder
     {
         return $query->where([
@@ -615,16 +646,25 @@ class Device extends BaseModel
         ]);
     }
 
+    /**
+     * Scope a query to only include devices that can be pinged.
+     */
     public function scopeCanPing(Builder $query): Builder
     {
         return $this->scopeWhereAttributeDisabled($query->where('disabled', 0), 'override_icmp_disable');
     }
 
+    /**
+     * Scope a query to only include devices that the given user has access to.
+     */
     public function scopeHasAccess($query, User $user): Builder
     {
         return $this->hasDeviceAccess($query, $user);
     }
 
+    /**
+     * Scope a query to only include devices that are in the given device group(s).
+     */
     public function scopeInDeviceGroup(Builder $query, $deviceGroup): Builder
     {
         return $query->whereIn(
@@ -636,6 +676,9 @@ class Device extends BaseModel
         );
     }
 
+    /**
+     * Scope a query to only include devices that are not in the given device group(s).
+     */
     public function scopeNotInDeviceGroup(Builder $query, $deviceGroup): Builder
     {
         return $query->whereNotIn(
@@ -647,6 +690,9 @@ class Device extends BaseModel
         );
     }
 
+    /**
+     * Scope a query to only include devices that are in the given service template(s).
+     */
     public function scopeInServiceTemplate(Builder $query, $serviceTemplate): Builder
     {
         return $query->whereIn(
@@ -658,6 +704,9 @@ class Device extends BaseModel
         );
     }
 
+    /**
+     * Scope a query to only include devices that are not in the given service template(s).
+     */
     public function scopeNotInServiceTemplate(Builder $query, $serviceTemplate): Builder
     {
         return $query->whereNotIn(
@@ -669,6 +718,16 @@ class Device extends BaseModel
         );
     }
 
+    /**
+     * Scope a query to only include devices matching the given device specification.
+     * Device specification can be:
+     * - empty or 'all' for all devices
+     * - 'new' for devices that have never been discovered (last_discovered is null)
+     * - 'even' for devices with an even device_id
+     * - 'odd' for devices with an odd device_id
+     * - a specific device_id
+     * - a hostname with optional wildcards (*)
+     */
     public function scopeWhereDeviceSpec(Builder $query, ?string $deviceSpec): Builder
     {
         if (empty($deviceSpec)) {

--- a/app/Models/Device.php
+++ b/app/Models/Device.php
@@ -532,7 +532,7 @@ class Device extends BaseModel
 
     // ---- Query scopes ----
 
-    public function scopeIsUp($query)
+    public function scopeIsUp(Builder $query): Builder
     {
         return $query->where([
             ['status', '=', 1],
@@ -542,7 +542,7 @@ class Device extends BaseModel
         ]);
     }
 
-    public function scopeIsActive($query)
+    public function scopeIsActive(Builder $query): Builder
     {
         return $query->where([
             ['ignore', '=', 0],
@@ -550,7 +550,7 @@ class Device extends BaseModel
         ]);
     }
 
-    public function scopeIsDown($query)
+    public function scopeIsDown(Builder $query): Builder
     {
         return $query->where([
             ['status', '=', 0],
@@ -559,7 +559,7 @@ class Device extends BaseModel
         ]);
     }
 
-    public function scopeIsIgnored($query)
+    public function scopeIsIgnored(Builder $query): Builder
     {
         return $query->where([
             ['ignore', '=', 1],
@@ -567,28 +567,28 @@ class Device extends BaseModel
         ]);
     }
 
-    public function scopeNotIgnored($query)
+    public function scopeNotIgnored(Builder $query): Builder
     {
         return $query->where([
             ['ignore', '=', 0],
         ]);
     }
 
-    public function scopeIsDisabled($query)
+    public function scopeIsDisabled(Builder $query): Builder
     {
         return $query->where([
             ['disabled', '=', 1],
         ]);
     }
 
-    public function scopeIsDisableNotify($query)
+    public function scopeIsDisableNotify(Builder $query): Builder
     {
         return $query->where([
             ['disable_notify', '=', 1],
         ]);
     }
 
-    public function scopeIsNotDisabled($query)
+    public function scopeIsNotDisabled(Builder $query): Builder
     {
         return $query->where([
             ['disable_notify', '=', 0],
@@ -607,7 +607,7 @@ class Device extends BaseModel
         });
     }
 
-    public function scopeWhereUptime($query, $uptime, $modifier = '<')
+    public function scopeWhereUptime(Builder $query, $uptime, $modifier = '<'): Builder
     {
         return $query->where([
             ['uptime', '>', 0],
@@ -620,12 +620,12 @@ class Device extends BaseModel
         return $this->scopeWhereAttributeDisabled($query->where('disabled', 0), 'override_icmp_disable');
     }
 
-    public function scopeHasAccess($query, User $user)
+    public function scopeHasAccess($query, User $user): Builder
     {
         return $this->hasDeviceAccess($query, $user);
     }
 
-    public function scopeInDeviceGroup($query, $deviceGroup)
+    public function scopeInDeviceGroup(Builder $query, $deviceGroup): Builder
     {
         return $query->whereIn(
             $query->qualifyColumn('device_id'), function ($query) use ($deviceGroup): void {
@@ -636,7 +636,7 @@ class Device extends BaseModel
         );
     }
 
-    public function scopeNotInDeviceGroup($query, $deviceGroup)
+    public function scopeNotInDeviceGroup(Builder $query, $deviceGroup): Builder
     {
         return $query->whereNotIn(
             $query->qualifyColumn('device_id'), function ($query) use ($deviceGroup): void {
@@ -647,7 +647,7 @@ class Device extends BaseModel
         );
     }
 
-    public function scopeInServiceTemplate($query, $serviceTemplate)
+    public function scopeInServiceTemplate(Builder $query, $serviceTemplate): Builder
     {
         return $query->whereIn(
             $query->qualifyColumn('device_id'), function ($query) use ($serviceTemplate): void {
@@ -658,7 +658,7 @@ class Device extends BaseModel
         );
     }
 
-    public function scopeNotInServiceTemplate($query, $serviceTemplate)
+    public function scopeNotInServiceTemplate(Builder $query, $serviceTemplate): Builder
     {
         return $query->whereNotIn(
             $query->qualifyColumn('device_id'), function ($query) use ($serviceTemplate): void {
@@ -892,7 +892,7 @@ class Device extends BaseModel
     }
 
     /**
-     * @return \Illuminate\Support\Collection<int, \App\Models\Link>
+     * @return \Illuminate\Support\Collection<int, Link>
      */
     public function allLinks(): \Illuminate\Support\Collection
     {
@@ -909,7 +909,7 @@ class Device extends BaseModel
 
     /**
      * @return HasMany<Ipv4Mac, $this>
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany<\App\Models\MacAccounting, $this>
+     * @return HasMany<MacAccounting, $this>
      */
     public function macAccounting(): HasMany
     {
@@ -917,7 +917,7 @@ class Device extends BaseModel
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany<\App\Models\Ipv4Mac, $this>
+     * @return HasMany<Ipv4Mac, $this>
      */
     public function macs(): HasMany
     {

--- a/app/Models/Device.php
+++ b/app/Models/Device.php
@@ -589,7 +589,6 @@ class Device extends BaseModel
         ]);
     }
 
-
     /**
      * Scope a query to only include devices that are disabled (regardless of status or ignore).
      */
@@ -611,8 +610,8 @@ class Device extends BaseModel
     }
 
     /**
-    * Scope a query to only include devices that are not disabled for notifications and not disabled (regardless of status or ignore).
-    */
+     * Scope a query to only include devices that are not disabled for notifications and not disabled (regardless of status or ignore).
+     */
     public function scopeIsNotDisabled(Builder $query): Builder
     {
         return $query->where([
@@ -622,8 +621,8 @@ class Device extends BaseModel
     }
 
     /**
-    * Scope a query to only include devices that have a specific attribute disabled (attribute value is null or not 'true').
-    */
+     * Scope a query to only include devices that have a specific attribute disabled (attribute value is null or not 'true').
+     */
     public function scopeWhereAttributeDisabled(Builder $query, string $attribute): Builder
     {
         return $query->leftJoin('devices_attribs', function (JoinClause $query) use ($attribute): void {

--- a/app/Models/DeviceGroup.php
+++ b/app/Models/DeviceGroup.php
@@ -94,6 +94,9 @@ class DeviceGroup extends BaseModel
 
     // ---- Query Scopes ----
 
+    /**
+     * Scope a query to only include device groups that the given user has access to.
+     */
     public function scopeHasAccess(Builder $query, User $user): Builder
     {
         if (Gate::allows('viewAll', DeviceGroup::class)) {
@@ -103,6 +106,9 @@ class DeviceGroup extends BaseModel
         return $query->whereIntegerInRaw('id', Permissions::deviceGroupsForUser($user));
     }
 
+    /**
+     * Scope a query to only include device groups that are associated with the given service template.
+     */
     public function scopeInServiceTemplate(Builder $query, $serviceTemplate): Builder
     {
         return $query->whereIn(
@@ -114,6 +120,9 @@ class DeviceGroup extends BaseModel
         );
     }
 
+    /**
+     * Scope a query to only include device groups that are not associated with the given service template.
+     */
     public function scopeNotInServiceTemplate(Builder $query, $serviceTemplate): Builder
     {
         return $query->whereNotIn(

--- a/app/Models/DeviceGroup.php
+++ b/app/Models/DeviceGroup.php
@@ -26,6 +26,7 @@
 
 namespace App\Models;
 
+use Illuminate\Contracts\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Support\Facades\Gate;
@@ -93,7 +94,7 @@ class DeviceGroup extends BaseModel
 
     // ---- Query Scopes ----
 
-    public function scopeHasAccess($query, User $user)
+    public function scopeHasAccess(Builder $query, User $user): Builder
     {
         if (Gate::allows('viewAll', DeviceGroup::class)) {
             return $query;
@@ -102,7 +103,7 @@ class DeviceGroup extends BaseModel
         return $query->whereIntegerInRaw('id', Permissions::deviceGroupsForUser($user));
     }
 
-    public function scopeInServiceTemplate($query, $serviceTemplate)
+    public function scopeInServiceTemplate(Builder $query, $serviceTemplate): Builder
     {
         return $query->whereIn(
             $query->qualifyColumn('id'), function ($query) use ($serviceTemplate): void {
@@ -113,7 +114,7 @@ class DeviceGroup extends BaseModel
         );
     }
 
-    public function scopeNotInServiceTemplate($query, $serviceTemplate)
+    public function scopeNotInServiceTemplate(Builder $query, $serviceTemplate): Builder
     {
         return $query->whereNotIn(
             $query->qualifyColumn('id'), function ($query) use ($serviceTemplate): void {
@@ -126,7 +127,7 @@ class DeviceGroup extends BaseModel
 
     // ---- Define Relationships ----
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\MorphToMany<\App\Models\AlertSchedule, $this>
+     * @return MorphToMany<AlertSchedule, $this>
      */
     public function alertSchedules(): MorphToMany
     {
@@ -134,7 +135,7 @@ class DeviceGroup extends BaseModel
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany<\App\Models\Device, $this>
+     * @return BelongsToMany<Device, $this>
      */
     public function devices(): BelongsToMany
     {
@@ -142,7 +143,7 @@ class DeviceGroup extends BaseModel
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany<\App\Models\Service, $this>
+     * @return BelongsToMany<Service, $this>
      */
     public function services(): BelongsToMany
     {
@@ -152,7 +153,7 @@ class DeviceGroup extends BaseModel
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany<\App\Models\User, $this>
+     * @return BelongsToMany<User, $this>
      */
     public function users(): BelongsToMany
     {
@@ -160,7 +161,7 @@ class DeviceGroup extends BaseModel
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany<\App\Models\ServiceTemplate, $this>
+     * @return BelongsToMany<ServiceTemplate, $this>
      */
     public function serviceTemplates(): BelongsToMany
     {

--- a/app/Models/DeviceRelatedModel.php
+++ b/app/Models/DeviceRelatedModel.php
@@ -27,6 +27,7 @@
 namespace App\Models;
 
 use App\Facades\DeviceCache;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 /**
@@ -36,12 +37,12 @@ class DeviceRelatedModel extends BaseModel
 {
     // ---- Query Scopes ----
 
-    public function scopeHasAccess($query, User $user)
+    public function scopeHasAccess(Builder $query, User $user): Builder
     {
         return $this->hasDeviceAccess($query, $user);
     }
 
-    public function scopeInDeviceGroup($query, $deviceGroup)
+    public function scopeInDeviceGroup(Builder $query, $deviceGroup): Builder
     {
         // Build the list of device IDs in SQL
         $deviceIdsSubquery = \DB::table('device_group_device')
@@ -55,7 +56,7 @@ class DeviceRelatedModel extends BaseModel
 
     // ---- Define Relationships ----
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo<\App\Models\Device, $this>
+     * @return BelongsTo<Device, $this>
      */
     public function device(): BelongsTo
     {

--- a/app/Models/Location.php
+++ b/app/Models/Location.php
@@ -155,12 +155,7 @@ class Location extends Model
 
     // ---- Query scopes ----
 
-    /**
-     * @param  Builder  $query
-     * @param  User  $user
-     * @return Builder
-     */
-    public function scopeHasAccess($query, $user)
+    public function scopeHasAccess(Builder $query, User $user): Builder
     {
         if (Gate::allows('viewAll', Location::class)) {
             return $query;
@@ -174,7 +169,7 @@ class Location extends Model
         return $query->whereIntegerInRaw('id', $ids);
     }
 
-    public function scopeInDeviceGroup($query, $deviceGroup)
+    public function scopeInDeviceGroup(Builder $query, $deviceGroup): Builder
     {
         return $query->whereHas('devices.groups', function ($query) use ($deviceGroup): void {
             $query->where('device_groups.id', $deviceGroup);
@@ -183,7 +178,7 @@ class Location extends Model
 
     // ---- Define Relationships ----
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany<\App\Models\Device, $this>
+     * @return HasMany<Device, $this>
      */
     public function devices(): HasMany
     {

--- a/app/Models/Location.php
+++ b/app/Models/Location.php
@@ -155,6 +155,9 @@ class Location extends Model
 
     // ---- Query scopes ----
 
+    /**
+     * Scope a query to only include locations that the given user has access to.
+     */
     public function scopeHasAccess(Builder $query, User $user): Builder
     {
         if (Gate::allows('viewAll', Location::class)) {
@@ -169,6 +172,9 @@ class Location extends Model
         return $query->whereIntegerInRaw('id', $ids);
     }
 
+    /**
+     * Scope a query to only include locations that have devices in the given device group.
+     */
     public function scopeInDeviceGroup(Builder $query, $deviceGroup): Builder
     {
         return $query->whereHas('devices.groups', function ($query) use ($deviceGroup): void {

--- a/app/Models/Plugin.php
+++ b/app/Models/Plugin.php
@@ -47,16 +47,25 @@ class Plugin extends BaseModel
 
     // ---- Query scopes ----
 
+    /**
+     * Scope a query to only include active plugins.
+     */
     public function scopeIsActive(Builder $query): Builder
     {
         return $query->where('plugin_active', 1);
     }
 
+    /**
+     * Scope a query to only include version 1 plugins.
+     */
     public function scopeVersionOne(Builder $query): Builder
     {
         return $query->where('version', 1);
     }
 
+    /**
+     * Scope a query to only include version 2 plugins.
+     */
     public function scopeVersionTwo(Builder $query): Builder
     {
         return $query->where('version', 2);

--- a/app/Models/Plugin.php
+++ b/app/Models/Plugin.php
@@ -47,21 +47,17 @@ class Plugin extends BaseModel
 
     // ---- Query scopes ----
 
-    /**
-     * @param  Builder  $query
-     * @return Builder
-     */
-    public function scopeIsActive($query)
+    public function scopeIsActive(Builder $query): Builder
     {
         return $query->where('plugin_active', 1);
     }
 
-    public function scopeVersionOne($query)
+    public function scopeVersionOne(Builder $query): Builder
     {
         return $query->where('version', 1);
     }
 
-    public function scopeVersionTwo($query)
+    public function scopeVersionTwo(Builder $query): Builder
     {
         return $query->where('version', 2);
     }

--- a/app/Models/Port.php
+++ b/app/Models/Port.php
@@ -182,6 +182,9 @@ class Port extends DeviceRelatedModel
 
     // ---- Query scopes ----
 
+    /**
+     * Scope a query to only include deleted ports.
+     */
     public function scopeIsDeleted(Builder $query): Builder
     {
         return $query->where([
@@ -189,6 +192,9 @@ class Port extends DeviceRelatedModel
         ]);
     }
 
+    /**
+     * Scope a query to only include non-deleted ports.
+     */
     public function scopeIsNotDeleted(Builder $query): Builder
     {
         return $query->where([
@@ -196,6 +202,9 @@ class Port extends DeviceRelatedModel
         ]);
     }
 
+    /**
+     * Scope a query to only include ports that are up.
+     */
     public function scopeIsUp(Builder $query): Builder
     {
         return $query->where([
@@ -206,6 +215,9 @@ class Port extends DeviceRelatedModel
         ]);
     }
 
+    /**
+     * Scope a query to only include ports that are down.
+     */
     public function scopeIsDown(Builder $query): Builder
     {
         return $query->where([
@@ -217,6 +229,9 @@ class Port extends DeviceRelatedModel
         ]);
     }
 
+    /**
+     * Scope a query to only include ports that are shutdown.
+     */
     public function scopeIsShutdown(Builder $query): Builder
     {
         return $query->where([
@@ -227,6 +242,9 @@ class Port extends DeviceRelatedModel
         ]);
     }
 
+    /**
+     * Scope a query to only include ports that are ignored.
+     */
     public function scopeIsIgnored(Builder $query): Builder
     {
         return $query->where([
@@ -235,6 +253,9 @@ class Port extends DeviceRelatedModel
         ]);
     }
 
+    /**
+     * Scope a query to only include ports that are disabled.
+     */
     public function scopeIsDisabled(Builder $query): Builder
     {
         return $query->where([
@@ -243,6 +264,9 @@ class Port extends DeviceRelatedModel
         ]);
     }
 
+    /**
+     * Scope a query to only include ports that have errors.
+     */
     public function scopeHasErrors(Builder $query): Builder
     {
         return $query->where([
@@ -256,6 +280,9 @@ class Port extends DeviceRelatedModel
         });
     }
 
+    /**
+     * Scope a query to only include ports that are valid (not deleted or disabled).
+     */
     public function scopeIsValid(Builder $query): Builder
     {
         return $query->where([
@@ -264,11 +291,17 @@ class Port extends DeviceRelatedModel
         ]);
     }
 
+    /**
+     * Scope a query to only include ports that the given user has access to.
+     */
     public function scopeHasAccess(Builder $query, User $user): Builder
     {
         return $this->hasPortAccess($query, $user);
     }
 
+    /**
+     * Scope a query to only include ports that are in the given port group.
+     */
     public function scopeInPortGroup(Builder $query, PortGroup $portGroup): Builder
     {
         return $query->whereIn($query->qualifyColumn('port_id'), function ($query) use ($portGroup): void {

--- a/app/Models/Port.php
+++ b/app/Models/Port.php
@@ -182,33 +182,21 @@ class Port extends DeviceRelatedModel
 
     // ---- Query scopes ----
 
-    /**
-     * @param  Builder  $query
-     * @return Builder
-     */
-    public function scopeIsDeleted($query)
+    public function scopeIsDeleted(Builder $query): Builder
     {
         return $query->where([
             [$this->qualifyColumn('deleted'), 1],
         ]);
     }
 
-    /**
-     * @param  Builder  $query
-     * @return Builder
-     */
-    public function scopeIsNotDeleted($query)
+    public function scopeIsNotDeleted(Builder $query): Builder
     {
         return $query->where([
             [$this->qualifyColumn('deleted'), 0],
         ]);
     }
 
-    /**
-     * @param  Builder  $query
-     * @return Builder
-     */
-    public function scopeIsUp($query)
+    public function scopeIsUp(Builder $query): Builder
     {
         return $query->where([
             [$this->qualifyColumn('deleted'), '=', 0],
@@ -218,11 +206,7 @@ class Port extends DeviceRelatedModel
         ]);
     }
 
-    /**
-     * @param  Builder  $query
-     * @return Builder
-     */
-    public function scopeIsDown($query)
+    public function scopeIsDown(Builder $query): Builder
     {
         return $query->where([
             [$this->qualifyColumn('deleted'), '=', 0],
@@ -233,11 +217,7 @@ class Port extends DeviceRelatedModel
         ]);
     }
 
-    /**
-     * @param  Builder  $query
-     * @return Builder
-     */
-    public function scopeIsShutdown($query)
+    public function scopeIsShutdown(Builder $query): Builder
     {
         return $query->where([
             [$this->qualifyColumn('deleted'), '=', 0],
@@ -247,11 +227,7 @@ class Port extends DeviceRelatedModel
         ]);
     }
 
-    /**
-     * @param  Builder  $query
-     * @return Builder
-     */
-    public function scopeIsIgnored($query)
+    public function scopeIsIgnored(Builder $query): Builder
     {
         return $query->where([
             [$this->qualifyColumn('deleted'), '=', 0],
@@ -259,11 +235,7 @@ class Port extends DeviceRelatedModel
         ]);
     }
 
-    /**
-     * @param  Builder  $query
-     * @return Builder
-     */
-    public function scopeIsDisabled($query)
+    public function scopeIsDisabled(Builder $query): Builder
     {
         return $query->where([
             [$this->qualifyColumn('deleted'), '=', 0],
@@ -271,11 +243,7 @@ class Port extends DeviceRelatedModel
         ]);
     }
 
-    /**
-     * @param  Builder  $query
-     * @return Builder
-     */
-    public function scopeHasErrors($query)
+    public function scopeHasErrors(Builder $query): Builder
     {
         return $query->where([
             [$this->qualifyColumn('deleted'), '=', 0],
@@ -288,11 +256,7 @@ class Port extends DeviceRelatedModel
         });
     }
 
-    /**
-     * @param  Builder  $query
-     * @return Builder
-     */
-    public function scopeIsValid($query)
+    public function scopeIsValid(Builder $query): Builder
     {
         return $query->where([
             [$this->qualifyColumn('deleted'), '=', 0],
@@ -300,12 +264,12 @@ class Port extends DeviceRelatedModel
         ]);
     }
 
-    public function scopeHasAccess($query, User $user)
+    public function scopeHasAccess(Builder $query, User $user): Builder
     {
         return $this->hasPortAccess($query, $user);
     }
 
-    public function scopeInPortGroup($query, $portGroup)
+    public function scopeInPortGroup(Builder $query, PortGroup $portGroup): Builder
     {
         return $query->whereIn($query->qualifyColumn('port_id'), function ($query) use ($portGroup): void {
             $query->select('port_id')
@@ -316,7 +280,7 @@ class Port extends DeviceRelatedModel
 
     // ---- Define Relationships ----
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\HasOne<\App\Models\PortAdsl, $this>
+     * @return HasOne<PortAdsl, $this>
      */
     public function adsl(): HasOne
     {
@@ -332,7 +296,7 @@ class Port extends DeviceRelatedModel
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\HasOne<\App\Models\PortVdsl, $this>
+     * @return HasOne<PortVdsl, $this>
      */
     public function vdsl(): HasOne
     {
@@ -340,7 +304,7 @@ class Port extends DeviceRelatedModel
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\MorphMany<\App\Models\Eventlog, $this>
+     * @return MorphMany<Eventlog, $this>
      */
     public function events(): MorphMany
     {
@@ -348,7 +312,7 @@ class Port extends DeviceRelatedModel
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany<\App\Models\PortsFdb, $this>
+     * @return HasMany<PortsFdb, $this>
      */
     public function fdbEntries(): HasMany
     {
@@ -356,7 +320,7 @@ class Port extends DeviceRelatedModel
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany<\App\Models\PortGroup, $this>
+     * @return BelongsToMany<PortGroup, $this>
      */
     public function groups(): BelongsToMany
     {
@@ -364,7 +328,7 @@ class Port extends DeviceRelatedModel
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany<\App\Models\Ipv4Address, $this>
+     * @return HasMany<Ipv4Address, $this>
      */
     public function ipv4(): HasMany
     {
@@ -372,7 +336,7 @@ class Port extends DeviceRelatedModel
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\HasManyThrough<\App\Models\Ipv4Network, \App\Models\Ipv4Address, $this>
+     * @return HasManyThrough<Ipv4Network, Ipv4Address, $this>
      */
     public function ipv4Networks(): HasManyThrough
     {
@@ -380,7 +344,7 @@ class Port extends DeviceRelatedModel
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany<\App\Models\Ipv6Address, $this>
+     * @return HasMany<Ipv6Address, $this>
      */
     public function ipv6(): HasMany
     {
@@ -388,7 +352,7 @@ class Port extends DeviceRelatedModel
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\HasManyThrough<\App\Models\Ipv6Network, \App\Models\Ipv6Address, $this>
+     * @return HasManyThrough<Ipv6Network, Ipv6Address, $this>
      */
     public function ipv6Networks(): HasManyThrough
     {
@@ -396,7 +360,7 @@ class Port extends DeviceRelatedModel
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany<\App\Models\Link, $this>
+     * @return HasMany<Link, $this>
      */
     public function links(): HasMany
     {
@@ -404,7 +368,7 @@ class Port extends DeviceRelatedModel
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany<\App\Models\Link, $this>
+     * @return HasMany<Link, $this>
      */
     public function remoteLinks(): HasMany
     {
@@ -412,7 +376,7 @@ class Port extends DeviceRelatedModel
     }
 
     /**
-     * @return \Illuminate\Support\Collection<int, \App\Models\Link>
+     * @return \Illuminate\Support\Collection<int, Link>
      */
     public function allLinks(): \Illuminate\Support\Collection
     {
@@ -420,7 +384,7 @@ class Port extends DeviceRelatedModel
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany<\App\Models\Port, $this>
+     * @return BelongsToMany<Port, $this>
      */
     public function xdpLinkedPorts(): BelongsToMany
     {
@@ -428,7 +392,7 @@ class Port extends DeviceRelatedModel
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\HasManyThrough<\App\Models\Port, \App\Models\Ipv4Mac, $this>
+     * @return HasManyThrough<Port, Ipv4Mac, $this>
      */
     public function macLinkedPorts(): HasManyThrough
     {
@@ -441,7 +405,7 @@ class Port extends DeviceRelatedModel
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany<\App\Models\MacAccounting, $this>
+     * @return HasMany<MacAccounting, $this>
      */
     public function macAccounting(): HasMany
     {
@@ -449,7 +413,7 @@ class Port extends DeviceRelatedModel
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany<\App\Models\Ipv4Mac, $this>
+     * @return HasMany<Ipv4Mac, $this>
      */
     public function macs(): HasMany
     {
@@ -457,7 +421,7 @@ class Port extends DeviceRelatedModel
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany<\App\Models\PortsNac, $this>
+     * @return HasMany<PortsNac, $this>
      */
     public function nac(): HasMany
     {
@@ -465,7 +429,7 @@ class Port extends DeviceRelatedModel
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany<\App\Models\Ipv6Nd, $this>
+     * @return HasMany<Ipv6Nd, $this>
      */
     public function nd(): HasMany
     {
@@ -473,7 +437,7 @@ class Port extends DeviceRelatedModel
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany<\App\Models\OspfNbr, $this>
+     * @return HasMany<OspfNbr, $this>
      */
     public function ospfNeighbors(): HasMany
     {
@@ -481,7 +445,7 @@ class Port extends DeviceRelatedModel
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany<\App\Models\OspfPort, $this>
+     * @return HasMany<OspfPort, $this>
      */
     public function ospfPorts(): HasMany
     {
@@ -489,7 +453,7 @@ class Port extends DeviceRelatedModel
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany<\App\Models\Ospfv3Nbr, $this>
+     * @return HasMany<Ospfv3Nbr, $this>
      */
     public function ospfv3Neighbors(): HasMany
     {
@@ -497,7 +461,7 @@ class Port extends DeviceRelatedModel
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany<\App\Models\Ospfv3Port, $this>
+     * @return HasMany<Ospfv3Port, $this>
      */
     public function ospfv3Ports(): HasMany
     {
@@ -505,7 +469,7 @@ class Port extends DeviceRelatedModel
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo<\App\Models\Port, $this>
+     * @return BelongsTo<Port, $this>
      */
     public function pagpParent(): BelongsTo
     {
@@ -513,7 +477,7 @@ class Port extends DeviceRelatedModel
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany<\App\Models\Pseudowire, $this>
+     * @return HasMany<Pseudowire, $this>
      */
     public function pseudowires(): HasMany
     {
@@ -521,7 +485,7 @@ class Port extends DeviceRelatedModel
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany<\App\Models\Qos, $this>
+     * @return HasMany<Qos, $this>
      */
     public function qos(): HasMany
     {
@@ -529,7 +493,7 @@ class Port extends DeviceRelatedModel
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany<\App\Models\Route, $this>
+     * @return HasMany<Route, $this>
      */
     public function routes(): HasMany
     {
@@ -537,7 +501,7 @@ class Port extends DeviceRelatedModel
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\HasManyThrough<\App\Models\Port, \App\Models\PortStack, $this>
+     * @return HasManyThrough<Port, PortStack, $this>
      */
     public function stackChildren(): HasManyThrough
     {
@@ -545,7 +509,7 @@ class Port extends DeviceRelatedModel
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\HasManyThrough<\App\Models\Port, \App\Models\PortStack, $this>
+     * @return HasManyThrough<Port, PortStack, $this>
      */
     public function stackParent(): HasManyThrough
     {
@@ -553,7 +517,7 @@ class Port extends DeviceRelatedModel
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany<\App\Models\PortStatistic, $this>
+     * @return HasMany<PortStatistic, $this>
      */
     public function statistics(): HasMany
     {
@@ -561,7 +525,7 @@ class Port extends DeviceRelatedModel
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany<\App\Models\PortStp, $this>
+     * @return HasMany<PortStp, $this>
      */
     public function stp(): HasMany
     {
@@ -569,7 +533,7 @@ class Port extends DeviceRelatedModel
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany<\App\Models\Transceiver, $this>
+     * @return HasMany<Transceiver, $this>
      */
     public function transceivers(): HasMany
     {
@@ -577,7 +541,7 @@ class Port extends DeviceRelatedModel
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany<\App\Models\User, $this>
+     * @return BelongsToMany<User, $this>
      */
     public function users(): BelongsToMany
     {
@@ -586,7 +550,7 @@ class Port extends DeviceRelatedModel
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany<\App\Models\PortVlan, $this>
+     * @return HasMany<PortVlan, $this>
      */
     public function vlans(): HasMany
     {
@@ -594,7 +558,7 @@ class Port extends DeviceRelatedModel
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\HasOne<\App\Models\Vrf, $this>
+     * @return HasOne<Vrf, $this>
      */
     public function vrf(): HasOne
     {
@@ -602,7 +566,7 @@ class Port extends DeviceRelatedModel
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\HasOne<\App\Models\PortSecurity, $this>
+     * @return HasOne<PortSecurity, $this>
      */
     public function portSecurity(): HasOne
     {

--- a/app/Models/PortGroup.php
+++ b/app/Models/PortGroup.php
@@ -35,6 +35,9 @@ class PortGroup extends BaseModel
     public $timestamps = false;
     protected $fillable = ['name', 'desc'];
 
+    /**
+     * Scope a query to only include port groups the user has access to.
+     */
     public function scopeHasAccess(Builder $query, User $user): Builder
     {
         if (Gate::allows('viewAll', PortGroup::class)) {

--- a/app/Models/PortGroup.php
+++ b/app/Models/PortGroup.php
@@ -26,6 +26,7 @@
 
 namespace App\Models;
 
+use Illuminate\Contracts\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Support\Facades\Gate;
 
@@ -34,7 +35,7 @@ class PortGroup extends BaseModel
     public $timestamps = false;
     protected $fillable = ['name', 'desc'];
 
-    public function scopeHasAccess($query, User $user)
+    public function scopeHasAccess(Builder $query, User $user): Builder
     {
         if (Gate::allows('viewAll', PortGroup::class)) {
             return $query;
@@ -45,7 +46,7 @@ class PortGroup extends BaseModel
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany<\App\Models\Port, $this>
+     * @return BelongsToMany<Port, $this>
      */
     public function ports(): BelongsToMany
     {

--- a/app/Models/PortRelatedModel.php
+++ b/app/Models/PortRelatedModel.php
@@ -26,20 +26,21 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 abstract class PortRelatedModel extends BaseModel
 {
     // ---- Query scopes ----
 
-    public function scopeHasAccess($query, User $user)
+    public function scopeHasAccess(Builder $query, User $user): Builder
     {
         return $this->hasPortAccess($query, $user);
     }
 
     // ---- Define Relationships ----
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo<\App\Models\Port, $this>
+     * @return BelongsTo<Port, $this>
      */
     public function port(): BelongsTo
     {

--- a/app/Models/Sensor.php
+++ b/app/Models/Sensor.php
@@ -165,6 +165,9 @@ class Sensor extends DeviceRelatedModel implements Keyable
         return "$this->sensor_class-$this->poller_type";
     }
 
+    /**
+     * Scope a query to only include sensors in the given state.
+     */
     public function scopeStateEq(Builder $query, SensorState $state): Builder
     {
         return $query->whereHas('translations', function ($q) use ($state): void {
@@ -173,6 +176,9 @@ class Sensor extends DeviceRelatedModel implements Keyable
         });
     }
 
+    /**
+     * Scope a query to only include sensors in an unknown state (state value does not match any translation or generic state).
+     */
     public function scopeStateUnknown(Builder $query): Builder
     {
         return $query->whereHas('translations', function ($q): void {
@@ -184,18 +190,27 @@ class Sensor extends DeviceRelatedModel implements Keyable
         });
     }
 
+    /**
+     * Scope a query to only include sensors in a critical state (current value outside of critical limits).
+     */
     public function scopeIsCritical(Builder $query): Builder
     {
         return $query->whereColumn('sensor_current', '<', 'sensor_limit_low')
             ->orWhereColumn('sensor_current', '>', 'sensor_limit');
     }
 
+    /**
+     * Scope a query to only include sensors in a warning state (current value outside of warning limits but within critical limits).
+     */
     public function scopeIsWarning(Builder $query): Builder
     {
         return $query->whereColumn('sensor_current', '<', 'sensor_limit_low_warn')
             ->orWhereColumn('sensor_current', '>', 'sensor_limit_warn');
     }
 
+    /**
+     * Scope a query to only include sensors that are disabled (sensor_alert = 0).
+     */
     public function scopeIsDisabled(Builder $query): Builder
     {
         return $query->where('sensor_alert', 0);

--- a/app/Models/Sensor.php
+++ b/app/Models/Sensor.php
@@ -132,7 +132,7 @@ class Sensor extends DeviceRelatedModel implements Keyable
 
     // ---- Define Relationships ----
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\MorphMany<\App\Models\Eventlog, $this>
+     * @return MorphMany<Eventlog, $this>
      */
     public function events(): MorphMany
     {
@@ -140,7 +140,7 @@ class Sensor extends DeviceRelatedModel implements Keyable
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\HasOneThrough<\App\Models\StateIndex, \App\Models\SensorToStateIndex, $this>
+     * @return HasOneThrough<StateIndex, SensorToStateIndex, $this>
      */
     public function stateIndex(): HasOneThrough
     {
@@ -148,7 +148,7 @@ class Sensor extends DeviceRelatedModel implements Keyable
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany<\App\Models\StateTranslation, $this>
+     * @return BelongsToMany<StateTranslation, $this>
      */
     public function translations(): BelongsToMany
     {
@@ -165,12 +165,7 @@ class Sensor extends DeviceRelatedModel implements Keyable
         return "$this->sensor_class-$this->poller_type";
     }
 
-    /**
-     * @param  Builder  $query
-     * @param  SensorState  $state
-     * @return Builder
-     */
-    public function scopeStateEq($query, $state)
+    public function scopeStateEq(Builder $query, SensorState $state): Builder
     {
         return $query->whereHas('translations', function ($q) use ($state): void {
             $q->where('state_generic_value', $state)
@@ -178,11 +173,7 @@ class Sensor extends DeviceRelatedModel implements Keyable
         });
     }
 
-    /**
-     * @param  Builder  $query
-     * @return Builder
-     */
-    public function scopeStateUnknown($query)
+    public function scopeStateUnknown(Builder $query): Builder
     {
         return $query->whereHas('translations', function ($q): void {
             $q->whereColumn('sensor_current', '=', 'state_value')
@@ -193,31 +184,19 @@ class Sensor extends DeviceRelatedModel implements Keyable
         });
     }
 
-    /**
-     * @param  Builder  $query
-     * @return Builder
-     */
-    public function scopeIsCritical($query)
+    public function scopeIsCritical(Builder $query): Builder
     {
         return $query->whereColumn('sensor_current', '<', 'sensor_limit_low')
             ->orWhereColumn('sensor_current', '>', 'sensor_limit');
     }
 
-    /**
-     * @param  Builder  $query
-     * @return Builder
-     */
-    public function scopeIsWarning($query)
+    public function scopeIsWarning(Builder $query): Builder
     {
         return $query->whereColumn('sensor_current', '<', 'sensor_limit_low_warn')
             ->orWhereColumn('sensor_current', '>', 'sensor_limit_warn');
     }
 
-    /**
-     * @param  Builder  $query
-     * @return Builder
-     */
-    public function scopeIsDisabled($query)
+    public function scopeIsDisabled(Builder $query): Builder
     {
         return $query->where('sensor_alert', 0);
     }

--- a/app/Models/Service.php
+++ b/app/Models/Service.php
@@ -27,6 +27,9 @@ class Service extends DeviceRelatedModel
 
     // ---- Query Scopes ----
 
+    /**
+     * Scope a query to only include active services (not ignored or disabled).
+     */
     public function scopeIsActive(Builder $query): Builder
     {
         return $query->where([
@@ -35,6 +38,9 @@ class Service extends DeviceRelatedModel
         ]);
     }
 
+    /**
+     * Scope a query to only include services that are in an OK state.
+     */
     public function scopeIsOk(Builder $query): Builder
     {
         return $query->where([
@@ -44,6 +50,9 @@ class Service extends DeviceRelatedModel
         ]);
     }
 
+    /**
+     * Scope a query to only include services that are in a critical state.
+     */
     public function scopeIsCritical(Builder $query): Builder
     {
         return $query->where([
@@ -53,6 +62,9 @@ class Service extends DeviceRelatedModel
         ]);
     }
 
+    /**
+     * Scope a query to only include services that are in a warning state.
+     */
     public function scopeIsWarning(Builder $query): Builder
     {
         return $query->where([
@@ -62,6 +74,9 @@ class Service extends DeviceRelatedModel
         ]);
     }
 
+    /**
+     * Scope a query to only include services that are ignored.
+     */
     public function scopeIsIgnored(Builder $query): Builder
     {
         return $query->where([
@@ -70,6 +85,9 @@ class Service extends DeviceRelatedModel
         ]);
     }
 
+    /**
+     * Scope a query to only include services that are disabled.
+     */
     public function scopeIsDisabled(Builder $query): Builder
     {
         return $query->where('service_disabled', 1);

--- a/app/Models/Service.php
+++ b/app/Models/Service.php
@@ -27,11 +27,7 @@ class Service extends DeviceRelatedModel
 
     // ---- Query Scopes ----
 
-    /**
-     * @param  Builder  $query
-     * @return Builder
-     */
-    public function scopeIsActive($query)
+    public function scopeIsActive(Builder $query): Builder
     {
         return $query->where([
             ['service_ignore', '=', 0],
@@ -39,11 +35,7 @@ class Service extends DeviceRelatedModel
         ]);
     }
 
-    /**
-     * @param  Builder  $query
-     * @return Builder
-     */
-    public function scopeIsOk($query)
+    public function scopeIsOk(Builder $query): Builder
     {
         return $query->where([
             ['service_ignore', '=', 0],
@@ -52,11 +44,7 @@ class Service extends DeviceRelatedModel
         ]);
     }
 
-    /**
-     * @param  Builder  $query
-     * @return Builder
-     */
-    public function scopeIsCritical($query)
+    public function scopeIsCritical(Builder $query): Builder
     {
         return $query->where([
             ['service_ignore', '=', 0],
@@ -65,11 +53,7 @@ class Service extends DeviceRelatedModel
         ]);
     }
 
-    /**
-     * @param  Builder  $query
-     * @return Builder
-     */
-    public function scopeIsWarning($query)
+    public function scopeIsWarning(Builder $query): Builder
     {
         return $query->where([
             ['service_ignore', '=', 0],
@@ -78,11 +62,7 @@ class Service extends DeviceRelatedModel
         ]);
     }
 
-    /**
-     * @param  Builder  $query
-     * @return Builder
-     */
-    public function scopeIsIgnored($query)
+    public function scopeIsIgnored(Builder $query): Builder
     {
         return $query->where([
             ['service_ignore', '=', 1],
@@ -90,11 +70,7 @@ class Service extends DeviceRelatedModel
         ]);
     }
 
-    /**
-     * @param  Builder  $query
-     * @return Builder
-     */
-    public function scopeIsDisabled($query)
+    public function scopeIsDisabled(Builder $query): Builder
     {
         return $query->where('service_disabled', 1);
     }

--- a/app/Models/SslCertificate.php
+++ b/app/Models/SslCertificate.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use AcmePhp\Ssl\Exception\CertificateParsingException;
 use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -93,12 +94,12 @@ class SslCertificate extends Model
         return $this->belongsTo(Device::class, 'device_id', 'device_id');
     }
 
-    public function scopeEnabled($query)
+    public function scopeEnabled(Builder $query): Builder
     {
         return $query->where('disabled', false);
     }
 
-    public function scopeDisabled($query)
+    public function scopeDisabled(Builder $query): Builder
     {
         return $query->where('disabled', true);
     }
@@ -106,7 +107,7 @@ class SslCertificate extends Model
     /**
      * Scope to certificates the user is allowed to see (linked to device they have access to, or no device).
      */
-    public function scopeHasAccess($query, $user)
+    public function scopeHasAccess(Builder $query, User $user): Builder
     {
         return $query->where(function ($q) use ($user): void {
             $q->whereNull('device_id')
@@ -160,7 +161,7 @@ class SslCertificate extends Model
 
         $daysUntilExpiry = null;
         if ($validTo !== null) {
-            $daysUntilExpiry = (int) round(\Carbon\Carbon::instance($validTo)->diffInSeconds(now(), false) / -86400);
+            $daysUntilExpiry = (int) round(Carbon::instance($validTo)->diffInSeconds(now(), false) / -86400);
         }
 
         return [

--- a/app/Models/SslCertificate.php
+++ b/app/Models/SslCertificate.php
@@ -94,11 +94,17 @@ class SslCertificate extends Model
         return $this->belongsTo(Device::class, 'device_id', 'device_id');
     }
 
+    /**
+     * Scope to only include enabled certificates.
+     */
     public function scopeEnabled(Builder $query): Builder
     {
         return $query->where('disabled', false);
     }
 
+    /**
+     * Scope to only include disabled certificates.
+     */
     public function scopeDisabled(Builder $query): Builder
     {
         return $query->where('disabled', true);

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -120,6 +120,9 @@ class User extends Authenticatable
         });
     }
 
+    /**
+     * Scope a query to only include users with the admin role.
+     */
     public function scopeAdminOnly(Builder $query): Builder
     {
         return $query->whereHas('roles', fn ($q) => $q->where('name', 'admin'));

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -125,7 +125,7 @@ class User extends Authenticatable
      */
     public function scopeAdminOnly(Builder $query): Builder
     {
-        return $query->whereHas('roles', fn ($q) => $q->where('name', 'admin'));
+        return self::query()->role('admin');
     }
 
     // ---- Accessors/Mutators ----

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -70,7 +70,7 @@ class User extends Authenticatable
     }
 
     /**
-     * @return int|Collection<int, \App\Models\Notification>
+     * @return int|Collection<int, Notification>
      */
     public function getNotifications(?string $type = null): int|Collection
     {
@@ -107,11 +107,8 @@ class User extends Authenticatable
     /**
      * This restricts the query to only users that match the current auth method
      * It is not needed when using user_id, but should be used for username and auth_id
-     *
-     * @param  Builder  $query
-     * @return Builder
      */
-    public function scopeThisAuth($query)
+    public function scopeThisAuth(Builder $query): Builder
     {
         // find user including ones where we might not know the auth type
         $type = LegacyAuth::getType();
@@ -123,9 +120,9 @@ class User extends Authenticatable
         });
     }
 
-    public function scopeAdminOnly($query)
+    public function scopeAdminOnly(Builder $query): Builder
     {
-        $query->role('admin');
+        return $query->whereHas('roles', fn ($q) => $q->where('name', 'admin'));
     }
 
     // ---- Accessors/Mutators ----
@@ -167,7 +164,7 @@ class User extends Authenticatable
 
     // ---- Define Relationships ----
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany<\App\Models\ApiToken, $this>
+     * @return HasMany<ApiToken, $this>
      */
     public function apiTokens(): HasMany
     {
@@ -175,7 +172,7 @@ class User extends Authenticatable
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany<\App\Models\Bill, $this>
+     * @return BelongsToMany<Bill, $this>
      */
     public function bills(): BelongsToMany
     {
@@ -189,7 +186,7 @@ class User extends Authenticatable
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany<\App\Models\Device, $this>
+     * @return BelongsToMany<Device, $this>
      */
     public function devicesOwned(): BelongsToMany
     {
@@ -197,7 +194,7 @@ class User extends Authenticatable
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany<\App\Models\DeviceGroup, $this>
+     * @return BelongsToMany<DeviceGroup, $this>
      */
     public function deviceGroups(): BelongsToMany
     {
@@ -215,7 +212,7 @@ class User extends Authenticatable
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany<\App\Models\Port, $this>
+     * @return BelongsToMany<Port, $this>
      */
     public function portsOwned(): BelongsToMany
     {
@@ -223,7 +220,7 @@ class User extends Authenticatable
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany<\App\Models\Dashboard, $this>
+     * @return HasMany<Dashboard, $this>
      */
     public function dashboards(): HasMany
     {
@@ -231,7 +228,7 @@ class User extends Authenticatable
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany<\App\Models\Notification, $this>
+     * @return BelongsToMany<Notification, $this>
      */
     public function notifications(): BelongsToMany
     {
@@ -239,7 +236,7 @@ class User extends Authenticatable
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany<\App\Models\NotificationAttrib, $this>
+     * @return HasMany<NotificationAttrib, $this>
      */
     public function notificationAttribs(): HasMany
     {
@@ -247,7 +244,7 @@ class User extends Authenticatable
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany<\App\Models\UserPref, $this>
+     * @return HasMany<UserPref, $this>
      */
     public function preferences(): HasMany
     {
@@ -255,7 +252,7 @@ class User extends Authenticatable
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany<\App\Models\UserWidget, $this>
+     * @return HasMany<UserWidget, $this>
      */
     public function widgets(): HasMany
     {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -122,7 +122,7 @@ class User extends Authenticatable
 
     /**
      * Scope a query to only include users with the admin role.
-     * @param Builder<User> $query
+     * @param  Builder<User>  $query
      */
     public function scopeAdminOnly(Builder $query): Builder
     {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -122,10 +122,11 @@ class User extends Authenticatable
 
     /**
      * Scope a query to only include users with the admin role.
+     * @param Builder<User> $query
      */
     public function scopeAdminOnly(Builder $query): Builder
     {
-        return self::query()->role('admin');
+        return $query->role('admin');
     }
 
     // ---- Accessors/Mutators ----

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -122,6 +122,7 @@ class User extends Authenticatable
 
     /**
      * Scope a query to only include users with the admin role.
+     *
      * @param  Builder<User>  $query
      */
     public function scopeAdminOnly(Builder $query): Builder

--- a/app/Models/UserPref.php
+++ b/app/Models/UserPref.php
@@ -26,6 +26,7 @@
 
 namespace App\Models;
 
+use Illuminate\Contracts\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class UserPref extends BaseModel
@@ -81,14 +82,14 @@ class UserPref extends BaseModel
 
     // ---- Query Scopes ----
 
-    public function scopePref($query, $pref)
+    public function scopePref(Builder $query, string $pref): Builder
     {
         return $query->where('pref', $pref);
     }
 
     // ---- Define Relationships ----
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo<\App\Models\User, $this>
+     * @return BelongsTo<User, $this>
      */
     public function user(): BelongsTo
     {

--- a/app/Models/UserPref.php
+++ b/app/Models/UserPref.php
@@ -82,6 +82,9 @@ class UserPref extends BaseModel
 
     // ---- Query Scopes ----
 
+    /**
+     * Scope a query to only include preferences with the given name.
+     */
     public function scopePref(Builder $query, string $pref): Builder
     {
         return $query->where('pref', $pref);


### PR DESCRIPTION
Added Builder type hints to to the scope methods. To be honest, I'm not sure how I feel about this, but right now it's inconsistent. If you don't want it, just close the PR.

- Some CS Fixer comes with.
- I needed to refractor tree or four scopes to make phpstan happy...

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
