### PR TITLE
Add check_dnssec_delegation override

### DIFF
--- a/includes/services/check_dnssec_delegation.inc.php
+++ b/includes/services/check_dnssec_delegation.inc.php
@@ -1,0 +1,3 @@
+<?php
+
+$check_cmd = \App\Facades\LibrenmsConfig::get('nagios_plugins') . '/check_dnssec_delegation ' . $service['service_param'];


### PR DESCRIPTION
The nagios plugin check_dnssec_delegation does not use a -H option, so service checks will fail without an override preventing this argument from being added.

This is the output when not overriding the arguments for check_dnssec_delegation:
```
Request:  '/usr/lib/nagios/plugins/check_dnssec_delegation' '-H' 'REMOTE_HOST' 'check-ds' 'domain'  
Unknown option: H
Usage: /usr/lib/nagios/plugins/check_dnssec_delegation [--dir <dir>] overview|check-dlv|check-ds|check-header zone [zone...]
       /usr/lib/nagios/plugins/check_dnssec_delegation --dir <dir> overview|check-dlv|check-ds|check-header
       /usr/lib/nagios/plugins/check_dnssec_delegation --help
```


#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
