### PR TITLE
Fix non-UTF-8 hrDeviceDescr crash via Utf8Sanitize cast

### DIFF
--- a/app/Casts/Utf8Sanitize.php
+++ b/app/Casts/Utf8Sanitize.php
@@ -35,6 +35,9 @@ use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Illuminate\Database\Eloquent\Model;
 use LibreNMS\Util\StringHelpers;
 
+/**
+ * @implements CastsAttributes<?string, ?string>
+ */
 class Utf8Sanitize implements CastsAttributes
 {
     /**

--- a/app/Casts/Utf8Sanitize.php
+++ b/app/Casts/Utf8Sanitize.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * Utf8Sanitize.php
+ *
+ * Custom Eloquent cast that converts a string attribute to valid UTF-8 before
+ * storage.  SNMP devices may return strings in non-UTF-8 encodings (e.g.
+ * Windows-1252 printer descriptions containing trademark symbols ™), which
+ * would otherwise cause database exceptions when written into UTF-8 columns.
+ *
+ * Apply this cast explicitly to individual string fields that carry raw SNMP
+ * data, giving precise control over which columns are sanitized.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * @link       https://www.librenms.org
+ *
+ * @copyright  2026 LibreNMS Contributors
+ */
+
+namespace App\Casts;
+
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Database\Eloquent\Model;
+use LibreNMS\Util\StringHelpers;
+
+class Utf8Sanitize implements CastsAttributes
+{
+    /**
+     * Cast the given value from storage — already UTF-8, return as-is.
+     *
+     * @param  array<string, mixed>  $attributes
+     */
+    public function get(Model $model, string $key, mixed $value, array $attributes): ?string
+    {
+        return $value;
+    }
+
+    /**
+     * Prepare the given value for storage, converting to valid UTF-8 if needed.
+     *
+     * @param  array<string, mixed>  $attributes
+     */
+    public function set(Model $model, string $key, mixed $value, array $attributes): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        return StringHelpers::inferEncoding((string) $value);
+    }
+}

--- a/app/Models/HrDevice.php
+++ b/app/Models/HrDevice.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Casts\Utf8Sanitize;
 use LibreNMS\Interfaces\Models\Keyable;
 
 class HrDevice extends DeviceRelatedModel implements Keyable
@@ -16,6 +17,10 @@ class HrDevice extends DeviceRelatedModel implements Keyable
         'hrDeviceErrors',
         'hrDeviceStatus',
         'hrProcessorLoad',
+    ];
+
+    protected $casts = [
+        'hrDeviceDescr' => Utf8Sanitize::class,
     ];
 
     public function getCompositeKey(): int

--- a/tests/Unit/Casts/Utf8SanitizeTest.php
+++ b/tests/Unit/Casts/Utf8SanitizeTest.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * Utf8SanitizeTest.php
+ *
+ * Tests for the Utf8Sanitize Eloquent cast.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * @link       https://www.librenms.org
+ *
+ * @copyright  2026 LibreNMS Contributors
+ */
+
+namespace LibreNMS\Tests\Unit\Casts;
+
+use App\Casts\Utf8Sanitize;
+use Illuminate\Database\Eloquent\Model;
+use LibreNMS\Tests\TestCase;
+use Mockery;
+
+class Utf8SanitizeTest extends TestCase
+{
+    private Utf8Sanitize $cast;
+
+    private Model $model;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->cast = new Utf8Sanitize();
+        $this->model = Mockery::mock(Model::class)->makePartial();
+    }
+
+    // ── set() ──────────────────────────────────────────────────────────────
+
+    public function testSetNullReturnsNull(): void
+    {
+        $result = $this->cast->set($this->model, 'hrDeviceDescr', null, []);
+        $this->assertNull($result);
+    }
+
+    public function testSetAlreadyUtf8PassesThrough(): void
+    {
+        $value = 'HP LaserJet 4350 Series';
+        $this->assertSame($value, $this->cast->set($this->model, 'hrDeviceDescr', $value, []));
+    }
+
+    public function testSetWindows1252TrademarkConvertedToUtf8(): void
+    {
+        // Windows-1252 byte 0x99 is the TRADE MARK SIGN (™); UTF-8 is 0xE2 0x84 0xA2
+        $win1252Input = "HP LaserJet\x99";
+        $result = $this->cast->set($this->model, 'hrDeviceDescr', $win1252Input, []);
+        $this->assertNotNull($result);
+        $this->assertTrue(mb_check_encoding($result, 'UTF-8'), 'Result must be valid UTF-8');
+        $this->assertStringContainsString('™', $result);
+    }
+
+    public function testSetEmptyStringPassesThrough(): void
+    {
+        $this->assertSame('', $this->cast->set($this->model, 'hrDeviceDescr', '', []));
+    }
+
+    // ── get() ──────────────────────────────────────────────────────────────
+
+    public function testGetReturnsValueAsIs(): void
+    {
+        $value = 'HP LaserJet 4350 Series™';
+        $this->assertSame($value, $this->cast->get($this->model, 'hrDeviceDescr', $value, []));
+    }
+
+    public function testGetNullReturnsNull(): void
+    {
+        $this->assertNull($this->cast->get($this->model, 'hrDeviceDescr', null, []));
+    }
+}


### PR DESCRIPTION
## What type of PR is this?

<!-- Please delete options that are not relevant. -->
Bug fix

## What does this do?

SNMP devices (e.g. printers) can return `hrDeviceDescr` values in non-UTF-8 encodings such as Windows-1252 — for example the trademark sign **™** arrives as byte `0x99` — causing a database exception when the value is written to a `utf8mb4` column:

```
SQLSTATE[HY000]: General error: 1366 Incorrect string value: '\x99...'
```

### Approach (addressing #19349 feedback)

[The previous PR (#19349)](https://github.com/librenms/librenms/pull/19349) used a model trait that hooked the `saving` event and sanitised **every** string attribute automatically. The maintainer correctly noted that this was the wrong approach and asked for a **cast** so we have explicit control over which fields are converted.

This PR introduces **`App\Casts\Utf8Sanitize`** — a single-responsibility Eloquent cast that calls `StringHelpers::inferEncoding()` in its `set()\ method. The cast is then listed explicitly in `HrDevice::$casts` for the one field that carries free-form SNMP text:

```php
protected $casts = [
    'hrDeviceDescr' => Utf8Sanitize::class,
];
```

`hrDeviceType` and `hrDeviceStatus` are MIB-derived enum strings (always ASCII) so they are deliberately left out.

The cast is reusable — any other model whose fields receive raw SNMP strings can opt in the same way.

### Files changed

| File | Change |
|------|--------|
| `app/Casts/Utf8Sanitize.php` | New cast — null-safe wrapper around `StringHelpers::inferEncoding()` |
| `app/Models/HrDevice.php` | Add `$casts` entry for `hrDeviceDescr` |
| `tests/Unit/Casts/Utf8SanitizeTest.php` | Unit tests: null, empty string, ASCII passthrough, Windows-1252 → UTF-8 |

## Fixes / Resolves
Closes #19328

## Screenshots (if applicable)
N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)