### PR TITLE
Fix non-closed HTML attribute

### DIFF
--- a/resources/views/auth/external-auth-failed.blade.php
+++ b/resources/views/auth/external-auth-failed.blade.php
@@ -3,7 +3,7 @@
 @section('content')
 <div class="container">
     <div class="row">
-        <div class="col-md-6 col-md-offset-3>
+        <div class="col-md-6 col-md-offset-3">
             <h1>External Authentication Failed.</h1>
             <p>Please close your browser window to try again or contact your administrator.</p>
             @if($message)


### PR DESCRIPTION
Adds a missing closing quote to a HTML attribute.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
