### PR TITLE
feat(services): allow service templates to use check_dhcp

### DIFF
--- a/includes/services/check_dhcp.inc.php
+++ b/includes/services/check_dhcp.inc.php
@@ -1,3 +1,9 @@
 <?php
 
-$check_cmd = \App\Facades\LibrenmsConfig::get('nagios_plugins') . '/check_dhcp ' . $service['service_param'];
+if ($service['service_ip']) {
+    $server = $service['service_ip'];
+} else {
+    $server = $service['hostname'];
+}
+
+$check_cmd = App\Facades\LibrenmsConfig::get('nagios_plugins') . '/check_dhcp -s ' . $server . ' ' . $service['service_param'];


### PR DESCRIPTION
## Allow service templates to use check_dhcp

`check_dhcp` has no `-H` flag, unlike `check_dns`, `check_ntp`, and most other plugins. That means the default `-H <hostname>` injection in `services.inc.php` doesn't apply, and a service template can't target a per-device server. This adds an override file that injects `-s <hostname>` from the device, mirroring the pattern `check_dns.inc.php` uses, allowing `check_dhcp` to be configured once as a template against a device group rather than copy-pasted per device.

### Changes

#### Service check (`includes/services/check_dhcp.inc.php`)
- Use `service_ip` if set, falling back to the attached device's hostname, as the `-s` target for check_dhcp
- Mirrors the existing pattern in `check_dns.inc.php`

### Notes
- Enables one-template-per-device-group monitoring of DHCP servers. Previously, `check_dhcp` had to be configured as per-device services with explicit `-s <server>` in `service_param` because template parameters are not substituted per device.
- **Behavior change for existing per-device services:** Existing per-device services may have an explicit `-s <server>` in their `service_param`. After this PR, those services will be invoked with **two** `-s` flags. This may produce unexpected results: check_dhcp treats multiple `-s` as "probe all of these servers" and returns WARNING if any server fails to respond. To restore single-server behavior, users should remove `-s <server>` from `service_param` and rely on the device hostname auto-injection.

### Tested on
- LibreNMS 26.6.1-dev against 4 ISC dhcpd hosts via one service template
- Each service correctly probes its own device via `-s`; verified via `./check-services.php -h <id> -v -d`

---
*This PR was developed with the assistance of Claude Opus 4.7.*

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
