### PR TITLE
Fix for orphaned alerts when device_id =< 0

### DIFF
--- a/app/Jobs/PingCheck.php
+++ b/app/Jobs/PingCheck.php
@@ -197,7 +197,7 @@ class PingCheck implements ShouldQueue
             Log::debug("Device $device->hostname changed status to $type, running alerts");
 
             if (count($waiting_on) === 0) {
-                Action::execute(RunAlertRulesAction::class, $device);
+                Action::execute(RunAlertRulesAction::class, device: $device);
             } else {
                 Log::debug('Alerts Deferred');
 

--- a/app/Listeners/CheckAlerts.php
+++ b/app/Listeners/CheckAlerts.php
@@ -36,7 +36,7 @@ class CheckAlerts
         Log::info('#### Start Alerts ####');
         $start = microtime(true);
 
-        Action::execute(RunAlertRulesAction::class, $event->device);
+        Action::execute(RunAlertRulesAction::class, device: $event->device);
 
         $end = round(microtime(true) - $start, 4);
         Log::info("#### End Alerts ({$end}s) ####\n");

--- a/app/Listeners/UpdateDeviceGroups.php
+++ b/app/Listeners/UpdateDeviceGroups.php
@@ -31,7 +31,7 @@ class UpdateDeviceGroups
         $dg_start = microtime(true);
 
         // update device groups
-        $group_changes = Action::execute(UpdateDeviceGroupsAction::class, $event->device);
+        $group_changes = Action::execute(UpdateDeviceGroupsAction::class, device: $event->device);
 
         $added = implode(',', $group_changes['attached']);
         $removed = implode(',', $group_changes['detached']);


### PR DESCRIPTION
Alternative fix to #19688.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
