### PR TITLE
device(pmp): extend yaml-discovery with operational PMP 450 SNMP sensors

### DIFF
--- a/resources/definitions/os_discovery/pmp.yaml
+++ b/resources/definitions/os_discovery/pmp.yaml
@@ -20,3 +20,87 @@ modules:
                         - { value: 1, generic: 0, descr: gpsSynchronized }
                         - { value: 2, generic: 2, descr: gpsLostSync }
                         - { value: 3, generic: 0, descr: generatingSync }
+        count:
+            data:
+                # AP — registered SMs
+                -
+                    oid: WHISP-APS-MIB::regCount
+                    num_oid: '.1.3.6.1.4.1.161.19.3.1.7.1.0'
+                    index: 0
+                    descr: 'Registered SMs'
+                # AP — registration failures since boot
+                -
+                    oid: WHISP-APS-MIB::regFailureCount
+                    num_oid: '.1.3.6.1.4.1.161.19.3.1.7.32.0'
+                    index: 1
+                    descr: 'Registration Failures'
+                # AP — virtual circuit count
+                -
+                    oid: WHISP-APS-MIB::vcCount
+                    num_oid: '.1.3.6.1.4.1.161.19.3.1.7.39.0'
+                    index: 2
+                    descr: 'VC Count'
+                # AP — invalid packet discards
+                -
+                    oid: WHISP-APS-MIB::invalidPacketDiscards
+                    num_oid: '.1.3.6.1.4.1.161.19.3.1.7.54.0'
+                    index: 3
+                    descr: 'Invalid Packet Discards'
+                # SM — TX power adjustment count
+                -
+                    oid: WHISP-SM-MIB::rfStatPowerAdjustmentCount
+                    num_oid: '.1.3.6.1.4.1.161.19.3.2.2.161.0'
+                    index: 4
+                    descr: 'TX Power Adjustments'
+                # SM — scan cycles
+                -
+                    oid: WHISP-SM-MIB::scanCycleCount
+                    num_oid: '.1.3.6.1.4.1.161.19.3.2.2.147.0'
+                    index: 5
+                    descr: 'Scan Cycles'
+        percent:
+            data:
+                # SM — beacons received
+                -
+                    oid: WHISP-SM-MIB::beaconsPercentReceived
+                    num_oid: '.1.3.6.1.4.1.161.19.3.2.2.139.0'
+                    index: 0
+                    descr: 'Beacons Received %'
+                # SM — MAPs received
+                -
+                    oid: WHISP-SM-MIB::mapsPercentReceived
+                    num_oid: '.1.3.6.1.4.1.161.19.3.2.2.140.0'
+                    index: 1
+                    descr: 'MAPs Received %'
+                # AP — failed-SM percent
+                -
+                    oid: WHISP-APS-MIB::failedSmPercent
+                    num_oid: '.1.3.6.1.4.1.161.19.3.1.7.51.0'
+                    index: 2
+                    descr: 'Failed SM %'
+        delay:
+            data:
+                # SM — air delay (round-trip ns; divide by 6.6713 for metres)
+                -
+                    oid: WHISP-SM-MIB::airDelayns
+                    num_oid: '.1.3.6.1.4.1.161.19.3.2.2.64.0'
+                    index: 0
+                    descr: 'Air Delay (round-trip ns)'
+        signal:
+            data:
+                # SM — running-average RSSI (radioDbmInt is already covered by
+                # Pmp.php discoverWirelessRssi(); add the average flavour here)
+                -
+                    oid: WHISP-SM-MIB::radioDbmAvg
+                    num_oid: '.1.3.6.1.4.1.161.19.3.2.2.61.0'
+                    index: 0
+                    descr: 'Cambium RSSI Avg'
+        frequency:
+            data:
+                # SM — current channel frequency (kHz → MHz)
+                -
+                    oid: WHISP-SM-MIB::currentChanFreq
+                    num_oid: '.1.3.6.1.4.1.161.19.3.2.2.67.0'
+                    index: 0
+                    descr: 'SM Channel Frequency'
+                    divisor: 1000


