### PR TITLE
Optimize plugin loading

### DIFF
--- a/app/Providers/PluginProvider.php
+++ b/app/Providers/PluginProvider.php
@@ -27,11 +27,12 @@
 namespace App\Providers;
 
 use App\Exceptions\PluginDoesNotImplementHookException;
+use Illuminate\Contracts\Support\DeferrableProvider;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
 use LibreNMS\Interfaces\Plugins\PluginManagerInterface;
 
-class PluginProvider extends ServiceProvider
+class PluginProvider extends ServiceProvider implements DeferrableProvider
 {
     public function register(): void
     {
@@ -41,6 +42,13 @@ class PluginProvider extends ServiceProvider
     public function boot(): void
     {
         $this->loadLocalPlugins($this->app->make(PluginManagerInterface::class));
+    }
+
+    public function provides(): array
+    {
+        return [
+            PluginManagerInterface::class,
+        ];
     }
 
     /**


### PR DESCRIPTION
we don't need to load plugins for every application run, only load them on demand defer provider loading entirely until needed

saves ~40ms on everything except web pages. (but this does save for ajax requests, etc)

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
