### PR TITLE
Standardise device rename operations and fix duplicate hostname check during rename

### DIFF
--- a/app/Observers/DeviceObserver.php
+++ b/app/Observers/DeviceObserver.php
@@ -88,6 +88,13 @@ class DeviceObserver
             $new_rrd_dir = Rrd::dirFromHost($new_name);
             $old_rrd_dir = Rrd::dirFromHost($old_name);
 
+            // Fail if another device has the same hostname
+            if(Device::where('hostname', $device->hostname)->whereNot('device_id', $device->device_id)->count() > 0) {
+                $device->hostname = $old_name;
+                Eventlog::log("Renaming of $old_name failed", $device, 'system', Severity::Error);
+                throw new HostRenameException("Renaming of $old_name failed");
+            }
+
             if (is_dir($new_rrd_dir)) {
                 $device->hostname = $old_name;
                 Eventlog::log("Renaming of $old_name failed due to existing RRD folder for $new_name", $device, 'system', Severity::Error);

--- a/app/Observers/DeviceObserver.php
+++ b/app/Observers/DeviceObserver.php
@@ -92,7 +92,7 @@ class DeviceObserver
             if (Device::where('hostname', $device->hostname)->whereNot('device_id', $device->device_id)->count() > 0) {
                 $device->hostname = $old_name;
                 Eventlog::log("Renaming of $old_name failed because there is already a device with the hostname $new_name", $device, 'system', Severity::Error);
-                throw new HostRenameException("Renaming of $old_name failed");
+                throw new HostRenameException("Renaming of $old_name failed because there is already a device with the hostname $new_name");
             }
 
             if (is_dir($new_rrd_dir)) {

--- a/app/Observers/DeviceObserver.php
+++ b/app/Observers/DeviceObserver.php
@@ -91,7 +91,7 @@ class DeviceObserver
             // Fail if another device has the same hostname
             if(Device::where('hostname', $device->hostname)->whereNot('device_id', $device->device_id)->count() > 0) {
                 $device->hostname = $old_name;
-                Eventlog::log("Renaming of $old_name failed", $device, 'system', Severity::Error);
+                Eventlog::log("Renaming of $old_name failed because there is already a device with the hostname $new_name", $device, 'system', Severity::Error);
                 throw new HostRenameException("Renaming of $old_name failed");
             }
 
@@ -108,7 +108,7 @@ class DeviceObserver
                 Eventlog::log("Hostname changed -> $new_name ($source)", $device, 'system', Severity::Notice);
             } else {
                 $device->hostname = $old_name;
-                Eventlog::log("Renaming of $old_name failed", $device, 'system', Severity::Error);
+                Eventlog::log("Renaming of $old_name failed because the RRD directory rename failed", $device, 'system', Severity::Error);
                 throw new HostRenameException("Renaming of $old_name failed");
             }
         }

--- a/app/Observers/DeviceObserver.php
+++ b/app/Observers/DeviceObserver.php
@@ -89,7 +89,7 @@ class DeviceObserver
             $old_rrd_dir = Rrd::dirFromHost($old_name);
 
             // Fail if another device has the same hostname
