### PR TITLE
Modals now appear lower than the navbar and reduced the gap below the navbar

### DIFF
--- a/html/css/styles.css
+++ b/html/css/styles.css
@@ -1314,6 +1314,7 @@ nav.navbar-sticky-top {
   border-top-width: 0;
   border-right-width: 0;
   border-radius: 0;
+  margin-bottom: 10px !important;
 }
 
 .navbar-brand {
@@ -2590,3 +2591,7 @@ label {
 }
 
 [x-cloak] {display: none !important;}
+
+.modal-content {
+  margin-top: 60px;
+}

--- a/resources/views/layouts/librenmsv1.blade.php
+++ b/resources/views/layouts/librenmsv1.blade.php
@@ -40,7 +40,7 @@
     <link href="{{ asset('css/select2.min.css') }}" rel="stylesheet">
     <link href="{{ asset('css/select2-bootstrap.min.css') }}" rel="stylesheet">
     <link href="{{ asset('css/query-builder.default.min.css') }}" rel="stylesheet">
-    <link href="{{ asset(LibrenmsConfig::get('stylesheet', 'css/styles.css')) }}?ver=05122026" rel="stylesheet">
+    <link href="{{ asset(LibrenmsConfig::get('stylesheet', 'css/styles.css')) }}?ver=05282026" rel="stylesheet">
     <link href="{{ asset('css/tw_dark.css?ver=19112025') }}" rel="stylesheet">
     @if(!in_array(session('applied_site_style', 'light'), ['light', 'dark']))
     <link href="{{ asset('css/' . session('applied_site_style') . '.css?ver=732417643') }}" rel="stylesheet">


### PR DESCRIPTION
Old:
<img width="1243" height="238" alt="image" src="https://github.com/user-attachments/assets/674904aa-7855-484a-9ebc-f283f9a91909" />

New:
<img width="979" height="223" alt="image" src="https://github.com/user-attachments/assets/57d69cb0-dabb-4eed-bb31-0b130e8500da" />

Rather than changing the z-index and causing other knock on issues, I've moved the modal down slightly so it doesn't appear under/over the navbar.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
