### PR TITLE
Fix uninitialized variables in smokeping graph templates

### DIFF
--- a/includes/html/graphs/device/smokeping_all_common.inc.php
+++ b/includes/html/graphs/device/smokeping_all_common.inc.php
@@ -21,6 +21,8 @@ if ($width > '500') {
     $descr_len = (12 + round(($width - 275) / 8));
 }
 
+$unit_text ??= '';
+
 if ($width > '500') {
     $rrd_options[] = 'COMMENT:' . substr(str_pad((string) $unit_text, $descr_len + 5), 0, $descr_len + 5) . " RTT      Loss    SDev   RTT\:SDev\l";
 } else {
@@ -49,7 +51,7 @@ foreach ($smokeping_files[$direction][$device['hostname']] as $source => $filena
         $rrd_options[] = 'CDEF:p' . $i . 'p' . $p . '=pin' . $i . 'p' . $p . ',UN,0,pin' . $i . 'p' . $p . ',IF';
     }
 
-    unset($pings_options, $m_options, $sdev_options);
+    $pings_options = $m_options = $sdev_options = '';
 
     foreach (range(2, $pings) as $p) {
         $pings_options .= ',p' . $i . 'p' . $p . ',UN,+';

--- a/includes/html/graphs/device/smokeping_all_common_avg.inc.php
+++ b/includes/html/graphs/device/smokeping_all_common_avg.inc.php
@@ -21,12 +21,16 @@ if ($width > '500') {
     $descr_len = (12 + round(($width - 275) / 8));
 }
 
+$unit_text ??= '';
+
 // FIXME str_pad really needs a "limit to length" so we can rid of all the substrs all over the code to limit the length as below...
 if ($width > '500') {
     $rrd_options[] = 'COMMENT:' . substr(str_pad((string) $unit_text, $descr_len + 5), 0, $descr_len + 5) . " RTT      Loss    SDev   RTT\:SDev\l";
 } else {
     $rrd_options[] = 'COMMENT:' . substr(str_pad((string) $unit_text, $descr_len + 5), 0, $descr_len + 5) . " RTT      Loss    SDev   RTT\:SDev\l";
 }
+
+$dm_list = $sd_list = $ploss_list = '';
 
 foreach ($smokeping_files[$direction][$device['hostname']] as $source => $filename) {
     if (! LibrenmsConfig::has("graph_colours.$colourset.$iter")) {
@@ -52,7 +56,7 @@ foreach ($smokeping_files[$direction][$device['hostname']] as $source => $filena
         $rrd_options[] = 'CDEF:p' . $i . 'p' . $p . '=pin' . $i . 'p' . $p . ',UN,0,pin' . $i . 'p' . $p . ',IF';
     }
 
-    unset($pings_options, $m_options, $sdev_options);
+    $pings_options = $m_options = $sdev_options = '';
 
     foreach (range(2, $pings) as $p) {
         $pings_options .= ',p' . $i . 'p' . $p . ',UN,+';

--- a/includes/html/graphs/smokeping/in.inc.php
+++ b/includes/html/graphs/smokeping/in.inc.php
@@ -23,6 +23,8 @@ if ($width > '500') {
     $descr_len = (12 + round(($width - 275) / 8));
 }
 
+$unit_text ??= '';
+
 if ($width > '500') {
     $rrd_options[] = 'COMMENT:' . substr(str_pad((string) $unit_text, $descr_len + 5), 0, $descr_len + 5) . " RTT      Loss    SDev   RTT\:SDev                              \l";
 } else {
@@ -64,7 +66,7 @@ foreach (range(1, $pings) as $p) {
     $rrd_options[] = 'CDEF:p' . $i . 'p' . $p . '=pin' . $i . 'p' . $p . ',UN,0,pin' . $i . 'p' . $p . ',IF';
 }
 
-unset($pings_options, $m_options, $sdev_options);
+$pings_options = $m_options = $sdev_options = '';
 
 foreach (range(2, $pings) as $p) {
     $pings_options .= ',p' . $i . 'p' . $p . ',UN,+';

--- a/includes/html/graphs/smokeping/out.inc.php
+++ b/includes/html/graphs/smokeping/out.inc.php
@@ -23,6 +23,8 @@ if ($width > '500') {
     $descr_len = (12 + round(($width - 275) / 8));
 }
 
+$unit_text ??= '';
+
 if ($width > '500') {
     $rrd_options[] = 'COMMENT:' . substr(str_pad((string) $unit_text, $descr_len + 5), 0, $descr_len + 5) . " RTT      Loss    SDev   RTT\:SDev                              \l";
 } else {
@@ -64,7 +66,7 @@ foreach (range(1, $pings) as $p) {
     $rrd_options[] = 'CDEF:p' . $i . 'p' . $p . '=pin' . $i . 'p' . $p . ',UN,0,pin' . $i . 'p' . $p . ',IF';
 }
 
-unset($pings_options, $m_options, $sdev_options);
+$pings_options = $m_options = $sdev_options = '';
 
 foreach (range(2, $pings) as $p) {
     $pings_options .= ',p' . $i . 'p' . $p . ',UN,+';


### PR DESCRIPTION
Found PHP undefined variable warnings while I was working on a smokeping UI issue. Smokeping graphs failed to render on a device's latency tab while in debug mode as well. This is similar to PR #19489 and #19490.

Initialized `$unit_text`
Initialized `$dm_list`, `$sd_list`, and `$ploss_list` before the foreach loop
Set `$pings_options`, `$m_options`, and `$sdev_options` to an empty string and removed the unset()

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [-] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [-] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
