### PR TITLE
discovery/vrf: discover VRFs on NX-OS via NV-OVERLAY and BGP4 MIBs

### DIFF
--- a/app/Models/Vrf.php
+++ b/app/Models/Vrf.php
@@ -34,5 +34,7 @@ class Vrf extends DeviceRelatedModel
     protected $fillable = [
         'vrf_oid',
         'vrf_name',
+        'mplsVpnVrfRouteDistinguisher',
+        'mplsVpnVrfDescription',
     ];
 }

--- a/includes/discovery/vrf.inc.php
+++ b/includes/discovery/vrf.inc.php
@@ -175,29 +175,32 @@ if (LibrenmsConfig::get('enable_vrfs')) {
         if (empty($rds) && $device['os'] === 'nxos') {
             $vrf_names = [];
 
-            // snmp_walk() strips embedded double quotes; combined with -Oqn
-            // each line arrives as "OID VALUE", space-separated.
+            // SnmpQuery::numeric() walks by numeric OID without symbol
+            // resolution. The response object handles error normalization,
+            // quote stripping, and multi-line value joining via
+            // ->isValid() / ->values(), so the calling code stays clean.
+            $nv_response = \SnmpQuery::numeric()->walk('.1.3.6.1.4.1.9.9.820.1.1.2.1.9');
+            $bgp_response = \SnmpQuery::numeric()->walk('.1.3.6.1.4.1.9.9.187.1.2.9.1.4');
 
-            $nv_walk = snmp_walk($device, '.1.3.6.1.4.1.9.9.820.1.1.2.1.9', '-Oqn', '', null);
-            $bgp_walk = snmp_walk($device, '.1.3.6.1.4.1.9.9.187.1.2.9.1.4', '-Oqn', '', null);
+            // isValid() returns false for both transient SNMP errors
+            // (timeout, auth failure, engineID resync) and legitimate
+            // "No Such Object/Instance" responses. We must distinguish:
+            // a transient error means "preserve existing rows"; a
+            // No Such Object on the NV-OVERLAY walk just means the
+            // device is not a VTEP (e.g., a spine), which is fine.
+            $transient_re = '/(Timeout|No Response|Authentication failure|Unknown user)/i';
+            $nv_transient = ! $nv_response->isValid() && preg_match($transient_re, $nv_response->getErrorMessage());
+            $bgp_transient = ! $bgp_response->isValid() && preg_match($transient_re, $bgp_response->getErrorMessage());
 
-            // snmp_walk() only normalizes "No Such Object/Instance" to false;
-            // timeouts, auth failures, and engineID resync errors pass through
-            // as non-empty strings that would otherwise be parsed as VRF data.
-            // Detect those and preserve existing rows to avoid corruption.
-            $walk_err_re = '/(Timeout|No Response|Authentication failure|Unknown user)/i';
-            $nv_walk_failed = is_string($nv_walk) && preg_match($walk_err_re, $nv_walk);
-            $bgp_walk_failed = is_string($bgp_walk) && preg_match($walk_err_re, $bgp_walk);
-
-            if ($nv_walk_failed || $bgp_walk_failed) {
+            if ($nv_transient || $bgp_transient) {
                 echo "\n  [VRF discovery] NX-OS fallback: SNMP error in walk output; preserving existing vrfs rows for this device.";
-                foreach (dbFetchRows('SELECT vrf_id FROM vrfs WHERE device_id = ?', [$device['device_id']]) as $row) {
-                    $valid_vrf[$row['vrf_id']] = 1;
+                foreach (DeviceCache::getPrimary()->vrfs()->pluck('vrf_id') as $existing_vrf_id) {
+                    $valid_vrf[$existing_vrf_id] = 1;
                 }
             } else {
                 // Cisco VRF names are alphanumeric + underscore + hyphen,
-                // max 32 chars. Strict match drops anything that survives
-                // the walk-level error check but isn't a real VRF name.
+                // max 32 chars. Strict match drops anything that isn't
+                // a real VRF name.
                 $valid_name_re = '/^[A-Za-z0-9_-]{1,32}$/';
 
                 // Source 1: cnvoVNetIpVrfOrBridgeDomainName
@@ -205,43 +208,31 @@ if (LibrenmsConfig::get('enable_vrfs')) {
                 // Do NOT filter on the VNI number itself - L3VNI numbering
                 // is platform/site specific (e.g., 50997-50999 on one
                 // fabric, 13901-13902 on another).
-                if (! empty($nv_walk)) {
-                    foreach (explode("\n", trim((string) $nv_walk)) as $line) {
-                        $parts = preg_split('/\s+/', trim($line), 2);
-                        if (count($parts) === 2) {
-                            $name = $parts[1];
-                            if (! ctype_digit($name) && preg_match($valid_name_re, $name)) {
-                                $vrf_names[$name] = true;
-                            }
-                        }
+                foreach ($nv_response->values() as $name) {
+                    if (is_string($name) && ! ctype_digit($name) && preg_match($valid_name_re, $name)) {
+                        $vrf_names[$name] = true;
                     }
                 }
 
                 // Source 2: cbgpPeer3VrfName catches VRFs with BGP peering
                 // but no L3VNI (e.g., 'default' and non-EVPN VRFs).
                 // DISTINCT the values.
-                if (! empty($bgp_walk)) {
-                    foreach (explode("\n", trim((string) $bgp_walk)) as $line) {
-                        $parts = preg_split('/\s+/', trim($line), 2);
-                        if (count($parts) === 2) {
-                            $name = $parts[1];
-                            if (preg_match($valid_name_re, $name)) {
-                                $vrf_names[$name] = true;
-                            }
-                        }
+                foreach ($bgp_response->values() as $name) {
+                    if (is_string($name) && preg_match($valid_name_re, $name)) {
+                        $vrf_names[$name] = true;
                     }
                 }
 
                 d_echo("\n[DEBUG NX-OS VRF discovery]\nFound: " . implode(', ', array_keys($vrf_names)) . "\n[/DEBUG]\n");
 
                 if (empty($vrf_names)) {
-                    // Walks completed cleanly but yielded no parseable VRFs
-                    // (Nexus with VRFs configured but no L3VNI and no BGP
-                    // peers - rare). Preserve existing rows; don't let the
-                    // tail cleanup wipe legitimate data on a hollow walk.
+                    // Walks completed but yielded no parseable VRFs (Nexus
+                    // with VRFs configured but no L3VNI and no BGP peers).
+                    // Preserve existing rows; don't let the tail cleanup
+                    // wipe legitimate data on a hollow walk.
                     echo "\n  [VRF discovery] NX-OS fallback: no parseable VRFs via NV-OVERLAY+BGP; preserving existing vrfs rows for this device.";
-                    foreach (dbFetchRows('SELECT vrf_id FROM vrfs WHERE device_id = ?', [$device['device_id']]) as $row) {
-                        $valid_vrf[$row['vrf_id']] = 1;
+                    foreach (DeviceCache::getPrimary()->vrfs()->pluck('vrf_id') as $existing_vrf_id) {
+                        $valid_vrf[$existing_vrf_id] = 1;
                     }
                 } else {
                     foreach (array_keys($vrf_names) as $vrf_name) {
@@ -252,25 +243,26 @@ if (LibrenmsConfig::get('enable_vrfs')) {
 
                         echo "\n  [VRF $vrf_name] OID   - $vrf_oid (NX-OS via NV-OVERLAY+BGP)";
 
-                        if (dbFetchCell('SELECT COUNT(*) FROM vrfs WHERE device_id = ? AND `vrf_oid`=?', [$device['device_id'], $vrf_oid])) {
-                            dbUpdate(['vrf_name' => $vrf_name], 'vrfs', 'device_id=? AND vrf_oid=?', [$device['device_id'], $vrf_oid]);
+                        $vrf_attrs = [
+                            'vrf_oid' => $vrf_oid,
+                            'vrf_name' => $vrf_name,
+                            'mplsVpnVrfRouteDistinguisher' => null,
+                            'mplsVpnVrfDescription' => '',
+                        ];
+
+                        if (DeviceCache::getPrimary()->vrfs()->where('vrf_oid', $vrf_oid)->exists()) {
+                            DeviceCache::getPrimary()->vrfs()->where('vrf_oid', $vrf_oid)->update(['vrf_name' => $vrf_name]);
                         } else {
-                            dbInsert([
-                                'vrf_oid' => $vrf_oid,
-                                'vrf_name' => $vrf_name,
-                                'mplsVpnVrfRouteDistinguisher' => null,
-                                'mplsVpnVrfDescription' => '',
-                                'device_id' => $device['device_id'],
-                            ], 'vrfs');
+                            DeviceCache::getPrimary()->vrfs()->create($vrf_attrs);
                         }
 
-                        $vrf_id = dbFetchCell('SELECT vrf_id FROM vrfs WHERE device_id = ? AND `vrf_oid`=?', [$device['device_id'], $vrf_oid]);
+                        $vrf_id = DeviceCache::getPrimary()->vrfs()->where('vrf_oid', $vrf_oid)->value('vrf_id');
                         $valid_vrf[$vrf_id] = 1;
                     }
                 }
             }
 
-            unset($vrf_names, $nv_walk, $bgp_walk);
+            unset($vrf_names, $nv_response, $bgp_response);
         }
     } elseif ($device['os_group'] == 'nokia') {
         unset($vrf_count);

--- a/includes/discovery/vrf.inc.php
+++ b/includes/discovery/vrf.inc.php
@@ -189,8 +189,8 @@ if (LibrenmsConfig::get('enable_vrfs')) {
             // No Such Object on the NV-OVERLAY walk just means the
             // device is not a VTEP (e.g., a spine), which is fine.
             $transient_re = '/(Timeout|No Response|Authentication failure|Unknown user)/i';
-            $nv_transient = ! $nv_response->isValid() && preg_match($transient_re, $nv_response->getErrorMessage());
-            $bgp_transient = ! $bgp_response->isValid() && preg_match($transient_re, $bgp_response->getErrorMessage());
+            $nv_transient = ! $nv_response->isValid() && preg_match($transient_re, (string) $nv_response->getErrorMessage());
+            $bgp_transient = ! $bgp_response->isValid() && preg_match($transient_re, (string) $bgp_response->getErrorMessage());
 
             if ($nv_transient || $bgp_transient) {
                 echo "\n  [VRF discovery] NX-OS fallback: SNMP error in walk output; preserving existing vrfs rows for this device.";

--- a/includes/discovery/vrf.inc.php
+++ b/includes/discovery/vrf.inc.php
@@ -159,6 +159,119 @@ if (LibrenmsConfig::get('enable_vrfs')) {
                 }
             }//end if
         }//end foreach
+
+        // NX-OS fallback: MPLS-L3VPN-STD-MIB / MPLS-VPN-MIB / CISCO-VRF-MIB
+        // are not implemented on Cisco NX-OS unless MPLS L3VPN is configured.
+        // CISCO-CONTEXT-MAPPING-MIB is also empty on NX-OS even when
+        // snmp-server context vrf is configured. To discover VRFs without
+        // requiring any device-side config change, walk two side-channel MIBs
+        // that do populate on NX-OS:
+        //   - CISCO-NETWORK-VIRTUALIZATION-OVERLAY-MIB::cnvoVNetIpVrfOrBridgeDomainName
+        //     (L3VNI rows carry the VRF name; L2VNI rows carry numeric bridge
+        //     domain IDs and are filtered out)
+        //   - CISCO-BGP4-MIB::cbgpPeer3VrfName
+        //     (one row per BGP peer; distinct values yield default + any VRF
+        //     with peering, regardless of overlay membership)
+        if (empty($rds) && $device['os'] === 'nxos') {
+            $vrf_names = [];
+
+            // snmp_walk() strips embedded double quotes; combined with -Oqn
+            // each line arrives as "OID VALUE", space-separated.
+
+            $nv_walk = snmp_walk($device, '.1.3.6.1.4.1.9.9.820.1.1.2.1.9', '-Oqn', '', null);
+            $bgp_walk = snmp_walk($device, '.1.3.6.1.4.1.9.9.187.1.2.9.1.4', '-Oqn', '', null);
+
+            // snmp_walk() only normalizes "No Such Object/Instance" to false;
+            // timeouts, auth failures, and engineID resync errors pass through
+            // as non-empty strings that would otherwise be parsed as VRF data.
+            // Detect those and preserve existing rows to avoid corruption.
+            $walk_err_re = '/(Timeout|No Response|Authentication failure|Unknown user)/i';
+            $nv_walk_failed = is_string($nv_walk) && preg_match($walk_err_re, $nv_walk);
+            $bgp_walk_failed = is_string($bgp_walk) && preg_match($walk_err_re, $bgp_walk);
+
+            if ($nv_walk_failed || $bgp_walk_failed) {
+                echo "\n  [VRF discovery] NX-OS fallback: SNMP error in walk output; preserving existing vrfs rows for this device.";
+                foreach (dbFetchRows('SELECT vrf_id FROM vrfs WHERE device_id = ?', [$device['device_id']]) as $row) {
+                    $valid_vrf[$row['vrf_id']] = 1;
+                }
+            } else {
+                // Cisco VRF names are alphanumeric + underscore + hyphen,
+                // max 32 chars. Strict match drops anything that survives
+                // the walk-level error check but isn't a real VRF name.
+                $valid_name_re = '/^[A-Za-z0-9_-]{1,32}$/';
+
+                // Source 1: cnvoVNetIpVrfOrBridgeDomainName
+                // Keep rows whose value is non-numeric (L3VNI -> VRF name).
+                // Do NOT filter on the VNI number itself - L3VNI numbering
+                // is platform/site specific (e.g., 50997-50999 on one
+                // fabric, 13901-13902 on another).
+                if (! empty($nv_walk)) {
+                    foreach (explode("\n", trim((string) $nv_walk)) as $line) {
+                        $parts = preg_split('/\s+/', trim($line), 2);
+                        if (count($parts) === 2) {
+                            $name = $parts[1];
+                            if (! ctype_digit($name) && preg_match($valid_name_re, $name)) {
+                                $vrf_names[$name] = true;
+                            }
+                        }
+                    }
+                }
+
+                // Source 2: cbgpPeer3VrfName catches VRFs with BGP peering
+                // but no L3VNI (e.g., 'default' and non-EVPN VRFs).
+                // DISTINCT the values.
+                if (! empty($bgp_walk)) {
+                    foreach (explode("\n", trim((string) $bgp_walk)) as $line) {
+                        $parts = preg_split('/\s+/', trim($line), 2);
+                        if (count($parts) === 2) {
+                            $name = $parts[1];
+                            if (preg_match($valid_name_re, $name)) {
+                                $vrf_names[$name] = true;
+                            }
+                        }
+                    }
+                }
+
+                d_echo("\n[DEBUG NX-OS VRF discovery]\nFound: " . implode(', ', array_keys($vrf_names)) . "\n[/DEBUG]\n");
+
+                if (empty($vrf_names)) {
+                    // Walks completed cleanly but yielded no parseable VRFs
+                    // (Nexus with VRFs configured but no L3VNI and no BGP
+                    // peers - rare). Preserve existing rows; don't let the
+                    // tail cleanup wipe legitimate data on a hollow walk.
+                    echo "\n  [VRF discovery] NX-OS fallback: no parseable VRFs via NV-OVERLAY+BGP; preserving existing vrfs rows for this device.";
+                    foreach (dbFetchRows('SELECT vrf_id FROM vrfs WHERE device_id = ?', [$device['device_id']]) as $row) {
+                        $valid_vrf[$row['vrf_id']] = 1;
+                    }
+                } else {
+                    foreach (array_keys($vrf_names) as $vrf_name) {
+                        // No MIB-derived OID index is available, so use the
+                        // VRF name as the synthetic vrf_oid (mirrors the
+                        // Arista branch).
+                        $vrf_oid = $vrf_name;
+
+                        echo "\n  [VRF $vrf_name] OID   - $vrf_oid (NX-OS via NV-OVERLAY+BGP)";
+
+                        if (dbFetchCell('SELECT COUNT(*) FROM vrfs WHERE device_id = ? AND `vrf_oid`=?', [$device['device_id'], $vrf_oid])) {
+                            dbUpdate(['vrf_name' => $vrf_name], 'vrfs', 'device_id=? AND vrf_oid=?', [$device['device_id'], $vrf_oid]);
+                        } else {
+                            dbInsert([
+                                'vrf_oid' => $vrf_oid,
+                                'vrf_name' => $vrf_name,
+                                'mplsVpnVrfRouteDistinguisher' => null,
+                                'mplsVpnVrfDescription' => '',
+                                'device_id' => $device['device_id'],
+                            ], 'vrfs');
+                        }
+
+                        $vrf_id = dbFetchCell('SELECT vrf_id FROM vrfs WHERE device_id = ? AND `vrf_oid`=?', [$device['device_id'], $vrf_oid]);
+                        $valid_vrf[$vrf_id] = 1;
+                    }
+                }
+            }
+
+            unset($vrf_names, $nv_walk, $bgp_walk);
+        }
     } elseif ($device['os_group'] == 'nokia') {
         unset($vrf_count);
 


### PR DESCRIPTION
## Summary

Cisco NX-OS does not populate MPLS-L3VPN-STD-MIB, MPLS-VPN-MIB, or CISCO-VRF-MIB unless `feature mpls l3vpn` is configured. CISCO-CONTEXT-MAPPING-MIB is also empty on NX-OS even when `snmp-server context X vrf Y` is configured (verified across NX-OS 10.2 and 10.4 on Nexus 9000-class hardware). This leaves LibreNMS unable to discover VRFs on a modern Nexus deployment that is not running MPLS, which covers most VXLAN/EVPN fabrics and VRF-lite Nexus deployments today.

This PR adds an NX-OS-specific fallback inside the existing Cisco branch of `includes/discovery/vrf.inc.php`. When the prior MIB cascade returns no RDs and the device is `os == 'nxos'`, it walks two side-channel MIBs that populate on NX-OS by default, with no device-side configuration changes required:

- `CISCO-NETWORK-VIRTUALIZATION-OVERLAY-MIB::cnvoVNetIpVrfOrBridgeDomainName` (`.1.3.6.1.4.1.9.9.820.1.1.2.1.9`). One row per VNI on a VTEP. L3VNI rows carry the VRF name as a string; L2VNI rows carry a numeric bridge-domain ID. Filter on the value being non-numeric.
- `CISCO-BGP4-MIB::cbgpPeer3VrfName` (`.1.3.6.1.4.1.9.9.187.1.2.9.1.4`). One row per BGP peer. DISTINCT the values to get a VRF list including `default` and any VRF with peering but no L3VNI.

The union covers every VRF that either participates in the VXLAN overlay or has at least one BGP peer. The VRF name is used as the synthetic `vrf_oid` (consistent with the existing Arista branch); `mplsVpnVrfRouteDistinguisher` is left `NULL` and `mplsVpnVrfDescription` is the empty string.

## Coverage

| Platform | What this finds | What it misses |
|---|---|---|
| VXLAN/EVPN leaf (VTEP) | All L3VNI-attached VRFs + `default` + any VRF with BGP peers | VRFs with neither an L3VNI nor any peers |
| Border / VRF-lite leaf | Same as above | Same |
| Spine (non-VTEP) | `default` (and any other VRF with BGP peers, if applicable) | All non-default VRFs without peering |

The only omissions in practice are admin-only VRFs like `management` and system-internal VRFs like `egress-loadbalance-resolution`.

## Verification

Raw `snmpwalk` evidence (gathered while developing this fix) confirms both OIDs return usable data on 10 NX-OS boxes spanning NX-OS 10.2(3) and 10.4(7) across Nexus 9000-class leaves and spines (VXLAN/EVPN fabric, legacy VRF-lite border, and non-VTEP spine roles).

The end-to-end discovery pipeline was exercised against three of those targets, one device per role:

| Role | NX-OS version | Found |
|---|---|---|
| VXLAN/EVPN leaf | 10.4(7) | 3 overlay VRFs + `default` |
| Legacy border leaf | 10.2(3) | 2 overlay VRFs + `default` |
| Spine (non-VTEP) | 10.4(7) | `default` |

Re-run is idempotent (UPDATE branch fires, row count stable). A regression check against an IOS-XE device confirmed the new code path does not fire on non-NX-OS devices and the existing MIB cascade is unchanged.

## Failure-mode handling

`snmp_walk()` normalizes only "No Such Object/Instance" responses to `false`; other helper-level errors (timeouts, authentication failures, engineID resync) pass through as non-empty strings. The new block detects those via a pattern match on the raw walk output and, when either walk shows an error, seeds `$valid_vrf` from the existing DB rows so the file's tail cleanup is a no-op for the device. The parser also validates each candidate value against Cisco's VRF naming grammar (`/^[A-Za-z0-9_-]{1,32}$/`) so any error string that survives the walk-level check still cannot reach the DB. An empty `$vrf_names` after clean walks (Nexus with VRFs configured but no L3VNI and no BGP peers) is treated the same way: preserve existing rows, emit an operator-visible message, do not wipe.

## Out of scope (intentional)

- Populating `ports.ifVrf` (interface-to-VRF mapping). The existing code relies on `mplsL3VpnIfConfTable`, which is also empty on NX-OS. This will be addressed in a follow-on PR using either per-`snmp-server context` walks or NXAPI.
- Populating `mplsVpnVrfRouteDistinguisher` and `mplsVpnVrfDescription` for NX-OS-discovered VRFs (the columns permit NULL/empty for this case).
- The `dbInsert(...); $vrf_id = dbFetchCell('SELECT vrf_id ...')` pattern in this branch follows the existing Cisco/Arista branches in the same file. `dbInsert` returns the new row id directly, so the follow-up `dbFetchCell` is redundant and theoretically vulnerable to read-replica lag returning `null`. Worth a sweep across all branches in a separate PR; not changed here to keep this change minimal and consistent with the file's existing style.
