### PR TITLE
fix(nokia-isam): raise SNMP timeout for slow SFP diag walk so dBm is …

### DIFF
--- a/includes/discovery/sensors/pre-cache/nokia-isam.inc.php
+++ b/includes/discovery/sensors/pre-cache/nokia-isam.inc.php
@@ -152,6 +152,14 @@ $portTable = [
 ];
 
 // dbm pre cache
+// Some ISAMs serve the SFP diagnostics subtree (SFP-MIB) slowly: the
+// sfpDiagAvailable walk alone takes several seconds and exceeds the default 1s
+// SNMP timeout, so it times out and no SFP dBm sensors are discovered (observed
+// on roughly half of a real ISAM fleet). Raise the timeout for the SFP queries
+// only (both the walk and the per-port gets below), then restore it.
+$nokiaIsamSfpTimeout = $device['timeout'] ?? null;
+$device['timeout'] = max((int) ($device['timeout'] ?? 0), 10);
+
 $pre_cache['nokiaIsamSfpPort'] = snmpwalk_cache_twopart_oid($device, 'sfpDiagAvailable', [], 'SFP-MIB', 'nokia');
 foreach ($pre_cache['nokiaIsamSfpPort'] as $slotId => $slot) {
     foreach ($slot as $portId => $port) {
@@ -184,4 +192,11 @@ foreach ($pre_cache['nokiaIsamSfpPort'] as $slotId => $slot) {
             unset($twopart_value);
         }
     }
+}
+
+// restore the original SNMP timeout
+if ($nokiaIsamSfpTimeout === null) {
+    unset($device['timeout']);
+} else {
+    $device['timeout'] = $nokiaIsamSfpTimeout;
 }


### PR DESCRIPTION
## What this PR is for

Some ISAMs serve the SFP diagnostics subtree (SFP-MIB) slowly: the `sfpDiagAvailable`
column walk alone takes ~3–5 s and exceeds the default 1 s SNMP timeout, so the sensors
pre-cache walk times out and no SFP dBm sensors are discovered. Observed on ~42 of 87
devices in a real fleet (7330/7356).

Measured on a 7330 (NANT-E): the `sfpDiagAvailable` column (`.1.3.6.1.4.1.637.61.1.56.5.1.3`)
times out at the 1 s default but completes in ~3.3 s with a higher timeout; optical power
is present (e.g. -4.89 / -7.29 dBm at slot 4352).

This raises the timeout to ≥10 s for the SFP queries only (the walk and the per-port gets)
and restores it afterwards. Discovery logic is unchanged.

Verified on hardware: 5 affected devices across both platforms went from 0 dBm sensors to
32 / 12 / 8 / 20 / 22 after the change.

**On test data:** this is a timeout-only issue and cannot be reproduced under snmpsim (which
always responds instantly) — the current code already produces correct dBm against a fast
fixture, so the change is not visible in the OS unit tests. Existing `nokia-isam` test data is
unchanged (no regression); the fix is validated on real hardware as above.

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
