### PR TITLE
fix(graphs): don't forward thumbnail size into the "open full graph" …

### DIFF
--- a/app/View/Components/Graph.php
+++ b/app/View/Components/Graph.php
@@ -4,6 +4,7 @@ namespace App\View\Components;
 
 use App\Models\Device;
 use App\Models\Port;
+use Illuminate\Support\Arr;
 use Illuminate\View\Component;
 
 class Graph extends Component
@@ -149,8 +150,9 @@ class Graph extends Component
 
     private function getLink(): string
     {
+        $linkVars = Arr::except($this->vars, ['width', 'height', 'legend', 'bg', 'absolute_size']);
         return match ($this->link) {
-            true => url('graphs') . '/' . http_build_query($this->vars + [
+            true => url('graphs') . '/' . http_build_query($linkVars + [
                 'type' => $this->type,
                 'from' => $this->from,
                 'to' => $this->to,

--- a/app/View/Components/Graph.php
+++ b/app/View/Components/Graph.php
@@ -152,11 +152,11 @@ class Graph extends Component
     {
         $linkVars = Arr::except($this->vars, ['width', 'height', 'legend', 'bg', 'absolute_size']);
         return match ($this->link) {
-            true => url('graphs') . '/' . http_build_query($linkVars + [
+            true => route('graphs', $linkVars + [
                 'type' => $this->type,
                 'from' => $this->from,
                 'to' => $this->to,
-            ], '', '/'),
+            ]),
             false => '',
             default => $this->link,
         };

--- a/app/View/Components/Graph.php
+++ b/app/View/Components/Graph.php
@@ -6,6 +6,7 @@ use App\Models\Device;
 use App\Models\Port;
 use Illuminate\Support\Arr;
 use Illuminate\View\Component;
+use LibreNMS\Util\Url;
 
 class Graph extends Component
 {
@@ -151,9 +152,9 @@ class Graph extends Component
     private function getLink(): string
     {
         $linkVars = Arr::except($this->vars, ['width', 'height', 'legend', 'bg', 'absolute_size']);
+
         return match ($this->link) {
-            true => route('graphs', $linkVars + [
-                'type' => $this->type,
+            true => Url::graphPageUrl($this->type, $linkVars + [
                 'from' => $this->from,
                 'to' => $this->to,
             ]),


### PR DESCRIPTION
…link

## Bug

Clicking a small "over:" preview graph in the device page header (e.g. Processor/Memory/Voltage mini-graphs) opens what should be the full-size graph page, but it renders at the *same tiny size* as the thumbnail (e.g. 150x45) instead of the normal full-size default (~1075px wide).

## Root cause

`Graph::getLink()` builds the "open full graph" href by merging the component's own `$vars` with `type`/`from`/`to`. For small preview graphs, `$vars` already contains `width`/`height`/`legend`/`bg` meant for the thumbnail itself (see `Device/Page::overviewGraphs()`).

Since #19813 ("port the graphs page to a dedicated Laravel controller + Blade view"), `GraphsPageController` honors an explicit `width`/`height` from the request and only falls back to its own computed full-size dimensions when they are absent:

```php
$width = max(10, $request->integer('width') ?: $graphWidth);
So a link carrying the thumbnail's own width=150&height=45 makes the
"full size" page render at that same tiny size.

Fix
DevicesController already works around this exact issue at another
call site via Arr::except($graph, ['height', 'width', 'legend', 'title']) before building its graph link. This PR applies the same
exclusion inside Graph::getLink() itself, so every consumer of the
shared <x-graph> / <x-graph-popup> / <x-linked-graph> components
gets it automatically, not just call sites that remember to filter
manually.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
