### PR TITLE
Device down status reason show all

### DIFF
--- a/LibreNMS/Alert/RunAlerts.php
+++ b/LibreNMS/Alert/RunAlerts.php
@@ -762,7 +762,7 @@ class RunAlerts
             return false;
         }
 
-        $down_parent_count = dbFetchCell("SELECT count(*) from devices as d LEFT JOIN device_relationships as r ON d.device_id=r.parent_device_id WHERE d.status=0 AND d.ignore=0 AND d.disabled=0 AND r.child_device_id=?", [$device]);
+        $down_parent_count = dbFetchCell('SELECT count(*) from devices as d LEFT JOIN device_relationships as r ON d.device_id=r.parent_device_id WHERE d.status=0 AND d.ignore=0 AND d.disabled=0 AND r.child_device_id=?', [$device]);
         if ($down_parent_count == $parent_count) {
             return true;
         }

--- a/LibreNMS/Alert/RunAlerts.php
+++ b/LibreNMS/Alert/RunAlerts.php
@@ -762,7 +762,7 @@ class RunAlerts
             return false;
         }
 
-        $down_parent_count = dbFetchCell("SELECT count(*) from devices as d LEFT JOIN devices_attribs as a ON d.device_id=a.device_id LEFT JOIN device_relationships as r ON d.device_id=r.parent_device_id WHERE d.status=0 AND d.ignore=0 AND d.disabled=0 AND r.child_device_id=? AND (d.status_reason='icmp' OR (a.attrib_type='override_icmp_disable' AND a.attrib_value=true))", [$device]);
+        $down_parent_count = dbFetchCell("SELECT count(*) from devices as d LEFT JOIN device_relationships as r ON d.device_id=r.parent_device_id WHERE d.status=0 AND d.ignore=0 AND d.disabled=0 AND r.child_device_id=?", [$device]);
         if ($down_parent_count == $parent_count) {
             return true;
         }

--- a/LibreNMS/Alert/RunAlerts.php
+++ b/LibreNMS/Alert/RunAlerts.php
@@ -47,6 +47,7 @@ use LibreNMS\Enum\AlertState;
 use LibreNMS\Enum\MaintenanceStatus;
 use LibreNMS\Enum\Severity;
 use LibreNMS\Exceptions\AlertTransportDeliveryException;
+use LibreNMS\Exceptions\RrdException;
 use LibreNMS\Polling\ConnectivityHelper;
 use LibreNMS\Util\Number;
 use LibreNMS\Util\Time;
@@ -127,20 +128,20 @@ class RunAlerts
         $obj['proc'] = $alert['proc'];
         $obj['status'] = $device->status;
         $obj['status_reason'] = $device->status_reason;
