### PR TITLE
Port state filter refinement

### DIFF
--- a/app/Models/Port.php
+++ b/app/Models/Port.php
@@ -368,9 +368,10 @@ class Port extends DeviceRelatedModel
     public function filterState(Builder $query, mixed $value, array $config): void
     {
         $this->applyMappedFilter($query, $value, $config, fn (Builder $q, $state) => match ($state) {
-            'shutdown' => $q->where('ifAdminStatus', '!=', 'up'),
-            'up' => $q->where('ifAdminStatus', 'up')->where('ifOperStatus', 'up'),
-            default => $q->where('ifAdminStatus', 'up')->where('ifOperStatus', '!=', 'up'),
+            'up' => $q->where('ifOperStatus', 'up'),
+            'shutdown' => $q->where('ifAdminStatus', 'down'),
+            default => $q->where('ifOperStatus', '!=', 'up')
+                ->where(fn (Builder $sub) => $sub->where('ifAdminStatus', '!=', 'down')->orWhereNull('ifAdminStatus')),
         });
     }
 


### PR DESCRIPTION
Improves handling of bad data

handle nulls better
if oper status is up, we don't need to check admin status


#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