### PR DESCRIPTION
## What's done

Extends `resources/definitions/os_discovery/pmp.yaml` to record additional scalar metrics from `WHISP-APS-MIB` and `WHISP-SM-MIB` that operators running Cambium PMP 450 / 450b / 450m want graphed and alertable.

Currently the file captures only chassis temperature and AP-side GPS sync. This PR adds 12 sensors across `count`, `percent`, `delay`, `signal`, `frequency` classes.

## Sensors added

### `count`
- `WHISP-APS-MIB::regCount` — registered SMs on this AP
- `WHISP-APS-MIB::regFailureCount` — registration failures since boot
- `WHISP-APS-MIB::vcCount` — virtual-circuit count
- `WHISP-APS-MIB::invalidPacketDiscards`
- `WHISP-SM-MIB::rfStatPowerAdjustmentCount`
- `WHISP-SM-MIB::scanCycleCount`

### `percent`
- `WHISP-SM-MIB::beaconsPercentReceived` — beacons RX (SM perspective)
- `WHISP-SM-MIB::mapsPercentReceived` — MAPs RX (SM perspective)
- `WHISP-APS-MIB::failedSmPercent`

### `delay`
- `WHISP-SM-MIB::airDelayns` — round-trip ns to AP. Divide by 6.6713 in the graph for metres. (LibreNMS yaml-discovery does not have a `distance` class.)

### `signal`
- `WHISP-SM-MIB::radioDbmAvg` — running-average RX dBm. Note that the instantaneous `radioDbmInt` is already covered by `Pmp.php::discoverWirelessRssi()`.

### `frequency`
- `WHISP-SM-MIB::currentChanFreq` — SM-perspective channel frequency, divisor 1000 (kHz → MHz).

## Why scalar `num_oid` instead of `{{ \$index }}` template

These are all scalar OIDs ending in `.0`. To register multiple rows in the same sensor class, each row needs a unique `index:` field (sensor_index in DB) — not a unique numeric OID instance. So the OID is hardcoded with `.0` and `index:` numbers the entries 0..N within the class.

## Test plan

- [x] Validate yaml syntax loads without error: `lnms device:discover <ap>` and `lnms device:discover <sm>` complete successfully.
- [x] Confirm AP-side OIDs return data on a PMP 450m sector AP running CANOPY 24.2.2 (sample: `regCount=39`, `failedSmPercent=5`, `regFailureCount=0`, `vcCount=39`, `invalidPacketDiscards=0`).
- [x] Confirm SM-side OIDs return data on a PMP 450b SM running CANOPY 24.2.2 (sample: `radioDbmAvg=-71`, `beaconsPercentReceived=100`, `mapsPercentReceived=100`, `airDelayns=108800` ≈ 16.3 km, `currentChanFreq=3310000` kHz, `rfStatPowerAdjustmentCount=4153`, `scanCycleCount=5`).
- [x] APs ignore SM-only OIDs and SMs ignore AP-only OIDs (LibreNMS prunes `noSuchObject` returns silently).
- [x] No change to existing `temperature` and `state` sensors.
- [x] Re-discovered fleet of 64 PMP devices (61 active) — all sensors populate as expected.

## Related

- Issue librenms/librenms#15928 (open) — request for additional PMP sensors.
- Forum thread librenms/librenms.community/26430 — request for richer Cambium 450 MIB coverage.
- Previous related PRs touched only `Pmp.php` Wireless* classes; this PR keeps the change yaml-only and additive.

## Risk

- **Low.** Yaml-only change, no PHP touch.
- Adds ~14 sensors per device. Negligible additional SNMP and RRD overhead.
- Backward compatible: any device whose firmware does not expose a given OID is silently skipped (existing LibreNMS yaml-discovery behaviour).