### PR TITLE
feature: Bulk SNMP credential management for Device Groups

### DIFF
--- a/app/Http/Controllers/BulkSnmpController.php
+++ b/app/Http/Controllers/BulkSnmpController.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\BulkSnmpRequest;
+use App\Models\DeviceGroup;
+use App\Services\BulkSnmpService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\View\View;
+
+class BulkSnmpController extends Controller
+{
+    public function __construct(protected BulkSnmpService $service)
+    {
+        $this->middleware('auth');
+    }
+
+    /**
+     * Render the bulk SNMP edit form for a Device Group.
+     */
+    public function show(int $deviceGroup): View
+    {
+        // Non-admins get a friendly explanation instead of a raw 403 page.
+        if (! Auth::user()?->hasRole('admin')) {
+            return view('device-group.bulk-snmp-denied');
+        }
+
+        $group = DeviceGroup::findOrFail($deviceGroup);
+
+        return view('device-group.bulk-snmp', [
+            'group' => $group,
+            'deviceCount' => $group->devices()->count(),
+            'authAlgos' => BulkSnmpService::AUTH_ALGOS,
+            'privAlgos' => BulkSnmpService::PRIV_ALGOS,
+            'securityLevels' => BulkSnmpService::SECURITY_LEVELS,
+        ]);
+    }
+
+    /**
+     * Test the supplied credentials against all devices in the group.
+     * Authorization handled by BulkSnmpRequest::authorize().
+     */
+    public function test(BulkSnmpRequest $request, int $deviceGroup): JsonResponse
+    {
+        $group = DeviceGroup::findOrFail($deviceGroup);
+        $devices = $this->getDevices($group, (bool) $request->input('skip_down'));
+
+        $fields = $this->service->buildUpdateFields($request->validated());
+        $results = $this->service->testCredentials($devices, $fields);
+
+        $passed = collect($results)->where('success', true)->count();
+
+        return response()->json([
+            'status' => 'ok',
+            'total' => $devices->count(),
+            'passed' => $passed,
+            'failed' => $devices->count() - $passed,
+            'results' => $results,
+        ]);
+    }
+
+    /**
+     * Apply the supplied credentials to all devices in the group.
+     * Authorization handled by BulkSnmpRequest::authorize().
+     */
+    public function apply(BulkSnmpRequest $request, int $deviceGroup): JsonResponse
+    {
+        $group = DeviceGroup::findOrFail($deviceGroup);
+        $devices = $this->getDevices($group, (bool) $request->input('skip_down'));
+
+        $fields = $this->service->buildUpdateFields($request->validated());
+        $result = $this->service->applyCredentials($devices, $fields);
+
+        return response()->json([
+            'status' => 'ok',
+            'total' => $devices->count(),
+            'success_count' => count($result['success']),
+            'failed_count' => count($result['failed']),
+            'success' => $result['success'],
+            'failed' => $result['failed'],
+        ]);
+    }
+
+    /**
+     * Fetch the device collection for a group, optionally skipping down devices.
+     *
+     * @return Collection<int,\App\Models\Device>
+     */
+    protected function getDevices(DeviceGroup $group, bool $skipDown): Collection
+    {
+        $query = $group->devices();
+
+        if ($skipDown) {
+            $query = $query->where('status', 1);
+        }
+
+        return $query->get();
+    }
+}

--- a/app/Http/Controllers/BulkSnmpController.php
+++ b/app/Http/Controllers/BulkSnmpController.php
@@ -6,6 +6,7 @@ use App\Http\Requests\BulkSnmpRequest;
 use App\Models\DeviceGroup;
 use App\Services\BulkSnmpService;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\View\View;
@@ -20,10 +21,15 @@ class BulkSnmpController extends Controller
     /**
      * Render the bulk SNMP edit form for a Device Group.
      */
