### PR TITLE
First draft of introducing problems and per entity alerting

### DIFF
--- a/LibreNMS/Alert/AlertRules.php
+++ b/LibreNMS/Alert/AlertRules.php
@@ -34,6 +34,8 @@ namespace LibreNMS\Alert;
 
 use App\Facades\DeviceCache;
 use App\Models\Alert;
+use App\Models\AlertLog;
+use App\Models\AlertProblem;
 use App\Models\AlertRule;
 use App\Models\Device;
 use App\Models\Eventlog;
@@ -71,10 +73,13 @@ readonly class AlertRules
 
         if ($this->device->disable_notify) {
             Log::info('Disable alerting is set, Clearing active alerts and skipping alert rules check');
+            AlertProblem::query()->where('device_id', $this->device->device_id)->where('open', 1)
+                ->update(['open' => 0, 'state' => AlertState::RECOVERED]);
             $this->device->alerts()->update([
                 'state' => AlertState::CLEAR,
                 'alerted' => 0,
                 'open' => 0,
+                'open_problem_count' => 0,
             ]);
 
             return false;
@@ -113,37 +118,6 @@ readonly class AlertRules
             return;
         }
 
-        $alert = $this->device->alerts()
-            ->where('rule_id', $rule->id)
-            ->latest('id')
-            ->first();
-
-        $do_alert = ! empty($rows) !== $invert;
-        if ($do_alert) {
-            $this->handleAlertTrigger($rule, $rows, $alert);
-        } else {
-            $this->handleAlertRecovery($rule, $alert);
-        }
-    }
-
-    /**
-     * Handle triggering or updating an active alert.
-     *
-     * @param  AlertRule  $rule
-     * @param  array  $rows
-     * @param  Alert|null  $alert
-     */
-    private function handleAlertTrigger(AlertRule $rule, array $rows, ?Alert $alert): void
-    {
-        $current_state = $alert?->state;
-
-        if ($current_state == AlertState::ACKNOWLEDGED) {
-            Log::info('Status: %ySKIP%n', ['color' => true]);
-
-            return;
-        }
-
-        // Cast to array rows and make sure ip is a string
         $rows = array_map(function ($row) {
             $row = (array) $row;
             if (isset($row['ip'])) {
@@ -153,82 +127,158 @@ readonly class AlertRules
             return $row;
         }, $rows);
 
-        if (in_array($current_state, [AlertState::ACTIVE, AlertState::WORSE, AlertState::BETTER, AlertState::CHANGED], true)) {
-            Log::info('Status: %bNOCHG%n', ['color' => true]);
+        $alert = $this->device->alerts()
+            ->where('rule_id', $rule->id)
+            ->latest('id')
+            ->first();
 
-            // NOCHG here doesn't mean no change full stop. It means no change to the alert state
-            // So we update the details column with any fresh changes to the alert output we might have.
-            $alert_log = $this->device->alertLogs()
-                ->where('rule_id', $rule->id)
-                ->latest('id')
-                ->first();
-
-            if ($alert_log) {
-                $alert_log->details = [
-                    ...($alert_log->details ?? []),
-                    'contacts' => AlertUtil::getContacts($rows),
-                    'rule' => $rows,
-                ];
-                $alert_log->save();
-            }
+        if ($alert?->state === AlertState::ACKNOWLEDGED) {
+            Log::info('Status: %ySKIP%n', ['color' => true]);
 
             return;
         }
 
-        // State is not active, trigger alert
-        $extra = ['contacts' => AlertUtil::getContacts($rows), 'rule' => $rows];
-        if ($this->device->alertLogs()->create(['state' => AlertState::ACTIVE, 'rule_id' => $rule->id, 'details' => $extra])) {
-            $alert_data = [
-                'state' => AlertState::ACTIVE,
-                'open' => 1,
-                'alerted' => 0,
-                'timestamp' => Carbon::now(),
-            ];
+        $do_alert = ! empty($rows) !== $invert;
+        $now = Carbon::now();
 
-            if ($alert) {
-                $alert->update($alert_data);
+        $faulting = [];
+        if ($do_alert) {
+            if ($invert || empty($rows)) {
+                $faulting[''] = ['type' => null, 'id' => null, 'rows' => $rows];
             } else {
-                $this->device->alerts()->create(array_merge($alert_data, [
-                    'rule_id' => $rule->id,
-                    'info' => [],
-                ]));
+                foreach ($rows as $row) {
+                    $key = AlertUtil::generateComparisonKeyForFault($row, AlertUtil::extractIdFieldsForFault($row));
+                    if (! isset($faulting[$key])) {
+                        [$type, $id] = AlertUtil::entityForFault($row);
+                        $faulting[$key] = ['type' => $type, 'id' => $id, 'rows' => []];
+                    }
+                    $faulting[$key]['rows'][] = $row;
+                }
             }
-            Log::info(PHP_EOL . 'Status: %rALERT%n', ['color' => true]);
         }
+
+        /** @var array<string, AlertProblem> $existing */
+        $existing = [];
+        foreach (AlertProblem::query()->where('rule_id', $rule->id)->where('device_id', $this->device->device_id)
+            ->where('open', 1)->where('state', '!=', AlertState::RECOVERED)->get() as $problem) {
+            /** @var AlertProblem $problem */
+            $existing[$problem->entity_key] = $problem;
+        }
+
+        foreach ($faulting as $key => $info) {
+            $details = ['rule' => $info['rows'], 'contacts' => AlertUtil::getContacts($info['rows'])];
+            if (isset($existing[$key])) {
+                $problem = $existing[$key];
+                $problem->details = $details;
+                $problem->severity = $rule->severity;
+                $problem->last_seen = $now;
+                $problem->save();
+                unset($existing[$key]);
+                Log::info('Status: %bNOCHG%n', ['color' => true]);
+            } else {
+                $problem = new AlertProblem;
+                $problem->rule_id = $rule->id;
+                $problem->device_id = $this->device->device_id;
+                $problem->entity_type = $info['type'];
+                $problem->entity_id = $info['id'];
+                $problem->entity_key = (string) $key;
+                $problem->severity = $rule->severity;
+                $problem->details = $details;
+                $this->recordProblemTransition($problem, AlertState::ACTIVE, $now);
+                Log::info(PHP_EOL . 'Status: %rALERT%n', ['color' => true]);
+            }
+        }
+
+        foreach ($existing as $problem) {
+            $this->recordProblemTransition($problem, AlertState::RECOVERED, $now);
+            Log::info(PHP_EOL . 'Status: %gOK%n', ['color' => true]);
+        }
+
+        $this->syncAlertState($rule);
     }
 
     /**
-     * Handle recovery of an alert.
-     *
-     * @param  AlertRule  $rule
-     * @param  Alert|null  $alert
+     * Persist a problem state change: save the problem row (with its current details) and append the
+     * matching alert_log entry. Set $problem->details before calling.
      */
-    private function handleAlertRecovery(AlertRule $rule, ?Alert $alert): void
+    private function recordProblemTransition(AlertProblem $problem, int $state, ?Carbon $now = null): void
     {
-        if ($alert && $alert->state == AlertState::RECOVERED) {
-            Log::info('Status: %bNOCHG%n', ['color' => true]);
+        $now ??= Carbon::now();
+        if (! $problem->exists) {
+            $problem->first_seen = $now;
+        }
+        $problem->state = $state;
+        $problem->open = 1; // recoveries stay open until the dispatcher sends the recovery notification
+        $problem->alerted = 0;
+        $problem->last_seen = $now;
+        $problem->timestamp = $now;
+        $problem->save();
 
-            return;
+        $details = is_array($problem->details) ? $problem->details : [];
+        AlertLog::create([
+            'rule_id' => $problem->rule_id,
+            'device_id' => $problem->device_id,
+            'problem_id' => $problem->id,
+            'state' => $state,
+            'time_logged' => $now,
+            'details' => $details,
+        ]);
+    }
+
+    /**
+     * Update the rule-level alerts row from the current open problem count.
+     * Worse/better is derived from the count delta (replaces the old fault diffing).
+     */
+    private function syncAlertState(AlertRule $rule): void
+    {
+        $base = AlertProblem::query()->where('rule_id', $rule->id)->where('device_id', $this->device->device_id)->where('open', 1);
+        $activeCount = (clone $base)->where('state', '!=', AlertState::RECOVERED)->count();
+        $unackCount = (clone $base)->where('state', AlertState::ACTIVE)->count();
+
+        $alertRow = Alert::query()->where('rule_id', $rule->id)->where('device_id', $this->device->device_id)->first();
+        $prevState = $alertRow?->state;
+        $prevCount = $alertRow?->open_problem_count ?? 0;
+
+        if ($activeCount == 0) {
+            $newState = AlertState::RECOVERED;
+        } elseif ($unackCount == 0) {
+            $newState = AlertState::ACKNOWLEDGED;
+        } elseif ($prevState === null || $prevState === AlertState::CLEAR) {
+            $newState = AlertState::ACTIVE;
+        } elseif ($activeCount > $prevCount) {
+            $newState = AlertState::WORSE;
+        } elseif ($activeCount < $prevCount) {
+            $newState = AlertState::BETTER;
+        } elseif (in_array($prevState, [AlertState::ACTIVE, AlertState::WORSE, AlertState::BETTER, AlertState::CHANGED], true)) {
+            $newState = $prevState;
+        } else {
+            $newState = AlertState::ACTIVE;
         }
 
-        if ($this->device->alertLogs()->create(['state' => AlertState::RECOVERED, 'rule_id' => $rule->id])) {
-            $alert_data = [
-                'state' => AlertState::RECOVERED,
-                'open' => 1,
-                'timestamp' => Carbon::now(),
-            ];
+        $stateChanged = ($prevState ?? -1) !== $newState || $activeCount !== $prevCount;
 
-            if ($alert) {
-                $alert->update(array_merge($alert_data, ['note' => '']));
-            } else {
-                $this->device->alerts()->create(array_merge($alert_data, [
-                    'rule_id' => $rule->id,
-                    'alerted' => 0,
-                    'info' => [],
-                ]));
+        if ($alertRow) {
+            $alertRow->state = $newState;
+            $alertRow->open_problem_count = $activeCount;
+            if ($stateChanged) {
+                $alertRow->open = 1;
+                $alertRow->alerted = 0;
+                $alertRow->timestamp = Carbon::now();
             }
-
-            Log::info(PHP_EOL . 'Status: %gOK%n', ['color' => true]);
+            if ($newState === AlertState::RECOVERED) {
+                $alertRow->note = '';
+            }
+            $alertRow->save();
+        } elseif ($activeCount > 0) {
+            $alertRow = new Alert;
+            $alertRow->state = $newState;
+            $alertRow->device_id = $this->device->device_id;
+            $alertRow->rule_id = $rule->id;
+            $alertRow->open = 1;
+            $alertRow->alerted = 0;
+            $alertRow->open_problem_count = $activeCount;
+            $alertRow->info = '[]';
+            $alertRow->save();
         }
     }
 }

--- a/LibreNMS/Alert/AlertUtil.php
+++ b/LibreNMS/Alert/AlertUtil.php
@@ -43,6 +43,25 @@ use PHPMailer\PHPMailer\PHPMailer;
 class AlertUtil
 {
     /**
+     * Map of alert-query id columns to registered morph aliases (see AppServiceProvider).
+     * Used to resolve the entity a problem is about (Port, Sensor, ...).
+     */
+    private const ENTITY_COLUMN_MAP = [
+        'port_id' => 'interface',
+        'sensor_id' => 'sensor',
+        'bgpPeer_id' => 'bgppeer',
+        'service_id' => 'service',
+        'mempool_id' => 'mempool',
+        'processor_id' => 'processor',
+        'storage_id' => 'storage',
+        'app_id' => 'application',
+        'accesspoint_id' => 'accesspoint',
+        'bill_id' => 'bill',
+        'device_group_id' => 'device_group',
+        'location_id' => 'location',
+    ];
+
+    /**
      * Get the rule_id for a specific alert
      *
      * @param  int  $alert_id
@@ -51,6 +70,57 @@ class AlertUtil
     private static function getRuleId($alert_id)
     {
         return Alert::find($alert_id)?->rule_id;
+    }
+
+    /**
+     * @param  array<string, mixed>  $element
+     * @return array<int, string>
+     */
+    public static function extractIdFieldsForFault(array $element): array
+    {
+        return array_filter(array_keys($element), fn ($key) =>
+            // Exclude location_id as it is not relevant for the comparison
+            ($key === 'id' || strpos((string) $key, '_id')) !== false && $key !== 'location_id');
+    }
+
+    /**
+     * @param  array<string, mixed>  $element
+     * @param  array<int, string>  $idFields
+     */
+    public static function generateComparisonKeyForFault(array $element, array $idFields): string
+    {
+        $keyParts = [];
+        foreach ($idFields as $field) {
+            $keyParts[] = $element[$field] ?? '';
+        }
+
+        return implode('|', $keyParts);
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     * @return array{0: ?string, 1: ?int}
+     */
+    public static function entityForFault(array $row): array
+    {
+        foreach (self::ENTITY_COLUMN_MAP as $column => $alias) {
+            if (! empty($row[$column])) {
+                return [$alias, (int) $row[$column]];
+            }
+        }
+
+        foreach ($row as $key => $value) {
+            if ($key === 'device_id' || $key === 'location_id' || empty($value)) {
+                continue;
+            }
+            if ($key === 'id' || str_ends_with((string) $key, '_id')) {
+                $alias = $key === 'id' ? null : substr((string) $key, 0, -3);
+
+                return [$alias, (int) $value];
+            }
+        }
+
+        return [null, null];
     }
 
     /**

--- a/LibreNMS/Alert/RunAlerts.php
+++ b/LibreNMS/Alert/RunAlerts.php
@@ -35,13 +35,13 @@ use App\Facades\DeviceCache;
 use App\Facades\LibrenmsConfig;
 use App\Facades\Rrd;
 use App\Models\AlertLog;
+use App\Models\AlertProblem;
 use App\Models\AlertRule;
 use App\Models\AlertTransport;
 use App\Models\ApplicationMetric;
 use App\Models\Eventlog;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
-use LibreNMS\Alerting\QueryBuilderParser;
 use LibreNMS\Enum\AlertRuleOperationPhase;
 use LibreNMS\Enum\AlertState;
 use LibreNMS\Enum\MaintenanceStatus;
@@ -192,24 +192,29 @@ class RunAlerts
                 $obj['diff'] = $extra['diff'];
             }
         } elseif ($alert['state'] == AlertState::RECOVERED) {
-            // Alert is now cleared
-            $id = dbFetchRow('SELECT alert_log.id,alert_log.time_logged,alert_log.details FROM alert_log WHERE alert_log.state != ? && alert_log.state != ? && alert_log.rule_id = ? && alert_log.device_id = ? && alert_log.id < ? ORDER BY id DESC LIMIT 1', [AlertState::ACKNOWLEDGED, AlertState::RECOVERED, $alert['rule_id'], $alert['device_id'], $alert['id']]);
-            if (empty($id['id'])) {
+            // Alert is now cleared. Scope to the same problem when notifying per entity.
+            $alert_log = AlertLog::where('state', '!=', AlertState::ACKNOWLEDGED)->where('state', '!=', AlertState::RECOVERED)->where('rule_id', $alert['rule_id'])->where('device_id', $alert['device_id'])->where('id', '<', $alert['id']);
+            if (! empty($alert['problem_id'])) {
+                $alert_log->where('problem_id', $alert['problem_id']);
+            }
+            $alert_log->orderBy('id', 'desc')->first();
+            if (empty($alert_log?->id)) {
                 return false;
             }
 
             $extra = [];
-            if (! empty($id['details'])) {
-                $extra = json_decode(gzuncompress($id['details']), true);
+            if (! empty($alert_log?->details)) {
+                $extra = json_decode(gzuncompress($alert_log?->details), true);
             }
 
             // Reset count to 0 so alerts will continue
             $extra['count'] = 0;
-            dbUpdate(['details' => gzcompress(json_encode($id['details']), 9)], 'alert_log', 'id = ?', [$alert['id']]);
+            $alert_log->details = gzcompress(json_encode($alert_log?->details), 9);
+            $alert_log->save();
 
             $obj['title'] = $template->title_rec ?: 'Device ' . $obj['display'] . ' recovered from ' . ($alert['name'] ?: $alert['rule']);
-            $obj['elapsed'] = Time::formatInterval(strtotime((string) $alert['time_logged']) - strtotime((string) $id['time_logged']), true) ?: 'none';
-            $obj['id'] = $id['id'];
+            $obj['elapsed'] = Time::formatInterval(strtotime((string) $alert['time_logged']) - strtotime((string) $alert_log?->time_logged), true) ?: 'none';
+            $obj['id'] = $alert_log?->id;
             foreach ($extra['rule'] as $incident) {
                 $i++;
                 $obj['faults'][$i] = $incident;
@@ -287,22 +292,58 @@ class RunAlerts
      */
     public function issueAlert($alert)
     {
-        if (LibrenmsConfig::get('alert.fixed-contacts') == false) {
-            if (empty($alert['query'])) {
-                $alert['query'] = QueryBuilderParser::fromJson($alert['builder'])->toSql();
+        $perEntity = (bool) AlertRule::query()->where('id', $alert['rule_id'])->value('notify_per_entity');
+
+        $recovering = (int) $alert['state'] === AlertState::RECOVERED;
+        $problems = AlertProblem::query()
+            ->where('rule_id', $alert['rule_id'])
+            ->where('device_id', $alert['device_id'])
+            ->where('open', 1)
+            ->where('state', $recovering ? '=' : '!=', AlertState::RECOVERED)
+            ->orderBy('id')
+            ->get();
+
+        // Build the set of notifications to send: one per problem (per-entity) or one aggregate (grouped).
+        $units = [];
+        if ($problems->isEmpty()) {
+            $units[] = $alert; // legacy fallback (e.g. data with no problem rows yet)
+        } elseif ($perEntity) {
+            foreach ($problems as $problem) {
+                $unit = $alert;
+                $unit['state'] = (int) $problem->state;
+                $unit['problem_id'] = $problem->id;
+                $unit['details']['rule'] = $problem->details['rule'] ?? [];
+                $unit['details']['contacts'] = $problem->details['contacts'] ?? ($alert['details']['contacts'] ?? []);
+                $latestLogId = AlertLog::query()->where('problem_id', $problem->id)->max('id');
+                if ($latestLogId) {
+                    $unit['id'] = $latestLogId;
+                }
+                $unit['time_logged'] = (string) ($problem->last_seen ?? $problem->timestamp);
+                $units[] = $unit;
             }
-            $sql = $alert['query'];
-            $qry = dbFetchRows($sql, [$alert['device_id']]);
-            $alert['details']['contacts'] = AlertUtil::getContacts($qry);
+        } else {
+            $rows = [];
+            foreach ($problems as $problem) {
+                foreach (($problem->details['rule'] ?? []) as $row) {
+                    $rows[] = $row;
+                }
+            }
+            $alert['details']['rule'] = $rows;
+            if (LibrenmsConfig::get('alert.fixed-contacts') == false) {
+                $alert['details']['contacts'] = AlertUtil::getContacts($rows);
+            }
+            $units[] = $alert;
         }
 
-        $obj = $this->describeAlert($alert);
-        if (is_array($obj)) {
-            echo 'Issuing Alert-UID #' . $alert['id'] . '/' . $alert['state'] . ':' . PHP_EOL;
-            if ($alert['state'] != AlertState::ACKNOWLEDGED || LibrenmsConfig::get('alert.acknowledged') === true) {
-                $this->extTransports($obj);
+        foreach ($units as $unit) {
+            $obj = $this->describeAlert($unit);
+            if (is_array($obj)) {
+                echo 'Issuing Alert-UID #' . $unit['id'] . '/' . $unit['state'] . ':' . PHP_EOL;
+                if ($unit['state'] != AlertState::ACKNOWLEDGED || LibrenmsConfig::get('alert.acknowledged') === true) {
+                    $this->extTransports($obj);
+                }
+                echo "\r\n";
             }
-            echo "\r\n";
         }
 
         return true;
@@ -328,150 +369,6 @@ class RunAlerts
                 dbUpdate(['open' => AlertState::CLEAR], 'alerts', 'rule_id = ? && device_id = ?', [$alert['rule_id'], $alert['device_id']]);
             }
         }
-    }
-
-    /**
-     * Run Follow-Up alerts
-     *
-     * @return void
-     */
-    public function runFollowUp()
-    {
-        foreach ($this->loadAlerts('alerts.state > ' . AlertState::CLEAR . ' && alerts.open = 0') as $alert) {
-            if ($alert['state'] != AlertState::ACKNOWLEDGED || ($alert['info']['until_clear'] === false)) {
-                $rextra = json_decode((string) $alert['extra'], true);
-                if ($rextra['invert']) {
-                    continue;
-                }
-
-                if (empty($alert['query'])) {
-                    $alert['query'] = QueryBuilderParser::fromJson($alert['builder'])->toSql();
-                }
-                $chk = dbFetchRows($alert['query'], [$alert['device_id']]);
-                //make sure we can json_encode all the datas later
-                $current_alert_count = count($chk);
-                for ($i = 0; $i < $current_alert_count; $i++) {
-                    if (isset($chk[$i]['ip'])) {
-                        $chk[$i]['ip'] = inet6_ntop($chk[$i]['ip']);
-                    }
-                }
-                $alert['details']['rule'] ??= []; // if details.rule is missing, set it to an empty array
-                $ret = 'Alert #' . $alert['id'];
-                $state = AlertState::CLEAR;
-
-                // Get the added and resolved items
-                [$added_diff, $resolved_diff] = $this->diffBetweenFaults($alert['details']['rule'], $chk);
-                $previous_alert_count = count($alert['details']['rule']);
-
-                if (! empty($added_diff) && ! empty($resolved_diff)) {
-                    $ret .= ' Changed';
-                    $state = AlertState::CHANGED;
-                    $alert['details']['diff'] = ['added' => $added_diff, 'resolved' => $resolved_diff];
-                } elseif (! empty($added_diff)) {
-                    $ret .= ' Worse';
-                    $state = AlertState::WORSE;
-                    $alert['details']['diff'] = ['added' => $added_diff];
-                } elseif (! empty($resolved_diff)) {
-                    $ret .= ' Better';
-                    $state = AlertState::BETTER;
-                    $alert['details']['diff'] = ['resolved' => $resolved_diff];
-                    // Failsafe if the diff didn't return any results
-                } elseif ($current_alert_count > $previous_alert_count) {
-                    $ret .= ' Worse';
-                    $state = AlertState::WORSE;
-                    Eventlog::log('Alert got worse but the diff was not, ensure that a "id" or "_id" field is available for rule ' . $alert['name'], $alert['device_id'], 'alert', Severity::Warning);
-                    // Failsafe if the diff didn't return any results
-                } elseif ($current_alert_count < $previous_alert_count) {
-                    $ret .= ' Better';
-                    $state = AlertState::BETTER;
-                    Eventlog::log('Alert got better but the diff was not, ensure that a "id" or "_id" field is available for rule ' . $alert['name'], $alert['device_id'], 'alert', Severity::Warning);
-                }
-
-                if ($state > AlertState::CLEAR && $current_alert_count > 0) {
-                    $alert['details']['rule'] = $chk;
-                    if (dbInsert([
-                        'state' => $state,
-                        'device_id' => $alert['device_id'],
-                        'rule_id' => $alert['rule_id'],
-                        'details' => gzcompress(json_encode($alert['details']), 9),
-                    ], 'alert_log')) {
-                        dbUpdate(['state' => $state, 'open' => 1, 'alerted' => 1], 'alerts', 'rule_id = ? && device_id = ?', [$alert['rule_id'], $alert['device_id']]);
-                    }
-
-                    echo $ret . ' (' . $previous_alert_count . '/' . $current_alert_count . ")\r\n";
-                }
-            }
-        }
-    }
-
-    /**
-     * Extract the fields that are used to identify the elements in the array of a "fault"
-     *
-     * @param  array  $element
-     * @return array
-     */
-    private function extractIdFieldsForFault($element)
-    {
-        return array_filter(array_keys($element), fn ($key) =>
-            // Exclude location_id as it is not relevant for the comparison
-            ($key === 'id' || strpos((string) $key, '_id')) !== false && $key !== 'location_id');
-    }
-
-    /**
-     * Generate a comparison key for an element based on the fields that identify it for a "fault"
-     *
-     * @param  array  $element
-     * @param  array  $idFields
-     * @return string
-     */
-    private function generateComparisonKeyForFault($element, $idFields)
-    {
-        $keyParts = [];
-        foreach ($idFields as $field) {
-            $keyParts[] = $element[$field] ?? '';
-        }
-
-        return implode('|', $keyParts);
-    }
-
-    /**
-     * Find new elements in the array for faults
-     * PHP array_diff is not working well for it
-     *
-     * @param  array  $array1
-     * @param  array  $array2
-     * @return array [$added, $removed]
-     */
-    private function diffBetweenFaults($array1, $array2)
-    {
-        $array1_keys = [];
-        $added_elements = [];
-        $removed_elements = [];
-
-        // Create associative array for quick lookup of $array1 elements
-        foreach ($array1 as $element1) {
-            $element1_ids = $this->extractIdFieldsForFault($element1);
-            $element1_key = $this->generateComparisonKeyForFault($element1, $element1_ids);
-            $array1_keys[$element1_key] = $element1;
-        }
-
-        // Iterate through $array2 and determine added elements
-        foreach ($array2 as $element2) {
-            $element2_ids = $this->extractIdFieldsForFault($element2);
-            $element2_key = $this->generateComparisonKeyForFault($element2, $element2_ids);
-
-            if (! isset($array1_keys[$element2_key])) {
-                $added_elements[] = $element2;
-            } else {
-                // Remove matched elements
-                unset($array1_keys[$element2_key]);
-            }
-        }
-
-        // Remaining elements in $array1_keys are the removed elements
-        $removed_elements = array_values($array1_keys);
-
-        return [$added_elements, $removed_elements];
     }
 
     public function loadAlerts($where)
@@ -645,6 +542,16 @@ class RunAlerts
             if (! $noiss) {
                 dbUpdate(['alerted' => $alert['state']], 'alerts', 'rule_id = ? && device_id = ?', [$alert['rule_id'], $alert['device_id']]);
                 $this->issueAlert($alert);
+            }
+
+            if ((int) $alert['state'] === AlertState::RECOVERED) {
+                // Recovery has been handled (sent or muted): close the recovered problems so they are terminal.
+                AlertProblem::query()
+                    ->where('rule_id', $alert['rule_id'])
+                    ->where('device_id', $alert['device_id'])
+                    ->where('open', 1)
+                    ->where('state', AlertState::RECOVERED)
+                    ->update(['open' => 0]);
             }
         }
     }

--- a/alerts.php
+++ b/alerts.php
@@ -55,8 +55,6 @@ if ($alerts_lock->get()) {
         echo 'Start: ' . date('r') . "\r\n";
         echo 'ClearStaleAlerts():' . PHP_EOL;
         $alerts->clearStaleAlerts();
-        echo "RunFollowUp():\r\n";
-        $alerts->runFollowUp();
         echo "RunAlerts():\r\n";
         $alerts->runAlerts();
         echo "RunAcks():\r\n";

--- a/app/Http/Controllers/Ajax/AlertDetailsController.php
+++ b/app/Http/Controllers/Ajax/AlertDetailsController.php
@@ -38,8 +38,29 @@ class AlertDetailsController
     {
         $this->authorize('view', $alertLog);
 
+        $details = $alertLog->details['rule'] ?? null;
+
+        if ($alertLog->problem_id && $alertLog->rule && ! $alertLog->rule->notify_per_entity) {
+            $rows = [];
+            $siblings = AlertLog::query()
+                ->where('device_id', $alertLog->device_id)
+                ->where('rule_id', $alertLog->rule_id)
+                ->where('state', $alertLog->state->value)
+                ->where('time_logged', $alertLog->time_logged)
+                ->whereNotNull('problem_id')
+                ->get(['id', 'details']);
+            foreach ($siblings as $sibling) {
+                foreach ((array) ($sibling->details['rule'] ?? []) as $row) {
+                    $rows[] = $row;
+                }
+            }
+            if (! empty($rows)) {
+                $details = $rows;
+            }
+        }
+
         return response()->json([
-            'details' => $alertLog->details['rule'] ?? 'No Details found',
+            'details' => $details ?: 'No Details found',
         ]);
     }
 }

--- a/app/Http/Controllers/AlertController.php
+++ b/app/Http/Controllers/AlertController.php
@@ -4,15 +4,20 @@ namespace App\Http\Controllers;
 
 use App\Facades\LibrenmsConfig;
 use App\Models\Alert;
+use App\Models\AlertProblem;
 use App\Models\Eventlog;
 use Illuminate\Http\Request;
+use LibreNMS\Enum\AlertState;
 use LibreNMS\Enum\Severity;
 
 class AlertController extends Controller
 {
-    public function ack(Request $request, Alert $alert): \Illuminate\Http\JsonResponse
+    public function ack(Request $request, AlertProblem $problem): \Illuminate\Http\JsonResponse
     {
-        $this->authorize('update', $alert);
+        $alert = Alert::query()->where('rule_id', $problem->rule_id)->where('device_id', $problem->device_id)->first();
+        if ($alert) {
+            $this->authorize('update', $alert);
+        }
 
         $this->validate($request, [
             'state' => 'required|int',
@@ -22,38 +27,56 @@ class AlertController extends Controller
 
         $state = $request->input('state');
         $state_description = '';
-        if ($state == 2) {
-            $alert->state = 1;
+        $newState = null;
+        if ($state == AlertState::ACKNOWLEDGED) {
+            $newState = AlertState::ACTIVE;
             $state_description = 'UnAck';
-            $alert->open = 1;
-        } elseif ($state >= 1) {
-            $alert->state = 2;
+        } elseif ($state >= AlertState::ACTIVE) {
+            $newState = AlertState::ACKNOWLEDGED;
             $state_description = 'Ack';
-            $alert->open = 1;
         }
 
-        $info = $alert->info;
-        $info['until_clear'] = filter_var($request->input('ack_until_clear'), FILTER_VALIDATE_BOOLEAN);
-        $alert->info = $info;
+        if ($newState === null) {
+            return response()->json([
+                'message' => 'Problem has not been acknowledged.',
+                'status' => 'error',
+            ]);
+        }
 
+        $untilClear = filter_var($request->input('ack_until_clear'), FILTER_VALIDATE_BOOLEAN);
         $timestamp = date(LibrenmsConfig::get('dateformat.long'));
         $username = $request->user()->username;
         $ack_msg = $request->input('ack_msg');
-        $alert->note = trim($alert->note . PHP_EOL . "$timestamp - $state_description ($username) " . $ack_msg);
+        $note_suffix = "$timestamp - $state_description ($username) " . $ack_msg;
 
-        if ($alert->save()) {
-            $rule_name = $alert->rule->name;
+        $targets = $problem->rule?->notify_per_entity
+            ? collect([$problem])
+            : AlertProblem::query()->where('rule_id', $problem->rule_id)->where('device_id', $problem->device_id)->where('open', 1)->get();
+
+        $saved = false;
+        foreach ($targets as $target) {
+            $target->state = $newState;
+            $target->open = 1;
+            $info = $target->info ?: [];
+            $info['until_clear'] = $untilClear;
+            $target->info = $info;
+            $target->note = trim($target->note . PHP_EOL . $note_suffix);
+            $saved = $target->save() || $saved;
+        }
+
+        if ($saved) {
+            $rule_name = $problem->rule?->name;
             $act = strtolower($state_description) . 'nowledged';
-            Eventlog::log("$username {$act} alert $rule_name note: $ack_msg", $alert->device_id, 'alert', Severity::Info, $alert->id);
+            Eventlog::log("$username {$act} alert $rule_name note: $ack_msg", $problem->device_id, 'alert', Severity::Info, $problem->id);
 
             return response()->json([
-                'message' => "Alert {$state_description}nowledged.",
+                'message' => "Problem {$state_description}nowledged.",
                 'status' => 'ok',
             ]);
         }
 
         return response()->json([
-            'message' => 'Alert has not been acknowledged.',
+            'message' => 'Problem has not been acknowledged.',
             'status' => 'error',
         ]);
     }

--- a/app/Http/Controllers/AlertRuleController.php
+++ b/app/Http/Controllers/AlertRuleController.php
@@ -3,11 +3,14 @@
 namespace App\Http\Controllers;
 
 use App\Http\Requests\AlertRuleRequest;
+use App\Models\Alert;
+use App\Models\AlertProblem;
 use App\Models\AlertRule;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
 use LibreNMS\Alerting\QueryBuilderParser;
+use LibreNMS\Enum\AlertState;
 
 class AlertRuleController extends Controller
 {
@@ -65,6 +68,7 @@ class AlertRuleController extends Controller
             'severity' => $alertRule->severity,
             'adv_query' => $alertRule->query,
             'invert_map' => $alertRule->invert_map,
+            'notify_per_entity' => $alertRule->notify_per_entity,
         ]);
     }
 
@@ -105,7 +109,13 @@ class AlertRuleController extends Controller
 
         $alertRule->disabled = ! $request->boolean('state', $alertRule->disabled);
         $success = $alertRule->save();
-        url('graphs', ['id' => 42, 'type' => 'sensor_']);
+
+        if ($success && $alertRule->disabled) {
+            AlertProblem::where('rule_id', $alertRule->id)->where('open', 1)
+                ->update(['open' => 0, 'state' => AlertState::RECOVERED]);
+            Alert::where('rule_id', $alertRule->id)
+                ->update(['state' => AlertState::CLEAR, 'open' => 0, 'alerted' => 0, 'open_problem_count' => 0]);
+        }
 
         return response()->json(['status' => $success ? 200 : 422], $success ? 200 : 422);
     }
@@ -161,6 +171,7 @@ class AlertRuleController extends Controller
             'proc',
             'notes',
             'invert_map',
+            'notify_per_entity',
         ]));
         $alertRule->disabled ??= false;
         $alertRule->builder = json_decode((string) $request->validated('builder_json', '[]'), true);

--- a/app/Http/Controllers/Device/Tabs/AlertsController.php
+++ b/app/Http/Controllers/Device/Tabs/AlertsController.php
@@ -51,7 +51,7 @@ class AlertsController implements DeviceTab
 
     public function name(): string
     {
-        return __('Alerts');
+        return __('Problems');
     }
 
     public function data(Device $device, Request $request): array

--- a/app/Http/Controllers/Table/AlertLogController.php
+++ b/app/Http/Controllers/Table/AlertLogController.php
@@ -83,6 +83,18 @@ class AlertLogController extends TableController
             ->with(['device', 'rule'])
             ->hasAccess($request->user());
 
+        $query->whereRaw('(
+            coalesce((select ar.notify_per_entity from alert_rules ar where ar.id = alert_log.rule_id), 0) = 1
+            or alert_log.problem_id is null
+            or alert_log.id = (
+                select min(al2.id) from alert_log al2
+                where al2.device_id = alert_log.device_id
+                  and al2.rule_id = alert_log.rule_id
+                  and al2.state = alert_log.state
+                  and al2.time_logged = alert_log.time_logged
+            )
+        )');
+
         $sort = $request->input('sort');
         if (isset($sort['severity']) || isset($sort['alert_rule'])) {
             $query->leftJoin('alert_rules', 'alert_log.rule_id', '=', 'alert_rules.id');
@@ -102,11 +114,38 @@ class AlertLogController extends TableController
      */
     public function formatItem(Model $model): array
     {
+        $details = is_array($model->details) ? $model->details : [];
+        $entity_count = 1;
+        if ($model->problem_id && $model->rule && ! $model->rule->notify_per_entity) {
+            $siblings = AlertLog::query()
+                ->where('device_id', $model->device_id)
+                ->where('rule_id', $model->rule_id)
+                ->where('state', $model->state->value)
+                ->where('time_logged', $model->time_logged)
+                ->whereNotNull('problem_id')
+                ->get(['id', 'details']);
+            $entity_count = $siblings->count();
+            if ($entity_count > 1) {
+                $rows = [];
+                foreach ($siblings as $sibling) {
+                    foreach ((array) ($sibling->details['rule'] ?? []) as $row) {
+                        $rows[] = $row;
+                    }
+                }
+                $details = ['rule' => $rows] + $details;
+            }
+        }
+
         $fault_detail = view('alerts.fault-detail', [
-            'details' => $this->parser->parse($model->details),
+            'details' => $this->parser->parse($details),
         ])->render();
 
         $status = Html::severityToLabel($model->state->asSeverity(), title: $model->state->name, class: 'alert-status');
+
+        $alert_rule = e($model->rule?->name);
+        if ($entity_count > 1) {
+            $alert_rule .= ' <span class="label label-default">' . $entity_count . '&times;</span>';
+        }
 
         return [
             'id' => $model->id,
@@ -114,7 +153,7 @@ class AlertLogController extends TableController
             'details' => '<a class="fa fa-plus incident-toggle" style="display:none" data-toggle="collapse" data-target="#incident' . $model->id . '" data-parent="#alerts"></a>',
             'verbose_details' => "<button type='button' class='btn btn-alert-details verbose-alert-details' style='display:none' aria-label='Details' id='alert-details' data-alert_log_id='$model->id'><i class='fa-solid fa-circle-info'></i></button>",
             'hostname' => '<div class="incident">' . Url::modernDeviceLink($model->device) . '<div id="incident' . $model->id . '" class="collapse">' . $fault_detail . '</div></div>',
-            'alert_rule' => e($model->rule?->name),
+            'alert_rule' => $alert_rule,
             'status' => $status,
             'severity' => $model->rule?->severity,
         ];

--- a/app/Http/Requests/AlertRuleRequest.php
+++ b/app/Http/Requests/AlertRuleRequest.php
@@ -61,6 +61,7 @@ class AlertRuleRequest extends FormRequest
             'mute' => ['sometimes', 'boolean'],
             'acknowledgement' => ['sometimes', 'boolean'],
             'invert_map' => ['sometimes', 'boolean'],
+            'notify_per_entity' => ['sometimes', 'boolean'],
 
             'maps' => ['sometimes', 'array'],
             'maps.*' => ['string'],
@@ -83,7 +84,7 @@ class AlertRuleRequest extends FormRequest
         ]);
 
         // Convert checkbox values ('on' string) to boolean
-        $this->merge(collect(['invert', 'recovery', 'mute', 'acknowledgement', 'invert_map', 'override_query'])
+        $this->merge(collect(['invert', 'recovery', 'mute', 'acknowledgement', 'invert_map', 'notify_per_entity', 'override_query'])
             ->mapWithKeys(fn ($field) => [$field => match ($this->input($field)) {
                 'on', '1', 1, true => true,
                 default => false

--- a/app/Models/Alert.php
+++ b/app/Models/Alert.php
@@ -31,6 +31,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use LibreNMS\Enum\AlertState;
 
 class Alert extends Model
@@ -98,6 +99,15 @@ class Alert extends Model
     public function rule(): BelongsTo
     {
         return $this->belongsTo(AlertRule::class, 'rule_id', 'id');
+    }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany<\App\Models\AlertProblem, $this>
+     */
+    public function problems(): HasMany
+    {
+        return $this->hasMany(AlertProblem::class, 'rule_id', 'rule_id')
+            ->where('alert_problems.device_id', $this->device_id);
     }
 
     /**

--- a/app/Models/AlertLog.php
+++ b/app/Models/AlertLog.php
@@ -33,4 +33,12 @@ class AlertLog extends DeviceRelatedModel
     {
         return $this->belongsTo(AlertRule::class, 'rule_id', 'id');
     }
+
+    /**
+     * @return BelongsTo<AlertProblem, $this>
+     */
+    public function problem(): BelongsTo
+    {
+        return $this->belongsTo(AlertProblem::class, 'problem_id', 'id');
+    }
 }

--- a/app/Models/AlertProblem.php
+++ b/app/Models/AlertProblem.php
@@ -63,6 +63,7 @@ class AlertProblem extends DeviceRelatedModel
 
     /**
      * @param  Builder<AlertProblem>  $query
+     * @return Builder<AlertProblem>
      */
     public function scopeOpen($query): Builder
     {
@@ -71,6 +72,7 @@ class AlertProblem extends DeviceRelatedModel
 
     /**
      * @param  Builder<AlertProblem>  $query
+     * @return Builder<AlertProblem>
      */
     public function scopeActive($query): Builder
     {
@@ -79,6 +81,7 @@ class AlertProblem extends DeviceRelatedModel
 
     /**
      * @param  Builder<AlertProblem>  $query
+     * @return Builder<AlertProblem>
      */
     public function scopeAcknowledged($query): Builder
     {
@@ -105,6 +108,8 @@ class AlertProblem extends DeviceRelatedModel
 
     /**
      * The entity this problem is about (Port, Sensor, Device, ...), resolved via the morph map.
+     *
+     * @return MorphTo<\Illuminate\Database\Eloquent\Model, $this>
      */
     public function entity(): MorphTo
     {

--- a/app/Models/AlertProblem.php
+++ b/app/Models/AlertProblem.php
@@ -1,0 +1,113 @@
+<?php
+
+/**
+ * app/Models/AlertProblem.php
+ *
+ * Model for access to alert_problems table data. A problem is a per-entity incident
+ * created when an alert rule matches; its state changes are recorded in alert_log.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * @link       https://www.librenms.org
+ */
+
+namespace App\Models;
+
+use App\Casts\CompressedJson;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+use LibreNMS\Enum\AlertState;
+
+/**
+ * @property int $id
+ * @property int $rule_id
+ * @property int $device_id
+ * @property string|null $entity_type
+ * @property int|null $entity_id
+ * @property string $entity_key
+ * @property int $state
+ * @property int $alerted
+ * @property int $open
+ * @property string|null $severity
+ * @property string|null $note
+ * @property array<string, mixed> $info
+ * @property array<string, mixed> $details
+ */
+class AlertProblem extends DeviceRelatedModel
+{
+    public $timestamps = false;
+    protected $table = 'alert_problems';
+
+    protected $casts = [
+        'info' => 'array',
+        'details' => CompressedJson::class,
+        'first_seen' => 'datetime',
+        'last_seen' => 'datetime',
+        'timestamp' => 'datetime',
+    ];
+
+    // ---- Query scopes ----
+
+    /**
+     * @param  Builder<AlertProblem>  $query
+     */
+    public function scopeOpen($query): Builder
+    {
+        return $query->where('open', 1);
+    }
+
+    /**
+     * @param  Builder<AlertProblem>  $query
+     */
+    public function scopeActive($query): Builder
+    {
+        return $query->where('state', AlertState::ACTIVE);
+    }
+
+    /**
+     * @param  Builder<AlertProblem>  $query
+     */
+    public function scopeAcknowledged($query): Builder
+    {
+        return $query->where('state', AlertState::ACKNOWLEDGED);
+    }
+
+    // ---- Define Relationships ----
+
+    /**
+     * @return BelongsTo<AlertRule, $this>
+     */
+    public function rule(): BelongsTo
+    {
+        return $this->belongsTo(AlertRule::class, 'rule_id', 'id');
+    }
+
+    /**
+     * @return HasMany<AlertLog, $this>
+     */
+    public function logs(): HasMany
+    {
+        return $this->hasMany(AlertLog::class, 'problem_id');
+    }
+
+    /**
+     * The entity this problem is about (Port, Sensor, Device, ...), resolved via the morph map.
+     */
+    public function entity(): MorphTo
+    {
+        return $this->morphTo('entity', 'entity_type', 'entity_id');
+    }
+}

--- a/app/Models/AlertRule.php
+++ b/app/Models/AlertRule.php
@@ -45,6 +45,7 @@ use LibreNMS\Enum\AlertState;
  * @property string $query
  * @property array<string, mixed>|null $builder
  * @property bool|int $invert_map
+ * @property bool|int $notify_per_entity
  * @property int|null $alert_operation_id
  * @property AlertOperation|null $alertOperation
  */
@@ -59,6 +60,7 @@ class AlertRule extends BaseModel
         static::deleting(function (AlertRule $rule): void {
             $rule->alerts()->delete();
             $rule->logs()->delete();
+            AlertProblem::where('rule_id', $rule->id)->delete();
             $rule->templateMaps()->delete();
 
             $rule->devices()->detach();
@@ -77,6 +79,7 @@ class AlertRule extends BaseModel
         'query',
         'builder',
         'invert_map',
+        'notify_per_entity',
         'alert_operation_id',
     ];
 
@@ -84,6 +87,7 @@ class AlertRule extends BaseModel
         'builder' => 'array',
         'extra' => 'array',
         'alert_operation_id' => 'integer',
+        'notify_per_entity' => 'boolean',
     ];
 
     // ---- Query scopes ----

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -116,6 +116,14 @@ class AppServiceProvider extends ServiceProvider
             'device' => \App\Models\Device::class,
             'device_group' => \App\Models\DeviceGroup::class,
             'location' => \App\Models\Location::class,
+            'bgppeer' => \App\Models\BgpPeer::class,
+            'service' => \App\Models\Service::class,
+            'mempool' => \App\Models\Mempool::class,
+            'processor' => \App\Models\Processor::class,
+            'storage' => \App\Models\Storage::class,
+            'application' => \App\Models\Application::class,
+            'accesspoint' => \App\Models\AccessPoint::class,
+            'bill' => \App\Models\Bill::class,
         ], $sensor_types));
     }
 

--- a/database/migrations/2026_06_02_120000_create_alert_problems_table.php
+++ b/database/migrations/2026_06_02_120000_create_alert_problems_table.php
@@ -1,0 +1,149 @@
+<?php
+
+/**
+ * Adds the alert_problems table plus supporting columns on alert_log (problem_id),
+ * alert_rules (notify_per_entity) and alerts (open_problem_count), then backfills one
+ * open problem per currently active alert.
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use LibreNMS\Enum\AlertState;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $this->createProblemsTable();
+        $this->addSupportingColumns();
+        $this->backfillProblems();
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('alert_problems');
+
+        if (Schema::hasColumn('alert_log', 'problem_id')) {
+            Schema::table('alert_log', function (Blueprint $table) {
+                $table->dropIndex('alert_log_problem_id_index');
+                $table->dropColumn('problem_id');
+            });
+        }
+
+        if (Schema::hasColumn('alert_rules', 'notify_per_entity')) {
+            Schema::table('alert_rules', function (Blueprint $table) {
+                $table->dropColumn('notify_per_entity');
+            });
+        }
+
+        if (Schema::hasColumn('alerts', 'open_problem_count')) {
+            Schema::table('alerts', function (Blueprint $table) {
+                $table->dropColumn('open_problem_count');
+            });
+        }
+    }
+
+    private function createProblemsTable(): void
+    {
+        if (Schema::hasTable('alert_problems')) {
+            return;
+        }
+
+        Schema::create('alert_problems', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('rule_id');
+            $table->unsignedInteger('device_id');
+            $table->string('entity_type', 64)->nullable();
+            $table->unsignedBigInteger('entity_id')->nullable();
+            $table->string('entity_key', 255)->default('');
+            $table->integer('state')->default(AlertState::ACTIVE);
+            $table->integer('alerted')->default(0);
+            $table->integer('open')->default(1);
+            $table->string('severity', 16)->nullable();
+            $table->text('note')->nullable();
+            $table->text('info')->nullable();
+            $table->binary('details')->nullable();
+            $table->timestamp('first_seen')->nullable();
+            $table->timestamp('last_seen')->nullable();
+            $table->timestamp('timestamp')->useCurrent();
+
+            $table->index(['rule_id', 'device_id', 'entity_key']);
+            $table->index(['entity_type', 'entity_id']);
+            $table->index(['device_id', 'open']);
+            $table->index('state');
+        });
+
+        if (\LibreNMS\DB\Eloquent::getDriver() == 'mysql') {
+            DB::statement('ALTER TABLE `alert_problems` CHANGE `details` `details` longblob NULL ;');
+        }
+    }
+
+    private function addSupportingColumns(): void
+    {
+        if (! Schema::hasColumn('alert_log', 'problem_id')) {
+            Schema::table('alert_log', function (Blueprint $table) {
+                $table->unsignedInteger('problem_id')->nullable()->after('device_id');
+                $table->index('problem_id');
+            });
+        }
+
+        if (! Schema::hasColumn('alert_rules', 'notify_per_entity')) {
+            Schema::table('alert_rules', function (Blueprint $table) {
+                $table->boolean('notify_per_entity')->default(false)->after('invert_map');
+            });
+        }
+
+        if (! Schema::hasColumn('alerts', 'open_problem_count')) {
+            Schema::table('alerts', function (Blueprint $table) {
+                $table->unsignedInteger('open_problem_count')->default(0)->after('open');
+            });
+        }
+    }
+
+    private function backfillProblems(): void
+    {
+        if (! Schema::hasTable('alerts')) {
+            return;
+        }
+
+        // Active states that should carry an open problem after the upgrade.
+        $activeStates = [AlertState::ACTIVE, AlertState::ACKNOWLEDGED, AlertState::WORSE, AlertState::BETTER, AlertState::CHANGED];
+
+        foreach (DB::table('alerts')->whereIn('state', $activeStates)->orderBy('id')->get() as $alert) {
+            // Problems only carry ACTIVE/ACKNOWLEDGED/RECOVERED; collapse worse/better/changed to active.
+            $problemState = (int) $alert->state === AlertState::ACKNOWLEDGED ? AlertState::ACKNOWLEDGED : AlertState::ACTIVE;
+
+            $latestLog = DB::table('alert_log')
+                ->where('rule_id', $alert->rule_id)
+                ->where('device_id', $alert->device_id)
+                ->orderByDesc('id')
+                ->first(['id', 'details', 'time_logged']);
+
+            $problemId = DB::table('alert_problems')->insertGetId([
+                'rule_id' => $alert->rule_id,
+                'device_id' => $alert->device_id,
+                'entity_type' => null,
+                'entity_id' => null,
+                'entity_key' => '',
+                'state' => $problemState,
+                'alerted' => (int) ($alert->alerted ?? 0),
+                'open' => 1,
+                'severity' => null,
+                'note' => $alert->note ?? null,
+                'info' => $alert->info ?? null,
+                'details' => $latestLog->details ?? null,
+                'first_seen' => $latestLog->time_logged ?? $alert->timestamp,
+                'last_seen' => $alert->timestamp,
+                'timestamp' => $alert->timestamp,
+            ]);
+
+            if ($latestLog !== null) {
+                DB::table('alert_log')->where('id', $latestLog->id)->update(['problem_id' => $problemId]);
+            }
+
+            DB::table('alerts')->where('id', $alert->id)->update(['open_problem_count' => 1]);
+        }
+    }
+};

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -1603,7 +1603,7 @@ function list_alerts(Illuminate\Http\Request $request): JsonResponse
 {
     $id = $request->route('id');
 
-    $sql = 'SELECT `D`.`hostname`, `A`.*, `R`.`severity`,`R`.`name`,`R`.`proc`,`R`.`notes` FROM `alerts` AS `A`, `devices` AS `D`, `alert_rules` AS `R` WHERE `D`.`device_id` = `A`.`device_id` AND `A`.`rule_id` = `R`.`id` ';
+    $sql = 'SELECT `D`.`hostname`, `A`.*, `R`.`severity`,`R`.`name`,`R`.`proc`,`R`.`notes` FROM `alert_problems` AS `A`, `devices` AS `D`, `alert_rules` AS `R` WHERE `D`.`device_id` = `A`.`device_id` AND `A`.`rule_id` = `R`.`id` ';
     $sql .= 'AND `A`.`state` IN ';
     if ($request->has('state')) {
         $param = explode(',', (string) $request->input('state'));
@@ -1637,7 +1637,7 @@ function list_alerts(Illuminate\Http\Request $request): JsonResponse
 
     if ($request->has('order')) {
         [$sort_column, $sort_order] = explode(' ', (string) $request->input('order'), 2);
-        validate_column_list($sort_column, 'alerts');
+        validate_column_list($sort_column, 'alert_problems');
         if (in_array($sort_order, ['asc', 'desc'])) {
             $order = $request->input('order');
         }
@@ -1929,6 +1929,10 @@ function add_edit_rule(Illuminate\Http\Request $request)
         $saveData['invert_map'] = filter_var($data['invert_map'], FILTER_VALIDATE_BOOLEAN);
     }
 
+    if (array_key_exists('notify_per_entity', $data)) {
+        $saveData['notify_per_entity'] = filter_var($data['notify_per_entity'], FILTER_VALIDATE_BOOLEAN);
+    }
+
     if (is_numeric($rule_id)) {
         $alertRule = \App\Models\AlertRule::find($rule_id);
         if (! $alertRule) {
@@ -1988,24 +1992,40 @@ function delete_rule(Illuminate\Http\Request $request)
 
 function ack_alert(Illuminate\Http\Request $request)
 {
-    $alert_id = $request->route('id');
+    $problem_id = $request->route('id');
     $data = json_decode($request->getContent(), true);
 
-    if (! is_numeric($alert_id)) {
-        return api_error(400, 'Invalid alert has been provided');
+    if (! is_numeric($problem_id)) {
+        return api_error(400, 'Invalid problem has been provided');
     }
 
-    $alert = dbFetchRow('SELECT note, info FROM alerts WHERE id=?', [$alert_id]);
-    $note = $alert['note'];
-    $info = json_decode((string) $alert['info'], true);
-    if (! empty($note)) {
-        $note .= PHP_EOL;
+    $problem = dbFetchRow('SELECT `ap`.`rule_id`, `ap`.`device_id`, `r`.`notify_per_entity` FROM `alert_problems` `ap` JOIN `alert_rules` `r` ON `r`.`id` = `ap`.`rule_id` WHERE `ap`.`id` = ?', [$problem_id]);
+    if (empty($problem)) {
+        return api_success_noresult(200, 'No Alert by that ID');
     }
-    $note .= date(LibrenmsConfig::get('dateformat.long')) . ' - Ack (' . Auth::user()->username . ") {$data['note']}";
-    $info['until_clear'] = $data['until_clear'];
-    $info = json_encode($info);
 
-    if (dbUpdate(['state' => 2, 'note' => $note, 'info' => $info], 'alerts', '`id` = ? LIMIT 1', [$alert_id])) {
+    if (empty($problem['notify_per_entity'])) {
+        $targets = dbFetchRows('SELECT id, note, info FROM alert_problems WHERE device_id = ? AND rule_id = ? AND open = 1', [$problem['device_id'], $problem['rule_id']]);
+    } else {
+        $targets = dbFetchRows('SELECT id, note, info FROM alert_problems WHERE id = ?', [$problem_id]);
+    }
+
+    $updated = false;
+    foreach ($targets as $target) {
+        $note = $target['note'];
+        $info = json_decode((string) $target['info'], true) ?: [];
+        if (! empty($note)) {
+            $note .= PHP_EOL;
+        }
+        $note .= date(LibrenmsConfig::get('dateformat.long')) . ' - Ack (' . Auth::user()->username . ") {$data['note']}";
+        $info['until_clear'] = $data['until_clear'];
+
+        if (dbUpdate(['state' => 2, 'note' => $note, 'info' => json_encode($info)], 'alert_problems', '`id` = ? LIMIT 1', [$target['id']])) {
+            $updated = true;
+        }
+    }
+
+    if ($updated) {
         return api_success_noresult(200, 'Alert has been acknowledged');
     } else {
         return api_success_noresult(200, 'No Alert by that ID');
@@ -2014,22 +2034,38 @@ function ack_alert(Illuminate\Http\Request $request)
 
 function unmute_alert(Illuminate\Http\Request $request)
 {
-    $alert_id = $request->route('id');
+    $problem_id = $request->route('id');
     $data = json_decode($request->getContent(), true);
 
-    if (! is_numeric($alert_id)) {
-        return api_error(400, 'Invalid alert has been provided');
+    if (! is_numeric($problem_id)) {
+        return api_error(400, 'Invalid problem has been provided');
     }
 
-    $alert = dbFetchRow('SELECT note, info FROM alerts WHERE id=?', [$alert_id]);
-    $note = $alert['note'];
-
-    if (! empty($note)) {
-        $note .= PHP_EOL;
+    $problem = dbFetchRow('SELECT `ap`.`rule_id`, `ap`.`device_id`, `r`.`notify_per_entity` FROM `alert_problems` `ap` JOIN `alert_rules` `r` ON `r`.`id` = `ap`.`rule_id` WHERE `ap`.`id` = ?', [$problem_id]);
+    if (empty($problem)) {
+        return api_success_noresult(200, 'No alert by that ID');
     }
-    $note .= date(LibrenmsConfig::get('dateformat.long')) . ' - Ack (' . Auth::user()->username . ") {$data['note']}";
 
-    if (dbUpdate(['state' => 1, 'note' => $note], 'alerts', '`id` = ? LIMIT 1', [$alert_id])) {
+    if (empty($problem['notify_per_entity'])) {
+        $targets = dbFetchRows('SELECT id, note FROM alert_problems WHERE device_id = ? AND rule_id = ? AND open = 1', [$problem['device_id'], $problem['rule_id']]);
+    } else {
+        $targets = dbFetchRows('SELECT id, note FROM alert_problems WHERE id = ?', [$problem_id]);
+    }
+
+    $updated = false;
+    foreach ($targets as $target) {
+        $note = $target['note'];
+        if (! empty($note)) {
+            $note .= PHP_EOL;
+        }
+        $note .= date(LibrenmsConfig::get('dateformat.long')) . ' - Ack (' . Auth::user()->username . ") {$data['note']}";
+
+        if (dbUpdate(['state' => 1, 'note' => $note], 'alert_problems', '`id` = ? LIMIT 1', [$target['id']])) {
+            $updated = true;
+        }
+    }
+
+    if ($updated) {
         return api_success_noresult(200, 'Alert has been unmuted');
     } else {
         return api_success_noresult(200, 'No alert by that ID');

--- a/includes/html/forms/alert-notes.inc.php
+++ b/includes/html/forms/alert-notes.inc.php
@@ -24,6 +24,7 @@
  * @author     Neil Lathwood <gh+n@laf.io>
  */
 use App\Models\Alert;
+use App\Models\AlertProblem;
 use Illuminate\Support\Facades\Gate;
 
 header('Content-type: application/json');
@@ -32,7 +33,7 @@ $alert_id = $vars['alert_id'] ?? null;
 $sub_type = $vars['sub_type'] ?? '';
 $note = isset($vars['note']) ? strip_tags($vars['note']) : '';
 
-if (! is_numeric($alert_id) || ! ($alert = Alert::find($alert_id))) {
+if (! is_numeric($alert_id) || ! ($problem = AlertProblem::find($alert_id))) {
     abort(response()->json([
         'status' => 'error',
         'message' => 'Invalid alert id',
@@ -40,8 +41,9 @@ if (! is_numeric($alert_id) || ! ($alert = Alert::find($alert_id))) {
     ]));
 }
 
+$alert = Alert::query()->where('rule_id', $problem->rule_id)->where('device_id', $problem->device_id)->first();
 $ability = $sub_type === 'get_note' ? 'view' : 'update';
-if (Gate::denies($ability, $alert)) {
+if (! $alert || Gate::denies($ability, $alert)) {
     abort(response()->json([
         'status' => 'error',
         'message' => 'You are not authorised to access this alert',
@@ -52,10 +54,13 @@ if (Gate::denies($ability, $alert)) {
 if ($sub_type === 'get_note') {
     $status = 'ok';
     $message = 'Alert note retrieved';
-    $note = (string) $alert->note;
+    $note = (string) $problem->note;
 } else {
-    $alert->note = $note;
-    if ($alert->save()) {
+    $query = $problem->rule?->notify_per_entity
+        ? AlertProblem::whereKey($problem->id)
+        : AlertProblem::where('rule_id', $problem->rule_id)->where('device_id', $problem->device_id)->where('open', 1);
+
+    if ($query->update(['note' => $note])) {
         $status = 'ok';
         $message = 'Note updated';
     } else {

--- a/includes/html/modal/alert_ack.inc.php
+++ b/includes/html/modal/alert_ack.inc.php
@@ -58,7 +58,7 @@ use App\Facades\LibrenmsConfig;
         var ack_until_clear = $("#ack_until_clear").bootstrapSwitch('state');
         $.ajax({
             type: "POST",
-            url: '<?php echo route('alert.ack', ['alert' => ':alert_id']) ?>'.replace(':alert_id', ack_alert_id),
+            url: '<?php echo route('alert.ack', ['problem' => ':alert_id']) ?>'.replace(':alert_id', ack_alert_id),
             dataType: "json",
             data: { state: ack_alert_state, ack_msg: ack_alert_note, ack_until_clear: ack_until_clear },
             success: function (data) {

--- a/includes/html/modal/new_alert_rule.inc.php
+++ b/includes/html/modal/new_alert_rule.inc.php
@@ -104,6 +104,12 @@ $default_invert_map = LibrenmsConfig::get('alert_rule.invert_map');
                                         <input type='checkbox' name='acknowledgement' id='acknowledgement'>
                                     </div>
                                 </div>
+                                <div class="form-group form-inline">
+                                    <label for='notify_per_entity' class='col-sm-3 col-md-2 control-label' title="Send a separate notification per matching entity (e.g. each port) instead of one grouped notification.">Notify per matching entity </label>
+                                    <div class='col-sm-2' title="Send a separate notification per matching entity (e.g. each port) instead of one grouped notification.">
+                                        <input type='checkbox' name='notify_per_entity' id='notify_per_entity'>
+                                    </div>
+                                </div>
                                 <div class="form-group">
                                     <label for="alert_operation_id" class="col-sm-3 col-md-2 control-label" title="Notification behaviour (escalation, transports). Configure under Alerts → Operations.">Operation </label>
                                     <div class="col-sm-9 col-md-10">
@@ -334,6 +340,7 @@ $default_invert_map = LibrenmsConfig::get('alert_rule.invert_map');
                 $("#acknowledgement").bootstrapSwitch('state', <?=$default_acknowledgement_alerts?>);
                 $("#override_query").bootstrapSwitch('state', false);
                 $("#invert_map").bootstrapSwitch('state', <?=$default_invert_map?>);
+                $("#notify_per_entity").bootstrapSwitch('state', false);
                 $(this).find("input[type=text]").val("");
                 $('#adv_query').val('');
                 $('#notes').val('');
@@ -405,6 +412,8 @@ $default_invert_map = LibrenmsConfig::get('alert_rule.invert_map');
                 }else{
                     $("[name='invert_map']").bootstrapSwitch('state', false);
                 }
+
+                $("[name='notify_per_entity']").bootstrapSwitch('state', rule.notify_per_entity == 1 || rule.notify_per_entity === true);
 
                 $("[name='override_query']").bootstrapSwitch('state', extra.options.override_query);
             }

--- a/includes/html/pages/alerts.inc.php
+++ b/includes/html/pages/alerts.inc.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the

--- a/includes/html/pages/alerts.inc.php
+++ b/includes/html/pages/alerts.inc.php
@@ -13,22 +13,5 @@
  * @author     LibreNMS Contributors
 */
 
-$no_refresh = true;
-$page_title = 'Alerts';
-?>
-
-<div class="panel panel-default panel-condensed">
-    <div class="panel-heading">
-        <strong>Alerts</strong>
-    </div>
-
-    <?php
-    $device['device_id'] = '-1';
-    require_once 'includes/html/modal/alert_details.php';
-    require_once 'includes/html/modal/alert_notes.inc.php';
-    require_once 'includes/html/modal/alert_ack.inc.php';
-    require_once 'includes/html/common/alerts.inc.php';
-    echo implode('', $common_output);
-    unset($device['device_id']);
-    ?>
-</div>
+// Backwards-compatible alias: the alerts page is now the Problems page.
+require 'includes/html/pages/problems.inc.php';

--- a/includes/html/pages/problems.inc.php
+++ b/includes/html/pages/problems.inc.php
@@ -1,0 +1,34 @@
+<?php
+/*
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.  Please see LICENSE.txt at the top level of
+ * the source code distribution for details.
+ *
+ * @package    LibreNMS
+ * @subpackage webui
+ * @link       https://www.librenms.org
+ * @copyright  2017 LibreNMS
+ * @author     LibreNMS Contributors
+*/
+
+$no_refresh = true;
+$page_title = 'Problems';
+?>
+
+<div class="panel panel-default panel-condensed">
+    <div class="panel-heading">
+        <strong>Problems</strong>
+    </div>
+
+    <?php
+    $device['device_id'] = '-1';
+    require_once 'includes/html/modal/alert_details.php';
+    require_once 'includes/html/modal/alert_notes.inc.php';
+    require_once 'includes/html/modal/alert_ack.inc.php';
+    require_once 'includes/html/common/alerts.inc.php';
+    echo implode('', $common_output);
+    unset($device['device_id']);
+    ?>
+</div>

--- a/includes/html/table/alerts.inc.php
+++ b/includes/html/table/alerts.inc.php
@@ -17,7 +17,7 @@
 use Illuminate\Support\Facades\Gate;
 use LibreNMS\Util\Time;
 
-$where = ' `devices`.`disabled` = 0';
+$where = ' `devices`.`disabled` = 0 AND `alert_rules`.`disabled` = 0 AND `alerts`.`open` = 1';
 $param = [];
 $alert_states = [
     // divined from librenms/alerts.php
@@ -88,7 +88,9 @@ if (! empty($searchPhrase)) {
     $param[] = "%$searchPhrase%";
 }
 
-$sql = ' FROM `alerts` LEFT JOIN `devices` ON `alerts`.`device_id`=`devices`.`device_id`';
+$where .= ' AND (`alert_rules`.`notify_per_entity` = 1 OR `alerts`.`id` = (SELECT MIN(`p2`.`id`) FROM `alert_problems` `p2` WHERE `p2`.`device_id` = `alerts`.`device_id` AND `p2`.`rule_id` = `alerts`.`rule_id` AND `p2`.`open` = 1 AND `p2`.`state` != ' . $alert_states['recovered'] . '))';
+
+$sql = ' FROM `alert_problems` AS `alerts` LEFT JOIN `devices` ON `alerts`.`device_id`=`devices`.`device_id`';
 
 if (Gate::denies('viewAll', \App\Models\Alert::class)) {
     $device_ids = Permissions::devicesForUser()->toArray() ?: [0];
@@ -123,12 +125,27 @@ if ($rowCount != -1) {
     $sql .= " LIMIT $limit_low,$limit_high";
 }
 
-$sql = "SELECT `alerts`.*, `devices`.`hostname`, `devices`.`sysName`, `devices`.`display`, `devices`.`os`, `devices`.`hardware`, `locations`.`location`, `alert_rules`.`name`, `alert_rules`.`severity`, `alert_rules`.`builder` $sql";
+$sql = "SELECT `alerts`.*, `devices`.`hostname`, `devices`.`sysName`, `devices`.`display`, `devices`.`os`, `devices`.`hardware`, `locations`.`location`, `alert_rules`.`name`, `alert_rules`.`severity`, `alert_rules`.`builder`, `alert_rules`.`notify_per_entity` $sql";
 
 $rulei = 0;
 foreach (dbFetchRows($sql, $param) as $alert) {
-    $log = dbFetchCell('SELECT details FROM alert_log WHERE rule_id = ? AND device_id = ? ORDER BY id DESC LIMIT 1', [$alert['rule_id'], $alert['device_id']]);
-    $alert_log_id = dbFetchCell('SELECT id FROM alert_log WHERE rule_id = ? AND device_id = ? ORDER BY id DESC LIMIT 1', [$alert['rule_id'], $alert['device_id']]);
+    $log = $alert['details']; // problems carry their current fault detail directly
+
+    $entity_count = 1;
+    if (empty($alert['notify_per_entity'])) {
+        $grouped_rows = [];
+        $grouped_problems = dbFetchRows('SELECT `details` FROM `alert_problems` WHERE `device_id` = ? AND `rule_id` = ? AND `open` = 1 AND `state` != ?', [$alert['device_id'], $alert['rule_id'], $alert_states['recovered']]);
+        $entity_count = count($grouped_problems);
+        foreach ($grouped_problems as $grouped_problem) {
+            $grouped_detail = json_decode(@gzuncompress($grouped_problem['details']), true) ?: [];
+            foreach (($grouped_detail['rule'] ?? []) as $grouped_fault) {
+                $grouped_rows[] = $grouped_fault;
+            }
+        }
+        $log = gzcompress(json_encode(['rule' => $grouped_rows]), 9);
+    }
+
+    $alert_log_id = dbFetchCell('SELECT id FROM alert_log WHERE problem_id = ? ORDER BY id DESC LIMIT 1', [$alert['id']]);
     [$fault_detail, $max_row_length] = alert_details($log);
     $info = json_decode((string) $alert['info'], true);
 
@@ -177,7 +194,7 @@ foreach (dbFetchRows($sql, $param) as $alert) {
         $severity_ico = '<span class="alert-status label-primary">&nbsp;</span>';
     }
 
-    $proc = dbFetchCell('SELECT proc FROM alerts,alert_rules WHERE alert_rules.id = alerts.rule_id AND alerts.id = ?', [$alert['id']]);
+    $proc = dbFetchCell('SELECT proc FROM alert_problems,alert_rules WHERE alert_rules.id = alert_problems.rule_id AND alert_problems.id = ?', [$alert['id']]);
     if (($proc == '') || ($proc == 'NULL')) {
         $has_proc = '';
     } else {
@@ -196,7 +213,7 @@ foreach (dbFetchRows($sql, $param) as $alert) {
 
     $response[] = [
         'id' => $rulei++,
-        'rule' => '<i title="' . htmlentities((string) $alert['builder']) . '"><a href="' . \LibreNMS\Util\Url::generate(['page' => 'alert-rules']) . '">' . htmlentities((string) $alert['name']) . '</a></i>',
+        'rule' => '<i title="' . htmlentities((string) $alert['builder']) . '"><a href="' . \LibreNMS\Util\Url::generate(['page' => 'alert-rules']) . '">' . htmlentities((string) $alert['name']) . '</a></i>' . ($entity_count > 1 ? ' <span class="label label-default" title="' . $entity_count . ' matching entities grouped into this alert">' . $entity_count . '&times;</span>' : ''),
         'details' => '<a class="fa-solid fa-plus incident-toggle" style="display:none" data-toggle="collapse" data-target="#incident' . $alert['id'] . '" data-parent="#alerts"></a>',
         'verbose_details' => "<button type='button' class='btn btn-alert-details command-alert-details' aria-label='Details' id='alert-details' data-alert_log_id='{$alert_log_id}'><i class='fa-solid fa-circle-info'></i></button>",
         'hostname' => $hostname,

--- a/resources/views/layouts/menu.blade.php
+++ b/resources/views/layouts/menu.blade.php
@@ -601,8 +601,8 @@
                             class="fa fa-exclamation-circle text-{{ $alert_menu_class }} fa-fw fa-lg"
                             aria-hidden="true"></i> <span class="tw:md:hidden tw:2xl:inline-block">{{ __('Alerts') }}</span></a>
                     <ul class="dropdown-menu">
-                        <li><a href="{{ url('alerts') }}"><i class="fa fa-bell fa-fw fa-lg"
-                                                             aria-hidden="true"></i> {{ __('Notifications') }}</a></li>
+                        <li><a href="{{ url('problems') }}"><i class="fa fa-bell fa-fw fa-lg"
+                                                             aria-hidden="true"></i> {{ __('Problems') }}</a></li>
                         <li><a href="{{ url('alert-log') }}"><i class="fa fa-file-text fa-fw fa-lg"
                                                                 aria-hidden="true"></i> {{ __('Alert History') }}</a></li>
                         <li><a href="{{ url('alert-stats') }}"><i class="fa fa-bar-chart fa-fw fa-lg"

--- a/routes/api.php
+++ b/routes/api.php
@@ -37,6 +37,8 @@ Route::prefix('v0')->group(function (): void {
         Route::get('portgroups/{group}', [App\Api\Controllers\LegacyApiController::class, 'get_graph_by_portgroup'])->name('get_graph_by_portgroup');
         Route::get('alerts/{id}', [App\Api\Controllers\LegacyApiController::class, 'list_alerts'])->name('get_alert');
         Route::get('alerts', [App\Api\Controllers\LegacyApiController::class, 'list_alerts'])->name('list_alerts');
+        Route::get('problems/{id}', [App\Api\Controllers\LegacyApiController::class, 'list_alerts'])->name('get_problem');
+        Route::get('problems', [App\Api\Controllers\LegacyApiController::class, 'list_alerts'])->name('list_problems');
         Route::get('rules/{id}', [App\Api\Controllers\LegacyApiController::class, 'list_alert_rules'])->name('get_alert_rule');
         Route::get('rules', [App\Api\Controllers\LegacyApiController::class, 'list_alert_rules'])->name('list_alert_rules');
         Route::get('routing/vrf/{id}', [App\Api\Controllers\LegacyApiController::class, 'get_vrf'])->name('get_vrf');
@@ -86,6 +88,8 @@ Route::prefix('v0')->group(function (): void {
         Route::delete('bills/{bill_id}', [App\Api\Controllers\LegacyApiController::class, 'delete_bill'])->name('delete_bill');
         Route::put('alerts/{id}', [App\Api\Controllers\LegacyApiController::class, 'ack_alert'])->name('ack_alert');
         Route::put('alerts/unmute/{id}', [App\Api\Controllers\LegacyApiController::class, 'unmute_alert'])->name('unmute_alert');
+        Route::put('problems/{id}', [App\Api\Controllers\LegacyApiController::class, 'ack_alert'])->name('ack_problem');
+        Route::put('problems/unmute/{id}', [App\Api\Controllers\LegacyApiController::class, 'unmute_alert'])->name('unmute_problem');
         Route::post('alert_templates', [App\Api\Controllers\LegacyApiController::class, 'add_edit_alert_template'])->name('add_alert_template');
         Route::put('alert_templates', [App\Api\Controllers\LegacyApiController::class, 'add_edit_alert_template'])->name('edit_alert_template');
         // Route::delete('alert_templates/{id}', [App\Api\Controllers\LegacyApiController::class, 'delete_alert_template'])->name('delete_alert_template');

--- a/routes/web.php
+++ b/routes/web.php
@@ -94,7 +94,8 @@ Route::get('graph/{path?}', GraphController::class)
 // WebUI
 Route::middleware(['auth'])->group(function (): void {
     // pages
-    Route::post('alert/{alert}/ack', [AlertController::class, 'ack'])->name('alert.ack');
+    Route::post('alert/{problem}/ack', [AlertController::class, 'ack'])->name('alert.ack');
+    Route::post('problem/{problem}/ack', [AlertController::class, 'ack'])->name('problem.ack');
     Route::get('devices/{view?}/{graph?}/{vars?}', [DevicesController::class, 'index'])->where('vars', '.*')->name('devices');
     Route::resource('device-groups', DeviceGroupController::class);
     Route::any('inventory', App\Http\Controllers\InventoryController::class)->name('inventory');

--- a/tests/AlertingTest.php
+++ b/tests/AlertingTest.php
@@ -26,6 +26,7 @@
 
 namespace LibreNMS\Tests;
 
+use LibreNMS\Alert\AlertUtil;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use RegexIterator;
@@ -39,6 +40,48 @@ final class AlertingTest extends TestCase
         foreach ($rules as $rule) {
             $this->assertIsArray($rule);
         }
+    }
+
+    public function testExtractIdFieldsForFault(): void
+    {
+        $fields = AlertUtil::extractIdFieldsForFault([
+            'id' => 9,
+            'port_id' => 5,
+            'device_id' => 1,
+            'location_id' => 2,
+            'ifName' => 'eth0',
+        ]);
+
+        $this->assertContains('id', $fields);
+        $this->assertContains('port_id', $fields);
+        $this->assertContains('device_id', $fields);
+        // location_id is intentionally excluded, and non-id fields are not considered.
+        $this->assertNotContains('location_id', $fields);
+        $this->assertNotContains('ifName', $fields);
+    }
+
+    public function testGenerateComparisonKeyForFault(): void
+    {
+        $row = ['device_id' => 1, 'port_id' => 5, 'ifName' => 'eth0'];
+        $key = AlertUtil::generateComparisonKeyForFault($row, AlertUtil::extractIdFieldsForFault($row));
+
+        // The same entity always yields the same dedupe key, distinct from other ports.
+        $this->assertSame('1|5', $key);
+        $this->assertNotSame($key, AlertUtil::generateComparisonKeyForFault(
+            ['device_id' => 1, 'port_id' => 6],
+            AlertUtil::extractIdFieldsForFault(['device_id' => 1, 'port_id' => 6])
+        ));
+    }
+
+    public function testEntityForFault(): void
+    {
+        // Known columns map to the registered morph aliases.
+        $this->assertSame(['interface', 5], AlertUtil::entityForFault(['device_id' => 1, 'port_id' => 5]));
+        $this->assertSame(['sensor', 9], AlertUtil::entityForFault(['device_id' => 1, 'sensor_id' => 9]));
+        // Unknown *_id columns fall back to the stripped column name.
+        $this->assertSame(['bgpPeer', 7], AlertUtil::entityForFault(['device_id' => 1, 'bgpPeer_id' => 7]));
+        // A device-level row (no entity id) resolves to no specific entity.
+        $this->assertSame([null, null], AlertUtil::entityForFault(['device_id' => 1, 'ifName' => 'eth0']));
     }
 
     public function testTransports(): void

--- a/tests/Feature/AlertRulesTest.php
+++ b/tests/Feature/AlertRulesTest.php
@@ -4,6 +4,7 @@ namespace LibreNMS\Tests\Feature;
 
 use App\Models\Alert;
 use App\Models\AlertLog;
+use App\Models\AlertProblem;
 use App\Models\AlertRule;
 use App\Models\Device;
 use Illuminate\Support\Carbon;
@@ -136,15 +137,23 @@ class AlertRulesTest extends TestCase
             'state' => AlertState::ACTIVE,
             'open' => 1,
             'alerted' => 0,
+            'open_problem_count' => 1,
             'info' => [],
         ]);
 
-        $log = AlertLog::create([
-            'device_id' => $device->device_id,
+        AlertProblem::create([
             'rule_id' => $rule->id,
+            'device_id' => $device->device_id,
+            'entity_key' => (string) $device->device_id,
             'state' => AlertState::ACTIVE,
+            'open' => 1,
+            'alerted' => 0,
             'details' => ['old' => 'data'],
         ]);
+
+        $logCount = AlertLog::where('device_id', $device->device_id)
+            ->where('rule_id', $rule->id)
+            ->count();
 
         $alertRules = new AlertRules($device);
         $alertRules->run();
@@ -156,10 +165,15 @@ class AlertRulesTest extends TestCase
             'state' => AlertState::ACTIVE,
         ]);
 
-        // AlertLog should be updated with new details (contacts and rule)
-        $updatedLog = AlertLog::find($log->id);
-        $this->assertArrayHasKey('contacts', $updatedLog->details);
-        $this->assertArrayHasKey('rule', $updatedLog->details);
+        $this->assertEquals($logCount, AlertLog::where('device_id', $device->device_id)
+            ->where('rule_id', $rule->id)
+            ->count());
+
+        $problem = AlertProblem::where('device_id', $device->device_id)
+            ->where('rule_id', $rule->id)
+            ->first();
+        $this->assertArrayHasKey('contacts', $problem->details);
+        $this->assertArrayHasKey('rule', $problem->details);
     }
 
     public function testRunRulesSkipsAcknowledgedAlert(): void
@@ -207,7 +221,18 @@ class AlertRulesTest extends TestCase
             'state' => AlertState::ACTIVE,
             'open' => 1,
             'alerted' => 0,
+            'open_problem_count' => 1,
             'info' => [],
+        ]);
+
+        AlertProblem::create([
+            'rule_id' => $rule->id,
+            'device_id' => $device->device_id,
+            'entity_key' => (string) $device->device_id,
+            'state' => AlertState::ACTIVE,
+            'open' => 1,
+            'alerted' => 0,
+            'details' => ['old' => 'data'],
         ]);
 
         $alertRules = new AlertRules($device);
@@ -442,16 +467,24 @@ class AlertRulesTest extends TestCase
             'state' => $state,
             'open' => 1,
             'alerted' => 1,
+            'open_problem_count' => 1,
             'info' => [],
             'timestamp' => $initialTimestamp,
         ]);
 
-        AlertLog::create([
-            'device_id' => $device->device_id,
+        AlertProblem::create([
             'rule_id' => $rule->id,
-            'state' => $state,
+            'device_id' => $device->device_id,
+            'entity_key' => (string) $device->device_id,
+            'state' => AlertState::ACTIVE,
+            'open' => 1,
+            'alerted' => 0,
             'details' => ['old' => 'data'],
         ]);
+
+        $logCount = AlertLog::where('device_id', $device->device_id)
+            ->where('rule_id', $rule->id)
+            ->count();
 
         $alertRules = new AlertRules($device);
         $alertRules->run();
@@ -464,13 +497,14 @@ class AlertRulesTest extends TestCase
         $actual = $alert->timestamp instanceof Carbon ? $alert->timestamp->toDateTimeString() : $alert->timestamp;
         $this->assertEquals($initialTimestamp->toDateTimeString(), $actual, 'Alert timestamp was reset');
 
-        // AlertLog should have been updated but state remains same
-        $updatedLog = AlertLog::where('device_id', $device->device_id)
+        $this->assertEquals($logCount, AlertLog::where('device_id', $device->device_id)
             ->where('rule_id', $rule->id)
-            ->latest('id')
+            ->count());
+
+        $problem = AlertProblem::where('device_id', $device->device_id)
+            ->where('rule_id', $rule->id)
             ->first();
-        $this->assertEquals($state, $updatedLog->state->value, "Latest AlertLog state was changed from $state");
-        $this->assertArrayHasKey('contacts', $updatedLog->details);
+        $this->assertArrayHasKey('contacts', $problem->details);
     }
 
     public function testRunRulesWithDeviceId(): void


### PR DESCRIPTION
I need to do more testing on this but pushing what I have so far as I it's quite a change to alerting!

This moves the Alerts link to be Problems (or we could change this to Faults), the reason be is this is just a list in the UI and not an alert that's been sent out. In fact, alerts don't have to be sent out so it makes more sense to call that page Problems.

I want to add more to problems page to show notifications / alerts that have been sent out including more of a history within it.

Sending single notifications out could also slow things down as it's sending more per fault so could easily cause a backlog. Do we do a count before hand and if over a certain amount of notifications do we then merge them back together.

Not all tables have an id we can use to create the per fault entities but most ones we care about do. One issue table is the wireless_sensors as it uses the same column names as sensors. I might have to add an additional check for a wireless table only column name.

<img width="1330" height="697" alt="image" src="https://github.com/user-attachments/assets/9038a81d-9106-46ab-9cd5-c2a9bd2d5f72" />

<img width="275" height="61" alt="image" src="https://github.com/user-attachments/assets/4cd1468a-e240-442c-8afa-9b1f1ad3e824" />

<img width="2015" height="889" alt="image" src="https://github.com/user-attachments/assets/d61a46f2-60f3-46c5-8d3e-997cc1184a7c" />

<img width="579" height="989" alt="image" src="https://github.com/user-attachments/assets/9d1fc176-617a-4767-89bc-be473cf2f85b" />



DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
