### PR TITLE
bgp: fix 4-byte local ASN detection (AS_TRANS 23456) using vendor MIBs

### DIFF
--- a/includes/discovery/bgp-peers.inc.php
+++ b/includes/discovery/bgp-peers.inc.php
@@ -16,6 +16,27 @@ if (empty($bgpLocalAs)) {
     $bgpLocalAs = \SnmpQuery::get('BGP4-MIB::bgpLocalAs.0')->value();
 }
 
+if (!empty($bgpLocalAs) && $bgpLocalAs == "23456") { // 4Byte ASN
+	if ($device['os_group'] === 'arista') {
+        $entries = \SnmpQuery::walk('ARISTA-BGP4V2-MIB::aristaBgp4V2PeerLocalAs')->values();
+        if (!empty($entries)) {
+    	    $bgpLocalAs = reset($entries);
+        }
+	} elseif ($device['os'] == 'junos') {
+        $entries = \SnmpQuery::walk('BGP4-V2-MIB-JUNIPER::jnxBgpM2PeerLocalAs')->values();
+        if (!empty($entries)) {
+    	    $bgpLocalAs = reset($entries);
+        }
+	} elseif ($device['os_group'] === 'cisco') {
+        $entries = \SnmpQuery::walk('CISCO-BGP4-MIB::cbgpPeer2LocalAs')->values();
+        if (!empty($entries)) {
+    	    $bgpLocalAs = reset($entries);
+        }
+	} elseif ($device['os'] === 'cumulus') {
+        $bgpLocalAs = \SnmpQuery::get('CUMULUS-BGPUN-MIB::bgpLocalAs.0')->value(); 
+	}
+}
+
 foreach (DeviceCache::getPrimary()->getVrfContexts() as $context_name) {
     $device['context_name'] = $context_name;
     $peer2 = false;


### PR DESCRIPTION
LibreNMS relies on BGP4-MIB::bgpLocalAs to determine the local ASN, which only supports 2-byte ASNs. When devices use 4-byte ASNs, this value is reported as AS_TRANS (23456), causing incorrect detection of iBGP/eBGP relationships.

This patch detects AS_TRANS (23456) and retrieves the correct local ASN using vendor-specific MIBs where available:

- Arista EOS: ARISTA-BGP4V2-MIB::aristaBgp4V2PeerLocalAs
- Juniper:    BGP4-V2-MIB-JUNIPER::jnxBgpM2PeerLocalAs
- Cisco:      CISCO-BGP4-MIB::cbgpPeer2LocalAs
- Cumulus:    CUMULUS-BGPUN-MIB::bgpLocalAs

Since some vendor OIDs expose per-peer values, the first available entry is used as the device local ASN.

This ensures correct handling of 4-byte ASNs and fixes incorrect classification of iBGP sessions as eBGP in the UI.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
