### PR TITLE
A first step / attempt in moving billing ingestion toward normal port…

### DIFF
--- a/app/Console/Commands/BillingShadowCompare.php
+++ b/app/Console/Commands/BillingShadowCompare.php
@@ -4,6 +4,7 @@ namespace App\Console\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Collection;
 
 class BillingShadowCompare extends Command
 {
@@ -100,8 +101,11 @@ class BillingShadowCompare extends Command
 
         return 0;
     }
+    /**
+    * @return Collection<int, int<1, max>>
+    */
+    private function getBillIds(?int $billId, int $limit, int $minPortCount): Collection
 
-    private function getBillIds(?int $billId, int $limit, int $minPortCount)
     {
         if ($billId !== null && $billId > 0) {
             return collect([$billId]);
@@ -117,6 +121,20 @@ class BillingShadowCompare extends Command
             ->pluck('bill_id');
     }
 
+    /**
+     * @return array{
+     *     bill_id: int,
+     *     member_ports: int,
+     *     shadow_ports: int,
+     *     coverage_percent: float|int,
+     *     shadow_intervals: int,
+     *     bill_samples: int,
+     *     shadow_total: int,
+     *     bill_total: int,
+     *     diff_total: int,
+     *     diff_percent: float|int|null
+     * }
+     */
     private function compareBill(int $billId, int $startTs, int $endTs): array
     {
         $memberPorts = DB::table('bill_ports')
@@ -152,8 +170,8 @@ class BillingShadowCompare extends Command
                     continue;
                 }
 
-                $fromTs = strtotime($previous->timestamp);
-                $toTs = strtotime($row->timestamp);
+                $fromTs = strtotime((string) $previous->timestamp);
+                $toTs = strtotime((string) $row->timestamp);
 
                 $period = $toTs - $fromTs;
                 $inDelta = (int) $row->in_counter - (int) $previous->in_counter;
@@ -203,7 +221,7 @@ class BillingShadowCompare extends Command
         ];
 
         foreach ($billRows as $row) {
-            $rowEnd = strtotime($row->timestamp);
+            $rowEnd = strtotime((string) $row->timestamp);
             $rowStart = $rowEnd - (int) $row->period;
 
             $overlapStart = max($startTs, $rowStart);

--- a/app/Console/Commands/BillingShadowCompare.php
+++ b/app/Console/Commands/BillingShadowCompare.php
@@ -1,0 +1,246 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+class BillingShadowCompare extends Command
+{
+    protected $signature = 'billing:shadow-compare
+        {--bill_id= : Compare one specific bill ID}
+        {--since= : Start timestamp, format: YYYY-MM-DD HH:MM:SS}
+        {--until= : End timestamp, format: YYYY-MM-DD HH:MM:SS. Defaults to now}
+        {--limit=10 : Maximum number of bills to compare when --bill_id is not supplied}
+        {--min-port-count=1 : Only compare bills with at least this many shadow ports}
+    ';
+
+    protected $description = 'Compare shadow billing port data against existing bill_data';
+
+    public function handle(): int
+    {
+        $since = $this->option('since');
+        $until = $this->option('until') ?: date('Y-m-d H:i:s');
+        $billId = $this->option('bill_id') !== null ? (int) $this->option('bill_id') : null;
+        $limit = max(1, (int) $this->option('limit'));
+        $minPortCount = max(1, (int) $this->option('min-port-count'));
+
+        if (empty($since)) {
+            $this->error('Missing required option: --since');
+            $this->line("Example: ./lnms billing:shadow-compare --bill_id=538 --since='2026-06-08 13:25:00' --until='2026-06-08 14:05:00'");
+
+            return 1;
+        }
+
+        $startTs = strtotime($since);
+        $endTs = strtotime($until);
+
+        if ($startTs === false || $endTs === false || $endTs <= $startTs) {
+            $this->error('Invalid time range.');
+
+            return 1;
+        }
+
+        $billIds = $this->getBillIds($billId, $limit, $minPortCount);
+
+        if ($billIds->isEmpty()) {
+            $this->warn('No bills found for comparison.');
+
+            return 0;
+        }
+
+        $rows = [];
+
+        foreach ($billIds as $id) {
+            $result = $this->compareBill((int) $id, $startTs, $endTs);
+
+            $status = 'OK';
+
+            if ($result['shadow_ports'] < $result['member_ports']) {
+                $status = 'INCOMPLETE';
+            } elseif ($result['bill_total'] < 100000000) {
+                $status = 'LOW_VOLUME';
+            }
+
+            $rows[] = [
+                'Bill ID' => $result['bill_id'],
+                'Ports' => $result['member_ports'],
+                'Shadow Ports' => $result['shadow_ports'],
+                'Coverage' => $result['coverage_percent'] . '%',
+                'Intervals' => $result['shadow_intervals'],
+                'Bill Samples' => $result['bill_samples'],
+                'Shadow Total' => $result['shadow_total'],
+                'Bill Total' => $result['bill_total'],
+                'Diff' => $result['diff_total'],
+                'Diff %' => $result['diff_percent'] === null ? '-' : $result['diff_percent'] . '%',
+                'Status' => $status,
+            ];
+        }
+
+        $this->line('Billing shadow comparison');
+        $this->line("Range: {$since} -> {$until}");
+        $this->newLine();
+
+        $this->table(
+            [
+                'Bill ID',
+                'Ports',
+                'Shadow Ports',
+                'Coverage',
+                'Intervals',
+                'Bill Samples',
+                'Shadow Total',
+                'Bill Total',
+                'Diff',
+                'Diff %',
+                'Status',
+            ],
+            $rows
+        );
+
+        return 0;
+    }
+
+    private function getBillIds(?int $billId, int $limit, int $minPortCount)
+    {
+        if ($billId !== null && $billId > 0) {
+            return collect([$billId]);
+        }
+
+        return DB::table('bill_port_data')
+            ->select('bill_id')
+            ->selectRaw('COUNT(DISTINCT port_id) as port_count')
+            ->groupBy('bill_id')
+            ->havingRaw('COUNT(DISTINCT port_id) >= ?', [$minPortCount])
+            ->orderByDesc('port_count')
+            ->limit($limit)
+            ->pluck('bill_id');
+    }
+
+    private function compareBill(int $billId, int $startTs, int $endTs): array
+    {
+        $memberPorts = DB::table('bill_ports')
+            ->where('bill_id', $billId)
+            ->pluck('port_id')
+            ->map(fn ($id) => (int) $id)
+            ->all();
+
+        $shadowRows = DB::table('bill_port_data')
+            ->where('bill_id', $billId)
+            ->whereIn('port_id', $memberPorts)
+            ->where('timestamp', '>=', date('Y-m-d H:i:s', $startTs - 900))
+            ->where('timestamp', '<=', date('Y-m-d H:i:s', $endTs + 900))
+            ->orderBy('port_id')
+            ->orderBy('timestamp')
+            ->get()
+            ->groupBy('port_id');
+
+        $shadow = [
+            'ports_seen' => [],
+            'intervals_used' => 0,
+            'in_delta' => 0,
+            'out_delta' => 0,
+            'delta' => 0,
+        ];
+
+        foreach ($shadowRows as $portId => $rows) {
+            $previous = null;
+
+            foreach ($rows as $row) {
+                if ($previous === null) {
+                    $previous = $row;
+                    continue;
+                }
+
+                $fromTs = strtotime($previous->timestamp);
+                $toTs = strtotime($row->timestamp);
+
+                $period = $toTs - $fromTs;
+                $inDelta = (int) $row->in_counter - (int) $previous->in_counter;
+                $outDelta = (int) $row->out_counter - (int) $previous->out_counter;
+
+                if ($period < 1 || $inDelta < 0 || $outDelta < 0) {
+                    $previous = $row;
+                    continue;
+                }
+
+                $overlapStart = max($startTs, $fromTs);
+                $overlapEnd = min($endTs, $toTs);
+                $overlap = $overlapEnd - $overlapStart;
+
+                if ($overlap <= 0) {
+                    $previous = $row;
+                    continue;
+                }
+
+                $ratio = $overlap / $period;
+
+                $allocatedIn = (int) round($inDelta * $ratio);
+                $allocatedOut = (int) round($outDelta * $ratio);
+
+                $shadow['ports_seen'][(int) $portId] = true;
+                $shadow['intervals_used']++;
+                $shadow['in_delta'] += $allocatedIn;
+                $shadow['out_delta'] += $allocatedOut;
+                $shadow['delta'] += ($allocatedIn + $allocatedOut);
+
+                $previous = $row;
+            }
+        }
+
+        $billRows = DB::table('bill_data')
+            ->where('bill_id', $billId)
+            ->where('timestamp', '>=', date('Y-m-d H:i:s', $startTs - 900))
+            ->where('timestamp', '<=', date('Y-m-d H:i:s', $endTs + 900))
+            ->orderBy('timestamp')
+            ->get();
+
+        $bill = [
+            'samples' => 0,
+            'in_delta' => 0,
+            'out_delta' => 0,
+            'delta' => 0,
+        ];
+
+        foreach ($billRows as $row) {
+            $rowEnd = strtotime($row->timestamp);
+            $rowStart = $rowEnd - (int) $row->period;
+
+            $overlapStart = max($startTs, $rowStart);
+            $overlapEnd = min($endTs, $rowEnd);
+            $overlap = $overlapEnd - $overlapStart;
+
+            if ($overlap <= 0 || (int) $row->period < 1) {
+                continue;
+            }
+
+            $ratio = $overlap / (int) $row->period;
+
+            $bill['samples']++;
+            $bill['in_delta'] += (int) round((int) $row->in_delta * $ratio);
+            $bill['out_delta'] += (int) round((int) $row->out_delta * $ratio);
+            $bill['delta'] += (int) round((int) $row->delta * $ratio);
+        }
+
+        $memberPortCount = count($memberPorts);
+        $shadowPortCount = count($shadow['ports_seen']);
+        $diffTotal = $shadow['delta'] - $bill['delta'];
+
+        return [
+            'bill_id' => $billId,
+            'member_ports' => $memberPortCount,
+            'shadow_ports' => $shadowPortCount,
+            'coverage_percent' => $memberPortCount > 0
+                ? round(($shadowPortCount / $memberPortCount) * 100, 2)
+                : 0,
+            'shadow_intervals' => $shadow['intervals_used'],
+            'bill_samples' => $bill['samples'],
+            'shadow_total' => $shadow['delta'],
+            'bill_total' => $bill['delta'],
+            'diff_total' => $diffTotal,
+            'diff_percent' => $bill['delta'] > 0
+                ? round(($diffTotal / $bill['delta']) * 100, 4)
+                : null,
+        ];
+    }
+}

--- a/database/migrations/2026_06_08_000000_create_bill_port_data_table.php
+++ b/database/migrations/2026_06_08_000000_create_bill_port_data_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration {
+    public function up(): void
+    {
+        Schema::create('bill_port_data', function (Blueprint $table): void {
+            $table->id();
+            $table->unsignedInteger('bill_id');
+            $table->unsignedInteger('port_id');
+            $table->unsignedInteger('device_id');
+            $table->timestamp('timestamp')->useCurrent();
+            $table->unsignedInteger('poll_period');
+            $table->unsignedBigInteger('in_counter')->default(0);
+            $table->unsignedBigInteger('out_counter')->default(0);
+            $table->unsignedBigInteger('in_delta')->default(0);
+            $table->unsignedBigInteger('out_delta')->default(0);
+            $table->boolean('processed')->default(false);
+
+            $table->index(['bill_id', 'timestamp'], 'bill_port_data_bill_id_timestamp_index');
+            $table->index(['port_id', 'timestamp'], 'bill_port_data_port_id_timestamp_index');
+            $table->index(['processed'], 'bill_port_data_processed_index');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('bill_port_data');
+    }
+};

--- a/database/migrations/2026_06_08_000000_create_bill_port_data_table.php
+++ b/database/migrations/2026_06_08_000000_create_bill_port_data_table.php
@@ -4,7 +4,8 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class() extends Migration {
+return new class() extends Migration
+{
     public function up(): void
     {
         Schema::create('bill_port_data', function (Blueprint $table): void {

--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -938,6 +938,9 @@ foreach ($ports as $port) {
                 include 'ports/cisco-if-extension.inc.php';
             }
         }
+        // Emit shadow billing input samples for bill-member ports.
+        // This does not affect production billing yet; poll-billing.php remains authoritative.
+        include 'ports/billing-port-data.inc.php';
 
         // Update Database if $port['update'] is not empty
         // or if previous poll time $port['poll_time'] is different from device globally previous port time $device_global_ports["poll_prev"]

--- a/includes/polling/ports/billing-port-data.inc.php
+++ b/includes/polling/ports/billing-port-data.inc.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * Emit per-port billing shadow samples from the normal port poller.
+ *
+ * This is intentionally append-only and non-authoritative.
+ * Production billing still uses poll-billing.php and bill_data.
+ */
+
+use Illuminate\Support\Facades\DB;
+
+if (empty($port_id) || empty($device['device_id'])) {
+    return;
+}
+
+if (empty($polled_period) || $polled_period < 1) {
+    return;
+}
+
+if (! array_key_exists('ifInOctets', $this_port) || ! array_key_exists('ifOutOctets', $this_port)) {
+    return;
+}
+
+$in_counter = (int) $this_port['ifInOctets'];
+$out_counter = (int) $this_port['ifOutOctets'];
+
+$in_delta = (int) ($current_port_stats['ifInOctets_diff'] ?? 0);
+$out_delta = (int) ($current_port_stats['ifOutOctets_diff'] ?? 0);
+
+if ($in_delta < 0 || $out_delta < 0) {
+    return;
+}
+
+$bill_ids = DB::table('bill_ports')
+    ->where('port_id', $port_id)
+    ->pluck('bill_id');
+
+if ($bill_ids->isEmpty()) {
+    return;
+}
+
+$rows = [];
+$timestamp = date('Y-m-d H:i:s', $polled);
+
+foreach ($bill_ids as $bill_id) {
+    $rows[] = [
+        'bill_id' => (int) $bill_id,
+        'port_id' => (int) $port_id,
+        'device_id' => (int) $device['device_id'],
+        'timestamp' => $timestamp,
+        'poll_period' => (int) $polled_period,
+        'in_counter' => $in_counter,
+        'out_counter' => $out_counter,
+        'in_delta' => $in_delta,
+        'out_delta' => $out_delta,
+        'processed' => 0,
+    ];
+}
+
+DB::table('bill_port_data')->insert($rows);

--- a/resources/definitions/schema/db_schema.yaml
+++ b/resources/definitions/schema/db_schema.yaml
@@ -384,6 +384,24 @@ bill_port_counters:
     - { Field: bill_id, Type: 'int unsigned', 'Null': false, Extra: '' }
   Indexes:
     PRIMARY: { Name: PRIMARY, Columns: [port_id, bill_id], Unique: true, Type: BTREE }
+bill_port_data:
+  Columns:
+    - { Field: id, Type: 'bigint unsigned', 'Null': false, Extra: auto_increment }
+    - { Field: bill_id, Type: 'int unsigned', 'Null': false, Extra: '' }
+    - { Field: port_id, Type: 'int unsigned', 'Null': false, Extra: '' }
+    - { Field: device_id, Type: 'int unsigned', 'Null': false, Extra: '' }
+    - { Field: timestamp, Type: timestamp, 'Null': false, Extra: '', Default: CURRENT_TIMESTAMP }
+    - { Field: poll_period, Type: 'int unsigned', 'Null': false, Extra: '' }
+    - { Field: in_counter, Type: 'bigint unsigned', 'Null': false, Extra: '', Default: '0' }
+    - { Field: out_counter, Type: 'bigint unsigned', 'Null': false, Extra: '', Default: '0' }
+    - { Field: in_delta, Type: 'bigint unsigned', 'Null': false, Extra: '', Default: '0' }
+    - { Field: out_delta, Type: 'bigint unsigned', 'Null': false, Extra: '', Default: '0' }
+    - { Field: processed, Type: tinyint, 'Null': false, Extra: '', Default: '0' }
+  Indexes:
+    PRIMARY: { Name: PRIMARY, Columns: [id], Unique: true, Type: BTREE }
+    bill_port_data_bill_id_timestamp_index: { Name: bill_port_data_bill_id_timestamp_index, Columns: [bill_id, timestamp], Unique: false, Type: BTREE }
+    bill_port_data_port_id_timestamp_index: { Name: bill_port_data_port_id_timestamp_index, Columns: [port_id, timestamp], Unique: false, Type: BTREE }
+    bill_port_data_processed_index: { Name: bill_port_data_processed_index, Columns: [processed], Unique: false, Type: BTREE }
 cache:
   Columns:
     - { Field: key, Type: varchar(255), 'Null': false, Extra: '' }
@@ -719,9 +737,9 @@ devices_perms:
     devices_perms_user_id_index: { Name: devices_perms_user_id_index, Columns: [user_id], Unique: false, Type: BTREE }
 device_graphs:
   Columns:
-    - { Field: id, Type: 'bigint unsigned', 'Null': false, Extra: auto_increment }
     - { Field: device_id, Type: 'int unsigned', 'Null': false, Extra: '' }
     - { Field: graph, Type: varchar(255), 'Null': true, Extra: '' }
+    - { Field: id, Type: 'bigint unsigned', 'Null': false, Extra: auto_increment }
   Indexes:
     PRIMARY: { Name: PRIMARY, Columns: [id], Unique: true, Type: BTREE }
     device_graphs_device_id_index: { Name: device_graphs_device_id_index, Columns: [device_id], Unique: false, Type: BTREE }


### PR DESCRIPTION
A first step / attempt in moving billing ingestion toward normal port polling, following feedback to PR/19482 that billing should be folded into the normal polling/scheduled process model rather than parallelizing poll-billing.php.

What this does:
- Adds bill_port_data as a shadow table for per-port billing samples emitted by normal port polling.
- Emits append-only billing input samples for ports that are members of bills.
- Adds billing:shadow-compare as a read-only diagnostic command to compare shadow data against existing bill_data.
- Leaves poll-billing.php and billing-calculate.php authoritative and unchanged.

The goal is to collect parity data before replacing the existing billing ingestion path.

Example:

[librenms@obiwan ~]$ ./lnms billing:shadow-compare --since='2026-06-08 13:25:00' --until='2026-06-08 14:05:00' --limit=6 --min-port-count=4
Billing shadow comparison
Range: 2026-06-08 13:25:00 -> 2026-06-08 14:05:00

+---------+-------+--------------+----------+-----------+--------------+--------------+-------------+------------+----------+------------+
| Bill ID | Ports | Shadow Ports | Coverage | Intervals | Bill Samples | Shadow Total | Bill Total  | Diff       | Diff %   | Status     |
+---------+-------+--------------+----------+-----------+--------------+--------------+-------------+------------+----------+------------+
| 88      | 8     | 8            | 100%     | 84        | 9            | 74818061885  | 74742670364 | 75391521   | 0.1009%  | OK         |
| 1       | 6     | 6            | 100%     | 63        | 9            | 11542151854  | 11534854657 | 7297197    | 0.0633%  | OK         |
| 44      | 6     | 6            | 100%     | 63        | 9            | 9412462323   | 9426579275  | -14116952  | -0.1498% | OK         |
| 283     | 6     | 6            | 100%     | 63        | 9            | 13184863     | 12707367    | 477496     | 3.7576%  | LOW_VOLUME |
| 319     | 6     | 6            | 100%     | 63        | 9            | 183062469    | 181987427   | 1075042    | 0.5907%  | OK         |
| 452     | 6     | 5            | 83.33%   | 51        | 9            | 11271341559  | 11830384651 | -559043092 | -4.7255% | INCOMPLETE |
+---------+-------+--------------+----------+-----------+--------------+--------------+-------------+------------+----------+------------+
[librenms@obiwan ~]$

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
