### PR TITLE
AlertRules utility cleanup

### DIFF
--- a/LibreNMS/Alert/AlertRules.php
+++ b/LibreNMS/Alert/AlertRules.php
@@ -64,7 +64,7 @@ readonly class AlertRules
     public function run(): bool
     {
         if ($this->device->getMaintenanceStatus() === MaintenanceStatus::SkipAlerts) {
-            Log::info("Under Maintenance, skipping alert rules check.");
+            Log::info('Under Maintenance, skipping alert rules check.');
 
             return false;
         }

--- a/LibreNMS/Alert/AlertRules.php
+++ b/LibreNMS/Alert/AlertRules.php
@@ -45,7 +45,7 @@ use PDOException;
 
 class AlertRules
 {
-    public function runRules($device_id)
+    public function runRules($device_id): bool
     {
         //Check to see if under maintenance
         if (AlertUtil::getMaintenanceStatus($device_id) === MaintenanceStatus::SkipAlerts) {
@@ -94,22 +94,14 @@ class AlertRules
                 continue; // skip this rule
             }
 
-            $cnt = count($qry);
-            for ($i = 0; $i < $cnt; $i++) {
-                if (isset($qry[$i]['ip'])) {
-                    $qry[$i]['ip'] = inet6_ntop($qry[$i]['ip']);
+            foreach ($qry as &$row) {
+                if (isset($row['ip'])) {
+                    $row['ip'] = inet6_ntop($row['ip']);
                 }
             }
-            $s = count($qry);
-            if ($s == 0 && $inv === false) {
-                $doalert = false;
-            } elseif ($s > 0 && $inv === false) {
-                $doalert = true;
-            } elseif ($s == 0 && $inv === true) {
-                $doalert = true;
-            } else {
-                $doalert = false;
-            }
+
+            $matched = ! empty($qry);
+            $doalert = $matched !== $inv;
 
             $current_state = dbFetchCell('SELECT state FROM alerts WHERE rule_id = ? AND device_id = ? ORDER BY id DESC LIMIT 1', [$rule['id'], $device_id]);
             if ($doalert) {
@@ -156,5 +148,7 @@ class AlertRules
                 }
             }
         }
+
+        return true;
     }
 }

--- a/LibreNMS/Alert/AlertRules.php
+++ b/LibreNMS/Alert/AlertRules.php
@@ -114,22 +114,12 @@ readonly class AlertRules
             return;
         }
 
-        $rows = array_map(function ($row) {
-            $row = (array) $row;
-            if (isset($row['ip'])) {
-                $row['ip'] = inet6_ntop($row['ip']);
-            }
-
-            return $row;
-        }, $rows);
-
-        $do_alert = ! empty($rows) !== $invert;
-
         $alert = $this->device->alerts()
             ->where('rule_id', $rule->id)
             ->latest('id')
             ->first();
 
+        $do_alert = ! empty($rows) !== $invert;
         if ($do_alert) {
             $this->handleAlertTrigger($rule, $rows, $alert);
         } else {
@@ -153,6 +143,16 @@ readonly class AlertRules
 
             return;
         }
