### PR TITLE
DNOS: Add Stack Port Link status

### DIFF
--- a/resources/definitions/os_discovery/dnos.yaml
+++ b/resources/definitions/os_discovery/dnos.yaml
@@ -236,3 +236,13 @@ modules:
                         - { value: 0, descr: 'Standalone', generic: 3 }
                         - { value: 1, descr: 'Primary', generic: 0 }
                         - { value: 2, descr: 'Secondary', generic: 0 }
+                -
+                    oid: DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortTable
+                    value: DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortLinkStatus
+                    num_oid: '.1.3.6.1.4.1.6027.3.26.1.3.5.1.4.{{ $index }}'
+                    descr: 'Port {{ $index }}'
+                    group: 'Stack'
+                    state_name: dellNetStackPortLinkStatus
+                    states:
+                        - { value: 1, descr: 'up', generic: 0 }
+                        - { value: 2, descr: 'down', generic: 2 }


### PR DESCRIPTION
There would be more information. Does is more make sense to create a port for this or just this sensor?

I see a problem that the output of this walk is from a running system and there is no DataRate...

```
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortIndex.1.49 = INTEGER: 49
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortIndex.1.53 = INTEGER: 53
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortIndex.2.49 = INTEGER: 49
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortIndex.2.53 = INTEGER: 53
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortIndex.3.49 = INTEGER: 49
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortIndex.3.53 = INTEGER: 53
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortIndex.4.49 = INTEGER: 49
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortIndex.4.53 = INTEGER: 53
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortConfiguredMode.1.49 = INTEGER: stack(1)
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortConfiguredMode.1.53 = INTEGER: stack(1)
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortConfiguredMode.2.49 = INTEGER: stack(1)
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortConfiguredMode.2.53 = INTEGER: stack(1)
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortConfiguredMode.3.49 = INTEGER: stack(1)
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortConfiguredMode.3.53 = INTEGER: stack(1)
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortConfiguredMode.4.49 = INTEGER: stack(1)
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortConfiguredMode.4.53 = INTEGER: stack(1)
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortRunningMode.1.49 = INTEGER: stack(1)
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortRunningMode.1.53 = INTEGER: stack(1)
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortRunningMode.2.49 = INTEGER: stack(1)
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortRunningMode.2.53 = INTEGER: stack(1)
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortRunningMode.3.49 = INTEGER: stack(1)
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortRunningMode.3.53 = INTEGER: stack(1)
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortRunningMode.4.49 = INTEGER: stack(1)
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortRunningMode.4.53 = INTEGER: stack(1)
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortLinkStatus.1.49 = INTEGER: up(1)
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortLinkStatus.1.53 = INTEGER: up(1)
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortLinkStatus.2.49 = INTEGER: up(1)
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortLinkStatus.2.53 = INTEGER: up(1)
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortLinkStatus.3.49 = INTEGER: down(2)
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortLinkStatus.3.53 = INTEGER: up(1)
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortLinkStatus.4.49 = INTEGER: up(1)
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortLinkStatus.4.53 = INTEGER: down(2)
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortLinkSpeed.1.49 = Gauge32: 40
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortLinkSpeed.1.53 = Gauge32: 40
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortLinkSpeed.2.49 = Gauge32: 40
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortLinkSpeed.2.53 = Gauge32: 40
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortLinkSpeed.3.49 = Gauge32: 40
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortLinkSpeed.3.53 = Gauge32: 40
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortLinkSpeed.4.49 = Gauge32: 40
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortLinkSpeed.4.53 = Gauge32: 40
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortRxDataRate.1.49 = Counter32: 0
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortRxDataRate.1.53 = Counter32: 0
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortRxDataRate.2.49 = Counter32: 0
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortRxDataRate.2.53 = Counter32: 0
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortRxDataRate.3.49 = Counter32: 0
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortRxDataRate.3.53 = Counter32: 0
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortRxDataRate.4.49 = Counter32: 0
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortRxDataRate.4.53 = Counter32: 0
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortRxErrorRate.1.49 = Counter32: 0
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortRxErrorRate.1.53 = Counter32: 0
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortRxErrorRate.2.49 = Counter32: 0
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortRxErrorRate.2.53 = Counter32: 0
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortRxErrorRate.3.49 = Counter32: 0
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortRxErrorRate.3.53 = Counter32: 0
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortRxErrorRate.4.49 = Counter32: 0
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortRxErrorRate.4.53 = Counter32: 0
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortRxTotalErrors.1.49 = Counter32: 0
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortRxTotalErrors.1.53 = Counter32: 0
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortRxTotalErrors.2.49 = Counter32: 0
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortRxTotalErrors.2.53 = Counter32: 0
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortRxTotalErrors.3.49 = Counter32: 0
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortRxTotalErrors.3.53 = Counter32: 0
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortRxTotalErrors.4.49 = Counter32: 0
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortRxTotalErrors.4.53 = Counter32: 0
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortTxDataRate.1.49 = Counter32: 0
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortTxDataRate.1.53 = Counter32: 0
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortTxDataRate.2.49 = Counter32: 0
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortTxDataRate.2.53 = Counter32: 0
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortTxDataRate.3.49 = Counter32: 0
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortTxDataRate.3.53 = Counter32: 0
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortTxDataRate.4.49 = Counter32: 0
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortTxDataRate.4.53 = Counter32: 0
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortTxErrorRate.1.49 = Counter32: 0
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortTxErrorRate.1.53 = Counter32: 0
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortTxErrorRate.2.49 = Counter32: 0
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortTxErrorRate.2.53 = Counter32: 0
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortTxErrorRate.3.49 = Counter32: 0
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortTxErrorRate.3.53 = Counter32: 0
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortTxErrorRate.4.49 = Counter32: 0
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortTxErrorRate.4.53 = Counter32: 0
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortTxTotalErrors.1.49 = Counter32: 0
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortTxTotalErrors.1.53 = Counter32: 0
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortTxTotalErrors.2.49 = Counter32: 0
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortTxTotalErrors.2.53 = Counter32: 0
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortTxTotalErrors.3.49 = Counter32: 0
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortTxTotalErrors.3.53 = Counter32: 0
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortTxTotalErrors.4.49 = Counter32: 0
DELL-NETWORKING-CHASSIS-MIB::dellNetStackPortTxTotalErrors.4.53 = Counter32: 0
```




Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
