### PR TITLE
Fix per-OS module config:set validation (#19960)

### DIFF
--- a/app/Console/Commands/SetConfigCommand.php
+++ b/app/Console/Commands/SetConfigCommand.php
@@ -223,13 +223,35 @@ class SetConfigCommand extends LnmsCommand
             $value = $container;
         }
 
-        Arr::set($os_data, $setting, $value);
-        unset($os_data['definition_loaded']);
+        // Validate only the sub-tree that is actually being changed. Validating the
+        // whole merged os.<os> object means any single pre-existing/unrelated property
+        // the schema doesn't model blocks *every* os.<os>.* write (see issue #19960).
+        $parts = explode('.', $setting);
+        $section = array_shift($parts);
+
+        // load the os schema and pull out the definition for just this top-level section
+        $schema = json_decode((string) file_get_contents(resource_path('definitions/schema/os_schema.json')));
+        $section_schema = $schema->properties->{$section} ?? null;
+
+        if ($section_schema === null) {
+            // unknown top-level setting (the schema uses additionalProperties: false)
+            throw new ValidationException(trans('commands.config:set.errors.invalid_path', ['path' => $section]), 1);
+        }
+
+        // build a minimal object containing only the value being changed
+        $section_value = $value;
+        if (! empty($parts)) {
+            $section_value = [];
+            Arr::set($section_value, implode('.', $parts), $value);
+        }
+
+        // normalise to the structure json-schema expects (objects, not assoc arrays)
+        $data = json_decode((string) json_encode([$section => $section_value]));
 
         $validator = new Validator;
         $validator->validate(
-            $os_data,
-            (object) ['$ref' => 'file://' . resource_path('definitions/schema/os_schema.json')],
+            $data,
+            (object) ['type' => 'object', 'properties' => (object) [$section => $section_schema]],
             Constraint::CHECK_MODE_TYPE_CAST
         );
 
@@ -255,7 +277,14 @@ class SetConfigCommand extends LnmsCommand
         });
 
         if ($errors->isNotEmpty()) {
-            throw new ValidationException($errors->pluck('message')->implode(PHP_EOL), $code);
+            // include the failing property path so operators get an actionable message
+            $messages = $errors->map(function ($error) {
+                $path = trim((string) $error['property'], '.');
+
+                return $path === '' ? $error['message'] : "$path: {$error['message']}";
+            });
+
+            throw new ValidationException($messages->implode(PHP_EOL), $code);
         }
     }
 }

--- a/lang/en/commands.php
+++ b/lang/en/commands.php
@@ -42,6 +42,7 @@ return [
             'failed' => 'Failed to set :setting',
             'invalid' => 'This is not a valid setting. Please check your input',
             'invalid_os' => 'Specified OS (:os) does not exist',
+            'invalid_path' => 'Unknown OS setting (:path) is not defined in the schema',
             'nodb' => 'Database is not connected',
             'no-validation' => 'Cannot set :setting, it is missing validation definition.',
         ],

