### PR TITLE
Add Nokia SAPs as a billable source in traffic bills

### DIFF
--- a/LibreNMS/Billing.php
+++ b/LibreNMS/Billing.php
@@ -113,6 +113,23 @@ class Billing
         return $return;
     }
 
+    public static function getLastSapCounter($sap_id, $bill_id): array
+    {
+        $row = \App\Models\BillSapCounter::where('sap_id', $sap_id)->where('bill_id', $bill_id)->first();
+        if ($row !== null) {
+            return [
+                'timestamp' => $row->timestamp,
+                'in_counter' => $row->in_counter,
+                'in_delta' => $row->in_delta,
+                'out_counter' => $row->out_counter,
+                'out_delta' => $row->out_delta,
+                'state' => 'ok',
+            ];
+        }
+
+        return ['state' => 'failed'];
+    }
+
     public static function getLastMeasurement($bill_id): array
     {
         $return = [];

--- a/LibreNMS/Modules/Mpls.php
+++ b/LibreNMS/Modules/Mpls.php
@@ -222,7 +222,8 @@ class Mpls implements Module
                 ->leftJoin('mpls_services', 'mpls_saps.svc_id', 'mpls_services.svc_id')
                 ->orderBy('mpls_services.svc_oid')->orderBy('mpls_saps.sapPortId')->orderBy('mpls_saps.sapEncapValue')
                 ->select(['mpls_saps.*', 'mpls_services.svc_oid'])
-                ->get()->map->makeHidden(['sap_id', 'svc_id', 'device_id']),
+                // sapIngressOctets/sapEgressOctets are cumulative traffic counters (used for billing), not inventory
+                ->get()->map->makeHidden(['sap_id', 'svc_id', 'device_id', 'sapIngressOctets', 'sapEgressOctets']),
         ];
     }
 }

--- a/LibreNMS/OS/Timos.php
+++ b/LibreNMS/OS/Timos.php
@@ -625,9 +625,13 @@ class Timos extends OS implements MplsDiscovery, MplsPolling, TransceiverDiscove
                 ->addDataset('sapIngressDroppedBits', 'COUNTER', 0)
                 ->addDataset('sapEgressDroppedBits', 'COUNTER', 0);
 
+            // Cumulative traffic octet counters, also persisted to the DB for billing
+            $sapIngressOctets = ($value['sapBaseStatsIngressPchipOfferedLoPrioOctets'] ?? 0) + ($value['sapBaseStatsIngressPchipOfferedHiPrioOctets'] ?? 0);
+            $sapEgressOctets = ($value['sapBaseStatsEgressQchipForwardedOutProfOctets'] ?? 0) + ($value['sapBaseStatsEgressQchipForwardedInProfOctets'] ?? 0);
+
             $fields = [
-                'sapIngressBits' => (($value['sapBaseStatsIngressPchipOfferedLoPrioOctets'] ?? 0) + ($value['sapBaseStatsIngressPchipOfferedHiPrioOctets'] ?? 0)) * 8,
-                'sapEgressBits' => (($value['sapBaseStatsEgressQchipForwardedOutProfOctets'] ?? 0) + ($value['sapBaseStatsEgressQchipForwardedInProfOctets'] ?? 0)) * 8,
+                'sapIngressBits' => $sapIngressOctets * 8,
+                'sapEgressBits' => $sapEgressOctets * 8,
                 'sapIngressDroppedBits' => (($value['sapBaseStatsIngressQchipDroppedLoPrioOctets'] ?? 0) + ($value['sapBaseStatsIngressQchipDroppedHiPrioOctets'] ?? 0)) * 8,
                 'sapEgressDroppedBits' => (($value['sapBaseStatsEgressQchipDroppedOutProfOctets'] ?? 0) + ($value['sapBaseStatsEgressQchipDroppedInProfOctets'] ?? 0)) * 8,
             ];
@@ -655,6 +659,8 @@ class Timos extends OS implements MplsDiscovery, MplsPolling, TransceiverDiscove
                 'sapOperStatus' => $value['sapOperStatus'],
                 'sapLastMgmtChange' => round($value['sapLastMgmtChange'] / 100),
                 'sapLastStatusChange' => round($value['sapLastStatusChange'] / 100),
+                'sapIngressOctets' => $sapIngressOctets,
+                'sapEgressOctets' => $sapEgressOctets,
             ]);
         })->filter();
     }

--- a/app/Http/Controllers/Select/DeviceController.php
+++ b/app/Http/Controllers/Select/DeviceController.php
@@ -45,6 +45,7 @@ class DeviceController extends SelectController
             'user' => 'nullable|int',
             'key' => 'nullable|in:device_id,hostname',
             'exclude' => 'nullable|int',
+            'has' => 'nullable|in:mplsSaps',
         ];
     }
 
@@ -74,6 +75,7 @@ class DeviceController extends SelectController
 
         return Device::hasAccess($request->user())
             ->when($request->input('exclude'), fn ($query, $exclude) => $query->where('device_id', '!=', $exclude))
+            ->when($request->input('has'), fn ($query, $has) => $query->has($has))
             ->select(['device_id', 'hostname', 'sysName', 'display', 'icon'])
             ->orderBy('hostname');
     }

