### PR TITLE
Update outage only on status change

### DIFF
--- a/app/Actions/Device/SetDeviceAvailability.php
+++ b/app/Actions/Device/SetDeviceAvailability.php
@@ -34,7 +34,9 @@ class SetDeviceAvailability
 
         if ($commit) {
             $device->save();
-            $this->updateDeviceOutage->execute($device, $available);
+            if ($changed) {
+                $this->updateDeviceOutage->execute($device, $available);
+            }
         }
 
         return $changed;


### PR DESCRIPTION
saves some sql queries

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
