### PR TITLE
Remove python dependency check from daily.sh

### DIFF
--- a/daily.php
+++ b/daily.php
@@ -184,13 +184,6 @@ if ($options['f'] === 'handle_notifiable') {
                     2
                 );
                 exit(1);
-            } elseif ($options['r'] === 'python3-deps') {
-                Notifications::create($error_title,
-                    'Python 3 dependencies are missing. You need to install them via pip3 install -r requirements.txt or system packages to continue to receive updates.  If you do not install Python 3 and required packages, LibreNMS will continue to function but stop receiving bug fixes and updates.',
-                    'daily.sh',
-                    2
-                );
-                exit(1);
             }
         }
 

--- a/daily.sh
+++ b/daily.sh
@@ -130,10 +130,12 @@ set_notifiable_result() {
 #   Exit-Code: 0 >= min ver, 1 < min ver
 #######################################
 check_dependencies() {
-    local branch ver_71 ver_72 ver_73 ver_81 ver_82 python3 python_deps phpver pythonver old_branches msg
+    local branch ver_71 ver_72 ver_73 ver_81 ver_82 python3 phpver pythonver old_branches msg
 
     branch=$(git rev-parse --abbrev-ref HEAD)
-    scripts/check_requirements.py > /dev/null 2>&1 || pip3 install -r requirements.txt > /dev/null 2>&1
+
+    # attempt to install python requirements, will likely fail
+    pip3 install -r requirements.txt > /dev/null 2>&1
 
     ver_71=$(php -r "echo (int)version_compare(PHP_VERSION, '7.1.3', '<');")
     ver_72=$(php -r "echo (int)version_compare(PHP_VERSION, '7.2.5', '<');")
@@ -141,19 +143,18 @@ check_dependencies() {
     ver_81=$(php -r "echo (int)version_compare(PHP_VERSION, '8.1', '<');")
     ver_82=$(php -r "echo (int)version_compare(PHP_VERSION, '8.2', '<');")
     python3=$(python3 -c "import sys;print(int(sys.version_info < (3, 4)))" 2> /dev/null)
-    python_deps=$("${LIBRENMS_DIR}/scripts/check_requirements.py" > /dev/null 2>&1; echo $?)
     phpver="master"
     pythonver="master"
 
     old_branches="^(php53|php56|php71-python2|php72|php73|php81)$"
-    if [[ $branch =~ $old_branches ]] && [[ "$ver_82" == "0" && "$python3" == "0" && "$python_deps" == "0" ]]; then
+    if [[ $branch =~ $old_branches ]] && [[ "$ver_82" == "0" && "$python3" == "0" ]]; then
         status_run "Supported PHP and Python version, switched back to master branch." 'git checkout master'
     elif [[ "$ver_71" != "0" ]]; then
         phpver="php56"
         if [[ "$branch" != "php56" ]]; then
             status_run "Unsupported PHP version, switched to php56 branch." 'git checkout php56'
         fi
-    elif [[ "$ver_72" != "0" || "$python3" != "0" || "$python_deps" != "0" ]]; then
+    elif [[ "$ver_72" != "0" || "$python3" != "0" ]]; then
         msg=""
         if [[ "$ver_72" != "0" ]]; then
             msg="Unsupported PHP version, $msg"
@@ -162,9 +163,6 @@ check_dependencies() {
         if [[ "$python3" != "0" ]]; then
             msg="python3 is not available, $msg"
             pythonver="python3-missing"
-        elif [[ "$python_deps" != "0" ]]; then
-            msg="Python 3 dependencies missing, $msg"
-            pythonver="python3-deps"
         fi
 
         if [[ "$branch" != "php71-python2" ]]; then


### PR DESCRIPTION
Do not revert to python2 version anymore due to the dependency check failing. 
Just let users find that out via validate.php
Not removing the python scripts yet due to usage in daily.sh

fixes #19350


#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