--- a/app/Http/Controllers/Select/SapController.php
+++ b/app/Http/Controllers/Select/SapController.php
@@ -1,0 +1,109 @@
+<?php
+
+/**
+ * SapController.php
+ *
+ * Select2 controller for Nokia SAP (Service Access Point) selection.
+ * Used for adding SAPs to a bill.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * @link       https://www.librenms.org
+ *
+ * @copyright  2026 LibreNMS Contributors
+ */
+
+namespace App\Http\Controllers\Select;
+
+use App\Models\MplsSap;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\Request;
+
+/**
+ * @extends SelectController<MplsSap>
+ */
+class SapController extends SelectController
+{
+    /**
+     * Defines validation rules (will override base validation rules for select2 responses too)
+     *
+     * @return array<string, string>
+     */
+    protected function rules(): array
+    {
+        return [
+            'device' => 'nullable|int',
+        ];
+    }
+
+    /**
+     * Defines search fields will be searched in order
+     *
+     * @return list<string>
+     */
+    protected function searchFields(Request $request): array
+    {
+        return ['svc_oid', 'ifName', 'sapEncapValue', 'sapDescription', 'devices.hostname', 'devices.sysName'];
+    }
+
+    /**
+     * Defines the base query for this resource
+     */
+    protected function baseQuery(Request $request): Builder
+    {
+        $query = MplsSap::hasAccess($request->user())
+            ->has('device')
+            ->with(['device' => function ($query): void {
+                $query->select(['device_id', 'hostname', 'sysName', 'display']);
+            }])
+            ->select(['mpls_saps.device_id', 'sap_id', 'svc_oid', 'sapPortId', 'ifName', 'sapEncapValue', 'sapDescription', 'sapType']);
+
+        if ($request->input('term')) {
+            // join with devices for searches
+            $query->leftJoin('devices', 'devices.device_id', 'mpls_saps.device_id');
+        }
+
+        // Filter by device if specified
+        if ($device_id = $request->input('device')) {
+            $query->where('mpls_saps.device_id', $device_id);
+        }
+
+        $query->orderBy('svc_oid')->orderBy('sapPortId')->orderBy('sapEncapValue');
+
+        return $query;
+    }
+
+    /**
+     * Format a SAP item for Select2 display
+     *
+     * @param  MplsSap  $model
+     * @return array{id: int|string, text: string, icon?: string, device_id?: int}
+     */
+    public function formatItem(Model $model): array
+    {
+        // Match the device MPLS SAPs view: Service ID - SAP Port - Encapsulation
+        $port = $model->ifName ?: $model->sapPortId;
+        $text = $model->svc_oid . ' - ' . $port . ' - ' . $model->sapEncapValue;
+        if ($model->sapDescription) {
+            $text .= ' (' . $model->sapDescription . ')';
+        }
+
+        return [
+            'id' => $model->sap_id,
+            'text' => $text,
+            'device_id' => $model->device_id,
+        ];
+    }
+}

--- a/app/Models/Bill.php
+++ b/app/Models/Bill.php
@@ -72,10 +72,26 @@ class Bill extends BaseModel
     }
 
     /**
+     * @return HasMany<BillSapCounter, $this>
+     */
+    public function sapCounters(): HasMany
+    {
+        return $this->hasMany(BillSapCounter::class, 'bill_id', 'bill_id');
+    }
+
+    /**
      * @return BelongsToMany<Port, $this>
      */
     public function ports(): BelongsToMany
     {
         return $this->belongsToMany(Port::class, 'bill_ports', 'bill_id', 'port_id');
+    }
+
+    /**
+     * @return BelongsToMany<MplsSap, $this>
+     */
+    public function saps(): BelongsToMany
+    {
+        return $this->belongsToMany(MplsSap::class, 'bill_saps', 'bill_id', 'sap_id');
     }
 }

--- a/app/Models/BillSap.php
+++ b/app/Models/BillSap.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class BillSap extends BillRelatedModel
+{
+    protected $table = 'bill_saps';
+    public $timestamps = false;
+
+    protected $fillable = [
+        'bill_id',
+        'sap_id',
+        'bill_sap_autoadded',
+    ];
+
+    // ---- Define Relationships ----
+
+    /**
+     * @return BelongsTo<MplsSap, $this>
+     */
+    public function sap(): BelongsTo
+    {
+        return $this->belongsTo(MplsSap::class, 'sap_id', 'sap_id');
+    }
+}

--- a/app/Models/BillSapCounter.php
+++ b/app/Models/BillSapCounter.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models;
+
+class BillSapCounter extends BillRelatedModel
+{
+    protected $table = 'bill_sap_counters';
+    protected $primaryKey = null; // Composite primary key
+    public $incrementing = false;
+    protected $keyType = 'int';
+    public $timestamps = false;
+
+    protected $fillable = [
+        'sap_id',
+        'bill_id',
+        'timestamp',
+        'in_counter',
+        'in_delta',
+        'out_counter',
+        'out_delta',
+    ];
+}

--- a/app/Models/MplsSap.php
+++ b/app/Models/MplsSap.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use LibreNMS\Interfaces\Models\Keyable;
 
@@ -26,6 +27,8 @@ class MplsSap extends DeviceRelatedModel implements Keyable
         'sapOperStatus',
         'sapLastMgmtChange',
         'sapLastStatusChange',
+        'sapIngressOctets',
+        'sapEgressOctets',
     ];
 
     // ---- Helper Functions ----
@@ -53,5 +56,13 @@ class MplsSap extends DeviceRelatedModel implements Keyable
     public function service(): BelongsTo
     {
         return $this->belongsTo(MplsService::class, 'svc_id');
+    }
+
+    /**
+     * @return BelongsToMany<Bill, $this>
+     */
+    public function bills(): BelongsToMany
+    {
+        return $this->belongsToMany(Bill::class, 'bill_saps', 'sap_id', 'bill_id');
     }
 }

