### PR TITLE
Fix snmprec capture for communities containing '@' (e.g. Juniper routing-instance)

### DIFF
--- a/LibreNMS/Util/ModuleTestHelper.php
+++ b/LibreNMS/Util/ModuleTestHelper.php
@@ -213,8 +213,20 @@ class ModuleTestHelper
             $mibdir = $mibdir_matches[1];
             $method = $snmp_matches[1][$index];
             $oids = explode("' '", trim($snmp_matches[3][$index]));
-            preg_match("/('-c' '.*@([^']+)'|'-n' '([^']+)')/", $line, $context_matches);
-            $context = $context_matches[2] ?? $context_matches[3] ?? null;
+            // Recover the SNMP context used for this query. SNMPv3 passes it via -n.
+            // SNMPv2c encodes it onto the community as "community@context" (see NetSnmpQuery),
+            // so derive it by stripping the device's known community rather than splitting on
+            // the last '@' -- the community itself may contain '@' (e.g. Juniper routing-instance
+            // access "@community"), which would otherwise be misread as a context.
+            $context = null;
+            if (preg_match("/'-n' '([^']+)'/", $line, $v3_context)) {
+                $context = $v3_context[1];
+            } elseif (preg_match("/'-c' '([^']*)'/", $line, $community_match)) {
+                $base_community = (string) ($device['community'] ?? '');
+                if ($base_community !== '' && Str::startsWith($community_match[1], $base_community . '@')) {
+                    $context = substr($community_match[1], strlen($base_community) + 1);
+                }
+            }
 
             foreach ($oids as $oid) {
                 $snmp_oids[$context]["{$oid}_$method"] = [


### PR DESCRIPTION
Fix snmprec capture for communities containing '@' (e.g. Juniper routing-instance)

collectOids() inferred the SNMPv2c context by splitting the community on '@'. A community that legitimately contains '@' (Juniper '@community' for routing-instance access) was misread as a context, so the capture re-query rebuilt the community as community@community and the device dropped it. Derive the context by stripping the device's known community instead.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