-    public function show(int $deviceGroup): View
+    public function show(int $deviceGroup): View|RedirectResponse
     {
-        // Non-admins get a friendly explanation instead of a raw 403 page.
-        if (! Auth::user()?->hasRole('admin')) {
+        // Not logged in -> send to login.
+        if (! Auth::check()) {
+            return redirect()->guest(route('login'));
+        }
+
+        // Logged in but not an admin -> friendly explanation, not a raw 403.
+        if (! Auth::user()->hasRole('admin')) {
             return view('device-group.bulk-snmp-denied');
         }
 

--- a/app/Http/Requests/BulkSnmpRequest.php
+++ b/app/Http/Requests/BulkSnmpRequest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Services\BulkSnmpService;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Auth;
+
+class BulkSnmpRequest extends FormRequest
+{
+    /**
+     * Determine whether the user is authorized to make this request.
+     * LibreNMS uses Spatie Laravel Permission; 'admin' is the privileged role.
+     */
+    public function authorize(): bool
+    {
+        return Auth::check() && Auth::user()->hasRole('admin');
+    }
+
+    /**
+     * Provide a clear message when authorization fails.
+     * The AJAX frontend surfaces this text to the user.
+     */
+    protected function failedAuthorization(): void
+    {
+        throw new AuthorizationException(
+            __('bulk-snmp.denied.message')
+        );
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string,mixed>
+     */
+    public function rules(): array
+    {
+        $rules = [
+            'snmpver' => 'required|in:v1,v2c,v3',
+            'port' => 'nullable|integer|between:1,65535',
+            'transport' => 'nullable|in:udp,udp6,tcp,tcp6',
+            'skip_down' => 'nullable|boolean',
+        ];
+
+        if ($this->input('snmpver') === 'v3') {
+            $rules += [
+                'authlevel' => 'required|in:' . implode(',', BulkSnmpService::SECURITY_LEVELS),
+                'authname' => 'required|string|max:64',
+                'authpass' => 'nullable|string|min:8|max:64',
+                'authalgo' => 'required|in:' . implode(',', BulkSnmpService::AUTH_ALGOS),
+                'cryptopass' => 'nullable|string|min:8|max:64',
+                'cryptoalgo' => 'required|in:' . implode(',', BulkSnmpService::PRIV_ALGOS),
+            ];
+        } else {
+            // v1 / v2c
+            $rules['community'] = 'required|string|max:64';
+        }
+
+        return $rules;
+    }
+
+    /**
+     * Custom messages for validator errors.
+     *
+     * @return array<string,string>
+     */
+    public function messages(): array
+    {
+        return [
+            'authpass.min' => __('bulk-snmp.validation.password_min'),
+            'cryptopass.min' => __('bulk-snmp.validation.password_min'),
+        ];
+    }
+}

--- a/app/Services/BulkSnmpService.php
+++ b/app/Services/BulkSnmpService.php
@@ -1,0 +1,195 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Device;
+use App\Models\Eventlog;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use LibreNMS\Enum\Severity;
+
+/**
+ * Bulk SNMP credentials updater for Device Groups.
+ *
+ * Provides validation, dry-run testing and atomic per-device update
+ * of SNMP credentials for all devices in a Device Group.
+ */
+class BulkSnmpService
+{
+    /**
+     * SNMP fields that this service is allowed to update.
+     * Whitelisted to prevent accidental mass-edit of other fields.
+     */
+    public const ALLOWED_FIELDS = [
+        'snmpver',
+        'community',
+        'authlevel',
+        'authname',
+        'authpass',
+        'authalgo',
+        'cryptopass',
+        'cryptoalgo',
+        'port',
+        'transport',
+    ];
+
+    /**
+     * Valid SNMPv3 authentication algorithms as understood by net-snmp/LibreNMS.
+     */
+    public const AUTH_ALGOS = ['MD5', 'SHA', 'SHA-224', 'SHA-256', 'SHA-384', 'SHA-512'];
+
+    /**
+     * Valid SNMPv3 privacy algorithms.
+     */
+    public const PRIV_ALGOS = ['DES', 'AES', 'AES-192', 'AES-256'];
+
+    /**
+     * Valid SNMPv3 security levels.
+     */
+    public const SECURITY_LEVELS = ['noAuthNoPriv', 'authNoPriv', 'authPriv'];
+
+    /**
+     * Build a sanitized array of SNMP update fields from validated input.
+     *
+     * Only fields present and allowed will be returned, so partial updates
+     * (e.g. only rotate passwords) are possible.
+     *
+     * @param  array<string,mixed>  $input
+     * @return array<string,mixed>
+     */
+    public function buildUpdateFields(array $input): array
+    {
+        $fields = [];
+        foreach (self::ALLOWED_FIELDS as $key) {
+            if (array_key_exists($key, $input) && $input[$key] !== null && $input[$key] !== '') {
+                $fields[$key] = $input[$key];
+            }
+        }
+
+        return $fields;
+    }
+
+    /**
+     * Test a set of SNMP credentials against every device in the collection.
+     * Runs a synchronous SNMP get on `sysObjectID.0` per device.
+     *
+     * @param  Collection<int,Device>  $devices
+     * @param  array<string,mixed>  $credentials
+     * @return array<int,array{device_id:int,hostname:string,success:bool,message:string}>
+     */
+    public function testCredentials(Collection $devices, array $credentials): array
+    {
+        $results = [];
+
+        foreach ($devices as $device) {
+            $result = $this->testSingleDevice($device, $credentials);
+            $results[] = [
+                'device_id' => $device->device_id,
+                'hostname' => $device->hostname,
+                'success' => $result['success'],
+                'message' => $result['message'],
+            ];
+        }
+
+        return $results;
+    }
+
+    /**
+     * Apply credentials to every device in the collection.
+     * Each device update is wrapped in its own try/catch so a single failure
+     * does not abort the rest. Eventlog entries are written per device.
+     *
+     * @param  Collection<int,Device>  $devices
+     * @param  array<string,mixed>  $fields
+     * @return array{success:array<int,array<string,mixed>>,failed:array<int,array<string,mixed>>}
+     */
+    public function applyCredentials(Collection $devices, array $fields): array
+    {
+        $success = [];
+        $failed = [];
+
+        // Strip non-allowed fields as a defense in depth measure.
+        $fields = array_intersect_key($fields, array_flip(self::ALLOWED_FIELDS));
+
+        if (empty($fields)) {
+            return ['success' => [], 'failed' => []];
+        }
+
+        foreach ($devices as $device) {
+            try {
+                // forceFill() bypasses Laravel mass-assignment protection.
+                // Safe here: $fields is already whitelisted against ALLOWED_FIELDS above.
+                $device->forceFill($fields);
+                $device->save();
+
+                Eventlog::log(
+                    sprintf(
+                        'Bulk SNMP update: fields [%s] changed by %s',
+                        implode(', ', array_keys($fields)),
+                        Auth::user()->username ?? 'system'
+                    ),
+                    $device->device_id,
+                    'system',
+                    Severity::Notice
+                );
+
+                $success[] = [
+                    'device_id' => $device->device_id,
+                    'hostname' => $device->hostname,
+                ];
+            } catch (\Throwable $e) {
+                Log::error('BulkSnmp apply failed for device ' . $device->device_id . ': ' . $e->getMessage());
+
+                $failed[] = [
+                    'device_id' => $device->device_id,
+                    'hostname' => $device->hostname,
+                    'message' => $e->getMessage(),
+                ];
+            }
+        }
+
+        return ['success' => $success, 'failed' => $failed];
+    }
+
+    /**
+     * Perform a single SNMP test against a device using the given credentials.
+     * Falls back to the device's existing fields for any value not supplied.
+     *
+     * @param  array<string,mixed>  $credentials
+     * @return array{success:bool,message:string}
+     */
+    protected function testSingleDevice(Device $device, array $credentials): array
+    {
+        // Build a temporary device snapshot with the new creds applied,
+        // without persisting any change to the database.
+        $original = $device->getOriginal();
+
+        try {
+            // forceFill() bypasses mass-assignment protection; whitelisted above.
+            $device->forceFill(array_intersect_key($credentials, array_flip(self::ALLOWED_FIELDS)));
+
+            $oid = '.1.3.6.1.2.1.1.2.0'; // sysObjectID.0
+            $result = \SnmpQuery::device($device)->get($oid);
+
+            $value = $result->value();
+            $success = ! empty($value);
+
+            return [
+                'success' => $success,
+                'message' => $success ? 'SNMP reachable' : 'No response or auth failure',
+            ];
+        } catch (\Throwable $e) {
+            return [
+                'success' => false,
+                'message' => $e->getMessage(),
+            ];
+        } finally {
+            // Restore original attributes; never persist the test attempt.
+            foreach ($original as $key => $value) {
+                $device->setAttribute($key, $value);
+            }
+        }
+    }
+}

--- a/app/Services/BulkSnmpService.php
+++ b/app/Services/BulkSnmpService.php
@@ -6,7 +6,6 @@ use App\Models\Device;
 use App\Models\Eventlog;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use LibreNMS\Enum\Severity;
 

--- a/lang/en/bulk-snmp.php
+++ b/lang/en/bulk-snmp.php
@@ -1,0 +1,64 @@
+<?php
+
+return [
+    'title' => 'Bulk SNMP Credentials',
+    'group_label' => 'Device Group',
+    'device_count' => ':count device|:count devices',
+    'description' => 'Update SNMP credentials for every device in this group. Apply this AFTER you have configured the new credentials on the devices themselves.',
+
+    'sections' => [
+        'snmp_version' => 'SNMP Version',
+        'credentials' => 'Credentials',
+        'options' => 'Options',
+    ],
+
+    'fields' => [
+        'snmpver' => 'SNMP Version',
+        'community' => 'Community String',
+        'authlevel' => 'Security Level',
+        'authname' => 'Auth Username',
+        'authpass' => 'Auth Password',
+        'authalgo' => 'Auth Algorithm',
+        'cryptopass' => 'Crypto Password',
+        'cryptoalgo' => 'Crypto Algorithm',
+        'port' => 'SNMP Port',
+        'transport' => 'Transport',
+        'skip_down' => 'Skip devices that are currently down',
+    ],
+
+    'buttons' => [
+        'open' => 'Bulk SNMP Edit',
+        'cancel' => 'Cancel',
+        'test' => 'Test Credentials',
+        'apply' => 'Apply to :count Devices',
+        'close' => 'Close',
+    ],
+
+    'feedback' => [
+        'testing' => 'Testing credentials on :count devices...',
+        'applying' => 'Applying credentials to :count devices...',
+        'test_result' => ':passed of :total devices reachable',
+        'apply_result' => ':success of :total devices updated successfully',
+        'no_devices' => 'No devices in this group',
+        'all_down' => 'All devices in this group are currently down',
+        'confirm_apply' => 'You are about to update SNMP credentials for :count devices. Continue?',
+        'devices_reachable' => 'devices reachable',
+        'devices_updated' => 'devices updated',
+        'working' => 'Working...',
+    ],
+
+    'validation' => [
+        'password_min' => 'SNMPv3 passwords must be at least 8 characters.',
+    ],
+
+    'denied' => [
+        'title' => 'Administrator access required',
+        'message' => 'Bulk SNMP credential management is restricted to administrators.',
+        'contact' => 'If you need to update SNMP credentials for a device group, please contact a LibreNMS administrator.',
+        'back' => 'Back to dashboard',
+    ],
+
+    'eventlog' => [
+        'updated' => 'Bulk SNMP update: fields [:fields] changed by :user',
+    ],
+];

--- a/resources/views/device-group/bulk-snmp-denied.blade.php
+++ b/resources/views/device-group/bulk-snmp-denied.blade.php
@@ -1,0 +1,30 @@
+@extends('layouts.librenmsv1')
+
+@section('title', __('bulk-snmp.denied.title'))
+
+@section('content')
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-md-6 col-md-offset-3">
+            <div class="panel panel-warning" style="margin-top: 40px;">
+                <div class="panel-heading">
+                    <h3 class="panel-title">
+                        <i class="fa fa-lock"></i> {{ __('bulk-snmp.denied.title') }}
+                    </h3>
+                </div>
+                <div class="panel-body text-center" style="padding: 30px;">
+                    <p style="font-size: 16px;">
+                        {{ __('bulk-snmp.denied.message') }}
+                    </p>
+                    <p class="text-muted">
+                        {{ __('bulk-snmp.denied.contact') }}
+                    </p>
+                    <a href="{{ url('/') }}" class="btn btn-default" style="margin-top: 10px;">
+                        <i class="fa fa-home"></i> {{ __('bulk-snmp.denied.back') }}
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/device-group/bulk-snmp.blade.php
+++ b/resources/views/device-group/bulk-snmp.blade.php
@@ -1,0 +1,320 @@
+@extends('layouts.librenmsv1')
+
+@section('title', __('bulk-snmp.title'))
+
+@section('content')
+<div class="container-fluid"
+     x-data="bulkSnmpForm({
+        groupId: {{ $group->id }},
+        deviceCount: {{ $deviceCount }},
+        testUrl: '{{ route('device-group.bulk-snmp.test', $group) }}',
+        applyUrl: '{{ route('device-group.bulk-snmp.apply', $group) }}',
+        csrfToken: '{{ csrf_token() }}',
+     })">
+
+    <div class="row">
+        <div class="col-md-8 col-md-offset-2">
+
+            <div class="page-header">
+                <h2>
+                    <i class="fa fa-key"></i> {{ __('bulk-snmp.title') }}
+                    <small>{{ $group->name }} &mdash;
+                        {{ trans_choice('bulk-snmp.device_count', $deviceCount, ['count' => $deviceCount]) }}
+                    </small>
+                </h2>
+            </div>
+
+            <div class="alert alert-info">
+                <i class="fa fa-info-circle"></i> {{ __('bulk-snmp.description') }}
+            </div>
+
+            <form @submit.prevent="apply">
+                @csrf
+
+                {{-- SNMP Version --}}
+                <div class="panel panel-default">
+                    <div class="panel-heading">{{ __('bulk-snmp.sections.snmp_version') }}</div>
+                    <div class="panel-body">
+                        <div class="btn-group" role="group">
+                            <template x-for="v in ['v2c','v3']" :key="v">
+                                <button type="button" class="btn"
+                                        @click="form.snmpver = v"
+                                        :class="form.snmpver === v ? 'btn-primary' : 'btn-default'"
+                                        x-text="v"></button>
+                            </template>
+                        </div>
+                    </div>
+                </div>
+
+                {{-- v2c fields --}}
+                <template x-if="form.snmpver === 'v2c'">
+                    <div class="panel panel-default">
+                        <div class="panel-heading">{{ __('bulk-snmp.sections.credentials') }}</div>
+                        <div class="panel-body">
+                            <div class="form-group">
+                                <label for="community">{{ __('bulk-snmp.fields.community') }}</label>
+                                <input type="text" id="community" class="form-control"
+                                       x-model="form.community" autocomplete="off" />
+                            </div>
+                        </div>
+                    </div>
+                </template>
+
+                {{-- v3 fields --}}
+                <template x-if="form.snmpver === 'v3'">
+                    <div class="panel panel-default">
+                        <div class="panel-heading">{{ __('bulk-snmp.sections.credentials') }}</div>
+                        <div class="panel-body">
+                            <div class="row">
+                                <div class="col-sm-6">
+                                    <div class="form-group">
+                                        <label for="authlevel">{{ __('bulk-snmp.fields.authlevel') }}</label>
+                                        <select id="authlevel" class="form-control" x-model="form.authlevel">
+                                            @foreach ($securityLevels as $lvl)
+                                                <option value="{{ $lvl }}">{{ $lvl }}</option>
+                                            @endforeach
+                                        </select>
+                                    </div>
+                                </div>
+                                <div class="col-sm-6">
+                                    <div class="form-group">
+                                        <label for="authname">{{ __('bulk-snmp.fields.authname') }}</label>
+                                        <input type="text" id="authname" class="form-control"
+                                               x-model="form.authname" autocomplete="off" />
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div class="row">
+                                <div class="col-sm-6">
+                                    <div class="form-group">
+                                        <label for="authalgo">{{ __('bulk-snmp.fields.authalgo') }}</label>
+                                        <select id="authalgo" class="form-control" x-model="form.authalgo">
+                                            @foreach ($authAlgos as $algo)
+                                                <option value="{{ $algo }}">{{ $algo }}</option>
+                                            @endforeach
+                                        </select>
+                                    </div>
+                                </div>
+                                <div class="col-sm-6">
+                                    <div class="form-group">
+                                        <label for="authpass">{{ __('bulk-snmp.fields.authpass') }}</label>
+                                        <input type="password" id="authpass" class="form-control"
+                                               x-model="form.authpass" autocomplete="new-password" />
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div class="row">
+                                <div class="col-sm-6">
+                                    <div class="form-group">
+                                        <label for="cryptoalgo">{{ __('bulk-snmp.fields.cryptoalgo') }}</label>
+                                        <select id="cryptoalgo" class="form-control" x-model="form.cryptoalgo">
+                                            @foreach ($privAlgos as $algo)
+                                                <option value="{{ $algo }}">{{ $algo }}</option>
+                                            @endforeach
+                                        </select>
+                                    </div>
+                                </div>
+                                <div class="col-sm-6">
+                                    <div class="form-group">
+                                        <label for="cryptopass">{{ __('bulk-snmp.fields.cryptopass') }}</label>
+                                        <input type="password" id="cryptopass" class="form-control"
+                                               x-model="form.cryptopass" autocomplete="new-password" />
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </template>
+
+                {{-- Options --}}
+                <div class="panel panel-default">
+                    <div class="panel-body">
+                        <div class="checkbox">
+                            <label>
+                                <input type="checkbox" x-model="form.skip_down" />
+                                {{ __('bulk-snmp.fields.skip_down') }}
+                            </label>
+                        </div>
+                    </div>
+                </div>
+
+                {{-- Error banner --}}
+                <template x-if="errorMessage">
+                    <div class="alert alert-danger">
+                        <i class="fa fa-exclamation-triangle"></i>
+                        <span x-text="errorMessage"></span>
+                    </div>
+                </template>
+
+                {{-- Test results --}}
+                <template x-if="testResults">
+                    <div class="panel panel-info">
+                        <div class="panel-heading">
+                            <span x-text="testResults.passed"></span>
+                            / <span x-text="testResults.total"></span>
+                            {{ __('bulk-snmp.feedback.devices_reachable') }}
+                        </div>
+                        <div class="panel-body" style="max-height: 250px; overflow-y: auto;">
+                            <table class="table table-condensed table-striped">
+                                <tbody>
+                                    <template x-for="r in testResults.results" :key="r.device_id">
+                                        <tr>
+                                            <td style="width: 24px;">
+                                                <span x-show="r.success" class="text-success">
+                                                    <i class="fa fa-check"></i>
+                                                </span>
+                                                <span x-show="!r.success" class="text-danger">
+                                                    <i class="fa fa-times"></i>
+                                                </span>
+                                            </td>
+                                            <td x-text="r.hostname"></td>
+                                            <td class="text-muted" x-text="r.message"></td>
+                                        </tr>
+                                    </template>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </template>
+
+                {{-- Apply results --}}
+                <template x-if="applyResults">
+                    <div class="panel"
+                         :class="applyResults.failed_count > 0 ? 'panel-warning' : 'panel-success'">
+                        <div class="panel-heading">
+                            <span x-text="applyResults.success_count"></span>
+                            / <span x-text="applyResults.total"></span>
+                            {{ __('bulk-snmp.feedback.devices_updated') }}
+                        </div>
+                        <template x-if="applyResults.failed_count > 0">
+                            <div class="panel-body">
+                                <table class="table table-condensed">
+                                    <tbody>
+                                        <template x-for="f in applyResults.failed" :key="f.device_id">
+                                            <tr class="text-danger">
+                                                <td><i class="fa fa-times"></i></td>
+                                                <td x-text="f.hostname"></td>
+                                                <td x-text="f.message"></td>
+                                            </tr>
+                                        </template>
+                                    </tbody>
+                                </table>
+                            </div>
+                        </template>
+                    </div>
+                </template>
+
+                {{-- Buttons --}}
+                <div class="form-group">
+                    <a href="{{ route('device-groups.edit', $group->id) }}" class="btn btn-default">
+                        {{ __('bulk-snmp.buttons.cancel') }}
+                    </a>
+                    <button type="button" class="btn btn-default" @click="runTest" :disabled="loading">
+                        <i class="fa fa-flask"></i> {{ __('bulk-snmp.buttons.test') }}
+                    </button>
+                    <button type="submit" class="btn btn-primary" :disabled="loading">
+                        <i class="fa fa-key"></i>
+                        {{ __('bulk-snmp.buttons.apply', ['count' => $deviceCount]) }}
+                    </button>
+                    <span x-show="loading" class="text-muted">
+                        <i class="fa fa-spinner fa-spin"></i> {{ __('bulk-snmp.feedback.working') }}
+                    </span>
+                </div>
+            </form>
+
+        </div>
+    </div>
+</div>
+
+<script>
+function bulkSnmpForm(config) {
+    return {
+        loading: false,
+        testResults: null,
+        applyResults: null,
+        errorMessage: null,
+        form: {
+            snmpver: 'v3',
+            community: '',
+            authlevel: 'authPriv',
+            authname: '',
+            authpass: '',
+            authalgo: 'SHA',
+            cryptopass: '',
+            cryptoalgo: 'AES',
+            skip_down: false,
+        },
+
+        /**
+         * Perform a request and return parsed JSON, or throw a readable error.
+         */
+        async request(url) {
+            const resp = await fetch(url, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRF-TOKEN': config.csrfToken,
+                    'Accept': 'application/json',
+                },
+                body: JSON.stringify(this.form),
+            });
+
+            let data = null;
+            try {
+                data = await resp.json();
+            } catch (e) {
+                data = null;
+            }
+
+            if (!resp.ok) {
+                // 403 = not authorized, 422 = validation, 500 = server error
+                if (resp.status === 403) {
+                    throw new Error(
+                        '{{ __('bulk-snmp.denied.message') }}'
+                    );
+                }
+                if (resp.status === 422 && data && data.errors) {
+                    const first = Object.values(data.errors)[0];
+                    throw new Error(Array.isArray(first) ? first[0] : first);
+                }
+                throw new Error(
+                    (data && data.message) ? data.message : ('HTTP ' + resp.status)
+                );
+            }
+            return data;
+        },
+
+        async runTest() {
+            this.loading = true;
+            this.testResults = null;
+            this.errorMessage = null;
+            try {
+                this.testResults = await this.request(config.testUrl);
+            } catch (e) {
+                this.errorMessage = e.message;
+            } finally {
+                this.loading = false;
+            }
+        },
+
+        async apply() {
+            if (!confirm('{{ __('bulk-snmp.feedback.confirm_apply', ['count' => $deviceCount]) }}')) {
+                return;
+            }
+            this.loading = true;
+            this.applyResults = null;
+            this.errorMessage = null;
+            try {
+                this.applyResults = await this.request(config.applyUrl);
+            } catch (e) {
+                this.errorMessage = e.message;
+            } finally {
+                this.loading = false;
+            }
+        },
+    }
+}
+</script>
+@endsection

