### PR TITLE
Fix/graphpopup mini graph size

### DIFF
--- a/LibreNMS/Util/Url.php
+++ b/LibreNMS/Util/Url.php
@@ -411,8 +411,6 @@ class Url
         $original_from = $args['from'] ?? '';
         $popup_title = $args['popup_title'] ?? 'Graph';
 
-        // Build the trigger graph from the caller's own width/height/legend
-        // before overriding them below for the day/week/month/year popup graphs.
         $graph = $content ?: self::graphTag($args);
 
         $args['width'] = 340;

--- a/LibreNMS/Util/Url.php
+++ b/LibreNMS/Util/Url.php
@@ -411,12 +411,15 @@ class Url
         $original_from = $args['from'] ?? '';
         $popup_title = $args['popup_title'] ?? 'Graph';
 
+        // Build the trigger graph from the caller's own width/height/legend
+        // before overriding them below for the day/week/month/year popup graphs.
+        $graph = $content ?: self::graphTag($args);
+
         $args['width'] = 340;
         $args['height'] = 100;
         $args['legend'] = 'yes';
         $columns = count($graph_periods) < 4 ? 1 : 2;
 
-        $graph = $content ?: self::graphTag($args);
         $popup = "<div class=\'list-large\'>$popup_title</div>";
         $popup .= "<div style=\"display:grid;grid-template-columns:repeat($columns,max-content);\">";
         foreach ($graph_periods as $period) {


### PR DESCRIPTION
Fixes a bug introduced in #19993,

Which moved the trigger-graph build after the width/height/legend override meant only for the popup's
That caused every caller relying on a small custom size render oversized (340x100, legend on) instead of their requested dimensions. 

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [X] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
