### PR TITLE
Auto-discover next-hop gateways as pingonly child devices

### DIFF
--- a/LibreNMS/Modules/DiscoveryNextHops.php
+++ b/LibreNMS/Modules/DiscoveryNextHops.php
@@ -58,6 +58,8 @@ class DiscoveryNextHops implements Module
 
     /**
      * @inheritDoc
+     *
+     * @return array<string>
      */
     public function dependencies(): array
     {
@@ -136,6 +138,7 @@ class DiscoveryNextHops implements Module
     /**
      * Filter the device's routes table down to interesting next-hops.
      *
+     * @param  array<string>  $extra_supernets  CIDR strings to also consider beyond the default route
      * @return array<string, array{route: \App\Models\Route, is_default: bool}>
      */
     private function collectCandidates(Device $device, bool $only_default, array $extra_supernets): array
@@ -179,6 +182,8 @@ class DiscoveryNextHops implements Module
 
     /**
      * Create a new pingonly device for this next-hop and link it to its parent.
+     *
+     * @param  array{route: \App\Models\Route, is_default: bool}  $meta
      */
     private function createPingonlyHop(string $hop_ip, array $meta, Device $parent): bool
     {
@@ -278,6 +283,8 @@ class DiscoveryNextHops implements Module
 
     /**
      * @inheritDoc
+     *
+     * @return array<string, mixed>|null
      */
     public function dump(Device $device, string $type): ?array
     {

--- a/LibreNMS/Modules/DiscoveryNextHops.php
+++ b/LibreNMS/Modules/DiscoveryNextHops.php
@@ -37,6 +37,8 @@ use App\Models\Eventlog;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
 use LibreNMS\Enum\Severity;
+use LibreNMS\Exceptions\HostExistsException;
+use LibreNMS\Exceptions\HostUnreachableException;
 use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Module;
 use LibreNMS\OS;
@@ -110,10 +112,12 @@ class DiscoveryNextHops implements Module
                 continue;
             }
 
-            // If the hop is already a monitored device, just ensure parent linkage
-            $existing = Device::where('hostname', $hop_ip)
-                ->orWhere('overwrite_ip', $hop_ip)
-                ->first();
+            // If the hop matches any already-monitored device — by hostname,
+            // by primary IP, or by any of its interface IPs — just ensure
+            // parent linkage. Device::findByIp() walks ipv4_addresses /
+            // ipv6_addresses, so this catches the "next-hop is core-router's
+            // eth0" case that hostname-only matching misses.
+            $existing = Device::findByIp($hop_ip);
 
             if ($existing) {
                 if ($this->ensureParentRelationship($existing, $device)) {
@@ -123,8 +127,7 @@ class DiscoveryNextHops implements Module
                 continue;
             }
 
-            // Create new pingonly device
-            if ($this->createPingonlyHop($hop_ip, $meta, $device)) {
+            if ($this->createDiscoveredHop($hop_ip, $meta, $device)) {
                 $created++;
             }
         }
@@ -181,11 +184,20 @@ class DiscoveryNextHops implements Module
     }
 
     /**
-     * Create a new pingonly device for this next-hop and link it to its parent.
+     * Create a new device for this next-hop and link it to its parent.
+     *
+     * Two modes:
+     *   - Default route (WAN gateway): pingonly with force=true. Public IPs
+     *     aren't in `nets` and rarely speak SNMP, so we skip those checks
+     *     and create the device directly.
+     *   - Internal supernet next-hop: SNMP-first with ping_fallback=true.
+     *     Respects `nets`, attempts SNMP credential discovery, falls back
+     *     to pingonly if SNMP fails. Lets manageable internal routers get
+     *     fully discovered instead of stub pingonly entries.
      *
      * @param  array{route: \App\Models\Route, is_default: bool}  $meta
      */
-    private function createPingonlyHop(string $hop_ip, array $meta, Device $parent): bool
+    private function createDiscoveredHop(string $hop_ip, array $meta, Device $parent): bool
     {
         $route = $meta['route'];
         $is_default = $meta['is_default'];
@@ -199,21 +211,37 @@ class DiscoveryNextHops implements Module
                 $parent->hostname
             );
 
-        $newDevice = new Device([
-            'hostname' => $hop_ip,
-            'snmp_disable' => 1,
-            'os' => 'ping',
-            'sysName' => $sysName,
-            'type' => 'firewall',
-        ]);
+        if ($is_default) {
+            $newDevice = new Device([
+                'hostname' => $hop_ip,
+                'snmp_disable' => 1,
+                'os' => 'ping',
+                'sysName' => $sysName,
+                'type' => 'firewall',
+            ]);
+            $force = true;
+            $ping_fallback = false;
+        } else {
+            // Internal next-hop — try SNMP first, let LibreNMS auto-detect OS
+            $newDevice = new Device([
+                'hostname' => $hop_ip,
+                'sysName' => $sysName,
+            ]);
+            $force = false;
+            $ping_fallback = true;
+        }
 
         try {
-            $action = new ValidateDeviceAndCreate($newDevice, force: true);
+            $action = new ValidateDeviceAndCreate($newDevice, force: $force, ping_fallback: $ping_fallback);
             if (! $action->execute()) {
                 Log::debug("next-hop $hop_ip: creation no-op (already exists)");
 
                 return false;
             }
+        } catch (HostExistsException|HostUnreachableException $e) {
+            Log::info("next-hop $hop_ip: skipped — " . $e->getMessage());
+
+            return false;
         } catch (\Throwable $e) {
             Log::warning("next-hop $hop_ip: creation failed: " . $e->getMessage());
 
@@ -226,10 +254,14 @@ class DiscoveryNextHops implements Module
             $this->ensureParentRelationship($persisted, $parent);
         }
 
+        $kind = ($persisted && ! $persisted->snmp_disable)
+            ? sprintf('SNMP-managed (%s)', $persisted->os)
+            : 'pingonly';
+
         Eventlog::log(
             sprintf(
-                'Next-hop discovery: added %s as pingonly child of %s (%s)',
-                $hop_ip, $parent->hostname, $sysName
+                'Next-hop discovery: added %s as %s child of %s (%s)',
+                $hop_ip, $kind, $parent->hostname, $sysName
             ),
             $parent->device_id,
             'discovery',

--- a/LibreNMS/Modules/DiscoveryNextHops.php
+++ b/LibreNMS/Modules/DiscoveryNextHops.php
@@ -1,0 +1,286 @@
+<?php
+
+/**
+ * DiscoveryNextHops.php
+ *
+ * Auto-creates pingonly child devices, one per "interesting" next-hop
+ * found in a monitored device's routing table. Default route by default
+ * (the ISP / WAN gateway), plus optional user-flagged supernets for
+ * internal routers.
+ *
+ * Depends on the existing `route` discovery module: that module already
+ * walks IP-FORWARD-MIB::inetCidrRouteTable (and friends) and persists the
+ * data to the `routes` table. We just consume what's already there.
+ *
+ * Each newly-discovered next-hop:
+ *   - is added as a pingonly device (snmp_disable=1, os=ping),
+ *   - has the discovering device set as its parent (device_relationships),
+ *   - so failures propagate cleanly via existing dependency-aware alerting.
+ *
+ * Why this matters: today, when an ISP gateway becomes unreachable, the
+ * monitored router itself stays "up" in LibreNMS — the dashboard shows
+ * green while no traffic actually leaves the network. This module makes
+ * each next-hop a first-class monitored entity.
+ *
+ * @link       https://www.librenms.org
+ *
+ * @copyright  2026 Kamil Bienkiewicz
+ * @author     Kamil Bienkiewicz
+ */
+
+namespace LibreNMS\Modules;
+
+use App\Actions\Device\ValidateDeviceAndCreate;
+use App\Facades\LibrenmsConfig;
+use App\Models\Device;
+use App\Models\Eventlog;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+use LibreNMS\Enum\Severity;
+use LibreNMS\Interfaces\Data\DataStorageInterface;
+use LibreNMS\Interfaces\Module;
+use LibreNMS\OS;
+use LibreNMS\Polling\ModuleStatus;
+
+class DiscoveryNextHops implements Module
+{
+    /** Route type 4 = remote (per IANA / IP-FORWARD-MIB::inetCidrRouteType) */
+    private const ROUTE_TYPE_REMOTE = 4;
+
+    /** Sentinel "no next-hop" addresses we filter out */
+    private const NULL_HOPS = ['0.0.0.0', '::', '0:0:0:0:0:0:0:0'];
+
+    /** Sentinel default-route destinations */
+    private const DEFAULT_DESTS = ['0.0.0.0', '::', '0:0:0:0:0:0:0:0'];
+
+    /** Per-IP discovery debounce (seconds) — same pattern as DiscoveryArp */
+    private const DEBOUNCE_TTL = 3600;
+
+    /**
+     * @inheritDoc
+     */
+    public function dependencies(): array
+    {
+        return ['route'];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function shouldDiscover(OS $os, ModuleStatus $status): bool
+    {
+        return $status->isEnabledAndDeviceUp($os->getDevice());
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function shouldPoll(OS $os, ModuleStatus $status): bool
+    {
+        return false;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function discover(OS $os): void
+    {
+        $device = $os->getDevice();
+        $only_default = (bool) LibrenmsConfig::get('autodiscovery.discovery-next-hops.only-default-route', true);
+        $extra_supernets = (array) LibrenmsConfig::get('autodiscovery.discovery-next-hops.supernets', []);
+
+        $candidates = $this->collectCandidates($device, $only_default, $extra_supernets);
+
+        Log::info(sprintf(
+            'Found %d next-hop candidate(s) on %s',
+            count($candidates), $device->hostname
+        ));
+
+        $created = 0;
+        $linked = 0;
+        $skipped_existing = 0;
+        $skipped_debounced = 0;
+
+        foreach ($candidates as $hop_ip => $meta) {
+            // Per-IP debounce: don't re-evaluate the same hop more than once per hour
+            if (! Cache::add('next_hops_discovery:' . $hop_ip, true, self::DEBOUNCE_TTL)) {
+                $skipped_debounced++;
+                continue;
+            }
+
+            // If the hop is already a monitored device, just ensure parent linkage
+            $existing = Device::where('hostname', $hop_ip)
+                ->orWhere('overwrite_ip', $hop_ip)
+                ->first();
+
+            if ($existing) {
+                if ($this->ensureParentRelationship($existing, $device)) {
+                    $linked++;
+                }
+                $skipped_existing++;
+                continue;
+            }
+
+            // Create new pingonly device
+            if ($this->createPingonlyHop($hop_ip, $meta, $device)) {
+                $created++;
+            }
+        }
+
+        Log::info(sprintf(
+            '  Next-hops: %d new, %d already-existing (linked: %d), %d debounced',
+            $created, $skipped_existing, $linked, $skipped_debounced
+        ));
+    }
+
+    /**
+     * Filter the device's routes table down to interesting next-hops.
+     *
+     * @return array<string, array{route: \App\Models\Route, is_default: bool}>
+     */
+    private function collectCandidates(Device $device, bool $only_default, array $extra_supernets): array
+    {
+        $candidates = [];
+
+        $routes = $device->routes()
+            ->where('inetCidrRouteType', self::ROUTE_TYPE_REMOTE)
+            ->get();
+
+        foreach ($routes as $route) {
+            $hop = $route->inetCidrRouteNextHop;
+            if (in_array($hop, self::NULL_HOPS, true)) {
+                continue;
+            }
+
+            $is_default = in_array($route->inetCidrRouteDest, self::DEFAULT_DESTS, true)
+                       && (int) $route->inetCidrRoutePfxLen === 0;
+
+            if (! $is_default) {
+                if ($only_default) {
+                    $supernet = $route->inetCidrRouteDest . '/' . $route->inetCidrRoutePfxLen;
+                    if (! in_array($supernet, $extra_supernets, true)) {
+                        continue;
+                    }
+                }
+            }
+
+            // Keep only one entry per unique next-hop IP. Prefer the default route
+            // if both default and non-default share the same next-hop.
+            if (! isset($candidates[$hop]) || $is_default) {
+                $candidates[$hop] = [
+                    'route' => $route,
+                    'is_default' => $is_default,
+                ];
+            }
+        }
+
+        return $candidates;
+    }
+
+    /**
+     * Create a new pingonly device for this next-hop and link it to its parent.
+     */
+    private function createPingonlyHop(string $hop_ip, array $meta, Device $parent): bool
+    {
+        $route = $meta['route'];
+        $is_default = $meta['is_default'];
+
+        $sysName = $is_default
+            ? sprintf('Internet via %s', $parent->hostname)
+            : sprintf(
+                'Network %s/%s via %s',
+                $route->inetCidrRouteDest,
+                $route->inetCidrRoutePfxLen,
+                $parent->hostname
+            );
+
+        $newDevice = new Device([
+            'hostname' => $hop_ip,
+            'snmp_disable' => 1,
+            'os' => 'ping',
+            'sysName' => $sysName,
+            'type' => 'firewall',
+        ]);
+
+        try {
+            $action = new ValidateDeviceAndCreate($newDevice, force: true);
+            if (! $action->execute()) {
+                Log::debug("next-hop $hop_ip: creation no-op (already exists)");
+
+                return false;
+            }
+        } catch (\Throwable $e) {
+            Log::warning("next-hop $hop_ip: creation failed: " . $e->getMessage());
+
+            return false;
+        }
+
+        // Re-fetch the persisted Device so we have its device_id for parent linkage
+        $persisted = Device::where('hostname', $hop_ip)->first();
+        if ($persisted) {
+            $this->ensureParentRelationship($persisted, $parent);
+        }
+
+        Eventlog::log(
+            sprintf(
+                "Next-hop discovery: added %s as pingonly child of %s (%s)",
+                $hop_ip, $parent->hostname, $sysName
+            ),
+            $parent->device_id,
+            'discovery',
+            Severity::Notice
+        );
+
+        return true;
+    }
+
+    /**
+     * Make sure $child's parents() includes $parent. Idempotent.
+     *
+     * @return bool true if a new attachment was created, false if already linked
+     */
+    private function ensureParentRelationship(Device $child, Device $parent): bool
+    {
+        if ($child->device_id === $parent->device_id) {
+            return false;
+        }
+        if ($child->parents()->where('parent_device_id', $parent->device_id)->exists()) {
+            return false;
+        }
+        $child->parents()->attach($parent->device_id);
+
+        return true;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function poll(OS $os, DataStorageInterface $datastore): void
+    {
+        // no polling — pingonly children are polled by the standard ICMP path
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function dataExists(Device $device): bool
+    {
+        return false;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function cleanup(Device $device): int
+    {
+        return 0;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function dump(Device $device, string $type): ?array
+    {
+        return null;
+    }
+}

--- a/LibreNMS/Modules/DiscoveryNextHops.php
+++ b/LibreNMS/Modules/DiscoveryNextHops.php
@@ -228,7 +228,7 @@ class DiscoveryNextHops implements Module
 
         Eventlog::log(
             sprintf(
-                "Next-hop discovery: added %s as pingonly child of %s (%s)",
+                'Next-hop discovery: added %s as pingonly child of %s (%s)',
                 $hop_ip, $parent->hostname, $sysName
             ),
             $parent->device_id,

--- a/doc/Extensions/Auto-Discovery.md
+++ b/doc/Extensions/Auto-Discovery.md
@@ -113,6 +113,55 @@ within the Modules section.
     lnms config:set discovery_modules.discovery-arp true
     ```
 
+### Next Hops
+
+Disabled by default.
+
+Adds the *next-hop gateway* of each "interesting" route in a device's
+routing table as a pingonly child device. Default behaviour: only the
+default route's next-hop is discovered (i.e. the upstream / WAN
+gateway). Optionally you can also flag specific supernets so internal
+next-hop routers get the same treatment.
+
+The motivation: when a monitored router is up but its upstream is
+unreachable, no entity in LibreNMS reflects that today. By making each
+next-hop a first-class monitored device — pingonly, parented to its
+discovering router — outage detection, latency graphs, and
+dependency-aware alerting all light up automatically.
+
+This module depends on the `route` module being enabled (it consumes
+the routes already populated in the `routes` table — no extra SNMP
+walking).
+
+To enable, set `discovery_modules.discovery-next-hops` either globally
+or per device.
+
+!!! setting "discovery/discovery_modules"
+    ```bash
+    lnms config:set discovery_modules.discovery-next-hops true
+    ```
+
+By default only the default route's next-hop is captured. To also
+include specific internal supernets:
+
+!!! setting "discovery/autodiscovery"
+    ```bash
+    lnms config:set autodiscovery.discovery-next-hops.supernets.+ '10.0.0.0/8'
+    lnms config:set autodiscovery.discovery-next-hops.supernets.+ '172.16.0.0/12'
+    ```
+
+To capture all remote next-hops (default + every other non-default route):
+
+!!! setting "discovery/autodiscovery"
+    ```bash
+    lnms config:set autodiscovery.discovery-next-hops.only-default-route false
+    ```
+
+Discovered next-hops are added with `snmp_disable=1` and `os=ping`, and
+the discovering device is set as their parent in `device_relationships`,
+so existing dependency-aware alerting suppresses cascade alarms when a
+parent goes down.
+
 ### XDP
 
 Enabled by default. Can be disabled with:

--- a/doc/Extensions/Auto-Discovery.md
+++ b/doc/Extensions/Auto-Discovery.md
@@ -157,10 +157,25 @@ To capture all remote next-hops (default + every other non-default route):
     lnms config:set autodiscovery.discovery-next-hops.only-default-route false
     ```
 
-Discovered next-hops are added with `snmp_disable=1` and `os=ping`, and
-the discovering device is set as their parent in `device_relationships`,
-so existing dependency-aware alerting suppresses cascade alarms when a
-parent goes down.
+If the next-hop IP already belongs to a monitored device — by hostname,
+primary IP, or any of its discovered interface IPs — no duplicate is
+created; the discovering device is just attached as its parent.
+
+For genuinely new next-hops, two creation modes apply:
+
+- **Default route** (the WAN gateway, typically a public IP): added as
+  a pingonly device (`snmp_disable=1`, `os=ping`). SNMP and `nets`
+  checks are skipped, since upstream gateways are rarely SNMP-reachable
+  and not expected to be inside `nets`.
+- **Internal supernet next-hop**: SNMP credential discovery is attempted
+  first (so a manageable internal router gets fully discovered with
+  full interface, CPU, memory, etc. metrics). If SNMP fails, the device
+  falls back to pingonly. The `nets` allowlist applies — make sure your
+  internal supernets are listed in `nets` for this path to fire.
+
+In both cases the discovering device is set as the parent in
+`device_relationships`, so existing dependency-aware alerting suppresses
+cascade alarms when a parent goes down.
 
 ### XDP
 

--- a/includes/discovery/discovery-next-hops.inc.php
+++ b/includes/discovery/discovery-next-hops.inc.php
@@ -1,0 +1,9 @@
+<?php
+
+use LibreNMS\OS;
+
+if (empty($os) || ! $os instanceof OS) {
+    $os = OS::make($device);
+}
+
+(new \LibreNMS\Modules\DiscoveryNextHops())->discover($os);

--- a/resources/definitions/config_definitions.json
+++ b/resources/definitions/config_definitions.json
@@ -7527,6 +7527,27 @@
             "section": "smokeping",
             "order": 3,
             "type": "text"
+        },
+        "discovery_modules.discovery-next-hops": {
+            "order": 275,
+            "group": "discovery",
+            "section": "discovery_modules",
+            "default": false,
+            "type": "boolean"
+        },
+        "autodiscovery.discovery-next-hops.only-default-route": {
+            "order": 25,
+            "group": "discovery",
+            "section": "autodiscovery",
+            "default": true,
+            "type": "boolean"
+        },
+        "autodiscovery.discovery-next-hops.supernets": {
+            "order": 26,
+            "group": "discovery",
+            "section": "autodiscovery",
+            "default": [],
+            "type": "array"
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds a new discovery module `discovery-next-hops` that, given a monitored router with the standard `route` module enabled, automatically adds the next-hop gateway of the default route (and optionally additional flagged supernets) as a **pingonly child device**, with `device_relationships` linking it to the discovering router as parent.

## Motivation

Today, when a monitored router is up but its upstream gateway is unreachable, no entity in LibreNMS reflects that state. The router shows green, the dashboard looks fine, but no traffic actually leaves the network. This module makes each next-hop a first-class monitored entity — outage detection, latency graphs, and dependency-aware alerting all activate without further config.

Concrete use case: a recent ~15-minute upstream outage on my home network was visible only as `dpinger sendto error: 64` lines in the firewall's local log. With this module, the WAN gateway would have been a pingonly device with parent=firewall, and the standard alert pipeline would have fired immediately.

## Implementation

- New `LibreNMS\Modules\DiscoveryNextHops` class, modeled closely on `DiscoveryArp`.
- Depends on the existing `route` module (consumes data from the `routes` table — no additional SNMP walking).
- Filters `inetCidrRouteType=remote` (excludes local / broadcast / reject / etc.).
- For each unique next-hop:
    - If already a monitored device → ensures parent linkage only.
    - Else → creates via `ValidateDeviceAndCreate(force: true)` with `snmp_disable=1`, `os=ping`, `type=firewall`.
- Per-IP debounce (1-hour cache) to avoid re-evaluating the same hop on back-to-back runs.

## Configuration

- `discovery_modules.discovery-next-hops` — enable per-device or globally (default `false`)
- `autodiscovery.discovery-next-hops.only-default-route` — bool, default `true`
- `autodiscovery.discovery-next-hops.supernets` — array of CIDRs to ALSO consider beyond the default route, default empty

## Status

**Draft.** Looking for early feedback on:
1. Module name (`discovery-next-hops` vs alternatives — happy to rename)
2. Whether `os=ping` and `type=firewall` are the right defaults for new pingonly children, or if we should add a `next-hop` icon/type
3. Whether to ship the per-supernet config knob in v1 or defer it (keeping only the default-route case)
4. Cleanup behaviour: should `cleanup()` remove next-hop children when the parent is removed? (Currently no — preserves history. Open to making it configurable.)

Documentation added to `doc/Extensions/Auto-Discovery.md` matching the format of existing modules.

Tested locally against pfSense (via bsnmpd) and OpenWrt (via net-snmp) — both expose `IP-FORWARD-MIB::inetCidrRouteTable`, the existing `route` module already handles them, and the new module sees the data correctly.