### PR TITLE
Improve save-test-data.php to auto-include necessary modules

### DIFF
--- a/LibreNMS/Util/ModuleTestHelper.php
+++ b/LibreNMS/Util/ModuleTestHelper.php
@@ -292,6 +292,34 @@ class ModuleTestHelper
     }
 
     /**
+     * Resolve the module overrides for a specific os/variant combination.
+     * When $modules is empty, reads the existing JSON to auto-include any
+     * globally-disabled modules that already have test data.
+     *
+     * @param  array<string>  $modules  User-supplied module list (empty = auto)
+     * @return array<string, bool|array<string>>
+     */
+    public static function getValidModules(string $os, ?string $variant, array $modules): array
+    {
+        if (! empty($modules)) {
+            return ModuleList::fromUserOverrides($modules)->overrides;
+        }
+
+        $base_name = $variant ? "{$os}_{$variant}" : $os;
+        $json_file = base_path("tests/data/{$base_name}.json");
+        if (! is_file($json_file)) {
+            return [];
+        }
+
+        $decoded = json_decode(file_get_contents($json_file), true);
+        if (json_last_error() || empty($decoded)) {
+            return [];
+        }
+
+        return self::resolveModuleDependencies(array_keys($decoded));
+    }
+
+    /**
      * Given a json filename or basename, extract os and variant
      *
      * @param  string  $os_file  Either a filename or the basename

--- a/scripts/save-test-data.php
+++ b/scripts/save-test-data.php
@@ -96,7 +96,7 @@ if (isset($options['v'])) {
 $os_list = [];
 
 if (isset($os_name) && isset($variant)) {
-    $os_list = [$full_os_name => [$os_name, $variant, ModuleList::fromUserOverrides($modules)->overrides]];
+    $os_list = [$full_os_name => [$os_name, $variant, ModuleTestHelper::getValidModules($os_name, $variant, $modules)]];
 } elseif (isset($os_name)) {
     $os_list = ModuleTestHelper::findOsWithData($modules, $os_name);
 } else {


### PR DESCRIPTION
Please give a short description what your pull request is for

While working on generating test data for #19833, I noticed `save-test-data.php -o ciscosb -v c1200-e-2g` needs explicit `-m ports-stack` to get correct test data.

The reason is `ports-stack` module is globally disabled, but present in existing test data for ciscosb. And this case is not handled automatically when explicit variant is specified as `-v` option.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
