### PR TITLE
Fix graph periods config

### DIFF
--- a/LibreNMS/Util/Html.php
+++ b/LibreNMS/Util/Html.php
@@ -116,7 +116,7 @@ class Html
         $graph_array['height'] = round($graph_array['width'] / 2.15);
 
         $graph_data = [];
-        foreach ($periods as $period) {
+        foreach ($periods as $period => $period_text) {
             $graph_array['from'] = LibrenmsConfig::get("time.$period");
             $graph_array_zoom = $graph_array;
             $graph_array_zoom['height'] = '150';

--- a/app/Http/Controllers/GraphsPageController.php
+++ b/app/Http/Controllers/GraphsPageController.php
@@ -100,12 +100,12 @@ class GraphsPageController extends Controller
         $currentDuration = ($to ?: $now) - $from;
         $periodThumbs = [];
 
-        foreach (LibrenmsConfig::get('graphs.row.normal') as $period) {
+        foreach (LibrenmsConfig::get('graphs.row.normal') as $period => $text) {
             $periodFrom = (int) LibrenmsConfig::get("time.$period");
             $periodDuration = $now - $periodFrom;
             $periodThumbs[] = [
                 'text' => __("settings.settings.graphs.row.normal.options.$period"),
-                'active' => ! $to && $periodDuration > 0 && abs($currentDuration - $periodDuration) <= 5,
+                'active' => ! $to && $periodDuration > 0 && abs($currentDuration - $periodDuration) <= 0.05 * $periodDuration,
                 'link' => $this->graphUrl($request, ['from' => Time::toRelativeOffset($periodDuration), 'to' => null]),
                 'vars' => $request->toVars([
                     'height' => '90',

--- a/includes/html/pages/graphs.inc.php
+++ b/includes/html/pages/graphs.inc.php
@@ -88,7 +88,7 @@ if (! $auth) {
 
         echo '<table width=100% class="thumbnail_graph_table"><tr>';
 
-        foreach ($thumb_array as $period) {
+        foreach ($thumb_array as $period => $text) {
             $text = __("settings.settings.graphs.row.normal.options.$period");
             $graph_array['from'] = LibrenmsConfig::get("time.$period");
 

--- a/resources/definitions/config_definitions.json
+++ b/resources/definitions/config_definitions.json
@@ -4417,11 +4417,25 @@
             }
         },
         "graphs.mini.normal": {
-            "default": ["day", "week", "month", "year"],
+            "default": {
+                "day": "24 Hours",
+                "week": "One Week",
+                "month": "One Month",
+                "year": "One Year"
+            },
             "type": "array"
         },
         "graphs.mini.widescreen": {
-            "default": ["sixhour", "day", "week", "twoweek", "month", "twomonth", "year", "twoyear"],
+            "default": {
+                "sixhour": "6 Hours",
+                "day": "24 Hours",
+                "week": "One Week",
+                "twoweek": "Two Weeks",
+                "month": "One Month",
+                "twomonth": "Two Months",
+                "year": "One Year",
+                "twoyear": "Two Years"
+            },
             "type": "array"
         },
         "graphs.port_speed_zoom": {
@@ -4432,7 +4446,17 @@
             "order": 4
         },
         "graphs.row.normal": {
-            "default": ["sixhour", "day", "twoday", "week", "twoweek", "month", "twomonth", "year", "twoyear"],
+            "default": {
+                "sixhour": "6 Hours",
+                "day": "24 Hours",
+                "twoday": "48 Hours",
+                "week": "One Week",
+                "twoweek": "Two Weeks",
+                "month": "One Month",
+                "twomonth": "Two Months",
+                "year": "One Year",
+                "twoyear": "Two Years"
+            },
             "type": "array"
         },
         "graylog.base_uri": {


### PR DESCRIPTION
revert format for graphs.mini.normal, graphs.mini.widescreen, and graphs.row.normal settings but continue to use translations.
Also, graphs page period thumbnail selection fix.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
