### PR TITLE
Cleanup SslCertificate Model

### DIFF
--- a/app/Console/Commands/MaintenanceDiscoverSslCertificates.php
+++ b/app/Console/Commands/MaintenanceDiscoverSslCertificates.php
@@ -56,15 +56,11 @@ class MaintenanceDiscoverSslCertificates extends LnmsCommand
                 continue;
             }
 
-            $existing = SslCertificate::where('device_id', $device->device_id)
-                ->where('host', $host)
-                ->where('port', $port)
-                ->first();
-
-            $cert = $existing ?? new SslCertificate([
+            $cert = SslCertificate::firstOrNew([
                 'device_id' => $device->device_id,
                 'host' => $host,
                 'port' => $port,
+            ], [
                 'disabled' => false,
             ]);
 
@@ -78,12 +74,12 @@ class MaintenanceDiscoverSslCertificates extends LnmsCommand
                 continue;
             }
 
-            if ($existing) {
+            if ($cert->exists) {
                 $changes = $cert->getTrackedChanges();
                 $cert->save();
                 if ($changes !== '') {
                     $updated++;
-                    Eventlog::log("SSL certificate updated: {$host}:{$port} – {$changes}", $device->device_id, 'ssl-certificate', Severity::Info, $existing->id);
+                    Eventlog::log("SSL certificate updated: {$host}:{$port} – {$changes}", $device->device_id, 'ssl-certificate', Severity::Info, $cert->id);
                 }
             } else {
                 $cert->save();

--- a/app/Console/Commands/MaintenanceDiscoverSslCertificates.php
+++ b/app/Console/Commands/MaintenanceDiscoverSslCertificates.php
@@ -2,16 +2,11 @@
 
 namespace App\Console\Commands;
 
-use AcmePhp\Ssl\Exception\CertificateParsingException;
 use App\Console\LnmsCommand;
 use App\Facades\LibrenmsConfig;
 use App\Models\Device;
 use App\Models\Eventlog;
 use App\Models\SslCertificate;
-use Jalle19\CertificateParser\Parser;
-use Jalle19\CertificateParser\Provider\Exception\ProviderException;
-use Jalle19\CertificateParser\Provider\StreamContext;
-use Jalle19\CertificateParser\Provider\StreamSocketProvider;
 use LibreNMS\Enum\Severity;
 use Symfony\Component\Console\Input\InputOption;
 
@@ -44,10 +39,6 @@ class MaintenanceDiscoverSslCertificates extends LnmsCommand
             return 0;
         }
 
-        $parser = new Parser();
-        $context = new StreamContext();
-        $context->setVerifyPeerName(false);
-
         $port = 443;
         $timeout = 10;
         $created = 0;
@@ -65,42 +56,39 @@ class MaintenanceDiscoverSslCertificates extends LnmsCommand
                 continue;
             }
 
-            try {
-                $provider = new StreamSocketProvider($host, $port, $timeout, $context);
-                $results = $parser->parse($provider);
-            } catch (ProviderException|CertificateParsingException $e) {
-                if ($this->getOutput()->isVerbose()) {
-                    $this->line("  {$host}:{$port} – " . $e->getMessage());
-                }
-                $failed++;
-                continue;
-            }
-
-            $data = array_merge(SslCertificate::attributesFromParserResults($results), [
-                'device_id' => $device->device_id,
-                'host' => $host,
-                'port' => $port,
-                'last_checked_at' => now(),
-                'disabled' => false,
-            ]);
-
             $existing = SslCertificate::where('device_id', $device->device_id)
                 ->where('host', $host)
                 ->where('port', $port)
                 ->first();
 
+            $cert = $existing ?? new SslCertificate([
+                'device_id' => $device->device_id,
+                'host' => $host,
+                'port' => $port,
+                'disabled' => false,
+            ]);
+
+            try {
+                $cert->updateFromHost($timeout);
+            } catch (\Throwable $e) {
+                if ($this->getOutput()->isVerbose()) {
+                    $this->line("  $host:$port – " . $e->getMessage());
+                }
+                $failed++;
+                continue;
+            }
+
             if ($existing) {
-                $changes = SslCertificate::formatAttributeChanges($existing->only(['subject', 'issuer', 'valid_to', 'valid_from', 'fingerprint', 'days_until_expiry']), $data);
-                // Always persist bookkeeping fields like last_checked_at, even if there are no meaningful changes.
-                $existing->update($data);
+                $changes = $cert->getTrackedChanges();
+                $cert->save();
                 if ($changes !== '') {
                     $updated++;
                     Eventlog::log("SSL certificate updated: {$host}:{$port} – {$changes}", $device->device_id, 'ssl-certificate', Severity::Info, $existing->id);
                 }
             } else {
-                $cert = SslCertificate::create($data);
+                $cert->save();
                 $created++;
-                $msg = "SSL certificate discovered: {$host}:{$port} – Subject: {$data['subject']}, Issuer: {$data['issuer']}, Valid until: " . ($data['valid_to'] ?? 'N/A') . ', Days until expiry: ' . ($data['days_until_expiry'] ?? 'N/A');
+                $msg = "SSL certificate discovered: {$host}:{$port} – Subject: {$cert->subject}, Issuer: {$cert->issuer}, Valid until: " . ($cert->valid_to?->format('Y-m-d H:i:s') ?? 'N/A') . ', Days until expiry: ' . ($cert->days_until_expiry ?? 'N/A');
                 Eventlog::log($msg, $device->device_id, 'ssl-certificate', Severity::Info, $cert->id);
             }
         }

