### PR TITLE
Redirect all graphs page urls to new page

### DIFF
--- a/app/Http/Requests/GraphsPageRequest.php
+++ b/app/Http/Requests/GraphsPageRequest.php
@@ -10,6 +10,7 @@ use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Validator;
 use LibreNMS\Util\Time;
+use LibreNMS\Util\Url;
 
 class GraphsPageRequest extends FormRequest
 {
@@ -19,6 +20,11 @@ class GraphsPageRequest extends FormRequest
     public ?Port $port = null;
     public int $from = 0;
     public int $to = 0;
+
+    protected function prepareForValidation(): void
+    {
+        $this->merge(Url::parseLegacyPathVars($this->path()));
+    }
 
     /**
      * Determine if the user is authorized to make this request.

--- a/routes/web.php
+++ b/routes/web.php
@@ -98,7 +98,7 @@ Route::middleware(['auth'])->group(function (): void {
     Route::post('alert/{alert}/ack', [AlertController::class, 'ack'])->name('alert.ack');
     Route::get('devices/{view?}/{graph?}/{vars?}', [DevicesController::class, 'index'])->where('vars', '.*')->name('devices');
     Route::resource('device-groups', DeviceGroupController::class);
-    Route::get('graphs', GraphsPageController::class)->name('graphs');
+    Route::get('graphs/{path?}', GraphsPageController::class)->where('path', '.*')->name('graphs');
     Route::any('inventory', App\Http\Controllers\InventoryController::class)->name('inventory');
     Route::get('inventory/purge', [App\Http\Controllers\InventoryController::class, 'purge'])->name('inventory.purge');
     Route::get('outages', [OutagesController::class, 'index'])->name('outages');


### PR DESCRIPTION
We can easily revert this if there is some glaring issue we can't fix quickly.

allows legacy path style urls to work on the new graph page.

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
