### PR TITLE
device_display_default setting should invalidate device display name cache

### DIFF
--- a/app/ConfigRepository.php
+++ b/app/ConfigRepository.php
@@ -26,6 +26,7 @@
 
 namespace App;
 
+use App\Events\SettingChanged;
 use App\Models\Callback;
 use App\Models\GraphType;
 use Exception;
@@ -263,7 +264,9 @@ class ConfigRepository
             $deleted = Models\Config::withChildren($key)->delete();
 
             if ($deleted > 0) {
+                // delete statement above doens't trigger Eloquent events
                 $this->invalidateCache();
+                event("setting.changed.$key", new SettingChanged($key, $this->get($key)));
             }
 
             return true;

--- a/app/Events/SettingChanged.php
+++ b/app/Events/SettingChanged.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class SettingChanged
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(
+        public readonly string $key,
+        public readonly mixed $value = null,
+    ) {
+    }
+}

--- a/app/Listeners/RegenerateDeviceDisplayNames.php
+++ b/app/Listeners/RegenerateDeviceDisplayNames.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Events\SettingChanged;
+use App\Models\Device;
+use Illuminate\Support\Facades\Log;
+
+class RegenerateDeviceDisplayNames
+{
+    /**
+     * Handle the event.
+     */
+    public function handle(SettingChanged $event): void
+    {
+        Device::withoutEvents(function () {
+            Device::whereNull('display_template')
+                ->orWhere('display_template', '')
+                ->select(['device_id', 'display_template', 'hostname', 'sysName', 'ip', 'overwrite_ip'])
+                ->chunkById(500, function ($devices) {
+                    foreach ($devices as $device) {
+                        try {
+                            $device->regenerateDisplayName();
+                            $device->timestamps = false;
+                            $device->save();
+                        } catch (\Throwable $e) {
+                            Log::error("Failed to regen device {$device->device_id}: " . $e->getMessage());
+                        }
+                    }
+                });
+        });
+    }
+}

--- a/app/Listeners/RegenerateDeviceDisplayNames.php
+++ b/app/Listeners/RegenerateDeviceDisplayNames.php
@@ -13,11 +13,11 @@ class RegenerateDeviceDisplayNames
      */
     public function handle(SettingChanged $event): void
     {
-        Device::withoutEvents(function () {
+        Device::withoutEvents(function (): void {
             Device::whereNull('display_template')
                 ->orWhere('display_template', '')
                 ->select(['device_id', 'display_template', 'hostname', 'sysName', 'ip', 'overwrite_ip'])
-                ->chunkById(500, function ($devices) {
+                ->chunkById(500, function ($devices): void {
                     foreach ($devices as $device) {
                         try {
                             $device->regenerateDisplayName();

--- a/app/Observers/ConfigObserver.php
+++ b/app/Observers/ConfigObserver.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Observers;
+
+use App\Events\SettingChanged;
+use App\Facades\LibrenmsConfig;
+use App\Models\Config;
+
+class ConfigObserver
+{
+    public function saved(Config $config): void
+    {
+        event("setting.changed.$config->config_name", new SettingChanged($config->config_name, $config->config_value));
+    }
+
+    /**
+     * Handle the config "deleted" event.
+     */
+    public function deleted(Config $config): void
+    {
+        LibrenmsConfig::invalidateCache();
+        event("setting.changed.$config->config_name", new SettingChanged($config->config_name, LibrenmsConfig::get($config->config_name)));
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -149,6 +149,7 @@ class AppServiceProvider extends ServiceProvider
 
     private function bootObservers()
     {
+        \App\Models\Config::observe(\App\Observers\ConfigObserver::class);
         \App\Models\Device::observe(\App\Observers\DeviceObserver::class);
         \App\Models\Mempool::observe(\App\Observers\MempoolObserver::class);
         \App\Models\Package::observe(\App\Observers\PackageObserver::class);

--- a/app/Providers/ConfigServiceProvider.php
+++ b/app/Providers/ConfigServiceProvider.php
@@ -4,6 +4,8 @@ namespace App\Providers;
 
 use App\ConfigRepository;
 use App\Facades\LibrenmsConfig;
+use App\Listeners\RegenerateDeviceDisplayNames;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\ServiceProvider;
 
@@ -25,5 +27,13 @@ class ConfigServiceProvider extends ServiceProvider
                 LibrenmsConfig::reload();
             }
         });
+    }
+
+    /**
+     * Bootstrap services.
+     */
+    public function boot(): void
+    {
+        Event::listen('setting.changed.device_display_default', RegenerateDeviceDisplayNames::class);
     }
 }


### PR DESCRIPTION
#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
