### PR TITLE
Add missing policies in preperation for API v1

### DIFF
--- a/app/Policies/AccessPointPolicy.php
+++ b/app/Policies/AccessPointPolicy.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Policies;
+
+class AccessPointPolicy extends DeviceRelatedPolicy
+{
+}

--- a/app/Policies/AlertOperationSegmentPolicy.php
+++ b/app/Policies/AlertOperationSegmentPolicy.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\AlertOperationSegment;
+use App\Models\User;
+
+/**
+ * Segments are managed through their parent {@see \App\Models\AlertOperation}.
+ * Authorization mirrors the parent: the v1 API exposes segments as a read-only
+ * sub-resource so {@see \App\Restify\AlertOperationSegmentRepository} only needs
+ * view/viewAny here. Writes happen via the operation, gated by AlertOperationPolicy.
+ */
+class AlertOperationSegmentPolicy
+{
+    use ChecksGlobalPermissions;
+
+    public function __construct()
+    {
+        $this->globalPrefix = 'alert-operation';
+    }
+
+    public function viewAny(User $user): bool
+    {
+        return $this->hasGlobalPermission($user, 'view')
+            || $this->hasGlobalPermission($user, 'viewAll')
+            || $this->hasGlobalPermission($user, 'create')
+            || $this->hasGlobalPermission($user, 'update')
+            || $this->hasGlobalPermission($user, 'delete');
+    }
+
+    public function viewAll(User $user): bool
+    {
+        return $this->hasGlobalPermission($user, 'viewAll');
+    }
+
+    public function view(User $user, AlertOperationSegment $segment): bool
+    {
+        if ($this->hasGlobalPermission($user, 'viewAll')) {
+            return true;
+        }
+
+        return $this->hasGlobalPermission($user, 'view');
+    }
+
+    /**
+     * Determine whether the user can create models.
+     */
+    public function create(User $user): bool
+    {
+        return $this->hasGlobalPermission($user, 'create');
+    }
+
+    /**
+     * Determine whether the user can update models.
+     */
+    public function update(User $user): bool
+    {
+        return $this->hasGlobalPermission($user, 'update');
+    }
+
+    /**
+     * Determine whether the user can delete models.
+     */
+    public function delete(User $user): bool
+    {
+        return $this->hasGlobalPermission($user, 'delete');
+    }
+}

--- a/app/Policies/AlertOperationSegmentPolicy.php
+++ b/app/Policies/AlertOperationSegmentPolicy.php
@@ -17,7 +17,7 @@ class AlertOperationSegmentPolicy
 
     public function __construct()
     {
-        $this->globalPrefix = 'alert-operation';
+        $this->globalPrefix = 'alert-rule';
     }
 
     public function viewAny(User $user): bool

--- a/app/Policies/AlertTransportGroupPolicy.php
+++ b/app/Policies/AlertTransportGroupPolicy.php
@@ -2,10 +2,8 @@
 
 namespace App\Policies;
 
-use App\Models\AlertTransport;
 use App\Models\AlertTransportGroup;
 use App\Models\User;
