### PR TITLE
Add Oxidized Git history fallback for disabled devices

### DIFF
--- a/app/Actions/Oxidized/BuildDeviceOutput.php
+++ b/app/Actions/Oxidized/BuildDeviceOutput.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Actions\Oxidized;
+
+use App\Facades\LibrenmsConfig;
+use App\Models\Device;
+
+class BuildDeviceOutput
+{
+    public function execute(Device $device): array
+    {
+        $output = [
+            'hostname' => $device->hostname,
+            'os' => $device->os,
+            'ip' => $device->ip,
+        ];
+
+        $custom_ssh_port = $device->getAttrib('override_device_ssh_port');
+        if (! empty($custom_ssh_port)) {
+            $output['ssh_port'] = $custom_ssh_port;
+        }
+
+        $custom_telnet_port = $device->getAttrib('override_device_telnet_port');
+        if (! empty($custom_telnet_port)) {
+            $output['telnet_port'] = $custom_telnet_port;
+        }
+
+        // Pre-populate the group with the default
+        if (LibrenmsConfig::get('oxidized.group_support') === true && ! empty(LibrenmsConfig::get('oxidized.default_group'))) {
+            $output['group'] = LibrenmsConfig::get('oxidized.default_group');
+        }
+
+        foreach (LibrenmsConfig::get('oxidized.maps', []) as $maps_column => $maps) {
+            // Based on Oxidized group support we can apply groups by setting group_support to true
+            if ($maps_column == 'group' && LibrenmsConfig::get('oxidized.group_support', true) !== true) {
+                continue;
+            }
+
+            foreach ($maps as $field_type => $fields) {
+                if ($field_type == 'sysname') {
+                    $value = $device->sysName; // fix typo in previous code forcing users to use sysname instead of sysName
+                } elseif ($field_type == 'location') {
+                    $value = $device->location->location;
+                } else {
+                    $value = $device->$field_type;
+                }
+
+                foreach ($fields as $field) {
+                    if (isset($field['regex']) && preg_match($field['regex'] . 'i', (string) $value)) {
+                        $output[$maps_column] = $field['value'] ?? $field[$maps_column];  // compatibility with old format
+                        break;
+                    } elseif (isset($field['match']) && $field['match'] == $value) {
+                        $output[$maps_column] = $field['value'] ?? $field[$maps_column]; // compatibility with old format
+                        break;
+                    }
+                }
+            }
+        }
+
+        return $output;
+    }
+}

--- a/app/Actions/Oxidized/BuildDeviceOutput.php
+++ b/app/Actions/Oxidized/BuildDeviceOutput.php
@@ -26,7 +26,10 @@ class BuildDeviceOutput
         }
 
         // Pre-populate the group with the default
