### PR TITLE
fixes Xdsl.php when the SNMP response data in an unexpected format

### DIFF
--- a/LibreNMS/Modules/Xdsl.php
+++ b/LibreNMS/Modules/Xdsl.php
@@ -146,7 +146,8 @@ class Xdsl implements Module
 
         foreach ($adsl as $ifIndex => $data) {
             if (! is_array($data)) {
-                Log::warning("XDSL: Invalid data received for ifIndex $ifIndex. Expected array, got " . gettype($data));
+                $received = is_string($data) ? "Data: \"$data\"" : "Type: " . gettype($data);
+                Log::warning("XDSL: Skipping port (ifIndex $ifIndex) - device returned malformed SNMP response. $received");
                 continue;
             }
 
@@ -200,8 +201,9 @@ class Xdsl implements Module
         $vdslPorts = new Collection;
 
         foreach ($vdsl as $ifIndex => $data) {
-            if (! is_array($data)) {
-                Log::warning("XDSL: Invalid data received for ifIndex $ifIndex. Expected array, got " . gettype($data));
+           if (! is_array($data)) {
+                $received = is_string($data) ? "Data: \"$data\"" : "Type: " . gettype($data);
+                Log::warning("XDSL: Skipping port (ifIndex $ifIndex) - device returned malformed SNMP response. $received");
                 continue;
             }
             $portVdsl = new PortVdsl([

--- a/LibreNMS/Modules/Xdsl.php
+++ b/LibreNMS/Modules/Xdsl.php
@@ -145,7 +145,7 @@ class Xdsl implements Module
         $adslPorts = new Collection;
 
         foreach ($adsl as $ifIndex => $data) {
-            if (!is_array($data)) {
+            if (! is_array($data)) {
                 Log::warning("XDSL: Invalid data received for ifIndex $ifIndex. Expected array, got " . gettype($data));
                 continue;
             }
@@ -200,7 +200,7 @@ class Xdsl implements Module
         $vdslPorts = new Collection;
 
         foreach ($vdsl as $ifIndex => $data) {
-            if (!is_array($data)) {
+            if (! is_array($data)) {
                 Log::warning("XDSL: Invalid data received for ifIndex $ifIndex. Expected array, got " . gettype($data));
                 continue;
             }

--- a/LibreNMS/Modules/Xdsl.php
+++ b/LibreNMS/Modules/Xdsl.php
@@ -145,6 +145,11 @@ class Xdsl implements Module
         $adslPorts = new Collection;
 
         foreach ($adsl as $ifIndex => $data) {
+            if (!is_array($data)) {
+                Log::warning("XDSL: Invalid data received for ifIndex $ifIndex. Expected array, got " . gettype($data));
+                continue;
+            }
+
             // Values are 1/10
             foreach ($this->adslTenthValues as $oid) {
                 if (isset($data[$oid])) {
@@ -195,6 +200,10 @@ class Xdsl implements Module
         $vdslPorts = new Collection;
 
         foreach ($vdsl as $ifIndex => $data) {
+            if (!is_array($data)) {
+                Log::warning("XDSL: Invalid data received for ifIndex $ifIndex. Expected array, got " . gettype($data));
+                continue;
+            }
             $portVdsl = new PortVdsl([
                 'port_id' => PortCache::getIdFromIfIndex($ifIndex, $os->getDevice()),
                 'xdsl2ChStatusActDataRateXtur' => $data['xdsl2ChStatusActDataRate']['xtur'] ?? 0,

--- a/LibreNMS/Modules/Xdsl.php
+++ b/LibreNMS/Modules/Xdsl.php
@@ -146,7 +146,7 @@ class Xdsl implements Module
 
         foreach ($adsl as $ifIndex => $data) {
             if (! is_array($data)) {
-                $received = is_string($data) ? "Data: \"$data\"" : "Type: " . gettype($data);
+                $received = is_string($data) ? 'Data: ' . $data . ' : 'Type: ' . gettype($data);
                 Log::warning("XDSL: Skipping port (ifIndex $ifIndex) - device returned malformed SNMP response. $received");
                 continue;
             }
@@ -201,8 +201,8 @@ class Xdsl implements Module
         $vdslPorts = new Collection;
 
         foreach ($vdsl as $ifIndex => $data) {
-           if (! is_array($data)) {
-                $received = is_string($data) ? "Data: \"$data\"" : "Type: " . gettype($data);
+            if (! is_array($data)) {
+                $received = is_string($data) ? 'Data: ' . $data . ' : 'Type: ' . gettype($data);
                 Log::warning("XDSL: Skipping port (ifIndex $ifIndex) - device returned malformed SNMP response. $received");
                 continue;
             }

--- a/LibreNMS/Modules/Xdsl.php
+++ b/LibreNMS/Modules/Xdsl.php
@@ -146,7 +146,7 @@ class Xdsl implements Module
 
         foreach ($adsl as $ifIndex => $data) {
             if (! is_array($data)) {
-                $received = is_string($data) ? 'Data: ' . $data . ' : 'Type: ' . gettype($data);
+                $received = is_string($data) ? 'Data: "' . $data . '"' : 'Type: ' . gettype($data);
                 Log::warning("XDSL: Skipping port (ifIndex $ifIndex) - device returned malformed SNMP response. $received");
                 continue;
             }
@@ -202,7 +202,7 @@ class Xdsl implements Module
 
         foreach ($vdsl as $ifIndex => $data) {
             if (! is_array($data)) {
-                $received = is_string($data) ? 'Data: ' . $data . ' : 'Type: ' . gettype($data);
+                $received = is_string($data) ? 'Data: "' . $data . '"' : 'Type: ' . gettype($data);
                 Log::warning("XDSL: Skipping port (ifIndex $ifIndex) - device returned malformed SNMP response. $received");
                 continue;
             }


### PR DESCRIPTION

This PR fixes a TypeError in the Xdsl module that occurs when the SNMP response for adslMibObjects or vdsl2LineTable returns data in an unexpected format (e.g., a string instead of an array). 
This usually happens with older or buggy DSLAM implementations (like some my ZTE models).
Currently, the code passes the $data variable directly into the PortAdsl or PortVdsl constructor without validating that it is an array, leading to a fatal error:TypeError: Illuminate\Database\Eloquent\Model::__construct(): Argument https://github.com/librenms/librenms/issues/1 ($attributes) must be of type array, string given.

Changes:Added is_array($data) checks in pollAdsl and pollVdsl methods before model instantiation.
Added a warning log when invalid data is received to help with debugging.
Testing:Tested with my device returning malformed ADSL SNMP tables.
Verified that the discovery/polling process continues for other ports/modules instead of crashing.

Discovery text:
ADSL( Failed to discover this port, ifIndex invalid : /0 bps/0 bps)   
  

Exception: TypeError Illuminate\Database\Eloquent\Model::__construct(): Argument #1 ($attributes) must be of type array, string given, called in /opt/librenms/LibreNMS/Modules/Xdsl.php on line 159 @ /opt/librenms/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Model.php:297
#0 /opt/librenms/LibreNMS/Modules/Xdsl.php(159): Illuminate\Database\Eloquent\Model->__construct()
#1 /opt/librenms/LibreNMS/Modules/Xdsl.php(78): LibreNMS\Modules\Xdsl->pollAdsl()
#2 /opt/librenms/app/Jobs/DiscoverDevice.php(130): LibreNMS\Modules\Xdsl->discover()
#3 /opt/librenms/app/Jobs/DiscoverDevice.php(55): App\Jobs\DiscoverDevice->discoverModules()
#4 /opt/librenms/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(36): App\Jobs\DiscoverDevice->handle()
#5 /opt/librenms/vendor/laravel/framework/src/Illuminate/Container/Util.php(43): Illuminate\Container\BoundMethod::Illuminate\Container\{closure}()
#6 /opt/librenms/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(96): Illuminate\Container\Util::unwrapIfClosure()
#7 /opt/librenms/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(35): Illuminate\Container\BoundMethod::callBoundMethod()
#8 /opt/librenms/vendor/laravel/framework/src/Illuminate/Container/Container.php(799): Illuminate\Container\BoundMethod::call()
#9 /opt/librenms/vendor/laravel/framework/src/Illuminate/Bus/Dispatcher.php(129): Illuminate\Container\Container->call()
#10 /opt/librenms/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(180): Illuminate\Bus\Dispatcher->Illuminate\Bus\{closure}()
#11 /opt/librenms/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(137): Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}()
#12 /opt/librenms/vendor/laravel/framework/src/Illuminate/Bus/Dispatcher.php(133): Illuminate\Pipeline\Pipeline->then()
#13 /opt/librenms/vendor/laravel/framework/src/Illuminate/Queue/CallQueuedHandler.php(136): Illuminate\Bus\Dispatcher->dispatchNow()
#14 /opt/librenms/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(180): Illuminate\Queue\CallQueuedHandler->Illuminate\Queue\{closure}()
#15 /opt/librenms/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(137): Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}()
#16 /opt/librenms/vendor/laravel/framework/src/Illuminate/Queue/CallQueuedHandler.php(129): Illuminate\Pipeline\Pipeline->then()
#17 /opt/librenms/vendor/laravel/framework/src/Illuminate/Queue/CallQueuedHandler.php(70): Illuminate\Queue\CallQueuedHandler->dispatchThroughMiddleware()
#18 /opt/librenms/vendor/laravel/framework/src/Illuminate/Queue/Jobs/Job.php(102): Illuminate\Queue\CallQueuedHandler->call()
#19 /opt/librenms/vendor/laravel/framework/src/Illuminate/Queue/SyncQueue.php(131): Illuminate\Queue\Jobs\Job->fire()
#20 /opt/librenms/vendor/laravel/framework/src/Illuminate/Queue/SyncQueue.php(111): Illuminate\Queue\SyncQueue->executeJob()
#21 /opt/librenms/vendor/laravel/framework/src/Illuminate/Bus/Dispatcher.php(246): Illuminate\Queue\SyncQueue->push()
#22 /opt/librenms/vendor/laravel/framework/src/Illuminate/Bus/Dispatcher.php(230): Illuminate\Bus\Dispatcher->pushCommandToQueue()
#23 /opt/librenms/vendor/laravel/framework/src/Illuminate/Bus/Dispatcher.php(98): Illuminate\Bus\Dispatcher->dispatchToQueue()
#24 /opt/librenms/app/PerDeviceProcess.php(78): Illuminate\Bus\Dispatcher->dispatchSync()
#25 /opt/librenms/app/Console/Commands/DeviceDiscover.php(76): App\PerDeviceProcess->run()
#26 /opt/librenms/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(36): App\Console\Commands\DeviceDiscover->handle()
#27 /opt/librenms/vendor/laravel/framework/src/Illuminate/Container/Util.php(43): Illuminate\Container\BoundMethod::Illuminate\Container\{closure}()
#28 /opt/librenms/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(96): Illuminate\Container\Util::unwrapIfClosure()
#29 /opt/librenms/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(35): Illuminate\Container\BoundMethod::callBoundMethod()
#30 /opt/librenms/vendor/laravel/framework/src/Illuminate/Container/Container.php(799): Illuminate\Container\BoundMethod::call()
#31 /opt/librenms/vendor/laravel/framework/src/Illuminate/Console/Command.php(211): Illuminate\Container\Container->call()
#32 /opt/librenms/vendor/symfony/console/Command/Command.php(341): Illuminate\Console\Command->execute()
#33 /opt/librenms/vendor/laravel/framework/src/Illuminate/Console/Command.php(180): Symfony\Component\Console\Command\Command->run()
#34 /opt/librenms/vendor/symfony/console/Application.php(1117): Illuminate\Console\Command->run()
#35 /opt/librenms/vendor/symfony/console/Application.php(356): Symfony\Component\Console\Application->doRunCommand()
#36 /opt/librenms/vendor/symfony/console/Application.php(195): Symfony\Component\Console\Application->doRun()
#37 /opt/librenms/vendor/laravel/framework/src/Illuminate/Foundation/Console/Kernel.php(198): Symfony\Component\Console\Application->run()
#38 /opt/librenms/lnms(35): Illuminate\Foundation\Console\Kernel->handle()
#39 {main}  



Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
