### PR TITLE
fix: repair Show Previous on multi-interface bits graphs

### DIFF
--- a/includes/html/graphs/generic_multi_seperated.inc.php
+++ b/includes/html/graphs/generic_multi_seperated.inc.php
@@ -29,10 +29,12 @@ $out_thing = '';
 $in_thingX = '';
 $out_thingX = '';
 $plus = '';
+$plusX = '';
 $pluses = '';
 $plusesX = '';
 $rrddescr_len = 14; // length of the padded rrd_descr in legend
 $seperator = '';
+$seperatorX = '';
 $descr = '';
 $descr_out = '';
 
@@ -194,7 +196,7 @@ foreach ($rrd_list ?? [] as $rrd) {
     $iter++;
 }
 
-if ($previous) {
+if ($previous && ! $nototal && ! empty($rrd_list)) {
     $rrd_options[] = 'CDEF:inBX=' . $in_thingX . $plusesX;
     $rrd_options[] = 'CDEF:outBX=' . $out_thingX . $plusesX;
     $rrd_options[] = 'CDEF:octetsX=inBX,outBX,+';
@@ -216,7 +218,7 @@ if ($previous) {
     $rrd_options[] = 'VDEF:totX=octetsX,TOTAL';
 }
 
-if ($previous) {
+if ($previous && ! $nototal && ! empty($rrd_list)) {
     $rrd_options[] = 'AREA:in' . $format . 'X#99999999' . $stacked['transparency'] . ':';
     $rrd_optionsb[] = 'AREA:dout' . $format . 'X#99999999' . $transparency . ':';
     $rrd_options[] = 'LINE1.25:in' . $format . 'X#666666:';

--- a/includes/html/graphs/generic_multi_seperated.inc.php
+++ b/includes/html/graphs/generic_multi_seperated.inc.php
@@ -50,7 +50,7 @@ if ($width > '1500') {
 
 $stacked = generate_stacked_graphs();
 
-$units_descr = \LibreNMS\Data\Store\Rrd::fixedSafeDescr($units_descr ?? '', $rrddescr_len + 5);
+$units_descr = LibreNMS\Data\Store\Rrd::fixedSafeDescr($units_descr ?? '', $rrddescr_len + 5);
 
 if ($format == 'octets' || $format == 'bytes') {
     $units = 'Bps';
@@ -149,8 +149,8 @@ foreach ($rrd_list ?? [] as $rrd) {
     }
 
     if (! $nodetails) {
-        $descr = \LibreNMS\Data\Store\Rrd::fixedSafeDescr($rrd['descr'], $rrddescr_len) . '  In';
-        $descr_out = \LibreNMS\Data\Store\Rrd::fixedSafeDescr('', $rrddescr_len) . ' Out';
+        $descr = LibreNMS\Data\Store\Rrd::fixedSafeDescr($rrd['descr'], $rrddescr_len) . '  In';
+        $descr_out = LibreNMS\Data\Store\Rrd::fixedSafeDescr('', $rrddescr_len) . ' Out';
     }
 
     $rrd_options[] = 'AREA:inbits' . $i . '#' . $colour_in . $stacked['transparency'] . ":$descr$stack";
@@ -248,7 +248,7 @@ if (! $nototal && ! empty($rrd_list)) {
 
     $rrd_options[] = 'COMMENT: \\n';
 
-    $rrd_options[] = 'HRULE:999999999999999#FFFFFF:' . \LibreNMS\Data\Store\Rrd::fixedSafeDescr('Total', $rrddescr_len) . '  In';
+    $rrd_options[] = 'HRULE:999999999999999#FFFFFF:' . LibreNMS\Data\Store\Rrd::fixedSafeDescr('Total', $rrddescr_len) . '  In';
     $rrd_options[] = 'GPRINT:inbits:LAST:%6.' . $float_precision . "lf%s$units";
     $rrd_options[] = 'GPRINT:inbits:AVERAGE:%6.' . $float_precision . "lf%s$units";
     $rrd_options[] = 'GPRINT:inbits:MAX:%6.' . $float_precision . "lf%s$units";
@@ -261,7 +261,7 @@ if (! $nototal && ! empty($rrd_list)) {
     }
     $rrd_options[] = 'COMMENT:\\n';
 
-    $rrd_options[] = 'HRULE:999999999999990#FFFFFF:' . \LibreNMS\Data\Store\Rrd::fixedSafeDescr('', $rrddescr_len) . ' Out';
+    $rrd_options[] = 'HRULE:999999999999990#FFFFFF:' . LibreNMS\Data\Store\Rrd::fixedSafeDescr('', $rrddescr_len) . ' Out';
     $rrd_options[] = 'GPRINT:outbits:LAST:%6.' . $float_precision . "lf%s$units";
     $rrd_options[] = 'GPRINT:outbits:AVERAGE:%6.' . $float_precision . "lf%s$units";
     $rrd_options[] = 'GPRINT:outbits:MAX:%6.' . $float_precision . "lf%s$units";
@@ -274,7 +274,7 @@ if (! $nototal && ! empty($rrd_list)) {
     }
     $rrd_options[] = 'COMMENT:\\n';
 
-    $rrd_options[] = 'HRULE:999999999999990#FFFFFF:' . \LibreNMS\Data\Store\Rrd::fixedSafeDescr('', $rrddescr_len) . ' Agg';
+    $rrd_options[] = 'HRULE:999999999999990#FFFFFF:' . LibreNMS\Data\Store\Rrd::fixedSafeDescr('', $rrddescr_len) . ' Agg';
     $rrd_options[] = 'GPRINT:bits:LAST:%6.' . $float_precision . "lf%s$units";
     $rrd_options[] = 'GPRINT:bits:AVERAGE:%6.' . $float_precision . "lf%s$units";
     $rrd_options[] = 'GPRINT:bits:MAX:%6.' . $float_precision . "lf%s$units";


### PR DESCRIPTION
## Description

`generic_multi_seperated.inc.php` (used by `device_bits` and other multi-interface graphs) breaks whenever `previous=yes`:

- **Full-size graphs** (`width > 500`, so `!nototal`): `$seperatorX` / `$plusX` are used before they're initialised → `Undefined variable $seperatorX`. Laravel boots with `error_reporting(-1)`, so this `E_WARNING` becomes a fatal `ErrorException` and `graph.php` 500s — a broken graph image for end users.
- **Small graphs** (`nototal`): the previous-period aggregate `CDEF:inBX=…` is built from the empty accumulators → empty RPN → rrdtool `can not parse an empty rpn expression`.

This is independent of which page generated the URL — both the legacy graphs page and any other caller go through the same `graph.php` → `Graph::get()` pipeline. `port_bits` is unaffected because it uses `generic_data.inc.php`, which doesn't use this aggregate pattern.

Fixes #19820.

## Changes

- Initialise `$seperatorX` / `$plusX` alongside their current-period counterparts.
- Guard the two previous-period aggregate blocks with the same `! $nototal && ! empty($rrd_list)` condition already used for the current-period aggregate, so the comparison overlay is only emitted when there is data to aggregate.
- Separate commit: php-cs-fixer compliance for the touched file (drops redundant leading backslashes on `\LibreNMS\Data\Store\Rrd`, equivalent in this global-namespace file).

## Before / After

`device_bits` + `previous=yes`:

| | Full size (w≈532) | Thumbnail (w≈150) |
|---|---|---|
| **Before** | 500 `Undefined variable $seperatorX` | `can not parse an empty rpn expression` |
| **After** | renders with previous-period overlay | renders (overlay omitted, consistent with totals being hidden at that size) |

### Screenshots

BEFORE
<img width="2560" height="1380" alt="graphs_page_BEFORE" src="https://github.com/user-attachments/assets/95c76ea7-ed1f-43f9-af1c-e102dcb3d76e" />

AFTER
<img width="2560" height="1380" alt="graphs_page_AFTER" src="https://github.com/user-attachments/assets/06ec07ea-6c01-49a3-8714-2d1e53d039b4" />

## Testing

Verified against a live instance via `Graph::get()` for `device_bits&previous=yes` at full size (w=532) and small size (w=150): both render after the fix, both fail before it. RRD-backed graph rendering isn't covered by the feature-test suite (needs on-disk RRD files).

#### Please note
- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated test data. — N/A
