### PR TITLE
gpsd: raise satellites/satellites_used RRD max from 40 to 200 for multi-constellation receivers

### DIFF
--- a/includes/polling/applications/gpsd.inc.php
+++ b/includes/polling/applications/gpsd.inc.php
@@ -150,8 +150,8 @@ $basic_rrd_def = RrdDefinition::make()
     ->addDataset('mode', 'GAUGE', 0, 4)
     ->addDataset('hdop', 'GAUGE', 0, 100)
     ->addDataset('vdop', 'GAUGE', 0, 100)
-    ->addDataset('satellites', 'GAUGE', 0, 40)
-    ->addDataset('satellites_used', 'GAUGE', 0, 40);
+    ->addDataset('satellites', 'GAUGE', 0, 200)
+    ->addDataset('satellites_used', 'GAUGE', 0, 200);
 
 // Update basic RRD
 $basic_tags = [


### PR DESCRIPTION
## Summary

Modern multi-constellation GNSS receivers (GPS + GLONASS + Galileo + BeiDou, sometimes also QZSS/NavIC) routinely report 70–80+ satellites visible and 60+ used in fix, exceeding the existing RRD `GAUGE` max of 40 declared by `gpsd.inc.php`.

When the polled value exceeds the data source max, RRD records `Unknown` (graphed as `0`) — even though the application is correctly returning the real value. Visible-satellites graphs flat-line at 0 on otherwise healthy multi-constellation feeds while `satellites_used` (typically ≤40 in fix when there are fewer working sigid combinations) renders normally, producing confusing "used > visible" visualisations.

Companion to https://github.com/librenms/librenms-agent/pull/620 which fixes the agent side returning 0 due to gpsd SKY-frame parsing.

## Change

Raise both data-source maxima from 40 to 200:

```diff
-        ->addDataset('satellites', 'GAUGE', 0, 40)
-        ->addDataset('satellites_used', 'GAUGE', 0, 40);
+        ->addDataset('satellites', 'GAUGE', 0, 200)
+        ->addDataset('satellites_used', 'GAUGE', 0, 200);
```

200 was chosen to give comfortable headroom for any near-term constellation expansion — the current theoretical maximum across all live GNSS systems is around 140 satellites.

## Reproduction

Receiver: Quectel LC29H multi-constellation GNSS HAT, gpsd 3.25, Debian 13 Trixie aarch64. Extend script returns `satellites=79, satellites_used=68`.

Before fix (`rrdtool lastupdate`):

```
 mode hdop vdop satellites satellites_used
1778517949: 3 0.42 0.6 0 64       ← satellites=0 because 79 > DS max 40
```

After fix (locally `rrdtool tune --maximum satellites:200 --maximum satellites_used:200`) and a single re-poll:

```
1778523493: 3 0.42 0.59 75 66      ← correct
```

## Test plan

- [x] Existing single-constellation deployments (≤40 visible) continue to record correctly — `0 ≤ value ≤ 40` is within the new wider range.
- [x] Multi-constellation receiver (LC29H + gpsd 3.25): polled values 75–79 are recorded as integers in RRD instead of dropping to Unknown/0.
- [ ] Existing RRD files with the old max of 40 need `rrdtool tune --maximum satellites:200 --maximum satellites_used:200` on the per-device app-gpsd-*.rrd file for users seeing the issue; new deployments after this merge use the wider max automatically.

I'm happy to add an upgrade note / migration helper if maintainers prefer.

## Note on the agent side

A receiver returning 79 sats hits this bug only because the agent script in librenms-agent#620 returns the correct value. Without that companion fix the agent returns `0/0` regardless of DS max. Both PRs together fix the end-to-end pipeline; either alone is partial.