### PR TITLE
zfs: fix undefined variable $all_return with legacy extend script output

### DIFF
--- a/includes/polling/applications/zfs.inc.php
+++ b/includes/polling/applications/zfs.inc.php
@@ -7,6 +7,7 @@ use LibreNMS\Exceptions\JsonAppMissingKeysException;
 use LibreNMS\RRD\RrdDefinition;
 
 $name = 'zfs';
+$all_return = ['version' => null];
 // Is set to false later if missing keys are found.
 $not_legacy = 1;
 


### PR DESCRIPTION
## Summary
- `$all_return` in `includes/polling/applications/zfs.inc.php` is only assigned inside the `try` block around `json_app_get()`. When a script uses the legacy (non-versioned, unwrapped) JSON output format — which includes the current official `librenms-agent` `snmp/zfs-linux` script — `json_app_get()` throws `JsonAppMissingKeysException`, `$all_return` is never assigned, and `$zfs` is set from the caught exception instead.
- Later in the same file, `$all_return['version']` is referenced unconditionally when building `$app->data`, producing a PHP warning on every single poll:
  ```
  PHP Error(2): Undefined variable $all_return
  PHP Error(2): Trying to access array offset on value of type null
  ```
- Impact is cosmetic (pool metrics still store correctly since `$zfs` is set independently; only `version` ends up `null`), but the warning is real and reproducible every poll cycle for anyone using the documented, current `zfs-linux` script.
- Fix: initialize `$all_return` with a sane default (`['version' => null]`) before the `try` block, so the later reference is always safe regardless of which branch is taken.

Fixes #20026

## Test plan
- [x] `php -l` clean on the modified file
- [x] Verified the exact failure reproduces against a live device running the current official `librenms-agent` `snmp/zfs-linux` extend script (confirmed via direct polling before this fix, warnings gone after)
- [x] Confirmed pool data (`pools`, `health`) already stored correctly before this fix — this change only addresses the spurious warning / null `version` field, no behavior change to metric storage
- [ ] Full local PHPUnit suite not run to completion in my environment (test-DB connection issue unrelated to this change); relying on CI for full suite validation given the change is a single-line, narrowly-scoped null-safety fix