### PR TITLE
Remove enable_footer config option

### DIFF
--- a/doc/Support/Configuration.md
+++ b/doc/Support/Configuration.md
@@ -557,13 +557,6 @@ which will force a full discovery run within the configured time window.
     lnms config:set enable_clear_discovery true
     ```
 
-Disable the footer of the WebUI by setting `enable_footer` to 0.
-
-!!! setting "webui/general"
-    ```bash
-    lnms config:set enable_footer true
-    ```
-
 Show the `X`th percentile in the graph instead of the default 95th percentile.
 
 !!! setting "webui/graph"

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -961,10 +961,6 @@ return [
             'description' => 'Enable Clear Discovery',
             'help' => 'Enables the ability to clear discovery date and time for a device. This will force a rediscovery of the device.',
         ],
-        'enable_footer' => [
-            'description' => 'Enable Footer',
-            'help' => 'Enables the footer on all pages.',
-        ],
         'enable_inventory' => [
             'description' => 'Enable Inventory',
             'help' => 'Enables the inventory page, which shows the hardware inventory of devices.',

--- a/resources/definitions/config_definitions.json
+++ b/resources/definitions/config_definitions.json
@@ -2250,13 +2250,6 @@
             "section": "device",
             "order": 8
         },
-        "enable_footer": {
-            "default": false,
-            "type": "boolean",
-            "group": "webui",
-            "section": "general",
-            "order": 0
-        },
         "enable_inventory": {
             "default": true,
             "type": "boolean",

--- a/resources/views/layouts/legacy_page.blade.php
+++ b/resources/views/layouts/legacy_page.blade.php
@@ -9,16 +9,4 @@
         </div>
     </div>
     <x-refresh-timer :refresh="$refresh"></x-refresh-timer>
-
-    @config('enable_footer')
-    <nav class="navbar navbar-default {{ $navbar }} navbar-fixed-bottom">
-        <div class="container">
-            <div class="row">
-                <div class="col-md-12 text-center">
-                    <h5>Powered by <a href="{{ \App\Facades\LibrenmsConfig::get('project_home') }}" target="_blank" rel="noopener" class="red">{{ \App\Facades\LibrenmsConfig::get('project_name') }}</a>.</h5>
-                </div>
-            </div>
-        </div>
-    </nav>
-    @endconfig
 @endsection


### PR DESCRIPTION
Fixes #19814 by removing the config option for enable_footer.

It only broke in a testing env so for normal users this would still have worked on legacy pages. Not sure theirs a real benefit to keep it in place though so just removed it.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
