### PR TITLE
Add invert_map to add_edit_rule

### DIFF
--- a/doc/API/Alerts.md
+++ b/doc/API/Alerts.md
@@ -301,6 +301,8 @@ Input (JSON):
 - devices: This is either an array of device ids or -1 for a global rule
 - groups: Array of device group ids
 - locations: Array of location ids
+- invert_map: Optional boolean. When `true`, the rule applies to all
+  devices except the selected devices, groups and locations.
 - builder: The rule which should be in the format entity.condition
   value (i.e devices.status != 0 for devices marked as down). It must
   be json encoded in the format rules are currently stored.
@@ -350,6 +352,8 @@ Input (JSON):
 - devices: This is either an array of device ids or -1 for a global rule
 - groups: Array of device group ids
 - locations: Array of location ids
+- invert_map: Optional boolean. When `true`, the rule applies to all
+  devices except the selected devices, groups and locations.
 - builder: The rule which should be in the format entity.condition
   value (i.e devices.status != 0 for devices marked as down). It must
   be json encoded in the format rules are currently stored.

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -1936,6 +1936,10 @@ function add_edit_rule(Illuminate\Http\Request $request)
         $saveData['alert_operation_id'] = ($v === null || $v === '') ? null : (int) $v;
     }
 
+    if (array_key_exists('invert_map', $data)) {
+        $saveData['invert_map'] = filter_var($data['invert_map'], FILTER_VALIDATE_BOOLEAN);
+    }
+
     if (is_numeric($rule_id)) {
         $alertRule = \App\Models\AlertRule::find($rule_id);
         if (! $alertRule) {


### PR DESCRIPTION
The current add_edit_rule api function ignores the invert_map parameter. This means we cannot change or edit rules to only fire if they are not part of a specific group.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
