### PR TITLE
fix: remove redundant ob_end_clean() after ob_get_clean()

### DIFF
--- a/app/Http/Controllers/DeviceController.php
+++ b/app/Http/Controllers/DeviceController.php
@@ -81,10 +81,8 @@ class DeviceController
 
         extract($data); // set preloaded data into variables
         include "includes/html/pages/device/$tab.inc.php";
-        $output = ob_get_clean();
-        ob_end_clean();
 
-        return $output;
+        return ob_get_clean();
     }
 
     public function rediscover(Device $device): JsonResponse

--- a/app/Http/Controllers/LegacyController.php
+++ b/app/Http/Controllers/LegacyController.php
@@ -58,7 +58,6 @@ class LegacyController extends Controller
         }
 
         $html = ob_get_clean();
-        ob_end_clean();
 
         if (isset($pagetitle) && is_array($pagetitle)) {
             // if prefix is set, put it in front


### PR DESCRIPTION
### What / why

`ob_get_clean()` both returns **and deletes** the active output buffer. In two controllers it is immediately followed by `ob_end_clean()`, which then tries to delete a buffer that no longer exists:

- `app/Http/Controllers/DeviceController.php::renderLegacyTab()`
- `app/Http/Controllers/LegacyController.php::index()`

When PHP runs with `output_buffering = 0` (e.g. `php artisan serve`, and a number of PHP-FPM configs) there is no outer buffer left to delete, so the call fails. On PHP 8.4 that failure is raised as an `ErrorException` and 500s the page:

```
ErrorException: ob_end_clean(): Failed to delete buffer. No buffer to delete
  at app/Http/Controllers/DeviceController.php:85 (renderLegacyTab)
```

It bites every device tab that falls through to the legacy renderer (e.g. the `overview` tab), and legacy pages via `LegacyController`.

### Why it isn't widely reported

The PHP production `php.ini` ships `output_buffering = 4096`. That default top-level buffer absorbs the stray `ob_end_clean()` (it silently deletes *that* instead), so installs on the production ini never notice. The bug only surfaces when `output_buffering = 0`.

### Fix

Drop the redundant `ob_end_clean()` after `ob_get_clean()`. The `ob_start()` / `ob_end_clean()` pair in `LegacyController` that guards plugin start-up output is a correct, balanced pair and is left untouched.

#### Please note

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it. — N/A, no UI changes (removes a fatal; rendered output is unchanged)
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated test data. — N/A