### PR TITLE
 Fix health API returning empty results for processor, storage and mempool

### DIFF
--- a/doc/API/Devices.md
+++ b/doc/API/Devices.md
@@ -250,6 +250,11 @@ Route: `/api/v0/devices/:hostname/health(/:type)(/:sensor_id)`
 - type (optional) is health type / sensor class
 - sensor_id (optional) is the sensor id to retrieve specific information.
 
+`type` may be a sensor class (e.g. `device_voltage`) or one of the special
+classes `device_processor`, `device_storage` and `device_mempool`, which are
+stored in their own tables rather than the `sensors` table. The `device_`
+prefix is optional, so `processor` and `device_processor` are equivalent.
+
 Input:
 
   -
@@ -343,6 +348,28 @@ Output:
             "entPhysicalIndex_measured": null,
             "lastupdate": "2017-01-13 13:50:26",
             "sensor_prev": "1"
+        }
+    ]
+}
+```
+
+Example (processor list):
+
+```curl
+curl -H 'X-Auth-Token: YOURAPITOKENHERE' https://foo.example/api/v0/devices/localhost/health/processor
+```
+
+Output:
+
+```
+{
+    "status": "ok",
+    "message": "",
+    "count": 1,
+    "graphs": [
+        {
+            "sensor_id": "1",
+            "desc": "Processor"
         }
     ]
 }

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -30,6 +30,7 @@ use App\Models\Ipv6Address;
 use App\Models\Ipv6Network;
 use App\Models\Link;
 use App\Models\Location;
+use App\Models\Mempool;
 use App\Models\MplsSap;
 use App\Models\MplsService;
 use App\Models\OspfPort;
@@ -43,8 +44,10 @@ use App\Models\PortGroup;
 use App\Models\PortSecurity;
 use App\Models\PortsFdb;
 use App\Models\PortsNac;
+use App\Models\Processor;
 use App\Models\Sensor;
 use App\Models\ServiceTemplate;
+use App\Models\Storage;
 use App\Models\UserPref;
 use App\Models\Vlan;
 use App\Models\Vrf;
@@ -1046,24 +1049,27 @@ function list_available_health_graphs(Illuminate\Http\Request $request)
         $graphs = [];
 
         // processors, storage and mempools are not stored in the `sensors` table,
