### PR TITLE
Fix dynamic graphs

### DIFF
--- a/app/Http/Requests/GraphsPageRequest.php
+++ b/app/Http/Requests/GraphsPageRequest.php
@@ -170,7 +170,7 @@ class GraphsPageRequest extends FormRequest
     {
         $vars = $this->except(['page', 'username', 'password']);
         $vars['from'] = $this->from;
-        $vars['to'] = $this->to;
+        $vars['to'] = $this->to ?: null;
 
         return array_merge($vars, $overrides);
     }

--- a/resources/views/graphs/show.blade.php
+++ b/resources/views/graphs/show.blade.php
@@ -113,7 +113,7 @@
                     q(item).rrdGraphPng({
                         canvasPadding: 120,
                         initialStart: {{ is_numeric($mainGraphVars['from']) ? $mainGraphVars['from'] : '(new Date()).getTime() / 1000 - 24*3600' }},
-                        initialRange: {{ is_numeric($mainGraphVars['to']) ? $mainGraphVars['to'] - $mainGraphVars['from'] : '24*3600' }}
+                        initialRange: {{ isset($mainGraphVars['to']) ? $mainGraphVars['to'] - $mainGraphVars['from'] : time() - $mainGraphVars['from'] }}
                     })
                 );
             });


### PR DESCRIPTION
Do not allow to=0 to propagate, causes the rrdtool js to generate negative to timestamps.

https://community.librenms.org/t/dragging-zooming-graphs-broken/29350

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
