### PR TITLE
Tests: Data Provider cache 

### DIFF
--- a/LibreNMS/Util/DataProviderCache.php
+++ b/LibreNMS/Util/DataProviderCache.php
@@ -27,7 +27,7 @@ class DataProviderCache
 
         $data = $callback();
 
-        if (!is_dir(dirname($cacheFile))) {
+        if (! is_dir(dirname($cacheFile))) {
             @mkdir(dirname($cacheFile), 0755, true);
         }
 

--- a/LibreNMS/Util/DataProviderCache.php
+++ b/LibreNMS/Util/DataProviderCache.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LibreNMS\Util;
+
+class DataProviderCache
+{
+    /**
+     * Cache test or data provider result in a persistent file cache on disk.
+     * Automatically invalidates if the monitored file or directory modification time ($watchPath) is newer than the cache file.
+     *
+     * @param  string  $key  Unique cache identifier key
+     * @param  string  $watchPath  File or directory path to monitor for mtime changes
+     * @param  callable(): mixed  $callback
+     * @return mixed
+     */
+    public static function remember(string $key, string $watchPath, callable $callback): mixed
+    {
+        $basePath = realpath(__DIR__ . '/../..');
+        $cacheFile = $basePath . '/storage/framework/cache/test_' . $key . '.php';
+        $watchMtime = self::getWatchMtime($watchPath);
+
+        if (file_exists($cacheFile) && filemtime($cacheFile) >= $watchMtime) {
+            return require $cacheFile;
+        }
+
+        $data = $callback();
+
+        if (!is_dir(dirname($cacheFile))) {
+            @mkdir(dirname($cacheFile), 0755, true);
+        }
+
+        @file_put_contents($cacheFile, '<?php return ' . var_export($data, true) . ';');
+
+        return $data;
+    }
+
+    private static function getWatchMtime(string $watchPath): int
+    {
+        $mtime = @filemtime($watchPath);
+        if ($mtime === false) {
+            return PHP_INT_MAX; // Force cache invalidation if filesystem stat fails
+        }
+
+        if (is_dir($watchPath)) {
+            $files = glob(rtrim($watchPath, '/') . '/*');
+            if ($files) {
+                foreach ($files as $file) {
+                    $fmtime = @filemtime($file);
+                    if ($fmtime !== false && $fmtime > $mtime) {
+                        $mtime = $fmtime;
+                    }
+                }
+            }
+        }
+
+        return $mtime;
+    }
+
+    /**
+     * Clear all persistent test cache files.
+     */
+    public static function clear(): void
+    {
+        $basePath = realpath(__DIR__ . '/../..');
+        $dir = $basePath . '/storage/framework/cache';
+
+        if (is_dir($dir)) {
+            foreach (glob($dir . '/test_*.php') as $file) {
+                @unlink($file);
+            }
+        }
+    }
+}

--- a/LibreNMS/Util/ModuleTestHelper.php
+++ b/LibreNMS/Util/ModuleTestHelper.php
@@ -246,8 +246,14 @@ class ModuleTestHelper
      */
     public static function findOsWithData(array $modules = [], ?string $os_filter = null, ?string $base_path = null): array
     {
-        $os_list = [];
+        static $cache = [];
         $base_path ??= base_path();
+        $cache_key = md5(implode(',', $modules) . '|' . ($os_filter ?? '') . '|' . $base_path);
+        if (isset($cache[$cache_key])) {
+            return $cache[$cache_key];
+        }
+
+        $os_list = [];
 
         foreach (glob($base_path . '/tests/data/*.json') as $file) {
             $base_name = basename($file, '.json');
@@ -288,7 +294,7 @@ class ModuleTestHelper
             }
         }
 
-        return $os_list;
+        return $cache[$cache_key] = $os_list;
     }
 
     /**

--- a/LibreNMS/Util/ModuleTestHelper.php
+++ b/LibreNMS/Util/ModuleTestHelper.php
@@ -246,55 +246,54 @@ class ModuleTestHelper
      */
     public static function findOsWithData(array $modules = [], ?string $os_filter = null, ?string $base_path = null): array
     {
-        static $cache = [];
-        $base_path ??= base_path();
-        $cache_key = md5(implode(',', $modules) . '|' . ($os_filter ?? '') . '|' . $base_path);
-        if (isset($cache[$cache_key])) {
-            return $cache[$cache_key];
-        }
+        $base_path ??= (function_exists('base_path') ? base_path() : realpath(__DIR__ . '/../..'));
+        $cacheKey = 'os_modules_' . md5(implode(',', $modules) . '|' . ($os_filter ?? '') . '|' . $base_path);
+        $dataPath = $base_path . '/tests/data';
 
-        $os_list = [];
+        return DataProviderCache::remember($cacheKey, $dataPath, function () use ($modules, $os_filter, $base_path) {
+            $os_list = [];
 
-        foreach (glob($base_path . '/tests/data/*.json') as $file) {
-            $base_name = basename($file, '.json');
-            [$os, $variant] = self::extractVariant($file, $base_path);
+            foreach (glob($base_path . '/tests/data/*.json') as $file) {
+                $base_name = basename($file, '.json');
+                [$os, $variant] = self::extractVariant($file, $base_path);
 
-            if ($os_filter != '' && $os_filter != $os) {
-                continue;
+                if ($os_filter != '' && $os_filter != $os) {
+                    continue;
+                }
+
+                // calculate valid modules
+                $decoded = json_decode(file_get_contents($file), true);
+
+                if (json_last_error()) {
+                    echo "Invalid json data: $base_name\n";
+                    exit(1);
+                }
+
+                $data_modules = array_keys($decoded);
+
+                if (empty($modules)) {
+                    $valid_modules = $data_modules;
+                } else {
+                    $valid_modules = array_intersect($modules, $data_modules);
+                }
+
+                if (empty($valid_modules)) {
+                    continue;  // no test data for selected modules
+                }
+
+                try {
+                    $os_list[$base_name] = [
+                        $os,
+                        $variant,
+                        self::resolveModuleDependencies($valid_modules),
+                    ];
+                } catch (InvalidModuleException $e) {
+                    throw new InvalidModuleException('Invalid module ' . $e->getMessage() . " in $os $variant");
+                }
             }
 
-            // calculate valid modules
-            $decoded = json_decode(file_get_contents($file), true);
-
-            if (json_last_error()) {
-                echo "Invalid json data: $base_name\n";
-                exit(1);
-            }
-
-            $data_modules = array_keys($decoded);
-
-            if (empty($modules)) {
-                $valid_modules = $data_modules;
-            } else {
-                $valid_modules = array_intersect($modules, $data_modules);
-            }
-
-            if (empty($valid_modules)) {
-                continue;  // no test data for selected modules
-            }
-
-            try {
-                $os_list[$base_name] = [
-                    $os,
-                    $variant,
-                    self::resolveModuleDependencies($valid_modules),
-                ];
-            } catch (InvalidModuleException $e) {
-                throw new InvalidModuleException('Invalid module ' . $e->getMessage() . " in $os $variant");
-            }
-        }
-
-        return $cache[$cache_key] = $os_list;
+            return $os_list;
+        });
     }
 
     /**

--- a/tests/MibTest.php
+++ b/tests/MibTest.php
@@ -132,6 +132,11 @@ final class MibTest extends TestCase
      */
     public static function mibFiles(): array
     {
+        static $cache = null;
+        if ($cache !== null) {
+            return $cache;
+        }
+
         $mib_base = self::basePath('mibs');
         $install_dir = self::basePath();
 
@@ -149,7 +154,7 @@ final class MibTest extends TestCase
             ];
         }
 