--- a/app/Console/Commands/MaintenanceRefreshSslCertificates.php
+++ b/app/Console/Commands/MaintenanceRefreshSslCertificates.php
@@ -2,15 +2,10 @@
 
 namespace App\Console\Commands;
 
-use AcmePhp\Ssl\Exception\CertificateParsingException;
 use App\Console\LnmsCommand;
 use App\Facades\LibrenmsConfig;
 use App\Models\Eventlog;
 use App\Models\SslCertificate;
-use Jalle19\CertificateParser\Parser;
-use Jalle19\CertificateParser\Provider\Exception\ProviderException;
-use Jalle19\CertificateParser\Provider\StreamContext;
-use Jalle19\CertificateParser\Provider\StreamSocketProvider;
 use LibreNMS\Enum\Severity;
 use Symfony\Component\Console\Input\InputOption;
 
@@ -48,10 +43,6 @@ class MaintenanceRefreshSslCertificates extends LnmsCommand
             return 0;
         }
 
-        $parser = new Parser();
-        $context = new StreamContext();
-        $context->setVerifyPeerName(false);
-
         $timeout = 10;
         $refreshed = 0;
         $failed = 0;
@@ -59,23 +50,17 @@ class MaintenanceRefreshSslCertificates extends LnmsCommand
         /** @var \App\Models\SslCertificate $cert */
         foreach ($certificates as $cert) {
             try {
-                $provider = new StreamSocketProvider($cert->host, $cert->port, $timeout, $context);
-                $results = $parser->parse($provider);
-            } catch (ProviderException|CertificateParsingException $e) {
+                $cert->updateFromHost($timeout);
+            } catch (\Throwable $e) {
                 if ($this->getOutput()->isVerbose()) {
-                    $this->line("  {$cert->host}:{$cert->port} – " . $e->getMessage());
+                    $this->line("  $cert->host:$cert->port – " . $e->getMessage());
                 }
                 $failed++;
                 continue;
             }
 
-            $attrData = SslCertificate::attributesFromParserResults($results);
-            $newData = array_merge($attrData, [
-                'last_checked_at' => now(),
-            ]);
-            $oldAttrs = $cert->only(['subject', 'issuer', 'valid_to', 'valid_from', 'fingerprint', 'days_until_expiry']);
-            $changes = SslCertificate::formatAttributeChanges($oldAttrs, $attrData);
-            $cert->update($newData);
+            $changes = $cert->getTrackedChanges();
+            $cert->save();
             if ($changes !== '') {
                 $refreshed++;
                 Eventlog::log("SSL certificate refreshed: {$cert->host}:{$cert->port} – {$changes}", $cert->device_id, 'ssl-certificate', Severity::Info, $cert->id);

--- a/app/Console/Commands/MaintenanceRefreshSslCertificates.php
+++ b/app/Console/Commands/MaintenanceRefreshSslCertificates.php
@@ -27,7 +27,7 @@ class MaintenanceRefreshSslCertificates extends LnmsCommand
         $id = $this->option('id');
 
         $query = SslCertificate::query()->where('disabled', 0);
-        if ($id !== null && is_numeric($id)) {
+        if (is_numeric($id)) {
             $query->where('id', $id);
         }
         $certificates = $query->get();
@@ -47,7 +47,6 @@ class MaintenanceRefreshSslCertificates extends LnmsCommand
         $refreshed = 0;
         $failed = 0;
 
-        /** @var \App\Models\SslCertificate $cert */
         foreach ($certificates as $cert) {
             try {
                 $cert->updateFromHost($timeout);

--- a/app/Http/Controllers/SslCertificateController.php
+++ b/app/Http/Controllers/SslCertificateController.php
@@ -70,7 +70,7 @@ class SslCertificateController extends Controller
         $cert->save();
 
         return redirect()->route('ssl-certificates.index')
-            ->with('success', __('SSL certificate added for :host.', ['host' => $validated['host'] . ':' . ((int)($validated['port'] ?? 443))]));
+            ->with('success', __('SSL certificate added for :host.', ['host' => $validated['host'] . ':' . ((int) ($validated['port'] ?? 443))]));
     }
 
     /**

--- a/app/Http/Controllers/SslCertificateController.php
+++ b/app/Http/Controllers/SslCertificateController.php
@@ -52,28 +52,25 @@ class SslCertificateController extends Controller
                 ->withErrors(['device_id' => __('You may only assign certificates to devices you can access.')]);
         }
 
-        $host = $validated['host'];
-        $port = (int) ($validated['port'] ?? 443);
-        $deviceId = (int) $validated['device_id'];
+        $cert = new SslCertificate([
+            'device_id' => $request->integer('device_id'),
+            'host' => $request->string('host'),
+            'port' => $request->integer('port', 443),
+            'disabled' => false,
+        ]);
 
         try {
-            $cert = SslCertificate::fetchAndParse($host, $port);
+            $cert->updateFromHost();
         } catch (\Throwable $e) {
             return redirect()->route('ssl-certificates.create')
                 ->withInput()
                 ->withErrors(['host' => __('Failed to fetch certificate: :error', ['error' => $e->getMessage()])]);
         }
 
-        $cert['device_id'] = $deviceId;
-        $cert['host'] = $host;
-        $cert['port'] = $port;
-        $cert['last_checked_at'] = now();
-        $cert['disabled'] = false;
-
-        SslCertificate::create($cert);
+        $cert->save();
 
         return redirect()->route('ssl-certificates.index')
-            ->with('success', __('SSL certificate added for :host.', ['host' => $host . ':' . $port]));
+            ->with('success', __('SSL certificate added for :host.', ['host' => $validated['host'] . ':' . ((int)($validated['port'] ?? 443))]));
     }
 
     /**
@@ -104,7 +101,7 @@ class SslCertificateController extends Controller
         ]);
 
         if ($request->has('disabled')) {
-            $ssl_certificate->disabled = (bool) $request->input('disabled');
+            $ssl_certificate->disabled = $request->boolean('disabled');
             $ssl_certificate->save();
         }
 

--- a/app/Models/SslCertificate.php
+++ b/app/Models/SslCertificate.php
@@ -63,7 +63,7 @@ class SslCertificate extends Model
     }
 
     /**
-     * @param Builder<SslCertificate> $query
+     * @param  Builder<SslCertificate>  $query
      * @return Builder<SslCertificate>
      */
     public function scopeEnabled(Builder $query): Builder
@@ -72,7 +72,7 @@ class SslCertificate extends Model
     }
 
     /**
-     * @param Builder<SslCertificate> $query
+     * @param  Builder<SslCertificate>  $query
      * @return Builder<SslCertificate>
      */
     public function scopeDisabled(Builder $query): Builder
@@ -83,8 +83,8 @@ class SslCertificate extends Model
     /**
      * Scope to certificates the user is allowed to see (linked to device they have access to, or no device).
      *
-     * @param Builder<SslCertificate> $query
-     * @param mixed $user
+     * @param  Builder<SslCertificate>  $query
+     * @param  mixed  $user
      * @return Builder<SslCertificate>
      */
     public function scopeHasAccess(Builder $query, $user): Builder

--- a/app/Models/SslCertificate.php
+++ b/app/Models/SslCertificate.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use AcmePhp\Ssl\Exception\CertificateParsingException;
 use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -12,38 +13,6 @@ use Jalle19\CertificateParser\Provider\Exception\ProviderException;
 use Jalle19\CertificateParser\Provider\StreamContext;
 use Jalle19\CertificateParser\Provider\StreamSocketProvider;
 
-/**
- * @property int|null $id
- * @property int|null $device_id
- * @property string $host
- * @property int $port
- * @property string|null $issuer
- * @property string|null $issuer_country
- * @property string|null $issuer_organization
- * @property string|null $subject
- * @property array|null $subject_alternative_names
- * @property string|null $serial_number
- * @property string|null $serial_number_hex
- * @property bool $self_signed
- * @property string|null $signature_algorithm
- * @property int|null $certificate_version
- * @property string|null $key_usage
- * @property string|null $extended_key_usage
- * @property string|null $basic_constraints
- * @property string|null $subject_key_identifier
- * @property string|null $authority_key_identifier
- * @property Carbon|null $valid_from
- * @property Carbon|null $valid_to
- * @property int|null $days_until_expiry
- * @property string|null $fingerprint
- * @property string|null $pem
- * @property Carbon|null $last_checked_at
- * @property bool $disabled
- * @property \Illuminate\Support\Carbon|null $created_at
- * @property \Illuminate\Support\Carbon|null $updated_at
- * @property \Illuminate\Support\Carbon|null $deleted_at
- * @property-read Device|null $device
- */
 class SslCertificate extends Model
 {
     use SoftDeletes;
@@ -93,22 +62,34 @@ class SslCertificate extends Model
         return $this->belongsTo(Device::class, 'device_id', 'device_id');
     }
 
-    public function scopeEnabled($query)
+    /**
+     * @param Builder<SslCertificate> $query
+     * @return Builder<SslCertificate>
+     */
+    public function scopeEnabled(Builder $query): Builder
     {
         return $query->where('disabled', false);
     }
 
-    public function scopeDisabled($query)
+    /**
+     * @param Builder<SslCertificate> $query
+     * @return Builder<SslCertificate>
+     */
+    public function scopeDisabled(Builder $query): Builder
     {
         return $query->where('disabled', true);
     }
 
     /**
      * Scope to certificates the user is allowed to see (linked to device they have access to, or no device).
+     *
+     * @param Builder<SslCertificate> $query
+     * @param mixed $user
+     * @return Builder<SslCertificate>
      */
-    public function scopeHasAccess($query, $user)
+    public function scopeHasAccess(Builder $query, $user): Builder
     {
-        return $query->where(function ($q) use ($user): void {
+        return $query->where(function (Builder $q) use ($user): void {
             $q->whereNull('device_id')
                 ->orWhereIn('device_id', Device::hasAccess($user)->select('device_id'));
         });
@@ -129,83 +110,25 @@ class SslCertificate extends Model
     }
 
     /**
-     * Build attribute array from parser results (ParsedCertificate + raw openssl_x509_parse).
-     *
-     * @param  \Jalle19\CertificateParser\ParserResults  $results
-     * @return array<string, mixed>
+     * Get a formatted string of changes for tracked attributes.
      */
-    public static function attributesFromParserResults($results): array
+    public function getTrackedChanges(): string
     {
-        $cert = $results->getParsedCertificate();
-        $raw = $results->getRawCertificate();
-        $validFrom = method_exists($cert, 'getValidFrom') ? $cert->getValidFrom() : null;
-        $validTo = $cert->getValidTo();
-
-        $issuerCountry = $raw['issuer']['C'] ?? null;
-        $issuerOrg = $raw['issuer']['O'] ?? null;
-
-        $serialNumber = method_exists($cert, 'getSerialNumber') ? $cert->getSerialNumber() : ($raw['serialNumber'] ?? null);
-        $serialNumberHex = $raw['serialNumberHex'] ?? null;
-        $selfSigned = method_exists($cert, 'isSelfSigned') ? $cert->isSelfSigned() : (method_exists($cert, 'getSelfSigned') ? $cert->getSelfSigned() : false);
-
-        $signatureAlgorithm = $raw['signatureTypeSN'] ?? $raw['signatureTypeLN'] ?? null;
-        $version = isset($raw['version']) ? (int) $raw['version'] + 1 : null; // OpenSSL: 2 = X.509 v3
-
-        $extensions = $raw['extensions'] ?? [];
-        $keyUsage = $extensions['keyUsage'] ?? null;
-        $extendedKeyUsage = $extensions['extendedKeyUsage'] ?? null;
-        $basicConstraints = $extensions['basicConstraints'] ?? null;
-        $subjectKeyId = $extensions['subjectKeyIdentifier'] ?? null;
-        $authorityKeyId = $extensions['authorityKeyIdentifier'] ?? null;
-
-        $daysUntilExpiry = null;
-        if ($validTo !== null) {
-            $daysUntilExpiry = (int) round(\Carbon\Carbon::instance($validTo)->diffInSeconds(now(), false) / -86400);
-        }
-
-        return [
-            'issuer' => $cert->getIssuer(),
-            'issuer_country' => $issuerCountry,
-            'issuer_organization' => $issuerOrg,
-            'subject' => $cert->getSubject(),
-            'subject_alternative_names' => $cert->getSubjectAlternativeNames(),
-            'serial_number' => $serialNumber,
-            'serial_number_hex' => $serialNumberHex,
-            'self_signed' => $selfSigned,
-            'signature_algorithm' => $signatureAlgorithm,
-            'certificate_version' => $version,
-            'key_usage' => $keyUsage,
-            'extended_key_usage' => $extendedKeyUsage,
-            'basic_constraints' => $basicConstraints,
-            'subject_key_identifier' => $subjectKeyId,
-            'authority_key_identifier' => $authorityKeyId,
-            'valid_from' => $validFrom !== null ? $validFrom->format('Y-m-d H:i:s') : null,
-            'valid_to' => $validTo !== null ? $validTo->format('Y-m-d H:i:s') : null,
-            'days_until_expiry' => $daysUntilExpiry,
-            'fingerprint' => $results->getFingerprint(),
-            'pem' => $results->getPemString(),
-        ];
-    }
-
-    /**
-     * Build a string describing which certificate attribute fields changed (old -> new).
-     * Used for eventlog messages when discovering or refreshing certificates.
-     *
-     * @param  array<string, mixed>  $old  previous attribute values (e.g. from model only())
-     * @param  array<string, mixed>  $new  new attribute values
-     * @return string comma-separated "field (old → new)" for each changed field
-     */
-    public static function formatAttributeChanges(array $old, array $new): string
-    {
+        $dirty = $this->getDirty();
         $parts = [];
         $fields = ['subject', 'issuer', 'valid_to', 'valid_from', 'fingerprint', 'days_until_expiry'];
+
         foreach ($fields as $field) {
-            $o = $old[$field] ?? null;
-            $n = $new[$field] ?? null;
-            if ($o !== $n && (string) $o !== (string) $n) {
+            if (array_key_exists($field, $dirty)) {
+                $o = $this->getOriginal($field);
+                $n = $this->getAttribute($field);
+
                 $oStr = $o instanceof \DateTimeInterface ? $o->format('Y-m-d H:i:s') : (string) $o;
                 $nStr = $n instanceof \DateTimeInterface ? $n->format('Y-m-d H:i:s') : (string) $n;
-                $parts[] = "{$field} ({$oStr} → {$nStr})";
+
+                if ($oStr !== $nStr) {
+                    $parts[] = "{$field} ({$oStr} → {$nStr})";
+                }
             }
         }
 
@@ -213,23 +136,52 @@ class SslCertificate extends Model
     }
 
     /**
-     * Fetch certificate from host:port and return array of attributes for create/update.
+     * Fetch certificate details from the host and port and update this model's attributes.
      *
-     * @throws ProviderException|CertificateParsingException
+     * @throws \Exception
      */
-    public static function fetchAndParse(string $host, int $port = 443, int $timeout = 10): array
+    public function updateFromHost(int $timeout = 10): void
     {
         $context = new StreamContext;
         $context->setVerifyPeerName(false);
-        $provider = new StreamSocketProvider($host, $port, $timeout, $context);
+        $provider = new StreamSocketProvider($this->host, $this->port, $timeout, $context);
         $parser = new Parser;
 
         try {
             $results = $parser->parse($provider);
         } catch (ProviderException|CertificateParsingException $e) {
-            throw new \Exception("Failed to fetch certificate from {$host}:{$port}: {$e->getMessage()}");
+            throw new \Exception("Failed to fetch certificate from $this->host:$this->port: {$e->getMessage()}");
         }
 
-        return self::attributesFromParserResults($results);
+        $cert = $results->getParsedCertificate();
+        $raw = $results->getRawCertificate();
+        $validFrom = method_exists($cert, 'getValidFrom') ? $cert->getValidFrom() : null;
+        $validTo = $cert->getValidTo();
+
+        $this->issuer = $cert->getIssuer();
+        $this->issuer_country = $raw['issuer']['C'] ?? null;
+        $this->issuer_organization = $raw['issuer']['O'] ?? null;
+        $this->subject = $cert->getSubject();
+        $this->subject_alternative_names = $cert->getSubjectAlternativeNames();
+        $this->serial_number = method_exists($cert, 'getSerialNumber') ? $cert->getSerialNumber() : ($raw['serialNumber'] ?? null);
+        $this->serial_number_hex = $raw['serialNumberHex'] ?? null;
+        $this->self_signed = method_exists($cert, 'isSelfSigned') ? $cert->isSelfSigned() : (method_exists($cert, 'getSelfSigned') ? $cert->getSelfSigned() : false);
+        $this->signature_algorithm = $raw['signatureTypeSN'] ?? $raw['signatureTypeLN'] ?? null;
+        $this->certificate_version = isset($raw['version']) ? (int) $raw['version'] + 1 : null; // OpenSSL: 2 = X.509 v3
+
+        $extensions = $raw['extensions'] ?? [];
+        $this->key_usage = $extensions['keyUsage'] ?? null;
+        $this->extended_key_usage = $extensions['extendedKeyUsage'] ?? null;
+        $this->basic_constraints = $extensions['basicConstraints'] ?? null;
+        $this->subject_key_identifier = $extensions['subjectKeyIdentifier'] ?? null;
+        $this->authority_key_identifier = $extensions['authorityKeyIdentifier'] ?? null;
+
+        $this->valid_from = $validFrom !== null ? Carbon::instance($validFrom) : null;
+        $this->valid_to = Carbon::instance($validTo);
+        $this->days_until_expiry = (int) round($this->valid_to->diffInSeconds(now()) / -86400);
+
+        $this->fingerprint = $results->getFingerprint();
+        $this->pem = $results->getPemString();
+        $this->last_checked_at = now();
     }
 }

--- a/app/Models/SslCertificate.php
+++ b/app/Models/SslCertificate.php
@@ -13,6 +13,38 @@ use Jalle19\CertificateParser\Provider\Exception\ProviderException;
 use Jalle19\CertificateParser\Provider\StreamContext;
 use Jalle19\CertificateParser\Provider\StreamSocketProvider;
 
+/**
+ * @property int|null $id
+ * @property int|null $device_id
+ * @property string $host
+ * @property int $port
+ * @property string|null $issuer
+ * @property string|null $issuer_country
+ * @property string|null $issuer_organization
+ * @property string|null $subject
+ * @property array|null $subject_alternative_names
+ * @property string|null $serial_number
+ * @property string|null $serial_number_hex
+ * @property bool $self_signed
+ * @property string|null $signature_algorithm
+ * @property int|null $certificate_version
+ * @property string|null $key_usage
+ * @property string|null $extended_key_usage
+ * @property string|null $basic_constraints
+ * @property string|null $subject_key_identifier
+ * @property string|null $authority_key_identifier
+ * @property Carbon|null $valid_from
+ * @property Carbon|null $valid_to
+ * @property int|null $days_until_expiry
+ * @property string|null $fingerprint
+ * @property string|null $pem
+ * @property Carbon|null $last_checked_at
+ * @property bool $disabled
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property \Illuminate\Support\Carbon|null $deleted_at
+ * @property-read Device|null $device
+ */
 class SslCertificate extends Model
 {
     use SoftDeletes;

--- a/app/Policies/SslCertificatePolicy.php
+++ b/app/Policies/SslCertificatePolicy.php
@@ -2,6 +2,8 @@
 
 namespace App\Policies;
 
+use App\Facades\Permissions;
+use App\Models\SslCertificate;
 use App\Models\User;
 
 class SslCertificatePolicy
@@ -13,7 +15,7 @@ class SslCertificatePolicy
      */
     public function viewAny(User $user): bool
     {
-        return $this->hasGlobalPermission($user, 'view')
+        return $this->hasGlobalPermission($user, 'view', true)
             || $this->hasGlobalPermission($user, 'create')
             || $this->hasGlobalPermission($user, 'delete');
     }
@@ -21,9 +23,10 @@ class SslCertificatePolicy
     /**
      * Determine whether the user can view the SSL certificate.
      */
-    public function view(User $user): bool
+    public function view(User $user, SslCertificate $sslCertificate): bool
     {
-        return $this->hasGlobalPermission($user, 'view');
+        return $this->hasGlobalPermission($user, 'view', true)
+            && ($sslCertificate->device_id === null || Permissions::canAccessDevice($sslCertificate->device_id, $user));
     }
 
     /**


### PR DESCRIPTION
the use of attributes as arrays caused some phpstan errors on new versions refactor to just use Model properties directly


#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