-        if (LibrenmsConfig::get('oxidized.group_support') === true && ! empty(LibrenmsConfig::get('oxidized.default_group'))) {
+        if (
+            LibrenmsConfig::get('oxidized.group_support') === true
+            && ! empty(LibrenmsConfig::get('oxidized.default_group'))
+        ) {
             $output['group'] = LibrenmsConfig::get('oxidized.default_group');
         }
 
@@ -38,7 +41,8 @@ class BuildDeviceOutput
 
             foreach ($maps as $field_type => $fields) {
                 if ($field_type == 'sysname') {
-                    $value = $device->sysName; // fix typo in previous code forcing users to use sysname instead of sysName
+                    // fix typo in previous code forcing users to use sysname instead of sysName
+                    $value = $device->sysName;
                 } elseif ($field_type == 'location') {
                     $value = $device->location?->location;
                 } else {
@@ -47,10 +51,12 @@ class BuildDeviceOutput
 
                 foreach ($fields as $field) {
                     if (isset($field['regex']) && preg_match($field['regex'] . 'i', (string) $value)) {
-                        $output[$maps_column] = $field['value'] ?? $field[$maps_column];  // compatibility with old format
+                        // compatibility with old format
+                        $output[$maps_column] = $field['value'] ?? $field[$maps_column];
                         break;
                     } elseif (isset($field['match']) && $field['match'] == $value) {
-                        $output[$maps_column] = $field['value'] ?? $field[$maps_column]; // compatibility with old format
+                        // compatibility with old format
+                        $output[$maps_column] = $field['value'] ?? $field[$maps_column];
                         break;
                     }
                 }

--- a/app/Actions/Oxidized/BuildDeviceOutput.php
+++ b/app/Actions/Oxidized/BuildDeviceOutput.php
@@ -7,6 +7,9 @@ use App\Models\Device;
 
 class BuildDeviceOutput
 {
+    /**
+     * @return array<string, mixed>
+     */
     public function execute(Device $device): array
     {
         $output = [

--- a/app/Actions/Oxidized/BuildDeviceOutput.php
+++ b/app/Actions/Oxidized/BuildDeviceOutput.php
@@ -40,7 +40,7 @@ class BuildDeviceOutput
                 if ($field_type == 'sysname') {
                     $value = $device->sysName; // fix typo in previous code forcing users to use sysname instead of sysName
                 } elseif ($field_type == 'location') {
-                    $value = $device->location->location;
+                    $value = $device->location?->location;
                 } else {
                     $value = $device->$field_type;
                 }

--- a/app/Actions/Oxidized/BuildGitHistoryViewData.php
+++ b/app/Actions/Oxidized/BuildGitHistoryViewData.php
@@ -37,32 +37,22 @@ class BuildGitHistoryViewData
 
         $historyConfig = $this->findGitHistoryConfig->execute($device);
         if ($historyConfig === null) {
-            return null;
+            return $this->emptyHistoryData($device, [
+                'repo' => '',
+                'file' => '',
+                'source' => 'not_found',
+            ], 'No matching historical Oxidized Git configuration found for this device. Check the Oxidized history repository base path, additional repository paths, permissions, and Oxidized Git output.');
         }
 
         $configVersions = $this->readGitHistoryConfig->versions($historyConfig['repo'], $historyConfig['file']);
         $configTotal = count($configVersions);
 
         if ($configTotal === 0) {
-            $oxidizedOutput = $this->buildDeviceOutput->execute($device);
-
-            return [
-                'text' => '',
-                'config_versions' => [],
-                'config_total' => 0,
-                'warning' => 'No readable historical Oxidized Git versions found for this device. Check the configured repository path, permissions, and Oxidized Git output.',
-                'node_info' => [
-                    'name' => $oxidizedOutput['hostname'] ?? $device->hostname,
-                    'ip' => $oxidizedOutput['ip'] ?? $device->ip,
-                    'model' => strtoupper((string) ($oxidizedOutput['os'] ?? $device->os)),
-                    'last_sync' => 'N/A',
-                    'status' => 'historical',
-                    'source' => 'Local Oxidized Git history',
-                ],
-                'author' => '',
-                'message' => '',
-                'source' => $historyConfig,
-            ];
+            return $this->emptyHistoryData(
+                $device,
+                $historyConfig,
+                'No readable historical Oxidized Git versions found for this device. Check the configured repository path, permissions, and Oxidized Git output.'
+            );
         }
 
         foreach ($configVersions as $key => $version) {
@@ -107,6 +97,42 @@ class BuildGitHistoryViewData
         }
 
         return $data;
+    }
+
+    /**
+     * @param array{repo: string, file: string, source: string} $historyConfig
+     * @return array{
+     *     text: string,
+     *     config_versions: array<int, array<string, mixed>>,
+     *     config_total: int,
+     *     warning: string,
+     *     node_info: array<string, mixed>,
+     *     author: string,
+     *     message: string,
+     *     source: array{repo: string, file: string, source: string}
+     * }
+     */
+    private function emptyHistoryData(Device $device, array $historyConfig, string $warning): array
+    {
+        $oxidizedOutput = $this->buildDeviceOutput->execute($device);
+
+        return [
+            'text' => '',
+            'config_versions' => [],
+            'config_total' => 0,
+            'warning' => $warning,
+            'node_info' => [
+                'name' => $oxidizedOutput['hostname'] ?? $device->hostname,
+                'ip' => $oxidizedOutput['ip'] ?? $device->ip,
+                'model' => strtoupper((string) ($oxidizedOutput['os'] ?? $device->os)),
+                'last_sync' => 'N/A',
+                'status' => 'historical',
+                'source' => 'Local Oxidized Git history',
+            ],
+            'author' => '',
+            'message' => '',
+            'source' => $historyConfig,
+        ];
     }
 
     public function eligible(Device $device): bool

--- a/app/Actions/Oxidized/BuildGitHistoryViewData.php
+++ b/app/Actions/Oxidized/BuildGitHistoryViewData.php
@@ -20,7 +20,7 @@ class BuildGitHistoryViewData
      *     text: string,
      *     config_versions: array<int, array<string, mixed>>,
      *     config_total: int,
-     *     current_config: array{oid: string, date: string, version: int},
+     *     current_config?: array{oid: string, date: string, version: int},
      *     previous_config?: array{oid: string, date: string, version: int},
      *     warning?: string,
      *     node_info: array<string, mixed>,
@@ -44,7 +44,25 @@ class BuildGitHistoryViewData
         $configTotal = count($configVersions);
 
         if ($configTotal === 0) {
-            return null;
+            $oxidizedOutput = $this->buildDeviceOutput->execute($device);
+
+            return [
+                'text' => '',
+                'config_versions' => [],
+                'config_total' => 0,
+                'warning' => 'No readable historical Oxidized Git versions found for this device. Check the configured repository path, permissions, and Oxidized Git output.',
+                'node_info' => [
+                    'name' => $oxidizedOutput['hostname'] ?? $device->hostname,
+                    'ip' => $oxidizedOutput['ip'] ?? $device->ip,
+                    'model' => strtoupper((string) ($oxidizedOutput['os'] ?? $device->os)),
+                    'last_sync' => 'N/A',
+                    'status' => 'historical',
+                    'source' => 'Local Oxidized Git history',
+                ],
+                'author' => '',
+                'message' => '',
+                'source' => $historyConfig,
+            ];
         }
 
         foreach ($configVersions as $key => $version) {

--- a/app/Actions/Oxidized/BuildGitHistoryViewData.php
+++ b/app/Actions/Oxidized/BuildGitHistoryViewData.php
@@ -1,0 +1,205 @@
+<?php
+
+namespace App\Actions\Oxidized;
+
+use App\Facades\LibrenmsConfig;
+use App\Models\Device;
+
+class BuildGitHistoryViewData
+{
+    public function __construct(
+        private readonly BuildDeviceOutput $buildDeviceOutput,
+        private readonly FindGitHistoryConfig $findGitHistoryConfig,
+        private readonly ReadGitHistoryConfig $readGitHistoryConfig,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $input
+     * @return array{
+     *     text: string,
+     *     config_versions: array<int, array<string, mixed>>,
+     *     config_total: int,
+     *     current_config: array{oid: string, date: string, version: int},
+     *     previous_config?: array{oid: string, date: string, version: int},
+     *     warning?: string,
+     *     node_info: array<string, mixed>,
+     *     author: string,
+     *     message: string,
+     *     source: array{repo: string, file: string, source: string}
+     * }|null
+     */
+    public function execute(Device $device, array $input = []): ?array
+    {
+        if (! $this->eligible($device)) {
+            return null;
+        }
+
+        $historyConfig = $this->findGitHistoryConfig->execute($device);
+        if ($historyConfig === null) {
+            return null;
+        }
+
+        $configVersions = $this->readGitHistoryConfig->versions($historyConfig['repo'], $historyConfig['file']);
+        $configTotal = count($configVersions);
+
+        if ($configTotal === 0) {
+            return null;
+        }
+
+        foreach ($configVersions as $key => $version) {
+            $configVersions[$key]['version'] = $configTotal - $key;
+        }
+
+        $versionsByOid = [];
+        foreach ($configVersions as $version) {
+            $versionsByOid[$version['oid']] = $version;
+        }
+
+        $currentConfig = $this->currentConfig($input, $configVersions, $versionsByOid);
+        $previousConfig = $this->previousConfig($input, $currentConfig, $configVersions, $versionsByOid);
+
+        $selectedVersion = $versionsByOid[$currentConfig['oid']] ?? [];
+        $text = $this->configText($historyConfig, $currentConfig, $previousConfig);
+
+        $oxidizedOutput = $this->buildDeviceOutput->execute($device);
+
+        $data = [
+            'text' => $text,
+            'config_versions' => $configVersions,
+            'config_total' => $configTotal,
+            'current_config' => $currentConfig,
+            'node_info' => [
+                'name' => $oxidizedOutput['hostname'] ?? $device->hostname,
+                'ip' => $oxidizedOutput['ip'] ?? $device->ip,
+                'model' => $oxidizedOutput['os'] ?? $device->os,
+                'last_sync' => $configVersions[0]['date'],
+                'status' => 'historical',
+                'source' => 'Local Oxidized Git history',
+            ],
+            'author' => $selectedVersion['author']['name'] ?? '',
+            'message' => $selectedVersion['message'] ?? '',
+            'source' => $historyConfig,
+        ];
+
+        if ($previousConfig !== null) {
+            $data['previous_config'] = $previousConfig;
+        } elseif (isset($input['diff'])) {
+            $data['warning'] = 'No previous version, please select a different version.';
+        }
+
+        return $data;
+    }
+
+    public function eligible(Device $device): bool
+    {
+        if (LibrenmsConfig::get('oxidized.history.enabled') !== true) {
+            return false;
+        }
+
+        $output = $this->buildDeviceOutput->execute($device);
+
+        return (bool) $device->disabled
+            || $device->getAttrib('override_Oxidized_disable') === 'true'
+            || in_array($device->type, LibrenmsConfig::get('oxidized.ignore_types', []))
+            || in_array($device->os, LibrenmsConfig::get('oxidized.ignore_os', []))
+            || (
+                isset($output['group'])
+                && in_array($output['group'], LibrenmsConfig::get('oxidized.ignore_groups', []))
+            );
+    }
+
+    /**
+     * @param array<string, mixed> $input
+     * @param array<int, array<string, mixed>> $configVersions
+     * @param array<string, array<string, mixed>> $versionsByOid
+     * @return array{oid: string, date: string, version: int}
+     */
+    private function currentConfig(array $input, array $configVersions, array $versionsByOid): array
+    {
+        if (isset($input['config'])) {
+            $postedConfig = explode('|', (string) $input['config']);
+            $postedOid = $postedConfig[0] ?? '';
+
+            if (isset($versionsByOid[$postedOid])) {
+                return [
+                    'oid' => $versionsByOid[$postedOid]['oid'],
+                    'date' => $versionsByOid[$postedOid]['date'],
+                    'version' => (int) $versionsByOid[$postedOid]['version'],
+                ];
+            }
+        }
+
+        return [
+            'oid' => $configVersions[0]['oid'],
+            'date' => $configVersions[0]['date'],
+            'version' => (int) $configVersions[0]['version'],
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $input
+     * @param array{oid: string, date: string, version: int} $currentConfig
+     * @param array<int, array<string, mixed>> $configVersions
+     * @param array<string, array<string, mixed>> $versionsByOid
+     * @return array{oid: string, date: string, version: int}|null
+     */
+    private function previousConfig(array $input, array $currentConfig, array $configVersions, array $versionsByOid): ?array
+    {
+        if (! isset($input['diff'])) {
+            return null;
+        }
+
+        $postedPrevious = explode('|', (string) ($input['prevconfig'] ?? ''));
+        $postedPreviousOid = $postedPrevious[0] ?? '';
+
+        if (isset($versionsByOid[$postedPreviousOid]) && $postedPreviousOid !== $currentConfig['oid']) {
+            return [
+                'oid' => $versionsByOid[$postedPreviousOid]['oid'],
+                'date' => $versionsByOid[$postedPreviousOid]['date'],
+                'version' => (int) $versionsByOid[$postedPreviousOid]['version'],
+            ];
+        }
+
+        if ($currentConfig['version'] === 1) {
+            return null;
+        }
+
+        foreach ($configVersions as $key => $version) {
+            if ($version['oid'] === $currentConfig['oid'] && isset($configVersions[$key + 1])) {
+                return [
+                    'oid' => $configVersions[$key + 1]['oid'],
+                    'date' => $configVersions[$key + 1]['date'],
+                    'version' => (int) $configVersions[$key + 1]['version'],
+                ];
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array{repo: string, file: string, source: string} $historyConfig
+     * @param array{oid: string, date: string, version: int} $currentConfig
+     * @param array{oid: string, date: string, version: int}|null $previousConfig
+     */
+    private function configText(array $historyConfig, array $currentConfig, ?array $previousConfig): string
+    {
+        if ($previousConfig !== null) {
+            $diff = $this->readGitHistoryConfig->diff(
+                $historyConfig['repo'],
+                $historyConfig['file'],
+                $currentConfig['oid'],
+                $previousConfig['oid']
+            );
+
+            return $diff ?: 'No Difference';
+        }
+
+        return $this->readGitHistoryConfig->config(
+            $historyConfig['repo'],
+            $historyConfig['file'],
+            $currentConfig['oid']
+        );
+    }
+}

--- a/app/Actions/Oxidized/BuildGitHistoryViewData.php
+++ b/app/Actions/Oxidized/BuildGitHistoryViewData.php
@@ -14,6 +14,11 @@ class BuildGitHistoryViewData
     private const NO_READABLE_HISTORY_WARNING = 'No readable historical Oxidized Git versions found '
         . 'for this device. Check the configured repository path, permissions, and Oxidized Git output.';
 
+    private const UNABLE_TO_READ_CONFIG_WARNING = 'Unable to read selected historical Oxidized '
+        . 'configuration version.';
+
+    private const UNABLE_TO_READ_DIFF_WARNING = 'Unable to read historical Oxidized configuration diff.';
+
     public function __construct(
         private readonly BuildDeviceOutput $buildDeviceOutput,
         private readonly FindGitHistoryConfig $findGitHistoryConfig,
@@ -79,12 +84,12 @@ class BuildGitHistoryViewData
         $previousConfig = $this->previousConfig($input, $currentConfig, $configVersions, $versionsByOid);
 
         $selectedVersion = $versionsByOid[$currentConfig['oid']] ?? [];
-        $text = $this->configText($historyConfig, $currentConfig, $previousConfig);
+        $configText = $this->configText($historyConfig, $currentConfig, $previousConfig);
 
         $oxidizedOutput = $this->buildDeviceOutput->execute($device);
 
         $data = [
-            'text' => $text,
+            'text' => $configText['text'],
             'config_versions' => $configVersions,
             'config_total' => $configTotal,
             'current_config' => $currentConfig,
@@ -100,6 +105,10 @@ class BuildGitHistoryViewData
             'message' => $selectedVersion['message'] ?? '',
             'source' => $historyConfig,
         ];
+
+        if (isset($configText['warning'])) {
+            $data['warning'] = $configText['warning'];
+        }
 
         if ($previousConfig !== null) {
             $data['previous_config'] = $previousConfig;
@@ -245,8 +254,9 @@ class BuildGitHistoryViewData
      * @param array{repo: string, file: string, source: string} $historyConfig
      * @param array{oid: string, date: string, version: int} $currentConfig
      * @param array{oid: string, date: string, version: int}|null $previousConfig
+     * @return array{text: string, warning?: string}
      */
-    private function configText(array $historyConfig, array $currentConfig, ?array $previousConfig): string
+    private function configText(array $historyConfig, array $currentConfig, ?array $previousConfig): array
     {
         if ($previousConfig !== null) {
             $diff = $this->readGitHistoryConfig->diff(
@@ -256,13 +266,29 @@ class BuildGitHistoryViewData
                 $previousConfig['oid']
             );
 
-            return $diff ?: 'No Difference';
+            if ($diff === null) {
+                return [
+                    'text' => '',
+                    'warning' => self::UNABLE_TO_READ_DIFF_WARNING,
+                ];
+            }
+
+            return ['text' => $diff !== '' ? $diff : 'No Difference'];
         }
 
-        return $this->readGitHistoryConfig->config(
+        $config = $this->readGitHistoryConfig->config(
             $historyConfig['repo'],
             $historyConfig['file'],
             $currentConfig['oid']
         );
+
+        if ($config === null) {
+            return [
+                'text' => '',
+                'warning' => self::UNABLE_TO_READ_CONFIG_WARNING,
+            ];
+        }
+
+        return ['text' => $config];
     }
 }

--- a/app/Actions/Oxidized/BuildGitHistoryViewData.php
+++ b/app/Actions/Oxidized/BuildGitHistoryViewData.php
@@ -148,7 +148,10 @@ class BuildGitHistoryViewData
 
     public function eligible(Device $device): bool
     {
-        if (LibrenmsConfig::get('oxidized.history.enabled') !== true) {
+        if (
+            LibrenmsConfig::get('oxidized.enabled') !== true
+            || LibrenmsConfig::get('oxidized.history.enabled') !== true
+        ) {
             return false;
         }
 
@@ -156,11 +159,11 @@ class BuildGitHistoryViewData
 
         return (bool) $device->disabled
             || $device->getAttrib('override_Oxidized_disable') === 'true'
-            || in_array($device->type, LibrenmsConfig::get('oxidized.ignore_types', []))
-            || in_array($device->os, LibrenmsConfig::get('oxidized.ignore_os', []))
+            || in_array($device->type, LibrenmsConfig::get('oxidized.ignore_types', []), true)
+            || in_array($device->os, LibrenmsConfig::get('oxidized.ignore_os', []), true)
             || (
                 isset($output['group'])
-                && in_array($output['group'], LibrenmsConfig::get('oxidized.ignore_groups', []))
+                && in_array($output['group'], LibrenmsConfig::get('oxidized.ignore_groups', []), true)
             );
     }
 

--- a/app/Actions/Oxidized/BuildGitHistoryViewData.php
+++ b/app/Actions/Oxidized/BuildGitHistoryViewData.php
@@ -7,6 +7,13 @@ use App\Models\Device;
 
 class BuildGitHistoryViewData
 {
+    private const NO_MATCHING_HISTORY_WARNING = 'No matching historical Oxidized Git configuration found '
+        . 'for this device. Check the Oxidized history repository base path, additional repository paths, '
+        . 'permissions, and Oxidized Git output.';
+
+    private const NO_READABLE_HISTORY_WARNING = 'No readable historical Oxidized Git versions found '
+        . 'for this device. Check the configured repository path, permissions, and Oxidized Git output.';
+
     public function __construct(
         private readonly BuildDeviceOutput $buildDeviceOutput,
         private readonly FindGitHistoryConfig $findGitHistoryConfig,
@@ -37,11 +44,15 @@ class BuildGitHistoryViewData
 
         $historyConfig = $this->findGitHistoryConfig->execute($device);
         if ($historyConfig === null) {
-            return $this->emptyHistoryData($device, [
-                'repo' => '',
-                'file' => '',
-                'source' => 'not_found',
-            ], 'No matching historical Oxidized Git configuration found for this device. Check the Oxidized history repository base path, additional repository paths, permissions, and Oxidized Git output.');
+            return $this->emptyHistoryData(
+                $device,
+                [
+                    'repo' => '',
+                    'file' => '',
+                    'source' => 'not_found',
+                ],
+                self::NO_MATCHING_HISTORY_WARNING
+            );
         }
 
         $configVersions = $this->readGitHistoryConfig->versions($historyConfig['repo'], $historyConfig['file']);
@@ -51,7 +62,7 @@ class BuildGitHistoryViewData
             return $this->emptyHistoryData(
                 $device,
                 $historyConfig,
-                'No readable historical Oxidized Git versions found for this device. Check the configured repository path, permissions, and Oxidized Git output.'
+                self::NO_READABLE_HISTORY_WARNING
             );
         }
 
@@ -188,7 +199,12 @@ class BuildGitHistoryViewData
      * @param array<string, array<string, mixed>> $versionsByOid
      * @return array{oid: string, date: string, version: int}|null
      */
-    private function previousConfig(array $input, array $currentConfig, array $configVersions, array $versionsByOid): ?array
+    private function previousConfig(
+        array $input,
+        array $currentConfig,
+        array $configVersions,
+        array $versionsByOid
+    ): ?array
     {
         if (! isset($input['diff'])) {
             return null;

--- a/app/Actions/Oxidized/BuildGitHistoryViewData.php
+++ b/app/Actions/Oxidized/BuildGitHistoryViewData.php
@@ -27,7 +27,7 @@ class BuildGitHistoryViewData
     }
 
     /**
-     * @param array<string, mixed> $input
+     * @param  array<string, mixed>  $input
      * @return array{
      *     text: string,
      *     config_versions: array<int, array<string, mixed>>,
@@ -120,7 +120,7 @@ class BuildGitHistoryViewData
     }
 
     /**
-     * @param array{repo: string, file: string, source: string} $historyConfig
+     * @param  array{repo: string, file: string, source: string}  $historyConfig
      * @return array{
      *     text: string,
      *     config_versions: array<int, array<string, mixed>>,
@@ -177,9 +177,9 @@ class BuildGitHistoryViewData
     }
 
     /**
-     * @param array<string, mixed> $input
-     * @param array<int, array<string, mixed>> $configVersions
-     * @param array<string, array<string, mixed>> $versionsByOid
+     * @param  array<string, mixed>  $input
+     * @param  array<int, array<string, mixed>>  $configVersions
+     * @param  array<string, array<string, mixed>>  $versionsByOid
      * @return array{oid: string, date: string, version: int}
      */
     private function currentConfig(array $input, array $configVersions, array $versionsByOid): array
@@ -205,10 +205,10 @@ class BuildGitHistoryViewData
     }
 
     /**
-     * @param array<string, mixed> $input
-     * @param array{oid: string, date: string, version: int} $currentConfig
-     * @param array<int, array<string, mixed>> $configVersions
-     * @param array<string, array<string, mixed>> $versionsByOid
+     * @param  array<string, mixed>  $input
+     * @param  array{oid: string, date: string, version: int}  $currentConfig
+     * @param  array<int, array<string, mixed>>  $configVersions
+     * @param  array<string, array<string, mixed>>  $versionsByOid
      * @return array{oid: string, date: string, version: int}|null
      */
     private function previousConfig(
@@ -216,8 +216,7 @@ class BuildGitHistoryViewData
         array $currentConfig,
         array $configVersions,
         array $versionsByOid
-    ): ?array
-    {
+    ): ?array {
         if (! isset($input['diff'])) {
             return null;
         }
@@ -251,9 +250,9 @@ class BuildGitHistoryViewData
     }
 
     /**
-     * @param array{repo: string, file: string, source: string} $historyConfig
-     * @param array{oid: string, date: string, version: int} $currentConfig
-     * @param array{oid: string, date: string, version: int}|null $previousConfig
+     * @param  array{repo: string, file: string, source: string}  $historyConfig
+     * @param  array{oid: string, date: string, version: int}  $currentConfig
+     * @param  array{oid: string, date: string, version: int}|null  $previousConfig
      * @return array{text: string, warning?: string}
      */
     private function configText(array $historyConfig, array $currentConfig, ?array $previousConfig): array

--- a/app/Actions/Oxidized/BuildGitHistoryViewData.php
+++ b/app/Actions/Oxidized/BuildGitHistoryViewData.php
@@ -72,7 +72,7 @@ class BuildGitHistoryViewData
             'node_info' => [
                 'name' => $oxidizedOutput['hostname'] ?? $device->hostname,
                 'ip' => $oxidizedOutput['ip'] ?? $device->ip,
-                'model' => $oxidizedOutput['os'] ?? $device->os,
+                'model' => strtoupper((string) ($oxidizedOutput['os'] ?? $device->os)),
                 'last_sync' => $configVersions[0]['date'],
                 'status' => 'historical',
                 'source' => 'Local Oxidized Git history',

--- a/app/Actions/Oxidized/FindGitHistoryConfig.php
+++ b/app/Actions/Oxidized/FindGitHistoryConfig.php
@@ -66,6 +66,12 @@ class FindGitHistoryConfig
     public function candidateFilenames(Device $device): array
     {
         $candidates = [];
+        $output = $this->buildDeviceOutput->execute($device);
+
+        $this->addCandidate($candidates, $output['hostname'] ?? null);
+        $this->addShortHostnameCandidate($candidates, $output['hostname'] ?? null);
+
+        $this->addCandidate($candidates, $output['ip'] ?? null);
 
         $this->addCandidate($candidates, $device->hostname);
         $this->addShortHostnameCandidate($candidates, $device->hostname);

--- a/app/Actions/Oxidized/FindGitHistoryConfig.php
+++ b/app/Actions/Oxidized/FindGitHistoryConfig.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace App\Actions\Oxidized;
+
+use App\Facades\LibrenmsConfig;
+use App\Models\Device;
+use Symfony\Component\Process\Process;
+
+class FindGitHistoryConfig
+{
+    public function __construct(private readonly BuildDeviceOutput $buildDeviceOutput)
+    {
+    }
+
+    /**
+     * @return array{repo: string, file: string, source: string}|null
+     */
+    public function execute(Device $device): ?array
+    {
+        if (LibrenmsConfig::get('oxidized.history.enabled') !== true) {
+            return null;
+        }
+
+        $candidates = $this->candidateFilenames($device);
+        if (empty($candidates)) {
+            return null;
+        }
+
+        foreach ($this->candidateRepos($device) as $repo => $source) {
+            foreach ($candidates as $candidate) {
+                if ($this->gitFileExists($repo, $candidate)) {
+                    return [
+                        'repo' => $repo,
+                        'file' => $candidate,
+                        'source' => $source,
+                    ];
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function candidateFilenames(Device $device): array
+    {
+        $candidates = [];
+
+        $this->addCandidate($candidates, $device->hostname);
+        $this->addShortHostnameCandidate($candidates, $device->hostname);
+
+        $this->addCandidate($candidates, $device->sysName);
+        $this->addShortHostnameCandidate($candidates, $device->sysName);
+
+        $this->addCandidate($candidates, $device->ip);
+
+        return array_values(array_unique(array_filter($candidates)));
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function candidateRepos(Device $device): array
+    {
+        $repos = [];
+        $basePath = $this->configuredBasePath();
+
+        if ($basePath !== null) {
+            $output = $this->buildDeviceOutput->execute($device);
+            $group = $output['group'] ?? null;
+
+            if (is_string($group) && $this->isSafePathName($group)) {
+                $this->addRepo($repos, $basePath . DIRECTORY_SEPARATOR . $group . '.git', 'group');
+            }
+        }
+
+        foreach (LibrenmsConfig::get('oxidized.history.git_repo_paths', []) as $repo) {
+            if (is_string($repo)) {
+                $this->addRepo($repos, $repo, 'configured');
+            }
+        }
+
+        if ($basePath !== null) {
+            foreach (glob($basePath . DIRECTORY_SEPARATOR . '*.git') ?: [] as $repo) {
+                $this->addRepo($repos, $repo, 'base_path');
+            }
+        }
+
+        return $repos;
+    }
+
+    private function configuredBasePath(): ?string
+    {
+        $basePath = LibrenmsConfig::get('oxidized.history.git_repo_base_path');
+
+        if (! is_string($basePath) || $basePath === '' || ! is_dir($basePath)) {
+            return null;
+        }
+
+        return rtrim($basePath, DIRECTORY_SEPARATOR);
+    }
+
+    private function addCandidate(array &$candidates, mixed $value): void
+    {
+        if (is_string($value) && $value !== '') {
+            $candidates[] = $value;
+        }
+    }
+
+    private function addShortHostnameCandidate(array &$candidates, mixed $value): void
+    {
+        if (! is_string($value) || $value === '' || filter_var($value, FILTER_VALIDATE_IP)) {
+            return;
+        }
+
+        if (str_contains($value, '.')) {
+            $candidates[] = strtok($value, '.');
+        }
+    }
+
+    private function isSafePathName(string $name): bool
+    {
+        return $name !== '' && basename($name) === $name && ! str_contains($name, DIRECTORY_SEPARATOR);
+    }
+
+    private function addRepo(array &$repos, string $repo, string $source): void
+    {
+        $repo = rtrim($repo, DIRECTORY_SEPARATOR);
+
+        if (! isset($repos[$repo]) && $this->isBareGitRepo($repo)) {
+            $repos[$repo] = $source;
+        }
+    }
+
+    private function isBareGitRepo(string $repo): bool
+    {
+        if (! is_dir($repo)) {
+            return false;
+        }
+
+        $process = new Process(['git', '--git-dir=' . $repo, 'rev-parse', '--is-bare-repository']);
+        $process->run();
+
+        return $process->isSuccessful() && trim($process->getOutput()) === 'true';
+    }
+
+    private function gitFileExists(string $repo, string $file): bool
+    {
+        $process = new Process(['git', '--git-dir=' . $repo, 'cat-file', '-e', 'HEAD:' . $file]);
+        $process->run();
+
+        return $process->isSuccessful();
+    }
+}

--- a/app/Actions/Oxidized/FindGitHistoryConfig.php
+++ b/app/Actions/Oxidized/FindGitHistoryConfig.php
@@ -204,6 +204,7 @@ class FindGitHistoryConfig
         $process = new Process([
             'git',
             '--git-dir=' . $repo,
+            '--literal-pathspecs',
             'log',
             '--diff-filter=ACMRTUXB',
             '-n',

--- a/app/Actions/Oxidized/FindGitHistoryConfig.php
+++ b/app/Actions/Oxidized/FindGitHistoryConfig.php
@@ -185,6 +185,7 @@ class FindGitHistoryConfig
         }
 
         $process = new Process(['git', '--git-dir=' . $repo, 'rev-parse', '--is-bare-repository']);
+        $process->setTimeout(10);
         $process->run();
 
         return $process->isSuccessful() && trim($process->getOutput()) === 'true';

--- a/app/Actions/Oxidized/FindGitHistoryConfig.php
+++ b/app/Actions/Oxidized/FindGitHistoryConfig.php
@@ -145,7 +145,15 @@ class FindGitHistoryConfig
 
     private function isSafePathName(string $name): bool
     {
-        return $name !== '' && basename($name) === $name && ! str_contains($name, DIRECTORY_SEPARATOR);
+        return $name !== ''
+            && ! str_starts_with($name, '-')
+            && ! str_contains($name, "\0")
+            && ! str_contains($name, "\n")
+            && ! str_contains($name, "\r")
+            && ! str_contains($name, '/')
+            && ! str_contains($name, '\\')
+            && ! str_contains($name, '..')
+            && basename($name) === $name;
     }
 
     private function isSafeGitPath(string $path): bool

--- a/app/Actions/Oxidized/FindGitHistoryConfig.php
+++ b/app/Actions/Oxidized/FindGitHistoryConfig.php
@@ -130,7 +130,7 @@ class FindGitHistoryConfig
     }
 
     /**
-     * @param array<int, string> $candidates
+     * @param  array<int, string>  $candidates
      */
     private function addCandidate(array &$candidates, mixed $value): void
     {
@@ -140,7 +140,7 @@ class FindGitHistoryConfig
     }
 
     /**
-     * @param array<int, string> $candidates
+     * @param  array<int, string>  $candidates
      */
     private function addShortHostnameCandidate(array &$candidates, mixed $value): void
     {
@@ -180,7 +180,7 @@ class FindGitHistoryConfig
     }
 
     /**
-     * @param array<string, bool> $seen
+     * @param  array<string, bool>  $seen
      * @return iterable<string, string>
      */
     private function yieldRepo(array &$seen, string $repo, string $source): iterable

--- a/app/Actions/Oxidized/FindGitHistoryConfig.php
+++ b/app/Actions/Oxidized/FindGitHistoryConfig.php
@@ -60,11 +60,11 @@ class FindGitHistoryConfig
     }
 
     /**
-     * @return array<string, string>
+     * @return iterable<string, string>
      */
-    public function candidateRepos(Device $device): array
+    public function candidateRepos(Device $device): iterable
     {
-        $repos = [];
+        $seen = [];
         $basePath = $this->configuredBasePath();
 
         if ($basePath !== null) {
@@ -72,23 +72,21 @@ class FindGitHistoryConfig
             $group = $output['group'] ?? null;
 
             if (is_string($group) && $this->isSafePathName($group)) {
-                $this->addRepo($repos, $basePath . DIRECTORY_SEPARATOR . $group . '.git', 'group');
+                yield from $this->yieldRepo($seen, $basePath . DIRECTORY_SEPARATOR . $group . '.git', 'group');
             }
         }
 
         foreach (LibrenmsConfig::get('oxidized.history.git_repo_paths', []) as $repo) {
             if (is_string($repo)) {
-                $this->addRepo($repos, $repo, 'configured');
+                yield from $this->yieldRepo($seen, $repo, 'configured');
             }
         }
 
         if ($basePath !== null) {
             foreach (glob($basePath . DIRECTORY_SEPARATOR . '*.git') ?: [] as $repo) {
-                $this->addRepo($repos, $repo, 'base_path');
+                yield from $this->yieldRepo($seen, $repo, 'base_path');
             }
         }
-
-        return $repos;
     }
 
     private function configuredBasePath(): ?string
@@ -125,12 +123,22 @@ class FindGitHistoryConfig
         return $name !== '' && basename($name) === $name && ! str_contains($name, DIRECTORY_SEPARATOR);
     }
 
-    private function addRepo(array &$repos, string $repo, string $source): void
+    /**
+     * @param array<string, bool> $seen
+     * @return iterable<string, string>
+     */
+    private function yieldRepo(array &$seen, string $repo, string $source): iterable
     {
         $repo = rtrim($repo, DIRECTORY_SEPARATOR);
 
-        if (! isset($repos[$repo]) && $this->isBareGitRepo($repo)) {
-            $repos[$repo] = $source;
+        if (isset($seen[$repo])) {
+            return;
+        }
+
+        $seen[$repo] = true;
+
+        if ($this->isBareGitRepo($repo)) {
+            yield $repo => $source;
         }
     }
 

--- a/app/Actions/Oxidized/FindGitHistoryConfig.php
+++ b/app/Actions/Oxidized/FindGitHistoryConfig.php
@@ -129,6 +129,9 @@ class FindGitHistoryConfig
         return rtrim($basePath, DIRECTORY_SEPARATOR);
     }
 
+    /**
+     * @param array<int, string> $candidates
+     */
     private function addCandidate(array &$candidates, mixed $value): void
     {
         if (is_string($value) && $this->isSafeGitPath($value)) {
@@ -136,6 +139,9 @@ class FindGitHistoryConfig
         }
     }
 
+    /**
+     * @param array<int, string> $candidates
+     */
     private function addShortHostnameCandidate(array &$candidates, mixed $value): void
     {
         if (! is_string($value) || $value === '' || filter_var($value, FILTER_VALIDATE_IP)) {

--- a/app/Actions/Oxidized/FindGitHistoryConfig.php
+++ b/app/Actions/Oxidized/FindGitHistoryConfig.php
@@ -47,7 +47,7 @@ class FindGitHistoryConfig
 
         foreach ($this->candidateRepos($device) as $repo => $source) {
             foreach ($candidates as $candidate) {
-                if ($this->gitFileExists($repo, $candidate)) {
+                if ($this->gitFileHasHistory($repo, $candidate)) {
                     return [
                         'repo' => $repo,
                         'file' => $candidate,
@@ -190,11 +190,22 @@ class FindGitHistoryConfig
         return $process->isSuccessful() && trim($process->getOutput()) === 'true';
     }
 
-    private function gitFileExists(string $repo, string $file): bool
+    private function gitFileHasHistory(string $repo, string $file): bool
     {
-        $process = new Process(['git', '--git-dir=' . $repo, 'cat-file', '-e', 'HEAD:' . $file]);
+        $process = new Process([
+            'git',
+            '--git-dir=' . $repo,
+            'log',
+            '--diff-filter=ACMRTUXB',
+            '-n',
+            '1',
+            '--format=%H',
+            '--',
+            $file,
+        ]);
+        $process->setTimeout(10);
         $process->run();
 
-        return $process->isSuccessful();
+        return $process->isSuccessful() && trim($process->getOutput()) !== '';
     }
 }

--- a/app/Actions/Oxidized/FindGitHistoryConfig.php
+++ b/app/Actions/Oxidized/FindGitHistoryConfig.php
@@ -8,6 +8,11 @@ use Symfony\Component\Process\Process;
 
 class FindGitHistoryConfig
 {
+    /**
+     * @var array<int, array{repo: string, file: string, source: string}|null>
+     */
+    private static array $resolved = [];
+
     public function __construct(private readonly BuildDeviceOutput $buildDeviceOutput)
     {
     }
@@ -16,6 +21,20 @@ class FindGitHistoryConfig
      * @return array{repo: string, file: string, source: string}|null
      */
     public function execute(Device $device): ?array
+    {
+        $cacheKey = (int) $device->device_id;
+
+        if (array_key_exists($cacheKey, self::$resolved)) {
+            return self::$resolved[$cacheKey];
+        }
+
+        return self::$resolved[$cacheKey] = $this->resolve($device);
+    }
+
+    /**
+     * @return array{repo: string, file: string, source: string}|null
+     */
+    private function resolve(Device $device): ?array
     {
         if (LibrenmsConfig::get('oxidized.history.enabled') !== true) {
             return null;

--- a/app/Actions/Oxidized/FindGitHistoryConfig.php
+++ b/app/Actions/Oxidized/FindGitHistoryConfig.php
@@ -150,6 +150,7 @@ class FindGitHistoryConfig
     private function isSafePathName(string $name): bool
     {
         return $name !== ''
+            && $name !== '.'
             && ! str_starts_with($name, '-')
             && ! str_contains($name, "\0")
             && ! str_contains($name, "\n")
@@ -163,6 +164,7 @@ class FindGitHistoryConfig
     private function isSafeGitPath(string $path): bool
     {
         return $path !== ''
+            && $path !== '.'
             && ! str_starts_with($path, '-')
             && ! str_contains($path, "\0")
             && ! str_contains($path, "\n")

--- a/app/Actions/Oxidized/FindGitHistoryConfig.php
+++ b/app/Actions/Oxidized/FindGitHistoryConfig.php
@@ -37,7 +37,10 @@ class FindGitHistoryConfig
      */
     private function resolve(Device $device): ?array
     {
-        if (LibrenmsConfig::get('oxidized.history.enabled') !== true) {
+        if (
+            LibrenmsConfig::get('oxidized.enabled') !== true
+            || LibrenmsConfig::get('oxidized.history.enabled') !== true
+        ) {
             return null;
         }
 

--- a/app/Actions/Oxidized/FindGitHistoryConfig.php
+++ b/app/Actions/Oxidized/FindGitHistoryConfig.php
@@ -102,7 +102,7 @@ class FindGitHistoryConfig
 
     private function addCandidate(array &$candidates, mixed $value): void
     {
-        if (is_string($value) && $value !== '') {
+        if (is_string($value) && $this->isSafeGitPath($value)) {
             $candidates[] = $value;
         }
     }
@@ -114,13 +114,24 @@ class FindGitHistoryConfig
         }
 
         if (str_contains($value, '.')) {
-            $candidates[] = strtok($value, '.');
+            $this->addCandidate($candidates, strtok($value, '.'));
         }
     }
 
     private function isSafePathName(string $name): bool
     {
         return $name !== '' && basename($name) === $name && ! str_contains($name, DIRECTORY_SEPARATOR);
+    }
+
+    private function isSafeGitPath(string $path): bool
+    {
+        return $path !== ''
+            && ! str_starts_with($path, '-')
+            && ! str_contains($path, "\0")
+            && ! str_contains($path, "\n")
+            && ! str_contains($path, "\r")
+            && ! str_contains($path, DIRECTORY_SEPARATOR)
+            && ! str_contains($path, '..');
     }
 
     /**

--- a/app/Actions/Oxidized/FindGitHistoryConfig.php
+++ b/app/Actions/Oxidized/FindGitHistoryConfig.php
@@ -4,6 +4,7 @@ namespace App\Actions\Oxidized;
 
 use App\Facades\LibrenmsConfig;
 use App\Models\Device;
+use Symfony\Component\Process\Exception\ProcessTimedOutException;
 use Symfony\Component\Process\Process;
 
 class FindGitHistoryConfig
@@ -194,9 +195,8 @@ class FindGitHistoryConfig
 
         $process = new Process(['git', '--git-dir=' . $repo, 'rev-parse', '--is-bare-repository']);
         $process->setTimeout(10);
-        $process->run();
 
-        return $process->isSuccessful() && trim($process->getOutput()) === 'true';
+        return $this->runProcess($process) && trim($process->getOutput()) === 'true';
     }
 
     private function gitFileHasHistory(string $repo, string $file): bool
@@ -213,8 +213,18 @@ class FindGitHistoryConfig
             $file,
         ]);
         $process->setTimeout(10);
-        $process->run();
 
-        return $process->isSuccessful() && trim($process->getOutput()) !== '';
+        return $this->runProcess($process) && trim($process->getOutput()) !== '';
+    }
+
+    private function runProcess(Process $process): bool
+    {
+        try {
+            $process->run();
+        } catch (ProcessTimedOutException) {
+            return false;
+        }
+
+        return $process->isSuccessful();
     }
 }

--- a/app/Actions/Oxidized/ReadGitHistoryConfig.php
+++ b/app/Actions/Oxidized/ReadGitHistoryConfig.php
@@ -10,7 +10,7 @@ class ReadGitHistoryConfig
     /**
      * @return array<int, array{oid: string, date: string, timestamp: int, author: array{name: string}, message: string}>
      */
-    public function versions(string $repo, string $file, int $limit = 50): array
+    public function versions(string $repo, string $file, int $limit = 200): array
     {
         $limit = max(1, min($limit, 200));
 

--- a/app/Actions/Oxidized/ReadGitHistoryConfig.php
+++ b/app/Actions/Oxidized/ReadGitHistoryConfig.php
@@ -25,6 +25,7 @@ class ReadGitHistoryConfig
             '--',
             $file,
         ]);
+        $process->setTimeout(10);
         $process->run();
 
         if (! $process->isSuccessful()) {
@@ -77,6 +78,7 @@ class ReadGitHistoryConfig
             'cat-file',
             '--batch-check',
         ]);
+        $process->setTimeout(10);
 
         $process->setInput(implode(PHP_EOL, array_map(
             static fn (string $oid): string => $oid . ':' . $file,
@@ -108,6 +110,7 @@ class ReadGitHistoryConfig
             'show',
             $oid . ':' . $file,
         ]);
+        $process->setTimeout(10);
         $process->run();
 
         return $process->isSuccessful() ? $process->getOutput() : '';
@@ -119,12 +122,15 @@ class ReadGitHistoryConfig
             'git',
             '--git-dir=' . $repo,
             'diff',
+            '--no-ext-diff',
+            '--no-textconv',
             '--find-renames',
             $previousOid,
             $currentOid,
             '--',
             $file,
         ]);
+        $process->setTimeout(10);
         $process->run();
 
         return $process->isSuccessful() ? $process->getOutput() : '';

--- a/app/Actions/Oxidized/ReadGitHistoryConfig.php
+++ b/app/Actions/Oxidized/ReadGitHistoryConfig.php
@@ -3,6 +3,7 @@
 namespace App\Actions\Oxidized;
 
 use App\Facades\LibrenmsConfig;
+use Symfony\Component\Process\Exception\ProcessTimedOutException;
 use Symfony\Component\Process\Process;
 
 class ReadGitHistoryConfig
@@ -32,9 +33,8 @@ class ReadGitHistoryConfig
             $file,
         ]);
         $process->setTimeout(10);
-        $process->run();
 
-        if (! $process->isSuccessful()) {
+        if (! $this->runProcess($process)) {
             return [];
         }
 
@@ -91,9 +91,7 @@ class ReadGitHistoryConfig
             $oids
         )) . PHP_EOL);
 
-        $process->run();
-
-        if (! $process->isSuccessful()) {
+        if (! $this->runProcess($process)) {
             return [];
         }
 
@@ -117,9 +115,12 @@ class ReadGitHistoryConfig
             $oid . ':' . $file,
         ]);
         $process->setTimeout(10);
-        $process->run();
 
-        return $process->isSuccessful() ? $process->getOutput() : '';
+        if (! $this->runProcess($process)) {
+            return '';
+        }
+
+        return $process->getOutput();
     }
 
     public function diff(string $repo, string $file, string $currentOid, string $previousOid): string
@@ -137,8 +138,22 @@ class ReadGitHistoryConfig
             $file,
         ]);
         $process->setTimeout(10);
-        $process->run();
 
-        return $process->isSuccessful() ? $process->getOutput() : '';
+        if (! $this->runProcess($process)) {
+            return '';
+        }
+
+        return $process->getOutput();
+    }
+
+    private function runProcess(Process $process): bool
+    {
+        try {
+            $process->run();
+        } catch (ProcessTimedOutException) {
+            return false;
+        }
+
+        return $process->isSuccessful();
     }
 }

--- a/app/Actions/Oxidized/ReadGitHistoryConfig.php
+++ b/app/Actions/Oxidized/ReadGitHistoryConfig.php
@@ -24,6 +24,7 @@ class ReadGitHistoryConfig
         $process = new Process([
             'git',
             '--git-dir=' . $repo,
+            '--literal-pathspecs',
             'log',
             '--diff-filter=ACMRTUXB',
             '-n',
@@ -128,6 +129,7 @@ class ReadGitHistoryConfig
         $process = new Process([
             'git',
             '--git-dir=' . $repo,
+            '--literal-pathspecs',
             'diff',
             '--no-ext-diff',
             '--no-textconv',

--- a/app/Actions/Oxidized/ReadGitHistoryConfig.php
+++ b/app/Actions/Oxidized/ReadGitHistoryConfig.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Actions\Oxidized;
+
+use App\Facades\LibrenmsConfig;
+use Symfony\Component\Process\Process;
+
+class ReadGitHistoryConfig
+{
+    /**
+     * @return array<int, array{oid: string, date: string, timestamp: int, author: array{name: string}, message: string}>
+     */
+    public function versions(string $repo, string $file, int $limit = 50): array
+    {
+        $limit = max(1, min($limit, 200));
+
+        $process = new Process([
+            'git',
+            '--git-dir=' . $repo,
+            'log',
+            '-n',
+            (string) $limit,
+            '--pretty=format:%H%x1f%ct%x1f%an%x1f%s',
+            '--',
+            $file,
+        ]);
+        $process->run();
+
+        if (! $process->isSuccessful()) {
+            return [];
+        }
+
+        $versions = [];
+
+        foreach (explode(PHP_EOL, trim($process->getOutput())) as $line) {
+            if ($line === '') {
+                continue;
+            }
+
+            [$oid, $timestamp, $author, $message] = array_pad(explode("\x1f", $line, 4), 4, '');
+
+            if ($oid === '' || ! ctype_digit($timestamp)) {
+                continue;
+            }
+
+            $versions[] = [
+                'oid' => $oid,
+                'date' => date(LibrenmsConfig::get('dateformat.long'), (int) $timestamp),
+                'timestamp' => (int) $timestamp,
+                'author' => ['name' => $author],
+                'message' => $message,
+            ];
+        }
+
+        return $versions;
+    }
+
+    public function config(string $repo, string $file, string $oid = 'HEAD'): string
+    {
+        $process = new Process([
+            'git',
+            '--git-dir=' . $repo,
+            'show',
+            $oid . ':' . $file,
+        ]);
+        $process->run();
+
+        return $process->isSuccessful() ? $process->getOutput() : '';
+    }
+
+    public function diff(string $repo, string $file, string $currentOid, string $previousOid): string
+    {
+        $process = new Process([
+            'git',
+            '--git-dir=' . $repo,
+            'diff',
+            '--find-renames',
+            $previousOid,
+            $currentOid,
+            '--',
+            $file,
+        ]);
+        $process->run();
+
+        return $process->isSuccessful() ? $process->getOutput() : '';
+    }
+}

--- a/app/Actions/Oxidized/ReadGitHistoryConfig.php
+++ b/app/Actions/Oxidized/ReadGitHistoryConfig.php
@@ -53,7 +53,51 @@ class ReadGitHistoryConfig
             ];
         }
 
-        return $versions;
+        $existingFiles = $this->existingFilesAt($repo, $file, array_column($versions, 'oid'));
+
+        return array_values(array_filter(
+            $versions,
+            static fn (array $version): bool => $existingFiles[$version['oid']] ?? false
+        ));
+    }
+
+    /**
+     * @param string[] $oids
+     * @return array<string, bool>
+     */
+    private function existingFilesAt(string $repo, string $file, array $oids): array
+    {
+        if (empty($oids)) {
+            return [];
+        }
+
+        $process = new Process([
+            'git',
+            '--git-dir=' . $repo,
+            'cat-file',
+            '--batch-check',
+        ]);
+
+        $process->setInput(implode(PHP_EOL, array_map(
+            static fn (string $oid): string => $oid . ':' . $file,
+            $oids
+        )) . PHP_EOL);
+
+        $process->run();
+
+        if (! $process->isSuccessful()) {
+            return [];
+        }
+
+        $existing = [];
+        $lines = explode(PHP_EOL, trim($process->getOutput()));
+
+        foreach ($oids as $index => $oid) {
+            $line = $lines[$index] ?? '';
+            $existing[$oid] = preg_match('/^[0-9a-f]{40,64} blob [0-9]+$/', $line) === 1;
+        }
+
+        return $existing;
     }
 
     public function config(string $repo, string $file, string $oid = 'HEAD'): string

--- a/app/Actions/Oxidized/ReadGitHistoryConfig.php
+++ b/app/Actions/Oxidized/ReadGitHistoryConfig.php
@@ -8,7 +8,13 @@ use Symfony\Component\Process\Process;
 class ReadGitHistoryConfig
 {
     /**
-     * @return array<int, array{oid: string, date: string, timestamp: int, author: array{name: string}, message: string}>
+     * @return array<int, array{
+     *     oid: string,
+     *     date: string,
+     *     timestamp: int,
+     *     author: array{name: string},
+     *     message: string
+     * }>
      */
     public function versions(string $repo, string $file, int $limit = 200): array
     {

--- a/app/Actions/Oxidized/ReadGitHistoryConfig.php
+++ b/app/Actions/Oxidized/ReadGitHistoryConfig.php
@@ -39,7 +39,7 @@ class ReadGitHistoryConfig
 
             [$oid, $timestamp, $author, $message] = array_pad(explode("\x1f", $line, 4), 4, '');
 
-            if ($oid === '' || ! ctype_digit($timestamp)) {
+            if ($oid === '' || ! ctype_digit($timestamp) || ! $this->gitFileExistsAt($repo, $file, $oid)) {
                 continue;
             }
 
@@ -83,5 +83,19 @@ class ReadGitHistoryConfig
         $process->run();
 
         return $process->isSuccessful() ? $process->getOutput() : '';
+    }
+
+    private function gitFileExistsAt(string $repo, string $file, string $oid): bool
+    {
+        $process = new Process([
+            'git',
+            '--git-dir=' . $repo,
+            'cat-file',
+            '-e',
+            $oid . ':' . $file,
+        ]);
+        $process->run();
+
+        return $process->isSuccessful();
     }
 }

--- a/app/Actions/Oxidized/ReadGitHistoryConfig.php
+++ b/app/Actions/Oxidized/ReadGitHistoryConfig.php
@@ -70,7 +70,7 @@ class ReadGitHistoryConfig
     }
 
     /**
-     * @param string[] $oids
+     * @param  string[]  $oids
      * @return array<string, bool>
      */
     private function existingFilesAt(string $repo, string $file, array $oids): array

--- a/app/Actions/Oxidized/ReadGitHistoryConfig.php
+++ b/app/Actions/Oxidized/ReadGitHistoryConfig.php
@@ -107,7 +107,7 @@ class ReadGitHistoryConfig
         return $existing;
     }
 
-    public function config(string $repo, string $file, string $oid = 'HEAD'): string
+    public function config(string $repo, string $file, string $oid = 'HEAD'): ?string
     {
         $process = new Process([
             'git',
@@ -118,13 +118,13 @@ class ReadGitHistoryConfig
         $process->setTimeout(10);
 
         if (! $this->runProcess($process)) {
-            return '';
+            return null;
         }
 
         return $process->getOutput();
     }
 
-    public function diff(string $repo, string $file, string $currentOid, string $previousOid): string
+    public function diff(string $repo, string $file, string $currentOid, string $previousOid): ?string
     {
         $process = new Process([
             'git',
@@ -142,7 +142,7 @@ class ReadGitHistoryConfig
         $process->setTimeout(10);
 
         if (! $this->runProcess($process)) {
-            return '';
+            return null;
         }
 
         return $process->getOutput();

--- a/app/Actions/Oxidized/ReadGitHistoryConfig.php
+++ b/app/Actions/Oxidized/ReadGitHistoryConfig.php
@@ -18,6 +18,7 @@ class ReadGitHistoryConfig
             'git',
             '--git-dir=' . $repo,
             'log',
+            '--diff-filter=ACMRTUXB',
             '-n',
             (string) $limit,
             '--pretty=format:%H%x1f%ct%x1f%an%x1f%s',
@@ -39,7 +40,7 @@ class ReadGitHistoryConfig
 
             [$oid, $timestamp, $author, $message] = array_pad(explode("\x1f", $line, 4), 4, '');
 
-            if ($oid === '' || ! ctype_digit($timestamp) || ! $this->gitFileExistsAt($repo, $file, $oid)) {
+            if ($oid === '' || ! ctype_digit($timestamp)) {
                 continue;
             }
 
@@ -83,19 +84,5 @@ class ReadGitHistoryConfig
         $process->run();
 
         return $process->isSuccessful() ? $process->getOutput() : '';
-    }
-
-    private function gitFileExistsAt(string $repo, string $file, string $oid): bool
-    {
-        $process = new Process([
-            'git',
-            '--git-dir=' . $repo,
-            'cat-file',
-            '-e',
-            $oid . ':' . $file,
-        ]);
-        $process->run();
-
-        return $process->isSuccessful();
     }
 }

--- a/app/Http/Controllers/Device/Tabs/ShowConfigController.php
+++ b/app/Http/Controllers/Device/Tabs/ShowConfigController.php
@@ -43,7 +43,9 @@ class ShowConfigController extends Controller implements DeviceTab
     public function visible(Device $device): bool
     {
         if (Gate::allows('show-config', $device)) {
-            return $this->oxidizedEnabled($device) || $this->oxidizedHistoryEnabled($device) || $this->getRancidConfigFile() !== false;
+            return $this->oxidizedEnabled($device)
+                || $this->oxidizedHistoryEnabled($device)
+                || $this->getRancidConfigFile() !== false;
         }
 
         return false;

--- a/app/Http/Controllers/Device/Tabs/ShowConfigController.php
+++ b/app/Http/Controllers/Device/Tabs/ShowConfigController.php
@@ -79,6 +79,7 @@ class ShowConfigController extends Controller implements DeviceTab
         if (
             LibrenmsConfig::get('oxidized.enabled') !== true
             || ! LibrenmsConfig::has('oxidized.url')
+            || (bool) $device->disabled
             || $device->getAttrib('override_Oxidized_disable') === 'true'
             || in_array($device->type, LibrenmsConfig::get('oxidized.ignore_types', []), true)
             || in_array($device->os, LibrenmsConfig::get('oxidized.ignore_os', []), true)

--- a/app/Http/Controllers/Device/Tabs/ShowConfigController.php
+++ b/app/Http/Controllers/Device/Tabs/ShowConfigController.php
@@ -72,13 +72,26 @@ class ShowConfigController extends Controller implements DeviceTab
         ];
     }
 
-    private function oxidizedEnabled(Device $device)
+    private function oxidizedEnabled(Device $device): bool
     {
-        return LibrenmsConfig::get('oxidized.enabled') === true
-                && LibrenmsConfig::has('oxidized.url')
-                && $device->getAttrib('override_Oxidized_disable') !== 'true'
-                && ! in_array($device->type, LibrenmsConfig::get('oxidized.ignore_types', []))
-                && ! in_array($device->os, LibrenmsConfig::get('oxidized.ignore_os', []));
+        if (
+            LibrenmsConfig::get('oxidized.enabled') !== true
+            || ! LibrenmsConfig::has('oxidized.url')
+            || $device->getAttrib('override_Oxidized_disable') === 'true'
+            || in_array($device->type, LibrenmsConfig::get('oxidized.ignore_types', []), true)
+            || in_array($device->os, LibrenmsConfig::get('oxidized.ignore_os', []), true)
+        ) {
+            return false;
+        }
+
+        $ignoreGroups = LibrenmsConfig::get('oxidized.ignore_groups', []);
+        if (empty($ignoreGroups)) {
+            return true;
+        }
+
+        $output = app(\App\Actions\Oxidized\BuildDeviceOutput::class)->execute($device);
+
+        return ! isset($output['group']) || ! in_array($output['group'], $ignoreGroups, true);
     }
 
     private function oxidizedHistoryEnabled(Device $device): bool

--- a/app/Http/Controllers/Device/Tabs/ShowConfigController.php
+++ b/app/Http/Controllers/Device/Tabs/ShowConfigController.php
@@ -43,7 +43,7 @@ class ShowConfigController extends Controller implements DeviceTab
     public function visible(Device $device): bool
     {
         if (Gate::allows('show-config', $device)) {
-            return $this->oxidizedEnabled($device) || $this->getRancidConfigFile() !== false;
+            return $this->oxidizedEnabled($device) || $this->oxidizedHistoryEnabled($device) || $this->getRancidConfigFile() !== false;
         }
 
         return false;
@@ -79,6 +79,14 @@ class ShowConfigController extends Controller implements DeviceTab
                 && $device->getAttrib('override_Oxidized_disable') !== 'true'
                 && ! in_array($device->type, LibrenmsConfig::get('oxidized.ignore_types', []))
                 && ! in_array($device->os, LibrenmsConfig::get('oxidized.ignore_os', []));
+    }
+
+    private function oxidizedHistoryEnabled(Device $device): bool
+    {
+        $viewDataBuilder = app(\App\Actions\Oxidized\BuildGitHistoryViewData::class);
+
+        return $viewDataBuilder->eligible($device)
+            && app(\App\Actions\Oxidized\FindGitHistoryConfig::class)->execute($device) !== null;
     }
 
     private function getRancidPath()

--- a/doc/Extensions/Oxidized.md
+++ b/doc/Extensions/Oxidized.md
@@ -313,10 +313,10 @@ If a device is disabled or removed from LibreNMS then the Oxidized
 configuration is normally no longer available via the LibreNMS web interface.
 
 If Oxidized is configured with Git output using local bare Git repositories,
-LibreNMS can optionally show historical configurations for devices that are
-disabled or excluded from the Oxidized source. This only reads existing local
-Git history; it does not add the device back to the Oxidized source API or
-trigger new backups.
+LibreNMS can optionally show historical configurations for devices that still
+exist in LibreNMS but are disabled or excluded from the Oxidized source. This
+only reads existing local Git history; it does not add the device back to the
+Oxidized source API or trigger new backups.
 
 !!! setting "external/oxidized"
     ~~~bash
@@ -334,9 +334,9 @@ repository paths with `oxidized.history.git_repo_paths`.
     lnms config:set oxidized.history.git_repo_paths.+ /var/lib/oxidized/configs.git
     ~~~
 
-If this fallback is not enabled, or no matching local Git history is found, you
-can still access these configurations directly in the Git repository of Oxidized
-(if using Git for version control).
+For devices removed from LibreNMS, or if this fallback is not enabled or no
+matching local Git history is found, you can still access these configurations
+directly in the Git repository of Oxidized (if using Git for version control).
 
 1: Check in your Oxidized where are stored your Git repositories:
 

--- a/doc/Extensions/Oxidized.md
+++ b/doc/Extensions/Oxidized.md
@@ -309,10 +309,34 @@ next_adds_job: true
 
 ## Accessing configuration of a disabled/removed device
 
-When you're disabling or removing a device from LibreNMS, the
-configuration will no longer be available via the LibreNMS web interface.  
-You can gain access to these configurations directly in the Git repository of
-Oxidized (if using Git for version control).
+If a device is disabled or removed from LibreNMS then the Oxidized
+configuration is normally no longer available via the LibreNMS web interface.
+
+If Oxidized is configured with Git output using local bare Git repositories,
+LibreNMS can optionally show historical configurations for devices that are
+disabled or excluded from the Oxidized source. This only reads existing local
+Git history; it does not add the device back to the Oxidized source API or
+trigger new backups.
+
+!!! setting "external/oxidized"
+    ~~~bash
+    lnms config:set oxidized.history.enabled true
+    lnms config:set oxidized.history.git_repo_base_path /opt/librenms/.config/oxidized
+    ~~~
+
+LibreNMS will try `<base path>/<group>.git` first when the Oxidized group can
+be derived from the existing variable mapping logic. If repositories are stored
+elsewhere, or if a single shared repository is used, add explicit local bare Git
+repository paths with `oxidized.history.git_repo_paths`.
+
+!!! setting "external/oxidized"
+    ~~~bash
+    lnms config:set oxidized.history.git_repo_paths.+ /var/lib/oxidized/configs.git
+    ~~~
+
+If this fallback is not enabled, or no matching local Git history is found, you
+can still access these configurations directly in the Git repository of Oxidized
+(if using Git for version control).
 
 1: Check in your Oxidized where are stored your Git repositories:
 

--- a/doc/Extensions/Oxidized.md
+++ b/doc/Extensions/Oxidized.md
@@ -318,6 +318,11 @@ exist in LibreNMS but are disabled or excluded from the Oxidized source. This
 only reads existing local Git history; it does not add the device back to the
 Oxidized source API or trigger new backups.
 
+This fallback only supports local bare Git repositories that can be read
+directly with standard Git commands. Oxidized file output, HTTP output,
+encrypted output that cannot be read as plain Git history, or other non-Git
+history backends are not supported.
+
 !!! setting "external/oxidized"
     ~~~bash
     lnms config:set oxidized.history.enabled true

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -2134,7 +2134,10 @@ function list_oxidized(Illuminate\Http\Request $request)
     foreach ($devices as $device) {
         $output = $buildOxidizedOutput->execute($device);
         //Exclude groups from being sent to Oxidized
-        if (isset($output['group']) && in_array($output['group'], LibrenmsConfig::get('oxidized.ignore_groups'))) {
+        if (
+            isset($output['group'])
+            && in_array($output['group'], LibrenmsConfig::get('oxidized.ignore_groups', []), true)
+        ) {
             continue;
         }
 

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -2128,52 +2128,11 @@ function list_oxidized(Illuminate\Http\Request $request)
              ->select(['devices.device_id', 'hostname', 'sysName', 'sysDescr', 'sysObjectID', 'hardware', 'os', 'ip', 'location_id', 'purpose', 'notes', 'poller_group'])
              ->get();
 
+    $buildOxidizedOutput = app(\App\Actions\Oxidized\BuildDeviceOutput::class);
+
     /** @var Device $device */
     foreach ($devices as $device) {
-        $output = [
-            'hostname' => $device->hostname,
-            'os' => $device->os,
-            'ip' => $device->ip,
-        ];
-        $custom_ssh_port = $device->getAttrib('override_device_ssh_port');
-        if (! empty($custom_ssh_port)) {
-            $output['ssh_port'] = $custom_ssh_port;
-        }
-        $custom_telnet_port = $device->getAttrib('override_device_telnet_port');
-        if (! empty($custom_telnet_port)) {
-            $output['telnet_port'] = $custom_telnet_port;
-        }
-        // Pre-populate the group with the default
-        if (LibrenmsConfig::get('oxidized.group_support') === true && ! empty(LibrenmsConfig::get('oxidized.default_group'))) {
-            $output['group'] = LibrenmsConfig::get('oxidized.default_group');
-        }
-
-        foreach (LibrenmsConfig::get('oxidized.maps') as $maps_column => $maps) {
-            // Based on Oxidized group support we can apply groups by setting group_support to true
-            if ($maps_column == 'group' && LibrenmsConfig::get('oxidized.group_support', true) !== true) {
-                continue;
-            }
-
-            foreach ($maps as $field_type => $fields) {
-                if ($field_type == 'sysname') {
-                    $value = $device->sysName; // fix typo in previous code forcing users to use sysname instead of sysName
-                } elseif ($field_type == 'location') {
-                    $value = $device->location->location;
-                } else {
-                    $value = $device->$field_type;
-                }
-
-                foreach ($fields as $field) {
-                    if (isset($field['regex']) && preg_match($field['regex'] . 'i', (string) $value)) {
-                        $output[$maps_column] = $field['value'] ?? $field[$maps_column];  // compatibility with old format
-                        break;
-                    } elseif (isset($field['match']) && $field['match'] == $value) {
-                        $output[$maps_column] = $field['value'] ?? $field[$maps_column]; // compatibility with old format
-                        break;
-                    }
-                }
-            }
-        }
+        $output = $buildOxidizedOutput->execute($device);
         //Exclude groups from being sent to Oxidized
         if (isset($output['group']) && in_array($output['group'], LibrenmsConfig::get('oxidized.ignore_groups'))) {
             continue;

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -2119,7 +2119,7 @@ function list_oxidized(Illuminate\Http\Request $request)
 {
     $return = [];
     $devices = Device::query()
-            ->with('attribs')
+            ->with(['attribs', 'location'])
              ->where('disabled', 0)
              ->when($request->route('hostname'), fn ($query, $hostname) => $query->where('hostname', $hostname))
              ->whereNotIn('type', LibrenmsConfig::get('oxidized.ignore_types', []))

--- a/includes/html/pages/device/showconfig.inc.php
+++ b/includes/html/pages/device/showconfig.inc.php
@@ -181,7 +181,10 @@ if (Gate::allows('showConfig', DeviceCache::getPrimary())) {
 
             $text = implode("\n", $lines);
         }
-    } elseif (($oxidizedHistoryViewData = app(\App\Actions\Oxidized\BuildGitHistoryViewData::class)->execute($primary_device, $_POST)) !== null) {
+    } elseif (
+        ($oxidizedHistoryViewData = app(\App\Actions\Oxidized\BuildGitHistoryViewData::class)
+            ->execute($primary_device, $_POST)) !== null
+    ) {
         if (! empty($oxidizedHistoryViewData['warning'])) {
             print_error($oxidizedHistoryViewData['warning']);
         }

--- a/includes/html/pages/device/showconfig.inc.php
+++ b/includes/html/pages/device/showconfig.inc.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Facades\Gate;
 use Symfony\Component\Process\Process;
 
 if (Gate::allows('showConfig', DeviceCache::getPrimary())) {
+    $primary_device = DeviceCache::getPrimary();
     if (LibrenmsConfig::get('rancid_repo_type') == 'git-bare' && is_dir($rancid_path)) {
         echo '<div style="clear: both;">';
 
@@ -180,6 +181,20 @@ if (Gate::allows('showConfig', DeviceCache::getPrimary())) {
 
             $text = implode("\n", $lines);
         }
+    } elseif (($oxidizedHistoryViewData = app(\App\Actions\Oxidized\BuildGitHistoryViewData::class)->execute($primary_device, $_POST)) !== null) {
+        if (! empty($oxidizedHistoryViewData['warning'])) {
+            print_error($oxidizedHistoryViewData['warning']);
+        }
+
+        if (isset($oxidizedHistoryViewData['previous_config'])) {
+            $previous_config = $oxidizedHistoryViewData['previous_config'];
+        }
+
+        $author = $oxidizedHistoryViewData['author'];
+        $msg = $oxidizedHistoryViewData['message'];
+        $text = $oxidizedHistoryViewData['text'];
+
+        echo view('device.showconfig.oxidized-history', ['history' => $oxidizedHistoryViewData])->render();
     } elseif (LibrenmsConfig::get('oxidized.enabled') === true && LibrenmsConfig::has('oxidized.url')) {
         // Try with hostname as set in librenms first
         $oxidized_hostname = $device['hostname'];

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -1636,15 +1636,22 @@ return [
             'history' => [
                 'enabled' => [
                     'description' => 'Enable Oxidized Git history fallback',
-                    'help' => 'Show historical Oxidized configurations for disabled or Oxidized-excluded devices using local Oxidized Git output repositories. Requires Oxidized Git output with local bare Git repositories. Disabled devices are still not sent to Oxidized for new backups.',
+                    'help' => 'Show historical Oxidized configurations for disabled or Oxidized-excluded devices '
+                        . 'using local Oxidized Git output repositories. Requires Oxidized Git output with local '
+                        . 'bare Git repositories. Disabled devices are still not sent to Oxidized for new backups.',
                 ],
                 'git_repo_base_path' => [
                     'description' => 'Oxidized history Git repository base path',
-                    'help' => 'Directory containing local Oxidized bare Git repositories for the history fallback. LibreNMS will try <group>.git first, based on Oxidized Variable Mapping. Requires Oxidized Git output. Example: /opt/librenms/.config/oxidized',
+                    'help' => 'Directory containing local Oxidized bare Git repositories for the history fallback. '
+                        . 'LibreNMS will try <group>.git first, based on Oxidized Variable Mapping. Requires '
+                        . 'Oxidized Git output. Example: /opt/librenms/.config/oxidized',
                 ],
                 'git_repo_paths' => [
                     'description' => 'Additional Oxidized history Git repository paths',
-                    'help' => 'Optional explicit local Oxidized bare Git repository paths to search, for example when using a single repository or repositories stored outside the base path. Add one repository path per entry. Example: /var/lib/oxidized/configs.git. Requires Oxidized Git output.',
+                    'help' => 'Optional explicit local Oxidized bare Git repository paths to search, for example '
+                        . 'when using a single repository or repositories stored outside the base path. Add one '
+                        . 'repository path per entry. Example: /var/lib/oxidized/configs.git. Requires '
+                        . 'Oxidized Git output.',
                 ],
             ],
             'reload_nodes' => [

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -1633,6 +1633,20 @@ return [
                 'description' => 'Do not backup these device types',
                 'help' => 'Do not backup the listed device types with Oxidized. Only allows existing types.',
             ],
+            'history' => [
+                'enabled' => [
+                    'description' => 'Enable disabled device config history',
+                    'help' => 'Show historical Oxidized configurations for disabled or Oxidized-excluded devices using local Git repositories. Disabled devices are still not sent to Oxidized for new backups.',
+                ],
+                'git_repo_base_path' => [
+                    'description' => 'Oxidized Git repository base path',
+                    'help' => 'Directory containing local Oxidized Git repositories. LibreNMS will try <group>.git first, based on Oxidized Variable Mapping. Example: /opt/librenms/.config/oxidized',
+                ],
+                'git_repo_paths' => [
+                    'description' => 'Additional Oxidized Git repository paths',
+                    'help' => 'Optional explicit local Oxidized Git bare repository paths to search if the base path and group repository do not match.',
+                ],
+            ],
             'reload_nodes' => [
                 'description' => 'Reload Oxidized nodes list, each time a device is added',
             ],

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -1644,7 +1644,7 @@ return [
                 ],
                 'git_repo_paths' => [
                     'description' => 'Additional Oxidized history Git repository paths',
-                    'help' => 'Optional explicit local Oxidized bare Git repository paths to search, for example when using a single repository or repositories stored outside the base path. Requires Oxidized Git output.',
+                    'help' => 'Optional explicit local Oxidized bare Git repository paths to search, for example when using a single repository or repositories stored outside the base path. Add one repository path per entry. Example: /var/lib/oxidized/configs.git. Requires Oxidized Git output.',
                 ],
             ],
             'reload_nodes' => [

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -1635,16 +1635,16 @@ return [
             ],
             'history' => [
                 'enabled' => [
-                    'description' => 'Enable disabled device config history',
-                    'help' => 'Show historical Oxidized configurations for disabled or Oxidized-excluded devices using local Git repositories. Disabled devices are still not sent to Oxidized for new backups.',
+                    'description' => 'Enable Oxidized Git history fallback',
+                    'help' => 'Show historical Oxidized configurations for disabled or Oxidized-excluded devices using local Oxidized Git output repositories. Requires Oxidized Git output with local bare Git repositories. Disabled devices are still not sent to Oxidized for new backups.',
                 ],
                 'git_repo_base_path' => [
-                    'description' => 'Oxidized Git repository base path',
-                    'help' => 'Directory containing local Oxidized Git repositories. LibreNMS will try <group>.git first, based on Oxidized Variable Mapping. Example: /opt/librenms/.config/oxidized',
+                    'description' => 'Oxidized history Git repository base path',
+                    'help' => 'Directory containing local Oxidized bare Git repositories for the history fallback. LibreNMS will try <group>.git first, based on Oxidized Variable Mapping. Requires Oxidized Git output. Example: /opt/librenms/.config/oxidized',
                 ],
                 'git_repo_paths' => [
-                    'description' => 'Additional Oxidized Git repository paths',
-                    'help' => 'Optional explicit local Oxidized Git bare repository paths to search if the base path and group repository do not match.',
+                    'description' => 'Additional Oxidized history Git repository paths',
+                    'help' => 'Optional explicit local Oxidized bare Git repository paths to search, for example when using a single repository or repositories stored outside the base path. Requires Oxidized Git output.',
                 ],
             ],
             'reload_nodes' => [

--- a/resources/definitions/config_definitions.json
+++ b/resources/definitions/config_definitions.json
@@ -5770,6 +5770,34 @@
                 "value.*": "exists:devices,type"
             }
         },
+        "oxidized.history.enabled": {
+            "default": false,
+            "group": "external",
+            "section": "oxidized",
+            "order": 6,
+            "type": "boolean"
+        },
+        "oxidized.history.git_repo_base_path": {
+            "default": false,
+            "group": "external",
+            "section": "oxidized",
+            "order": 6,
+            "type": "text",
+            "validate": {
+                "value": "nullable|string"
+            }
+        },
+        "oxidized.history.git_repo_paths": {
+            "default": [],
+            "type": "array",
+            "group": "external",
+            "section": "oxidized",
+            "order": 6,
+            "validate": {
+                "value": "array",
+                "value.*": "string"
+            }
+        },
         "oxidized.maps": {
             "default": {
                 "os": {

--- a/resources/definitions/config_definitions.json
+++ b/resources/definitions/config_definitions.json
@@ -5778,7 +5778,7 @@
             "type": "boolean"
         },
         "oxidized.history.git_repo_base_path": {
-            "default": false,
+            "default": "",
             "group": "external",
             "section": "oxidized",
             "order": 10,

--- a/resources/definitions/config_definitions.json
+++ b/resources/definitions/config_definitions.json
@@ -5774,14 +5774,14 @@
             "default": false,
             "group": "external",
             "section": "oxidized",
-            "order": 6,
+            "order": 9,
             "type": "boolean"
         },
         "oxidized.history.git_repo_base_path": {
             "default": false,
             "group": "external",
             "section": "oxidized",
-            "order": 6,
+            "order": 10,
             "type": "text",
             "validate": {
                 "value": "nullable|string"
@@ -5792,7 +5792,7 @@
             "type": "array",
             "group": "external",
             "section": "oxidized",
-            "order": 6,
+            "order": 11,
             "validate": {
                 "value": "array",
                 "value.*": "string"

--- a/resources/views/device/showconfig/oxidized-history.blade.php
+++ b/resources/views/device/showconfig/oxidized-history.blade.php
@@ -1,0 +1,44 @@
+<br>
+<div class="row">
+    <div class="col-sm-4">
+        <div class="panel panel-primary">
+            <div class="panel-heading">Sync status: <strong>{{ $history['node_info']['status'] }}</strong></div>
+            <ul class="list-group">
+                <li class="list-group-item"><strong>Node:</strong> {{ $history['node_info']['name'] }}</li>
+                <li class="list-group-item"><strong>IP:</strong> {{ $history['node_info']['ip'] }}</li>
+                <li class="list-group-item"><strong>Model:</strong> {{ $history['node_info']['model'] }}</li>
+                <li class="list-group-item"><strong>Last Sync:</strong> {{ $history['node_info']['last_sync'] }}</li>
+                <li class="list-group-item"><strong>Source:</strong> {{ $history['node_info']['source'] }}</li>
+            </ul>
+        </div>
+    </div>
+
+    @if($history['config_total'] > 1)
+        <div class="col-sm-8">
+            <form class="form-horizontal" action="" method="post">
+                @csrf
+
+                <div class="form-group">
+                    <label for="config" class="col-sm-2 control-label">Config version</label>
+                    <div class="col-sm-6">
+                        <select id="config" name="config" class="form-control">
+                            @foreach($history['config_versions'] as $version)
+                                <option value="{{ $version['oid'] }}|{{ $version['date'] }}|{{ $version['version'] }}"
+                                    @if($history['current_config']['oid'] === $version['oid']) selected @endif
+                                >@if($history['current_config']['oid'] === $version['oid'] && isset($history['previous_config']))+@elseif($history['current_config']['oid'] === $version['oid'])*@elseif(isset($history['previous_config']['oid']) && $history['previous_config']['oid'] === $version['oid'])&nbsp;-@else&nbsp;&nbsp;@endif{{ $version['version'] }} :: {{ $version['date'] }}</option>
+                            @endforeach
+                        </select>
+                    </div>
+                </div>
+
+                <div class="form-group">
+                    <div class="col-sm-offset-2 col-sm-6">
+                        <input type="hidden" name="prevconfig" value="{{ implode('|', $history['current_config']) }}">
+                        <button type="submit" class="btn btn-primary btn-sm" name="show">Show version</button>
+                        <button type="submit" class="btn btn-primary btn-sm" name="diff">Show diff</button>
+                    </div>
+                </div>
+            </form>
+        </div>
+    @endif
+</div>

--- a/resources/views/device/showconfig/oxidized-history.blade.php
+++ b/resources/views/device/showconfig/oxidized-history.blade.php
@@ -25,7 +25,8 @@
                             @foreach($history['config_versions'] as $version)
                                 @php
                                     $isCurrent = $history['current_config']['oid'] === $version['oid'];
-                                    $isPrevious = isset($history['previous_config']['oid']) && $history['previous_config']['oid'] === $version['oid'];
+                                    $isPrevious = isset($history['previous_config']['oid'])
+                                        && $history['previous_config']['oid'] === $version['oid'];
 
                                     if ($isCurrent && isset($history['previous_config'])) {
                                         $marker = '+';

--- a/resources/views/device/showconfig/oxidized-history.blade.php
+++ b/resources/views/device/showconfig/oxidized-history.blade.php
@@ -2,13 +2,25 @@
 <div class="row">
     <div class="col-sm-4">
         <div class="panel panel-primary">
-            <div class="panel-heading">Sync status: <strong>{{ $history['node_info']['status'] }}</strong></div>
+            <div class="panel-heading">
+                {{ __('Sync status') }}: <strong>{{ $history['node_info']['status'] }}</strong>
+            </div>
             <ul class="list-group">
-                <li class="list-group-item"><strong>Node:</strong> {{ $history['node_info']['name'] }}</li>
-                <li class="list-group-item"><strong>IP:</strong> {{ $history['node_info']['ip'] }}</li>
-                <li class="list-group-item"><strong>Model:</strong> {{ $history['node_info']['model'] }}</li>
-                <li class="list-group-item"><strong>Last Sync:</strong> {{ $history['node_info']['last_sync'] }}</li>
-                <li class="list-group-item"><strong>Source:</strong> {{ $history['node_info']['source'] }}</li>
+                <li class="list-group-item">
+                    <strong>{{ __('Node') }}:</strong> {{ $history['node_info']['name'] }}
+                </li>
+                <li class="list-group-item">
+                    <strong>{{ __('IP') }}:</strong> {{ $history['node_info']['ip'] }}
+                </li>
+                <li class="list-group-item">
+                    <strong>{{ __('Model') }}:</strong> {{ $history['node_info']['model'] }}
+                </li>
+                <li class="list-group-item">
+                    <strong>{{ __('Last Sync') }}:</strong> {{ $history['node_info']['last_sync'] }}
+                </li>
+                <li class="list-group-item">
+                    <strong>{{ __('Source') }}:</strong> {{ $history['node_info']['source'] }}
+                </li>
             </ul>
         </div>
     </div>
@@ -19,7 +31,7 @@
                 @csrf
 
                 <div class="form-group">
-                    <label for="config" class="col-sm-2 control-label">Config version</label>
+                    <label for="config" class="col-sm-2 control-label">{{ __('Config version') }}</label>
                     <div class="col-sm-6">
                         <select id="config" name="config" class="form-control">
                             @foreach($history['config_versions'] as $version)
@@ -50,8 +62,12 @@
                 <div class="form-group">
                     <div class="col-sm-offset-2 col-sm-6">
                         <input type="hidden" name="prevconfig" value="{{ implode('|', $history['current_config']) }}">
-                        <button type="submit" class="btn btn-primary btn-sm" name="show">Show version</button>
-                        <button type="submit" class="btn btn-primary btn-sm" name="diff">Show diff</button>
+                        <button type="submit" class="btn btn-primary btn-sm" name="show">
+                            {{ __('Show version') }}
+                        </button>
+                        <button type="submit" class="btn btn-primary btn-sm" name="diff">
+                            {{ __('Show diff') }}
+                        </button>
                     </div>
                 </div>
             </form>

--- a/resources/views/device/showconfig/oxidized-history.blade.php
+++ b/resources/views/device/showconfig/oxidized-history.blade.php
@@ -23,9 +23,24 @@
                     <div class="col-sm-6">
                         <select id="config" name="config" class="form-control">
                             @foreach($history['config_versions'] as $version)
+                                @php
+                                    $isCurrent = $history['current_config']['oid'] === $version['oid'];
+                                    $isPrevious = isset($history['previous_config']['oid']) && $history['previous_config']['oid'] === $version['oid'];
+
+                                    if ($isCurrent && isset($history['previous_config'])) {
+                                        $marker = '+';
+                                    } elseif ($isCurrent) {
+                                        $marker = '*';
+                                    } elseif ($isPrevious) {
+                                        $marker = ' -';
+                                    } else {
+                                        $marker = '  ';
+                                    }
+                                @endphp
+
                                 <option value="{{ $version['oid'] }}|{{ $version['date'] }}|{{ $version['version'] }}"
-                                    @if($history['current_config']['oid'] === $version['oid']) selected @endif
-                                >@if($history['current_config']['oid'] === $version['oid'] && isset($history['previous_config']))+@elseif($history['current_config']['oid'] === $version['oid'])*@elseif(isset($history['previous_config']['oid']) && $history['previous_config']['oid'] === $version['oid'])&nbsp;-@else&nbsp;&nbsp;@endif{{ $version['version'] }} :: {{ $version['date'] }}</option>
+                                    @if($isCurrent) selected @endif
+                                >{{ $marker }}{{ $version['version'] }} :: {{ $version['date'] }}</option>
                             @endforeach
                         </select>
                     </div>


### PR DESCRIPTION
## Summary

This adds an optional Oxidized Git history fallback for devices that still exist in LibreNMS but are no longer included in the Oxidized source, such as disabled devices or devices excluded by Oxidized settings.

The fallback only reads existing local Oxidized bare Git repositories. It does not add the device back to the Oxidized source and does not trigger new backups.

Normal active Oxidized devices continue to use the existing Oxidized API path.

## Behavior

- Active devices continue using the existing Oxidized API integration.
- Disabled or Oxidized-excluded devices can show historical configs if matching local Git history exists.
- The Config tab is only shown for the fallback when matching Git history is found.
- `oxidized.enabled=false` disables the history fallback even if `oxidized.history.enabled=true`.
- Removed devices are still handled by the existing manual Git repository method documented in the Oxidized docs.

## New settings

- `oxidized.history.enabled`
- `oxidized.history.git_repo_base_path`
- `oxidized.history.git_repo_paths`

This requires Oxidized Git output using local bare Git repositories readable by standard Git commands.

This fallback only reads local bare Git repositories directly. Other Oxidized output backends, such as file, git-crypt, or HTTP output, are not read by this fallback unless they are available as a normal local bare Git repository with configuration history readable through `git log`, `git show`, `git cat-file`, and `git diff`.

## Implementation notes

- Adds dedicated Oxidized history actions for local Git lookup, version reading, diff reading, and view data building.
- Extracts reusable Oxidized output mapping logic into `BuildDeviceOutput` so the normal Oxidized API output and history fallback use the same hostname/IP/group mapping behavior.
- Updates the Config tab visibility logic so disabled or Oxidized-excluded devices can use the fallback only when matching Git history exists.
- Keeps active devices on the existing Oxidized API path.
- Adds a new history view partial for the Config tab version selector and historical status panel.
- Extends the existing legacy `showconfig.inc.php` flow to render the history fallback when normal Oxidized output is not available.
- Adds new settings in `resources/definitions/config_definitions.json` and labels/help text in `lang/en/settings.php`.
- Documents the fallback in `doc/Extensions/Oxidized.md`.

Git/history handling:

- Finds historical configs even when the file no longer exists in Git HEAD.
- Skips delete/rename commits where the selected file no longer exists.
- Uses batched `git cat-file --batch-check` for version validation.
- Adds Git command timeouts and catches timeout exceptions.
- Uses `--literal-pathspecs` for Git pathspec calls.
- Uses `--no-ext-diff` and `--no-textconv` for diffs.
- Avoids showing `No Difference` when Git diff/read fails; a warning is shown instead.

## Testing

- PHP lint on changed PHP/Blade files: passed
- `resources/definitions/config_definitions.json` validation: passed
- `git diff --check`: passed
- `./lnms translation:generate`: ran in `/opt/librenms`; no PR file changes detected
- `./lnms dev:check`: PHP lint, PHPStan Deprecated, and PHPStan passed; the check stopped while installing Python developer dependencies because the local system Python environment is externally managed
- Manual Oxidized history fallback testing: passed
  - disabled device with matching Git history shows Config tab
  - fallback loads historical config from local bare Git repo
  - version selector works
  - show version works
  - show diff works
  - `oxidized.enabled=false` disables the fallback
  - normal config read path works after read-failure handling
  - normal diff path works after read-failure handling

#### Screenshots

Historical Oxidized Git history fallback shown for a disabled device:

<img width="1582" height="638" alt="Oxidized Git history fallback shown for a disabled device" src="https://github.com/user-attachments/assets/a485a9b3-c5b4-40b5-8da4-b7678e3f8939" />

New Oxidized Git history fallback settings:

<img width="1529" height="237" alt="Oxidized Git history fallback settings" src="https://github.com/user-attachments/assets/7cc12196-9a11-4c1b-a3d7-1553233dda42" />

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