-        if (ConnectivityHelper::pingIsAllowed($device)) {
+
+        if ((new ConnectivityHelper($device))->icmpIsEnabled()) {
             try {
                 $last_ping = Rrd::lastUpdate(Rrd::name($device->hostname, 'icmp-perf'));
-            } catch (\Exception $e) {
+                if ($last_ping) {
+                    $obj['ping_timestamp'] = $last_ping->timestamp;
+                    $obj['ping_loss'] = Number::calculatePercent($last_ping->get('xmt') - $last_ping->get('rcv'), $last_ping->get('xmt'));
+                    $obj['ping_min'] = $last_ping->get('min');
+                    $obj['ping_max'] = $last_ping->get('max');
+                    $obj['ping_avg'] = $last_ping->get('avg');
+                    $obj['debug'] = 'unsupported';
+                }
+            } catch (RrdException $e) {
                 Log::error("Error getting last ping for device {$device->hostname}: {$e->getMessage()}");
-                $last_ping = null;
-            }
-            if ($last_ping) {
-                $obj['ping_timestamp'] = $last_ping->timestamp;
-                $obj['ping_loss'] = Number::calculatePercent($last_ping->get('xmt') - $last_ping->get('rcv'), $last_ping->get('xmt'));
-                $obj['ping_min'] = $last_ping->get('min');
-                $obj['ping_max'] = $last_ping->get('max');
-                $obj['ping_avg'] = $last_ping->get('avg');
-                $obj['debug'] = 'unsupported';
             }
         }
         $extra = $alert['details'];

--- a/LibreNMS/Data/Source/Ipmitool.php
+++ b/LibreNMS/Data/Source/Ipmitool.php
@@ -33,6 +33,7 @@ use Illuminate\Contracts\Process\ProcessResult;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Process;
 use LibreNMS\Exceptions\IpmiConnectionFailed;
+use LibreNMS\Polling\ConnectivityHelper;
 
 class Ipmitool
 {
@@ -64,7 +65,7 @@ class Ipmitool
     {
         $device ??= DeviceCache::getPrimary();
 
-        if ($device->getAttrib('ipmi_hostname') === null) {
+        if (! (new ConnectivityHelper($device))->ipmiIsEnabled()) {
             return null;
         }
 

--- a/LibreNMS/Data/Store/Rrd.php
+++ b/LibreNMS/Data/Store/Rrd.php
@@ -159,6 +159,9 @@ class Rrd extends BaseDatastore
         }
     }
 
+    /**
+     * @throws RrdException
+     */
     public function lastUpdate(string $filename): ?TimeSeriesPoint
     {
         $output = $this->command('lastupdate', $filename);

--- a/LibreNMS/Enum/AvailabilitySource.php
+++ b/LibreNMS/Enum/AvailabilitySource.php
@@ -7,4 +7,5 @@ enum AvailabilitySource: string
     case None = '';
     case Snmp = 'snmp';
     case Icmp = 'icmp';
+    case Both = 'icmp,snmp';
 }

--- a/LibreNMS/Interfaces/Module.php
+++ b/LibreNMS/Interfaces/Module.php
@@ -29,6 +29,7 @@ namespace LibreNMS\Interfaces;
 use App\Models\Device;
 use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\OS;
+use LibreNMS\Polling\ConnectivityHelper;
 use LibreNMS\Polling\ModuleStatus;
 
 interface Module
@@ -41,12 +42,12 @@ interface Module
     /**
      * Should this module be run?
      */
-    public function shouldDiscover(OS $os, ModuleStatus $status): bool;
+    public function shouldDiscover(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool;
 
     /**
      * Should polling run for this device?
      */
-    public function shouldPoll(OS $os, ModuleStatus $status): bool;
+    public function shouldPoll(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool;
 
     /**
      * Discover this module. Heavier processes can be run here

--- a/LibreNMS/Modules/ArpTable.php
+++ b/LibreNMS/Modules/ArpTable.php
@@ -15,6 +15,7 @@ use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Discovery\ArpTableDiscovery;
 use LibreNMS\Interfaces\Module;
 use LibreNMS\OS;
+use LibreNMS\Polling\ConnectivityHelper;
 use LibreNMS\Polling\ModuleStatus;
 use LibreNMS\Util\Mac;
 use SnmpQuery;
@@ -34,17 +35,17 @@ class ArpTable implements Module
     /**
      * @inheritDoc
      */
-    public function shouldDiscover(OS $os, ModuleStatus $status): bool
+    public function shouldDiscover(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
-        return $status->isEnabledAndDeviceUp($os->getDevice());
+        return $status->isEnabled() && $connectivity->snmpIsAvailable();
     }
 
     /**
      * @inheritDoc
      */
-    public function shouldPoll(OS $os, ModuleStatus $status): bool
+    public function shouldPoll(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
-        return $status->isEnabledAndDeviceUp($os->getDevice());
+        return $status->isEnabled() && $connectivity->snmpIsAvailable();
     }
 
     /**

--- a/LibreNMS/Modules/Availability.php
+++ b/LibreNMS/Modules/Availability.php
@@ -31,6 +31,7 @@ use App\Models\Device;
 use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Module;
 use LibreNMS\OS;
+use LibreNMS\Polling\ConnectivityHelper;
 use LibreNMS\Polling\ModuleStatus;
 use LibreNMS\RRD\RrdDefinition;
 use LibreNMS\Util\Time;
@@ -45,7 +46,7 @@ class Availability implements Module
         return [];
     }
 
-    public function shouldDiscover(OS $os, ModuleStatus $status): bool
+    public function shouldDiscover(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
         return false;
     }
@@ -60,9 +61,9 @@ class Availability implements Module
     /**
      * @inheritDoc
      */
-    public function shouldPoll(OS $os, ModuleStatus $status): bool
+    public function shouldPoll(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
-        return $status->isEnabled();
+        return $status->isEnabled() && $connectivity->hasAvailability();
     }
 
     /**

--- a/LibreNMS/Modules/Core.php
+++ b/LibreNMS/Modules/Core.php
@@ -37,6 +37,7 @@ use LibreNMS\Enum\Severity;
 use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Module;
 use LibreNMS\OS;
+use LibreNMS\Polling\ConnectivityHelper;
 use LibreNMS\Polling\ModuleStatus;
 use LibreNMS\RRD\RrdDefinition;
 use LibreNMS\Util\Compare;
@@ -55,9 +56,9 @@ class Core implements Module
         return [];
     }
 
-    public function shouldDiscover(OS $os, ModuleStatus $status): bool
+    public function shouldDiscover(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
-        return ! $os->getDevice()->snmp_disable && $os->getDevice()->status;
+        return $connectivity->snmpIsAvailable();
     }
 
     public function discover(OS $os): void
@@ -99,9 +100,9 @@ class Core implements Module
         }
     }
 
-    public function shouldPoll(OS $os, ModuleStatus $status): bool
+    public function shouldPoll(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
-        return ! $os->getDevice()->snmp_disable && $os->getDevice()->status;
+        return $connectivity->snmpIsAvailable();
     }
 
     public function poll(OS $os, DataStorageInterface $datastore): void

--- a/LibreNMS/Modules/DiscoveryArp.php
+++ b/LibreNMS/Modules/DiscoveryArp.php
@@ -13,6 +13,7 @@ use LibreNMS\Exceptions\InvalidIpException;
 use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Module;
 use LibreNMS\OS;
+use LibreNMS\Polling\ConnectivityHelper;
 use LibreNMS\Polling\ModuleStatus;
 use LibreNMS\Util\IPv4;
 
@@ -29,15 +30,15 @@ class DiscoveryArp implements Module
     /**
      * @inheritDoc
      */
-    public function shouldDiscover(OS $os, ModuleStatus $status): bool
+    public function shouldDiscover(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
-        return $status->isEnabledAndDeviceUp($os->getDevice());
+        return $status->isEnabled() && $connectivity->snmpIsAvailable();
     }
 
     /**
      * @inheritDoc
      */
-    public function shouldPoll(OS $os, ModuleStatus $status): bool
+    public function shouldPoll(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
         return false;
     }

--- a/LibreNMS/Modules/EntityPhysical.php
+++ b/LibreNMS/Modules/EntityPhysical.php
@@ -9,6 +9,7 @@ use LibreNMS\DB\SyncsModels;
 use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Module;
 use LibreNMS\OS;
+use LibreNMS\Polling\ConnectivityHelper;
 use LibreNMS\Polling\ModuleStatus;
 
 class EntityPhysical implements Module
@@ -26,17 +27,17 @@ class EntityPhysical implements Module
     /**
      * @inheritDoc
      */
-    public function shouldDiscover(OS $os, ModuleStatus $status): bool
+    public function shouldDiscover(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
-        return $status->isEnabledAndDeviceUp($os->getDevice());
+        return $status->isEnabled() && $connectivity->snmpIsAvailable();
     }
 
     /**
      * @inheritDoc
      */
-    public function shouldPoll(OS $os, ModuleStatus $status): bool
+    public function shouldPoll(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
-        return $status->isEnabledAndDeviceUp($os->getDevice());
+        return $status->isEnabled() && $connectivity->snmpIsAvailable();
     }
 
     /**

--- a/LibreNMS/Modules/HrDevice.php
+++ b/LibreNMS/Modules/HrDevice.php
@@ -8,6 +8,7 @@ use LibreNMS\DB\SyncsModels;
 use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Module;
 use LibreNMS\OS;
+use LibreNMS\Polling\ConnectivityHelper;
 use LibreNMS\Polling\ModuleStatus;
 
 class HrDevice implements Module
@@ -25,15 +26,15 @@ class HrDevice implements Module
     /**
      * @inheritDoc
      */
-    public function shouldDiscover(OS $os, ModuleStatus $status): bool
+    public function shouldDiscover(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
-        return $status->isEnabledAndDeviceUp($os->getDevice());
+        return $status->isEnabled() && $connectivity->snmpIsAvailable();
     }
 
     /**
      * @inheritDoc
      */
-    public function shouldPoll(OS $os, ModuleStatus $status): bool
+    public function shouldPoll(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
         return false;
     }

--- a/LibreNMS/Modules/IpSystemStats.php
+++ b/LibreNMS/Modules/IpSystemStats.php
@@ -28,6 +28,7 @@ use Illuminate\Support\Facades\Log;
 use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Module;
 use LibreNMS\OS;
+use LibreNMS\Polling\ConnectivityHelper;
 use LibreNMS\Polling\ModuleStatus;
 use LibreNMS\RRD\RrdDefinition;
 use SnmpQuery;
@@ -45,7 +46,7 @@ class IpSystemStats implements Module
     /**
      * @inheritDoc
      */
-    public function shouldDiscover(OS $os, ModuleStatus $status): bool
+    public function shouldDiscover(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
         return false;
     }
@@ -61,9 +62,9 @@ class IpSystemStats implements Module
     /**
      * @inheritDoc
      */
-    public function shouldPoll(OS $os, ModuleStatus $status): bool
+    public function shouldPoll(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
-        return $status->isEnabledAndDeviceUp($os->getDevice());
+        return $status->isEnabled() && $connectivity->snmpIsAvailable();
     }
 
     /**

--- a/LibreNMS/Modules/Ipv4Addresses.php
+++ b/LibreNMS/Modules/Ipv4Addresses.php
@@ -39,6 +39,7 @@ use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Discovery\Ipv4AddressDiscovery;
 use LibreNMS\Interfaces\Module;
 use LibreNMS\OS;
+use LibreNMS\Polling\ConnectivityHelper;
 use LibreNMS\Polling\ModuleStatus;
 use LibreNMS\Util\IPv4;
 use SnmpQuery;
@@ -58,15 +59,15 @@ class Ipv4Addresses implements Module
     /**
      * @inheritDoc
      */
-    public function shouldDiscover(OS $os, ModuleStatus $status): bool
+    public function shouldDiscover(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
-        return $status->isEnabledAndDeviceUp($os->getDevice());
+        return $status->isEnabled() && $connectivity->snmpIsAvailable();
     }
 
     /**
      * @inheritDoc
      */
-    public function shouldPoll(OS $os, ModuleStatus $status): bool
+    public function shouldPoll(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
         return false;
     }

--- a/LibreNMS/Modules/Ipv6Addresses.php
+++ b/LibreNMS/Modules/Ipv6Addresses.php
@@ -15,6 +15,7 @@ use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Discovery\Ipv6AddressDiscovery;
 use LibreNMS\Interfaces\Module;
 use LibreNMS\OS;
+use LibreNMS\Polling\ConnectivityHelper;
 use LibreNMS\Polling\ModuleStatus;
 use LibreNMS\Util\IP;
 use LibreNMS\Util\IPv4;
@@ -36,15 +37,15 @@ class Ipv6Addresses implements Module
     /**
      * @inheritDoc
      */
-    public function shouldDiscover(OS $os, ModuleStatus $status): bool
+    public function shouldDiscover(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
-        return $status->isEnabledAndDeviceUp($os->getDevice());
+        return $status->isEnabled() && $connectivity->snmpIsAvailable();
     }
 
     /**
      * @inheritDoc
      */
-    public function shouldPoll(OS $os, ModuleStatus $status): bool
+    public function shouldPoll(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
         return false;
     }

--- a/LibreNMS/Modules/Ipv6Nd.php
+++ b/LibreNMS/Modules/Ipv6Nd.php
@@ -13,6 +13,7 @@ use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Discovery\Ipv6NdDiscovery;
 use LibreNMS\Interfaces\Module;
 use LibreNMS\OS;
+use LibreNMS\Polling\ConnectivityHelper;
 use LibreNMS\Polling\ModuleStatus;
 use LibreNMS\Util\IPv6;
 use LibreNMS\Util\Mac;
@@ -33,15 +34,15 @@ class Ipv6Nd implements Module
     /**
      * @inheritDoc
      */
-    public function shouldDiscover(OS $os, ModuleStatus $status): bool
+    public function shouldDiscover(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
-        return $status->isEnabledAndDeviceUp($os->getDevice());
+        return $status->isEnabled() && $connectivity->snmpIsAvailable();
     }
 
     /**
      * @inheritDoc
      */
-    public function shouldPoll(OS $os, ModuleStatus $status): bool
+    public function shouldPoll(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
         return false;
     }

--- a/LibreNMS/Modules/Isis.php
+++ b/LibreNMS/Modules/Isis.php
@@ -39,6 +39,7 @@ use LibreNMS\Interfaces\Discovery\IsIsDiscovery;
 use LibreNMS\Interfaces\Module;
 use LibreNMS\Interfaces\Polling\IsIsPolling;
 use LibreNMS\OS;
+use LibreNMS\Polling\ConnectivityHelper;
 use LibreNMS\Polling\ModuleStatus;
 use LibreNMS\Util\IP;
 
@@ -61,9 +62,9 @@ class Isis implements Module
         return ['ports'];
     }
 
-    public function shouldDiscover(OS $os, ModuleStatus $status): bool
+    public function shouldDiscover(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
-        return $status->isEnabledAndDeviceUp($os->getDevice());
+        return $status->isEnabled() && $connectivity->snmpIsAvailable();
     }
 
     /**
@@ -82,9 +83,9 @@ class Isis implements Module
         $this->syncModels($os->getDevice(), 'isisAdjacencies', $adjacencies);
     }
 
-    public function shouldPoll(OS $os, ModuleStatus $status): bool
+    public function shouldPoll(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
-        return $status->isEnabledAndDeviceUp($os->getDevice());
+        return $status->isEnabled() && $connectivity->snmpIsAvailable();
     }
 
     /**

--- a/LibreNMS/Modules/LegacyModule.php
+++ b/LibreNMS/Modules/LegacyModule.php
@@ -90,10 +90,10 @@ class LegacyModule implements Module
     {
         // all legacy modules require snmp except ipmi and unix-agent
         return $status->isEnabled() && match ($this->name) {
-                'ipmi' => $connectivity->ipmiIsAvailable(),
-                'unix-agent' => $connectivity->unixAgentIsAvailable(),
-                default => $connectivity->snmpIsAvailable(),
-            };
+            'ipmi' => $connectivity->ipmiIsAvailable(),
+            'unix-agent' => $connectivity->unixAgentIsAvailable(),
+            default => $connectivity->snmpIsAvailable(),
+        };
     }
 
     public function poll(OS $os, DataStorageInterface $datastore): void

--- a/LibreNMS/Modules/LegacyModule.php
+++ b/LibreNMS/Modules/LegacyModule.php
@@ -34,6 +34,7 @@ use LibreNMS\Component;
 use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Module;
 use LibreNMS\OS;
+use LibreNMS\Polling\ConnectivityHelper;
 use LibreNMS\Polling\ModuleStatus;
 use LibreNMS\Util\Debug;
 use Symfony\Component\Yaml\Yaml;
@@ -61,9 +62,9 @@ class LegacyModule implements Module
     {
     }
 
-    public function shouldDiscover(OS $os, ModuleStatus $status): bool
+    public function shouldDiscover(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
-        return $this->shouldPoll($os, $status);
+        return $this->shouldPoll($os, $status, $connectivity);
     }
 
     public function discover(OS $os): void
@@ -85,10 +86,14 @@ class LegacyModule implements Module
         Debug::enableErrorReporting(); // and back to normal
     }
 
-    public function shouldPoll(OS $os, ModuleStatus $status): bool
+    public function shouldPoll(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
         // all legacy modules require snmp except ipmi and unix-agent
-        return $status->isEnabledAndDeviceUp($os->getDevice(), check_snmp: ! in_array($this->name, ['ipmi', 'unix-agent']));
+        return $status->isEnabled() && match ($this->name) {
+                'ipmi' => $connectivity->ipmiIsAvailable(),
+                'unix-agent' => $connectivity->unixAgentIsAvailable(),
+                default => $connectivity->snmpIsAvailable(),
+            };
     }
 
     public function poll(OS $os, DataStorageInterface $datastore): void

--- a/LibreNMS/Modules/MacAccounting.php
+++ b/LibreNMS/Modules/MacAccounting.php
@@ -34,6 +34,7 @@ use LibreNMS\Interfaces\Discovery\MacAccountingDiscovery;
 use LibreNMS\Interfaces\Module;
 use LibreNMS\Interfaces\Polling\MacAccountingPolling;
 use LibreNMS\OS;
+use LibreNMS\Polling\ConnectivityHelper;
 use LibreNMS\Polling\ModuleStatus;
 use LibreNMS\RRD\RrdDefinition;
 
@@ -50,17 +51,17 @@ class MacAccounting implements Module
     /**
      * @inheritDoc
      */
-    public function shouldDiscover(OS $os, ModuleStatus $status): bool
+    public function shouldDiscover(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
-        return $status->isEnabledAndDeviceUp($os->getDevice());
+        return $status->isEnabled() && $connectivity->snmpIsAvailable();
     }
 
     /**
      * @inheritDoc
      */
-    public function shouldPoll(OS $os, ModuleStatus $status): bool
+    public function shouldPoll(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
-        return $status->isEnabledAndDeviceUp($os->getDevice());
+        return $status->isEnabled() && $connectivity->snmpIsAvailable();
     }
 
     /**

--- a/LibreNMS/Modules/Mempools.php
+++ b/LibreNMS/Modules/Mempools.php
@@ -36,6 +36,7 @@ use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Module;
 use LibreNMS\Interfaces\Polling\MempoolsPolling;
 use LibreNMS\OS;
+use LibreNMS\Polling\ConnectivityHelper;
 use LibreNMS\Polling\ModuleStatus;
 use LibreNMS\RRD\RrdDefinition;
 use LibreNMS\Util\Number;
@@ -52,9 +53,9 @@ class Mempools implements Module
         return [];
     }
 
-    public function shouldDiscover(OS $os, ModuleStatus $status): bool
+    public function shouldDiscover(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
-        return $status->isEnabledAndDeviceUp($os->getDevice());
+        return $status->isEnabled() && $connectivity->snmpIsAvailable();
     }
 
     public function discover(OS $os): void
@@ -85,9 +86,9 @@ class Mempools implements Module
         $mempools->each($this->printMempool(...));
     }
 
-    public function shouldPoll(OS $os, ModuleStatus $status): bool
+    public function shouldPoll(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
-        return $status->isEnabledAndDeviceUp($os->getDevice());
+        return $status->isEnabled() && $connectivity->snmpIsAvailable();
     }
 
     public function poll(OS $os, DataStorageInterface $datastore): void

--- a/LibreNMS/Modules/Mpls.php
+++ b/LibreNMS/Modules/Mpls.php
@@ -36,6 +36,7 @@ use LibreNMS\Interfaces\Discovery\MplsDiscovery;
 use LibreNMS\Interfaces\Module;
 use LibreNMS\Interfaces\Polling\MplsPolling;
 use LibreNMS\OS;
+use LibreNMS\Polling\ConnectivityHelper;
 use LibreNMS\Polling\ModuleStatus;
 
 class Mpls implements Module
@@ -50,9 +51,9 @@ class Mpls implements Module
         return ['ports', 'vrf'];
     }
 
-    public function shouldDiscover(OS $os, ModuleStatus $status): bool
+    public function shouldDiscover(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
-        return $status->isEnabledAndDeviceUp($os->getDevice()) && $os instanceof MplsDiscovery;
+        return $status->isEnabled() && $connectivity->snmpIsAvailable() && $os instanceof MplsDiscovery;
     }
 
     /**
@@ -98,9 +99,9 @@ class Mpls implements Module
         }
     }
 
-    public function shouldPoll(OS $os, ModuleStatus $status): bool
+    public function shouldPoll(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
-        return $status->isEnabledAndDeviceUp($os->getDevice()) && $os instanceof MplsPolling;
+        return $status->isEnabled() && $connectivity->snmpIsAvailable() && $os instanceof MplsPolling;
     }
 
     /**

--- a/LibreNMS/Modules/Nac.php
+++ b/LibreNMS/Modules/Nac.php
@@ -34,6 +34,7 @@ use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Module;
 use LibreNMS\Interfaces\Polling\NacPolling;
 use LibreNMS\OS;
+use LibreNMS\Polling\ConnectivityHelper;
 use LibreNMS\Polling\ModuleStatus;
 
 class Nac implements Module
@@ -46,7 +47,7 @@ class Nac implements Module
         return ['ports'];
     }
 
-    public function shouldDiscover(OS $os, ModuleStatus $status): bool
+    public function shouldDiscover(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
         return false;
     }
@@ -62,9 +63,9 @@ class Nac implements Module
         // not implemented
     }
 
-    public function shouldPoll(OS $os, ModuleStatus $status): bool
+    public function shouldPoll(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
-        return $status->isEnabledAndDeviceUp($os->getDevice()) && $os instanceof NacPolling;
+        return $status->isEnabled() && $connectivity->snmpIsAvailable() && $os instanceof NacPolling;
     }
 
     /**

--- a/LibreNMS/Modules/Netstats.php
+++ b/LibreNMS/Modules/Netstats.php
@@ -37,6 +37,7 @@ use LibreNMS\Interfaces\Polling\Netstats\SnmpNetstatsPolling;
 use LibreNMS\Interfaces\Polling\Netstats\TcpNetstatsPolling;
 use LibreNMS\Interfaces\Polling\Netstats\UdpNetstatsPolling;
 use LibreNMS\OS;
+use LibreNMS\Polling\ConnectivityHelper;
 use LibreNMS\Polling\ModuleStatus;
 use LibreNMS\RRD\RrdDefinition;
 
@@ -178,7 +179,7 @@ class Netstats implements Module
         'tcp' => TcpNetstatsPolling::class,
     ];
 
-    public function shouldDiscover(OS $os, ModuleStatus $status): bool
+    public function shouldDiscover(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
         return false;
     }
@@ -191,9 +192,9 @@ class Netstats implements Module
         // no discovery
     }
 
-    public function shouldPoll(OS $os, ModuleStatus $status): bool
+    public function shouldPoll(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
-        return $status->isEnabledAndDeviceUp($os->getDevice());
+        return $status->isEnabled() && $connectivity->snmpIsAvailable();
     }
 
     /**

--- a/LibreNMS/Modules/Os.php
+++ b/LibreNMS/Modules/Os.php
@@ -35,6 +35,7 @@ use LibreNMS\Enum\Severity;
 use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Module;
 use LibreNMS\Interfaces\Polling\OSPolling;
+use LibreNMS\Polling\ConnectivityHelper;
 use LibreNMS\Polling\ModuleStatus;
 use LibreNMS\Util\Url;
 
@@ -48,9 +49,9 @@ class Os implements Module
         return [];
     }
 
-    public function shouldDiscover(\LibreNMS\OS $os, ModuleStatus $status): bool
+    public function shouldDiscover(\LibreNMS\OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
-        return $status->isEnabledAndDeviceUp($os->getDevice());
+        return $status->isEnabled() && $connectivity->snmpIsAvailable();
     }
 
     public function discover(\LibreNMS\OS $os): void
@@ -78,9 +79,9 @@ class Os implements Module
         $this->handleChanges($os);
     }
 
-    public function shouldPoll(\LibreNMS\OS $os, ModuleStatus $status): bool
+    public function shouldPoll(\LibreNMS\OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
-        return $status->isEnabledAndDeviceUp($os->getDevice());
+        return $status->isEnabled() && $connectivity->snmpIsAvailable();
     }
 
     public function poll(\LibreNMS\OS $os, DataStorageInterface $datastore): void

--- a/LibreNMS/Modules/Ospf.php
+++ b/LibreNMS/Modules/Ospf.php
@@ -38,6 +38,7 @@ use Illuminate\Support\Facades\Log;
 use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Module;
 use LibreNMS\OS;
+use LibreNMS\Polling\ConnectivityHelper;
 use LibreNMS\Polling\ModuleStatus;
 use LibreNMS\RRD\RrdDefinition;
 use SnmpQuery;
@@ -52,7 +53,7 @@ class Ospf implements Module
         return ['ports'];
     }
 
-    public function shouldDiscover(OS $os, ModuleStatus $status): bool
+    public function shouldDiscover(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
         return false;
     }
@@ -65,9 +66,9 @@ class Ospf implements Module
         // no discovery
     }
 
-    public function shouldPoll(OS $os, ModuleStatus $status): bool
+    public function shouldPoll(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
-        return $status->isEnabledAndDeviceUp($os->getDevice());
+        return $status->isEnabled() && $connectivity->snmpIsAvailable();
     }
 
     /**

--- a/LibreNMS/Modules/Ospfv3.php
+++ b/LibreNMS/Modules/Ospfv3.php
@@ -39,6 +39,7 @@ use LibreNMS\DB\SyncsModels;
 use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Module;
 use LibreNMS\OS;
+use LibreNMS\Polling\ConnectivityHelper;
 use LibreNMS\Polling\ModuleStatus;
 use LibreNMS\RRD\RrdDefinition;
 use LibreNMS\Util\IP;
@@ -57,9 +58,9 @@ class Ospfv3 implements Module
         return ['ports', 'vrf'];
     }
 
-    public function shouldDiscover(OS $os, ModuleStatus $status): bool
+    public function shouldDiscover(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
-        return $status->isEnabledAndDeviceUp($os->getDevice());
+        return $status->isEnabled() && $connectivity->snmpIsAvailable();
     }
 
     /**
@@ -127,9 +128,9 @@ class Ospfv3 implements Module
         Log::info(' (Total neighbors: ' . $ospf_neighbors->count() . ')');
     }
 
-    public function shouldPoll(OS $os, ModuleStatus $status): bool
+    public function shouldPoll(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
-        return $status->isEnabledAndDeviceUp($os->getDevice());
+        return $status->isEnabled() && $connectivity->snmpIsAvailable();
     }
 
     /**

--- a/LibreNMS/Modules/PortSecurity.php
+++ b/LibreNMS/Modules/PortSecurity.php
@@ -34,6 +34,7 @@ use LibreNMS\Interfaces\Discovery\PortSecurityDiscovery;
 use LibreNMS\Interfaces\Module;
 use LibreNMS\Interfaces\Polling\PortSecurityPolling;
 use LibreNMS\OS;
+use LibreNMS\Polling\ConnectivityHelper;
 use LibreNMS\Polling\ModuleStatus;
 
 class PortSecurity implements Module
@@ -48,9 +49,9 @@ class PortSecurity implements Module
         return [];
     }
 
-    public function shouldDiscover(OS $os, ModuleStatus $status): bool
+    public function shouldDiscover(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
-        return $status->isEnabledAndDeviceUp($os->getDevice()) && $os instanceof PortSecurityDiscovery;
+        return $status->isEnabled() && $connectivity->snmpIsAvailable() && $os instanceof PortSecurityDiscovery;
     }
 
     /**
@@ -61,9 +62,9 @@ class PortSecurity implements Module
         $this->poll($os, app('Datastore'));
     }
 
-    public function shouldPoll(OS $os, ModuleStatus $status): bool
+    public function shouldPoll(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
-        return $status->isEnabledAndDeviceUp($os->getDevice()) && $os instanceof PortSecurityPolling;
+        return $status->isEnabled() && $connectivity->snmpIsAvailable() && $os instanceof PortSecurityPolling;
     }
 
     /**

--- a/LibreNMS/Modules/PortsStack.php
+++ b/LibreNMS/Modules/PortsStack.php
@@ -35,6 +35,7 @@ use LibreNMS\DB\SyncsModels;
 use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Module;
 use LibreNMS\OS;
+use LibreNMS\Polling\ConnectivityHelper;
 use LibreNMS\Polling\ModuleStatus;
 
 class PortsStack implements Module
@@ -52,15 +53,15 @@ class PortsStack implements Module
     /**
      * @inheritDoc
      */
-    public function shouldDiscover(OS $os, ModuleStatus $status): bool
+    public function shouldDiscover(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
-        return $status->isEnabledAndDeviceUp($os->getDevice());
+        return $status->isEnabled() && $connectivity->snmpIsAvailable();
     }
 
     /**
      * @inheritDoc
      */
-    public function shouldPoll(OS $os, ModuleStatus $status): bool
+    public function shouldPoll(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
         return $status->isEnabledAndDeviceUp($os->getDevice());
     }

--- a/LibreNMS/Modules/PrinterSupplies.php
+++ b/LibreNMS/Modules/PrinterSupplies.php
@@ -34,6 +34,7 @@ use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Module;
 use LibreNMS\Interfaces\PrinterSuppliesContext;
 use LibreNMS\OS;
+use LibreNMS\Polling\ConnectivityHelper;
 use LibreNMS\Polling\ModuleStatus;
 use LibreNMS\RRD\RrdDefinition;
 use LibreNMS\Util\Number;
@@ -52,9 +53,9 @@ class PrinterSupplies implements Module
         return [];
     }
 
-    public function shouldDiscover(OS $os, ModuleStatus $status): bool
+    public function shouldDiscover(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
-        return $status->isEnabledAndDeviceUp($os->getDevice());
+        return $status->isEnabled() && $connectivity->snmpIsAvailable();
     }
 
     /**
@@ -80,9 +81,9 @@ class PrinterSupplies implements Module
         ModuleModelObserver::done();
     }
 
-    public function shouldPoll(OS $os, ModuleStatus $status): bool
+    public function shouldPoll(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
-        return $status->isEnabledAndDeviceUp($os->getDevice());
+        return $status->isEnabled() && $connectivity->snmpIsAvailable();
     }
 
     /**

--- a/LibreNMS/Modules/Qos.php
+++ b/LibreNMS/Modules/Qos.php
@@ -32,6 +32,7 @@ use LibreNMS\Interfaces\Discovery\QosDiscovery;
 use LibreNMS\Interfaces\Module;
 use LibreNMS\Interfaces\Polling\QosPolling;
 use LibreNMS\OS;
+use LibreNMS\Polling\ConnectivityHelper;
 use LibreNMS\Polling\ModuleStatus;
 use LibreNMS\RRD\RrdDefinition;
 
@@ -47,9 +48,9 @@ class Qos implements Module
         return [];
     }
 
-    public function shouldDiscover(OS $os, ModuleStatus $status): bool
+    public function shouldDiscover(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
-        return $status->isEnabledAndDeviceUp($os->getDevice()) && $os instanceof QosDiscovery;
+        return $status->isEnabled() && $connectivity->snmpIsAvailable() && $os instanceof QosDiscovery;
     }
 
     /**
@@ -68,9 +69,9 @@ class Qos implements Module
         }
     }
 
-    public function shouldPoll(OS $os, ModuleStatus $status): bool
+    public function shouldPoll(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
-        return $status->isEnabledAndDeviceUp($os->getDevice()) && $os instanceof QosPolling;
+        return $status->isEnabled() && $connectivity->snmpIsAvailable() && $os instanceof QosPolling;
     }
 
     /**

--- a/LibreNMS/Modules/Routes.php
+++ b/LibreNMS/Modules/Routes.php
@@ -40,6 +40,7 @@ use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Discovery\RouteDiscovery;
 use LibreNMS\Interfaces\Module;
 use LibreNMS\OS;
+use LibreNMS\Polling\ConnectivityHelper;
 use LibreNMS\Polling\ModuleStatus;
 use LibreNMS\Util\IPv4;
 use LibreNMS\Util\IPv6;
@@ -60,15 +61,15 @@ class Routes implements Module
     /**
      * @inheritDoc
      */
-    public function shouldDiscover(OS $os, ModuleStatus $status): bool
+    public function shouldDiscover(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
-        return $status->isEnabledAndDeviceUp($os->getDevice());
+        return $status->isEnabled() && $connectivity->snmpIsAvailable();
     }
 
     /**
      * @inheritDoc
      */
-    public function shouldPoll(OS $os, ModuleStatus $status): bool
+    public function shouldPoll(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
         return false;
     }

--- a/LibreNMS/Modules/Services.php
+++ b/LibreNMS/Modules/Services.php
@@ -29,6 +29,7 @@ use App\Models\Device;
 use App\Models\Service;
 use LibreNMS\Interfaces\Module;
 use LibreNMS\OS;
+use LibreNMS\Polling\ConnectivityHelper;
 use LibreNMS\Polling\ModuleStatus;
 use LibreNMS\Services as ServicesHelper;
 use SnmpQuery;
@@ -46,11 +47,11 @@ class Services implements Module
     /**
      * @inheritDoc
      */
-    public function shouldDiscover(OS $os, ModuleStatus $status): bool
+    public function shouldDiscover(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
         $device = $os->getDevice();
 
-        if (! $status->isEnabledAndDeviceUp($device)) {
+        if (! $status->isEnabled() || ! $connectivity->snmpIsAvailable()) {
             return false;
         }
 
@@ -103,7 +104,7 @@ class Services implements Module
     /**
      * @inheritDoc
      */
-    public function shouldPoll(OS $os, ModuleStatus $status): bool
+    public function shouldPoll(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
         // Services currently only support discovery, not polling.
         return false;

--- a/LibreNMS/Modules/Slas.php
+++ b/LibreNMS/Modules/Slas.php
@@ -30,6 +30,7 @@ use LibreNMS\Interfaces\Discovery\SlaDiscovery;
 use LibreNMS\Interfaces\Module;
 use LibreNMS\Interfaces\Polling\SlaPolling;
 use LibreNMS\OS;
+use LibreNMS\Polling\ConnectivityHelper;
 use LibreNMS\Polling\ModuleStatus;
 use LibreNMS\RRD\RrdDefinition;
 
@@ -45,9 +46,9 @@ class Slas implements Module
         return [];
     }
 
-    public function shouldDiscover(OS $os, ModuleStatus $status): bool
+    public function shouldDiscover(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
-        return $status->isEnabledAndDeviceUp($os->getDevice()) && $os instanceof SlaDiscovery;
+        return $status->isEnabled() && $connectivity->snmpIsAvailable() && $os instanceof SlaDiscovery;
     }
 
     /**
@@ -65,9 +66,9 @@ class Slas implements Module
         }
     }
 
-    public function shouldPoll(OS $os, ModuleStatus $status): bool
+    public function shouldPoll(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
-        return $status->isEnabledAndDeviceUp($os->getDevice()) && $os instanceof SlaPolling;
+        return $status->isEnabled() && $connectivity->snmpIsAvailable() && $os instanceof SlaPolling;
     }
 
     /**

--- a/LibreNMS/Modules/Storage.php
+++ b/LibreNMS/Modules/Storage.php
@@ -35,6 +35,7 @@ use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Module;
 use LibreNMS\Interfaces\Polling\StoragePolling;
 use LibreNMS\OS;
+use LibreNMS\Polling\ConnectivityHelper;
 use LibreNMS\Polling\ModuleStatus;
 use LibreNMS\RRD\RrdDefinition;
 use LibreNMS\Util\Number;
@@ -48,9 +49,9 @@ class Storage implements Module
         return [];
     }
 
-    public function shouldDiscover(OS $os, ModuleStatus $status): bool
+    public function shouldDiscover(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
-        return $status->isEnabledAndDeviceUp($os->getDevice());
+        return $status->isEnabled() && $connectivity->snmpIsAvailable();
     }
 
     /**
@@ -67,9 +68,9 @@ class Storage implements Module
         $saved->each($this->printStorage(...));
     }
 
-    public function shouldPoll(OS $os, ModuleStatus $status): bool
+    public function shouldPoll(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
-        return $status->isEnabledAndDeviceUp($os->getDevice());
+        return $status->isEnabled() && $connectivity->snmpIsAvailable();
     }
 
     /**

--- a/LibreNMS/Modules/Stp.php
+++ b/LibreNMS/Modules/Stp.php
@@ -33,6 +33,7 @@ use LibreNMS\DB\SyncsModels;
 use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Module;
 use LibreNMS\OS;
+use LibreNMS\Polling\ConnectivityHelper;
 use LibreNMS\Polling\ModuleStatus;
 
 class Stp implements Module
@@ -47,9 +48,9 @@ class Stp implements Module
         return ['ports', 'vlans'];
     }
 
-    public function shouldDiscover(OS $os, ModuleStatus $status): bool
+    public function shouldDiscover(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
-        return $status->isEnabledAndDeviceUp($os->getDevice());
+        return $status->isEnabled() && $connectivity->snmpIsAvailable();
     }
 
     public function discover(OS $os): void
@@ -67,9 +68,9 @@ class Stp implements Module
         ModuleModelObserver::done();
     }
 
-    public function shouldPoll(OS $os, ModuleStatus $status): bool
+    public function shouldPoll(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
-        return $status->isEnabledAndDeviceUp($os->getDevice());
+        return $status->isEnabled() && $connectivity->snmpIsAvailable();
     }
 
     public function poll(OS $os, DataStorageInterface $datastore): void

--- a/LibreNMS/Modules/Transceivers.php
+++ b/LibreNMS/Modules/Transceivers.php
@@ -34,6 +34,7 @@ use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Discovery\TransceiverDiscovery;
 use LibreNMS\Interfaces\Module;
 use LibreNMS\OS;
+use LibreNMS\Polling\ConnectivityHelper;
 use LibreNMS\Polling\ModuleStatus;
 
 class Transceivers implements Module
@@ -45,12 +46,12 @@ class Transceivers implements Module
         return ['ports'];
     }
 
-    public function shouldDiscover(OS $os, ModuleStatus $status): bool
+    public function shouldDiscover(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
-        return $status->isEnabledAndDeviceUp($os->getDevice()) && $os instanceof TransceiverDiscovery;
+        return $status->isEnabled() && $connectivity->snmpIsAvailable() && $os instanceof TransceiverDiscovery;
     }
 
-    public function shouldPoll(OS $os, ModuleStatus $status): bool
+    public function shouldPoll(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
         return false;
     }

--- a/LibreNMS/Modules/UcdDiskio.php
+++ b/LibreNMS/Modules/UcdDiskio.php
@@ -36,6 +36,7 @@ use LibreNMS\DB\SyncsModels;
 use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Module;
 use LibreNMS\OS;
+use LibreNMS\Polling\ConnectivityHelper;
 use LibreNMS\Polling\ModuleStatus;
 use LibreNMS\RRD\RrdDefinition;
 use SnmpQuery;
@@ -55,17 +56,17 @@ class UcdDiskio implements Module
     /**
      * @inheritDoc
      */
-    public function shouldDiscover(OS $os, ModuleStatus $status): bool
+    public function shouldDiscover(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
-        return $status->isEnabledAndDeviceUp($os->getDevice());
+        return $status->isEnabled() && $connectivity->snmpIsAvailable();
     }
 
     /**
      * @inheritDoc
      */
-    public function shouldPoll(OS $os, ModuleStatus $status): bool
+    public function shouldPoll(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
-        return $status->isEnabledAndDeviceUp($os->getDevice());
+        return $status->isEnabled() && $connectivity->snmpIsAvailable();
     }
 
     /**

--- a/LibreNMS/Modules/Vlans.php
+++ b/LibreNMS/Modules/Vlans.php
@@ -36,6 +36,7 @@ use LibreNMS\DB\SyncsModels;
 use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Module;
 use LibreNMS\OS;
+use LibreNMS\Polling\ConnectivityHelper;
 use LibreNMS\Polling\ModuleStatus;
 
 class Vlans implements Module
@@ -53,21 +54,21 @@ class Vlans implements Module
     /**
      * @inheritDoc
      */
-    public function shouldDiscover(OS $os, ModuleStatus $status): bool
+    public function shouldDiscover(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
-        return $status->isEnabledAndDeviceUp($os->getDevice());
+        return $status->isEnabled() && $connectivity->snmpIsAvailable();
     }
 
     /**
      * @inheritDoc
      */
-    public function shouldPoll(OS $os, ModuleStatus $status): bool
+    public function shouldPoll(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
         if (defined('PHPUNIT_RUNNING')) {
             return false; // FIXME improve test suite to skip polling when polling data is null
         }
 
-        return $status->isEnabledAndDeviceUp($os->getDevice());
+        return $status->isEnabled() && $connectivity->snmpIsAvailable();
     }
 
     /**

--- a/LibreNMS/Modules/Vminfo.php
+++ b/LibreNMS/Modules/Vminfo.php
@@ -34,6 +34,7 @@ use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Discovery\VminfoDiscovery;
 use LibreNMS\Interfaces\Polling\VminfoPolling;
 use LibreNMS\OS;
+use LibreNMS\Polling\ConnectivityHelper;
 use LibreNMS\Polling\ModuleStatus;
 
 class Vminfo implements \LibreNMS\Interfaces\Module
@@ -48,10 +49,12 @@ class Vminfo implements \LibreNMS\Interfaces\Module
         return [];
     }
 
-    public function shouldDiscover(OS $os, ModuleStatus $status): bool
+    public function shouldDiscover(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
         // libvirt does not use snmp, only ssh tunnels
-        return $status->isEnabledAndDeviceUp($os->getDevice(), check_snmp: ! LibrenmsConfig::get('enable_libvirt')) && $os instanceof VminfoDiscovery;
+        return $status->isEnabled()
+            && (LibrenmsConfig::get('enable_libvirt') || $connectivity->snmpIsAvailable())
+            && $os instanceof VminfoDiscovery;
     }
 
     /**
@@ -67,9 +70,9 @@ class Vminfo implements \LibreNMS\Interfaces\Module
         }
     }
 
-    public function shouldPoll(OS $os, ModuleStatus $status): bool
+    public function shouldPoll(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
-        return $status->isEnabledAndDeviceUp($os->getDevice()) && $os instanceof VminfoPolling;
+        return $status->isEnabled() && $connectivity->snmpIsAvailable() && $os instanceof VminfoPolling;
     }
 
     /**

--- a/LibreNMS/Modules/Wireless.php
+++ b/LibreNMS/Modules/Wireless.php
@@ -13,6 +13,7 @@ use LibreNMS\Enum\WirelessSensorType;
 use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Module;
 use LibreNMS\OS;
+use LibreNMS\Polling\ConnectivityHelper;
 use LibreNMS\Polling\ModuleStatus;
 use LibreNMS\RRD\RrdDefinition;
 use LibreNMS\Util\StringHelpers;
@@ -33,17 +34,17 @@ class Wireless implements Module
     /**
      * @inheritDoc
      */
-    public function shouldDiscover(OS $os, ModuleStatus $status): bool
+    public function shouldDiscover(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
-        return $status->isEnabledAndDeviceUp($os->getDevice());
+        return $status->isEnabled() && $connectivity->snmpIsAvailable();
     }
 
     /**
      * @inheritDoc
      */
-    public function shouldPoll(OS $os, ModuleStatus $status): bool
+    public function shouldPoll(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
-        return $status->isEnabledAndDeviceUp($os->getDevice());
+        return $status->isEnabled() && $connectivity->snmpIsAvailable();
     }
 
     /**

--- a/LibreNMS/Modules/Xdsl.php
+++ b/LibreNMS/Modules/Xdsl.php
@@ -39,6 +39,7 @@ use LibreNMS\Enum\IntegerType;
 use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Module;
 use LibreNMS\OS;
+use LibreNMS\Polling\ConnectivityHelper;
 use LibreNMS\Polling\ModuleStatus;
 use LibreNMS\RRD\RrdDefinition;
 use LibreNMS\Util\Number;
@@ -64,9 +65,9 @@ class Xdsl implements Module
         return ['ports'];
     }
 
-    public function shouldDiscover(OS $os, ModuleStatus $status): bool
+    public function shouldDiscover(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
-        return $status->isEnabledAndDeviceUp($os->getDevice());
+        return $status->isEnabled() && $connectivity->snmpIsAvailable();
     }
 
     /**
@@ -79,9 +80,9 @@ class Xdsl implements Module
         $this->pollVdsl($os);
     }
 
-    public function shouldPoll(OS $os, ModuleStatus $status): bool
+    public function shouldPoll(OS $os, ModuleStatus $status, ConnectivityHelper $connectivity): bool
     {
-        return $status->isEnabledAndDeviceUp($os->getDevice());
+        return $status->isEnabled() && $connectivity->snmpIsAvailable();
     }
 
     /**

--- a/LibreNMS/Polling/ConnectivityHelper.php
+++ b/LibreNMS/Polling/ConnectivityHelper.php
@@ -29,15 +29,59 @@ namespace LibreNMS\Polling;
 use App\Facades\LibrenmsConfig;
 use App\Models\Device;
 
-class ConnectivityHelper
+readonly class ConnectivityHelper
 {
-    public static function snmpIsAllowed(Device $device): bool
+    public function __construct(
+        private Device $device,
+    ) {}
+
+    public function isAvailable(): bool
     {
-        return $device->snmp_disable === false;
+        return $this->device->status;
     }
 
-    public static function pingIsAllowed(Device $device): bool
+    public function hasAvailability(): bool
     {
-        return LibrenmsConfig::get('icmp_check') && ! ($device->exists && $device->getAttrib('override_icmp_disable') === 'true');
+        return $this->icmpIsEnabled() || $this->snmpIsAvailable();
+    }
+
+    public function snmpIsEnabled(): bool
+    {
+        return $this->device->snmp_disable === false;
+    }
+
+    public function icmpIsEnabled(): bool
+    {
+        return LibrenmsConfig::get('icmp_check') && ! ($this->device->exists && $this->device->getAttrib('override_icmp_disable') === 'true');
+    }
+
+    public function snmpIsAvailable(): bool
+    {
+        return $this->snmpIsEnabled() && $this->isAvailable() && ! str_contains($this->device->status_reason, 'snmp');
+    }
+
+    public function icmpIsAvailable(): bool
+    {
+        return $this->icmpIsEnabled() && $this->isAvailable() &&! str_contains($this->device->status_reason, 'icmp');
+    }
+
+    public function ipmiIsEnabled(): bool
+    {
+        return $this->device->exists && $this->device->getAttrib('ipmi_hostname');
+    }
+
+    public function ipmiIsAvailable(): bool
+    {
+        return $this->ipmiIsEnabled();
+    }
+
+    public function unixAgentIsEnabled(): bool
+    {
+        return false;
+    }
+
+    public function unixAgentIsAvailable(): bool
+    {
+        return $this->unixAgentIsEnabled();
     }
 }

--- a/LibreNMS/Polling/ConnectivityHelper.php
+++ b/LibreNMS/Polling/ConnectivityHelper.php
@@ -33,7 +33,8 @@ readonly class ConnectivityHelper
 {
     public function __construct(
         private Device $device,
-    ) {}
+    ) {
+    }
 
     public function isAvailable(): bool
     {
@@ -62,7 +63,7 @@ readonly class ConnectivityHelper
 
     public function icmpIsAvailable(): bool
     {
-        return $this->icmpIsEnabled() && $this->isAvailable() &&! str_contains($this->device->status_reason, 'icmp');
+        return $this->icmpIsEnabled() && $this->isAvailable() && ! str_contains($this->device->status_reason, 'icmp');
     }
 
     public function ipmiIsEnabled(): bool

--- a/LibreNMS/Polling/ModuleStatus.php
+++ b/LibreNMS/Polling/ModuleStatus.php
@@ -79,11 +79,12 @@ class ModuleStatus implements \Stringable
 
     public function isEnabledAndDeviceUp(Device $device, bool $check_snmp = true): bool
     {
-        if ($check_snmp && $device->snmp_disable) {
+        $connectivity = new ConnectivityHelper($device);
+        if ($check_snmp && ! $connectivity->snmpIsAvailable()) {
             return false;
         }
 
-        return $this->isEnabled() && $device->status;
+        return $this->isEnabled() && $connectivity->isAvailable();
     }
 
     public function hasSubModules(): bool

--- a/app/Actions/Device/CheckDeviceAvailability.php
+++ b/app/Actions/Device/CheckDeviceAvailability.php
@@ -18,19 +18,22 @@ class CheckDeviceAvailability
 
     public function execute(Device $device, bool $commit = false): bool
     {
+        $connectivity = new ConnectivityHelper($device);
         $ping_response = $this->deviceIsPingable->execute($device);
 
+        $is_up_snmp = ! $connectivity->snmpIsEnabled() || $this->deviceIsSnmpable->execute($device);
+
         if ($ping_response->isAlive()) {
-            $is_up_snmp = ! ConnectivityHelper::snmpIsAllowed($device) || $this->deviceIsSnmpable->execute($device);
             $this->setDeviceAvailability->execute($device, $is_up_snmp, AvailabilitySource::Snmp, $commit);
 
             $device->mtu_status = $this->deviceMtuTest->execute($device);
         } else { // icmp down
-            $this->setDeviceAvailability->execute($device, false, AvailabilitySource::Icmp, $commit);
+            $reason = $is_up_snmp ? AvailabilitySource::Icmp : AvailabilitySource::Both;
+            $this->setDeviceAvailability->execute($device, false, $reason, $commit);
         }
 
         if ($commit) {
-            if (ConnectivityHelper::pingIsAllowed($device)) {
+            if ($connectivity->icmpIsEnabled()) {
                 $ping_response->saveStats($device);
             }
 

--- a/app/Actions/Device/DeviceIsPingable.php
+++ b/app/Actions/Device/DeviceIsPingable.php
@@ -18,7 +18,7 @@ class DeviceIsPingable
 
     public function execute(Device $device): FpingResponse
     {
-        if (! ConnectivityHelper::pingIsAllowed($device)) {
+        if (! (new ConnectivityHelper($device))->icmpIsEnabled()) {
             return FpingResponse::artificialUp($device->pollerTarget());
         }
 

--- a/app/Actions/Device/DeviceMtuTest.php
+++ b/app/Actions/Device/DeviceMtuTest.php
@@ -19,7 +19,7 @@ class DeviceMtuTest
 
     public function execute(Device $device): bool
     {
-        if (! ConnectivityHelper::pingIsAllowed($device)) {
+        if (! (new ConnectivityHelper($device))->icmpIsEnabled()) {
             return true;
         }
 

--- a/app/Http/Controllers/Device/EditMiscController.php
+++ b/app/Http/Controllers/Device/EditMiscController.php
@@ -75,6 +75,19 @@ class EditMiscController
     {
         if ($value === true) {
             $device->setAttrib($attrib, 'true');
+            if ($attrib === 'override_icmp_disable') {
+                $reasons = collect(explode(',', (string) $device->status_reason))
+                    ->reject(fn ($v) => $v === 'icmp')
+                    ->filter()
+                    ->implode(',');
+                if ($device->status_reason !== $reasons) {
+                    $device->status_reason = $reasons;
+                    if ($device->status == 0 && empty($reasons)) {
+                        $device->status = 1;
+                    }
+                    $device->save();
+                }
+            }
         } elseif ($value === null || $value === '' || $value === false) {
             $device->forgetAttrib($attrib);
         } else {

--- a/app/Jobs/DiscoverDevice.php
+++ b/app/Jobs/DiscoverDevice.php
@@ -23,6 +23,7 @@ use Illuminate\Support\Facades\Log;
 use LibreNMS\Enum\ProcessType;
 use LibreNMS\Enum\Severity;
 use LibreNMS\OS;
+use LibreNMS\Polling\ConnectivityHelper;
 use LibreNMS\Util\Dns;
 use LibreNMS\Util\Module;
 use LibreNMS\Util\ModuleList;
@@ -103,6 +104,7 @@ EOH, $this->device->hostname, $os_group ? " ($os_group)" : '', $this->device->de
 
         // update availability status
         app(CheckDeviceAvailability::class)->execute($this->device);
+        $connectivity = new ConnectivityHelper($this->device);
         $this->deviceArray['status'] = $this->device->status;
         $this->deviceArray['status_reason'] = $this->device->status_reason;
         $os = OS::make($this->deviceArray);
@@ -117,7 +119,7 @@ EOH, $this->device->hostname, $os_group ? " ($os_group)" : '', $this->device->de
 
             try {
                 $instance = Module::fromName($module);
-                $should_discover = $instance->shouldDiscover($os, $module_status);
+                $should_discover = $instance->shouldDiscover($os, $module_status, $connectivity);
 
                 if ($should_discover) {
                     Log::info("#### Load discovery module $module ####\n");

--- a/app/Jobs/PollDevice.php
+++ b/app/Jobs/PollDevice.php
@@ -54,6 +54,7 @@ class PollDevice implements ShouldQueue
     public function handle(): void
     {
         $this->initDevice();
+        $connectivity = new ConnectivityHelper($this->device);
         $this->initRrdDirectory();
         PollingDevice::dispatch($this->device);
         $this->os = OS::make($this->deviceArray);
@@ -64,7 +65,7 @@ class PollDevice implements ShouldQueue
         // check and save status
         app(CheckDeviceAvailability::class)->execute($this->device, true);
 
-        $this->pollModules();
+        $this->pollModules($connectivity);
 
         $measurement->end();
 
@@ -74,7 +75,7 @@ class PollDevice implements ShouldQueue
                 $this->recordPerformance($measurement);
             }
 
-            if (ConnectivityHelper::pingIsAllowed($this->device)) {
+            if ($connectivity->icmpIsEnabled()) {
                 $this->os->enableGraph('ping_perf');
             }
 
@@ -108,7 +109,7 @@ class PollDevice implements ShouldQueue
         DevicePolled::dispatch($this->device);
     }
 
-    private function pollModules(): void
+    private function pollModules(ConnectivityHelper $connectivity): void
     {
         // update $device array status
         $this->deviceArray['status'] = $this->device->status;
@@ -129,7 +130,7 @@ class PollDevice implements ShouldQueue
 
             try {
                 $instance = Module::fromName($module);
-                $should_poll = $instance->shouldPoll($this->os, $module_status);
+                $should_poll = $instance->shouldPoll($this->os, $module_status, $connectivity);
 
                 if ($should_poll) {
                     Log::info("#### Load poller module $module ####\n");

--- a/app/Observers/DeviceObserver.php
+++ b/app/Observers/DeviceObserver.php
@@ -69,6 +69,18 @@ class DeviceObserver
             $device->regenerateDisplayName();
         }
 
+        if ($device->isDirty('snmp_disable') && $device->snmp_disable) {
+            $reasons = collect(explode(',', (string) $device->status_reason))
+                ->reject(fn ($v) => $v === 'snmp')
+                ->filter()
+                ->implode(',');
+            $device->status_reason = $reasons;
+            if ($device->status == 0 && empty($reasons)) {
+                $device->status = 1;
+            }
+        }
+
+
         // handle device renames
         if ($device->isDirty('hostname')) {
             $new_name = $device->hostname;

--- a/app/Observers/DeviceObserver.php
+++ b/app/Observers/DeviceObserver.php
@@ -80,7 +80,6 @@ class DeviceObserver
             }
         }
 
-
         // handle device renames
         if ($device->isDirty('hostname')) {
             $new_name = $device->hostname;

--- a/check-services.php
+++ b/check-services.php
@@ -64,8 +64,8 @@ $services = $query->get();
 foreach ($services as $service) {
     // Run the polling function if service is enabled and the associated device is up, "Disable ICMP Test" option is not enabled,
     // or service hostname/ip is different from associated device
-    if (! $service['service_disabled'] && ($service['status'] == 1 || ($service['status'] == 0 && $service['status_reason'] === 'snmp') ||
-        $service->getAttrib('override_icmp_disable') === 'true' || (! is_null($service['service_ip']) && $service['service_ip'] !== $service['hostname'] &&
+    if (! $service['service_disabled'] && ($service['status'] == 1 || $service['status'] == 0 ||
+        (! is_null($service['service_ip']) && $service['service_ip'] !== $service['hostname'] &&
         $service['service_ip'] !== inet6_ntop($service['ip'])))) {
         poll_service($service);
         $polled_services++;

--- a/database/migrations/2026_06_13_103157_widen_devices_status_reason_column.php
+++ b/database/migrations/2026_06_13_103157_widen_devices_status_reason_column.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('devices', function (Blueprint $table) {
+            $table->string('status_reason', 255)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('devices', function (Blueprint $table) {
+            $table->string('status_reason', 50)->change();
+        });
+    }
+};

--- a/database/migrations/2026_06_17_230632_migrate_status_reason_format_in_rules_and_templates.php
+++ b/database/migrations/2026_06_17_230632_migrate_status_reason_format_in_rules_and_templates.php
@@ -67,6 +67,7 @@ return new class extends Migration
                 $changed = true;
             }
         }
+
         return $changed;
     }
 
@@ -85,6 +86,7 @@ return new class extends Migration
             if ($newStr !== $str) {
                 $changed = true;
             }
+
             return $newStr;
         };
 

--- a/database/migrations/2026_06_17_230632_migrate_status_reason_format_in_rules_and_templates.php
+++ b/database/migrations/2026_06_17_230632_migrate_status_reason_format_in_rules_and_templates.php
@@ -1,0 +1,107 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        $this->migrateAlertRules();
+        $this->migrateAlertTemplates();
+    }
+
+    private function migrateAlertRules(): void
+    {
+        $rules = DB::table('alert_rules')->get();
+
+        foreach ($rules as $ruleRow) {
+            $changed = false;
+            $builder = $ruleRow->builder;
+            $query = $ruleRow->query;
+
+            if (str_contains((string) $builder, '"field":"devices.status_reason"')) {
+                $builderData = json_decode($builder, true);
+                if (is_array($builderData)) {
+                    $builderChanged = $this->updateBuilderNode($builderData);
+                    if ($builderChanged) {
+                        $builder = json_encode($builderData);
+                        $changed = true;
+                    }
+                }
+            }
+
+            if (str_contains((string) $query, 'devices.status_reason = ') || str_contains((string) $query, 'devices.status_reason != ')) {
+                $query = preg_replace('/devices\.status_reason = \'([^\']+)\'/', 'devices.status_reason LIKE \'%$1%\'', $query);
+                $query = preg_replace('/devices\.status_reason != \'([^\']+)\'/', 'devices.status_reason NOT LIKE \'%$1%\'', $query);
+                $changed = true;
+            }
+
+            if ($changed) {
+                DB::table('alert_rules')->where('id', $ruleRow->id)->update([
+                    'builder' => $builder,
+                    'query' => $query,
+                ]);
+            }
+        }
+    }
+
+    private function updateBuilderNode(array &$node): bool
+    {
+        $changed = false;
+        if (isset($node['condition']) && isset($node['rules'])) {
+            foreach ($node['rules'] as &$subNode) {
+                if ($this->updateBuilderNode($subNode)) {
+                    $changed = true;
+                }
+            }
+        } elseif (isset($node['field']) && $node['field'] === 'devices.status_reason') {
+            if ($node['operator'] === 'equal') {
+                $node['operator'] = 'contains';
+                $changed = true;
+            } elseif ($node['operator'] === 'not_equal') {
+                $node['operator'] = 'not_contains';
+                $changed = true;
+            }
+        }
+        return $changed;
+    }
+
+    private function migrateAlertTemplates(): void
+    {
+        $templates = DB::table('alert_templates')->get();
+
+        $replaceFunc = function ($str, &$changed) {
+            if (empty($str)) {
+                return $str;
+            }
+
+            $newStr = preg_replace('/\$alert->status_reason\s*==\s*\'([^\']+)\'/', 'str_contains((string) $alert->status_reason, \'$1\')', (string) $str);
+            $newStr = preg_replace('/\$alert->status_reason\s*!=\s*\'([^\']+)\'/', '! str_contains((string) $alert->status_reason, \'$1\')', $newStr);
+
+            if ($newStr !== $str) {
+                $changed = true;
+            }
+            return $newStr;
+        };
+
+        foreach ($templates as $templateRow) {
+            $changed = false;
+
+            $templateStr = $replaceFunc($templateRow->template, $changed);
+            $titleStr = $replaceFunc($templateRow->title, $changed);
+            $titleRecStr = $replaceFunc($templateRow->title_rec, $changed);
+
+            if ($changed) {
+                DB::table('alert_templates')->where('id', $templateRow->id)->update([
+                    'template' => $templateStr,
+                    'title' => $titleStr,
+                    'title_rec' => $titleRecStr,
+                ]);
+            }
+        }
+    }
+};

--- a/database/migrations/2026_06_17_230632_migrate_status_reason_format_in_rules_and_templates.php
+++ b/database/migrations/2026_06_17_230632_migrate_status_reason_format_in_rules_and_templates.php
@@ -37,7 +37,7 @@ return new class extends Migration
             if (str_contains((string) $query, 'devices.status_reason')) {
                 $newQuery = preg_replace('/devices\.status_reason\s*=\s*[\'"]([^\'"]+)[\'"]/', 'devices.status_reason LIKE \'%$1%\'', (string) $query);
                 $newQuery = preg_replace('/devices\.status_reason\s*!=\s*[\'"]([^\'"]+)[\'"]/', 'devices.status_reason NOT LIKE \'%$1%\'', $newQuery);
-                
+
                 if ($newQuery !== $query) {
                     $query = $newQuery;
                     $changed = true;
@@ -54,7 +54,7 @@ return new class extends Migration
     }
 
     /**
-     * @param  array{condition?: string, field?: string, rules?: array, operator?: string}  $node
+     * @param  array{condition?: string, field?: string, rules?: array<int, mixed>, operator?: string}  $node
      */
     private function updateBuilderNode(array &$node): bool
     {

--- a/database/migrations/2026_06_17_230632_migrate_status_reason_format_in_rules_and_templates.php
+++ b/database/migrations/2026_06_17_230632_migrate_status_reason_format_in_rules_and_templates.php
@@ -34,10 +34,14 @@ return new class extends Migration
                 }
             }
 
-            if (str_contains((string) $query, 'devices.status_reason = ') || str_contains((string) $query, 'devices.status_reason != ')) {
-                $query = preg_replace('/devices\.status_reason = \'([^\']+)\'/', 'devices.status_reason LIKE \'%$1%\'', $query);
-                $query = preg_replace('/devices\.status_reason != \'([^\']+)\'/', 'devices.status_reason NOT LIKE \'%$1%\'', $query);
-                $changed = true;
+            if (str_contains((string) $query, 'devices.status_reason')) {
+                $newQuery = preg_replace('/devices\.status_reason\s*=\s*[\'"]([^\'"]+)[\'"]/', 'devices.status_reason LIKE \'%$1%\'', (string) $query);
+                $newQuery = preg_replace('/devices\.status_reason\s*!=\s*[\'"]([^\'"]+)[\'"]/', 'devices.status_reason NOT LIKE \'%$1%\'', $newQuery);
+                
+                if ($newQuery !== $query) {
+                    $query = $newQuery;
+                    $changed = true;
+                }
             }
 
             if ($changed) {
@@ -49,6 +53,9 @@ return new class extends Migration
         }
     }
 
+    /**
+     * @param  array{condition?: string, field?: string, rules?: array, operator?: string}  $node
+     */
     private function updateBuilderNode(array &$node): bool
     {
         $changed = false;
@@ -80,8 +87,8 @@ return new class extends Migration
                 return $str;
             }
 
-            $newStr = preg_replace('/\$alert->status_reason\s*==\s*\'([^\']+)\'/', 'str_contains((string) $alert->status_reason, \'$1\')', (string) $str);
-            $newStr = preg_replace('/\$alert->status_reason\s*!=\s*\'([^\']+)\'/', '! str_contains((string) $alert->status_reason, \'$1\')', $newStr);
+            $newStr = preg_replace('/\$alert->status_reason\s*={2,3}\s*[\'"]([^\'"]+)[\'"]/', 'str_contains((string) $alert->status_reason, \'$1\')', (string) $str);
+            $newStr = preg_replace('/\$alert->status_reason\s*!==?\s*[\'"]([^\'"]+)[\'"]/', '! str_contains((string) $alert->status_reason, \'$1\')', $newStr);
 
             if ($newStr !== $str) {
                 $changed = true;

--- a/doc/Alerting/Templates.md
+++ b/doc/Alerting/Templates.md
@@ -296,7 +296,7 @@ email or just the hostname in any other transport:
 
 ```php
 @if ($alert->status == 0)
-    @if ($alert->status_reason == 'icmp')
+    @if (str_contains((string) $alert->status_reason, 'icmp'))
         {{ $alert->debug['traceroute'] }}
     @endif
 @endif

--- a/resources/definitions/alert_rules.json
+++ b/resources/definitions/alert_rules.json
@@ -4,7 +4,7 @@
     "builder": {"condition":"AND","rules":[{"id":"macros.device_down","field":"macros.device_down","type":"integer","input":"radio","operator":"equal","value":"1"}],"valid":true}
   },
   {
-    "builder": {"condition":"AND","rules":[{"id":"macros.device_down","field":"macros.device_down","type":"integer","input":"radio","operator":"equal","value":"1"},{"id":"devices.status_reason","field":"devices.status_reason","type":"string","input":"text","operator":"equal","value":"icmp"}],"valid":true},
+    "builder": {"condition":"AND","rules":[{"id":"macros.device_down","field":"macros.device_down","type":"integer","input":"radio","operator":"equal","value":"1"},{"id":"devices.status_reason","field":"devices.status_reason","type":"string","input":"text","operator":"contains","value":"icmp"}],"valid":true},
     "name": "Device Down! Due to no ICMP response.",
     "default": true
   },

--- a/resources/definitions/alert_rules.json
+++ b/resources/definitions/alert_rules.json
@@ -9,7 +9,7 @@
     "default": true
   },
   {
-    "builder": {"condition":"AND","rules":[{"id":"macros.device_down","field":"macros.device_down","type":"integer","input":"radio","operator":"equal","value":"1"},{"id":"devices.status_reason","field":"devices.status_reason","type":"string","input":"text","operator":"equal","value":"snmp"}],"valid":true},
+    "builder": {"condition":"AND","rules":[{"id":"macros.device_down","field":"macros.device_down","type":"integer","input":"radio","operator":"equal","value":"1"},{"id":"devices.status_reason","field":"devices.status_reason","type":"string","input":"text","operator":"contains","value":"snmp"}],"valid":true},
     "name": "Device Down (SNMP unreachable)",
     "default": true,
     "notes": "Device may responds on ICMP but not on SNMP."

--- a/resources/definitions/schema/db_schema.yaml
+++ b/resources/definitions/schema/db_schema.yaml
@@ -658,7 +658,7 @@ devices:
     - { Field: location_id, Type: 'int unsigned', 'Null': true, Extra: '' }
     - { Field: os, Type: varchar(32), 'Null': true, Extra: '' }
     - { Field: status, Type: tinyint, 'Null': false, Extra: '', Default: '0' }
-    - { Field: status_reason, Type: varchar(50), 'Null': false, Extra: '' }
+    - { Field: status_reason, Type: varchar(255), 'Null': false, Extra: '' }
     - { Field: ignore, Type: tinyint, 'Null': false, Extra: '', Default: '0' }
     - { Field: disabled, Type: tinyint, 'Null': false, Extra: '', Default: '0' }
     - { Field: uptime, Type: bigint, 'Null': true, Extra: '' }

--- a/tests/Unit/ConnectivityHelperTest.php
+++ b/tests/Unit/ConnectivityHelperTest.php
@@ -38,13 +38,15 @@ final class ConnectivityHelperTest extends TestCase
             return $mock;
         });
 
-        // not called when snmp is disabled or ping up
+        // not called when snmp is disabled
         $up = new SnmpResponse('SNMPv2-MIB::sysObjectID.0 = .1');
         $down = new SnmpResponse('', '', 1);
         SnmpQuery::partialMock()->shouldReceive('get')
-            ->times(6)
+            ->times(8)
             ->andReturn(
                 $up,
+                $up,
+                $down,
                 $down,
                 $up,
                 $up,
@@ -76,7 +78,7 @@ final class ConnectivityHelperTest extends TestCase
         // ping down, snmp down
         $this->assertFalse(app(CheckDeviceAvailability::class)->execute($device));
         $this->assertFalse($device->status);
-        $this->assertEquals('icmp', $device->status_reason);
+        $this->assertEquals('icmp,snmp', $device->status_reason);
 
         /** ping disabled and snmp enabled */
         LibrenmsConfig::set('icmp_check', false);


### PR DESCRIPTION
Changes status_reason to contain all down polling methods, comma separated
Allow for individual polling method availability checks
ConnectivityHelper implementation will be changed in future PR.  This is to centralize checks and adjust module code.

## ⚠️ Breaking Change Notice: Device `status_reason` Format Update

We have updated how a device's `status_reason` is stored. Previously, this field contained a single reason string (e.g., `icmp` or `snmp`). To provide better visibility into device failures, `status_reason` is now a **comma-separated list** of all reasons a device is marked down (e.g., `icmp,snmp`).

### Automated Migration
We have included a database migration that will automatically update most standard Alert Rules and Alert Templates. 
* Standard rule conditions using **Equal to** or **Not Equal to** have been automatically converted to **Contains** and **Not Contains**.
* Template checks like `@if ($alert->status_reason == 'icmp')` have been automatically converted to use `str_contains()`.

### Action Required: Edge Cases
Because of the complexity of custom rules and templates, the automated migration cannot catch everything. **Please review your custom Alert Rules and Alert Templates if you use any of the following advanced configurations:**

#### 1. Alert Rules using `IN` or `NOT IN` 
If your rule checks multiple reasons using an `IN` array, the rule will no longer match correctly against a comma-separated string.
* **Old (Will Fail):** `devices.status_reason IN ('icmp', 'snmp')`
* **How to Fix:** Rebuild the rule in the Web UI using an **OR** group with multiple **Contains** checks.
  * *Example SQL:* `(devices.status_reason LIKE '%icmp%' OR devices.status_reason LIKE '%snmp%')`

#### 2. Alert Rules using strict `LIKE` queries
If you manually modified a rule's SQL query to use a strict `LIKE` without wildcards, it was skipped by the migration.
* **Old (Will Fail):** `devices.status_reason LIKE 'icmp'`
* **How to Fix:** Update your rule to include wildcards to match the comma-separated format.
  * *Example SQL:* `devices.status_reason LIKE '%icmp%'`

#### 3. Templates using `in_array()`
If your custom Alert Templates use `in_array()` to check the status reason, it will fail because the property is now a single comma-separated string rather than an exact match.
* **Old (Will Fail):** `@if (in_array($alert->status_reason, ['icmp', 'snmp']))`
* **How to Fix:** Use `str_contains()` for each value.
  * *Example:* `@if (str_contains($alert->status_reason, 'icmp') || str_contains($alert->status_reason, 'snmp'))`

#### 4. Templates using `@switch` Statements
Switch statements checking exact string matches were not automatically migrated.
* **Old (Will Fail):** 
  ```blade
  @switch($alert->status_reason)
      @case('icmp')

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