-        // so they need to be looked up in their own tables.
-        $health_tables = [
-            'processor' => ['table' => 'processors', 'id' => 'processor_id', 'descr' => 'processor_descr'],
-            'storage' => ['table' => 'storage', 'id' => 'storage_id', 'descr' => 'storage_descr'],
-            'mempool' => ['table' => 'mempools', 'id' => 'mempool_id', 'descr' => 'mempool_descr', 'deleted' => 'mempool_deleted'],
+        // so they need to be looked up via their own models.
+        $health_models = [
+            'processor' => ['model' => Processor::class, 'id' => 'processor_id', 'descr' => 'processor_descr'],
+            'storage' => ['model' => Storage::class, 'id' => 'storage_id', 'descr' => 'storage_descr'],
+            'mempool' => ['model' => Mempool::class, 'id' => 'mempool_id', 'descr' => 'mempool_descr', 'deleted' => 'mempool_deleted'],
         ];
 
         if (isset($type)) {
-            if (isset($health_tables[$type])) {
-                $health = $health_tables[$type];
+            if (isset($health_models[$type])) {
+                $health = $health_models[$type];
                 if (isset($sensor_id)) {
-                    $graphs = dbFetchRows("SELECT * FROM `{$health['table']}` WHERE `{$health['id']}` = ?", [$sensor_id]);
+                    $graphs = $health['model']::where($health['id'], $sensor_id)->get()->toArray();
                 } else {
-                    $where = "`device_id` = ?" . (isset($health['deleted']) ? " AND `{$health['deleted']}` = 0" : '');
-                    foreach (dbFetchRows("SELECT `{$health['id']}`, `{$health['descr']}` FROM `{$health['table']}` WHERE $where", [$device_id]) as $graph) {
+                    $query = $health['model']::where('device_id', $device_id);
+                    if (isset($health['deleted'])) {
+                        $query->where($health['deleted'], 0);
+                    }
+                    foreach ($query->get() as $graph) {
                         $graphs[] = [
-                            'sensor_id' => $graph[$health['id']],
-                            'desc' => $graph[$health['descr']],
+                            'sensor_id' => $graph->{$health['id']},
+                            'desc' => $graph->{$health['descr']},
                         ];
                     }
                 }

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -1045,8 +1045,29 @@ function list_available_health_graphs(Illuminate\Http\Request $request)
         $sensor_id = $request->route('sensor_id');
         $graphs = [];
 
+        // processors, storage and mempools are not stored in the `sensors` table,
+        // so they need to be looked up in their own tables.
+        $health_tables = [
+            'processor' => ['table' => 'processors', 'id' => 'processor_id', 'descr' => 'processor_descr'],
+            'storage' => ['table' => 'storage', 'id' => 'storage_id', 'descr' => 'storage_descr'],
+            'mempool' => ['table' => 'mempools', 'id' => 'mempool_id', 'descr' => 'mempool_descr', 'deleted' => 'mempool_deleted'],
+        ];
+
         if (isset($type)) {
-            if (isset($sensor_id)) {
+            if (isset($health_tables[$type])) {
+                $health = $health_tables[$type];
+                if (isset($sensor_id)) {
+                    $graphs = dbFetchRows("SELECT * FROM `{$health['table']}` WHERE `{$health['id']}` = ?", [$sensor_id]);
+                } else {
+                    $where = "`device_id` = ?" . (isset($health['deleted']) ? " AND `{$health['deleted']}` = 0" : '');
+                    foreach (dbFetchRows("SELECT `{$health['id']}`, `{$health['descr']}` FROM `{$health['table']}` WHERE $where", [$device_id]) as $graph) {
+                        $graphs[] = [
+                            'sensor_id' => $graph[$health['id']],
+                            'desc' => $graph[$health['descr']],
+                        ];
+                    }
+                }
+            } elseif (isset($sensor_id)) {
                 $graphs = dbFetchRows('SELECT * FROM `sensors` WHERE `sensor_id` = ?', [$sensor_id]);
             } else {
                 foreach (dbFetchRows('SELECT `sensor_id`, `sensor_descr` FROM `sensors` WHERE `device_id` = ? AND `sensor_class` = ? AND `sensor_deleted` = 0', [$device_id, $type]) as $graph) {

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -1053,7 +1053,7 @@ function list_available_health_graphs(Illuminate\Http\Request $request)
         $health_models = [
             'processor' => ['model' => Processor::class, 'id' => 'processor_id', 'descr' => 'processor_descr'],
             'storage' => ['model' => Storage::class, 'id' => 'storage_id', 'descr' => 'storage_descr'],
-            'mempool' => ['model' => Mempool::class, 'id' => 'mempool_id', 'descr' => 'mempool_descr', 'deleted' => 'mempool_deleted'],
+            'mempool' => ['model' => Mempool::class, 'id' => 'mempool_id', 'descr' => 'mempool_descr'],
         ];
 
         if (isset($type)) {
@@ -1062,11 +1062,7 @@ function list_available_health_graphs(Illuminate\Http\Request $request)
                 if (isset($sensor_id)) {
                     $graphs = $health['model']::where($health['id'], $sensor_id)->get()->toArray();
                 } else {
-                    $query = $health['model']::where('device_id', $device_id);
-                    if (isset($health['deleted'])) {
-                        $query->where($health['deleted'], 0);
-                    }
-                    foreach ($query->get() as $graph) {
+                    foreach ($health['model']::where('device_id', $device_id)->get() as $graph) {
                         $graphs[] = [
                             'sensor_id' => $graph->{$health['id']},
                             'desc' => $graph->{$health['descr']},


### PR DESCRIPTION

The list_available_health_graphs API endpoint (/api/v0/devices/:hostname/health/:type) returned count: 0 for processor, storage and mempool, even when the device clearly had that data in the WebUI.

The cause is that these three types are not stored in the sensors table like other health classes (temperature, voltage, etc.) — they live in their own processors, storage and mempools tables. The endpoint advertises them in the no-type listing as device_processor / device_storage / device_mempool, but when a type was supplied it only ever queried the sensors table, so it always came back empty.

This PR routes those three types to their correct tables for both the list view and the single-sensor (/:sensor_id) view, returning the same {sensor_id, desc} shape as the existing sensor path. The device_ prefix remains optional. Ordinary sensor classes are unchanged.

Example (before: count: 0, after):

```
$ curl -H 'X-Auth-Token: ...' https://librenms/api/v0/devices/localhost/health/processor
{
    "status": "ok",
    "count": 1,
    "graphs": [
        { "sensor_id": 1, "desc": "Processor" }
    ]
}
```
Fetching a specific id (/health/processor/1) returns the full row, including the value (processor_usage, mempool_perc/mempool_used, storage_perc/storage_used).

Docs updated in doc/API/Devices.md.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
