### PR TITLE
Add check_zone_auth override

### DIFF
--- a/includes/services/check_zone_auth.inc.php
+++ b/includes/services/check_zone_auth.inc.php
@@ -1,0 +1,3 @@
+<?php
+
+$check_cmd = \App\Facades\LibrenmsConfig::get('nagios_plugins') . '/check_zone_auth ' . $service['service_param'];


### PR DESCRIPTION
The nagios plugin check_zone_auth does not have a -H option. Therefore adding this check to a device in LibreNMS fails without an override:
```
Request:  '/usr/lib/nagios/plugins/check_zone_auth' '-H' 'REMOTE_HOST' '-Z' 'ZONE'  
Unknown option: H
usage: /usr/lib/nagios/plugins/check_zone_auth -Z zone [-N ns1,ns2,ns3]
	-Z specifies the zone to test
	-N optionally specifies the expected NS RRset
```

This commit adds an override to remove the -H option from automatically being added.

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
