### PR TITLE
Fix Slack and Discord tests

### DIFF
--- a/tests/Unit/Alert/Transports/DiscordTest.php
+++ b/tests/Unit/Alert/Transports/DiscordTest.php
@@ -33,6 +33,7 @@ use Illuminate\Support\Facades\Http;
 use LibreNMS\Alert\AlertData;
 use LibreNMS\Alert\Transport;
 use LibreNMS\Tests\TestCase;
+
 use function PHPUnit\Framework\assertEquals;
 
 final class DiscordTest extends TestCase

--- a/tests/Unit/Alert/Transports/DiscordTest.php
+++ b/tests/Unit/Alert/Transports/DiscordTest.php
@@ -33,7 +33,6 @@ use Illuminate\Support\Facades\Http;
 use LibreNMS\Alert\AlertData;
 use LibreNMS\Alert\Transport;
 use LibreNMS\Tests\TestCase;
-
 use function PHPUnit\Framework\assertEquals;
 
 final class DiscordTest extends TestCase
@@ -44,7 +43,7 @@ final class DiscordTest extends TestCase
 
         $transport = new Transport\Discord(new AlertTransport([
             'transport_config' => [
-                'url' => '',
+                'url' => 'https://discord.com/api/webhooks/number/id',
                 'options' => '',
                 'discord-embed-fields' => '',
             ],
@@ -56,7 +55,7 @@ final class DiscordTest extends TestCase
         $transport->deliverAlert(AlertData::testData($mock_device));
 
         Http::assertSent(function (Request $request) {
-            assertEquals('', $request->url());
+            assertEquals('https://discord.com/api/webhooks/number/id', $request->url());
             assertEquals('POST', $request->method());
             assertEquals('application/json', $request->header('Content-Type')[0]);
             assertEquals(

--- a/tests/Unit/Alert/Transports/SlackTest.php
+++ b/tests/Unit/Alert/Transports/SlackTest.php
@@ -40,13 +40,17 @@ final class SlackTest extends TestCase
     {
         Http::fake();
 
-        $slack = new Transport\Slack(new AlertTransport);
+        $slack = new Transport\Slack(new AlertTransport([
+            'transport_config' => [
+                'slack-url' => 'https://slack.com/some/webhook',
+            ],
+        ]));
 
         /** @var Device $mock_device */
         $mock_device = Device::factory()->make();
         $slack->deliverAlert(AlertData::testData($mock_device));
 
-        Http::assertSent(fn (Request $request) => $request->url() == '' &&
+        Http::assertSent(fn (Request $request) => $request->url() == 'https://slack.com/some/webhook' &&
         $request->method() == 'POST' &&
         $request->hasHeader('Content-Type', 'application/json') &&
         $request->data() == [


### PR DESCRIPTION
attempting to send an api call without url

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
