### PR TITLE
Stop leaking device group name to users without permission

### DIFF
--- a/app/Http/Controllers/DeviceGroupController.php
+++ b/app/Http/Controllers/DeviceGroupController.php
@@ -22,6 +22,8 @@ class DeviceGroupController extends Controller
      */
     public function index()
     {
+        $this->authorize('viewAll', DeviceGroup::Class);
+
         return view('device-group.index', [
             'device_groups' => DeviceGroup::orderBy('name')->withCount('devices')->get(),
         ]);

--- a/app/Http/Controllers/DeviceGroupController.php
+++ b/app/Http/Controllers/DeviceGroupController.php
@@ -22,8 +22,6 @@ class DeviceGroupController extends Controller
      */
     public function index()
     {
-        $this->authorize('viewAll', DeviceGroup::Class);
-
         return view('device-group.index', [
             'device_groups' => DeviceGroup::orderBy('name')->withCount('devices')->get(),
         ]);

--- a/includes/html/pages/devices.inc.php
+++ b/includes/html/pages/devices.inc.php
@@ -225,7 +225,7 @@ if ($format == 'graph') {
     }
     if (! empty($vars['group'])) {
         $where .= ' AND device_id IN ( ';
-        $where .= Devices::hasAccess(Auth::User())->whereHas('device_groups', function ($query) use ($vars) { $q->where('id', $vars['group']); })->pluck('device_id')->implode(',');
+        $where .= DB::table('device_group_device')->where('device_group_id', $vars['group'])->whereIntegerInRaw('device_id', Permissions::devicesForUser(Auth::User()))->pluck('device_id')->implode(',');
         $where .= ' )';
 
         show_device_group($vars['group']);

--- a/includes/html/pages/devices.inc.php
+++ b/includes/html/pages/devices.inc.php
@@ -14,6 +14,7 @@
 */
 
 use App\Facades\LibrenmsConfig;
+use App\Models\DeviceGroup;
 use App\Models\Location;
 use Illuminate\Support\Facades\DB;
 use LibreNMS\Util\StringHelpers;
@@ -30,7 +31,7 @@ function show_device_group(int|string|null $device_group_id): void
         $device_group_name = '';
     } else {
         $pre_text = __('Device Group') . ': ';
-        $device_group_name = DB::table('device_groups')->where('id', $device_group_id)->value('name') ?? __('Group not found');
+        $device_group_name = DeviceGroup::hasAccess(Auth::User())->find($device_group_id)->name ?? __('Group not found');
     }
     ?>
     <div class="panel-heading">
@@ -223,12 +224,8 @@ if ($format == 'graph') {
         $sql_param[] = $vars['poller_group'];
     }
     if (! empty($vars['group'])) {
-        $where .= ' AND ( ';
-        foreach (DB::table('device_group_device')->where('device_group_id', $vars['group'])->pluck('device_id') as $dev) {
-            $where .= 'device_id = ? OR ';
-            $sql_param[] = $dev;
-        }
-        $where = substr($where, 0, strlen($where) - 3);
+        $where .= ' AND device_id IN ( ';
+        $where .= Devices::hasAccess(Auth::User())->whereHas('device_groups', function ($query) use ($vars) { $q->where('id', $vars['group']); })->pluck('device_id')->implode(',');
         $where .= ' )';
 
         show_device_group($vars['group']);


### PR DESCRIPTION
This stops leaking the device group name to users who don't have permissions.  It also refactors the legacy SQL query for the device group to limit the devices to those the user has access to (they were being filtered elsewhere so it doesn't change what's on the web page).

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