-            if(Device::where('hostname', $device->hostname)->whereNot('device_id', $device->device_id)->count() > 0) {
+            if (Device::where('hostname', $device->hostname)->whereNot('device_id', $device->device_id)->count() > 0) {
                 $device->hostname = $old_name;
                 Eventlog::log("Renaming of $old_name failed because there is already a device with the hostname $new_name", $device, 'system', Severity::Error);
                 throw new HostRenameException("Renaming of $old_name failed");

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -17,29 +17,6 @@ use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use LibreNMS\Enum\Severity;
 
-function renamehost($id, $new, $source = 'console')
-{
-    $host = DeviceCache::get((int) $id)->hostname;
-    $new_rrd_dir = Rrd::dirFromHost($new);
-
-    if (is_dir($new_rrd_dir)) {
-        Eventlog::log("Renaming of $host failed due to existing RRD folder for $new", $id, 'system', Severity::Error);
-
-        return "Renaming of $host failed due to existing RRD folder for $new\n";
-    }
-
-    if (! is_dir($new_rrd_dir) && rename(Rrd::dirFromHost($host), $new_rrd_dir) === true) {
-        dbUpdate(['hostname' => $new, 'ip' => null], 'devices', 'device_id=?', [$id]);
-        Eventlog::log("Hostname changed -> $new ($source)", $id, 'system', Severity::Notice);
-
-        return '';
-    }
-
-    Eventlog::log("Renaming of $host failed", $id, 'system', Severity::Error);
-
-    return "Renaming of $host failed\n";
-}
-
 function device_discovery_trigger($id)
 {
     if (App::runningInConsole() === false) {

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -10,12 +10,10 @@
 
 use App\Facades\DeviceCache;
 use App\Facades\LibrenmsConfig;
-use App\Models\Eventlog;
 use App\Models\StateTranslation;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
-use LibreNMS\Enum\Severity;
 
 function device_discovery_trigger($id)
 {

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -2614,7 +2614,7 @@ function rename_device(Illuminate\Http\Request $request)
 
     if (empty($new_hostname)) {
         return api_error(500, 'Missing new hostname');
-    } elseif (! $device) {
+    } elseif (! $device->exists) {
         return api_error(404, 'Existing device not found');
     } else {
         try {

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -2614,7 +2614,7 @@ function rename_device(Illuminate\Http\Request $request)
 
     if (empty($new_hostname)) {
         return api_error(500, 'Missing new hostname');
-    } elseif (!$device) {
+    } elseif (! $device) {
         return api_error(404, 'Existing device not found');
     } else {
         try {

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -2614,7 +2614,7 @@ function rename_device(Illuminate\Http\Request $request)
 
     if (empty($new_hostname)) {
         return api_error(500, 'Missing new hostname');
-    } elseif (!device) {
+    } elseif (!$device) {
         return api_error(404, 'Existing device not found');
     } else {
         try {

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -2615,7 +2615,7 @@ function rename_device(Illuminate\Http\Request $request)
 
     if (empty($new_hostname)) {
         return api_error(500, 'Missing new hostname');
-    } elseif ($new_device) {
+    } elseif ($new_device && $new_device != $device_id) {
         return api_error(500, 'Device failed to rename, new hostname already exists');
     } else {
         if (renamehost($device_id, $new_hostname, 'api') == '') {

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -2609,18 +2609,18 @@ function update_device(Illuminate\Http\Request $request)
 function rename_device(Illuminate\Http\Request $request)
 {
     $hostname = $request->route('hostname');
-    $device_id = ctype_digit($hostname) ? $hostname : getidbyname($hostname);
+    $device = (ctype_digit($hostname) ? Device::find($hostname) : Device::where('hostname', $hostname)->first());
     $new_hostname = $request->route('new_hostname');
-    $new_device = getidbyname($new_hostname);
 
     if (empty($new_hostname)) {
         return api_error(500, 'Missing new hostname');
-    } elseif ($new_device && $new_device != $device_id) {
-        return api_error(500, 'Device failed to rename, new hostname already exists');
+    } elseif (!device) {
+        return api_error(404, 'Existing device not found');
     } else {
-        if (renamehost($device_id, $new_hostname, 'api') == '') {
-            return api_success_noresult(200, 'Device has been renamed');
-        } else {
+        try {
+            $device->hostname = $new_hostname;
+            $device->save();
+        } catch (\Throwable) {
             return api_error(500, 'Device failed to be renamed');
         }
     }

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -2609,7 +2609,7 @@ function update_device(Illuminate\Http\Request $request)
 function rename_device(Illuminate\Http\Request $request)
 {
     $hostname = $request->route('hostname');
-    $device = (ctype_digit($hostname) ? Device::find($hostname) : Device::where('hostname', $hostname)->first());
+    $device = DeviceCache::get($hostname);
     $new_hostname = $request->route('new_hostname');
 
     if (empty($new_hostname)) {

--- a/renamehost.php
+++ b/renamehost.php
@@ -13,15 +13,17 @@
 
 $init_modules = [];
 require __DIR__ . '/includes/init.php';
+
+use App\Facades\DeviceCache;
 use App\Models\Device;
 
 // Remove a host and all related data from the system
 if ($argv[1] && $argv[2]) {
     $hostname = $argv[1];
-    $device = (ctype_digit($hostname) ? Device::find($hostname) : Device::where('hostname', $hostname)->first());
+    $device = DeviceCache::get($hostname);
     $new_hostname = $argv[2];
 
-    if (! $device) {
+    if (! $device->exists) {
         echo "Existing device not found\n";
         exit(1);
     } else {

--- a/renamehost.php
+++ b/renamehost.php
@@ -13,30 +13,27 @@
 
 $init_modules = [];
 require __DIR__ . '/includes/init.php';
+use App\Models\Device;
 
 // Remove a host and all related data from the system
 if ($argv[1] && $argv[2]) {
-    $host = strtolower($argv[1]);
-    $id = getidbyname($host);
-    if ($id) {
-        $tohost = strtolower($argv[2]);
-        $toid = getidbyname($tohost);
-        if ($toid) {
-            echo "NOT renamed. New hostname $tohost already exists.\n";
-            exit(1);
-        } else {
-            $result = renamehost($id, $tohost, 'console');
-            if ($result == '') {
-                echo "Renamed $host\n";
-                exit(0);
-            } else {
-                echo "NOT renamed: $result";
-                exit(1);
-            }
-        }
-    } else {
-        echo "Host doesn't exist!\n";
+    $hostname = $argv[1];
+    $device = (ctype_digit($hostname) ? Device::find($hostname) : Device::where('hostname', $hostname)->first());
+    $new_hostname = $argv[2];
+
+    if (!$device) {
+        echo "Existing device not found\n";
         exit(1);
+    } else {
+        try {
+            $device->hostname = $new_hostname;
+            $device->save();
+            echo "Renamed $hostname\n";
+            exit(0);
+        } catch (\Throwable) {
+            echo "Device failed to be renamed\n";
+            exit(1);
+        }
     }
 } else {
     echo "Host Rename Tool\nUsage: ./renamehost.php <old hostname> <new hostname>\n";

--- a/renamehost.php
+++ b/renamehost.php
@@ -21,7 +21,7 @@ if ($argv[1] && $argv[2]) {
     $device = (ctype_digit($hostname) ? Device::find($hostname) : Device::where('hostname', $hostname)->first());
     $new_hostname = $argv[2];
 
-    if (!$device) {
+    if (! $device) {
         echo "Existing device not found\n";
         exit(1);
     } else {

--- a/renamehost.php
+++ b/renamehost.php
@@ -15,7 +15,7 @@ $init_modules = [];
 require __DIR__ . '/includes/init.php';
 
 use App\Facades\DeviceCache;
-use App\Models\Device;
+use LibreNMS\Exceptions\HostRenameException;
 
 // Remove a host and all related data from the system
 if ($argv[1] && $argv[2]) {
@@ -32,6 +32,9 @@ if ($argv[1] && $argv[2]) {
             $device->save();
             echo "Renamed $hostname\n";
             exit(0);
+        } catch (HostRenameException $e) {
+            echo $e->getMessage() . PHP_EOL;
+            exit(1);
         } catch (\Throwable) {
             echo "Device failed to be renamed\n";
             exit(1);


### PR DESCRIPTION
I am trying to rename some LibreNMS devices using the API where the only changes to the hostname is the capitalisation of some characters.  This was failing because the search for an existing device was finding the same device we are trying to rename.

This PR resolves this by allowing the rename to happen if the device ID returned from the search matches the device ID found when looking up the original hostname.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
