### PR TITLE
Update vyos.yaml for Hardware Platform support.

### DIFF
--- a/resources/definitions/os_discovery/vyos.yaml
+++ b/resources/definitions/os_discovery/vyos.yaml
@@ -1,3 +1,5 @@
 modules:
     os:
         sysDescr_regex: '/VyOS (?<version>\S+)/'
+        hardware:
+            - HOST-RESOURCES-MIB::hrDeviceDescr.196608


### PR DESCRIPTION
Simple fix to add support for Hardware Platform support for VyOS. Currently this is not detected and always empty. We will use the first detected CPU as the Hardware Platform. This works for virtual and bare metal VyOS deployments.

Please give a short description what your pull request is for
This will add Hardware Platform support for VyOS by using the real CPU model. Because VyOS is totally running in software, this a good representation of the hardware platform.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x
<img width="2495" height="1120" alt="platform-support-vyos" src="https://github.com/user-attachments/assets/b11a366b-725a-49ac-b231-d44bf544071a" />
] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
