### PR TITLE
Pushover: change warning to normal priority

### DIFF
--- a/LibreNMS/Alert/Transport/Pushover.php
+++ b/LibreNMS/Alert/Transport/Pushover.php
@@ -55,28 +55,26 @@ class Pushover extends Transport
         $data['user'] = $this->config['userkey'];
         // Entities are html encoded so this will cause them to be displayed correctly in pushover alerts
         $data['html'] = '1';
-        switch ($alert_data['severity']) {
-            case 'critical':
-                $data['priority'] = 1;
-                if (! empty($options['sound_critical'])) {
-                    $data['sound'] = $options['sound_critical'];
-                }
-                break;
-            case 'warning':
-                $data['priority'] = 1;
-                if (! empty($options['sound_warning'])) {
-                    $data['sound'] = $options['sound_warning'];
-                }
-                break;
+
+        if ($alert_data['severity'] == 'critical') {
+            $data['priority'] = 1;
+            if (! empty($options['sound_critical'])) {
+                $data['sound'] = $options['sound_critical'];
+            }
+        } elseif ($alert_data['severity'] == 'warning') {
+            $data['priority'] = 0;
+            if (! empty($options['sound_warning'])) {
+                $data['sound'] = $options['sound_warning'];
+            }
         }
-        switch ($alert_data['state']) {
-            case AlertState::RECOVERED:
-                $data['priority'] = 0;
-                if (! empty($options['sound_ok'])) {
-                    $data['sound'] = $options['sound_ok'];
-                }
-                break;
+
+        if ($alert_data['state'] == AlertState::RECOVERED) {
+            $data['priority'] = 0;
+            if (! empty($options['sound_ok'])) {
+                $data['sound'] = $options['sound_ok'];
+            }
         }
+
         $data['title'] = $alert_data['title'];
         $data['message'] = $alert_data['msg'];
         if ($options) {
@@ -103,9 +101,9 @@ class Pushover extends Transport
                     'type' => 'password',
                 ],
                 [
-                    'title' => 'User Key',
+                    'title' => 'User/Group Key',
                     'name' => 'userkey',
-                    'descr' => 'User Key',
+                    'descr' => 'User/Group Key',
                     'type' => 'password',
                 ],
                 [

--- a/doc/Alerting/Transports/Pushover.md
+++ b/doc/Alerting/Transports/Pushover.md
@@ -6,7 +6,7 @@ can add the following in Pushover Options:
 
 `sound=falling`
 
-You also have the possibility to change sound per severity:
+You also have the possibility to change sound per severity, sound_ok is used for recovery notifications:
 `sound_critical=falling`
 `sound_warning=siren`
 `sound_ok=magic`
@@ -16,8 +16,9 @@ Enabling Pushover support is fairly easy, there are only two required parameters
 Firstly you need to create a new Application (called LibreNMS, for
 example) in your account on the Pushover website ([https://pushover.net/apps](https://pushover.net/apps)).
 
-Now copy your API Key and obtain your User Key from the newly created
-Application and setup the transport.
+Now obtain your API Key from the newly created Application
+and your User Key or Group Key
+then setup the transport.
 
 [Pushover Docs](https://pushover.net/api)
 
@@ -26,5 +27,5 @@ Application and setup the transport.
 | Config | Example |
 | ------ | ------- |
 | Api Key | APPLICATIONAPIKEYGOESHERE |
-| User Key | USERKEYGOESHERE |
+| User/Group Key | USERORGROUPKEYGOESHERE |
 | Pushover Options | sound_critical=falling <br/> sound_warning=siren <br/> sound_ok=magic |


### PR DESCRIPTION
Change warning class alerts to normal priority (0), it was previously setting them to priority 1 which overrides downtime schedules. A few docs updates.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