--- a/resources/views/device-group/edit.blade.php
+++ b/resources/views/device-group/edit.blade.php
@@ -18,6 +18,12 @@
                         <button type="submit" class="btn btn-primary">{{ __('Save') }}</button>
                         <a type="button" class="btn btn-danger"
                            href="{{ route('device-groups.index') }}">{{ __('Cancel') }}</a>
+                        @can('admin')
+                            <a type="button" class="btn btn-default pull-right"
+                               href="{{ route('device-group.bulk-snmp.show', $device_group->id) }}">
+                                <i class="fa fa-key"></i> {{ __('Bulk SNMP Edit') }}
+                            </a>
+                        @endcan
                     </div>
                 </div>
             </form>

--- a/routes/web.php
+++ b/routes/web.php
@@ -437,7 +437,7 @@ Route::prefix('install')->group(function (): void {
 
 // Bulk SNMP routes (must be placed BEFORE the Legacy catch-all route)
 Route::middleware(['auth'])->group(function (): void {
-    Route::prefix('device-groups/{device_group}/bulk-snmp')->group(function () {
+    Route::prefix('device-groups/{device_group}/bulk-snmp')->group(function (): void {
         Route::get('/', [App\Http\Controllers\BulkSnmpController::class, 'show'])
             ->name('device-group.bulk-snmp.show');
         Route::post('/test', [App\Http\Controllers\BulkSnmpController::class, 'test'])

--- a/routes/web.php
+++ b/routes/web.php
@@ -107,8 +107,8 @@ Route::middleware(['auth'])->group(function (): void {
         Route::get('performance', [PollerController::class, 'performanceTab'])->name('poller.performance');
         Route::resource('{id}/settings', PollerSettingsController::class, ['as' => 'poller'])->only(['update', 'destroy']);
     });
-    Route::delete('ports/purge', [\App\Http\Controllers\PortsController::class, 'purge'])->name('ports.purge');
-    Route::get('ports/{view?}/{graph?}', [\App\Http\Controllers\PortsController::class, 'index'])
+    Route::delete('ports/purge', [App\Http\Controllers\PortsController::class, 'purge'])->name('ports.purge');
+    Route::get('ports/{view?}/{graph?}', [App\Http\Controllers\PortsController::class, 'index'])
         ->middleware('saved-filter:ports')->name('ports');
     Route::prefix('services')->name('services.')->group(function (): void {
         Route::resource('templates', ServiceTemplateController::class);
@@ -436,13 +436,13 @@ Route::prefix('install')->group(function (): void {
 });
 
 // Bulk SNMP routes (must be placed BEFORE the Legacy catch-all route)
-Route::middleware(['auth'])->group(function () {
+Route::middleware(['auth'])->group(function (): void {
     Route::prefix('device-groups/{device_group}/bulk-snmp')->group(function () {
-        Route::get('/', [\App\Http\Controllers\BulkSnmpController::class, 'show'])
+        Route::get('/', [App\Http\Controllers\BulkSnmpController::class, 'show'])
             ->name('device-group.bulk-snmp.show');
-        Route::post('/test', [\App\Http\Controllers\BulkSnmpController::class, 'test'])
+        Route::post('/test', [App\Http\Controllers\BulkSnmpController::class, 'test'])
             ->name('device-group.bulk-snmp.test');
-        Route::post('/apply', [\App\Http\Controllers\BulkSnmpController::class, 'apply'])
+        Route::post('/apply', [App\Http\Controllers\BulkSnmpController::class, 'apply'])
             ->name('device-group.bulk-snmp.apply');
     });
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -435,6 +435,18 @@ Route::prefix('install')->group(function (): void {
     Route::any('{path?}', [Install\InstallationController::class, 'invalid'])->where('path', '.*'); // 404
 });
 
+// Bulk SNMP routes (must be placed BEFORE the Legacy catch-all route)
+Route::middleware(['auth'])->group(function () {
+    Route::prefix('device-groups/{device_group}/bulk-snmp')->group(function () {
+        Route::get('/', [\App\Http\Controllers\BulkSnmpController::class, 'show'])
+            ->name('device-group.bulk-snmp.show');
+        Route::post('/test', [\App\Http\Controllers\BulkSnmpController::class, 'test'])
+            ->name('device-group.bulk-snmp.test');
+        Route::post('/apply', [\App\Http\Controllers\BulkSnmpController::class, 'apply'])
+            ->name('device-group.bulk-snmp.apply');
+    });
+});
+
 // Legacy routes
 Route::any('/dummy_legacy_auth/{path?}', [LegacyController::class, 'dummy'])->middleware('auth');
 Route::any('/dummy_legacy_unauth/{path?}', [LegacyController::class, 'dummy']);

--- a/tests/Feature/BulkSnmpTest.php
+++ b/tests/Feature/BulkSnmpTest.php
@@ -6,8 +6,8 @@ use App\Models\Device;
 use App\Models\DeviceGroup;
 use App\Models\User;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
-use Spatie\Permission\Models\Role;
 use LibreNMS\Tests\DBTestCase;
+use Spatie\Permission\Models\Role;
 
 /**
  * Feature tests for the bulk SNMP credentials feature.

--- a/tests/Feature/BulkSnmpTest.php
+++ b/tests/Feature/BulkSnmpTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Tests\Feature;
+namespace LibreNMS\Tests\Feature;
 
 use App\Models\Device;
 use App\Models\DeviceGroup;
 use App\Models\User;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Spatie\Permission\Models\Role;
-use Tests\TestCase;
+use LibreNMS\Tests\DBTestCase;
 
 /**
  * Feature tests for the bulk SNMP credentials feature.
@@ -16,7 +16,7 @@ use Tests\TestCase;
  * assign the 'admin' role explicitly. Adjust to match LibreNMS' own test
  * conventions/seeders if the project provides role helpers.
  */
-class BulkSnmpTest extends TestCase
+final class BulkSnmpTest extends DBTestCase
 {
     use DatabaseTransactions;
 

--- a/tests/Feature/BulkSnmpTest.php
+++ b/tests/Feature/BulkSnmpTest.php
@@ -5,6 +5,7 @@ namespace LibreNMS\Tests\Feature;
 use App\Models\Device;
 use App\Models\DeviceGroup;
 use App\Models\User;
+use Database\Factories\DeviceGroupFactory;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use LibreNMS\Tests\DBTestCase;
 use Spatie\Permission\Models\Role;
@@ -31,7 +32,7 @@ final class BulkSnmpTest extends DBTestCase
 
     public function testGuestCannotAccessBulkSnmpForm(): void
     {
-        $group = DeviceGroup::factory()->create();
+        $group = DeviceGroupFactory::new()->create();
 
         $this->get(route('device-group.bulk-snmp.show', $group))
             ->assertRedirect(); // redirected to login
@@ -40,7 +41,7 @@ final class BulkSnmpTest extends DBTestCase
     public function testNonAdminSeesFriendlyDeniedPage(): void
     {
         $user = User::factory()->create(); // no admin role
-        $group = DeviceGroup::factory()->create();
+        $group = DeviceGroupFactory::new()->create();
 
         $this->actingAs($user)
             ->get(route('device-group.bulk-snmp.show', $group))
@@ -51,7 +52,7 @@ final class BulkSnmpTest extends DBTestCase
     public function testNonAdminCannotApply(): void
     {
         $user = User::factory()->create(); // no admin role
-        $group = DeviceGroup::factory()->create();
+        $group = DeviceGroupFactory::new()->create();
 
         $this->actingAs($user)
             ->postJson(route('device-group.bulk-snmp.apply', $group), [
@@ -64,7 +65,7 @@ final class BulkSnmpTest extends DBTestCase
     public function testAdminCanAccessBulkSnmpForm(): void
     {
         $admin = $this->makeAdmin();
-        $group = DeviceGroup::factory()->create();
+        $group = DeviceGroupFactory::new()->create();
 
         $this->actingAs($admin)
             ->get(route('device-group.bulk-snmp.show', $group))
@@ -75,7 +76,7 @@ final class BulkSnmpTest extends DBTestCase
     public function testApplyValidatesV3RequiredFields(): void
     {
         $admin = $this->makeAdmin();
-        $group = DeviceGroup::factory()->create();
+        $group = DeviceGroupFactory::new()->create();
 
         $this->actingAs($admin)
             ->postJson(route('device-group.bulk-snmp.apply', $group), [
@@ -89,7 +90,7 @@ final class BulkSnmpTest extends DBTestCase
     public function testApplyValidatesV2cRequiredFields(): void
     {
         $admin = $this->makeAdmin();
-        $group = DeviceGroup::factory()->create();
+        $group = DeviceGroupFactory::new()->create();
 
         $this->actingAs($admin)
             ->postJson(route('device-group.bulk-snmp.apply', $group), [
@@ -103,7 +104,7 @@ final class BulkSnmpTest extends DBTestCase
     public function testApplyUpdatesAllDevicesInGroup(): void
     {
         $admin = $this->makeAdmin();
-        $group = DeviceGroup::factory()->create();
+        $group = DeviceGroupFactory::new()->create();
         $devices = Device::factory()->count(3)->create([
             'snmpver' => 'v2c',
             'community' => 'old_community',
@@ -130,7 +131,7 @@ final class BulkSnmpTest extends DBTestCase
     public function testApplySkipsDownDevicesWhenRequested(): void
     {
         $admin = $this->makeAdmin();
-        $group = DeviceGroup::factory()->create();
+        $group = DeviceGroupFactory::new()->create();
         Device::factory()->count(2)->create(['status' => 1]); // up
         Device::factory()->count(1)->create(['status' => 0]); // down
         $group->devices()->sync(Device::pluck('device_id'));

--- a/tests/Feature/BulkSnmpTest.php
+++ b/tests/Feature/BulkSnmpTest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Device;
+use App\Models\DeviceGroup;
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+/**
+ * Feature tests for the bulk SNMP credentials feature.
+ *
+ * NOTE: LibreNMS uses Spatie Laravel Permission for roles. These tests
+ * assign the 'admin' role explicitly. Adjust to match LibreNMS' own test
+ * conventions/seeders if the project provides role helpers.
+ */
+class BulkSnmpTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    protected function makeAdmin(): User
+    {
+        Role::findOrCreate('admin', 'web');
+        $user = User::factory()->create();
+        $user->assignRole('admin');
+
+        return $user;
+    }
+
+    public function testGuestCannotAccessBulkSnmpForm(): void
+    {
+        $group = DeviceGroup::factory()->create();
+
+        $this->get(route('device-group.bulk-snmp.show', $group))
+            ->assertRedirect(); // redirected to login
+    }
+
+    public function testNonAdminSeesFriendlyDeniedPage(): void
+    {
+        $user = User::factory()->create(); // no admin role
+        $group = DeviceGroup::factory()->create();
+
+        $this->actingAs($user)
+            ->get(route('device-group.bulk-snmp.show', $group))
+            ->assertOk()
+            ->assertSee(__('bulk-snmp.denied.title'));
+    }
+
+    public function testNonAdminCannotApply(): void
+    {
+        $user = User::factory()->create(); // no admin role
+        $group = DeviceGroup::factory()->create();
+
+        $this->actingAs($user)
+            ->postJson(route('device-group.bulk-snmp.apply', $group), [
+                'snmpver' => 'v2c',
+                'community' => 'whatever',
+            ])
+            ->assertForbidden();
+    }
+
+    public function testAdminCanAccessBulkSnmpForm(): void
+    {
+        $admin = $this->makeAdmin();
+        $group = DeviceGroup::factory()->create();
+
+        $this->actingAs($admin)
+            ->get(route('device-group.bulk-snmp.show', $group))
+            ->assertOk()
+            ->assertSee('Bulk SNMP');
+    }
+
+    public function testApplyValidatesV3RequiredFields(): void
+    {
+        $admin = $this->makeAdmin();
+        $group = DeviceGroup::factory()->create();
+
+        $this->actingAs($admin)
+            ->postJson(route('device-group.bulk-snmp.apply', $group), [
+                'snmpver' => 'v3',
+                // missing authname, authalgo, etc.
+            ])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['authname', 'authalgo', 'cryptoalgo', 'authlevel']);
+    }
+
+    public function testApplyValidatesV2cRequiredFields(): void
+    {
+        $admin = $this->makeAdmin();
+        $group = DeviceGroup::factory()->create();
+
+        $this->actingAs($admin)
+            ->postJson(route('device-group.bulk-snmp.apply', $group), [
+                'snmpver' => 'v2c',
+                // missing community
+            ])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['community']);
+    }
+
+    public function testApplyUpdatesAllDevicesInGroup(): void
+    {
+        $admin = $this->makeAdmin();
+        $group = DeviceGroup::factory()->create();
+        $devices = Device::factory()->count(3)->create([
+            'snmpver' => 'v2c',
+            'community' => 'old_community',
+        ]);
+        $group->devices()->sync($devices->pluck('device_id'));
+
+        $this->actingAs($admin)
+            ->postJson(route('device-group.bulk-snmp.apply', $group), [
+                'snmpver' => 'v2c',
+                'community' => 'new_community',
+            ])
+            ->assertOk()
+            ->assertJson([
+                'status' => 'ok',
+                'success_count' => 3,
+                'failed_count' => 0,
+            ]);
+
+        foreach ($devices as $device) {
+            $this->assertSame('new_community', $device->fresh()->community);
+        }
+    }
+
+    public function testApplySkipsDownDevicesWhenRequested(): void
+    {
+        $admin = $this->makeAdmin();
+        $group = DeviceGroup::factory()->create();
+        Device::factory()->count(2)->create(['status' => 1]); // up
+        Device::factory()->count(1)->create(['status' => 0]); // down
+        $group->devices()->sync(Device::pluck('device_id'));
+
+        $response = $this->actingAs($admin)
+            ->postJson(route('device-group.bulk-snmp.apply', $group), [
+                'snmpver' => 'v2c',
+                'community' => 'updated',
+                'skip_down' => true,
+            ])
+            ->assertOk()
+            ->json();
+
+        $this->assertSame(2, $response['total']);
+        $this->assertSame(2, $response['success_count']);
+    }
+}

--- a/tests/Feature/BulkSnmpTest.php
+++ b/tests/Feature/BulkSnmpTest.php
@@ -35,20 +35,19 @@ class BulkSnmpTest extends TestCase
         return $user;
     }
 
-    public function testGuestCannotAccessBulkSnmpForm(): void
+    private function makeUser(): User
     {
-        $group = DeviceGroupFactory::new()->create();
+        $user = User::factory()->create(['enabled' => 1]);
+        $user->assignRole('user');
 
-        $this->get(route('device-group.bulk-snmp.show', $group))
-            ->assertRedirect();
+        return $user;
     }
 
     public function testNonAdminSeesFriendlyDeniedPage(): void
     {
-        $user = User::factory()->create(['enabled' => 1]);
         $group = DeviceGroupFactory::new()->create();
 
-        $this->actingAs($user)
+        $this->actingAs($this->makeUser())
             ->get(route('device-group.bulk-snmp.show', $group))
             ->assertOk()
             ->assertSee(__('bulk-snmp.denied.title'));
@@ -56,10 +55,9 @@ class BulkSnmpTest extends TestCase
 
     public function testNonAdminCannotApply(): void
     {
-        $user = User::factory()->create(['enabled' => 1]);
         $group = DeviceGroupFactory::new()->create();
 
-        $this->actingAs($user)
+        $this->actingAs($this->makeUser())
             ->postJson(route('device-group.bulk-snmp.apply', $group), [
                 'snmpver' => 'v2c',
                 'community' => 'whatever',
@@ -69,10 +67,9 @@ class BulkSnmpTest extends TestCase
 
     public function testAdminCanAccessBulkSnmpForm(): void
     {
-        $admin = $this->makeAdmin();
         $group = DeviceGroupFactory::new()->create();
 
-        $this->actingAs($admin)
+        $this->actingAs($this->makeAdmin())
             ->get(route('device-group.bulk-snmp.show', $group))
             ->assertOk()
             ->assertSee('Bulk SNMP');
@@ -80,10 +77,9 @@ class BulkSnmpTest extends TestCase
 
     public function testApplyValidatesV3RequiredFields(): void
     {
-        $admin = $this->makeAdmin();
         $group = DeviceGroupFactory::new()->create();
 
-        $this->actingAs($admin)
+        $this->actingAs($this->makeAdmin())
             ->postJson(route('device-group.bulk-snmp.apply', $group), [
                 'snmpver' => 'v3',
             ])
@@ -93,10 +89,9 @@ class BulkSnmpTest extends TestCase
 
     public function testApplyValidatesV2cRequiredFields(): void
     {
-        $admin = $this->makeAdmin();
         $group = DeviceGroupFactory::new()->create();
 
-        $this->actingAs($admin)
+        $this->actingAs($this->makeAdmin())
             ->postJson(route('device-group.bulk-snmp.apply', $group), [
                 'snmpver' => 'v2c',
             ])
@@ -106,7 +101,6 @@ class BulkSnmpTest extends TestCase
 
     public function testApplyUpdatesAllDevicesInGroup(): void
     {
-        $admin = $this->makeAdmin();
         $group = DeviceGroupFactory::new()->create();
         $devices = Device::factory()->count(3)->create([
             'snmpver' => 'v2c',
@@ -114,7 +108,7 @@ class BulkSnmpTest extends TestCase
         ]);
         $group->devices()->sync($devices->pluck('device_id'));
 
-        $this->actingAs($admin)
+        $this->actingAs($this->makeAdmin())
             ->postJson(route('device-group.bulk-snmp.apply', $group), [
                 'snmpver' => 'v2c',
                 'community' => 'new_community',
@@ -133,13 +127,12 @@ class BulkSnmpTest extends TestCase
 
     public function testApplySkipsDownDevicesWhenRequested(): void
     {
-        $admin = $this->makeAdmin();
         $group = DeviceGroupFactory::new()->create();
         $up = Device::factory()->count(2)->create(['status' => 1]);
         $down = Device::factory()->count(1)->create(['status' => 0]);
         $group->devices()->sync($up->pluck('device_id')->merge($down->pluck('device_id')));
 
-        $response = $this->actingAs($admin)
+        $response = $this->actingAs($this->makeAdmin())
             ->postJson(route('device-group.bulk-snmp.apply', $group), [
                 'snmpver' => 'v2c',
                 'community' => 'updated',

--- a/tests/Feature/BulkSnmpTest.php
+++ b/tests/Feature/BulkSnmpTest.php
@@ -3,7 +3,6 @@
 namespace LibreNMS\Tests\Feature;
 
 use App\Models\Device;
-use App\Models\DeviceGroup;
 use App\Models\User;
 use Database\Factories\DeviceGroupFactory;
 use Illuminate\Foundation\Testing\DatabaseTransactions;

--- a/tests/Feature/BulkSnmpTest.php
+++ b/tests/Feature/BulkSnmpTest.php
@@ -2,28 +2,34 @@
 
 namespace LibreNMS\Tests\Feature;
 
+use App\Facades\LibrenmsConfig;
 use App\Models\Device;
 use App\Models\User;
 use Database\Factories\DeviceGroupFactory;
-use Illuminate\Foundation\Testing\DatabaseTransactions;
-use LibreNMS\Tests\DBTestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use LibreNMS\Tests\TestCase;
 use Spatie\Permission\Models\Role;
 
 /**
  * Feature tests for the bulk SNMP credentials feature.
- *
- * NOTE: LibreNMS uses Spatie Laravel Permission for roles. These tests
- * assign the 'admin' role explicitly. Adjust to match LibreNMS' own test
- * conventions/seeders if the project provides role helpers.
  */
-final class BulkSnmpTest extends DBTestCase
+class BulkSnmpTest extends TestCase
 {
-    use DatabaseTransactions;
+    use RefreshDatabase;
 
-    protected function makeAdmin(): User
+    protected function setUp(): void
     {
-        Role::findOrCreate('admin', 'web');
-        $user = User::factory()->create();
+        parent::setUp();
+
+        Role::findOrCreate('admin');
+        Role::findOrCreate('user');
+
+        LibrenmsConfig::set('auth_mechanism', 'mysql');
+    }
+
+    private function makeAdmin(): User
+    {
+        $user = User::factory()->create(['enabled' => 1]);
         $user->assignRole('admin');
 
         return $user;
@@ -34,12 +40,12 @@ final class BulkSnmpTest extends DBTestCase
         $group = DeviceGroupFactory::new()->create();
 
         $this->get(route('device-group.bulk-snmp.show', $group))
-            ->assertRedirect(); // redirected to login
+            ->assertRedirect();
     }
 
     public function testNonAdminSeesFriendlyDeniedPage(): void
     {
-        $user = User::factory()->create(); // no admin role
+        $user = User::factory()->create(['enabled' => 1]);
         $group = DeviceGroupFactory::new()->create();
 
         $this->actingAs($user)
@@ -50,7 +56,7 @@ final class BulkSnmpTest extends DBTestCase
 
     public function testNonAdminCannotApply(): void
     {
-        $user = User::factory()->create(); // no admin role
+        $user = User::factory()->create(['enabled' => 1]);
         $group = DeviceGroupFactory::new()->create();
 
         $this->actingAs($user)
@@ -80,7 +86,6 @@ final class BulkSnmpTest extends DBTestCase
         $this->actingAs($admin)
             ->postJson(route('device-group.bulk-snmp.apply', $group), [
                 'snmpver' => 'v3',
-                // missing authname, authalgo, etc.
             ])
             ->assertStatus(422)
             ->assertJsonValidationErrors(['authname', 'authalgo', 'cryptoalgo', 'authlevel']);
@@ -94,7 +99,6 @@ final class BulkSnmpTest extends DBTestCase
         $this->actingAs($admin)
             ->postJson(route('device-group.bulk-snmp.apply', $group), [
                 'snmpver' => 'v2c',
-                // missing community
             ])
             ->assertStatus(422)
             ->assertJsonValidationErrors(['community']);
@@ -131,9 +135,9 @@ final class BulkSnmpTest extends DBTestCase
     {
         $admin = $this->makeAdmin();
         $group = DeviceGroupFactory::new()->create();
-        Device::factory()->count(2)->create(['status' => 1]); // up
-        Device::factory()->count(1)->create(['status' => 0]); // down
-        $group->devices()->sync(Device::pluck('device_id'));
+        $up = Device::factory()->count(2)->create(['status' => 1]);
+        $down = Device::factory()->count(1)->create(['status' => 0]);
+        $group->devices()->sync($up->pluck('device_id')->merge($down->pluck('device_id')));
 
         $response = $this->actingAs($admin)
             ->postJson(route('device-group.bulk-snmp.apply', $group), [


### PR DESCRIPTION
## Why

It can happen to any of us. A security incident. An employee with credential access leaving the company. A compliance requirement. A change in company policy. Or simply good operational hygiene — rotating credentials on a schedule.

When that moment arrives, the SNMP community string (or SNMPv3 auth/priv credentials) needs to be replaced on **every monitored device**. Updating the devices themselves is the easy part — that is usually automated through the vendor's management platform.

The painful part is LibreNMS. Today, after the credentials change on the devices, every single device has to be edited **one by one** in the LibreNMS UI to match. For an environment with dozens or hundreds of devices, that is a lot of repetitive manual work — and every missed device means broken polling until someone notices.

This has been a long-standing gap. See #1047, which originally asked for SNMP credentials to be manageable at the Device Group level back in 2015.

## The solution

This PR adds a **Bulk SNMP Credentials** page, reachable from the Device Group edit screen. It lets an administrator update the SNMP settings of every device in a group in a single action.

The workflow is intentionally safe:

1. Change the credentials on the devices themselves (outside LibreNMS, as usual)
2. Open **Device Groups → [group] → Edit → Bulk SNMP Edit**
3. Enter the new credentials (SNMPv2c community, or full SNMPv3 set)
4. **Test Credentials** — runs a live SNMP query against every device in the group and reports per-device which ones respond, *without changing anything*
5. **Apply** — writes the new credentials to all devices in the group, with a per-device result report

### Features

- Supports **SNMPv2c** (community) and **SNMPv3** (security level, auth username/algorithm/password, crypto algorithm/password)
- **Test before apply** — optional dry-run that verifies reachability per device via a live SNMP query
- **Skip down devices** — option to exclude devices that are currently down (useful when those devices could not receive the new credentials yet)
- **Per-device result reporting** — a single failure does not abort the rest; the result panel shows exactly which devices succeeded and which failed
- **Eventlog entry per device** — every change is logged for audit purposes
- **Admin-only, handled gracefully** — the "Bulk SNMP Edit" button is only shown to administrators; if a non-admin reaches the page directly they get a clear explanation asking them to contact an administrator, not a raw 403; the test/apply endpoints reject non-admins and the UI surfaces a readable message

## Scope

This PR deliberately keeps the scope focused on a **bulk credential update** triggered from the Device Group page. Two related ideas are intentionally left out, to keep the change reviewable:

- A bulk action on the general devices list (would require bulk-selection infrastructure) — could be a follow-up PR
- Group-level *default* credentials that devices inherit (the original #1047 idea) — a larger change requiring a schema migration

## Implementation

**New files:**

- `app/Http/Controllers/BulkSnmpController.php` — three endpoints: show form, test, apply
- `app/Http/Requests/BulkSnmpRequest.php` — validation; v2c/v3 conditional rules; `admin` role authorization
- `app/Services/BulkSnmpService.php` — business logic; field whitelisting, per-device test and apply, Eventlog logging
- `resources/views/device-group/bulk-snmp.blade.php` — the UI (Bootstrap 3, consistent with the existing Device Group pages; Alpine.js for interactivity)
- `resources/views/device-group/bulk-snmp-denied.blade.php` — friendly "administrator access required" page for non-admins
- `lang/en/bulk-snmp.php` — translation strings
- `tests/Feature/BulkSnmpTest.php` — feature tests

**Modified files:**

- `routes/web.php` — three new routes under `device-groups/{device_group}/bulk-snmp`
- `resources/views/device-group/edit.blade.php` — adds the "Bulk SNMP Edit" button (admin-gated)

### Safety notes

- `BulkSnmpService` whitelists exactly which device columns may be written (`ALLOWED_FIELDS`), so the bulk update can never touch unrelated fields
- Each device update is wrapped individually; one failure is reported, not fatal
- The test action restores the device's original attributes afterwards and never persists the test attempt

## Testing done

- Verified on a homelab LibreNMS instance against real Cisco IOS devices
- SNMPv2c community update applied to a Device Group and confirmed in the `devices` table
- Test Credentials verified per-device reachability reporting
- Admin-only access confirmed — non-admins see the friendly "administrator access required" page; the apply/test endpoints reject them cleanly
- Feature tests included

## Screenshots
<img width="213" height="62" alt="Screenshot 2026-05-20 at 21 57 04" src="https://github.com/user-attachments/assets/327fde28-d6c8-4245-8c21-9fd872e42ab9" />

<img width="1167" height="749" alt="Screenshot 2026-05-20 at 21 57 39" src="https://github.com/user-attachments/assets/ce5a5322-3806-4b73-b36b-566aa2e70d73" />



## Notes for reviewers

- The page extends `layouts.librenmsv1` and uses Bootstrap 3 to stay consistent with the existing Device Group edit/create pages. Happy to reconsider if a Tailwind/Vue approach is preferred for new pages.
- `tests/Feature/BulkSnmpTest.php` assigns the `admin` role via Spatie's `assignRole()`. If the project has a preferred test helper/seeder for roles, I'll gladly adjust.

Closes #1047 (partially — bulk update; group-default inheritance left as potential follow-up).