--- a/database/migrations/2026_07_03_100000_add_octets_to_mpls_saps_table.php
+++ b/database/migrations/2026_07_03_100000_add_octets_to_mpls_saps_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up(): void
+    {
+        Schema::table('mpls_saps', function (Blueprint $table) {
+            $table->unsignedBigInteger('sapIngressOctets')->nullable()->after('sapLastStatusChange');
+            $table->unsignedBigInteger('sapEgressOctets')->nullable()->after('sapIngressOctets');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down(): void
+    {
+        Schema::table('mpls_saps', function (Blueprint $table) {
+            $table->dropColumn(['sapIngressOctets', 'sapEgressOctets']);
+        });
+    }
+};

--- a/database/migrations/2026_07_03_100001_create_bill_saps_table.php
+++ b/database/migrations/2026_07_03_100001_create_bill_saps_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up(): void
+    {
+        Schema::create('bill_saps', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedInteger('bill_id');
+            $table->unsignedInteger('sap_id');
+            $table->boolean('bill_sap_autoadded')->default(0);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down(): void
+    {
+        Schema::drop('bill_saps');
+    }
+};

--- a/database/migrations/2026_07_03_100002_create_bill_sap_counters_table.php
+++ b/database/migrations/2026_07_03_100002_create_bill_sap_counters_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up(): void
+    {
+        Schema::create('bill_sap_counters', function (Blueprint $table) {
+            $table->unsignedInteger('sap_id');
+            $table->timestamp('timestamp')->useCurrent();
+            $table->bigInteger('in_counter')->nullable();
+            $table->bigInteger('in_delta')->default(0);
+            $table->bigInteger('out_counter')->nullable();
+            $table->bigInteger('out_delta')->default(0);
+            $table->unsignedInteger('bill_id');
+            $table->primary(['sap_id', 'bill_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down(): void
+    {
+        Schema::drop('bill_sap_counters');
+    }
+};

--- a/doc/Extensions/Billing-Module.md
+++ b/doc/Extensions/Billing-Module.md
@@ -5,6 +5,11 @@ and add ports to it. It then tracks the ports usage and shows you the
 usage in the bill, including any overage.
 Accounting by both total transferred data and 95th percentile is supported.
 
+In addition to ports, Nokia SAPs (Service Access Points, discovered by the
+MPLS module on TiMOS/SR OS devices) can be added to a bill. A bill may mix
+ports and SAPs, or contain only SAPs. SAP traffic is collected by the MPLS
+module during normal polling, so that module must be enabled on the device.
+
 To enable and use the billing module you need to perform the following steps:
 
 !!! setting "system/billing"
@@ -29,7 +34,7 @@ To create a new bill, from the LibreNMS menu select Ports -> Traffic Bills and
 select `+ Create Bill`.
 
 Enter the relevant details within the form, ensuring that you select at least
-one device and port.
+one device and port (or, for Nokia TiMOS devices, at least one SAP).
 
 ## 95th Percentile Calculation
 

--- a/includes/html/graphs/bill/bits.inc.php
+++ b/includes/html/graphs/bill/bits.inc.php
@@ -10,8 +10,15 @@ $bill_id = $vars['id'] ?? 0;
 $rates = Billing::getRates($bill_id, $datefrom, $dateto, $vars['dir'] ?? null);
 
 $ports = dbFetchRows('SELECT * FROM `bill_ports` AS B, `ports` AS P, `devices` AS D WHERE B.bill_id = ? AND P.port_id = B.port_id AND D.device_id = P.device_id', [$bill_id]);
+$saps = App\Models\MplsSap::query()
+    ->select('mpls_saps.*', 'devices.hostname')
+    ->join('bill_saps', 'bill_saps.sap_id', '=', 'mpls_saps.sap_id')
+    ->join('devices', 'devices.device_id', '=', 'mpls_saps.device_id')
+    ->where('bill_saps.bill_id', $bill_id)
+    ->get();
 
-// Generate a list of ports and then call the multi_bits grapher to generate from the list
+// Generate a list of ports and saps and then call the multi_bits grapher to generate from the list
+$rrd_list = [];
 $i = 0;
 
 foreach ($ports as $port) {
@@ -19,6 +26,21 @@ foreach ($ports as $port) {
     if (Rrd::checkRrdExists($rrd_file)) {
         $rrd_list[$i]['filename'] = $rrd_file;
         $rrd_list[$i]['descr'] = $port['ifDescr'];
+        $i++;
+    }
+}
+
+// SAP traffic is stored in bits (not octets) under different datasource names,
+// so pass the datasource names and a divisor to normalise it to octets.
+foreach ($saps as $sap) {
+    $encap = $sap['sapEncapValue'] == '*' ? '4095' : $sap['sapEncapValue'];
+    $rrd_file = Rrd::name($sap['hostname'], 'sap-' . $sap['svc_oid'] . '.' . $sap['sapPortId'] . '.' . $encap);
+    if (Rrd::checkRrdExists($rrd_file)) {
+        $rrd_list[$i]['filename'] = $rrd_file;
+        $rrd_list[$i]['descr'] = $sap['sapDescription'] ?: ($sap['svc_oid'] . ' ' . $sap['ifName']);
+        $rrd_list[$i]['ds_in'] = 'sapIngressBits';
+        $rrd_list[$i]['ds_out'] = 'sapEgressBits';
+        $rrd_list[$i]['divisor'] = 8;
         $i++;
     }
 }

--- a/includes/html/graphs/generic_multi_bits_separated.inc.php
+++ b/includes/html/graphs/generic_multi_bits_separated.inc.php
@@ -58,20 +58,32 @@ if (! $noagg || ! $nodetails) {
 $iter = 0;
 $descr_out = '';
 foreach ($rrd_list as $rrd) {
-    if (! \App\Facades\LibrenmsConfig::get("graph_colours.$colours_in.$iter") || ! \App\Facades\LibrenmsConfig::get("graph_colours.$colours_out.$iter")) {
+    if (! App\Facades\LibrenmsConfig::get("graph_colours.$colours_in.$iter") || ! App\Facades\LibrenmsConfig::get("graph_colours.$colours_out.$iter")) {
         $iter = 0;
     }
 
-    $colour_in = \App\Facades\LibrenmsConfig::get("graph_colours.$colours_in.$iter");
-    $colour_out = \App\Facades\LibrenmsConfig::get("graph_colours.$colours_out.$iter");
+    $colour_in = App\Facades\LibrenmsConfig::get("graph_colours.$colours_in.$iter");
+    $colour_out = App\Facades\LibrenmsConfig::get("graph_colours.$colours_out.$iter");
 
     if (! $nodetails) {
-        $descr = \LibreNMS\Data\Store\Rrd::fixedSafeDescr($rrd['descr_in'] ?? $rrd['descr'] ?? '', $descr_len) . '  In';
-        $descr_out = \LibreNMS\Data\Store\Rrd::fixedSafeDescr($rrd['descr_out'] ?? '', $descr_len) . ' Out';
+        $descr = LibreNMS\Data\Store\Rrd::fixedSafeDescr($rrd['descr_in'] ?? $rrd['descr'] ?? '', $descr_len) . '  In';
+        $descr_out = LibreNMS\Data\Store\Rrd::fixedSafeDescr($rrd['descr_out'] ?? '', $descr_len) . ' Out';
     }
 
-    $rrd_options[] = 'DEF:' . $in . $i . '=' . $rrd['filename'] . ':' . $ds_in . ':AVERAGE';
-    $rrd_options[] = 'DEF:' . $out . $i . '=' . $rrd['filename'] . ':' . $ds_out . ':AVERAGE';
+    // Allow per-file datasource names and an optional divisor to normalise the
+    // datasource to the common unit (e.g. a datasource stored in bits when the
+    // rest of the graph is in octets). Defaults keep the original behaviour.
+    $ds_in_i = $rrd['ds_in'] ?? $ds_in;
+    $ds_out_i = $rrd['ds_out'] ?? $ds_out;
+    if (! empty($rrd['divisor'])) {
+        $rrd_options[] = 'DEF:' . $in . 'raw' . $i . '=' . $rrd['filename'] . ':' . $ds_in_i . ':AVERAGE';
+        $rrd_options[] = 'DEF:' . $out . 'raw' . $i . '=' . $rrd['filename'] . ':' . $ds_out_i . ':AVERAGE';
+        $rrd_options[] = 'CDEF:' . $in . $i . '=' . $in . 'raw' . $i . ',' . $rrd['divisor'] . ',/';
+        $rrd_options[] = 'CDEF:' . $out . $i . '=' . $out . 'raw' . $i . ',' . $rrd['divisor'] . ',/';
+    } else {
+        $rrd_options[] = 'DEF:' . $in . $i . '=' . $rrd['filename'] . ':' . $ds_in_i . ':AVERAGE';
+        $rrd_options[] = 'DEF:' . $out . $i . '=' . $rrd['filename'] . ':' . $ds_out_i . ':AVERAGE';
+    }
     $rrd_options[] = 'CDEF:inB' . $i . '=in' . $i . ",$multiplier,*";
     $rrd_options[] = 'CDEF:outB' . $i . '=out' . $i . ",$multiplier,*";
     $rrd_options[] = 'CDEF:outB' . $i . '_neg=outB' . $i . ',' . $stacked['stacked'] . ',*';

--- a/includes/html/modal/new_bill.inc.php
+++ b/includes/html/modal/new_bill.inc.php
@@ -47,6 +47,12 @@ $port_device_id = -1;
                         <select class="form-control input-sm" id="port_id" name="port_id"></select>
                     </div>
                 </div>
+                <div class="form-group">
+                    <label class="col-sm-4 control-label" for="sap_id">SAP</label>
+                    <div class="col-sm-8">
+                        <select class="form-control input-sm" id="sap_id" name="sap_id"></select>
+                    </div>
+                </div>
     <script type="text/javascript">
         const makePortData = function (param) {
             param.device = $('#device').val();
@@ -54,8 +60,10 @@ $port_device_id = -1;
         }
         init_select2('#device', 'device', {}, <?php echo "{id: $port_device_id, text: '" . (isset($device) ? format_hostname($device) : 'No Device') . "'}"; ?>, '', {dropdownParent: $('#create-bill .modal-content')});
         init_select2('#port_id', 'port', makePortData, <?php echo '{id: ' . ($port['port_id'] ?? '0') . ", text: '" . (isset($port['ifAlias']) ? htmlentities($port['ifAlias']) : 'No Port') . "'}"; ?>, '', {dropdownParent: $('#create-bill .modal-content')});
+        init_select2('#sap_id', 'sap', makePortData, {id: 0, text: 'No SAP'}, '', {dropdownParent: $('#create-bill .modal-content')});
         function billDeviceChanged() {
             $('#port_id').val(null).trigger('change'); // clear port selection
+            $('#sap_id').val(null).trigger('change'); // clear sap selection
         }
     </script>
     <?php

--- a/includes/html/pages/bill.inc.php
+++ b/includes/html/pages/bill.inc.php
@@ -74,6 +74,13 @@ if (Gate::allows('view', $bill)) {
         [$bill_id]
     );
 
+    $saps = App\Models\MplsSap::query()
+        ->select('mpls_saps.*', 'devices.hostname', 'devices.sysName')
+        ->join('bill_saps', 'bill_saps.sap_id', '=', 'mpls_saps.sap_id')
+        ->join('devices', 'devices.device_id', '=', 'mpls_saps.device_id')
+        ->where('bill_saps.bill_id', $bill_id)
+        ->get();
+
     $vars['view'] ??= 'quick';
 
     function print_port_list($ports)
@@ -95,7 +102,32 @@ if (Gate::allows('view', $bill)) {
         }
 
         echo '</div></div>';
-    }//end print_port_list?>
+    }//end print_port_list
+
+    function print_sap_list($saps)
+    {
+        if ($saps->isEmpty()) {
+            return;
+        }
+
+        echo '<div class="panel panel-default">
+            <div class="panel-heading">
+                <h3 class="panel-title">Billed SAPs</h3>
+            </div>
+            <div class="list-group">';
+
+        // Collected Earlier
+        foreach ($saps as $sap) {
+            $sapdescr = (empty($sap['sapDescription']) ? '' : ' - ' . htmlentities((string) $sap['sapDescription']));
+            $saplabel = htmlentities((string) $sap['ifName']) . ($sap['sapEncapValue'] ? ':' . htmlentities((string) $sap['sapEncapValue']) : '') . $sapdescr;
+
+            echo '<div class="list-group-item">';
+            echo generate_sap_url($sap, $saplabel) . ' on ' . generate_device_link($sap);
+            echo '</div>';
+        }
+
+        echo '</div></div>';
+    }//end print_sap_list?>
 
     <h2>Bill: <?php echo htmlentities((string) $bill_data['bill_name']); ?></h2>
 
@@ -132,7 +164,7 @@ if (Gate::allows('view', $bill)) {
         $sep = ' | ';
     }
 
-    echo '<div style="font-weight: bold; float: right;"><a href="' . \LibreNMS\Util\Url::generate(['page' => 'bills']) . '/"><i class="fa fa-arrow-left fa-lg icon-theme" aria-hidden="true"></i> Back to Bills</a></div>';
+    echo '<div style="font-weight: bold; float: right;"><a href="' . Url::generate(['page' => 'bills']) . '/"><i class="fa fa-arrow-left fa-lg icon-theme" aria-hidden="true"></i> Back to Bills</a></div>';
 
     print_optionbar_end();
 
@@ -162,6 +194,7 @@ if (Gate::allows('view', $bill)) {
 <div class="row">
 <div class="col-lg-6 col-lg-push-6">
         <?php print_port_list($ports) ?>
+        <?php print_sap_list($saps) ?>
 </div>
 <div class="col-lg-6 col-lg-pull-6">
 <div class="panel panel-default">

--- a/includes/html/pages/bill/actions.inc.php
+++ b/includes/html/pages/bill/actions.inc.php
@@ -4,11 +4,13 @@ $action = $_POST['action'] ?? 'none';
 $confirm = $_POST['confirm'] ?? 'none';
 
 if ($action == 'delete_bill' && $confirm == 'confirm') {
-    \App\Models\BillHistory::where('bill_id', $bill_id)->delete();
-    \App\Models\BillPort::where('bill_id', $bill_id)->delete();
-    \App\Models\BillData::where('bill_id', $bill_id)->delete();
-    \App\Models\BillPerm::where('bill_id', $bill_id)->delete();
-    \App\Models\Bill::where('bill_id', $bill_id)->delete();
+    App\Models\BillHistory::where('bill_id', $bill_id)->delete();
+    App\Models\BillPort::where('bill_id', $bill_id)->delete();
+    App\Models\BillSap::where('bill_id', $bill_id)->delete();
+    App\Models\BillSapCounter::where('bill_id', $bill_id)->delete();
+    App\Models\BillData::where('bill_id', $bill_id)->delete();
+    App\Models\BillPerm::where('bill_id', $bill_id)->delete();
+    App\Models\Bill::where('bill_id', $bill_id)->delete();
 
     echo '<div class=infobox>Bill Deleted. Redirecting to Bills list.</div>';
 
@@ -17,8 +19,8 @@ if ($action == 'delete_bill' && $confirm == 'confirm') {
 
 if ($action == 'reset_bill' && ($confirm == 'rrd' || $confirm == 'mysql')) {
     if ($confirm == 'mysql') {
-        \App\Models\BillHistory::where('bill_id', $bill_id)->delete();
-        \App\Models\BillData::where('bill_id', $bill_id)->delete();
+        App\Models\BillHistory::where('bill_id', $bill_id)->delete();
+        App\Models\BillData::where('bill_id', $bill_id)->delete();
     }
 
     if ($confirm == 'rrd') {
@@ -35,7 +37,16 @@ if ($action == 'add_bill_port') {
 }
 
 if ($action == 'delete_bill_port') {
-    \App\Models\BillPort::where('bill_id', $bill_id)->where('port_id', $_POST['port_id'])->delete();
+    App\Models\BillPort::where('bill_id', $bill_id)->where('port_id', $_POST['port_id'])->delete();
+}
+
+if ($action == 'add_bill_sap') {
+    App\Models\BillSap::create(['bill_id' => $_POST['bill_id'], 'sap_id' => $_POST['sap_id']]);
+}
+
+if ($action == 'delete_bill_sap') {
+    App\Models\BillSap::where('bill_id', $bill_id)->where('sap_id', $_POST['sap_id'])->delete();
+    App\Models\BillSapCounter::where('bill_id', $bill_id)->where('sap_id', $_POST['sap_id'])->delete();
 }
 
 if ($action == 'update_bill') {
@@ -43,18 +54,18 @@ if ($action == 'update_bill') {
         if ($_POST['bill_type'] == 'quota') {
             if (isset($_POST['bill_quota_type'])) {
                 if ($_POST['bill_quota_type'] == 'MB') {
-                    $multiplier = (1 * \App\Facades\LibrenmsConfig::get('billing.base'));
+                    $multiplier = (1 * App\Facades\LibrenmsConfig::get('billing.base'));
                 }
 
                 if ($_POST['bill_quota_type'] == 'GB') {
-                    $multiplier = (1 * \App\Facades\LibrenmsConfig::get('billing.base') * \App\Facades\LibrenmsConfig::get('billing.base'));
+                    $multiplier = (1 * App\Facades\LibrenmsConfig::get('billing.base') * App\Facades\LibrenmsConfig::get('billing.base'));
                 }
 
                 if ($_POST['bill_quota_type'] == 'TB') {
-                    $multiplier = (1 * \App\Facades\LibrenmsConfig::get('billing.base') * \App\Facades\LibrenmsConfig::get('billing.base') * \App\Facades\LibrenmsConfig::get('billing.base'));
+                    $multiplier = (1 * App\Facades\LibrenmsConfig::get('billing.base') * App\Facades\LibrenmsConfig::get('billing.base') * App\Facades\LibrenmsConfig::get('billing.base'));
                 }
 
-                $bill_quota = (is_numeric($_POST['bill_quota']) ? $_POST['bill_quota'] * \App\Facades\LibrenmsConfig::get('billing.base') * $multiplier : 0);
+                $bill_quota = (is_numeric($_POST['bill_quota']) ? $_POST['bill_quota'] * App\Facades\LibrenmsConfig::get('billing.base') * $multiplier : 0);
                 $bill_cdr = 0;
             }
         }
@@ -62,15 +73,15 @@ if ($action == 'update_bill') {
         if ($_POST['bill_type'] == 'cdr') {
             if (isset($_POST['bill_cdr_type'])) {
                 if ($_POST['bill_cdr_type'] == 'Kbps') {
-                    $multiplier = (1 * \App\Facades\LibrenmsConfig::get('billing.base'));
+                    $multiplier = (1 * App\Facades\LibrenmsConfig::get('billing.base'));
                 }
 
                 if ($_POST['bill_cdr_type'] == 'Mbps') {
-                    $multiplier = (1 * \App\Facades\LibrenmsConfig::get('billing.base') * \App\Facades\LibrenmsConfig::get('billing.base'));
+                    $multiplier = (1 * App\Facades\LibrenmsConfig::get('billing.base') * App\Facades\LibrenmsConfig::get('billing.base'));
                 }
 
                 if ($_POST['bill_cdr_type'] == 'Gbps') {
-                    $multiplier = (1 * \App\Facades\LibrenmsConfig::get('billing.base') * \App\Facades\LibrenmsConfig::get('billing.base') * \App\Facades\LibrenmsConfig::get('billing.base'));
+                    $multiplier = (1 * App\Facades\LibrenmsConfig::get('billing.base') * App\Facades\LibrenmsConfig::get('billing.base') * App\Facades\LibrenmsConfig::get('billing.base'));
                 }
 
                 $bill_cdr = (is_numeric($_POST['bill_cdr']) ? $_POST['bill_cdr'] * $multiplier : 0);

--- a/includes/html/pages/bill/edit.inc.php
+++ b/includes/html/pages/bill/edit.inc.php
@@ -3,9 +3,9 @@
 // Don't refresh this page to stop adding multiple ports
 $no_refresh = true;
 
-  // This needs more verification. Is it already added? Does it exist?
-  // Calculation to extract MB/GB/TB of Kbps/Mbps/Gbps
-$base = \App\Facades\LibrenmsConfig::get('billing.base');
+// This needs more verification. Is it already added? Does it exist?
+// Calculation to extract MB/GB/TB of Kbps/Mbps/Gbps
+$base = App\Facades\LibrenmsConfig::get('billing.base');
 
 if ($bill_data['bill_type'] == 'quota') {
     $data = $bill_data['bill_quota'];
@@ -101,8 +101,8 @@ if ($bill_data['bill_type'] == 'cdr') {
                 [$bill_data['bill_id']]
             );
 
-            if (is_array($ports)) {
-                ?>
+if (is_array($ports)) {
+    ?>
             <div class="list-group">
                 <?php   foreach ($ports as $port) {
                     $port = cleanPort($port);
@@ -125,16 +125,16 @@ if ($bill_data['bill_type'] == 'cdr') {
                 </div>
                 <?php
                 }
-                if (empty($emptyCheck)) { ?>
+    if (empty($emptyCheck)) { ?>
                 <div class="alert alert-info">There are no ports assigned to this bill</alert>
                 <?php                   } ?>
 
             </div>
 
                 <?php
-            }
-            $port_device_id = -1;
-            ?>
+}
+$port_device_id = -1;
+?>
         </div>
 
         <h4>Add Port</h4>
@@ -171,5 +171,89 @@ if ($bill_data['bill_type'] == 'cdr') {
     init_select2('#port_id', 'port', makePortData, 'Select Port');
     function billDeviceChanged() {
         $('#port_id').val(null).trigger('change'); // clear port selection
+    }
+</script>
+
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <h3 class="panel-title">Billed SAPs</h3>
+        </div>
+        <div class="panel-body">
+        <div class="form-group">
+            <?php
+$saps = App\Models\MplsSap::query()
+    ->select('mpls_saps.*', 'devices.hostname', 'devices.sysName')
+    ->join('bill_saps', 'bill_saps.sap_id', '=', 'mpls_saps.sap_id')
+    ->join('devices', 'devices.device_id', '=', 'mpls_saps.device_id')
+    ->where('bill_saps.bill_id', $bill_data['bill_id'])
+    ->orderBy('devices.device_id')
+    ->get();
+
+if ($saps->isNotEmpty()) {
+    ?>
+            <div class="list-group">
+                <?php   foreach ($saps as $sap) {
+                    $sapdescr = (empty($sap['sapDescription']) ? '' : ' - ' . htmlentities((string) $sap['sapDescription']));
+                    $saplabel = htmlentities((string) $sap['ifName']) . ($sap['sapEncapValue'] ? ':' . htmlentities((string) $sap['sapEncapValue']) : '') . $sapdescr; ?>
+                <div class="list-group-item">
+                    <form action="" class="form-inline" method="post" name="deletesap<?php echo $sap['sap_id'] ?>" style="display: none;">
+                        <?php echo csrf_field() ?>
+                        <input type="hidden" name="action" value="delete_bill_sap" />
+                        <input type="hidden" name="sap_id" value="<?php echo $sap['sap_id'] ?>" />
+                    </form>
+
+                    <button class="btn btn-danger btn-xs pull-right" onclick="if (confirm('Are you sure you wish to remove this SAP?')) { document.forms['deletesap<?php echo $sap['sap_id'] ?>'].submit(); }">
+                        <i class="fa fa-minus"></i>
+                        Remove SAP
+                    </button>
+                    <?php echo generate_device_link($sap); ?>
+                    <i class="fa fa-random"></i>
+                    <?php echo generate_sap_url($sap, $saplabel); ?>
+                </div>
+                <?php
+                } ?>
+            </div>
+                <?php
+} else { ?>
+            <div class="alert alert-info">There are no SAPs assigned to this bill</div>
+                <?php   } ?>
+        </div>
+
+        <h4>Add SAP</h4>
+
+        <form action="" method="post" class="form-horizontal" role="form">
+            <?php echo csrf_field() ?>
+            <input type="hidden" name="action" value="add_bill_sap" />
+            <input type="hidden" name="bill_id" value="<?php echo $bill_id; ?>" />
+
+            <div class="form-group">
+                <label class="col-sm-2 control-label" for="sap_device">Device</label>
+                <div class="col-sm-8">
+                    <select class="form-control input-sm" id="sap_device" name="sap_device" onchange="billSapDeviceChanged()"></select>
+                </div>
+            </div>
+            <div class="form-group">
+                <label class="col-sm-2 control-label" for="sap_id">SAP</label>
+                <div class="col-sm-8">
+                    <select class="form-control input-sm" id="sap_id" name="sap_id"></select>
+                </div>
+            </div>
+            <div class="col-sm-2 col-sm-offset-2">
+                <button type="submit" class="btn btn-primary" name="Submit" value=" Add "><i class="fa fa-plus"></i> Add SAP</button>
+            </div>
+        </form>
+    </div>
+    </div>
+</div>
+</div>
+<script type="text/javascript">
+    const makeSapData = function (param) {
+        param.device = $('#sap_device').val();
+        return param;
+    }
+    init_select2('#sap_device', 'device', {has: 'mplsSaps'}, 'Select Device');
+    init_select2('#sap_id', 'sap', makeSapData, 'Select SAP');
+    function billSapDeviceChanged() {
+        $('#sap_id').val(null).trigger('change'); // clear sap selection
     }
 </script>

--- a/includes/html/pages/bills.inc.php
+++ b/includes/html/pages/bills.inc.php
@@ -82,6 +82,10 @@ if (isset($_POST['addbill']) && $_POST['addbill'] == 'yes') {
         dbInsert(['bill_id' => $bill_id, 'port_id' => $_POST['port_id']], 'bill_ports');
     }
 
+    if (is_numeric($bill_id) && ! empty($_POST['sap_id']) && is_numeric($_POST['sap_id'])) {
+        \App\Models\BillSap::create(['bill_id' => $bill_id, 'sap_id' => $_POST['sap_id']]);
+    }
+
     header('Location: ' . \LibreNMS\Util\Url::generate(['page' => 'bill', 'bill_id' => $bill_id, 'view' => 'edit']));
     exit();
 }

--- a/poll-billing.php
+++ b/poll-billing.php
@@ -38,7 +38,7 @@ if (! isset($options['f']) && $scheduler != 'legacy' && $scheduler != 'cron') {
 $poller_start = microtime(true);
 Log::info("Starting Bill Polling Session ... \n");
 
-$query = \LibreNMS\DB\Eloquent::DB()->table('bills');
+$query = LibreNMS\DB\Eloquent::DB()->table('bills');
 
 if (isset($options['b'])) {
     $query->where('bill_id', $options['b']);
@@ -120,6 +120,69 @@ foreach ($query->get(['bill_id', 'bill_name']) as $bill) {
         $out_delta = ($out_delta + $port_data['out_delta']);
     }//end foreach
 
+    $sap_query = App\Models\MplsSap::query()
+        ->select('mpls_saps.*')
+        ->join('bill_saps', 'bill_saps.sap_id', '=', 'mpls_saps.sap_id')
+        ->join('devices', 'devices.device_id', '=', 'mpls_saps.device_id')
+        ->where('bill_saps.bill_id', $bill_id)
+        ->where('mpls_saps.sapOperStatus', 'up')
+        ->where('devices.status', 1);
+    if (LibrenmsConfig::get('distributed_poller') && LibrenmsConfig::get('distributed_billing')) {
+        $sap_query->whereIn('devices.poller_group', explode(',', (string) LibrenmsConfig::get('distributed_poller_group')));
+    }
+
+    foreach ($sap_query->get() as $sap_data) {
+        $sap_id = $sap_data->sap_id;
+
+        Log::info("  Polling SAP {$sap_data->sapDescription} ({$sap_data->ifName})");
+
+        // SAP traffic counters are collected by the mpls module and stored in the DB
+        $in_measurement = $sap_data->sapIngressOctets;
+        $out_measurement = $sap_data->sapEgressOctets;
+
+        if (! is_numeric($in_measurement) || ! is_numeric($out_measurement)) {
+            Log::error("WATCH out! - No SAP counters for sap_id $sap_id (has the mpls module polled yet?). Table 'bill_sap_counters' not updated");
+            continue;
+        }
+
+        $last_counters = Billing::getLastSapCounter($sap_id, $bill_id);
+        if ($last_counters['state'] == 'ok') {
+            // A SAP's traffic is bounded by the speed of its access port; use it to reject anomalous counter jumps
+            $ifSpeed = (int) App\Models\Port::where('device_id', $sap_data->device_id)->where('ifIndex', $sap_data->sapPortId)->value('ifSpeed');
+            $tmp_period = strtotime((string) $now) - strtotime((string) $last_counters['timestamp']);
+
+            if ($ifSpeed > 0 && (delta_to_bits($in_measurement, $tmp_period) - delta_to_bits($last_counters['in_counter'], $tmp_period)) > $ifSpeed) {
+                $sap_in_delta = $last_counters['in_delta'];
+            } elseif ($in_measurement >= $last_counters['in_counter']) {
+                $sap_in_delta = ($in_measurement - $last_counters['in_counter']);
+            } else {
+                $sap_in_delta = $last_counters['in_delta']; // counter reset/wrap, reuse previous delta
+            }
+
+            if ($ifSpeed > 0 && (delta_to_bits($out_measurement, $tmp_period) - delta_to_bits($last_counters['out_counter'], $tmp_period)) > $ifSpeed) {
+                $sap_out_delta = $last_counters['out_delta'];
+            } elseif ($out_measurement >= $last_counters['out_counter']) {
+                $sap_out_delta = ($out_measurement - $last_counters['out_counter']);
+            } else {
+                $sap_out_delta = $last_counters['out_delta']; // counter reset/wrap, reuse previous delta
+            }
+        } else {
+            $sap_in_delta = '0';
+            $sap_out_delta = '0';
+        }
+
+        Log::debug("****$now: " . $bill->bill_name . " SAP $sap_id in_delta: $sap_in_delta out_delta: $sap_out_delta");
+
+        LibreNMS\DB\Eloquent::DB()->table('bill_sap_counters')->updateOrInsert(
+            ['sap_id' => $sap_id, 'bill_id' => $bill_id],
+            ['timestamp' => $now, 'in_counter' => set_numeric($in_measurement), 'out_counter' => set_numeric($out_measurement), 'in_delta' => set_numeric($sap_in_delta), 'out_delta' => set_numeric($sap_out_delta)]
+        );
+
+        $delta = ($delta + $sap_in_delta + $sap_out_delta);
+        $in_delta = ($in_delta + $sap_in_delta);
+        $out_delta = ($out_delta + $sap_out_delta);
+    }//end foreach
+
     $last_data = Billing::getLastMeasurement($bill_id);
 
     if ($last_data['state'] == 'ok') {
@@ -145,13 +208,19 @@ foreach ($query->get(['bill_id', 'bill_name']) as $bill) {
         Log::debug("BILLING: negative period! id:$bill_id period:$period delta:$delta in_delta:$in_delta out_delta:$out_delta");
     } else {
         // NOTE: casting to string for mysqli bug (fixed by mysqlnd)
+        $sap_count_query = App\Models\BillSap::query()
+            ->join('mpls_saps', 'mpls_saps.sap_id', '=', 'bill_saps.sap_id')
+            ->join('devices', 'devices.device_id', '=', 'mpls_saps.device_id')
+            ->where('bill_saps.bill_id', $bill_id);
         if (LibrenmsConfig::get('distributed_poller') && LibrenmsConfig::get('distributed_billing')) {
             $port_count = dbFetchCell('SELECT COUNT(*) FROM `bill_ports` as P, `ports` as I, `devices` as D WHERE P.bill_id=? AND I.port_id = P.port_id AND D.device_id = I.device_id AND D.poller_group IN (' . LibrenmsConfig::get('distributed_poller_group') . ')', [$bill_id]);
+            $sap_count = $sap_count_query->whereIn('devices.poller_group', explode(',', (string) LibrenmsConfig::get('distributed_poller_group')))->count();
         } else {
             $port_count = dbFetchCell('SELECT COUNT(*) FROM `bill_ports` as P, `ports` as I, `devices` as D WHERE P.bill_id=? AND I.port_id = P.port_id AND D.device_id = I.device_id', [$bill_id]);
+            $sap_count = $sap_count_query->count();
         }
-        if ($port_count > 0) {
-            // If no ports are part of this bill then don't insert a zero value entry
+        if ($port_count > 0 || $sap_count > 0) {
+            // If no ports or saps are part of this bill then don't insert a zero value entry
             dbInsert(['bill_id' => $bill_id, 'timestamp' => $now, 'period' => $period, 'delta' => (string) $delta, 'in_delta' => (string) $in_delta, 'out_delta' => (string) $out_delta], 'bill_data');
         }
     }

--- a/resources/definitions/schema/db_schema.yaml
+++ b/resources/definitions/schema/db_schema.yaml
@@ -384,6 +384,25 @@ bill_port_counters:
     - { Field: bill_id, Type: 'int unsigned', 'Null': false, Extra: '' }
   Indexes:
     PRIMARY: { Name: PRIMARY, Columns: [port_id, bill_id], Unique: true, Type: BTREE }
+bill_sap_counters:
+  Columns:
+    - { Field: sap_id, Type: 'int unsigned', 'Null': false, Extra: '' }
+    - { Field: timestamp, Type: timestamp, 'Null': false, Extra: '', Default: CURRENT_TIMESTAMP }
+    - { Field: in_counter, Type: bigint, 'Null': true, Extra: '' }
+    - { Field: in_delta, Type: bigint, 'Null': false, Extra: '', Default: '0' }
+    - { Field: out_counter, Type: bigint, 'Null': true, Extra: '' }
+    - { Field: out_delta, Type: bigint, 'Null': false, Extra: '', Default: '0' }
+    - { Field: bill_id, Type: 'int unsigned', 'Null': false, Extra: '' }
+  Indexes:
+    PRIMARY: { Name: PRIMARY, Columns: [sap_id, bill_id], Unique: true, Type: BTREE }
+bill_saps:
+  Columns:
+    - { Field: id, Type: 'bigint unsigned', 'Null': false, Extra: auto_increment }
+    - { Field: bill_id, Type: 'int unsigned', 'Null': false, Extra: '' }
+    - { Field: sap_id, Type: 'int unsigned', 'Null': false, Extra: '' }
+    - { Field: bill_sap_autoadded, Type: tinyint, 'Null': false, Extra: '', Default: '0' }
+  Indexes:
+    PRIMARY: { Name: PRIMARY, Columns: [id], Unique: true, Type: BTREE }
 cache:
   Columns:
     - { Field: key, Type: varchar(255), 'Null': false, Extra: '' }
@@ -1201,6 +1220,8 @@ mpls_saps:
     - { Field: sapOperStatus, Type: "enum('up','down')", 'Null': true, Extra: '' }
     - { Field: sapLastMgmtChange, Type: bigint, 'Null': true, Extra: '' }
     - { Field: sapLastStatusChange, Type: bigint, 'Null': true, Extra: '' }
+    - { Field: sapIngressOctets, Type: 'bigint unsigned', 'Null': true, Extra: '' }
+    - { Field: sapEgressOctets, Type: 'bigint unsigned', 'Null': true, Extra: '' }
   Indexes:
     PRIMARY: { Name: PRIMARY, Columns: [sap_id], Unique: true, Type: BTREE }
     mpls_saps_device_id_index: { Name: mpls_saps_device_id_index, Columns: [device_id], Unique: false, Type: BTREE }

--- a/routes/web.php
+++ b/routes/web.php
@@ -118,8 +118,8 @@ Route::middleware(['auth'])->group(function (): void {
         Route::delete('{poller}', [PollerController::class, 'destroy'])->name('poller.destroy');
         Route::delete('cluster/{poller_cluster}', [PollerController::class, 'destroyCluster'])->name('poller-cluster.destroy');
     });
-    Route::delete('ports/purge', [\App\Http\Controllers\PortsController::class, 'purge'])->name('ports.purge');
-    Route::get('ports/{view?}/{graph?}', [\App\Http\Controllers\PortsController::class, 'index'])
+    Route::delete('ports/purge', [App\Http\Controllers\PortsController::class, 'purge'])->name('ports.purge');
+    Route::get('ports/{view?}/{graph?}', [App\Http\Controllers\PortsController::class, 'index'])
         ->middleware('saved-filter:ports')->name('ports');
     Route::prefix('services')->name('services.')->group(function (): void {
         Route::resource('templates', ServiceTemplateController::class);
@@ -348,6 +348,7 @@ Route::middleware(['auth'])->group(function (): void {
             Route::get('poller-group', Select\PollerGroupController::class)->name('ajax.select.poller-group');
             Route::get('port', Select\PortController::class)->name('ajax.select.port');
             Route::get('port-field', Select\PortFieldController::class)->name('ajax.select.port-field');
+            Route::get('sap', Select\SapController::class)->name('ajax.select.sap');
             Route::get('sensor', Select\SensorController::class)->name('ajax.select.sensor');
         });
 


### PR DESCRIPTION
Traffic bills could previously only be built from ports. This adds Nokia SAPs (Service Access Points, discovered by the MPLS module on TiMOS/SR OS devices) as a billable source alongside ports. A bill may mix ports and SAPs, or contain only SAPs.

The MPLS module already polls per-SAP traffic counters into RRD; it now also persists the cumulative ingress/egress octet counters to the mpls_saps table so the billing poller can read them (no extra SNMP in the billing path). poll-billing.php folds SAP deltas into the same bill_data rows used by ports, so the existing 95th/CDR/quota calculation and billing graphs work unchanged.

- migrations: add sapIngressOctets/sapEgressOctets to mpls_saps; create bill_saps and bill_sap_counters (mirroring bill_ports/bill_port_counters)
- models: BillSap, BillSapCounter; Bill::saps()/sapCounters(); MplsSap::bills()
- Timos::pollMplsSaps persists the cumulative octet counters
- Billing::getLastSapCounter() + poll-billing.php SAP loop (with access-port ifSpeed sanity clamp) and bill_data guard for SAP-only bills
- Select/SapController + /ajax/select/sap route; DeviceController gains an optional has=mplsSaps filter so the bill SAP picker only lists SAP devices
- bill edit/detail UI to add, list and remove SAPs (device-controlled SAP fields are html-escaped in the link labels)
- bill traffic graph plots SAP RRDs too; generic_multi_bits_separated gains optional per-file ds_in/ds_out/divisor so bits-based SAP data renders alongside octet-based port data
- docs

<img width="2001" height="808" alt="image" src="https://github.com/user-attachments/assets/5fbd1495-b492-4fdb-afad-8be054e525ac" />

<img width="656" height="696" alt="image" src="https://github.com/user-attachments/assets/083d27a4-b5c6-4475-bc85-3034ee691aad" />


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
