### PR TITLE
Graphs page ignore url set dimensions

### DIFF
--- a/app/Http/Controllers/GraphsPageController.php
+++ b/app/Http/Controllers/GraphsPageController.php
@@ -28,8 +28,8 @@ class GraphsPageController extends Controller
         [$subtypeOptions, $subtypeSelected] = $this->subtypeNavigationOptions($request);
 
         ['width' => $graphWidth, 'height' => $graphHeight, 'thumbWidth' => $thumbWidth] = $this->graphDimensions($request);
-        $width = max(10, $request->integer('width') ?: $graphWidth);
-        $height = max(10, $request->integer('height') ?: $graphHeight);
+        $width = $graphWidth;
+        $height = $graphHeight;
         $mainGraphVars = $request->toVars(['height' => $height, 'width' => $width]);
 
         return view('graphs.show', [
@@ -266,7 +266,7 @@ class GraphsPageController extends Controller
     private function graphUrl(GraphsPageRequest $request, array $changes = []): string
     {
         $params = array_merge(
-            $request->except(['page', 'username', 'password']),
+            $request->except(['page', 'username', 'password', 'width', 'height']),
             $changes
         );
 

--- a/tests/Feature/Http/GraphsPageControllerTest.php
+++ b/tests/Feature/Http/GraphsPageControllerTest.php
@@ -40,6 +40,20 @@ class GraphsPageControllerTest extends TestCase
         $this->assertNoPhpWarningOutput($response->getContent());
     }
 
+    public function testGraphPageIgnoresWidthAndHeightFromUrlInput(): void
+    {
+        $device = Device::factory()->create(['hostname' => 'graph-device.example.com']);
+
+        $response = $this->actingAs($this->adminUser())
+            ->get("/graphs?device={$device->device_id}&type=device_poller_perf&width=2000&height=1000");
+
+        $response->assertOk();
+        $response->assertDontSee('width=2000');
+        $response->assertDontSee('height=1000');
+        $response->assertSee('width=1075');
+        $response->assertSee('height=300');
+    }
+
     public function testDateSelectorUsesSelectedRange(): void
     {
         $device = Device::factory()->create();


### PR DESCRIPTION
Graphs page should set the graph size itself.  Otherwise we could end up zooming in on a tiny graph.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
