### PR TITLE
Unifi avoid crash from bad response

### DIFF
--- a/LibreNMS/OS/Unifi.php
+++ b/LibreNMS/OS/Unifi.php
@@ -101,7 +101,7 @@ class Unifi extends OS implements
 
         $radios = [];
         foreach ($client_oids as $index => $entry) {
-            $radio_name = $vap_radios[$index];
+            $radio_name = $vap_radios[$index] ?? $index;
             $radios[$radio_name]['oids'][] = '.1.3.6.1.4.1.41112.1.6.1.2.1.8.' . $index;
             if (isset($radios[$radio_name]['count'])) {
                 $radios[$radio_name]['count'] += $entry['unifiVapNumStations'];
@@ -135,7 +135,7 @@ class Unifi extends OS implements
         // discover client counts by SSID
         $ssids = [];
         foreach ($client_oids as $index => $entry) {
-            $ssid = $ssid_ids[$index];
+            $ssid = $ssid_ids[$index] ?? $index;
             if (! empty($ssid)) {
                 if (isset($ssids[$ssid])) {
                     $ssids[$ssid]['oids'][] = '.1.3.6.1.4.1.41112.1.6.1.2.1.8.' . $index;


### PR DESCRIPTION
New devices are returning bad and missing data, don't crash in this case.



#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
