### PR TITLE
Fix unknown typo in MIB files

### DIFF
--- a/mibs/huawei/HUAWEI-CBQOS-MIB
+++ b/mibs/huawei/HUAWEI-CBQOS-MIB
@@ -3383,7 +3383,7 @@ This object has no default value.
                 {
                 broadcast(1),
                 multicast(2),
-                unkonwnunicast(3)
+                unknownunicast(3)
                 }
             MAX-ACCESS read-only
             STATUS current

--- a/mibs/huawei/HUAWEI-HQOS-MIB
+++ b/mibs/huawei/HUAWEI-HQOS-MIB
@@ -1731,7 +1731,7 @@
                 {
                 broadcast(1),
                 multicast(2),
-                unkonwnUnicast(3)
+                unknownUnicast(3)
                 }
             MAX-ACCESS read-only
             STATUS current

--- a/mibs/moxa/MOXA-IKS6726A-MIB
+++ b/mibs/moxa/MOXA-IKS6726A-MIB
@@ -2373,17 +2373,17 @@ PortList ::= TEXTUAL-CONVENTION
             "Broadcast Storm Protection includes Multicast packets"
         ::= { broadcastStormProtection 2 } 
          
-    bcastStormIncludeUnkonwnMcastUcast OBJECT-TYPE
+    bcastStormIncludeUnknownMcastUcast OBJECT-TYPE
         SYNTAX INTEGER {no(0),yes(1)}
         MAX-ACCESS read-write               
         STATUS current
         DESCRIPTION
-            "Broadcast Storm Protection includes Unkonwn Multicast and Unknown Unicast Packet packets"
+            "Broadcast Storm Protection includes Unknown Multicast and Unknown Unicast Packet packets"
         ::= { broadcastStormProtection 3 } 
 
 	unicastFilterBehavior OBJECT IDENTIFIER ::= { broadcastStormProtection 4 }
 	
-    ufbIncludeUnkonwnUcast OBJECT-TYPE
+    ufbIncludeUnknownUcast OBJECT-TYPE
         SYNTAX INTEGER {no(0),yes(1)}
         MAX-ACCESS read-write               
         STATUS current

--- a/mibs/moxa/MOXA-PT7528V2-MIB
+++ b/mibs/moxa/MOXA-PT7528V2-MIB
@@ -2875,12 +2875,12 @@ PortList ::= TEXTUAL-CONVENTION
             "Broadcast Storm Protection includes Multicast packets"
         ::= { broadcastStormProtection 2 } 
          
-    bcastStormIncludeUnkonwnMcastUcast OBJECT-TYPE
+    bcastStormIncludeUnknownMcastUcast OBJECT-TYPE
         SYNTAX INTEGER {no(0),yes(1)}
         MAX-ACCESS read-write               
         STATUS current
         DESCRIPTION
-            "Broadcast Storm Protection includes Unkonwn Multicast and Unknown Unicast Packet packets"
+            "Broadcast Storm Protection includes Unknown Multicast and Unknown Unicast Packet packets"
         ::= { broadcastStormProtection 3 } 
 
 	-- Miles
@@ -2905,7 +2905,7 @@ PortList ::= TEXTUAL-CONVENTION
 		
 	unicastFilterBehavior OBJECT IDENTIFIER ::= { broadcastStormProtection 4 }
 	
-    ufbIncludeUnkonwnUcast OBJECT-TYPE
+    ufbIncludeUnknownUcast OBJECT-TYPE
         SYNTAX INTEGER {no(0),yes(1)}
         MAX-ACCESS read-write               
         STATUS current

--- a/mibs/sonicwall/SONICWALL-FIREWALL-IP-STATISTICS-MIB
+++ b/mibs/sonicwall/SONICWALL-FIREWALL-IP-STATISTICS-MIB
@@ -127,7 +127,7 @@ SwSpRadioType ::= TEXTUAL-CONVENTION
     DESCRIPTION
             "Enumerated types for SonicPoint radio.
              The following enumerated values are supported:
-                other(0)                    - radio type is unkonwn n/a
+                other(0)                    - radio type is unknown n/a
                 dot11n-only-24 (1)          - 2.4GHz n Only
                 dot11n-mixed-24 (2)         - 2.4GHz n/g/b
                 dot11g-only-24 (3)          - 2.4GHz g Only


### PR DESCRIPTION
## Summary
- fix `Unkonwn`/`unkonwn` typos in MIB files

Fixes #19693

## Tests
- `git diff --check`
- `grep -RIn --exclude-dir=.git -E 'Unkonwn|unkonwn' mibs/huawei/HUAWEI-HQOS-MIB mibs/huawei/HUAWEI-CBQOS-MIB mibs/sonicwall/SONICWALL-FIREWALL-IP-STATISTICS-MIB mibs/moxa/MOXA-IKS6726A-MIB mibs/moxa/MOXA-PT7528V2-MIB` (no matches)