### PR TITLE
Fixed MapQuest API url

### DIFF
--- a/app/ApiClients/MapquestApi.php
+++ b/app/ApiClients/MapquestApi.php
@@ -35,7 +35,7 @@ class MapquestApi extends BaseApi implements Geocoder
 {
     use GeocodingHelper;
 
-    protected string $base_uri = 'https://open.mapquestapi.com';
+    protected string $base_uri = 'https://mapquestapi.com';
     protected string $geocoding_uri = '/geocoding/v1/address';
 
     /**


### PR DESCRIPTION
This is a simple fix of MapQuest API url, as service changed it:
from: https://open.mapquestapi.com
to: https://mapquestapi.com

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
