### PR TITLE
Prevent graph title from being cropped off on both sides

### DIFF
--- a/LibreNMS/Data/Graphing/GraphParameters.php
+++ b/LibreNMS/Data/Graphing/GraphParameters.php
@@ -161,6 +161,7 @@ class GraphParameters implements \Stringable
         }
 
         // set up fonts
+        array_push($options, '--font', 'TITLE:' . $this->font_size . ':' . $this->font);
         array_push($options, '--font', 'LEGEND:' . $this->font_size . ':' . $this->font);
         array_push($options, '--font', 'AXIS:' . ($this->font_size - 1) . ':' . $this->font);
         array_push($options, '--font-render-mode', 'normal');
@@ -214,8 +215,7 @@ class GraphParameters implements \Stringable
         }
 
         if ($this->visible('title')) {
-            // remove single quotes, because we can't drop out of the string if this is sent to rrdtool stdin
-            $options[] = '--title=' . str_replace("'", '', $this->getTitle());
+            $options[] = '--title=' . $this->formatTitle();
         }
 
         if ($this->right_axis !== null) {
@@ -297,5 +297,28 @@ class GraphParameters implements \Stringable
         $title .= Str::title(str_replace('_', ' ', $this->subtype));
 
         return $title;
+    }
+
+    private function formatTitle(): string
+    {
+        $title = str_replace("'", '', $this->getTitle());
+
+        // linear approximation
+        $slope = 0.1332;
+        $intercept = 15.55;
+        $sizeAdjustment = 8 / $this->font_size; // Adjust the slope if the font size deviates from 8
+        $adjustedSlope = $slope * $sizeAdjustment;
+
+        $maxChars = (int) floor($this->width * $adjustedSlope + $intercept);
+
+        if ($maxChars <= 0) {
+            return '';
+        }
+
+        if (strlen($title) <= $maxChars) {
+            return $title;
+        }
+
+        return substr($title, 0, max(0, $maxChars - 3)) . '...';
     }
 }


### PR DESCRIPTION
preserve the left most data
Simple approximation of font width calculations



<img width="612" height="35" alt="image" src="https://github.com/user-attachments/assets/5e2dd924-ed51-48c3-ace5-2e9289ccc14a" />

Old:
<img width="612" height="35" alt="image" src="https://github.com/user-attachments/assets/c292dfd2-592b-4baa-99a8-a21929f28187" />


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
