### PR TITLE
Make sure some variables are defined in the disk_bits/generic_data graphs to fix missing variable errors

### DIFF
--- a/includes/html/graphs/diskio/bits.inc.php
+++ b/includes/html/graphs/diskio/bits.inc.php
@@ -5,4 +5,7 @@ $ds_out = 'written';
 
 $format = 'bytes';
 
+// Define port as null to avoid a variable does not exists error in the generic_data graph
+$port = null;
+
 require 'includes/html/graphs/generic_data.inc.php';

--- a/includes/html/graphs/diskio/bits.inc.php
+++ b/includes/html/graphs/diskio/bits.inc.php
@@ -5,7 +5,4 @@ $ds_out = 'written';
 
 $format = 'bytes';
 
-// Define port as null to avoid a variable does not exists error in the generic_data graph
-$port = null;
-
 require 'includes/html/graphs/generic_data.inc.php';

--- a/includes/html/graphs/generic_data.inc.php
+++ b/includes/html/graphs/generic_data.inc.php
@@ -27,23 +27,20 @@ $previous = $graph_params->visible('previous');
 $rrd_filename_out ??= $rrd_filename ?? '';
 $rrd_filename_in ??= $rrd_filename ?? '';
 
-// Define variables that may be populated later
-$ingress_speed = $egress_speed = null;
-
 if ($inverse) {
     $in = 'out';
     $out = 'in';
-    if ($port) {
+    if (!empty($port)) {
         [$ingress_speed, $egress_speed] = PortCache::get($port['port_id'])->getSpeeds();
     }
 } else {
     $in = 'in';
     $out = 'out';
-    if ($port) {
+    if (!empty($port)) {
         [$egress_speed, $ingress_speed] = PortCache::get($port['port_id'])->getSpeeds();
     }
 }
-$stacked = generate_stacked_graphs(($egress_speed || $ingress_speed) && ($vars['port_speed_zoom'] ?? LibrenmsConfig::get('graphs.port_speed_zoom')));
+$stacked = generate_stacked_graphs((isset($egress_speed) || isset($ingress_speed)) && ($vars['port_speed_zoom'] ?? LibrenmsConfig::get('graphs.port_speed_zoom')));
 
 if ($multiplier) {
     $rrd_options[] = 'DEF:p' . $out . 'octets=' . $rrd_filename_out . ':' . $ds_out . ':AVERAGE';
@@ -177,10 +174,10 @@ $rrd_options[] = 'LINE1:percentile_in#aa0000';
 $rrd_options[] = 'LINE1:dpercentile_out#aa0000';
 
 $speed_line_type = ($vars['port_speed_zoom'] ?? LibrenmsConfig::get('graphs.port_speed_zoom')) ? 'LINE2' : 'HRULE';
-if ($egress_speed && $ingress_speed && $ingress_speed != $egress_speed) {
+if (isset($egress_speed) && isset($ingress_speed) && $ingress_speed != $egress_speed) {
     $rrd_options[] = "$speed_line_type:$ingress_speed#000000:In Port Speed " . Number::formatSi($ingress_speed, 2, 0, 'bps') . '\\n';
     $rrd_options[] = "$speed_line_type:-$egress_speed#000000:Out Port Speed " . Number::formatSi($egress_speed, 2, 0, 'bps') . '\\n';
-} elseif ($egress_speed) {
+} elseif (isset($egress_speed)) {
     $rrd_options[] = "$speed_line_type:$egress_speed#000000:Port Speed " . Number::formatSi($egress_speed, 2, 0, 'bps') . '\\n';
 }
 

--- a/includes/html/graphs/generic_data.inc.php
+++ b/includes/html/graphs/generic_data.inc.php
@@ -27,6 +27,9 @@ $previous = $graph_params->visible('previous');
 $rrd_filename_out ??= $rrd_filename ?? '';
 $rrd_filename_in ??= $rrd_filename ?? '';
 
+// Define variables that may be populated later
+$ingress_speed = $egress_speed = null;
+
 if ($inverse) {
     $in = 'out';
     $out = 'in';

--- a/includes/html/graphs/generic_data.inc.php
+++ b/includes/html/graphs/generic_data.inc.php
@@ -30,17 +30,17 @@ $rrd_filename_in ??= $rrd_filename ?? '';
 if ($inverse) {
     $in = 'out';
     $out = 'in';
-    if (!empty($port)) {
+    if (! empty($port)) {
         [$ingress_speed, $egress_speed] = PortCache::get($port['port_id'])->getSpeeds();
     }
 } else {
     $in = 'in';
     $out = 'out';
-    if (!empty($port)) {
+    if (! empty($port)) {
         [$egress_speed, $ingress_speed] = PortCache::get($port['port_id'])->getSpeeds();
     }
 }
-$stacked = generate_stacked_graphs((isset($egress_speed) || isset($ingress_speed)) && ($vars['port_speed_zoom'] ?? LibrenmsConfig::get('graphs.port_speed_zoom')));
+$stacked = generate_stacked_graphs((! empty($egress_speed) || ! empty($ingress_speed)) && ($vars['port_speed_zoom'] ?? LibrenmsConfig::get('graphs.port_speed_zoom')));
 
 if ($multiplier) {
     $rrd_options[] = 'DEF:p' . $out . 'octets=' . $rrd_filename_out . ':' . $ds_out . ':AVERAGE';
@@ -174,10 +174,10 @@ $rrd_options[] = 'LINE1:percentile_in#aa0000';
 $rrd_options[] = 'LINE1:dpercentile_out#aa0000';
 
 $speed_line_type = ($vars['port_speed_zoom'] ?? LibrenmsConfig::get('graphs.port_speed_zoom')) ? 'LINE2' : 'HRULE';
-if (isset($egress_speed) && isset($ingress_speed) && $ingress_speed != $egress_speed) {
+if (! empty($egress_speed) && ! empty($ingress_speed) && $ingress_speed != $egress_speed) {
     $rrd_options[] = "$speed_line_type:$ingress_speed#000000:In Port Speed " . Number::formatSi($ingress_speed, 2, 0, 'bps') . '\\n';
     $rrd_options[] = "$speed_line_type:-$egress_speed#000000:Out Port Speed " . Number::formatSi($egress_speed, 2, 0, 'bps') . '\\n';
-} elseif (isset($egress_speed)) {
+} elseif (! empty($egress_speed)) {
     $rrd_options[] = "$speed_line_type:$egress_speed#000000:Port Speed " . Number::formatSi($egress_speed, 2, 0, 'bps') . '\\n';
 }
 


### PR DESCRIPTION
I noticed that the disk throughput graphs were getting the following error:
<img width="743" height="586" alt="image" src="https://github.com/user-attachments/assets/7ff41580-0801-40da-8eb7-fd34e7904357" />

The changes in this PR resolved the issues with these graphs.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