+
+        // Cast to array rows and make sure ip is a string
+        $rows = array_map(function ($row) {
+            $row = (array) $row;
+            if (isset($row['ip'])) {
+                $row['ip'] = inet6_ntop($row['ip']);
+            }
+
+            return $row;
+        }, $rows);
 
         if (in_array($current_state, [AlertState::ACTIVE, AlertState::WORSE, AlertState::BETTER, AlertState::CHANGED], true)) {
             Log::info('Status: %bNOCHG%n', ['color' => true]);

--- a/LibreNMS/Alert/AlertRules.php
+++ b/LibreNMS/Alert/AlertRules.php
@@ -53,14 +53,14 @@ class AlertRules
 
         //Check to see if under maintenance
         if (AlertUtil::getMaintenanceStatus($device_id) === MaintenanceStatus::SkipAlerts) {
-            echo "Under Maintenance, skipping alert rules check.\r\n";
+            Log::info("Under Maintenance, skipping alert rules check.");
 
             return false;
         }
 
         //Check to see if disable alerting is set
         if (AlertUtil::hasDisableNotify($device_id)) {
-            echo "Disable alerting is set, Clearing active alerts and skipping alert rules check\r\n";
+            Log::info('Disable alerting is set, Clearing active alerts and skipping alert rules check');
             Alert::where('device_id', $device_id)
                 ->update([
                     'state' => AlertState::CLEAR,
@@ -76,7 +76,7 @@ class AlertRules
             Log::info('Rule %p#' . $rule['id'] . ' (' . $rule['name'] . '):%n ', ['color' => true]);
             $extra = json_decode((string) $rule['extra'], true);
             $invert = (bool) ($extra['invert'] ?? false);
-            d_echo(PHP_EOL);
+
             if (empty($rule['query'])) {
                 $rule['query'] = QueryBuilderParser::fromJson($rule['builder'])->toSql();
             }
@@ -90,7 +90,7 @@ class AlertRules
             try {
                 $qry = array_map(fn ($row) => (array) $row, DB::select($sql, [$device_id]));
             } catch (PDOException $e) {
-                c_echo('%RError: %n' . $e->getMessage() . PHP_EOL);
+                Log::error('%RError: %n' . $e->getMessage(), ['color' => true]);
                 Eventlog::log("Error in alert rule {$rule['name']} ({$rule['id']}): " . $e->getMessage(), $device_id, 'alert', Severity::Error);
                 continue; // skip this rule
             }

--- a/LibreNMS/Alert/AlertRules.php
+++ b/LibreNMS/Alert/AlertRules.php
@@ -58,17 +58,6 @@ readonly class AlertRules
     }
 
     /**
-     * Static helper to get rules for a device.
-     *
-     * @param  Device|int  $device
-     * @return Collection<int, AlertRule>
-     */
-    public static function getRulesForDevice(Device|int $device): Collection
-    {
-        return (new self($device))->get();
-    }
-
-    /**
      * Run all alert rules for the given device.
      *
      * @return bool

--- a/LibreNMS/Alert/AlertRules.php
+++ b/LibreNMS/Alert/AlertRules.php
@@ -38,7 +38,6 @@ use App\Models\AlertRule;
 use App\Models\Device;
 use App\Models\Eventlog;
 use Carbon\Carbon;
-use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use LibreNMS\Alerting\QueryBuilderParser;
@@ -82,41 +81,11 @@ readonly class AlertRules
             return false;
         }
 
-        foreach ($this->get() as $rule) {
+        foreach (AlertRule::enabled()->forDevice($this->device)->get() as $rule) {
             $this->processRule($rule);
         }
 
         return true;
-    }
-
-    /**
-     * Get all alert rules that apply to this device.
-     *
-     * @return Collection<int, AlertRule>
-     */
-    public function get(): Collection
-    {
-        return AlertRule::enabled()
-            ->where(function ($query) {
-                $query->where(function ($query) {
-                    $query->whereDoesntHave('devices')
-                        ->whereDoesntHave('groups')
-                        ->whereDoesntHave('locations');
-                })->orWhere(function ($query) {
-                    $query->where('invert_map', 0)
-                        ->where(function ($query) {
-                            $query->whereHas('devices', fn ($q) => $q->where('devices.device_id', $this->device->device_id))
-                                ->orWhereHas('groups', fn ($q) => $q->whereHas('devices', fn ($dq) => $dq->where('devices.device_id', $this->device->device_id)))
-                                ->orWhereHas('locations', fn ($q) => $q->where('locations.id', $this->device->location_id));
-                        });
-                })->orWhere(function ($query) {
-                    $query->where('invert_map', 1)
-                        ->whereDoesntHave('devices', fn ($q) => $q->where('devices.device_id', $this->device->device_id))
-                        ->whereDoesntHave('groups', fn ($q) => $q->whereHas('devices', fn ($dq) => $dq->where('devices.device_id', $this->device->device_id)))
-                        ->whereDoesntHave('locations', fn ($q) => $q->where('locations.id', $this->device->location_id));
-                });
-            })
-            ->get();
     }
 
     /**
@@ -137,19 +106,22 @@ readonly class AlertRules
         }
 
         try {
-            $rows = array_map(fn ($row) => (array) $row, DB::select($sql, [$this->device->device_id]));
+            $rows = DB::select($sql, [$this->device->device_id]);
         } catch (PDOException $e) {
             Log::error('%RError: %n' . $e->getMessage(), ['color' => true]);
-            Eventlog::log("Error in alert rule {$rule->name} ({$rule->id}): " . $e->getMessage(), $this->device, 'alert', Severity::Error);
+            Eventlog::log("Error in alert rule $rule->name ($rule->id): " . $e->getMessage(), $this->device, 'alert', Severity::Error);
 
             return;
         }
 
-        foreach ($rows as &$row) {
+        $rows = array_map(function ($row) {
+            $row = (array) $row;
             if (isset($row['ip'])) {
                 $row['ip'] = inet6_ntop($row['ip']);
             }
-        }
+
+            return $row;
+        }, $rows);
 
         $do_alert = ! empty($rows) !== $invert;
 
@@ -159,20 +131,20 @@ readonly class AlertRules
             ->first();
 
         if ($do_alert) {
-            $this->handleAlertTrigger($rule->id, $rows, $alert);
+            $this->handleAlertTrigger($rule, $rows, $alert);
         } else {
-            $this->handleAlertRecovery($rule->id, $alert);
+            $this->handleAlertRecovery($rule, $alert);
         }
     }
 
     /**
      * Handle triggering or updating an active alert.
      *
-     * @param int $rule_id
-     * @param array $rows
-     * @param Alert|null $alert
+     * @param  AlertRule  $rule
+     * @param  array  $rows
+     * @param  Alert|null  $alert
      */
-    private function handleAlertTrigger(int $rule_id, array $rows, ?Alert $alert): void
+    private function handleAlertTrigger(AlertRule $rule, array $rows, ?Alert $alert): void
     {
         $current_state = $alert?->state;
 
@@ -182,17 +154,14 @@ readonly class AlertRules
             return;
         }
 
-        if ($current_state >= AlertState::ACTIVE) {
+        if (in_array($current_state, [AlertState::ACTIVE, AlertState::WORSE, AlertState::BETTER, AlertState::CHANGED], true)) {
             Log::info('Status: %bNOCHG%n', ['color' => true]);
 
             // NOCHG here doesn't mean no change full stop. It means no change to the alert state
             // So we update the details column with any fresh changes to the alert output we might have.
             $alert_log = $this->device->alertLogs()
-                ->join('alert_rules', 'alert_log.rule_id', '=', 'alert_rules.id')
-                ->where('alert_log.rule_id', $rule_id)
-                ->where('alert_rules.disabled', 0)
-                ->select('alert_log.*')
-                ->latest('alert_log.id')
+                ->where('rule_id', $rule->id)
+                ->latest('id')
                 ->first();
 
             if ($alert_log) {
@@ -207,7 +176,7 @@ readonly class AlertRules
 
         // State is not active, trigger alert
         $extra = ['contacts' => AlertUtil::getContacts($rows), 'rule' => $rows];
-        if ($this->device->alertLogs()->create(['state' => AlertState::ACTIVE, 'rule_id' => $rule_id, 'details' => $extra])) {
+        if ($this->device->alertLogs()->create(['state' => AlertState::ACTIVE, 'rule_id' => $rule->id, 'details' => $extra])) {
             $alert_data = [
                 'state' => AlertState::ACTIVE,
                 'open' => 1,
@@ -219,7 +188,7 @@ readonly class AlertRules
                 $alert->update($alert_data);
             } else {
                 $this->device->alerts()->create(array_merge($alert_data, [
-                    'rule_id' => $rule_id,
+                    'rule_id' => $rule->id,
                     'info' => [],
                 ]));
             }
@@ -230,10 +199,10 @@ readonly class AlertRules
     /**
      * Handle recovery of an alert.
      *
-     * @param int $rule_id
-     * @param Alert|null $alert
+     * @param  AlertRule  $rule
+     * @param  Alert|null  $alert
      */
-    private function handleAlertRecovery(int $rule_id, ?Alert $alert): void
+    private function handleAlertRecovery(AlertRule $rule, ?Alert $alert): void
     {
         if ($alert && $alert->state == AlertState::RECOVERED) {
             Log::info('Status: %bNOCHG%n', ['color' => true]);
@@ -241,7 +210,7 @@ readonly class AlertRules
             return;
         }
 
-        if ($this->device->alertLogs()->create(['state' => AlertState::RECOVERED, 'rule_id' => $rule_id])) {
+        if ($this->device->alertLogs()->create(['state' => AlertState::RECOVERED, 'rule_id' => $rule->id])) {
             $alert_data = [
                 'state' => AlertState::RECOVERED,
                 'open' => 1,
@@ -252,7 +221,7 @@ readonly class AlertRules
                 $alert->update(array_merge($alert_data, ['note' => '']));
             } else {
                 $this->device->alerts()->create(array_merge($alert_data, [
-                    'rule_id' => $rule_id,
+                    'rule_id' => $rule->id,
                     'alerted' => 0,
                     'info' => [],
                 ]));

--- a/LibreNMS/Alert/AlertRules.php
+++ b/LibreNMS/Alert/AlertRules.php
@@ -71,12 +71,11 @@ readonly class AlertRules
 
         if ($this->device->disable_notify) {
             Log::info('Disable alerting is set, Clearing active alerts and skipping alert rules check');
-            $this->device->alerts()
-                ->update([
-                    'state' => AlertState::CLEAR,
-                    'alerted' => 0,
-                    'open' => 0,
-                ]);
+            $this->device->alerts()->update([
+                'state' => AlertState::CLEAR,
+                'alerted' => 0,
+                'open' => 0,
+            ]);
 
             return false;
         }
@@ -165,10 +164,12 @@ readonly class AlertRules
                 ->first();
 
             if ($alert_log) {
-                $details = $alert_log->details ?? [];
-                $details['contacts'] = AlertUtil::getContacts($rows);
-                $details['rule'] = $rows;
-                $alert_log->update(['details' => $details]);
+                $alert_log->details = [
+                    ...($alert_log->details ?? []),
+                    'contacts' => AlertUtil::getContacts($rows),
+                    'rule' => $rows,
+                ];
+                $alert_log->save();
             }
 
             return;

--- a/LibreNMS/Alert/AlertRules.php
+++ b/LibreNMS/Alert/AlertRules.php
@@ -34,9 +34,11 @@ namespace LibreNMS\Alert;
 
 use App\Facades\DeviceCache;
 use App\Models\Alert;
+use App\Models\AlertRule;
 use App\Models\Device;
 use App\Models\Eventlog;
 use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use LibreNMS\Alerting\QueryBuilderParser;
@@ -51,9 +53,19 @@ readonly class AlertRules
 
     public function __construct(
         Device|int $device
-    )
-    {
+    ) {
         $this->device = is_int($device) ? DeviceCache::get($device) : $device;
+    }
+
+    /**
+     * Static helper to get rules for a device.
+     *
+     * @param  Device|int  $device
+     * @return Collection<int, AlertRule>
+     */
+    public static function getRulesForDevice(Device|int $device): Collection
+    {
+        return (new self($device))->get();
     }
 
     /**
@@ -81,36 +93,65 @@ readonly class AlertRules
             return false;
         }
 
-        foreach (AlertUtil::getRules($this->device->device_id) as $rule_data) {
-            $this->processRule($rule_data);
+        foreach ($this->get() as $rule) {
+            $this->processRule($rule);
         }
 
         return true;
     }
 
     /**
+     * Get all alert rules that apply to this device.
+     *
+     * @return Collection<int, AlertRule>
+     */
+    public function get(): Collection
+    {
+        return AlertRule::enabled()
+            ->where(function ($query) {
+                $query->where(function ($query) {
+                    $query->whereDoesntHave('devices')
+                        ->whereDoesntHave('groups')
+                        ->whereDoesntHave('locations');
+                })->orWhere(function ($query) {
+                    $query->where('invert_map', 0)
+                        ->where(function ($query) {
+                            $query->whereHas('devices', fn ($q) => $q->where('devices.device_id', $this->device->device_id))
+                                ->orWhereHas('groups', fn ($q) => $q->whereHas('devices', fn ($dq) => $dq->where('devices.device_id', $this->device->device_id)))
+                                ->orWhereHas('locations', fn ($q) => $q->where('locations.id', $this->device->location_id));
+                        });
+                })->orWhere(function ($query) {
+                    $query->where('invert_map', 1)
+                        ->whereDoesntHave('devices', fn ($q) => $q->where('devices.device_id', $this->device->device_id))
+                        ->whereDoesntHave('groups', fn ($q) => $q->whereHas('devices', fn ($dq) => $dq->where('devices.device_id', $this->device->device_id)))
+                        ->whereDoesntHave('locations', fn ($q) => $q->where('locations.id', $this->device->location_id));
+                });
+            })
+            ->get();
+    }
+
+    /**
      * Process a single alert rule for a device.
      *
-     * @param array $rule
+     * @param  AlertRule  $rule
      */
-    private function processRule(array $rule): void
+    private function processRule(AlertRule $rule): void
     {
-        Log::info('Rule %p#' . $rule['id'] . ' (' . $rule['name'] . '):%n ', ['color' => true]);
+        Log::info('Rule %p#' . $rule->id . ' (' . $rule->name . '):%n ', ['color' => true]);
 
-        $extra = json_decode((string) ($rule['extra'] ?? ''), true);
-        $invert = (bool) ($extra['invert'] ?? false);
+        $invert = (bool) ($rule->extra['invert'] ?? false);
 
-        $sql = $rule['query'] ?: QueryBuilderParser::fromJson($rule['builder'])->toSql();
+        $sql = $rule->query ?: QueryBuilderParser::fromJson($rule->builder)->toSql();
 
         if (empty($sql)) {
             return;
         }
 
         try {
-            $rows = array_map(fn($row) => (array) $row, DB::select($sql, [$this->device->device_id]));
+            $rows = array_map(fn ($row) => (array) $row, DB::select($sql, [$this->device->device_id]));
         } catch (PDOException $e) {
             Log::error('%RError: %n' . $e->getMessage(), ['color' => true]);
-            Eventlog::log("Error in alert rule {$rule['name']} ({$rule['id']}): " . $e->getMessage(), $this->device, 'alert', Severity::Error);
+            Eventlog::log("Error in alert rule {$rule->name} ({$rule->id}): " . $e->getMessage(), $this->device, 'alert', Severity::Error);
 
             return;
         }
@@ -124,14 +165,14 @@ readonly class AlertRules
         $do_alert = ! empty($rows) !== $invert;
 
         $alert = $this->device->alerts()
-            ->where('rule_id', $rule['id'])
+            ->where('rule_id', $rule->id)
             ->latest('id')
             ->first();
 
         if ($do_alert) {
-            $this->handleAlertTrigger($rule['id'], $rows, $alert);
+            $this->handleAlertTrigger($rule->id, $rows, $alert);
         } else {
-            $this->handleAlertRecovery($rule['id'], $alert);
+            $this->handleAlertRecovery($rule->id, $alert);
         }
     }
 

--- a/LibreNMS/Alert/AlertRules.php
+++ b/LibreNMS/Alert/AlertRules.php
@@ -32,6 +32,9 @@
 
 namespace LibreNMS\Alert;
 
+use App\Facades\DeviceCache;
+use App\Models\Alert;
+use App\Models\AlertLog;
 use App\Models\Eventlog;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\DB;
@@ -40,38 +43,39 @@ use LibreNMS\Alerting\QueryBuilderParser;
 use LibreNMS\Enum\AlertState;
 use LibreNMS\Enum\MaintenanceStatus;
 use LibreNMS\Enum\Severity;
-use PDO;
 use PDOException;
 
 class AlertRules
 {
-    public function runRules($device_id): bool
+    public function runRules(int $device_id): bool
     {
+        $device = DeviceCache::get($device_id);
+
         //Check to see if under maintenance
         if (AlertUtil::getMaintenanceStatus($device_id) === MaintenanceStatus::SkipAlerts) {
             echo "Under Maintenance, skipping alert rules check.\r\n";
 
             return false;
         }
+
         //Check to see if disable alerting is set
         if (AlertUtil::hasDisableNotify($device_id)) {
             echo "Disable alerting is set, Clearing active alerts and skipping alert rules check\r\n";
-            $device_alert['state'] = AlertState::CLEAR;
-            $device_alert['alerted'] = 0;
-            $device_alert['open'] = 0;
-            dbUpdate($device_alert, 'alerts', '`device_id` = ?', [$device_id]);
+            Alert::where('device_id', $device_id)
+                ->update([
+                    'state' => AlertState::CLEAR,
+                    'alerted' => 0,
+                    'open' => 0,
+                ]);
 
             return false;
         }
+
         //Checks each rule.
         foreach (AlertUtil::getRules($device_id) as $rule) {
             Log::info('Rule %p#' . $rule['id'] . ' (' . $rule['name'] . '):%n ', ['color' => true]);
             $extra = json_decode((string) $rule['extra'], true);
-            if (isset($extra['invert'])) {
-                $inv = (bool) $extra['invert'];
-            } else {
-                $inv = false;
-            }
+            $invert = (bool) ($extra['invert'] ?? false);
             d_echo(PHP_EOL);
             if (empty($rule['query'])) {
                 $rule['query'] = QueryBuilderParser::fromJson($rule['builder'])->toSql();
@@ -84,10 +88,7 @@ class AlertRules
 
             // set fetch assoc
             try {
-                $query = DB::connection()->getPdo()->prepare($sql);
-                $query->execute([$device_id]);
-
-                $qry = $query->fetchAll(PDO::FETCH_ASSOC);
+                $qry = array_map(fn ($row) => (array) $row, DB::select($sql, [$device_id]));
             } catch (PDOException $e) {
                 c_echo('%RError: %n' . $e->getMessage() . PHP_EOL);
                 Eventlog::log("Error in alert rule {$rule['name']} ({$rule['id']}): " . $e->getMessage(), $device_id, 'alert', Severity::Error);
@@ -101,9 +102,13 @@ class AlertRules
             }
 
             $matched = ! empty($qry);
-            $doalert = $matched !== $inv;
+            $doalert = $matched !== $invert;
 
-            $current_state = dbFetchCell('SELECT state FROM alerts WHERE rule_id = ? AND device_id = ? ORDER BY id DESC LIMIT 1', [$rule['id'], $device_id]);
+            $current_state = Alert::where('rule_id', $rule['id'])
+                ->where('device_id', $device_id)
+                ->latest('id')
+                ->value('state');
+
             if ($doalert) {
                 if ($current_state == AlertState::ACKNOWLEDGED) {
                     Log::info('Status: %ySKIP%n', ['color' => true]);
@@ -111,23 +116,29 @@ class AlertRules
                     Log::info('Status: %bNOCHG%n', ['color' => true]);
                     // NOCHG here doesn't mean no change full stop. It means no change to the alert state
                     // So we update the details column with any fresh changes to the alert output we might have.
-                    $alert_log = dbFetchRow('SELECT alert_log.id, alert_log.details FROM alert_log,alert_rules WHERE alert_log.rule_id = alert_rules.id && alert_log.device_id = ? && alert_log.rule_id = ? && alert_rules.disabled = 0
-     ORDER BY alert_log.id DESC LIMIT 1', [$device_id, $rule['id']]);
-                    $details = [];
-                    if (! empty($alert_log['details'])) {
-                        $details = json_decode(gzuncompress($alert_log['details']), true);
+                    $alert_log = AlertLog::join('alert_rules', 'alert_log.rule_id', '=', 'alert_rules.id')
+                        ->where('alert_log.device_id', $device_id)
+                        ->where('alert_log.rule_id', $rule['id'])
+                        ->where('alert_rules.disabled', 0)
+                        ->select('alert_log.*')
+                        ->latest('alert_log.id')
+                        ->first();
+
+                    if ($alert_log) {
+                        $details = $alert_log->details ?? [];
+                        $details['contacts'] = AlertUtil::getContacts($qry);
+                        $details['rule'] = $qry;
+                        $alert_log->update(['details' => $details]);
                     }
-                    $details['contacts'] = AlertUtil::getContacts($qry);
-                    $details['rule'] = $qry;
-                    $details = gzcompress(json_encode($details), 9);
-                    dbUpdate(['details' => $details], 'alert_log', 'id = ?', [$alert_log['id']]);
                 } else {
-                    $extra = gzcompress(json_encode(['contacts' => AlertUtil::getContacts($qry), 'rule' => $qry]), 9);
-                    if (dbInsert(['state' => AlertState::ACTIVE, 'device_id' => $device_id, 'rule_id' => $rule['id'], 'details' => $extra], 'alert_log')) {
+                    $extra = ['contacts' => AlertUtil::getContacts($qry), 'rule' => $qry];
+                    if (AlertLog::create(['state' => AlertState::ACTIVE, 'device_id' => $device_id, 'rule_id' => $rule['id'], 'details' => $extra])) {
                         if (is_null($current_state)) {
-                            dbInsert(['state' => AlertState::ACTIVE, 'device_id' => $device_id, 'rule_id' => $rule['id'], 'open' => 1, 'alerted' => 0], 'alerts');
+                            Alert::create(['state' => AlertState::ACTIVE, 'device_id' => $device_id, 'rule_id' => $rule['id'], 'open' => 1, 'alerted' => 0, 'info' => []]);
                         } else {
-                            dbUpdate(['state' => AlertState::ACTIVE, 'open' => 1, 'alerted' => 0, 'timestamp' => Carbon::now()], 'alerts', 'device_id = ? && rule_id = ?', [$device_id, $rule['id']]);
+                            Alert::where('device_id', $device_id)
+                                ->where('rule_id', $rule['id'])
+                                ->update(['state' => AlertState::ACTIVE, 'open' => 1, 'alerted' => 0, 'timestamp' => Carbon::now()]);
                         }
                         Log::info(PHP_EOL . 'Status: %rALERT%n', ['color' => true]);
                     }
@@ -136,11 +147,13 @@ class AlertRules
                 if (! is_null($current_state) && $current_state == AlertState::RECOVERED) {
                     Log::info('Status: %bNOCHG%n', ['color' => true]);
                 } else {
-                    if (dbInsert(['state' => AlertState::RECOVERED, 'device_id' => $device_id, 'rule_id' => $rule['id']], 'alert_log')) {
+                    if (AlertLog::create(['state' => AlertState::RECOVERED, 'device_id' => $device_id, 'rule_id' => $rule['id']])) {
                         if (is_null($current_state)) {
-                            dbInsert(['state' => AlertState::RECOVERED, 'device_id' => $device_id, 'rule_id' => $rule['id'], 'open' => 1, 'alerted' => 0], 'alerts');
+                            Alert::create(['state' => AlertState::RECOVERED, 'device_id' => $device_id, 'rule_id' => $rule['id'], 'open' => 1, 'alerted' => 0, 'info' => []]);
                         } else {
-                            dbUpdate(['state' => AlertState::RECOVERED, 'open' => 1, 'note' => '', 'timestamp' => Carbon::now()], 'alerts', 'device_id = ? && rule_id = ?', [$device_id, $rule['id']]);
+                            Alert::where('device_id', $device_id)
+                                ->where('rule_id', $rule['id'])
+                                ->update(['state' => AlertState::RECOVERED, 'open' => 1, 'note' => '', 'timestamp' => Carbon::now()]);
                         }
 
                         Log::info(PHP_EOL . 'Status: %gOK%n', ['color' => true]);

--- a/LibreNMS/Alert/AlertRules.php
+++ b/LibreNMS/Alert/AlertRules.php
@@ -34,7 +34,7 @@ namespace LibreNMS\Alert;
 
 use App\Facades\DeviceCache;
 use App\Models\Alert;
-use App\Models\AlertLog;
+use App\Models\Device;
 use App\Models\Eventlog;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\DB;
@@ -45,23 +45,33 @@ use LibreNMS\Enum\MaintenanceStatus;
 use LibreNMS\Enum\Severity;
 use PDOException;
 
-class AlertRules
+readonly class AlertRules
 {
-    public function runRules(int $device_id): bool
-    {
-        $device = DeviceCache::get($device_id);
+    private Device $device;
 
-        //Check to see if under maintenance
-        if (AlertUtil::getMaintenanceStatus($device_id) === MaintenanceStatus::SkipAlerts) {
+    public function __construct(
+        Device|int $device
+    )
+    {
+        $this->device = is_int($device) ? DeviceCache::get($device) : $device;
+    }
+
+    /**
+     * Run all alert rules for the given device.
+     *
+     * @return bool
+     */
+    public function run(): bool
+    {
+        if ($this->device->getMaintenanceStatus() === MaintenanceStatus::SkipAlerts) {
             Log::info("Under Maintenance, skipping alert rules check.");
 
             return false;
         }
 
-        //Check to see if disable alerting is set
-        if (AlertUtil::hasDisableNotify($device_id)) {
+        if ($this->device->disable_notify) {
             Log::info('Disable alerting is set, Clearing active alerts and skipping alert rules check');
-            Alert::where('device_id', $device_id)
+            $this->device->alerts()
                 ->update([
                     'state' => AlertState::CLEAR,
                     'alerted' => 0,
@@ -71,97 +81,154 @@ class AlertRules
             return false;
         }
 
-        //Checks each rule.
-        foreach (AlertUtil::getRules($device_id) as $rule) {
-            Log::info('Rule %p#' . $rule['id'] . ' (' . $rule['name'] . '):%n ', ['color' => true]);
-            $extra = json_decode((string) $rule['extra'], true);
-            $invert = (bool) ($extra['invert'] ?? false);
-
-            if (empty($rule['query'])) {
-                $rule['query'] = QueryBuilderParser::fromJson($rule['builder'])->toSql();
-            }
-            $sql = $rule['query'];
-
-            if (empty($sql)) {
-                continue; // no sql
-            }
-
-            // set fetch assoc
-            try {
-                $qry = array_map(fn ($row) => (array) $row, DB::select($sql, [$device_id]));
-            } catch (PDOException $e) {
-                Log::error('%RError: %n' . $e->getMessage(), ['color' => true]);
-                Eventlog::log("Error in alert rule {$rule['name']} ({$rule['id']}): " . $e->getMessage(), $device_id, 'alert', Severity::Error);
-                continue; // skip this rule
-            }
-
-            foreach ($qry as &$row) {
-                if (isset($row['ip'])) {
-                    $row['ip'] = inet6_ntop($row['ip']);
-                }
-            }
-
-            $matched = ! empty($qry);
-            $doalert = $matched !== $invert;
-
-            $current_state = Alert::where('rule_id', $rule['id'])
-                ->where('device_id', $device_id)
-                ->latest('id')
-                ->value('state');
-
-            if ($doalert) {
-                if ($current_state == AlertState::ACKNOWLEDGED) {
-                    Log::info('Status: %ySKIP%n', ['color' => true]);
-                } elseif ($current_state >= AlertState::ACTIVE) {
-                    Log::info('Status: %bNOCHG%n', ['color' => true]);
-                    // NOCHG here doesn't mean no change full stop. It means no change to the alert state
-                    // So we update the details column with any fresh changes to the alert output we might have.
-                    $alert_log = AlertLog::join('alert_rules', 'alert_log.rule_id', '=', 'alert_rules.id')
-                        ->where('alert_log.device_id', $device_id)
-                        ->where('alert_log.rule_id', $rule['id'])
-                        ->where('alert_rules.disabled', 0)
-                        ->select('alert_log.*')
-                        ->latest('alert_log.id')
-                        ->first();
-
-                    if ($alert_log) {
-                        $details = $alert_log->details ?? [];
-                        $details['contacts'] = AlertUtil::getContacts($qry);
-                        $details['rule'] = $qry;
-                        $alert_log->update(['details' => $details]);
-                    }
-                } else {
-                    $extra = ['contacts' => AlertUtil::getContacts($qry), 'rule' => $qry];
-                    if (AlertLog::create(['state' => AlertState::ACTIVE, 'device_id' => $device_id, 'rule_id' => $rule['id'], 'details' => $extra])) {
-                        if (is_null($current_state)) {
-                            Alert::create(['state' => AlertState::ACTIVE, 'device_id' => $device_id, 'rule_id' => $rule['id'], 'open' => 1, 'alerted' => 0, 'info' => []]);
-                        } else {
-                            Alert::where('device_id', $device_id)
-                                ->where('rule_id', $rule['id'])
-                                ->update(['state' => AlertState::ACTIVE, 'open' => 1, 'alerted' => 0, 'timestamp' => Carbon::now()]);
-                        }
-                        Log::info(PHP_EOL . 'Status: %rALERT%n', ['color' => true]);
-                    }
-                }
-            } else {
-                if (! is_null($current_state) && $current_state == AlertState::RECOVERED) {
-                    Log::info('Status: %bNOCHG%n', ['color' => true]);
-                } else {
-                    if (AlertLog::create(['state' => AlertState::RECOVERED, 'device_id' => $device_id, 'rule_id' => $rule['id']])) {
-                        if (is_null($current_state)) {
-                            Alert::create(['state' => AlertState::RECOVERED, 'device_id' => $device_id, 'rule_id' => $rule['id'], 'open' => 1, 'alerted' => 0, 'info' => []]);
-                        } else {
-                            Alert::where('device_id', $device_id)
-                                ->where('rule_id', $rule['id'])
-                                ->update(['state' => AlertState::RECOVERED, 'open' => 1, 'note' => '', 'timestamp' => Carbon::now()]);
-                        }
-
-                        Log::info(PHP_EOL . 'Status: %gOK%n', ['color' => true]);
-                    }
-                }
-            }
+        foreach (AlertUtil::getRules($this->device->device_id) as $rule_data) {
+            $this->processRule($rule_data);
         }
 
         return true;
+    }
+
+    /**
+     * Process a single alert rule for a device.
+     *
+     * @param array $rule
+     */
+    private function processRule(array $rule): void
+    {
+        Log::info('Rule %p#' . $rule['id'] . ' (' . $rule['name'] . '):%n ', ['color' => true]);
+
+        $extra = json_decode((string) ($rule['extra'] ?? ''), true);
+        $invert = (bool) ($extra['invert'] ?? false);
+
+        $sql = $rule['query'] ?: QueryBuilderParser::fromJson($rule['builder'])->toSql();
+
+        if (empty($sql)) {
+            return;
+        }
+
+        try {
+            $rows = array_map(fn($row) => (array) $row, DB::select($sql, [$this->device->device_id]));
+        } catch (PDOException $e) {
+            Log::error('%RError: %n' . $e->getMessage(), ['color' => true]);
+            Eventlog::log("Error in alert rule {$rule['name']} ({$rule['id']}): " . $e->getMessage(), $this->device, 'alert', Severity::Error);
+
+            return;
+        }
+
+        foreach ($rows as &$row) {
+            if (isset($row['ip'])) {
+                $row['ip'] = inet6_ntop($row['ip']);
+            }
+        }
+
+        $do_alert = ! empty($rows) !== $invert;
+
+        $alert = $this->device->alerts()
+            ->where('rule_id', $rule['id'])
+            ->latest('id')
+            ->first();
+
+        if ($do_alert) {
+            $this->handleAlertTrigger($rule['id'], $rows, $alert);
+        } else {
+            $this->handleAlertRecovery($rule['id'], $alert);
+        }
+    }
+
+    /**
+     * Handle triggering or updating an active alert.
+     *
+     * @param int $rule_id
+     * @param array $rows
+     * @param Alert|null $alert
+     */
+    private function handleAlertTrigger(int $rule_id, array $rows, ?Alert $alert): void
+    {
+        $current_state = $alert?->state;
+
+        if ($current_state == AlertState::ACKNOWLEDGED) {
+            Log::info('Status: %ySKIP%n', ['color' => true]);
+
+            return;
+        }
+
+        if ($current_state >= AlertState::ACTIVE) {
+            Log::info('Status: %bNOCHG%n', ['color' => true]);
+
+            // NOCHG here doesn't mean no change full stop. It means no change to the alert state
+            // So we update the details column with any fresh changes to the alert output we might have.
+            $alert_log = $this->device->alertLogs()
+                ->join('alert_rules', 'alert_log.rule_id', '=', 'alert_rules.id')
+                ->where('alert_log.rule_id', $rule_id)
+                ->where('alert_rules.disabled', 0)
+                ->select('alert_log.*')
+                ->latest('alert_log.id')
+                ->first();
+
+            if ($alert_log) {
+                $details = $alert_log->details ?? [];
+                $details['contacts'] = AlertUtil::getContacts($rows);
+                $details['rule'] = $rows;
+                $alert_log->update(['details' => $details]);
+            }
+
+            return;
+        }
+
+        // State is not active, trigger alert
+        $extra = ['contacts' => AlertUtil::getContacts($rows), 'rule' => $rows];
+        if ($this->device->alertLogs()->create(['state' => AlertState::ACTIVE, 'rule_id' => $rule_id, 'details' => $extra])) {
+            $alert_data = [
+                'state' => AlertState::ACTIVE,
+                'open' => 1,
+                'alerted' => 0,
+                'timestamp' => Carbon::now(),
+            ];
+
+            if ($alert) {
+                $alert->update($alert_data);
+            } else {
+                $this->device->alerts()->create(array_merge($alert_data, [
+                    'rule_id' => $rule_id,
+                    'info' => [],
+                ]));
+            }
+            Log::info(PHP_EOL . 'Status: %rALERT%n', ['color' => true]);
+        }
+    }
+
+    /**
+     * Handle recovery of an alert.
+     *
+     * @param int $rule_id
+     * @param Alert|null $alert
+     */
+    private function handleAlertRecovery(int $rule_id, ?Alert $alert): void
+    {
+        if ($alert && $alert->state == AlertState::RECOVERED) {
+            Log::info('Status: %bNOCHG%n', ['color' => true]);
+
+            return;
+        }
+
+        if ($this->device->alertLogs()->create(['state' => AlertState::RECOVERED, 'rule_id' => $rule_id])) {
+            $alert_data = [
+                'state' => AlertState::RECOVERED,
+                'open' => 1,
+                'timestamp' => Carbon::now(),
+            ];
+
+            if ($alert) {
+                $alert->update(array_merge($alert_data, ['note' => '']));
+            } else {
+                $this->device->alerts()->create(array_merge($alert_data, [
+                    'rule_id' => $rule_id,
+                    'alerted' => 0,
+                    'info' => [],
+                ]));
+            }
+
+            Log::info(PHP_EOL . 'Status: %gOK%n', ['color' => true]);
+        }
     }
 }

--- a/LibreNMS/Alert/AlertUtil.php
+++ b/LibreNMS/Alert/AlertUtil.php
@@ -30,7 +30,6 @@ use App\Facades\LibrenmsConfig;
 use App\Models\Alert;
 use App\Models\AlertOperationSegment;
 use App\Models\AlertRule;
-use App\Models\Device;
 use App\Models\DeviceGroup;
 use App\Models\User;
 use DeviceCache;
@@ -39,7 +38,6 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use LibreNMS\Enum\AlertRuleOperationPhase;
-use LibreNMS\Enum\MaintenanceStatus;
 use PHPMailer\PHPMailer\PHPMailer;
 
 class AlertUtil
@@ -360,49 +358,6 @@ class AlertUtil
                 $query->orWhereHas('bills', fn ($q) => $q->whereIn('bill_perms.bill_id', $bill_ids));
             }
         })->pluck('realname', 'email')->all();
-    }
-
-    public static function getRules($device_id)
-    {
-        $query = 'SELECT DISTINCT a.* FROM alert_rules a
-        LEFT JOIN alert_device_map d ON a.id=d.rule_id AND (a.invert_map = 0 OR a.invert_map = 1 AND d.device_id = ?)
-        LEFT JOIN alert_group_map g ON a.id=g.rule_id AND (a.invert_map = 0 OR a.invert_map = 1 AND g.group_id IN (SELECT DISTINCT device_group_id FROM device_group_device WHERE device_id = ?))
-        LEFT JOIN alert_location_map l ON a.id=l.rule_id AND (a.invert_map = 0 OR a.invert_map = 1 AND l.location_id IN (SELECT DISTINCT location_id FROM devices WHERE device_id = ?))
-        LEFT JOIN devices ld ON l.location_id=ld.location_id AND ld.device_id = ?
-        LEFT JOIN device_group_device dg ON g.group_id=dg.device_group_id AND dg.device_id = ?
-        WHERE a.disabled = 0 AND (
-            (d.device_id IS NULL AND g.group_id IS NULL AND l.location_id IS NULL)
-            OR (a.invert_map = 0 AND (d.device_id=? OR dg.device_id=? OR ld.device_id=?))
-            OR (a.invert_map = 1  AND (d.device_id != ? OR d.device_id IS NULL) AND (dg.device_id != ? OR dg.device_id IS NULL) AND (ld.device_id != ? OR ld.device_id IS NULL))
-        )';
-
-        $params = [$device_id, $device_id, $device_id, $device_id, $device_id, $device_id, $device_id, $device_id, $device_id, $device_id, $device_id];
-
-        return dbFetchRows($query, $params);
-    }
-
-    /**
-     * Check if device is under maintenance
-     *
-     * @param  int  $device_id  Device-ID
-     * @return MaintenanceStatus
-     */
-    public static function getMaintenanceStatus($device_id): MaintenanceStatus
-    {
-        return DeviceCache::get($device_id)->getMaintenanceStatus();
-    }
-
-    /**
-     * Check if device is set to ignore alerts
-     *
-     * @param  int  $device_id  Device-ID
-     * @return bool
-     */
-    public static function hasDisableNotify($device_id)
-    {
-        $device = Device::find($device_id);
-
-        return ! is_null($device) && $device->disable_notify;
     }
 
     /**

--- a/LibreNMS/Alert/RunAlerts.php
+++ b/LibreNMS/Alert/RunAlerts.php
@@ -266,7 +266,7 @@ class RunAlerts
     {
         global $rulescache;
         if (empty($rulescache[$device_id]) || ! isset($rulescache[$device_id])) {
-            foreach (AlertRules::getRulesForDevice($device_id) as $chk) {
+            foreach ((new AlertRules($device_id))->get() as $chk) {
                 $rulescache[$device_id][$chk->id] = true;
             }
         }

--- a/LibreNMS/Alert/RunAlerts.php
+++ b/LibreNMS/Alert/RunAlerts.php
@@ -34,7 +34,6 @@ namespace LibreNMS\Alert;
 use App\Facades\DeviceCache;
 use App\Facades\LibrenmsConfig;
 use App\Facades\Rrd;
-use App\Models\Alert;
 use App\Models\AlertLog;
 use App\Models\AlertTransport;
 use App\Models\ApplicationMetric;
@@ -267,8 +266,8 @@ class RunAlerts
     {
         global $rulescache;
         if (empty($rulescache[$device_id]) || ! isset($rulescache[$device_id])) {
-            foreach (AlertUtil::getRules($device_id) as $chk) {
-                $rulescache[$device_id][$chk['id']] = true;
+            foreach (AlertRules::getRulesForDevice($device_id) as $chk) {
+                $rulescache[$device_id][$chk->id] = true;
             }
         }
 
@@ -604,7 +603,7 @@ class RunAlerts
                 $noacc = false;
             }
 
-            $maintenance_status = AlertUtil::getMaintenanceStatus($alert['device_id']);
+            $maintenance_status = DeviceCache::get($alert['device_id'])->getMaintenanceStatus();
             // Do not send alert notifications for these types of scheduled maintenance
             if ($maintenance_status == MaintenanceStatus::MuteAlerts) {
                 $noiss = true;

--- a/LibreNMS/Alert/RunAlerts.php
+++ b/LibreNMS/Alert/RunAlerts.php
@@ -35,6 +35,7 @@ use App\Facades\DeviceCache;
 use App\Facades\LibrenmsConfig;
 use App\Facades\Rrd;
 use App\Models\AlertLog;
+use App\Models\AlertRule;
 use App\Models\AlertTransport;
 use App\Models\ApplicationMetric;
 use App\Models\Eventlog;
@@ -266,7 +267,7 @@ class RunAlerts
     {
         global $rulescache;
         if (empty($rulescache[$device_id]) || ! isset($rulescache[$device_id])) {
-            foreach ((new AlertRules($device_id))->get() as $chk) {
+            foreach (AlertRule::enabled()->forDevice(DeviceCache::get($device_id))->get() as $chk) {
                 $rulescache[$device_id][$chk->id] = true;
             }
         }

--- a/LibreNMS/Snmptrap/Dispatcher.php
+++ b/LibreNMS/Snmptrap/Dispatcher.php
@@ -67,8 +67,8 @@ class Dispatcher
             $trap->log($trap->toString($detailed));
         }
         if ($logging != 'none' || ! $fallback) {
-            $rules = new AlertRules;
-            $rules->runRules($trap->getDevice()->device_id);
+            $rules = new AlertRules($trap->getDevice());
+            $rules->run();
         }
 
         return ! $fallback;

--- a/app/Actions/Alerts/RunAlertRulesAction.php
+++ b/app/Actions/Alerts/RunAlertRulesAction.php
@@ -27,12 +27,16 @@
 namespace App\Actions\Alerts;
 
 use App\Models\Device;
+use Illuminate\Support\Facades\Log;
 use LibreNMS\Alert\AlertRules;
 
-class RunAlertRulesAction
+readonly class RunAlertRulesAction
 {
-    public function __construct(private readonly Device $device, private readonly AlertRules $rules)
+    private AlertRules $rules;
+
+    public function __construct(private Device $device, ?AlertRules $rules = null)
     {
+        $this->rules = $rules ?? new AlertRules($device);
     }
 
     public function execute(): void
@@ -40,6 +44,9 @@ class RunAlertRulesAction
         // TODO inline logic
         include_once base_path('includes/common.php');
         include_once base_path('includes/dbFacile.php');
-        $this->rules->runRules($this->device->device_id);
+
+        Log::debug("Running alert rules for {$this->device->hostname} ({$this->device->device_id})");
+
+        $this->rules->run();
     }
 }

--- a/app/Models/Alert.php
+++ b/app/Models/Alert.php
@@ -44,6 +44,8 @@ class Alert extends Model
         'open',
         'alerted',
         'info',
+        'timestamp',
+        'note',
     ];
 
     /**

--- a/app/Models/Alert.php
+++ b/app/Models/Alert.php
@@ -55,6 +55,7 @@ class Alert extends Model
     {
         return [
             'info' => 'array',
+            'timestamp' => 'datetime',
         ];
     }
 

--- a/app/Models/Alert.php
+++ b/app/Models/Alert.php
@@ -37,6 +37,14 @@ class Alert extends Model
 {
     use HasFactory;
     public $timestamps = false;
+    protected $fillable = [
+        'device_id',
+        'rule_id',
+        'state',
+        'open',
+        'alerted',
+        'info',
+    ];
 
     /**
      * @return array{info: 'array'}

--- a/app/Models/AlertLog.php
+++ b/app/Models/AlertLog.php
@@ -14,6 +14,12 @@ class AlertLog extends DeviceRelatedModel
     public const UPDATED_AT = null;
     public const CREATED_AT = 'time_logged';
     protected $table = 'alert_log';
+    protected $fillable = [
+        'device_id',
+        'rule_id',
+        'state',
+        'details',
+    ];
     protected $casts = [
         'state' => AlertLogState::class,
         'details' => CompressedJson::class,

--- a/app/Models/AlertRule.php
+++ b/app/Models/AlertRule.php
@@ -90,6 +90,34 @@ class AlertRule extends BaseModel
 
     /**
      * @param  Builder<AlertRule>  $query
+     * @param  Device  $device
+     * @return Builder
+     */
+    public function scopeForDevice(Builder $query, Device $device): Builder
+    {
+        return $query->where(function ($query) use ($device) {
+            $query->where(function ($query) {
+                $query->whereDoesntHave('devices')
+                    ->whereDoesntHave('groups')
+                    ->whereDoesntHave('locations');
+            })->orWhere(function ($query) use ($device) {
+                $query->where('invert_map', 0)
+                    ->where(function ($query) use ($device) {
+                        $query->whereHas('devices', fn ($q) => $q->where('devices.device_id', $device->device_id))
+                            ->orWhereHas('groups', fn ($q) => $q->whereHas('devices', fn ($dq) => $dq->where('devices.device_id', $device->device_id)))
+                            ->orWhereHas('locations', fn ($q) => $q->where('locations.id', $device->location_id));
+                    });
+            })->orWhere(function ($query) use ($device) {
+                $query->where('invert_map', 1)
+                    ->whereDoesntHave('devices', fn ($q) => $q->where('devices.device_id', $device->device_id))
+                    ->whereDoesntHave('groups', fn ($q) => $q->whereHas('devices', fn ($dq) => $dq->where('devices.device_id', $device->device_id)))
+                    ->whereDoesntHave('locations', fn ($q) => $q->where('locations.id', $device->location_id));
+            });
+        });
+    }
+
+    /**
+     * @param  Builder<AlertRule>  $query
      * @return Builder
      */
     public function scopeEnabled($query)

--- a/app/Models/AlertRule.php
+++ b/app/Models/AlertRule.php
@@ -95,19 +95,19 @@ class AlertRule extends BaseModel
      */
     public function scopeForDevice(Builder $query, Device $device): Builder
     {
-        return $query->where(function ($query) use ($device) {
-            $query->where(function ($query) {
+        return $query->where(function ($query) use ($device): void {
+            $query->where(function ($query): void {
                 $query->whereDoesntHave('devices')
                     ->whereDoesntHave('groups')
                     ->whereDoesntHave('locations');
-            })->orWhere(function ($query) use ($device) {
+            })->orWhere(function ($query) use ($device): void {
                 $query->where('invert_map', 0)
-                    ->where(function ($query) use ($device) {
+                    ->where(function ($query) use ($device): void {
                         $query->whereHas('devices', fn ($q) => $q->where('devices.device_id', $device->device_id))
                             ->orWhereHas('groups', fn ($q) => $q->whereHas('devices', fn ($dq) => $dq->where('devices.device_id', $device->device_id)))
                             ->orWhereHas('locations', fn ($q) => $q->where('locations.id', $device->location_id));
                     });
-            })->orWhere(function ($query) use ($device) {
+            })->orWhere(function ($query) use ($device): void {
                 $query->where('invert_map', 1)
                     ->whereDoesntHave('devices', fn ($q) => $q->where('devices.device_id', $device->device_id))
                     ->whereDoesntHave('groups', fn ($q) => $q->whereHas('devices', fn ($dq) => $dq->where('devices.device_id', $device->device_id)))

--- a/app/Models/AlertRule.php
+++ b/app/Models/AlertRule.php
@@ -91,26 +91,26 @@ class AlertRule extends BaseModel
     /**
      * @param  Builder<AlertRule>  $query
      * @param  Device  $device
-     * @return Builder
+     * @return Builder<AlertRule>
      */
     public function scopeForDevice(Builder $query, Device $device): Builder
     {
-        return $query->where(function ($query) use ($device): void {
-            $query->where(function ($query): void {
+        return $query->where(function (Builder $query) use ($device): void {
+            $query->where(function (Builder $query): void {
                 $query->whereDoesntHave('devices')
                     ->whereDoesntHave('groups')
                     ->whereDoesntHave('locations');
-            })->orWhere(function ($query) use ($device): void {
+            })->orWhere(function (Builder $query) use ($device): void {
                 $query->where('invert_map', 0)
-                    ->where(function ($query) use ($device): void {
+                    ->where(function (Builder $query) use ($device): void {
                         $query->whereHas('devices', fn ($q) => $q->where('devices.device_id', $device->device_id))
-                            ->orWhereHas('groups', fn ($q) => $q->whereHas('devices', fn ($dq) => $dq->where('devices.device_id', $device->device_id)))
+                            ->orWhereHas('groups.devices', fn ($q) => $q->where('devices.device_id', $device->device_id))
                             ->orWhereHas('locations', fn ($q) => $q->where('locations.id', $device->location_id));
                     });
-            })->orWhere(function ($query) use ($device): void {
+            })->orWhere(function (Builder $query) use ($device): void {
                 $query->where('invert_map', 1)
                     ->whereDoesntHave('devices', fn ($q) => $q->where('devices.device_id', $device->device_id))
-                    ->whereDoesntHave('groups', fn ($q) => $q->whereHas('devices', fn ($dq) => $dq->where('devices.device_id', $device->device_id)))
+                    ->whereDoesntHave('groups.devices', fn ($q) => $q->where('devices.device_id', $device->device_id))
                     ->whereDoesntHave('locations', fn ($q) => $q->where('locations.id', $device->location_id));
             });
         });

--- a/includes/html/output/query.inc.php
+++ b/includes/html/output/query.inc.php
@@ -25,9 +25,9 @@
  */
 
 use App\Facades\DeviceCache;
+use App\Models\AlertRule;
 use App\Models\Device;
 use Illuminate\Support\Facades\Gate;
-use LibreNMS\Alert\AlertRules;
 use LibreNMS\Alert\AlertUtil;
 use LibreNMS\Alerting\QueryBuilderParser;
 
@@ -43,7 +43,7 @@ switch ($type) {
     case 'alerts':
         $filename = "alerts-$hostname.txt";
         $device = DeviceCache::getByHostname($hostname);
-        $rules = (new AlertRules($device))->get();
+        $rules = AlertRule::enabled()->forDevice($device)->get();
         $output = '';
         $results = [];
         foreach ($rules as $rule) {

--- a/includes/html/output/query.inc.php
+++ b/includes/html/output/query.inc.php
@@ -27,6 +27,7 @@
 use App\Facades\DeviceCache;
 use App\Models\Device;
 use Illuminate\Support\Facades\Gate;
+use LibreNMS\Alert\AlertRules;
 use LibreNMS\Alert\AlertUtil;
 use LibreNMS\Alerting\QueryBuilderParser;
 
@@ -42,7 +43,7 @@ switch ($type) {
     case 'alerts':
         $filename = "alerts-$hostname.txt";
         $device = DeviceCache::getByHostname($hostname);
-        $rules = \LibreNMS\Alert\AlertRules::getRulesForDevice($device);
+        $rules = (new AlertRules($device))->get();
         $output = '';
         $results = [];
         foreach ($rules as $rule) {

--- a/includes/html/output/query.inc.php
+++ b/includes/html/output/query.inc.php
@@ -42,14 +42,11 @@ switch ($type) {
     case 'alerts':
         $filename = "alerts-$hostname.txt";
         $device = DeviceCache::getByHostname($hostname);
-        $rules = AlertUtil::getRules($device->device_id);
+        $rules = \LibreNMS\Alert\AlertRules::getRulesForDevice($device);
         $output = '';
         $results = [];
         foreach ($rules as $rule) {
-            if (empty($rule['query'])) {
-                $rule['query'] = QueryBuilderParser::fromJson($rule['builder'])->toSql();
-            }
-            $sql = $rule['query'];
+            $sql = $rule->query ?: QueryBuilderParser::fromJson($rule->builder)->toSql();
             $qry = dbFetchRow($sql, [$device->device_id]);
             if (is_array($qry)) {
                 $results[] = $qry;
@@ -58,20 +55,20 @@ switch ($type) {
                 $response = 'no match';
             }
 
-            $extra = json_decode((string) $rule['extra'], true);
-            if ($extra['options']['override_query'] === 'on' || $extra['options']['override_query'] === true) {
+            $extra = $rule->extra;
+            if (($extra['options']['override_query'] ?? null) === 'on' || ($extra['options']['override_query'] ?? null) === true) {
                 $qb = $extra['options']['override_query'];
             } else {
-                $qb = QueryBuilderParser::fromJson($rule['builder'] ?? []);
+                $qb = QueryBuilderParser::fromJson($rule->builder ?? []);
             }
 
-            $output .= 'Rule name: ' . $rule['name'] . PHP_EOL;
+            $output .= 'Rule name: ' . $rule->name . PHP_EOL;
             if ($qb instanceof QueryBuilderParser) {
                 $output .= 'Alert rule: ' . $qb->toSql(false) . PHP_EOL;
             } else {
                 $output .= 'Alert rule: Custom SQL Query' . PHP_EOL;
             }
-            $output .= 'Alert query: ' . $rule['query'] . PHP_EOL;
+            $output .= 'Alert query: ' . ($rule->query ?: $sql) . PHP_EOL;
             $output .= 'Rule match: ' . $response . PHP_EOL . PHP_EOL;
         }
         if (\App\Facades\LibrenmsConfig::get('alert.transports.mail') === true) {

--- a/includes/services.inc.php
+++ b/includes/services.inc.php
@@ -136,8 +136,8 @@ function poll_service($service)
         );
 
         // Run alert rules due to status changed
-        $rules = new AlertRules;
-        $rules->runRules($service['device_id']);
+        $rules = new AlertRules($service['device_id']);
+        $rules->run();
     }
 
     if ($service['service_message'] != $msg) {

--- a/tests/Feature/AlertRulesTest.php
+++ b/tests/Feature/AlertRulesTest.php
@@ -467,4 +467,171 @@ class AlertRulesTest extends TestCase
         $this->assertEquals($state, $updatedLog->state->value, "Latest AlertLog state was changed from $state");
         $this->assertArrayHasKey('contacts', $updatedLog->details);
     }
+
+    public function testRunRulesWithDeviceId(): void
+    {
+        $device = Device::factory()->create(['status' => 0]);
+        $rule = AlertRule::factory()->create([
+            'query' => 'SELECT * FROM devices WHERE device_id = ? AND status = 0',
+        ]);
+
+        $alertRules = new AlertRules($device->device_id);
+        $alertRules->run();
+
+        $this->assertDatabaseHas('alerts', [
+            'device_id' => $device->device_id,
+            'rule_id' => $rule->id,
+            'state' => AlertState::ACTIVE,
+        ]);
+    }
+
+    public function testRunRulesSkipsDisabledRule(): void
+    {
+        $device = Device::factory()->create(['status' => 0]);
+        $rule = AlertRule::factory()->create([
+            'query' => 'SELECT * FROM devices WHERE device_id = ? AND status = 0',
+            'disabled' => 1,
+        ]);
+
+        $alertRules = new AlertRules($device);
+        $alertRules->run();
+
+        $this->assertDatabaseMissing('alerts', [
+            'device_id' => $device->device_id,
+            'rule_id' => $rule->id,
+        ]);
+    }
+
+    public function testRunRulesUsesQueryBuilderJson(): void
+    {
+        $device = Device::factory()->create(['status' => 0]);
+        $builderJson = [
+            'condition' => 'AND',
+            'rules' => [
+                [
+                    'field' => 'devices.status',
+                    'operator' => 'equal',
+                    'value' => '0',
+                ],
+            ],
+        ];
+        $rule = AlertRule::factory()->create([
+            'query' => '',
+            'builder' => $builderJson,
+        ]);
+
+        $alertRules = new AlertRules($device);
+        $alertRules->run();
+
+        $this->assertDatabaseHas('alerts', [
+            'device_id' => $device->device_id,
+            'rule_id' => $rule->id,
+            'state' => AlertState::ACTIVE,
+        ]);
+    }
+
+    public function testRunRulesSkipsEmptySql(): void
+    {
+        $device = Device::factory()->create(['status' => 0]);
+        $rule = AlertRule::factory()->create([
+            'query' => '',
+            'builder' => [],
+        ]);
+
+        $alertRules = new AlertRules($device);
+        $result = $alertRules->run();
+
+        $this->assertTrue($result);
+        $this->assertDatabaseMissing('alerts', [
+            'device_id' => $device->device_id,
+            'rule_id' => $rule->id,
+        ]);
+    }
+
+    public function testRunRulesConvertsBinaryIp(): void
+    {
+        $device = Device::factory()->create(['status' => 0]);
+        // MySQL INET6_ATON converts string to binary
+        $rule = AlertRule::factory()->create([
+            'query' => 'SELECT INET6_ATON("192.0.2.1") AS ip FROM devices WHERE device_id = ?',
+        ]);
+
+        $alertRules = new AlertRules($device);
+        $alertRules->run();
+
+        $updatedLog = AlertLog::where('device_id', $device->device_id)
+            ->where('rule_id', $rule->id)
+            ->latest('id')
+            ->first();
+
+        $this->assertNotNull($updatedLog);
+        $details = $updatedLog->details;
+        $this->assertEquals('192.0.2.1', $details['rule'][0]['ip']);
+    }
+
+    public function testRunRulesRecoveryWithoutPreExistingAlert(): void
+    {
+        $device = Device::factory()->create(['status' => 1]);
+        $rule = AlertRule::factory()->create([
+            'query' => 'SELECT * FROM devices WHERE device_id = ? AND status = 0',
+        ]);
+
+        $alertRules = new AlertRules($device);
+        $alertRules->run();
+
+        $this->assertDatabaseHas('alerts', [
+            'device_id' => $device->device_id,
+            'rule_id' => $rule->id,
+            'state' => AlertState::RECOVERED,
+        ]);
+    }
+
+    public function testRunRulesNoChangeOnActiveAlertWithoutLog(): void
+    {
+        $device = Device::factory()->create(['status' => 0]);
+        $rule = AlertRule::factory()->create([
+            'query' => 'SELECT * FROM devices WHERE device_id = ? AND status = 0',
+        ]);
+
+        Alert::create([
+            'device_id' => $device->device_id,
+            'rule_id' => $rule->id,
+            'state' => AlertState::ACTIVE,
+            'open' => 1,
+            'alerted' => 0,
+            'info' => [],
+        ]);
+
+        // Note: No AlertLog is created in DB for this rule.
+
+        $alertRules = new AlertRules($device);
+        $alertRules->run();
+
+        $this->assertDatabaseHas('alerts', [
+            'device_id' => $device->device_id,
+            'rule_id' => $rule->id,
+            'state' => AlertState::ACTIVE,
+        ]);
+        // AlertLog was not created beforehand, and shouldn't cause errors.
+    }
+
+    public function testRunRulesInvertsResultToTriggerAlert(): void
+    {
+        $device = Device::factory()->create(['status' => 1]);
+        // The query returns empty for status = 0.
+        // With invert = true, empty means trigger alert (do_alert = true).
+        $rule = AlertRule::factory()->create([
+            'query' => 'SELECT * FROM devices WHERE device_id = ? AND status = 0',
+            'extra' => ['invert' => true],
+        ]);
+
+        $alertRules = new AlertRules($device);
+        $alertRules->run();
+
+        $this->assertDatabaseHas('alerts', [
+            'device_id' => $device->device_id,
+            'rule_id' => $rule->id,
+            'state' => AlertState::ACTIVE,
+        ]);
+    }
 }

--- a/tests/Feature/AlertRulesTest.php
+++ b/tests/Feature/AlertRulesTest.php
@@ -6,6 +6,7 @@ use App\Models\Alert;
 use App\Models\AlertLog;
 use App\Models\AlertRule;
 use App\Models\Device;
+use Illuminate\Support\Carbon;
 use LibreNMS\Alert\AlertRules;
 use LibreNMS\Enum\AlertState;
 use LibreNMS\Enum\Severity;
@@ -457,7 +458,8 @@ class AlertRulesTest extends TestCase
         $this->assertEquals($state, $alert->state, "Alert state was reset from $state to ACTIVE");
 
         // Timestamp should NOT have changed
-        $this->assertEquals($initialTimestamp->toDateTimeString(), $alert->timestamp->toDateTimeString(), 'Alert timestamp was reset');
+        $actual = $alert->timestamp instanceof Carbon ? $alert->timestamp->toDateTimeString() : $alert->timestamp;
+        $this->assertEquals($initialTimestamp->toDateTimeString(), $actual, 'Alert timestamp was reset');
 
         // AlertLog should have been updated but state remains same
         $updatedLog = AlertLog::where('device_id', $device->device_id)

--- a/tests/Feature/AlertRulesTest.php
+++ b/tests/Feature/AlertRulesTest.php
@@ -257,4 +257,153 @@ class AlertRulesTest extends TestCase
             'severity' => Severity::Error,
         ]);
     }
+
+    public function testRulesFiltering(): void
+    {
+        $device = Device::factory()->create(['status' => 0]);
+        $otherDevice = Device::factory()->create(['status' => 0]);
+
+        // 1. Rule mapped to this device - should trigger
+        $ruleMapped = AlertRule::factory()->create([
+            'name' => 'Mapped Rule',
+            'query' => 'SELECT * FROM devices WHERE device_id = ? AND status = 0',
+        ]);
+        $ruleMapped->devices()->attach($device->device_id);
+
+        // 2. Rule mapped to OTHER device - should NOT trigger
+        $ruleOtherMapped = AlertRule::factory()->create([
+            'name' => 'Other Mapped Rule',
+            'query' => 'SELECT * FROM devices WHERE device_id = ? AND status = 0',
+        ]);
+        $ruleOtherMapped->devices()->attach($otherDevice->device_id);
+
+        // 3. Global rule - should trigger
+        $ruleGlobal = AlertRule::factory()->create([
+            'name' => 'Global Rule',
+            'query' => 'SELECT * FROM devices WHERE device_id = ? AND status = 0',
+        ]);
+
+        $alertRules = new AlertRules($device);
+        $alertRules->run();
+
+        $this->assertDatabaseHas('alerts', [
+            'device_id' => $device->device_id,
+            'rule_id' => $ruleMapped->id,
+            'state' => AlertState::ACTIVE,
+        ]);
+
+        $this->assertDatabaseMissing('alerts', [
+            'device_id' => $device->device_id,
+            'rule_id' => $ruleOtherMapped->id,
+        ]);
+
+        $this->assertDatabaseHas('alerts', [
+            'device_id' => $device->device_id,
+            'rule_id' => $ruleGlobal->id,
+            'state' => AlertState::ACTIVE,
+        ]);
+    }
+
+    public function testRulesFilteringInverted(): void
+    {
+        $device = Device::factory()->create(['status' => 0]);
+
+        // 1. Rule mapped to this device, BUT inverted - should NOT trigger
+        $ruleInvertedMapped = AlertRule::factory()->create([
+            'name' => 'Inverted Mapped Rule',
+            'query' => 'SELECT * FROM devices WHERE device_id = ? AND status = 0',
+            'invert_map' => 1,
+        ]);
+        $ruleInvertedMapped->devices()->attach($device->device_id);
+
+        // 2. Rule mapped to OTHER device, inverted - should trigger
+        $otherDevice = Device::factory()->create();
+        $ruleInvertedOtherMapped = AlertRule::factory()->create([
+            'name' => 'Inverted Other Mapped Rule',
+            'query' => 'SELECT * FROM devices WHERE device_id = ? AND status = 0',
+            'invert_map' => 1,
+        ]);
+        $ruleInvertedOtherMapped->devices()->attach($otherDevice->device_id);
+
+        $alertRules = new AlertRules($device);
+        $alertRules->run();
+
+        $this->assertDatabaseMissing('alerts', [
+            'device_id' => $device->device_id,
+            'rule_id' => $ruleInvertedMapped->id,
+        ]);
+
+        $this->assertDatabaseHas('alerts', [
+            'device_id' => $device->device_id,
+            'rule_id' => $ruleInvertedOtherMapped->id,
+            'state' => AlertState::ACTIVE,
+        ]);
+    }
+
+    public function testRulesFilteringGroups(): void
+    {
+        $device = Device::factory()->create(['status' => 0]);
+        $group = \App\Models\DeviceGroup::factory()->create();
+        $group->devices()->attach($device->device_id);
+
+        $rule = AlertRule::factory()->create([
+            'name' => 'Group Rule',
+            'query' => 'SELECT * FROM devices WHERE device_id = ? AND status = 0',
+        ]);
+        $rule->groups()->attach($group->id);
+
+        $otherGroup = \App\Models\DeviceGroup::factory()->create();
+        $otherRule = AlertRule::factory()->create([
+            'name' => 'Other Group Rule',
+            'query' => 'SELECT * FROM devices WHERE device_id = ? AND status = 0',
+        ]);
+        $otherRule->groups()->attach($otherGroup->id);
+
+        $alertRules = new AlertRules($device);
+        $alertRules->run();
+
+        $this->assertDatabaseHas('alerts', [
+            'device_id' => $device->device_id,
+            'rule_id' => $rule->id,
+            'state' => AlertState::ACTIVE,
+        ]);
+
+        $this->assertDatabaseMissing('alerts', [
+            'device_id' => $device->device_id,
+            'rule_id' => $otherRule->id,
+        ]);
+    }
+
+    public function testRulesFilteringLocations(): void
+    {
+        $location = \App\Models\Location::factory()->create();
+        $device = Device::factory()->create(['status' => 0, 'location_id' => $location->id]);
+
+        $rule = AlertRule::factory()->create([
+            'name' => 'Location Rule',
+            'query' => 'SELECT * FROM devices WHERE device_id = ? AND status = 0',
+        ]);
+        $rule->locations()->attach($location->id);
+
+        $otherLocation = \App\Models\Location::factory()->create();
+        $otherRule = AlertRule::factory()->create([
+            'name' => 'Other Location Rule',
+            'query' => 'SELECT * FROM devices WHERE device_id = ? AND status = 0',
+        ]);
+        $otherRule->locations()->attach($otherLocation->id);
+
+        $alertRules = new AlertRules($device);
+        $alertRules->run();
+
+        $this->assertDatabaseHas('alerts', [
+            'device_id' => $device->device_id,
+            'rule_id' => $rule->id,
+            'state' => AlertState::ACTIVE,
+        ]);
+
+        $this->assertDatabaseMissing('alerts', [
+            'device_id' => $device->device_id,
+            'rule_id' => $otherRule->id,
+        ]);
+    }
 }

--- a/tests/Feature/AlertRulesTest.php
+++ b/tests/Feature/AlertRulesTest.php
@@ -406,4 +406,65 @@ class AlertRulesTest extends TestCase
             'rule_id' => $otherRule->id,
         ]);
     }
+
+    public function testRunRulesHandlesWorseStateAsNoChange(): void
+    {
+        $this->runActiveStateTest(AlertState::WORSE);
+    }
+
+    public function testRunRulesHandlesBetterStateAsNoChange(): void
+    {
+        $this->runActiveStateTest(AlertState::BETTER);
+    }
+
+    public function testRunRulesHandlesChangedStateAsNoChange(): void
+    {
+        $this->runActiveStateTest(AlertState::CHANGED);
+    }
+
+    private function runActiveStateTest(int $state): void
+    {
+        $device = Device::factory()->create(['status' => 0]);
+        $rule = AlertRule::factory()->create([
+            'query' => 'SELECT * FROM devices WHERE device_id = ? AND status = 0',
+        ]);
+
+        $initialTimestamp = \Carbon\Carbon::now()->subHour();
+
+        // Pre-existing alert in given state
+        $alert = Alert::create([
+            'device_id' => $device->device_id,
+            'rule_id' => $rule->id,
+            'state' => $state,
+            'open' => 1,
+            'alerted' => 1,
+            'info' => [],
+            'timestamp' => $initialTimestamp,
+        ]);
+
+        AlertLog::create([
+            'device_id' => $device->device_id,
+            'rule_id' => $rule->id,
+            'state' => $state,
+            'details' => ['old' => 'data'],
+        ]);
+
+        $alertRules = new AlertRules($device);
+        $alertRules->run();
+
+        // State should still be the same, not reset to ACTIVE
+        $alert->refresh();
+        $this->assertEquals($state, $alert->state, "Alert state was reset from $state to ACTIVE");
+
+        // Timestamp should NOT have changed
+        $this->assertEquals($initialTimestamp->toDateTimeString(), $alert->timestamp->toDateTimeString(), 'Alert timestamp was reset');
+
+        // AlertLog should have been updated but state remains same
+        $updatedLog = AlertLog::where('device_id', $device->device_id)
+            ->where('rule_id', $rule->id)
+            ->latest('id')
+            ->first();
+        $this->assertEquals($state, $updatedLog->state->value, "Latest AlertLog state was changed from $state");
+        $this->assertArrayHasKey('contacts', $updatedLog->details);
+    }
 }

--- a/tests/Feature/AlertRulesTest.php
+++ b/tests/Feature/AlertRulesTest.php
@@ -188,7 +188,10 @@ class AlertRulesTest extends TestCase
         ]);
 
         // No new AlertLog should be created for ACTIVE
-        $this->assertEquals(0, AlertLog::where('state', AlertState::ACTIVE)->count());
+        $this->assertEquals(0, AlertLog::where('device_id', $device->device_id)
+            ->where('rule_id', $rule->id)
+            ->where('state', AlertState::ACTIVE)
+            ->count());
     }
 
     public function testRunRulesClearsAlert(): void

--- a/tests/Feature/AlertRulesTest.php
+++ b/tests/Feature/AlertRulesTest.php
@@ -1,0 +1,260 @@
+<?php
+
+namespace LibreNMS\Tests\Feature;
+
+use App\Models\Alert;
+use App\Models\AlertLog;
+use App\Models\AlertRule;
+use App\Models\Device;
+use LibreNMS\Alert\AlertRules;
+use LibreNMS\Enum\AlertState;
+use LibreNMS\Enum\Severity;
+use LibreNMS\Tests\TestCase;
+
+class AlertRulesTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->dbSetUp();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->dbTearDown();
+        parent::tearDown();
+    }
+
+    public function testRunRulesSkipsUnderMaintenance(): void
+    {
+        $device = Device::factory()->create();
+
+        $schedule = \App\Models\AlertSchedule::forceCreate([
+            'title' => 'Maintenance',
+            'notes' => '',
+            'start' => \Carbon\Carbon::now()->subHour(),
+            'end' => \Carbon\Carbon::now()->addHour(),
+            'recurring' => 0,
+            'behavior' => 1, // SkipAlerts
+        ]);
+        $schedule->devices()->attach($device->device_id);
+
+        $alertRules = new AlertRules($device);
+        $result = $alertRules->run();
+
+        $this->assertFalse($result);
+    }
+
+    public function testRunRulesDisableAlerting(): void
+    {
+        $device = Device::factory()->create(['disable_notify' => 1]);
+        $rule = AlertRule::factory()->create();
+
+        Alert::create([
+            'device_id' => $device->device_id,
+            'rule_id' => $rule->id,
+            'state' => AlertState::ACTIVE,
+            'open' => 1,
+            'alerted' => 0,
+            'info' => [],
+        ]);
+
+        $alertRules = new AlertRules($device);
+        $result = $alertRules->run();
+
+        $this->assertFalse($result);
+        $this->assertDatabaseHas('alerts', [
+            'device_id' => $device->device_id,
+            'rule_id' => $rule->id,
+            'state' => AlertState::CLEAR,
+            'open' => 0,
+        ]);
+    }
+
+    public function testRunRulesTriggersAlert(): void
+    {
+        $device = Device::factory()->create(['status' => 0]);
+        $rule = AlertRule::factory()->create([
+            'query' => 'SELECT * FROM devices WHERE device_id = ? AND status = 0',
+        ]);
+
+        $alertRules = new AlertRules($device);
+        $alertRules->run();
+
+        $this->assertDatabaseHas('alerts', [
+            'device_id' => $device->device_id,
+            'rule_id' => $rule->id,
+            'state' => AlertState::ACTIVE,
+            'open' => 1,
+        ]);
+
+        $this->assertDatabaseHas('alert_log', [
+            'device_id' => $device->device_id,
+            'rule_id' => $rule->id,
+            'state' => AlertState::ACTIVE,
+        ]);
+    }
+
+    public function testRunRulesUpdatesExistingAlert(): void
+    {
+        $device = Device::factory()->create(['status' => 0]);
+        $rule = AlertRule::factory()->create([
+            'query' => 'SELECT * FROM devices WHERE device_id = ? AND status = 0',
+        ]);
+
+        // Pre-existing recovered alert
+        Alert::create([
+            'device_id' => $device->device_id,
+            'rule_id' => $rule->id,
+            'state' => AlertState::RECOVERED,
+            'open' => 1,
+            'alerted' => 0,
+            'info' => [],
+        ]);
+
+        $alertRules = new AlertRules($device);
+        $alertRules->run();
+
+        $this->assertDatabaseHas('alerts', [
+            'device_id' => $device->device_id,
+            'rule_id' => $rule->id,
+            'state' => AlertState::ACTIVE,
+        ]);
+    }
+
+    public function testRunRulesNoChangeOnActiveAlert(): void
+    {
+        $device = Device::factory()->create(['status' => 0]);
+        $rule = AlertRule::factory()->create([
+            'query' => 'SELECT * FROM devices WHERE device_id = ? AND status = 0',
+        ]);
+
+        Alert::create([
+            'device_id' => $device->device_id,
+            'rule_id' => $rule->id,
+            'state' => AlertState::ACTIVE,
+            'open' => 1,
+            'alerted' => 0,
+            'info' => [],
+        ]);
+
+        $log = AlertLog::create([
+            'device_id' => $device->device_id,
+            'rule_id' => $rule->id,
+            'state' => AlertState::ACTIVE,
+            'details' => ['old' => 'data'],
+        ]);
+
+        $alertRules = new AlertRules($device);
+        $alertRules->run();
+
+        // State should still be ACTIVE
+        $this->assertDatabaseHas('alerts', [
+            'device_id' => $device->device_id,
+            'rule_id' => $rule->id,
+            'state' => AlertState::ACTIVE,
+        ]);
+
+        // AlertLog should be updated with new details (contacts and rule)
+        $updatedLog = AlertLog::find($log->id);
+        $this->assertArrayHasKey('contacts', $updatedLog->details);
+        $this->assertArrayHasKey('rule', $updatedLog->details);
+    }
+
+    public function testRunRulesSkipsAcknowledgedAlert(): void
+    {
+        $device = Device::factory()->create(['status' => 0]);
+        $rule = AlertRule::factory()->create([
+            'query' => 'SELECT * FROM devices WHERE device_id = ? AND status = 0',
+        ]);
+
+        Alert::create([
+            'device_id' => $device->device_id,
+            'rule_id' => $rule->id,
+            'state' => AlertState::ACKNOWLEDGED,
+            'open' => 1,
+            'alerted' => 0,
+            'info' => [],
+        ]);
+
+        $alertRules = new AlertRules($device);
+        $alertRules->run();
+
+        $this->assertDatabaseHas('alerts', [
+            'device_id' => $device->device_id,
+            'rule_id' => $rule->id,
+            'state' => AlertState::ACKNOWLEDGED,
+        ]);
+
+        // No new AlertLog should be created for ACTIVE
+        $this->assertEquals(0, AlertLog::where('state', AlertState::ACTIVE)->count());
+    }
+
+    public function testRunRulesClearsAlert(): void
+    {
+        $device = Device::factory()->create(['status' => 1]);
+        $rule = AlertRule::factory()->create([
+            'query' => 'SELECT * FROM devices WHERE device_id = ? AND status = 0',
+        ]);
+
+        Alert::create([
+            'device_id' => $device->device_id,
+            'rule_id' => $rule->id,
+            'state' => AlertState::ACTIVE,
+            'open' => 1,
+            'alerted' => 0,
+            'info' => [],
+        ]);
+
+        $alertRules = new AlertRules($device);
+        $alertRules->run();
+
+        $this->assertDatabaseHas('alerts', [
+            'device_id' => $device->device_id,
+            'rule_id' => $rule->id,
+            'state' => AlertState::RECOVERED,
+        ]);
+
+        $this->assertDatabaseHas('alert_log', [
+            'device_id' => $device->device_id,
+            'rule_id' => $rule->id,
+            'state' => AlertState::RECOVERED,
+        ]);
+    }
+
+    public function testRunRulesInvertsResult(): void
+    {
+        $device = Device::factory()->create(['status' => 1]);
+        $rule = AlertRule::factory()->create([
+            'query' => 'SELECT * FROM devices WHERE device_id = ? AND status = 1',
+            'extra' => ['invert' => true],
+        ]);
+
+        $alertRules = new AlertRules($device);
+        $alertRules->run();
+
+        // status=1 matches query, but invert=true, so doalert=false
+        $this->assertDatabaseMissing('alerts', [
+            'device_id' => $device->device_id,
+            'rule_id' => $rule->id,
+            'state' => AlertState::ACTIVE,
+        ]);
+    }
+
+    public function testRunRulesHandlesQueryError(): void
+    {
+        $device = Device::factory()->create();
+        $rule = AlertRule::factory()->create([
+            'query' => 'SELECT invalid_column FROM devices WHERE device_id = ?',
+        ]);
+
+        $alertRules = new AlertRules($device);
+        $alertRules->run();
+
+        $this->assertDatabaseHas('eventlog', [
+            'device_id' => $device->device_id,
+            'type' => 'alert',
+            'severity' => Severity::Error,
+        ]);
+    }
+}


### PR DESCRIPTION
Refactor and clean up AlertRules class.  Remove legacy db usage.

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
