### PR TITLE
Fix graph time presets for week and month units (1w/2w/1mo/2mo)

### DIFF
--- a/LibreNMS/Util/Time.php
+++ b/LibreNMS/Util/Time.php
@@ -89,17 +89,19 @@ class Time
             return $time < 0 ? time() + $time : intval($time);
         }
 
-        if (preg_match('/^[+-]\d+[hdmy]$/', $time)) {
+        if (preg_match('/^([+-])(\d+)(mo|[smhdwy])$/', $time, $matches)) {
             $units = [
+                's' => 1,
                 'm' => 60,
                 'h' => 3600,
                 'd' => 86400,
+                'w' => 604800,
+                'mo' => 2592000,
                 'y' => 31557600,
             ];
-            $value = Number::cast(substr($time, 1, -1));
-            $unit = substr($time, -1);
+            $value = Number::cast($matches[2]);
 
-            $offset = ($time[0] == '-' ? -1 : 1) * $units[$unit] * $value;
+            $offset = ($matches[1] == '-' ? -1 : 1) * $units[$matches[3]] * $value;
 
             return time() + $offset;
         }

--- a/tests/Unit/TimeUtilityTest.php
+++ b/tests/Unit/TimeUtilityTest.php
@@ -54,6 +54,11 @@ final class TimeUtilityTest extends TestCase
         $this->assertEquals(time() - 180, Time::parseAt('-3m'), '-3m did not match');
         $this->assertEquals(time() - 7200, Time::parseAt('-2h'), '-2h did not match');
         $this->assertEquals(time() - 172800, Time::parseAt('-2d'), '-2d did not match');
+        $this->assertEquals(time() - 604800, Time::parseAt('-1w'), '-1w did not match');
+        $this->assertEquals(time() - 1209600, Time::parseAt('-2w'), '-2w did not match');
+        $this->assertEquals(time() - 2592000, Time::parseAt('-1mo'), '-1mo did not match');
+        $this->assertEquals(time() - 5184000, Time::parseAt('-2mo'), '-2mo did not match');
+        $this->assertEquals(time() - 90, Time::parseAt('-90s'), '-90s did not match');
         $this->assertEquals(time() - 63115200, Time::parseAt('-2y'), '-2y did not match');
         $this->assertEquals(429929439, Time::parseAt('429929439'));
         $this->assertEquals(212334234, Time::parseAt(212334234));


### PR DESCRIPTION
## Summary
Selecting the **1w**, **2w**, **1mo**, or **2mo** presets in the graph date-range picker fails to render and shows:

```
Error Drawing Graph: ERROR: start (1780725688) should be less than end (1780722000)
```

The **6h / 24h / 48h / 1y / 2y** presets work fine.

Fixes #19832.

## Root cause
The picker emits relative offsets (`-1w`, `-1mo`, …) as `from`. `LibreNMS\Util\Time::parseAt()` resolves these, but its fast-path regex only matched the single-letter units `h`, `d`, `m`, `y`:

```php
preg_match('/^[+-]\d+[hdmy]$/', $time)   // no 'w', no 'mo'
```

`-1w` / `-2w` / `-1mo` / `-2mo` don't match, so they fall through to `strtotime()`, which can't parse that compact syntax and returns a value near *now* (slightly in the future). That makes `from > to`, which RRDtool rejects.

The working presets all use letters in `[hdmy]`, so they hit the correct path and never reach `strtotime`.

## Fix
Teach `parseAt()` the `w` (week) and `mo` (month) units (and `s` for parity with `Time::parseInput()`, which already supports the full set). All nine presets now resolve to the correct point in the past.

## Tests
Added regression cases for `-1w`, `-2w`, `-1mo`, `-2mo`, and `-90s` to `tests/Unit/TimeUtilityTest.php`. `php-cs-fixer`, `phpstan`, and the unit test pass.