### PR TITLE
Device availability bar start time

### DIFF
--- a/includes/html/pages/device/overview/availability_bar.inc.php
+++ b/includes/html/pages/device/overview/availability_bar.inc.php
@@ -78,7 +78,11 @@ for ($i = 0; $i < $days; $i++) {
             $time_str = Time::format($outage->going_down, 'time');
             $duration_str = CarbonInterval::seconds($duration)->cascade()->forHumans(['short' => true, 'parts' => 2]);
 
-            $outage_lines[] = "Outage at $time_str &bull; $duration_str";
+            if ($outage->going_down >= $day_start) {
+                $outage_lines[] = "Outage at $time_str &bull; $duration_str";
+            } else {
+                $outage_lines[] = "Outage &bull; $duration_str";
+            }
         }
     }
 


### PR DESCRIPTION
Don't show outage start time if the outage didn't start on that day.

<img width="368" height="227" alt="image" src="https://github.com/user-attachments/assets/b2dc4176-2f32-42c9-9085-5520f53d22d8" />


#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
