### PR TITLE
Fix ghost alerts (device_id=0) generated on device ping status change

### DIFF
--- a/app/Action.php
+++ b/app/Action.php
@@ -37,6 +37,33 @@ class Action
      */
     public static function execute(string $action, ...$parameters)
     {
-        return app($action, $parameters)->execute();
+        return app($action, self::namedParameters($action, $parameters))->execute();
+    }
+
+    /**
+     * Map positional parameters to named keys using reflection so Laravel's
+     * IoC container resolves them by name rather than falling back to its
+     * type bindings.
+     */
+    private static function namedParameters(string $action, array $parameters): array
+    {
+        if (empty($parameters)) {
+            return [];
+        }
+
+        $constructor = (new \ReflectionClass($action))->getConstructor();
+
+        if (! $constructor) {
+            return $parameters;
+        }
+
+        $named = [];
+        foreach ($constructor->getParameters() as $i => $param) {
+            if (array_key_exists($i, $parameters)) {
+                $named[$param->getName()] = $parameters[$i];
+            }
+        }
+
+        return $named;
     }
 }


### PR DESCRIPTION
### Description

When a device changes ping status, `PingCheck` calls:

```php
Action::execute(RunAlertRulesAction::class, $device);
```

`Action::execute` forwards the argument as a positional array (`[0 => $device]`) to Laravel's `app()`. In Laravel 12, the IoC container matches constructor parameters by **name** only (`Container::hasParameterOverride` checks `array_key_exists($dependency->name, …)`), so the positional key `0` never matches the parameter named `device`. The container falls back to its `App\Models\Device` binding:

```php
// AppServiceProvider
$this->app->bind(\App\Models\Device::class, function ($app) {
    $cache = $app->make('device-cache');
    return $cache->hasPrimary() ? $cache->getPrimary() : new \App\Models\Device;
});
```

`PingCheck` runs in a process where `DeviceCache::setPrimary()` is never called, so `hasPrimary()` is false and the binding returns `new \App\Models\Device` — an unsaved model with `device_id = null`.

`runRules(null)` then runs against all global alert rules, and because `dbInsert()` uses `INSERT IGNORE`, MySQL coerces `null` to `0` for the `NOT NULL INT` column, creating one ghost `alert_log`/`alerts` row per global rule on every device ping status change. The entries self-heal after ~35 minutes via `RunAlerts::clearStaleAlerts()`.

**Fix:** Use reflection to map positional arguments to their named keys before passing to `app()`, so the container receives `['device' => $device]` and resolves correctly. Fixes all four callers of `Action::execute`.

- [x] Follows code guidelines
- [x] No WebUI changes
- [x] No discovery/polling/YAML changes
