### PR TITLE
Stop bad entStateLastChanged breaking entity-physical discovery

### DIFF
--- a/includes/discovery/entity-state.inc.php
+++ b/includes/discovery/entity-state.inc.php
@@ -43,7 +43,7 @@ if (! empty($entPhysical)) {
             $id = $entPhysical[$index];
 
             // format datetime
-            if (empty($state['entStateLastChanged'])) {
+            if (empty($state['entStateLastChanged']) || $state['entStateLastChanged'] === '0-0-0,0:0:0.0,.0:0') {
                 $state['entStateLastChanged'] = null;
             } else {
                 [$date, $time, $tz] = explode(',', (string) $state['entStateLastChanged']);

--- a/includes/polling/entity-state.inc.php
+++ b/includes/polling/entity-state.inc.php
@@ -38,7 +38,7 @@ if (! empty($entityStatesIndexes)) {
     $entLC = snmpwalk_group($device, 'entStateLastChanged', 'ENTITY-STATE-MIB', 0);
 
     foreach (current($entLC) as $index => $changed) {
-        if ($changed) { // skip empty entries
+        if ($changed || $changed === '0-0-0,0:0:0.0,.0:0') { // skip empty entries
             try {
                 [$date, $time, $tz] = explode(',', (string) $changed);
                 $lastChanged = new DateTime("$date $time", new DateTimeZone($tz));


### PR DESCRIPTION
Fixes #20022 

We have '0-0-0,0:0:0.0,.0:0' in lots of tests data so seems like a genuine value.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
