### PR TITLE
Update links to device groups and types

### DIFF
--- a/app/Http/Controllers/DeviceGroupController.php
+++ b/app/Http/Controllers/DeviceGroupController.php
@@ -77,7 +77,7 @@ class DeviceGroupController extends Controller
      */
     public function show(DeviceGroup $deviceGroup)
     {
-        return redirect(url('/devices/group=' . $deviceGroup->id));
+        return redirect(route('devices', ['filter' => ['groups.id' => ['eq' => $deviceGroup->id]]]));
     }
 
     /**

--- a/includes/html/dev-groups-overview-data.inc.php
+++ b/includes/html/dev-groups-overview-data.inc.php
@@ -18,7 +18,7 @@ if (count($device_groups)) {
                         <div class="col-sm-12">
                         <?php foreach ($device_groups as $group) { ?>
                             <span style="margin: 8px;">
-                                <a href="<?=url('devices/group=' . $group['id'])?>" target="_blank"><?=htmlspecialchars((string) $group['name'])?></a>
+                                <a href="<?=route('devices', ['filter' => ['groups.id' => ['eq' => $group['id']]]])?>" target="_blank"><?=htmlspecialchars((string) $group['name'])?></a>
                             </span>
                         <?php } ?>
                         </div>

--- a/resources/views/layouts/menu.blade.php
+++ b/resources/views/layouts/menu.blade.php
@@ -137,7 +137,7 @@
                         @if($device_types->isNotEmpty())
                         <ul class="dropdown-menu scrollable-menu">
                         @foreach($device_types as $type => $icon)
-                            <li><a href="{{ url("devices/type=$type") }}"><i class="fa fa-{{ $icon }} fa-fw fa-lg" aria-hidden="true"></i> {{ ucfirst($type) }}</a></li>
+                            <li><a href="{{ route('devices', ['filter' => ['type' => ['eq' => $type]]]) }}"><i class="fa fa-{{ $icon }} fa-fw fa-lg" aria-hidden="true"></i> {{ ucfirst($type) }}</a></li>
                         @endforeach
                         </ul>
                         @endif
@@ -150,7 +150,7 @@
                                 </a>
                             <ul class="dropdown-menu scrollable-menu">
                             @foreach($device_groups as $group)
-                                <li><a href="{{ url("devices/group=$group->id") }}" title="{{ $group->desc }}"><i class="fa fa-th fa-fw fa-lg" aria-hidden="true"></i> {{ ucfirst($group->name) }}</a></li>
+                                <li><a href="{{ route('devices', ['filter' => ['groups.id' => ['eq' => $group->id]]]) }}" title="{{ $group->desc }}"><i class="fa fa-th fa-fw fa-lg" aria-hidden="true"></i> {{ ucfirst($group->name) }}</a></li>
                             @endforeach
                             </ul>
                         </li>


### PR DESCRIPTION
Fixes: #19747 

Probably lots of ways to fix this but as type=X and group=X isn't available as a request input I felt it was better to fix at source.

Obviously book marked urls won't work so we could add fall back redirects for now

I think we can also get rid of https://github.com/librenms/librenms/blob/master/app/Http/Controllers/Table/DeviceController.php#L114-L123 but leaving for now.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
