### PR TITLE
Fix availability widget performance when scheduled maintenance is active

### DIFF
--- a/app/Http/Controllers/Widgets/AvailabilityMapController.php
+++ b/app/Http/Controllers/Widgets/AvailabilityMapController.php
@@ -97,13 +97,13 @@ class AvailabilityMapController extends WidgetController
         $active_maintenance = AlertSchedule::isActive()->pluck('schedule_id');
         if ($active_maintenance->count() > 0) {
             $active_maintenance_devices = Device::query()
-                ->whereHas('alertSchedules', function (Builder $q) use ($active_maintenance) {
+                ->whereHas('alertSchedules', function (Builder $q) use ($active_maintenance): void {
                     $q->wherein('alert_schedule.schedule_id', $active_maintenance);
                 })
-                ->orWhereHas('location.alertSchedules', function (Builder $q) use ($active_maintenance) {
+                ->orWhereHas('location.alertSchedules', function (Builder $q) use ($active_maintenance): void {
                     $q->wherein('alert_schedule.schedule_id', $active_maintenance);
                 })
-                ->orWhereHas('groups.alertSchedules', function (Builder $q) use ($active_maintenance) {
+                ->orWhereHas('groups.alertSchedules', function (Builder $q) use ($active_maintenance): void {
                     $q->wherein('alert_schedule.schedule_id', $active_maintenance);
                 })
                 ->pluck('device_id');

--- a/app/Http/Controllers/Widgets/AvailabilityMapController.php
+++ b/app/Http/Controllers/Widgets/AvailabilityMapController.php
@@ -31,6 +31,7 @@ use App\Models\AlertSchedule;
 use App\Models\Device;
 use App\Models\DeviceGroup;
 use App\Models\Service;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\View\View;
@@ -93,7 +94,19 @@ class AvailabilityMapController extends WidgetController
 
         // process status
         $uptime_warn = (int) LibrenmsConfig::get('uptime_warning', 86400);
-        $check_maintenance = AlertSchedule::isActive()->exists(); // check if any maintenance schedule is active
+        $active_maintenance = AlertSchedule::isActive()->pluck('schedule_id');
+        if ($active_maintenance->count() > 0) {
+            $active_maintenance_devices = Device::whereHas('alertSchedules', function (Builder $q) use ($active_maintenance) {
+                    $q->wherein('alert_schedule.schedule_id', $active_maintenance);
+                })
+                ->orWhereHas('location.alertSchedules', function (Builder $q) use ($active_maintenance) {
+                    $q->wherein('alert_schedule.schedule_id', $active_maintenance);
+                })
+                ->orWhereHas('groups.alertSchedules', function (Builder $q) use ($active_maintenance) {
+                    $q->wherein('alert_schedule.schedule_id', $active_maintenance);
+                })
+                ->pluck('device_id');
+        }
         // TODO: take a deeper look, why key ignored still has to exist
         $totals = ['warn' => 0, 'up' => 0, 'down' => 0, 'maintenance' => 0, 'ignored' => 0, 'ignored-up' => 0, 'ignored-down' => 0, 'disabled' => 0];
         $data = [];
@@ -103,7 +116,7 @@ class AvailabilityMapController extends WidgetController
             [$state_name, $class] = $this->parseDeviceState($device, $uptime_warn);
             $totals[$state_name]++;
 
-            if ($check_maintenance && $device->isUnderMaintenance()) {
+            if (isset($active_maintenance_devices) && $active_maintenance_devices->contains($device->device_id)) {
                 $class = 'label-default';
                 $totals['maintenance']++;
             }

--- a/app/Http/Controllers/Widgets/AvailabilityMapController.php
+++ b/app/Http/Controllers/Widgets/AvailabilityMapController.php
@@ -96,7 +96,8 @@ class AvailabilityMapController extends WidgetController
         $uptime_warn = (int) LibrenmsConfig::get('uptime_warning', 86400);
         $active_maintenance = AlertSchedule::isActive()->pluck('schedule_id');
         if ($active_maintenance->count() > 0) {
-            $active_maintenance_devices = Device::whereHas('alertSchedules', function (Builder $q) use ($active_maintenance) {
+            $active_maintenance_devices = Device::query()
+                ->whereHas('alertSchedules', function (Builder $q) use ($active_maintenance) {
                     $q->wherein('alert_schedule.schedule_id', $active_maintenance);
                 })
                 ->orWhereHas('location.alertSchedules', function (Builder $q) use ($active_maintenance) {

--- a/app/Models/Location.php
+++ b/app/Models/Location.php
@@ -31,6 +31,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Support\Facades\Gate;
 use LibreNMS\Util\Dns;
 
@@ -188,6 +189,14 @@ class Location extends Model
     public function devices(): HasMany
     {
         return $this->hasMany(Device::class, 'location_id');
+    }
+
+    /**
+     * @return MorphToMany<AlertSchedule, $this>
+     */
+    public function alertSchedules(): MorphToMany
+    {
+        return $this->morphToMany(AlertSchedule::class, 'alert_schedulable', 'alert_schedulables', 'alert_schedulable_id', 'schedule_id');
     }
 
     public function __toString(): string


### PR DESCRIPTION
Our availability map widget was periodically giving us slow performance, which I tracked down to doing one query per device when any maintenance schedule is active.

This PR resolves the issue by getting a list of device IDs affected by active maintenance schedules, and then checking this list for devices under maintenance.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
