### PR TITLE
BGP context aware peer polling (from #19242)

### DIFF
--- a/includes/discovery/bgp-peers.inc.php
+++ b/includes/discovery/bgp-peers.inc.php
@@ -32,6 +32,7 @@ $routing_snmp_contexts_raw = DeviceCache::getPrimary()->getAttrib('routing_snmp_
 $routing_snmp_contexts = json_decode((string) $routing_snmp_contexts_raw, true);
 
 $contexts = array_values(array_unique(array_merge(
+    [''],
     DeviceCache::getPrimary()->getVrfContexts(),
     $routing_snmp_contexts
 )));
@@ -225,6 +226,7 @@ $contexts = BgpPeer::where('device_id', $device['device_id'])
     ->all();
 
 $existing_contexts = array_values(array_unique(array_merge(
+    [''],
     DeviceCache::getPrimary()->getVrfContexts(),
     $routing_snmp_contexts
 )));

--- a/includes/polling/bgp-peers.inc.php
+++ b/includes/polling/bgp-peers.inc.php
@@ -515,13 +515,11 @@ if (! empty($peers)) {
                 $peer_data_raw = reset($peer_data_raw);  // get the first element of the array
             } elseif (empty($peer_data) && isset($peer_identifiers, $oid_map)) {
                 d_echo("Walking data... \n");
-
-                if (! isset($bgp_cache)) {
-                    $bgp_cache = SnmpQuery::enumStrings()->walk(array_keys($oid_map))->table(count($peer_identifiers));
+                $context_key = $device['context_name'] ?? '';
+                if (! isset($bgp_cache[$context_key])) {
+                    $bgp_cache[$context_key] = SnmpQuery::context($context_key)->enumStrings()->walk(array_keys($oid_map))->table(count($peer_identifiers));
                 }
-
-                // Fetch the snmp item related to this peer
-                $peer_data_raw = array_reduce($peer_identifiers, fn ($ret, $item) => $ret[$item] ?? [], $bgp_cache);
+                $peer_data_raw = array_reduce($peer_identifiers, fn ($ret, $item) => $ret[$item] ?? [], $bgp_cache[$context_key]);
             }
 
             // --- Fill in peer data if raw data has been fetched ---


### PR DESCRIPTION
Fixes BGP peer polling for devices that expose peers through multiple SNMP contexts for multi-VRF (or non-default VRF) deployments.

This was tested specifically against IOS-XR.

As this is fixing how we fetch data with this module, I do not believe any test changes are required.

Code was sourced from user in issue #19242.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
