### PR TITLE
fix: use EES identName as features instead of sysName

### DIFF
--- a/resources/definitions/os_discovery/ees.yaml
+++ b/resources/definitions/os_discovery/ees.yaml
@@ -4,7 +4,7 @@ modules:
     hardware: .1.3.6.1.4.1.6302.2.1.1.2.0
     version: EES-POWER-MIB::identControllerFirmwareVersion.0
     serial: EES-POWER-MIB::identControllerSerialNumber.0
-    sysName: .1.3.6.1.4.1.6302.2.1.1.4.0
+    features: EES-POWER-MIB::identName.0
 
   sensors:
     temperature:

--- a/tests/data/ees_controller.json
+++ b/tests/data/ees_controller.json
@@ -3,13 +3,13 @@
         "discovery": {
             "devices": [
                 {
-                    "sysName": "site",
+                    "sysName": null,
                     "sysObjectID": ".1.3.6.1.4.1.8072.3.2.10",
                     "sysDescr": "Linux ES_Controller 4.19.94-gbe5389fd85 #78 PREEMPT Mon Apr 11 17:10:45 CST 2022 armv7l",
                     "sysContact": "<private>",
                     "version": "5.2.05BP32",
                     "hardware": "NCU",
-                    "features": null,
+                    "features": "SITE",
                     "location": "<private>",
                     "os": "ees",
                     "type": "power",


### PR DESCRIPTION
The EES identName OID is a controller/site name, not the actual SNMP sysName. Mapping it to sysName causes LibreNMS to overwrite or log sysName changes when core discovery reads SNMPv2-MIB::sysName.0. This change stores the value in features instead, keeping the useful site name visible while leaving sysName aligned with the real SNMP value.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
