### PR TITLE
Remove dead scopeLimit on Notification model (breaks daily.sh under Laravel 11)

### DIFF
--- a/app/Models/Notification.php
+++ b/app/Models/Notification.php
@@ -116,24 +116,6 @@ class Notification extends Model
             ->where(['notifications_attribs.key' => 'sticky', 'notifications_attribs.value' => 1]);
     }
 
-    /**
-     * @param  Builder<Notification>  $query
-     * @return Builder<Notification>
-     */
-    public function scopeLimit(Builder $query)
-    {
-        return $query->select('notifications.*', 'key', 'users.username');
-    }
-
-    /**
-     * @param  Builder<Notification>  $query
-     * @return Builder|static
-     */
-    public function scopeSource(Builder $query)
-    {
-        return $query->leftJoin('users', 'notifications.source', '=', 'users.user_id');
-    }
-
     // ---- Define Relationships ----
     /**
      * @return \Illuminate\Database\Eloquent\Relations\HasMany<\App\Models\NotificationAttrib, $this>


### PR DESCRIPTION
Removes two unused query scopes (`scopeLimit` and `scopeSource`) from the `Notification` model. `scopeLimit` collides with the QueryBuilder native `limit()` method, and since the Laravel 11.x Shift this breaks `Notifications::create()` and consequently the tail of `daily.sh`.

#### Root cause

`app/Models/Notification.php` declares:

```php
public function scopeLimit(Builder $query)
{
    return $query->select('notifications.*', 'key', 'users.username');
}
```

Eloquent local scopes take precedence over QueryBuilder methods of the same name. Since the Laravel 11.x Shift (#17384), `firstOrCreate()` chains `->limit(1)` internally, which now invokes `scopeLimit` instead of applying a SQL `LIMIT`. The scope selects `notifications_attribs.key` and `users.username` without joining those tables, so every call to `LibreNMS\Util\Notifications::create()` (called from `daily.php:138`) crashes with:

```
SQLSTATE[42S22]: Column not found: 1054 Unknown column 'key' in 'SELECT'
(SQL: select `notifications`.*, `key`, `users`.`username` from `notifications` where (`checksum` = ...))
```

Concrete impact: `daily.sh` fails before its "fetch upstream notifications" step finishes, the last-update marker is never written, and `validate.php` then reports `Your install is over 24 hours out of date`.

#### Why removal rather than rename

`scopeLimit` and the adjacent `scopeSource` were introduced in 2018 (1ad7f3138b). A grep of the current `master` shows zero callers anywhere in `app/`, `LibreNMS/`, `routes/`, `includes/`, or `resources/views/`. They are dead code that only became harmful once Laravel 11 started reaching for `->limit(1)` inside core helpers.

#### Reproduction

LibreNMS 26.4.1, MariaDB 10.11.14, PHP 8.4. Any execution of `daily.sh` after the Laravel 11.x Shift.

#### Verification

Applied the same diff on a production instance (LibreNMS 26.4.1) and confirmed:

- `php -l app/Models/Notification.php` — no syntax errors
- `LibreNMS\Util\Notifications::create('test', 'body', 'src', 0)` returns `true` (notification persisted)
- Subsequent `daily.sh` run completes the notifications fetch without SQL error

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it. *(N/A — backend-only change)*
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/). *(N/A — no discovery/polling/yaml change)*

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.