### PR TITLE
epmp: add Cambium subscriber summary panel to device overview

### DIFF
--- a/includes/html/graphs/device/wireless_mcs.inc.php
+++ b/includes/html/graphs/device/wireless_mcs.inc.php
@@ -1,0 +1,9 @@
+<?php
+
+$scale_min = '0';
+
+$class = 'mcs';
+$unit = '';
+$unit_long = 'MCS';
+
+require 'includes/html/graphs/device/wireless-sensor.inc.php';

--- a/includes/html/graphs/wireless/mcs.inc.php
+++ b/includes/html/graphs/wireless/mcs.inc.php
@@ -1,0 +1,8 @@
+<?php
+
+$scale_min = '0';
+
+$unit_long = 'MCS';
+$unit = '';
+
+include 'wireless-sensor.inc.php';

--- a/includes/html/pages/device/overview.inc.php
+++ b/includes/html/pages/device/overview.inc.php
@@ -27,6 +27,7 @@ foreach (PluginManager::call(DeviceOverviewHook::class, ['device' => DeviceCache
 require 'overview/ports.inc.php';
 require 'overview/availability_bar.inc.php';
 require 'overview/transceivers.inc.php';
+require 'overview/cambium-subscribers.inc.php';
 
 if ($device['os'] == 'ping') {
     require 'overview/ping.inc.php';

--- a/includes/html/pages/device/overview/cambium-subscribers.inc.php
+++ b/includes/html/pages/device/overview/cambium-subscribers.inc.php
@@ -1,0 +1,96 @@
+<?php
+
+/**
+ * cambium-subscribers.inc.php
+ *
+ * Device overview panel: list connected SMs for a Cambium ePMP AP
+ * with the canonical link-health badges (downlink RSSI and downlink
+ * MCS) plus link distance.  Per-SM detail and history live on the
+ * device's wireless tab.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * @link       https://www.librenms.org
+ */
+
+use Illuminate\Support\Str;
+
+if (($device['os'] ?? null) !== 'epmp') {
+    return;
+}
+
+$subscriber_sensors = DeviceCache::getPrimary()->wirelessSensors()
+    ->where('sensor_deleted', 0)
+    ->whereIn('sensor_class', ['rssi', 'mcs', 'distance'])
+    ->where('sensor_index', '!=', '0')
+    ->orderBy('sensor_index')
+    ->get();
+
+if ($subscriber_sensors->isEmpty()) {
+    return;
+}
+
+// The ePMP poller (PR #19462) writes sensor_descr in the form
+// "<identity> <metric>", where <identity> is the subscriber label
+// from Epmp::formatSubscriberLabel() and <metric> is one of a known
+// fixed list. Strip the metric suffix to recover <identity>, then
+// strip any trailing "(...)" or "[...]" groups to leave just the
+// hostname-equivalent for the column display. All string-character
+// operations; no regex.
+$metric_suffixes = [
+    ' UL RSSI', ' DL RSSI',
+    ' UL SNR', ' DL SNR',
+    ' UL MCS', ' DL MCS',
+    ' Tx Quality', ' Tx Capacity', ' Distance',
+];
+
+$subscriberName = function (string $descr, string $fallback_index) use ($metric_suffixes): string {
+    foreach ($metric_suffixes as $suffix) {
+        if (str_ends_with($descr, $suffix)) {
+            $descr = substr($descr, 0, -strlen($suffix));
+            break;
+        }
+    }
+    if (str_contains($descr, ' (')) {
+        $descr = Str::before($descr, ' (');
+    }
+    if (str_contains($descr, ' [')) {
+        $descr = Str::before($descr, ' [');
+    }
+    $descr = trim($descr);
+
+    return $descr !== '' ? $descr : 'Subscriber ' . $fallback_index;
+};
+
+// ePMP per-subscriber sensor_type strings follow the pattern
+// epmp-ap-{direction}[-{class}] (see PR #19462). RSSI and SNR end at
+// the direction; MCS appends the class. Match either shape.
+$findSensor = fn ($smSensors, string $class, ?string $direction = null) => $smSensors->first(function ($sensor) use ($class, $direction) {
+    if ($sensor->sensor_class->value !== $class) {
+        return false;
+    }
+    if ($direction === null) {
+        return true;
+    }
+
+    return str_ends_with((string) $sensor->sensor_type, '-' . $direction)
+        || str_contains((string) $sensor->sensor_type, '-' . $direction . '-');
+});
+
+echo view('device.overview.cambium-subscribers', [
+    'sensors' => $subscriber_sensors,
+    'subscribers_link' => route('device', ['device' => $device['device_id'], 'tab' => 'wireless']),
+    'subscriberName' => $subscriberName,
+    'findSensor' => $findSensor,
+]);

--- a/resources/views/device/overview/cambium-subscribers.blade.php
+++ b/resources/views/device/overview/cambium-subscribers.blade.php
@@ -1,0 +1,46 @@
+<div class="row">
+    <div class="col-md-12">
+        <x-panel class="device-overview panel-condensed">
+            <x-slot name="heading">
+                <i class="fa fa-wifi fa-lg icon-theme" aria-hidden="true"></i>
+                <strong><a href="{{ $subscribers_link }}">{{ __('Subscribers') }}</a></strong>
+            </x-slot>
+            <table class="table table-hover table-condensed table-striped tw:mb-0!">
+                <thead>
+                    <tr>
+                        <th>{{ __('Subscriber') }}</th>
+                        <th>{{ __('Distance') }}</th>
+                        <th>{{ __('Signal') }}</th>
+                        <th>{{ __('MCS') }}</th>
+                    </tr>
+                </thead>
+                <tbody>
+                @foreach($sensors->groupBy('sensor_index')->sortKeys() as $index => $smSensors)
+                    @php
+                        $name     = $subscriberName($smSensors->first()->sensor_descr, (string) $index);
+                        $distance = $findSensor($smSensors, 'distance');
+                        $rssiDl   = $findSensor($smSensors, 'rssi', 'dl');
+                        $mcsDl    = $findSensor($smSensors, 'mcs', 'dl');
+                    @endphp
+                    <tr>
+                        <td><strong>{{ $name }}</strong></td>
+                        <td class="text-nowrap">
+                            @if($distance)<span class="text-muted">{{ $distance->formatValue() }}</span>@endif
+                        </td>
+                        <td class="text-nowrap">
+                            @if($rssiDl)
+                                <x-label :status="$rssiDl->currentStatus()">{{ $rssiDl->sensor_current }} dBm</x-label>
+                            @endif
+                        </td>
+                        <td class="text-nowrap">
+                            @if($mcsDl)
+                                <x-label :status="$mcsDl->currentStatus()">{{ $mcsDl->sensor_current }}</x-label>
+                            @endif
+                        </td>
+                    </tr>
+                @endforeach
+                </tbody>
+            </table>
+        </x-panel>
+    </div>
+</div>


### PR DESCRIPTION
Trying this again after PR #19463 was closed. I'm an operator running this in production, not a developer, but I think I can get this code to a level where it improves LibreNMS for other Cambium operators while passing the review bar.

### Screenshot

![Cambium subscriber summary panel on an ePMP AP device overview](https://raw.githubusercontent.com/isolson/librenms/screenshots/cambium-subscriber-panel.png)

### What this PR adds

A new device overview panel for Cambium ePMP APs that lists the connected SMs with their hostname-equivalent, link distance, downlink RSSI, and downlink MCS as the canonical at-a-glance link-health badges. Per-SM detail and history live on the existing wireless tab; the panel heading links there.

### Files

- `includes/html/pages/device/overview/cambium-subscribers.inc.php` (thin dispatcher: OS gate, query `wireless_sensors`, derive subscriber names with `str_ends_with` / `Str::before` against a known fixed list of metric suffixes, hand off to view).
- `resources/views/device/overview/cambium-subscribers.blade.php` (Blade view: `<x-panel>` + table + `<x-label>` per row, using closures passed from the dispatcher).
- `includes/html/pages/device/overview.inc.php` (one `require` line, alongside the other vendor-neutral panels, after `transceivers`).
- `includes/html/graphs/device/wireless_mcs.inc.php` and `includes/html/graphs/wireless/mcs.inc.php` (6 lines each): missing graph-type definitions for the `mcs` `WirelessSensorType` added by my previously merged #19462. Self-contained gap-fill; happy to split into a separate tiny PR if preferred.

### Dependencies and convention notes

- Builds on my previously merged #19462, which writes the per-subscriber `wireless_sensors` rows this panel displays. No new discovery or polling code in this PR.
- Mirrors the overview-panel conventions in two recent merged PRs:
  - **#16165** (Transceiver support, Tony Murray): the modern overview-panel idiom. Thin `.inc.php` dispatcher under `includes/html/pages/device/overview/` plus a Blade view under `resources/views/device/overview/` using `<x-panel>`, `<x-label>`, closures passed from the dispatcher to the view.
  - **#15985** (Custom maps in device overview, Tony Murray): the minimum-viable shape for an overview panel.
- OS gate matches the `ping` panel precedent (`overview/ping.inc.php`).
- Strings are routed through `__()` so they can be translated.
- No regex parsing of `sensor_descr`; subscriber-name extraction uses only `str_ends_with`/`substr`/`Str::before` against a known fixed list of suffixes written by #19462's `Epmp::formatSubscriberLabel()`.

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/). (No discovery/polling changes in this PR.)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
