### PR TITLE
Changed master channel exit code to 2

### DIFF
--- a/daily.php
+++ b/daily.php
@@ -64,7 +64,7 @@ if ($options['f'] === 'update') {
     }
 
     if (LibrenmsConfig::get('update_channel') == 'master') {
-        exit(1);
+        exit(2);
     } elseif (LibrenmsConfig::get('update_channel') == 'release') {
         exit(3);
     }

--- a/daily.sh
+++ b/daily.sh
@@ -293,7 +293,7 @@ main () {
         git checkout --quiet -- composer.json composer.lock
 
         update_res=0
-        if [[ "$up" == "1" ]] || [[ "$php_ver_ret" == "1" ]]; then
+        if [[ "$up" == "2" ]] || [[ "$php_ver_ret" == "1" ]]; then
             # Update current branch to latest
             branch=$(git rev-parse --abbrev-ref HEAD)
             if [[ "$branch" == "HEAD" ]]; then


### PR DESCRIPTION
Fixes: #19936

We could change the mysql connection exit code but the mysql client exits on 1 so seems more sensible to keep that.
Fatal exception on mysql connection failure but we probably don't want to as code updates still happen so that would stop us updating the code in case of a bad update.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
