### PR TITLE
fix: null-guard undefined array key in GraphParameters::extractType() (PHP 8.3)

### DIFF
--- a/LibreNMS/Data/Graphing/GraphParameters.php
+++ b/LibreNMS/Data/Graphing/GraphParameters.php
@@ -284,8 +284,8 @@ class GraphParameters implements \Stringable
     private function extractType(string $type): array
     {
         preg_match('/^(?P<type>[A-Za-z0-9]+)_(?P<subtype>.+)/', $type, $graphtype);
-        $type = basename($graphtype['type']);
-        $subtype = basename($graphtype['subtype']);
+        $type = basename($graphtype['type'] ?? '');
+        $subtype = basename($graphtype['subtype'] ?? '');
 
         return [$type, $subtype];
     }


### PR DESCRIPTION
## Problem

`GraphParameters::extractType()` at line 287-288 accesses `$graphtype['type']` and `$graphtype['subtype']` after `preg_match()`, but `preg_match()` may not match (e.g. when the graph type string contains no underscore). When the regex does not match, the named capture groups are absent from the `$graphtype` array.

Under PHP 8.3, accessing a missing array key is an `E_WARNING`:
```
PHP Warning: Undefined array key "type" in LibreNMS/Data/Graphing/GraphParameters.php on line 287
PHP Warning: Undefined array key "subtype" in LibreNMS/Data/Graphing/GraphParameters.php on line 288
```

These warnings fire on every API call to `/api/v0/devices/{id}/sensors` and clutter the LibreNMS error log significantly.

## Fix

Add a null coalescing fallback (`?? ''`) so `basename()` receives an empty string instead of an undefined key access:

```php
// Before:
$type    = basename($graphtype['type']);
$subtype = basename($graphtype['subtype']);

// After:
$type    = basename($graphtype['type'] ?? '');
$subtype = basename($graphtype['subtype'] ?? '');
```

No behaviour change when the regex matches. When it does not match, `$type` and `$subtype` are empty strings (same as what the original code would have produced in PHP 7 without an error).

## Testing

Reproduced the warning by calling `/api/v0/devices/{id}/sensors` on a LibreNMS instance running PHP 8.3. Warning absent after applying the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)