### PR TITLE
Bug fix when creating non-dynamic device groups

### DIFF
--- a/app/Models/DeviceGroup.php
+++ b/app/Models/DeviceGroup.php
@@ -46,7 +46,7 @@ class DeviceGroup extends BaseModel
         });
 
         static::saving(function (DeviceGroup $deviceGroup): void {
-            if ($deviceGroup->isDirty('rules')) {
+            if ($deviceGroup->type == 'dynamic' && $deviceGroup->isDirty('rules')) {
                 $deviceGroup->rules = $deviceGroup->getParser()->generateJoins()->toArray();
             }
         });


### PR DESCRIPTION
I was getting an exception on the changed line of code when trying to create a static device group.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
