### PR TITLE
Add check_zone_rrsig_expiration override

### DIFF
--- a/includes/services/check_zone_rrsig_expiration.inc.php
+++ b/includes/services/check_zone_rrsig_expiration.inc.php
@@ -1,0 +1,3 @@
+<?php
+
+$check_cmd = \App\Facades\LibrenmsConfig::get('nagios_plugins') . '/check_zone_rrsig_expiration ' . $service['service_param'];


### PR DESCRIPTION
The nagios plugin check_zone_rrsig_expiration does not have a -H option. Therefore trying to add this service to LibreNMS fails with the following error:
```
Request:  '/usr/lib/nagios/plugins/check_zone_rrsig_expiration' '-H' 'REMOTE_HOST' '-Z' 'ZONE'  
Unknown option: H
usage: /usr/lib/nagios/plugins/check_zone_rrsig_expiration -Z zone -d -t timeout -W days -C days
	-Z zone		zone to test
	-T type		query type (default SOA)
	-d 		debug
	-t seconds	timeout on DNS queries
	-W days		warning threshhold
	-C days		critical threshold
	-4		use IPv4 only
	-U bytes	EDNS0 UDP buffer size (default 4096)
```

This commit adds an override to remove the -H option from automatically being added.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
