### PR TITLE
Add Flowtriq alert transport

### DIFF
--- a/LibreNMS/Alert/Transport/Flowtriq.php
+++ b/LibreNMS/Alert/Transport/Flowtriq.php
@@ -31,6 +31,7 @@ use LibreNMS\Util\Http;
 
 class Flowtriq extends Transport
 {
+    /** @param  array<string, mixed>  $alert_data */
     public function deliverAlert(array $alert_data): bool
     {
         $url = $this->config['flowtriq-url'];

--- a/LibreNMS/Alert/Transport/Flowtriq.php
+++ b/LibreNMS/Alert/Transport/Flowtriq.php
@@ -1,0 +1,108 @@
+<?php
+
+/* Copyright (C) 2026 Flowtriq
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>. */
+
+/**
+ * Flowtriq Alert Transport
+ *
+ * @author Flowtriq <support@flowtriq.com>
+ * @copyright 2026 Flowtriq
+ * @license GPL
+ */
+
+namespace LibreNMS\Alert\Transport;
+
+use LibreNMS\Alert\Transport;
+use LibreNMS\Enum\AlertState;
+use LibreNMS\Exceptions\AlertTransportDeliveryException;
+use LibreNMS\Util\Http;
+
+class Flowtriq extends Transport
+{
+    public function deliverAlert(array $alert_data): bool
+    {
+        $url = $this->config['flowtriq-url'];
+
+        $alert_status = match ($alert_data['state']) {
+            AlertState::RECOVERED => 'recovered',
+            AlertState::ACKNOWLEDGED => 'acknowledged',
+            AlertState::WORSE => 'worse',
+            AlertState::BETTER => 'better',
+            default => 'alert',
+        };
+
+        $data = [
+            'source' => 'librenms',
+            'status' => $alert_status,
+            'alert_id' => $alert_data['alert_id'] ?? null,
+            'severity' => $alert_data['severity'] ?? null,
+            'title' => $alert_data['title'] ?? null,
+            'message' => strip_tags($alert_data['msg'] ?? ''),
+            'rule' => $alert_data['rule'] ?? null,
+            'timestamp' => $alert_data['timestamp'] ?? null,
+            'device' => [
+                'device_id' => $alert_data['device_id'] ?? null,
+                'hostname' => $alert_data['hostname'] ?? null,
+                'sysName' => $alert_data['sysName'] ?? null,
+                'os' => $alert_data['os'] ?? null,
+                'type' => $alert_data['type'] ?? null,
+                'ip' => $alert_data['ip'] ?? null,
+                'hardware' => $alert_data['hardware'] ?? null,
+                'location' => $alert_data['location'] ?? null,
+            ],
+        ];
+
+        $client = Http::client()->acceptJson();
+
+        $api_key = $this->config['flowtriq-api-key'] ?? '';
+        if (! empty($api_key)) {
+            $client = $client->withHeaders([
+                'X-API-Key' => $api_key,
+            ]);
+        }
+
+        $res = $client->post($url, $data);
+
+        if ($res->successful()) {
+            return true;
+        }
+
+        throw new AlertTransportDeliveryException($alert_data, $res->status(), $res->body(), $alert_data['msg'] ?? '', $data);
+    }
+
+    public static function configTemplate(): array
+    {
+        return [
+            'config' => [
+                [
+                    'title' => 'Webhook URL',
+                    'name' => 'flowtriq-url',
+                    'descr' => 'Flowtriq webhook endpoint URL',
+                    'type' => 'text',
+                ],
+                [
+                    'title' => 'API Key',
+                    'name' => 'flowtriq-api-key',
+                    'descr' => 'Flowtriq API key (optional)',
+                    'type' => 'password',
+                ],
+            ],
+            'validation' => [
+                'flowtriq-url' => 'required|url',
+                'flowtriq-api-key' => 'string',
+            ],
+        ];
+    }
+}

--- a/LibreNMS/Alert/Transport/Flowtriq.php
+++ b/LibreNMS/Alert/Transport/Flowtriq.php
@@ -83,6 +83,7 @@ class Flowtriq extends Transport
         throw new AlertTransportDeliveryException($alert_data, $res->status(), $res->body(), $alert_data['msg'] ?? '', $data);
     }
 
+    /** @return array<string, array<int|string, mixed>> */
     public static function configTemplate(): array
     {
         return [

--- a/doc/Alerting/Transports/Flowtriq.md
+++ b/doc/Alerting/Transports/Flowtriq.md
@@ -1,7 +1,5 @@
 ## Flowtriq
 
-[Flowtriq](https://flowtriq.com) is a DDoS detection and traffic analytics platform. Sending LibreNMS alerts to Flowtriq lets you correlate infrastructure alerts (device down, interface errors, BGP session drops) with DDoS attack data and traffic anomalies on the same timeline.
-
 To configure the transport, provide your Flowtriq webhook URL and, optionally, an API key for authentication.
 
 **Example:**

--- a/doc/Alerting/Transports/Flowtriq.md
+++ b/doc/Alerting/Transports/Flowtriq.md
@@ -1,0 +1,14 @@
+## Flowtriq
+
+[Flowtriq](https://flowtriq.com) is a DDoS detection and traffic analytics platform. Sending LibreNMS alerts to Flowtriq lets you correlate infrastructure alerts (device down, interface errors, BGP session drops) with DDoS attack data and traffic anomalies on the same timeline.
+
+To configure the transport, provide your Flowtriq webhook URL and, optionally, an API key for authentication.
+
+**Example:**
+
+| Config | Example |
+| ------ | ------- |
+| Webhook URL | https://app.flowtriq.com/api/webhooks/librenms |
+| API Key | your-api-key |
+
+For more information, see the [Flowtriq documentation](https://flowtriq.com/docs).


### PR DESCRIPTION
## Summary

Adds a new alert transport for [Flowtriq](https://flowtriq.com), a DDoS detection and traffic analytics platform.

Forwarding LibreNMS alerts to Flowtriq lets operators correlate infrastructure events (device down, interface errors, BGP session drops) with DDoS attacks and traffic anomalies on the same timeline. This makes it faster to determine whether a service disruption is caused by a volumetric attack, a routing change, or something else entirely.

The transport sends a structured JSON payload to a configurable Flowtriq webhook URL. It includes the alert source, status, severity, device details, and alert message. An optional API key can be provided for authentication (sent as an `X-API-Key` header).

### Configuration fields

| Field | Required | Description |
|-------|----------|-------------|
| Webhook URL | Yes | Flowtriq webhook endpoint |
| API Key | No | API key for authentication |

### Files changed

- `LibreNMS/Alert/Transport/Flowtriq.php` - Transport class
- `doc/Alerting/Transports/Flowtriq.md` - Documentation