### PR TITLE
Cisco port security code improvements

### DIFF
--- a/LibreNMS/Interfaces/Polling/PortSecurityPolling.php
+++ b/LibreNMS/Interfaces/Polling/PortSecurityPolling.php
@@ -28,14 +28,15 @@ namespace LibreNMS\Interfaces\Polling;
 
 use App\Models\PortSecurity;
 use Illuminate\Support\Collection;
+use LibreNMS\OS;
 
 interface PortSecurityPolling
 {
     /**
      * Poll the ports for port-security data
      *
-     * @param  mixed  $os
+     * @param  OS  $os
      * @return Collection<PortSecurity>
      */
-    public function pollPortSecurity($os): Collection;
+    public function pollPortSecurity(OS $os): Collection;
 }

--- a/LibreNMS/Interfaces/Polling/PortSecurityPolling.php
+++ b/LibreNMS/Interfaces/Polling/PortSecurityPolling.php
@@ -35,8 +35,7 @@ interface PortSecurityPolling
      * Poll the ports for port-security data
      *
      * @param  mixed  $os
-     * @param  mixed  $device
      * @return Collection<PortSecurity>
      */
-    public function pollPortSecurity($os, $device): Collection;
+    public function pollPortSecurity($os): Collection;
 }

--- a/LibreNMS/Modules/PortSecurity.php
+++ b/LibreNMS/Modules/PortSecurity.php
@@ -75,7 +75,7 @@ class PortSecurity implements Module
     {
         if ($os instanceof PortSecurityPolling) {
             $device = $os->getDevice();
-            $portsec = $os->pollPortSecurity($os, $device);
+            $portsec = $os->pollPortSecurity($os);
             ModuleModelObserver::observe(\App\Models\PortSecurity::class);
             $this->syncModels($device, 'portSecurity', $portsec);
         }

--- a/LibreNMS/Modules/PortSecurity.php
+++ b/LibreNMS/Modules/PortSecurity.php
@@ -68,8 +68,6 @@ class PortSecurity implements Module
 
     /**
      * Poll data for this module and update the DB
-     *
-     * @param  \LibreNMS\OS  $os
      */
     public function poll(OS $os, DataStorageInterface $datastore): void
     {

--- a/LibreNMS/OS/Traits/CiscoPortSecurity.php
+++ b/LibreNMS/OS/Traits/CiscoPortSecurity.php
@@ -26,21 +26,16 @@
 
 namespace LibreNMS\OS\Traits;
 
-use App\Models\Port;
+use App\Facades\PortCache;
 use App\Models\PortSecurity;
 use Illuminate\Support\Collection;
+use SnmpQuery;
 
 trait CiscoPortSecurity
 {
-    public function pollPortSecurity($os, $device): Collection
+    public function pollPortSecurity($os): Collection
     {
-        // Polling for current data
-        $port_id = 0;
-        $record = [];
-        $device = $device->toArray();
-
-        $portsec_snmp = [];
-        $portsec_snmp = \SnmpQuery::hideMib()->enumStrings()->walk([
+        return SnmpQuery::enumStrings()->walk([
             'CISCO-PORT-SECURITY-MIB::cpsIfPortSecurityEnable',
             'CISCO-PORT-SECURITY-MIB::cpsIfPortSecurityStatus',
             'CISCO-PORT-SECURITY-MIB::cpsIfMaxSecureMacAddr',
@@ -49,70 +44,28 @@ trait CiscoPortSecurity
             'CISCO-PORT-SECURITY-MIB::cpsIfViolationCount',
             'CISCO-PORT-SECURITY-MIB::cpsIfSecureLastMacAddress',
             'CISCO-PORT-SECURITY-MIB::cpsIfStickyEnable',
-        ])->table(1);
-
-        // Storing all polled data into an array using ifIndex as the index
-        // Getting all ports from device. Port has to exist in ports table to be populated in port_security
-        // Using ifIndex to map the port-security data to a port_id to compare/update against the correct records
-        $ports = new Port();
-        $device = $os->getDevice();
-        $device_id = $device->device_id;
-        $port_list = $ports->select('port_id', 'ifIndex')->where('device_id', $device_id)->get()->toArray();
-        $port_key = [];
-        foreach ($port_list as $item) {
-            $if_index = $item['ifIndex'];
-            $port_id = $item['port_id'];
-            $port_key[$if_index] = $port_id;
-            $portsec_snmp[$if_index]['ifIndex'] = $if_index;
-
-            if (array_key_exists($if_index, $portsec_snmp)) {
-                $portsec_snmp[$if_index]['port_id'] = $port_id;
-                $portsec_snmp[$if_index]['device_id'] = $device_id;
-            }
-        }
-
-        // Assigning port_id and device_id to SNMP array for comparison
-        $portsec = $device->portSecurity;
-
-        foreach ($portsec_snmp as $if_index => $snmp) {
-            if (! is_array($snmp) || ! array_key_exists($if_index, $port_key)) {
-                continue;
+        ])->mapTable(function ($snmp, $ifIndex) use ($os) {
+            if (! array_key_exists('CISCO-PORT-SECURITY-MIB::cpsIfPortSecurityEnable', $snmp)) {
+                return null;
             }
 
-            if (! array_key_exists('cpsIfPortSecurityEnable', $snmp)) {
-                continue;
+            $port_id = PortCache::getIdFromIfIndex($ifIndex);
+            if ($port_id === null) {
+                return null;
             }
 
-            $port_id = $port_key[$if_index];
-
-            $record = [
+            return new PortSecurity([
                 'port_id' => $port_id,
-                'device_id' => $device_id,
-                'port_security_enable' => ($snmp['cpsIfPortSecurityEnable'] ?? null) === 'true',
-                'status' => $snmp['cpsIfPortSecurityStatus'] ?? null,
-                'max_addresses' => $snmp['cpsIfMaxSecureMacAddr'] ?? null,
-                'address_count' => $snmp['cpsIfCurrentSecureMacAddrCount'] ?? null,
-                'violation_action' => $snmp['cpsIfViolationAction'] ?? null,
-                'violation_count' => $snmp['cpsIfViolationCount'] ?? null,
-                'last_mac_address' => $snmp['cpsIfSecureLastMacAddress'] ?? null,
-                'sticky_enable' => array_key_exists('cpsIfStickyEnable', $snmp) ? $snmp['cpsIfStickyEnable'] === 'true' : null,
-            ];
-
-            $attributes = array_filter($record, fn ($value) => $value !== null);
-
-            $entry = $portsec->where('port_id', $port_id)->first();
-
-            if ($entry) {
-                $entry->fill($attributes);
-
-                if ($entry->isDirty()) {
-                    $entry->save();
-                }
-            } else {
-                PortSecurity::create($attributes);
-            }
-        }
-
-        return $portsec;
+                'device_id' => $os->getDeviceId(),
+                'port_security_enable' => ($snmp['CISCO-PORT-SECURITY-MIB::cpsIfPortSecurityEnable'] ?? null) === 'true',
+                'status' => $snmp['CISCO-PORT-SECURITY-MIB::cpsIfPortSecurityStatus'] ?? null,
+                'max_addresses' => $snmp['CISCO-PORT-SECURITY-MIB::cpsIfMaxSecureMacAddr'] ?? null,
+                'address_count' => $snmp['CISCO-PORT-SECURITY-MIB::cpsIfCurrentSecureMacAddrCount'] ?? null,
+                'violation_action' => $snmp['CISCO-PORT-SECURITY-MIB::cpsIfViolationAction'] ?? null,
+                'violation_count' => $snmp['CISCO-PORT-SECURITY-MIB::cpsIfViolationCount'] ?? null,
+                'last_mac_address' => $snmp['CISCO-PORT-SECURITY-MIB::cpsIfSecureLastMacAddress'] ?? null,
+                'sticky_enable' => isset($snmp['CISCO-PORT-SECURITY-MIB::cpsIfStickyEnable']) ? $snmp['CISCO-PORT-SECURITY-MIB::cpsIfStickyEnable'] === 'true' : null,
+            ]);
+        })->filter();
     }
 }

--- a/LibreNMS/OS/Traits/CiscoPortSecurity.php
+++ b/LibreNMS/OS/Traits/CiscoPortSecurity.php
@@ -29,11 +29,12 @@ namespace LibreNMS\OS\Traits;
 use App\Facades\PortCache;
 use App\Models\PortSecurity;
 use Illuminate\Support\Collection;
+use LibreNMS\OS;
 use SnmpQuery;
 
 trait CiscoPortSecurity
 {
-    public function pollPortSecurity($os): Collection
+    public function pollPortSecurity(OS $os): Collection
     {
         return SnmpQuery::enumStrings()->walk([
             'CISCO-PORT-SECURITY-MIB::cpsIfPortSecurityEnable',


### PR DESCRIPTION
Use PortCache, removes a lot of unneeded code
Reduce sql queries (the os code was running uneeded sql) $device is redundant on the interface

after #19692 

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
