### PR TITLE
Escape url helpers more consistently

### DIFF
--- a/LibreNMS/Util/Url.php
+++ b/LibreNMS/Util/Url.php
@@ -30,6 +30,7 @@ use App\Facades\LibrenmsConfig;
 use App\Models\Device;
 use App\Models\Port;
 use Carbon\Carbon;
+use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\URL as LaravelUrl;
 use Illuminate\Support\Str;
@@ -43,7 +44,7 @@ class Url
     /**
      * Provisional device link generation
      */
-    public static function modernDeviceLink(?Device $device, string $text = '', string $extra = ''): string
+    public static function modernDeviceLink(?Device $device, Htmlable|string $text = '', string $extra = ''): string
     {
         if ($device === null) {
             return e($text);
@@ -59,7 +60,7 @@ class Url
             self::deviceUrl($device),
             $class,
             $device->device_id,
-            e($text ?: $device->displayName()),
+            e($text ?: $device->display),
             $extra ? '<br />' . e($extra) : $extra
         );
     }
@@ -67,7 +68,7 @@ class Url
     /**
      * Provisional port link generation
      */
-    public static function modernPortLink(?Port $port, string $text = '', string $extra = ''): string
+    public static function modernPortLink(?Port $port, Htmlable|string $text = '', string $extra = ''): string
     {
         if ($port === null) {
             return e($text);
@@ -91,18 +92,17 @@ class Url
      * @param  array  $vars
      * @param  int  $start
      * @param  int  $end
-     * @param  int  $escape_text
      * @param  int  $overlib
      * @return string
      */
-    public static function deviceLink($device, $text = '', $vars = [], $start = 0, $end = 0, $escape_text = 1, $overlib = 1)
+    public static function deviceLink(mixed $device, Htmlable|string|null $text = '', array $vars = [], int $start = 0, int $end = 0, bool|int $overlib = 1): string
     {
         if (! $device instanceof Device || ! $device->hostname) {
-            return $escape_text ? htmlentities((string) $text) : (string) $text;
+            return e($text);
         }
 
         if (Gate::denies('view', $device)) {
-            return $escape_text ? htmlentities($device->displayName()) : $device->displayName();
+            return e($device->display);
         }
 
         if (! $start) {
@@ -114,12 +114,10 @@ class Url
         }
 
         if (! $text) {
-            $text = $device->displayName();
+            $text = $device->display;
         }
 
-        if ($escape_text) {
-            $text = htmlentities($text);
-        }
+        $text = e($text);
 
         $class = self::deviceLinkDisplayClass($device);
         $graphs = Graph::getOverviewGraphsForDevice($device);
@@ -127,7 +125,7 @@ class Url
 
         // beginning of overlib box contains large hostname followed by hardware & OS details
         // because we are injecting this into javascript htmlentities alone won't work, so strip_tags too
-        $contents = '<div><span class="list-large">' . htmlentities(strip_tags($device->displayName())) . '</span>';
+        $contents = '<div><span class="list-large">' . e(strip_tags($device->display)) . '</span>';
         $devinfo = '';
         if ($device->hardware) {
             $devinfo .= $device->hardware;
@@ -146,11 +144,11 @@ class Url
         }
 
         if ($devinfo) {
-            $contents .= '<br />' . htmlentities(strip_tags($devinfo));
+            $contents .= '<br />' . e(strip_tags($devinfo));
         }
 
         if ($device->location_id) {
-            $contents .= '<br />' . htmlentities(strip_tags($device->location ?? ''));
+            $contents .= '<br />' . e(strip_tags($device->location ?? ''));
         }
 
         $contents .= '</div><br />';
@@ -175,10 +173,10 @@ class Url
         return $link;
     }
 
-    public static function portLink(?Port $port, ?string $text = null, ?string $type = null, bool $overlib = true, bool $single_graph = false, ?string $url = null): string
+    public static function portLink(?Port $port, Htmlable|string|null $text = null, ?string $type = null, bool $overlib = true, bool $single_graph = false, ?string $url = null): string
     {
         if ($port === null) {
-            return (string) $text;
+            return e($text);
         }
 
         $label = Rewrite::normalizeIfName($port->getLabel());
@@ -186,10 +184,12 @@ class Url
             $text = $label;
         }
 
+        $text = e($text);
+
         // strip tags due to complexity of sanitizing here
-        $content = '<div class=list-large>' . addslashes(htmlentities(strip_tags($port->device?->displayName() . ' - ' . $label))) . '</div>';
+        $content = '<div class=list-large>' . addslashes(e(strip_tags($port->device?->display . ' - ' . $label))) . '</div>';
         if ($description = $port->getDescription()) {
-            $content .= addslashes(htmlentities(strip_tags($description))) . '<br />';
+            $content .= addslashes(e(strip_tags($description))) . '<br />';
         }
 
         $content .= "<div style=\'width: 850px\'>";
@@ -230,16 +230,18 @@ class Url
      * @param  string  $type
      * @param  bool  $overlib
      * @param  bool  $single_graph
-     * @return mixed|string
+     * @return string
      */
-    public static function sensorLink($sensor, $text = null, $type = null, $overlib = true, $single_graph = false)
+    public static function sensorLink(mixed $sensor, Htmlable|string|null $text = null, ?string $type = null, bool $overlib = true, bool $single_graph = false): string
     {
         $label = $sensor->sensor_descr;
         if (! $text) {
             $text = $label;
         }
 
-        $content = '<div class=list-large>' . addslashes(htmlentities($sensor->device?->displayName() . ' - ' . $label)) . '</div>';
+        $text = e($text);
+
+        $content = '<div class=list-large>' . addslashes(e($sensor->device?->display . ' - ' . $label)) . '</div>';
 
         $content .= "<div style=\'width: 850px\'>";
         $graph_array = [

--- a/app/Http/Controllers/Widgets/TopDevicesController.php
+++ b/app/Http/Controllers/Widgets/TopDevicesController.php
@@ -36,6 +36,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;
 use Illuminate\View\View;
 use LibreNMS\Enum\IfOperStatus;
@@ -138,7 +139,7 @@ class TopDevicesController extends WidgetController
     {
         return [
             Url::deviceLink($device, $device->shortDisplayName()),
-            Url::deviceLink($device, Url::minigraphImage(
+            Url::deviceLink($device, new HtmlString(Url::minigraphImage(
                 $device,
                 Carbon::now()->subDays(1)->timestamp,
                 Carbon::now()->timestamp,
@@ -146,7 +147,7 @@ class TopDevicesController extends WidgetController
                 'no',
                 150,
                 21
-            ), $graph_params, 0, 0, 0),
+            )), $graph_params, 0, 0),
         ];
     }
 

--- a/includes/html/functions.inc.php
+++ b/includes/html/functions.inc.php
@@ -18,6 +18,7 @@ use App\Models\Device;
 use App\Models\Port;
 use App\Models\Sensor;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\HtmlString;
 use LibreNMS\Enum\ImageFormat;
 use LibreNMS\Util\Number;
 use LibreNMS\Util\Rewrite;
@@ -82,7 +83,11 @@ function generate_device_link($device, $text = null, $vars = [], $start = 0, $en
 {
     $deviceModel = DeviceCache::get((int) ($device['device_id'] ?? 0));
 
-    return Url::deviceLink($deviceModel, $text, $vars, $start, $end, $escape_text, $overlib);
+    if (! $escape_text) {
+        $text = new HtmlString($text);
+    }
+
+    return Url::deviceLink($deviceModel, $text, $vars, $start, $end, $overlib);
 }
 
 function bill_permitted($bill_id)


### PR DESCRIPTION
Allow Htmlable to be passed in for raw html output.
I reviewed callers and tried to make sure there will be no regressions.

fixes #19866

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