-        return $file_list;
+        return $cache = $file_list;
     }
 
     /**
@@ -159,6 +164,11 @@ final class MibTest extends TestCase
      */
     public static function mibDirs(): array
     {
+        static $cache = null;
+        if ($cache !== null) {
+            return $cache;
+        }
+
         $mib_base = self::basePath('mibs');
 
         $dirs = glob($mib_base . '/*', GLOB_ONLYDIR);
@@ -170,7 +180,7 @@ final class MibTest extends TestCase
             $final_list[$relative_dir] = [$dir];
         }
 
-        return $final_list;
+        return $cache = $final_list;
     }
 
     /**

--- a/tests/MibTest.php
+++ b/tests/MibTest.php
@@ -29,6 +29,7 @@ namespace LibreNMS\Tests;
 use App\Facades\LibrenmsConfig;
 use Exception;
 use Illuminate\Support\Str;
+use LibreNMS\Util\DataProviderCache;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use RecursiveDirectoryIterator;
@@ -132,29 +133,26 @@ final class MibTest extends TestCase
      */
     public static function mibFiles(): array
     {
-        static $cache = null;
-        if ($cache !== null) {
-            return $cache;
-        }
-
         $mib_base = self::basePath('mibs');
         $install_dir = self::basePath();
 
-        $file_list = [];
-        foreach (new RecursiveIteratorIterator(new RecursiveDirectoryIterator($mib_base)) as $file) {
-            /** @var SplFileInfo $file */
-            if ($file->isDir()) {
-                continue;
+        return DataProviderCache::remember('mib_files', $mib_base, function () use ($mib_base, $install_dir) {
+            $file_list = [];
+            foreach (new RecursiveIteratorIterator(new RecursiveDirectoryIterator($mib_base)) as $file) {
+                /** @var SplFileInfo $file */
+                if ($file->isDir()) {
+                    continue;
+                }
+                $mib_path = str_replace($mib_base . '/', '', $file->getPathname());
+                $file_list[$mib_path] = [
+                    str_replace($install_dir, '.', $file->getPath()),
+                    $file->getFilename(),
+                    self::extractMibName($file->getPathname()),
+                ];
             }
-            $mib_path = str_replace($mib_base . '/', '', $file->getPathname());
-            $file_list[$mib_path] = [
-                str_replace($install_dir, '.', $file->getPath()),
-                $file->getFilename(),
-                self::extractMibName($file->getPathname()),
-            ];
-        }
 
-        return $cache = $file_list;
+            return $file_list;
+        });
     }
 
     /**
@@ -164,23 +162,20 @@ final class MibTest extends TestCase
      */
     public static function mibDirs(): array
     {
-        static $cache = null;
-        if ($cache !== null) {
-            return $cache;
-        }
-
         $mib_base = self::basePath('mibs');
 
-        $dirs = glob($mib_base . '/*', GLOB_ONLYDIR);
-        array_unshift($dirs, $mib_base);
+        return DataProviderCache::remember('mib_dirs', $mib_base, function () use ($mib_base) {
+            $dirs = glob($mib_base . '/*', GLOB_ONLYDIR);
+            array_unshift($dirs, $mib_base);
 
-        $final_list = [];
-        foreach ($dirs as $dir) {
-            $relative_dir = ltrim(str_replace($mib_base, '', $dir), '/');
-            $final_list[$relative_dir] = [$dir];
-        }
+            $final_list = [];
+            foreach ($dirs as $dir) {
+                $relative_dir = ltrim(str_replace($mib_base, '', $dir), '/');
+                $final_list[$relative_dir] = [$dir];
+            }
 
-        return $cache = $final_list;
+            return $final_list;
+        });
     }
 
     /**


### PR DESCRIPTION
Cache data provider output for data providers that are slow and called multiple times.
Try to have automatic invalidation.
saves 3s-6s on test runs that reference the entire test suite such as lnms test --filter=<TestName>
Avoid Laravel cache so we don't have to boot the application in phpunit bootstrap

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
