### PR TITLE
Remove default fortigate -> fortios match for Oxidized config

### DIFF
--- a/resources/definitions/config_definitions.json
+++ b/resources/definitions/config_definitions.json
@@ -5757,7 +5757,6 @@
                         {"match": "ciscosb", "value": "ciscosmb"},
                         {"match": "f5", "value": "tmos"},
                         {"match": "fireware", "value": "firewareos"},
-                        {"match": "fortigate", "value": "fortios"},
                         {"match": "fortiswitch", "value": "fortios"},
                         {"match": "siklu-mhtg", "value": "siklumhtg"},
                         {"match": "vyos", "value": "vyatta"},


### PR DESCRIPTION
In a recent update, the FortiGate and FortiOS models have been split up in Oxidized. This means that the default override isn't needed anymore.

This will cause oxidized backups to fail if you use fortigate devices but haven't updated Oxidized to 0.36.0. If you need to restore functionality then please run:

`lnms config:set oxidized.maps.os.os.+ '{"match": "fortigate", "value": "fortios"}'`

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [X] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
