### PR TITLE
Device availability refactor

### DIFF
--- a/LibreNMS/Data/Source/Icmp/FpingResponse.php
+++ b/LibreNMS/Data/Source/Icmp/FpingResponse.php
@@ -26,11 +26,9 @@
 
 namespace LibreNMS\Data\Source\Icmp;
 
-use App\Facades\LibrenmsConfig;
 use App\Facades\Rrd;
 use App\Models\Device;
 use App\Models\DeviceStats;
-use Carbon\Carbon;
 use LibreNMS\Enum\FpingExitCode;
 use LibreNMS\Exceptions\FpingUnparsableLine;
 use LibreNMS\RRD\RrdDefinition;
@@ -219,30 +217,14 @@ class FpingResponse implements \Stringable
         return $str;
     }
 
+    /**
+     * Save ping stats to device_stats table and icmp-perf rrd
+     */
     public function saveStats(Device $device): void
     {
         $stats = $device->stats ?? new DeviceStats(['device_id' => $device->device_id]);
-        $stats->ping_last_timestamp = Carbon::now();
-        // Only update the latency if we have data
-        if ($this->avg_latency) {
-            $stats->ping_rtt_prev = $stats->ping_rtt_last ?: $this->avg_latency;
-            $stats->ping_rtt_last = $this->avg_latency;
-            // Average is calculated as the exponential weighted moving average
-            $stats->ping_rtt_avg = $stats->ping_rtt_avg ? $stats->ping_rtt_avg + (($stats->ping_rtt_last - $stats->ping_rtt_avg) * LibrenmsConfig::get('device_stats_avg_factor')) : $stats->ping_rtt_last;
-        }
-        // Only update loss if we transmitted a packet
-        if ($this->transmitted) {
-            $stats->ping_loss_prev = $stats->ping_loss_last ?: 100 * ($this->transmitted - $this->received) / $this->transmitted;
-            $stats->ping_loss_last = 100 * ($this->transmitted - $this->received) / $this->transmitted;
-            // Average is calculated as the exponential weighted moving average
-            $stats->ping_loss_avg = $stats->ping_loss_avg ? $stats->ping_loss_avg + (($stats->ping_loss_last - $stats->ping_loss_avg) * LibrenmsConfig::get('device_stats_avg_factor')) : $stats->ping_loss_last;
-        }
+        $stats->fillStats($this);
         $stats->save();
-
-        // Update the stats stored in the device table until the field is removed
-        $device->last_ping = Carbon::now();
-        $device->last_ping_timetaken = $this->avg_latency ?: $device->last_ping_timetaken;
-        $device->save();
 
         // detailed multi-ping capable graph
         app('Datastore')->put($device->toArray(), 'icmp-perf', [

--- a/app/Actions/Device/CheckDeviceAvailability.php
+++ b/app/Actions/Device/CheckDeviceAvailability.php
@@ -3,16 +3,17 @@
 namespace App\Actions\Device;
 
 use App\Models\Device;
-use LibreNMS\Enum\AvailabilitySource;
+use Carbon\Carbon;
 use LibreNMS\Polling\ConnectivityHelper;
 
-class CheckDeviceAvailability
+readonly class CheckDeviceAvailability
 {
     public function __construct(
-        private readonly SetDeviceAvailability $setDeviceAvailability,
-        private readonly DeviceIsPingable $deviceIsPingable,
-        private readonly DeviceIsSnmpable $deviceIsSnmpable,
-        private readonly DeviceMtuTest $deviceMtuTest,
+        private SetDeviceAvailability $setDeviceAvailability,
+        private DeviceIsPingable $deviceIsPingable,
+        private DeviceIsSnmpable $deviceIsSnmpable,
+        private DeviceMtuTest $deviceMtuTest,
+        private UpdateDeviceOutage $updateDeviceOutage,
     ) {
     }
 
@@ -21,15 +22,20 @@ class CheckDeviceAvailability
         $connectivity = new ConnectivityHelper($device);
         $ping_response = $this->deviceIsPingable->execute($device);
 
-        $is_up_snmp = ! $connectivity->snmpIsEnabled() || $this->deviceIsSnmpable->execute($device);
+        $results = [];
+        if ($connectivity->icmpIsEnabled()) {
+            $results['icmp'] = $ping_response->isAlive();
+            $device->last_ping = Carbon::now();
+            $device->last_ping_timetaken = $ping_response->avg_latency ?: $device->last_ping_timetaken;
+        }
+        if ($connectivity->snmpIsEnabled()) {
+            $results['snmp'] = $this->deviceIsSnmpable->execute($device);
+        }
+
+        $changed = $this->setDeviceAvailability->execute($device, $results);
 
         if ($ping_response->isAlive()) {
-            $this->setDeviceAvailability->execute($device, $is_up_snmp, AvailabilitySource::Snmp, $commit);
-
             $device->mtu_status = $this->deviceMtuTest->execute($device);
-        } else { // icmp down
-            $reason = $is_up_snmp ? AvailabilitySource::Icmp : AvailabilitySource::Both;
-            $this->setDeviceAvailability->execute($device, false, $reason, $commit);
         }
 
         if ($commit) {
@@ -37,7 +43,11 @@ class CheckDeviceAvailability
                 $ping_response->saveStats($device);
             }
 
-            $device->save(); // confirm device is saved
+            $device->save();
+
+            if ($changed) {
+                $this->updateDeviceOutage->execute($device);
+            }
         }
 
         return $device->status;

--- a/app/Actions/Device/SetDeviceAvailability.php
+++ b/app/Actions/Device/SetDeviceAvailability.php
@@ -21,7 +21,7 @@ class SetDeviceAvailability
         $connectivity = new ConnectivityHelper($device);
 
         // Determine which sources are currently enabled on this device
-        $enabled = collect(['icmp', 'snmp'])->filter(fn($source) => $connectivity->{"{$source}IsEnabled"}());
+        $enabled = collect(['icmp', 'snmp'])->filter(fn ($source) => $connectivity->{"{$source}IsEnabled"}());
 
         // Normalize keys: AvailabilitySource enum values or plain strings
         $checked = collect($results)->mapWithKeys(function ($passed, $source) {
@@ -31,11 +31,11 @@ class SetDeviceAvailability
         });
 
         // Previously failing sources that weren't checked this run are still considered failing
-        $previously_failed = collect(explode(',', (string) $device->status_reason))->map(fn($s) => trim($s))->filter();
+        $previously_failed = collect(explode(',', (string) $device->status_reason))->map(fn ($s) => trim($s))->filter();
         $unchecked_failures = $previously_failed->diff($checked->keys());
 
         // A source is failing if it failed in this run, or was previously failing and wasn't re-checked
-        $failing = $checked->filter(fn($passed) => ! $passed)->keys()->merge($unchecked_failures);
+        $failing = $checked->filter(fn ($passed) => ! $passed)->keys()->merge($unchecked_failures);
 
         // Only report failures for sources that are currently enabled
         $failed_sources = $failing->intersect($enabled)->sort()->values();

--- a/app/Actions/Device/SetDeviceAvailability.php
+++ b/app/Actions/Device/SetDeviceAvailability.php
@@ -8,37 +8,61 @@ use LibreNMS\Enum\AvailabilitySource;
 class SetDeviceAvailability
 {
     public function __construct(
-        private readonly UpdateDeviceOutage $updateDeviceOutage,
     ) {
     }
 
     /**
+     * Set status and status_reason fields based on availability results
+     * Does not persist to the database
+     *
      * @param  Device  $device
-     * @param  bool  $available
-     * @param  AvailabilitySource  $source
-     * @param  bool  $commit  Save changes to the database
+     * @param  array<string|\LibreNMS\Enum\AvailabilitySource, bool>  $results  e.g. ['icmp' => true, 'snmp' => false]
      * @return bool true if the status changed
      */
-    public function execute(Device $device, bool $available, AvailabilitySource $source = AvailabilitySource::None, bool $commit = true): bool
+    public function execute(Device $device, array $results): bool
     {
-        // if device was down and is now up, if reason was snmp and source is icmp, ignore
-        if ($available && ! $device->status && $device->status_reason == AvailabilitySource::Snmp->value) {
-            if ($source == AvailabilitySource::Icmp) {
-                return false;
+        // Parse current failed sources from status_reason
+        $current_failed = collect(explode(',', (string) $device->status_reason))
+            ->map(fn($s) => trim($s))
+            ->filter()
+            ->all();
+
+        $failed_in_run = [];
+        $checked = [];
+        foreach ($results as $source => $status) {
+            $sourceName = $source instanceof AvailabilitySource ? $source->value : (string) $source;
+            $checked[] = $sourceName;
+            if (! $status) {
+                $failed_in_run[] = $sourceName;
             }
         }
+
+        // Failed sources are:
+        // 1. Those that failed in this run
+        // 2. Those that were previously failed and were not checked in this run
+        $not_checked = array_diff($current_failed, $checked);
+        $all_failed = array_unique(array_merge($failed_in_run, $not_checked));
+
+        // Filter failed sources to only those that are currently enabled
+        $connectivity = new \LibreNMS\Polling\ConnectivityHelper($device);
+        $enabled_sources = [];
+        if ($connectivity->icmpIsEnabled()) {
+            $enabled_sources[] = 'icmp';
+        }
+        if ($connectivity->snmpIsEnabled()) {
+            $enabled_sources[] = 'snmp';
+        }
+        // In the future, additional availability sources can be appended to $enabled_sources here.
+        $all_failed = array_intersect($all_failed, $enabled_sources);
+
+        // Sort failed sources for consistency in status_reason
+        sort($all_failed);
+
+        $available = empty($all_failed);
 
         $device->status = $available;
-        $device->status_reason = $available ? AvailabilitySource::None->value : $source->value;
-        $changed = $device->isDirty('status');
+        $device->status_reason = implode(',', $all_failed);
 
-        if ($commit) {
-            $device->save();
-            if ($changed) {
-                $this->updateDeviceOutage->execute($device, $available);
-            }
-        }
-
-        return $changed;
+        return $device->isDirty('status');
     }
 }

--- a/app/Actions/Device/SetDeviceAvailability.php
+++ b/app/Actions/Device/SetDeviceAvailability.php
@@ -4,16 +4,13 @@ namespace App\Actions\Device;
 
 use App\Models\Device;
 use LibreNMS\Enum\AvailabilitySource;
+use LibreNMS\Polling\ConnectivityHelper;
 
 class SetDeviceAvailability
 {
-    public function __construct(
-    ) {
-    }
-
     /**
-     * Set status and status_reason fields based on availability results
-     * Does not persist to the database
+     * Set status and status_reason fields based on availability results.
+     * Does not persist to the database.
      *
      * @param  Device  $device
      * @param  array<string|\LibreNMS\Enum\AvailabilitySource, bool>  $results  e.g. ['icmp' => true, 'snmp' => false]
@@ -21,47 +18,30 @@ class SetDeviceAvailability
      */
     public function execute(Device $device, array $results): bool
     {
-        // Parse current failed sources from status_reason
-        $current_failed = collect(explode(',', (string) $device->status_reason))
-            ->map(fn($s) => trim($s))
-            ->filter()
-            ->all();
+        $connectivity = new ConnectivityHelper($device);
 
-        $failed_in_run = [];
-        $checked = [];
-        foreach ($results as $source => $status) {
-            $sourceName = $source instanceof AvailabilitySource ? $source->value : (string) $source;
-            $checked[] = $sourceName;
-            if (! $status) {
-                $failed_in_run[] = $sourceName;
-            }
-        }
+        // Determine which sources are currently enabled on this device
+        $enabled = collect(['icmp', 'snmp'])->filter(fn($source) => $connectivity->{"{$source}IsEnabled"}());
 
-        // Failed sources are:
-        // 1. Those that failed in this run
-        // 2. Those that were previously failed and were not checked in this run
-        $not_checked = array_diff($current_failed, $checked);
-        $all_failed = array_unique(array_merge($failed_in_run, $not_checked));
+        // Normalize keys: AvailabilitySource enum values or plain strings
+        $checked = collect($results)->mapWithKeys(function ($passed, $source) {
+            $name = $source instanceof AvailabilitySource ? $source->value : (string) $source;
 
-        // Filter failed sources to only those that are currently enabled
-        $connectivity = new \LibreNMS\Polling\ConnectivityHelper($device);
-        $enabled_sources = [];
-        if ($connectivity->icmpIsEnabled()) {
-            $enabled_sources[] = 'icmp';
-        }
-        if ($connectivity->snmpIsEnabled()) {
-            $enabled_sources[] = 'snmp';
-        }
-        // In the future, additional availability sources can be appended to $enabled_sources here.
-        $all_failed = array_intersect($all_failed, $enabled_sources);
+            return [$name => $passed];
+        });
 
-        // Sort failed sources for consistency in status_reason
-        sort($all_failed);
+        // Previously failing sources that weren't checked this run are still considered failing
+        $previously_failed = collect(explode(',', (string) $device->status_reason))->map(fn($s) => trim($s))->filter();
+        $unchecked_failures = $previously_failed->diff($checked->keys());
 
-        $available = empty($all_failed);
+        // A source is failing if it failed in this run, or was previously failing and wasn't re-checked
+        $failing = $checked->filter(fn($passed) => ! $passed)->keys()->merge($unchecked_failures);
 
-        $device->status = $available;
-        $device->status_reason = implode(',', $all_failed);
+        // Only report failures for sources that are currently enabled
+        $failed_sources = $failing->intersect($enabled)->sort()->values();
+
+        $device->status = $failed_sources->isEmpty();
+        $device->status_reason = $failed_sources->implode(',');
 
         return $device->isDirty('status');
     }

--- a/app/Actions/Device/UpdateDeviceOutage.php
+++ b/app/Actions/Device/UpdateDeviceOutage.php
@@ -9,14 +9,14 @@ use LibreNMS\Enum\MaintenanceStatus;
 
 class UpdateDeviceOutage
 {
-    public function execute(Device $device, bool $available): void
+    public function execute(Device $device): void
     {
         if (LibrenmsConfig::get('graphing.availability_consider_maintenance')
             && $device->getMaintenanceStatus() !== MaintenanceStatus::None) {
             return;
         }
 
-        if ($available) {
+        if ($device->status) {
             // Device is up, close any open outages
             $device->outages()->whereNull('up_again')->get()->each(function (DeviceOutage $outage): void {
                 $outage->up_again = time();

--- a/app/Jobs/PingCheck.php
+++ b/app/Jobs/PingCheck.php
@@ -29,6 +29,7 @@ namespace App\Jobs;
 use App\Action;
 use App\Actions\Alerts\RunAlertRulesAction;
 use App\Actions\Device\SetDeviceAvailability;
+use App\Actions\Device\UpdateDeviceOutage;
 use App\Models\Device;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -40,7 +41,6 @@ use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Log;
 use LibreNMS\Data\Source\Icmp\Fping;
 use LibreNMS\Data\Source\Icmp\FpingResponse;
-use LibreNMS\Enum\AvailabilitySource;
 
 class PingCheck implements ShouldQueue
 {
@@ -185,7 +185,11 @@ class PingCheck implements ShouldQueue
         }
 
         // mark up only if snmp is not down too
-        $changed = app(SetDeviceAvailability::class)->execute($device, $response->isAlive(), AvailabilitySource::Icmp, true);
+        $changed = app(SetDeviceAvailability::class)->execute($device, ['icmp' => $response->isAlive()]);
+        $device->save();
+        if ($changed) {
+            app(UpdateDeviceOutage::class)->execute($device);
+        }
 
         // mark as processed
         $this->processed->put($device->device_id, true);

--- a/app/Models/DeviceStats.php
+++ b/app/Models/DeviceStats.php
@@ -2,7 +2,10 @@
 
 namespace App\Models;
 
+use App\Facades\LibrenmsConfig;
+use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use LibreNMS\Data\Source\Icmp\FpingResponse;
 
 class DeviceStats extends DeviceRelatedModel
 {
@@ -18,4 +21,26 @@ class DeviceStats extends DeviceRelatedModel
         'ping_loss_prev',
         'ping_loss_avg',
     ];
+
+    public function fillStats(FpingResponse $response): void
+    {
+        $avg_factor = LibrenmsConfig::get('device_stats_avg_factor');
+        $this->ping_last_timestamp = Carbon::now();
+
+        // Only update the latency if we have data
+        if ($response->avg_latency) {
+            $this->ping_rtt_prev = $this->ping_rtt_last ?: $response->avg_latency;
+            $this->ping_rtt_last = $response->avg_latency;
+            // Average is calculated as the exponential weighted moving average
+            $this->ping_rtt_avg = $this->ping_rtt_avg ? $this->ping_rtt_avg + (($this->ping_rtt_last - $this->ping_rtt_avg) * $avg_factor) : $this->ping_rtt_last;
+        }
+
+        // Only update loss if we transmitted a packet
+        if ($response->transmitted) {
+            $this->ping_loss_prev = $this->ping_loss_last ?: 100 * ($response->transmitted - $response->received) / $response->transmitted;
+            $this->ping_loss_last = 100 * ($response->transmitted - $response->received) / $response->transmitted;
+            // Average is calculated as the exponential weighted moving average
+            $this->ping_loss_avg = $this->ping_loss_avg ? $this->ping_loss_avg + (($this->ping_loss_last - $this->ping_loss_avg) * $avg_factor) : $this->ping_loss_last;
+        }
+    }
 }


### PR DESCRIPTION
CheckDeviceAvailability is in charge of saving the device now so we only save once.
SetDeviceAvailability is only intended to be called once now with all checked sources.  This way it can make proper decisions.
Try to move responsibilities around to where they make sense.

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
