### PR TITLE
Fix LLDP remote_hostname carry-over when lldpRemSysName is empty

### DIFF
--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -383,6 +383,7 @@ if (($device['os'] == 'routeros') && version_compare($device['version'], '7.7', 
             }
 
             foreach ($lldp_instance as $lldp) {
+                unset($remote_device); // prevent stale remote_device leaking into neighbors with empty lldpRemSysName
                 // If lldpRemPortIdSubtype is 5 and lldpRemPortId is hex, convert it to ASCII.
                 if (isset($lldp['lldpRemPortId']) && $lldp['lldpRemPortIdSubtype'] == 5 && ctype_xdigit(str_replace([' ', ':', '-'], '', strtolower((string) $lldp['lldpRemPortId'])))) {
                     $lldp['lldpRemPortId'] = StringHelpers::hexToAscii($lldp['lldpRemPortId'], ':');


### PR DESCRIPTION
### Description

Fixes a data corruption bug in LLDP discovery: neighbors with an empty `lldpRemSysName` (typically endpoint devices such as Windows PCs using the built-in "Microsoft LLDP Protocol Driver", or Aruba AOS-CX ports facing such endpoints) can end up with `remote_hostname` in the `links` table incorrectly set to the hostname of a *different, unrelated* neighbor.

### Root cause

In `includes/discovery/discovery-protocols.inc.php`, in the generic `LLDP-MIB` branch, inside the per-neighbor `foreach ($lldp_instance as $lldp)` loop:

```php
if (! empty($remote_device_id)) {
    $remote_device = device_by_id_cache($remote_device_id);
    // ...
}
// ...
if (empty($lldp['lldpRemSysName']) && isset($remote_device)) {
    $lldp['lldpRemSysName'] = $remote_device['sysName'] ?: $remote_device['hostname'];
}
```

`$remote_device` is only assigned when a neighbor resolves to a monitored device, but it was never unset between loop iterations. So when a later port's neighbor sends an empty `lldpRemSysName` (typical for endpoint PCs), the `isset($remote_device)` fallback picks up the value left over from a *previous* iteration and stores that device's name as `remote_hostname`.

This produces rows like:

```
remote_device_id = 0, remote_port_id = NULL, remote_port = <a MAC address>, remote_hostname = <name of an unrelated, real monitored device>
```

Reported with full SNMP walk data and CLI cross-checks in #19163 (Aruba AOS-CX), and is the same underlying issue as #17873 (HP Procurve / Catalyst).

### Fix

Add `unset($remote_device);` at the top of the per-neighbor loop so a resolved device from one neighbor can never leak into the next neighbor's empty-sysName fallback.

### Verification

Verified in production (see [#19163 comment](https://github.com/librenms/librenms/issues/19163#issuecomment-4874603002)): after applying this fix and deleting the previously-created bogus `links` rows, repeated `lnms device:discover <id> -m discovery-protocols` runs no longer recreate them, while genuine LLDP neighbors (switch uplinks with a real sysName, IP phones, etc.) are unaffected.

`php -l` confirms no syntax errors in the modified file. I did not add an automated snmpsim/fixture regression test for this change — happy to add one if a maintainer can point me at the right fixture to extend.

Fixes #19163
