### PR TITLE
Add statistics to get_port_info

### DIFF
--- a/doc/API/Ports.md
+++ b/doc/API/Ports.md
@@ -248,7 +248,7 @@ Get all info for a particular port.
 Route: `/api/v0/ports/:portid?with=vlans`
 
 - portid must be an integer
-- it's possible to add allowed associated relations to the port using the `with` option. Allowed: `vlans`,`device`
+- it's possible to add allowed associated relations to the port using the `with` option. Allowed: `vlans`,`device`,`statistics`
 
 Input:
 

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -1297,7 +1297,7 @@ function get_port_info(Illuminate\Http\Request $request)
 
     return check_port_permission($port_id, null, function ($port_id) {
         $with = request()->input('with');
-        $allowed = ['vlans', 'device'];
+        $allowed = ['vlans', 'device', 'statistics'];
         $port = Port::where('port_id', $port_id)
                     ->when(in_array($with, $allowed), fn ($q) => $q->with($with))
                     ->get();


### PR DESCRIPTION
Provide data in the table ports_statistics through the API.

```
{
    "status": "ok",
    "port": [
        {
            "port_id": 12,
            "device_id": 3,
            "port_descr_type": null,
            "port_descr_descr": null,
            "port_descr_circuit": null,
            "port_descr_speed": null,
            "port_descr_notes": null,
            "ifDescr": "GigabitEthernet0\/8",
            "ifName": "Gi0\/8",
            "portName": null,
            "ifIndex": 10108,
            "ifSpeed": 1000000000,
            "ifSpeed_prev": 1000000000,
            "ifConnectorPresent": "true",
            "ifOperStatus": "up",
            "ifOperStatus_prev": "up",
            "ifAdminStatus": "up",
            "ifAdminStatus_prev": "up",
            "ifDuplex": "fullDuplex",
            "ifMtu": 1500,
            "ifType": "ethernetCsmacd",
            "ifAlias": "### description ###",
            "ifPhysAddress": "fcfbfb3d5788",
            "ifLastChange": 2603737208,
            "ifVlan": "1",
            "ifTrunk": "dot1Q",
            "ifVrf": 0,
            "ignore": 0,
            "disabled": 0,
            "deleted": 0,
            "pagpOperationMode": null,
            "pagpPortState": null,
            "pagpPartnerDeviceId": null,
            "pagpPartnerLearnMethod": null,
            "pagpPartnerIfIndex": null,
            "pagpPartnerGroupIfIndex": null,
            "pagpPartnerDeviceName": null,
            "pagpEthcOperationMode": null,
            "pagpDeviceId": null,
            "pagpGroupIfIndex": null,
            "ifInUcastPkts": 2355821808,
            "ifInUcastPkts_prev": 2355815433,
            "ifInUcastPkts_delta": 6375,
            "ifInUcastPkts_rate": 21,
            "ifOutUcastPkts": 2670776910,
            "ifOutUcastPkts_prev": 2670769538,
            "ifOutUcastPkts_delta": 7372,
            "ifOutUcastPkts_rate": 25,
            "ifInErrors": 0,
            "ifInErrors_prev": 0,
            "ifInErrors_delta": 0,
            "ifInErrors_rate": 0,
            "ifOutErrors": 0,
            "ifOutErrors_prev": 0,
            "ifOutErrors_delta": 0,
            "ifOutErrors_rate": 0,
            "ifInOctets": 1844085508047,
            "ifInOctets_prev": 1844080247969,
            "ifInOctets_delta": 5260078,
            "ifInOctets_rate": 17592,
            "ifOutOctets": 1985744013328,
            "ifOutOctets_prev": 1985739634639,
            "ifOutOctets_delta": 4378689,
            "ifOutOctets_rate": 14644,
            "poll_time": 1780588206,
            "poll_prev": 1780587907,
            "poll_period": 299,
            "statistics": [
                {
                    "port_id": 12,
                    "ifInNUcastPkts": 0,
                    "ifInNUcastPkts_prev": 0,
                    "ifInNUcastPkts_delta": 0,
                    "ifInNUcastPkts_rate": 0,
                    "ifOutNUcastPkts": 0,
                    "ifOutNUcastPkts_prev": 0,
                    "ifOutNUcastPkts_delta": 0,
                    "ifOutNUcastPkts_rate": 0,
                    "ifInDiscards": 0,
                    "ifInDiscards_prev": 0,
                    "ifInDiscards_delta": 0,
                    "ifInDiscards_rate": 0,
                    "ifOutDiscards": 46158,
                    "ifOutDiscards_prev": 46158,
                    "ifOutDiscards_delta": 0,
                    "ifOutDiscards_rate": 0,
                    "ifInUnknownProtos": 0,
                    "ifInUnknownProtos_prev": 0,
                    "ifInUnknownProtos_delta": 0,
                    "ifInUnknownProtos_rate": 0,
                    "ifInBroadcastPkts": 45321526,
                    "ifInBroadcastPkts_prev": 45321289,
                    "ifInBroadcastPkts_delta": 237,
                    "ifInBroadcastPkts_rate": 1,
                    "ifOutBroadcastPkts": 401196,
                    "ifOutBroadcastPkts_prev": 401196,
                    "ifOutBroadcastPkts_delta": 0,
                    "ifOutBroadcastPkts_rate": 0,
                    "ifInMulticastPkts": 154765087,
                    "ifInMulticastPkts_prev": 154764632,
                    "ifInMulticastPkts_delta": 455,
                    "ifInMulticastPkts_rate": 2,
                    "ifOutMulticastPkts": 35635496,
                    "ifOutMulticastPkts_prev": 35635176,
                    "ifOutMulticastPkts_delta": 320,
                    "ifOutMulticastPkts_rate": 1
                }
            ]
        }
    ]
}
```

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
