### PR TITLE
Add dark mode styling to device config output

### DIFF
--- a/includes/html/pages/device/showconfig.inc.php
+++ b/includes/html/pages/device/showconfig.inc.php
@@ -362,7 +362,7 @@ if (Gate::allows('showConfig', DeviceCache::getPrimary())) {
         $geshi->enable_line_numbers(GESHI_FANCY_LINE_NUMBERS);
         $geshi->set_overall_style('color: black;');
         // $geshi->set_line_style('color: #999999');
-        echo '<div class="config">';
+        echo '<div class="config device-config-output">';
         echo '<input id="linenumbers" class="btn btn-primary" type="submit" value="Hide line numbers"/>';
         echo $geshi->parse_code();
         echo '</div>';

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -52,6 +52,54 @@
   }
 }
 
+/* Improve device config readability in dark mode. */
+.dark .device-config-output {
+  background-color: #32383e;
+  border: 1px solid var(--color-dark-gray-100);
+  color: #d1d5db;
+  overflow-x: auto;
+  padding: 10px;
+}
+
+.dark .device-config-output > div,
+.dark .device-config-output pre,
+.dark .device-config-output table,
+.dark .device-config-output tbody,
+.dark .device-config-output tr,
+.dark .device-config-output td,
+.dark .device-config-output ol,
+.dark .device-config-output li,
+.dark .device-config-output .de1,
+.dark .device-config-output .de2 {
+  background-color: #32383e !important;
+  border-color: var(--color-dark-gray-100) !important;
+  color: #d1d5db !important;
+}
+
+.dark .device-config-output li::marker {
+  color: #9ca3af;
+}
+
+.dark .device-config-output span[style*="#991111"] {
+  color: #ff7b72 !important;
+}
+
+.dark .device-config-output span[style*="#00b000"] {
+  color: #7ee787 !important;
+}
+
+.dark .device-config-output span[style*="#440088"] {
+  color: #d2a8ff !important;
+}
+
+.dark .device-config-output span[style*="#0011dd"] {
+  color: #79c0ff !important;
+}
+
+.dark .device-config-output span[style*="#888822"] {
+  color: #d29922 !important;
+}
+
 .device-link-up {
     @apply tw:font-bold tw:text-blue-900 tw:visited:text-blue-900 tw:dark:text-dark-white-100 tw:dark:visited:text-dark-white-100
 }


### PR DESCRIPTION
## Summary

This adds dark-mode styling for the device Config tab output.

Previously, the GeSHi-rendered config output kept its default/light styling in dark mode, which made the Config tab stand out from the surrounding LibreNMS dark UI. This change adds a scoped wrapper class for the device config output and applies dark-mode styling so the config area uses a dark background consistent with the rest of the page.

Because GeSHi emits inline colors for diff output, the default diff colors do not work well on the new dark background. The diff colors are adjusted only in dark mode so added, removed, hunk/header, metadata, and file marker lines remain readable.

## Changes

* Adds `device-config-output` to the existing config output wrapper.
* Adds scoped dark-mode CSS for the device config output.
* Applies a dark LibreNMS-style background to the Config tab output in dark mode.
* Adjusts GeSHi diff colors in dark mode to match the new dark background.

## Testing

* Verified visually in dark mode:

  * normal config output
  * diff output
  * line numbers
  * surrounding panel/background consistency
* Verified light mode still works.
* Tested default GeSHi diff colors on the dark background, but they were not readable enough.
* `php -l includes/html/pages/device/showconfig.inc.php`
* `git diff --check`
* `./lnms dev:check lint`

## Screenshots

### Dark mode config output

<img width="1603" height="778" alt="Screenshot 2026-06-21 175803" src="https://github.com/user-attachments/assets/51c3b788-5b8c-4a46-bd63-4e1383716118" />

### Dark mode diff output

<img width="1661" height="874" alt="Screenshot 2026-06-21 175926" src="https://github.com/user-attachments/assets/ebc05d0f-98f0-434a-92eb-329a68aa144b" />

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