-use Illuminate\Support\Collection;
 
 class AlertTransportGroupPolicy
 {

--- a/app/Policies/AlertTransportGroupPolicy.php
+++ b/app/Policies/AlertTransportGroupPolicy.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\AlertTransport;
+use App\Models\AlertTransportGroup;
+use App\Models\User;
+use Illuminate\Support\Collection;
+
+class AlertTransportGroupPolicy
+{
+    use ChecksGlobalPermissions;
+
+    public function __construct()
+    {
+        $this->globalPrefix = 'alert';
+    }
+
+    public function viewAny(User $user): bool
+    {
+        return $this->hasGlobalPermission($user, 'view')
+            || $this->hasGlobalPermission($user, 'viewAll')
+            || $this->hasGlobalPermission($user, 'create')
+            || $this->hasGlobalPermission($user, 'update')
+            || $this->hasGlobalPermission($user, 'delete');
+    }
+
+    public function viewAll(User $user): bool
+    {
+        return $this->hasGlobalPermission($user, 'viewAll');
+    }
+
+    public function view(User $user, AlertTransportGroup $group): bool
+    {
+        if ($this->hasGlobalPermission($user, 'viewAll')) {
+            return true;
+        }
+
+        return $this->hasGlobalPermission($user, 'view');
+    }
+
+    public function create(User $user): bool
+    {
+        return $this->hasGlobalPermission($user, 'create');
+    }
+
+    public function update(User $user): bool
+    {
+        return $this->hasGlobalPermission($user, 'update');
+    }
+
+    public function delete(User $user): bool
+    {
+        return $this->hasGlobalPermission($user, 'delete');
+    }
+}

--- a/app/Policies/AlertTransportGroupPolicy.php
+++ b/app/Policies/AlertTransportGroupPolicy.php
@@ -11,29 +11,19 @@ class AlertTransportGroupPolicy
 
     public function __construct()
     {
-        $this->globalPrefix = 'alert';
+        $this->globalPrefix = 'alert-transport';
     }
 
     public function viewAny(User $user): bool
     {
         return $this->hasGlobalPermission($user, 'view')
-            || $this->hasGlobalPermission($user, 'viewAll')
             || $this->hasGlobalPermission($user, 'create')
             || $this->hasGlobalPermission($user, 'update')
             || $this->hasGlobalPermission($user, 'delete');
     }
 
-    public function viewAll(User $user): bool
-    {
-        return $this->hasGlobalPermission($user, 'viewAll');
-    }
-
     public function view(User $user, AlertTransportGroup $group): bool
     {
-        if ($this->hasGlobalPermission($user, 'viewAll')) {
-            return true;
-        }
-
         return $this->hasGlobalPermission($user, 'view');
     }
 

--- a/app/Policies/AuthLogPolicy.php
+++ b/app/Policies/AuthLogPolicy.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\User;
+
+class AuthLogPolicy
+{
+    use ChecksGlobalPermissions;
+
+    public function viewAny(User $user): bool
+    {
+        return $this->hasGlobalPermission($user, 'view');
+    }
+
+    public function view(User $user): bool
+    {
+        return $this->hasGlobalPermission($user, 'view');
+    }
+}

--- a/app/Policies/AvailabilityPolicy.php
+++ b/app/Policies/AvailabilityPolicy.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Policies;
+
+class AvailabilityPolicy extends DeviceRelatedPolicy
+{
+}

--- a/app/Policies/CefSwitchingPolicy.php
+++ b/app/Policies/CefSwitchingPolicy.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Policies;
+
+class CefSwitchingPolicy extends DeviceRelatedPolicy
+{
+}

--- a/app/Policies/DeviceRelatedPolicy.php
+++ b/app/Policies/DeviceRelatedPolicy.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\User;
+
+/**
+ * Shared policy for device-scoped, read-only resources.
+ *
+ * Authorization is governed entirely by the global `device` permission set;
+ * row-level device access is enforced by each model's query scope, not here.
+ * Concrete per-model policies extend this so Laravel can resolve them by the
+ * `<Model>Policy` naming convention.
+ */
+abstract class DeviceRelatedPolicy
+{
+    use ChecksGlobalPermissions;
+
+    public function __construct()
+    {
+        $this->globalPrefix = 'device';
+    }
+
+    public function viewAny(User $user): bool
+    {
+        return $this->hasGlobalPermission($user, 'view')
+            || $this->hasGlobalPermission($user, 'viewAll')
+            || $this->hasGlobalPermission($user, 'create')
+            || $this->hasGlobalPermission($user, 'update')
+            || $this->hasGlobalPermission($user, 'delete');
+    }
+
+    public function view(User $user): bool
+    {
+        return $this->hasGlobalPermission($user, 'view');
+    }
+}

--- a/app/Policies/DiskIoPolicy.php
+++ b/app/Policies/DiskIoPolicy.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Policies;
+
+class DiskIoPolicy extends DeviceRelatedPolicy
+{
+}

--- a/app/Policies/IpsecTunnelPolicy.php
+++ b/app/Policies/IpsecTunnelPolicy.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Policies;
+
+class IpsecTunnelPolicy extends DeviceRelatedPolicy
+{
+}

--- a/app/Policies/Ipv4AddressPolicy.php
+++ b/app/Policies/Ipv4AddressPolicy.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Policies;
+
+class Ipv4AddressPolicy extends DeviceRelatedPolicy
+{
+}

--- a/app/Policies/Ipv4MacPolicy.php
+++ b/app/Policies/Ipv4MacPolicy.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Policies;
+
+class Ipv4MacPolicy extends DeviceRelatedPolicy
+{
+}

--- a/app/Policies/Ipv4NetworkPolicy.php
+++ b/app/Policies/Ipv4NetworkPolicy.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Policies;
+
+class Ipv4NetworkPolicy extends DeviceRelatedPolicy
+{
+}

--- a/app/Policies/Ipv6AddressPolicy.php
+++ b/app/Policies/Ipv6AddressPolicy.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Policies;
+
+class Ipv6AddressPolicy extends DeviceRelatedPolicy
+{
+}

--- a/app/Policies/Ipv6NdPolicy.php
+++ b/app/Policies/Ipv6NdPolicy.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Policies;
+
+class Ipv6NdPolicy extends DeviceRelatedPolicy
+{
+}

--- a/app/Policies/Ipv6NetworkPolicy.php
+++ b/app/Policies/Ipv6NetworkPolicy.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Policies;
+
+class Ipv6NetworkPolicy extends DeviceRelatedPolicy
+{
+}

--- a/app/Policies/MplsLspPathPolicy.php
+++ b/app/Policies/MplsLspPathPolicy.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Policies;
+
+class MplsLspPathPolicy extends RoutingRelatedPolicy
+{
+}

--- a/app/Policies/MplsLspPolicy.php
+++ b/app/Policies/MplsLspPolicy.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Policies;
+
+class MplsLspPolicy extends RoutingRelatedPolicy
+{
+}

--- a/app/Policies/MplsSapPolicy.php
+++ b/app/Policies/MplsSapPolicy.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Policies;
+
+class MplsSapPolicy extends RoutingRelatedPolicy
+{
+}

--- a/app/Policies/MplsSdpBindPolicy.php
+++ b/app/Policies/MplsSdpBindPolicy.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Policies;
+
+class MplsSdpBindPolicy extends RoutingRelatedPolicy
+{
+}

--- a/app/Policies/MplsSdpPolicy.php
+++ b/app/Policies/MplsSdpPolicy.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Policies;
+
+class MplsSdpPolicy extends RoutingRelatedPolicy
+{
+}

--- a/app/Policies/MplsServicePolicy.php
+++ b/app/Policies/MplsServicePolicy.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Policies;
+
+class MplsServicePolicy extends RoutingRelatedPolicy
+{
+}

--- a/app/Policies/MplsTunnelArHopPolicy.php
+++ b/app/Policies/MplsTunnelArHopPolicy.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Policies;
+
+class MplsTunnelArHopPolicy extends RoutingRelatedPolicy
+{
+}

--- a/app/Policies/MplsTunnelCHopPolicy.php
+++ b/app/Policies/MplsTunnelCHopPolicy.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Policies;
+
+class MplsTunnelCHopPolicy extends RoutingRelatedPolicy
+{
+}

--- a/app/Policies/OspfAreaPolicy.php
+++ b/app/Policies/OspfAreaPolicy.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Policies;
+
+class OspfAreaPolicy extends RoutingRelatedPolicy
+{
+}

--- a/app/Policies/OspfInstancePolicy.php
+++ b/app/Policies/OspfInstancePolicy.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Policies;
+
+class OspfInstancePolicy extends RoutingRelatedPolicy
+{
+}

--- a/app/Policies/OspfNbrPolicy.php
+++ b/app/Policies/OspfNbrPolicy.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Policies;
+
+class OspfNbrPolicy extends RoutingRelatedPolicy
+{
+}

--- a/app/Policies/OspfPortPolicy.php
+++ b/app/Policies/OspfPortPolicy.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Policies;
+
+class OspfPortPolicy extends RoutingRelatedPolicy
+{
+}

--- a/app/Policies/Ospfv3AreaPolicy.php
+++ b/app/Policies/Ospfv3AreaPolicy.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Policies;
+
+class Ospfv3AreaPolicy extends RoutingRelatedPolicy
+{
+}

--- a/app/Policies/Ospfv3InstancePolicy.php
+++ b/app/Policies/Ospfv3InstancePolicy.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Policies;
+
+class Ospfv3InstancePolicy extends RoutingRelatedPolicy
+{
+}

--- a/app/Policies/Ospfv3NbrPolicy.php
+++ b/app/Policies/Ospfv3NbrPolicy.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Policies;
+
+class Ospfv3NbrPolicy extends RoutingRelatedPolicy
+{
+}

--- a/app/Policies/Ospfv3PortPolicy.php
+++ b/app/Policies/Ospfv3PortPolicy.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Policies;
+
+class Ospfv3PortPolicy extends RoutingRelatedPolicy
+{
+}

--- a/app/Policies/PollerClusterStatPolicy.php
+++ b/app/Policies/PollerClusterStatPolicy.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\User;
+
+class PollerClusterStatPolicy
+{
+    use ChecksGlobalPermissions;
+
+    public function __construct()
+    {
+        $this->globalPrefix = 'poller';
+    }
+
+    public function viewAny(User $user): bool
+    {
+        return $this->hasGlobalPermission($user, 'view')
+            || $this->hasGlobalPermission($user, 'update')
+            || $this->hasGlobalPermission($user, 'delete');
+    }
+
+    public function view(User $user): bool
+    {
+        return $this->hasGlobalPermission($user, 'view');
+    }
+}

--- a/app/Policies/PortAdslPolicy.php
+++ b/app/Policies/PortAdslPolicy.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Policies;
+
+class PortAdslPolicy extends PortRelatedPolicy
+{
+}

--- a/app/Policies/PortRelatedPolicy.php
+++ b/app/Policies/PortRelatedPolicy.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\User;
+
+/**
+ * Shared policy for port-scoped, read-only resources.
+ *
+ * Authorization is governed entirely by the global `port` permission set;
+ * row-level port/device access is enforced by each model's query scope, not here.
+ * Concrete per-model policies extend this so Laravel can resolve them by the
+ * `<Model>Policy` naming convention.
+ */
+abstract class PortRelatedPolicy
+{
+    use ChecksGlobalPermissions;
+
+    public function __construct()
+    {
+        $this->globalPrefix = 'port';
+    }
+
+    public function viewAny(User $user): bool
+    {
+        return $this->hasGlobalPermission($user, 'view')
+            || $this->hasGlobalPermission($user, 'viewAll')
+            || $this->hasGlobalPermission($user, 'update')
+            || $this->hasGlobalPermission($user, 'delete');
+    }
+
+    public function view(User $user): bool
+    {
+        return $this->hasGlobalPermission($user, 'view');
+    }
+}

--- a/app/Policies/PortSecurityPolicy.php
+++ b/app/Policies/PortSecurityPolicy.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Policies;
+
+class PortSecurityPolicy extends PortRelatedPolicy
+{
+}

--- a/app/Policies/PortStackPolicy.php
+++ b/app/Policies/PortStackPolicy.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Policies;
+
+class PortStackPolicy extends PortRelatedPolicy
+{
+}

--- a/app/Policies/PortStatisticPolicy.php
+++ b/app/Policies/PortStatisticPolicy.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Policies;
+
+class PortStatisticPolicy extends PortRelatedPolicy
+{
+}

--- a/app/Policies/PortStpPolicy.php
+++ b/app/Policies/PortStpPolicy.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Policies;
+
+class PortStpPolicy extends PortRelatedPolicy
+{
+}

--- a/app/Policies/PortVdslPolicy.php
+++ b/app/Policies/PortVdslPolicy.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Policies;
+
+class PortVdslPolicy extends PortRelatedPolicy
+{
+}

--- a/app/Policies/PortVlanPolicy.php
+++ b/app/Policies/PortVlanPolicy.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Policies;
+
+class PortVlanPolicy extends PortRelatedPolicy
+{
+}

--- a/app/Policies/PortsFdbPolicy.php
+++ b/app/Policies/PortsFdbPolicy.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Policies;
+
+class PortsFdbPolicy extends PortRelatedPolicy
+{
+}

--- a/app/Policies/PseudowirePolicy.php
+++ b/app/Policies/PseudowirePolicy.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Policies;
+
+class PseudowirePolicy extends RoutingRelatedPolicy
+{
+}

--- a/app/Policies/RoutingRelatedPolicy.php
+++ b/app/Policies/RoutingRelatedPolicy.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\User;
+
+/**
+ * Shared policy for routing-scoped resources (MPLS, OSPF, VRF, ...).
+ *
+ * Authorization is governed entirely by the global `routing` permission set;
+ * row-level device access is enforced by each model's query scope, not here.
+ * Concrete per-model policies extend this so Laravel can resolve them by the
+ * `<Model>Policy` naming convention.
+ */
+abstract class RoutingRelatedPolicy
+{
+    use ChecksGlobalPermissions;
+
+    public function __construct()
+    {
+        $this->globalPrefix = 'routing';
+    }
+
+    public function viewAny(User $user): bool
+    {
+        return $this->hasGlobalPermission($user, 'view')
+            || $this->hasGlobalPermission($user, 'viewAll')
+            || $this->hasGlobalPermission($user, 'update');
+    }
+
+    public function view(User $user): bool
+    {
+        return $this->hasGlobalPermission($user, 'view');
+    }
+}

--- a/app/Policies/SlaPolicy.php
+++ b/app/Policies/SlaPolicy.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Policies;
+
+class SlaPolicy extends DeviceRelatedPolicy
+{
+}

--- a/app/Policies/StpPolicy.php
+++ b/app/Policies/StpPolicy.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Policies;
+
+class StpPolicy extends DeviceRelatedPolicy
+{
+}

--- a/app/Policies/TransceiverPolicy.php
+++ b/app/Policies/TransceiverPolicy.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Policies;
+
+class TransceiverPolicy extends DeviceRelatedPolicy
+{
+}

--- a/app/Policies/VrfLitePolicy.php
+++ b/app/Policies/VrfLitePolicy.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Policies;
+
+class VrfLitePolicy extends RoutingRelatedPolicy
+{
+}


### PR DESCRIPTION
As the V1 API  will allow any db model to be accessed there will need to be policies in place for this.

I divided most of the policies into 3 groups:
- DeviceRelatedPolicy
- PortRelatedPolicy
- RoutingRelatedPolicy
- 
These all inherit from their respective policies to make editing future changes to authorization easier.


Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