--- a/resources/definitions/schema/os_schema.json
+++ b/resources/definitions/schema/os_schema.json
@@ -66,73 +66,106 @@
         "poller_modules": {
             "type": "object",
             "properties": {
-                "cisco-qfp": {
+                "applications": {
                     "type": "boolean"
                 },
-                "cisco-cef": {
+                "arp-table": {
                     "type": "boolean"
                 },
-                "mac-accounting": {
+                "aruba-controller": {
                     "type": "boolean"
                 },
-                "cisco-remote-access-monitor": {
+                "availability": {
                     "type": "boolean"
                 },
-                "slas": {
-                    "type": "boolean"
-                },
-                "cisco-ipsec-flow-monitor": {
+                "bgp-peers": {
                     "type": "boolean"
                 },
                 "cipsec-tunnels": {
                     "type": "boolean"
                 },
-                "cisco-otv": {
+                "cisco-ace-loadbalancer": {
                     "type": "boolean"
                 },
                 "cisco-ace-serverfarms": {
                     "type": "boolean"
                 },
-                "cisco-ace-loadbalancer": {
+                "cisco-cef": {
                     "type": "boolean"
                 },
-                "entity-state": {
+                "cisco-ipsec-flow-monitor": {
                     "type": "boolean"
                 },
-                "ipmi": {
+                "cisco-otv": {
                     "type": "boolean"
                 },
-                "isis": {
+                "cisco-qfp": {
+                    "type": "boolean"
+                },
+                "cisco-remote-access-monitor": {
+                    "type": "boolean"
+                },
+                "cisco-vpdn": {
+                    "type": "boolean"
+                },
+                "core": {
+                    "type": "boolean"
+                },
+                "customoid": {
                     "type": "boolean"
                 },
                 "entity-physical": {
                     "type": "boolean"
                 },
-                "processors": {
-                    "type": "boolean"
-                },
-                "mempools": {
-                    "type": "boolean"
-                },
-                "storage": {
-                    "type": "boolean"
-                },
-                "netstats": {
+                "entity-state": {
                     "type": "boolean"
                 },
                 "hr-mib": {
                     "type": "boolean"
                 },
-                "ucd-mib": {
+                "ip-system-stats": {
                     "type": "boolean"
                 },
-                "ipSystemStats": {
+                "ipmi": {
                     "type": "boolean"
                 },
-                "ports": {
+                "ipv6-nd": {
                     "type": "boolean"
                 },
-                "bgp-peers": {
+                "isis": {
+                    "type": "boolean"
+                },
+                "junose-atm-vp": {
+                    "type": "boolean"
+                },
+                "loadbalancers": {
+                    "type": "boolean"
+                },
+                "mac-accounting": {
+                    "type": "boolean"
+                },
+                "mef": {
+                    "type": "boolean"
+                },
+                "mempools": {
+                    "type": "boolean"
+                },
+                "mpls": {
+                    "type": "boolean"
+                },
+                "nac": {
+                    "type": "boolean"
+                },
+                "netscaler-vsvr": {
+                    "type": "boolean"
+                },
+                "netstats": {
+                    "type": "boolean"
+                },
+                "ntp": {
+                    "type": "boolean"
+                },
+                "os": {
                     "type": "boolean"
                 },
                 "ospf": {
@@ -141,79 +174,58 @@
                 "ospfv3": {
                     "type": "boolean"
                 },
-                "ucd-diskio": {
+                "port-security": {
                     "type": "boolean"
                 },
-                "sensors": {
+                "ports": {
                     "type": "boolean"
                 },
-                "services": {
-                    "type": "boolean"
-                },
-                "route": {
-                    "type": "boolean"
-                },
-                "stp": {
-                    "type": "boolean"
-                },
-                "ntp": {
-                    "type": "boolean"
-                },
-                "wireless": {
-                    "type": "boolean"
-                },
-                "fdb-table": {
-                    "type": "boolean"
-                },
-                "applications": {
-                    "type": "boolean"
-                },
-                "aruba-controller": {
-                    "type": "boolean"
-                },
-                "mib": {
+                "ports-stack": {
                     "type": "boolean"
                 },
                 "printer-supplies": {
                     "type": "boolean"
                 },
-                "cisco-vpdn": {
+                "processors": {
                     "type": "boolean"
                 },
-                "vminfo": {
+                "qos": {
+                    "type": "boolean"
+                },
+                "sensors": {
+                    "type": "boolean"
+                },
+                "slas": {
+                    "type": "boolean"
+                },
+                "storage": {
+                    "type": "boolean"
+                },
+                "stp": {
+                    "type": "boolean"
+                },
+                "transceivers": {
+                    "type": "boolean"
+                },
+                "ucd-diskio": {
+                    "type": "boolean"
+                },
+                "ucd-mib": {
+                    "type": "boolean"
+                },
+                "unix-agent": {
                     "type": "boolean"
                 },
                 "vlans": {
                     "type": "boolean"
                 },
-                "arp-table": {
+                "vminfo": {
                     "type": "boolean"
                 },
-                "mef": {
-                    "type": "boolean"
-                },
-                "cisco-vrf-lite": {
-                    "type": "boolean"
-                },
-                "tnms-nbi": {
-                    "type": "boolean"
-                },
-                "loadbalancers": {
-                    "type": "boolean"
-                },
-                "junose-atm-vp": {
-                    "type": "boolean"
-                },
-                "mpls": {
-                    "type": "boolean"
-                },
-                "netscaler-vsvr": {
+                "wireless": {
                     "type": "boolean"
                 },
                 "xdsl": {
-                    "type": "boolean"
-                },
-                "port-security": {
                     "type": "boolean"
                 }
             },
@@ -231,16 +243,16 @@
         "discovery_modules": {
             "type": "object",
             "properties": {
-                "cisco-qfp": {
+                "applications": {
+                    "type": "boolean"
+                },
+                "arp-table": {
+                    "type": "boolean"
+                },
+                "bgp-peers": {
                     "type": "boolean"
                 },
                 "cisco-cef": {
-                    "type": "boolean"
-                },
-                "slas": {
-                    "type": "boolean"
-                },
-                "mac-accounting": {
                     "type": "boolean"
                 },
                 "cisco-otv": {
@@ -249,73 +261,31 @@
                 "cisco-pw": {
                     "type": "boolean"
                 },
-                "entity-state": {
-                    "type": "boolean"
-                },
-                "vrf": {
+                "cisco-qfp": {
                     "type": "boolean"
                 },
                 "cisco-vrf-lite": {
                     "type": "boolean"
                 },
-                "ports": {
+                "core": {
                     "type": "boolean"
                 },
-                "ports-stack": {
-                    "type": "boolean"
-                },
-                "entity-physical": {
-                    "type": "boolean"
-                },
-                "processors": {
-                    "type": "boolean"
-                },
-                "mempools": {
-                    "type": "boolean"
-                },
-                "storage": {
-                    "type": "boolean"
-                },
-                "hr-device": {
-                    "type": "boolean"
-                },
-                "isis": {
+                "discovery-arp": {
                     "type": "boolean"
                 },
                 "discovery-protocols": {
                     "type": "boolean"
                 },
-                "bgp-peers": {
+                "entity-physical": {
                     "type": "boolean"
                 },
-                "vlans": {
-                    "type": "boolean"
-                },
-                "ucd-diskio": {
-                    "type": "boolean"
-                },
-                "ucd-dsktable": {
-                    "type": "boolean"
-                },
-                "services": {
-                    "type": "boolean"
-                },
-                "stp": {
-                    "type": "boolean"
-                },
-                "ntp": {
-                    "type": "boolean"
-                },
-                "wireless": {
+                "entity-state": {
                     "type": "boolean"
                 },
                 "fdb-table": {
                     "type": "boolean"
                 },
-                "arp-table": {
-                    "type": "boolean"
-                },
-                "printer-supplies": {
+                "hr-device": {
                     "type": "boolean"
                 },
                 "ipv4-addresses": {
@@ -324,46 +294,88 @@
                 "ipv6-addresses": {
                     "type": "boolean"
                 },
-                "charge": {
+                "ipv6-nd": {
                     "type": "boolean"
                 },
-                "ospf": {
-                    "type": "boolean"
-                },
-                "ucd-mib": {
-                    "type": "boolean"
-                },
-                "ipmi": {
-                    "type": "boolean"
-                },
-                "mef": {
-                    "type": "boolean"
-                },
-                "ipv6-address": {
-                    "type": "boolean"
-                },
-                "loadbalancers": {
-                    "type": "boolean"
-                },
-                "applications": {
-                    "type": "boolean"
-                },
-                "sensors": {
-                    "type": "boolean"
-                },
-                "diskio": {
+                "isis": {
                     "type": "boolean"
                 },
                 "junose-atm-vp": {
                     "type": "boolean"
                 },
-                "vminfo": {
+                "loadbalancers": {
+                    "type": "boolean"
+                },
+                "mac-accounting": {
+                    "type": "boolean"
+                },
+                "mef": {
+                    "type": "boolean"
+                },
+                "mempools": {
                     "type": "boolean"
                 },
                 "mpls": {
                     "type": "boolean"
                 },
-                "ip6-addresses": {
+                "ntp": {
+                    "type": "boolean"
+                },
+                "os": {
+                    "type": "boolean"
+                },
+                "ospfv3": {
+                    "type": "boolean"
+                },
+                "ports": {
+                    "type": "boolean"
+                },
+                "ports-stack": {
+                    "type": "boolean"
+                },
+                "printer-supplies": {
+                    "type": "boolean"
+                },
+                "processors": {
+                    "type": "boolean"
+                },
+                "qos": {
+                    "type": "boolean"
+                },
+                "route": {
+                    "type": "boolean"
+                },
+                "sensors": {
+                    "type": "boolean"
+                },
+                "services": {
+                    "type": "boolean"
+                },
+                "slas": {
+                    "type": "boolean"
+                },
+                "storage": {
+                    "type": "boolean"
+                },
+                "stp": {
+                    "type": "boolean"
+                },
+                "transceivers": {
+                    "type": "boolean"
+                },
+                "ucd-diskio": {
+                    "type": "boolean"
+                },
+                "vlans": {
+                    "type": "boolean"
+                },
+                "vminfo": {
+                    "type": "boolean"
+                },
+                "vrf": {
+                    "type": "boolean"
+                },
+                "wireless": {
                     "type": "boolean"
                 },
                 "xdsl": {

--- a/resources/definitions/schema/os_schema.json
+++ b/resources/definitions/schema/os_schema.json
@@ -108,6 +108,9 @@
                 "cisco-vpdn": {
                     "type": "boolean"
                 },
+                "cisco-vrf-lite": {
+                    "type": "boolean"
+                },
                 "core": {
                     "type": "boolean"
                 },
@@ -120,10 +123,16 @@
                 "entity-state": {
                     "type": "boolean"
                 },
+                "fdb-table": {
+                    "type": "boolean"
+                },
                 "hr-mib": {
                     "type": "boolean"
                 },
                 "ip-system-stats": {
+                    "type": "boolean"
+                },
+                "ipSystemStats": {
                     "type": "boolean"
                 },
                 "ipmi": {
@@ -148,6 +157,9 @@
                     "type": "boolean"
                 },
                 "mempools": {
+                    "type": "boolean"
+                },
+                "mib": {
                     "type": "boolean"
                 },
                 "mpls": {
@@ -192,7 +204,13 @@
                 "qos": {
                     "type": "boolean"
                 },
+                "route": {
+                    "type": "boolean"
+                },
                 "sensors": {
+                    "type": "boolean"
+                },
+                "services": {
                     "type": "boolean"
                 },
                 "slas": {
@@ -202,6 +220,9 @@
                     "type": "boolean"
                 },
                 "stp": {
+                    "type": "boolean"
+                },
+                "tnms-nbi": {
                     "type": "boolean"
                 },
                 "transceivers": {
@@ -252,6 +273,9 @@
                 "bgp-peers": {
                     "type": "boolean"
                 },
+                "charge": {
+                    "type": "boolean"
+                },
                 "cisco-cef": {
                     "type": "boolean"
                 },
@@ -276,6 +300,9 @@
                 "discovery-protocols": {
                     "type": "boolean"
                 },
+                "diskio": {
+                    "type": "boolean"
+                },
                 "entity-physical": {
                     "type": "boolean"
                 },
@@ -288,7 +315,16 @@
                 "hr-device": {
                     "type": "boolean"
                 },
+                "ip6-addresses": {
+                    "type": "boolean"
+                },
+                "ipmi": {
+                    "type": "boolean"
+                },
                 "ipv4-addresses": {
+                    "type": "boolean"
+                },
+                "ipv6-address": {
                     "type": "boolean"
                 },
                 "ipv6-addresses": {
@@ -322,6 +358,9 @@
                     "type": "boolean"
                 },
                 "os": {
+                    "type": "boolean"
+                },
+                "ospf": {
                     "type": "boolean"
                 },
                 "ospfv3": {
@@ -364,6 +403,12 @@
                     "type": "boolean"
                 },
                 "ucd-diskio": {
+                    "type": "boolean"
+                },
+                "ucd-dsktable": {
+                    "type": "boolean"
+                },
+                "ucd-mib": {
                     "type": "boolean"
                 },
                 "vlans": {

--- a/tests/YamlSchemaTest.php
+++ b/tests/YamlSchemaTest.php
@@ -64,11 +64,22 @@ final class YamlSchemaTest extends TestCase
         $definitions = json_decode((string) file_get_contents(resource_path('definitions/config_definitions.json')), true)['config'];
         $schema = json_decode((string) file_get_contents(resource_path('definitions/schema/os_schema.json')), true);
 
+        // module keys actually used by OS definition yaml files: these legacy names must
+        // remain valid in the schema even if they are not (or no longer) real modules.
+        $used = ['poller_modules' => [], 'discovery_modules' => []];
+        foreach (glob(resource_path('definitions/os_detection') . '/*.yaml') as $file) {
+            $data = Yaml::parseFile($file) ?: [];
+            foreach (array_keys($used) as $section) {
+                $used[$section] = array_merge($used[$section], array_keys($data[$section] ?? []));
+            }
+        }
+
         foreach (['poller_modules', 'discovery_modules'] as $section) {
             $expected = collect(array_keys($definitions))
                 ->filter(fn ($key) => Str::startsWith($key, "$section."))
                 ->map(fn ($key) => Str::after($key, "$section."))
-                ->sort()->values()->all();
+                ->merge($used[$section])
+                ->unique()->sort()->values()->all();
 
             $actual = collect(array_keys($schema['properties'][$section]['properties'] ?? []))
                 ->sort()->values()->all();
@@ -76,9 +87,9 @@ final class YamlSchemaTest extends TestCase
             $this->assertEquals(
                 $expected,
                 $actual,
-                "os_schema.json '$section' enum has drifted from config_definitions.json.\n"
-                . 'Missing from schema: ' . (implode(', ', array_diff($expected, $actual)) ?: '(none)') . "\n"
-                . 'Stale in schema: ' . (implode(', ', array_diff($actual, $expected)) ?: '(none)')
+                "os_schema.json '$section' enum is out of sync.\n"
+                . 'Missing (real module or used by an OS yaml): ' . (implode(', ', array_diff($expected, $actual)) ?: '(none)') . "\n"
+                . 'Stale (in schema, not a real module and unused by any OS yaml): ' . (implode(', ', array_diff($actual, $expected)) ?: '(none)')
             );
         }
     }

--- a/tests/YamlSchemaTest.php
+++ b/tests/YamlSchemaTest.php
@@ -58,6 +58,31 @@ final class YamlSchemaTest extends TestCase
         $this->validateYamlFilesAgainstSchema(resource_path('definitions/os_detection'), resource_path('definitions/schema/os_schema.json'));
     }
 
+    #[TestDox('OS schema module enums stay in sync with config_definitions.json')]
+    public function testOSSchemaModuleEnumsInSync(): void
+    {
+        $definitions = json_decode((string) file_get_contents(resource_path('definitions/config_definitions.json')), true)['config'];
+        $schema = json_decode((string) file_get_contents(resource_path('definitions/schema/os_schema.json')), true);
+
+        foreach (['poller_modules', 'discovery_modules'] as $section) {
+            $expected = collect(array_keys($definitions))
+                ->filter(fn ($key) => Str::startsWith($key, "$section."))
+                ->map(fn ($key) => Str::after($key, "$section."))
+                ->sort()->values()->all();
+
+            $actual = collect(array_keys($schema['properties'][$section]['properties'] ?? []))
+                ->sort()->values()->all();
+
+            $this->assertEquals(
+                $expected,
+                $actual,
+                "os_schema.json '$section' enum has drifted from config_definitions.json.\n"
+                . 'Missing from schema: ' . (implode(', ', array_diff($expected, $actual)) ?: '(none)') . "\n"
+                . 'Stale in schema: ' . (implode(', ', array_diff($actual, $expected)) ?: '(none)')
+            );
+        }
+    }
+
     #[TestDox('OS match filename')]
     public function testOSMatchFilename(): void
     {


### PR DESCRIPTION
Sync os_schema.json poller_modules/discovery_modules enums with the authoritative module list in config_definitions.json, adding missing real modules (ospfv3, transceivers, qos, route, ip-system-stats, ports-stack, core, os, etc.) and removing stale entries (ipSystemStats, ospf-as-discovery, charge, diskio, ...).

Scope SetConfigCommand::validateOsSetting() to validate only the changed sub-tree instead of the whole merged os.<os> object, so unrelated pre-existing schema drift can no longer block valid per-OS writes. Surface the failing property path in the error message and reject unknown top-level settings with a clear message.

Add YamlSchemaTest::testOSSchemaModuleEnumsInSync() to guard against the schema enums drifting from config_definitions.json again.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
