### PR TITLE
Graphs page fix active duration code

### DIFF
--- a/app/Http/Controllers/GraphsPageController.php
+++ b/app/Http/Controllers/GraphsPageController.php
@@ -96,16 +96,16 @@ class GraphsPageController extends Controller
      */
     private function periodThumbnails(GraphsPageRequest $request, int $from, int $to, int $thumbWidth): array
     {
-        $thumbTo = LibrenmsConfig::get('time.now');
-        $currentDuration = $to - $from;
+        $now = (int) LibrenmsConfig::get('time.now');
+        $currentDuration = ($to ?: $now) - $from;
         $periodThumbs = [];
 
         foreach (LibrenmsConfig::get('graphs.row.normal') as $period) {
-            $periodFrom = LibrenmsConfig::get("time.{$period}");
-            $periodDuration = (int) $thumbTo - (int) $periodFrom;
+            $periodFrom = (int) LibrenmsConfig::get("time.$period");
+            $periodDuration = $now - $periodFrom;
             $periodThumbs[] = [
-                'text' => __("settings.settings.graphs.row.normal.options.{$period}"),
-                'active' => $periodDuration > 0 && abs($currentDuration - $periodDuration) <= 0.1 * $periodDuration,
+                'text' => __("settings.settings.graphs.row.normal.options.$period"),
+                'active' => ! $to && $periodDuration > 0 && abs($currentDuration - $periodDuration) <= 5,
                 'link' => $this->graphUrl($request, ['from' => Time::toRelativeOffset($periodDuration), 'to' => null]),
                 'vars' => $request->toVars([
                     'height' => '90',

--- a/app/Http/Requests/GraphsPageRequest.php
+++ b/app/Http/Requests/GraphsPageRequest.php
@@ -161,6 +161,8 @@ class GraphsPageRequest extends FormRequest
     public function toVars(array $overrides = []): array
     {
         $vars = $this->except(['page', 'username', 'password']);
+        $vars['from'] = $this->from;
+        $vars['to'] = $this->to;
 
         if ($this->port) {
             $vars['device'] = $this->port->device_id;

--- a/app/Http/Requests/GraphsPageRequest.php
+++ b/app/Http/Requests/GraphsPageRequest.php
@@ -32,7 +32,7 @@ class GraphsPageRequest extends FormRequest
         [$this->type, $this->subtype] = explode('_', $typeInput, 2);
 
         $this->from = (int) (Time::parseAt($this->input('from', '')) ?: LibrenmsConfig::get('time.day'));
-        $this->to = (int) (Time::parseAt($this->input('to', '')) ?: LibrenmsConfig::get('time.now'));
+        $this->to = Time::parseAt($this->input('to', ''));
 
         // Include legacy database and HTML helper functions
         include_once base_path('includes/dbFacile.php');
@@ -161,8 +161,6 @@ class GraphsPageRequest extends FormRequest
     public function toVars(array $overrides = []): array
     {
         $vars = $this->except(['page', 'username', 'password']);
-        $vars['from'] = $this->from;
-        $vars['to'] = $this->to;
 
         if ($this->port) {
             $vars['device'] = $this->port->device_id;


### PR DESCRIPTION
The range active heuristic was wrong, and it selected 24hrs if ANY 24-hour range was active for example.
And actually, setting to to the now timestamp is actually a bit incorrect behavior.


#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
