### PR TITLE
MariaDB 11.7 is EOL

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,11 +37,11 @@ jobs:
           -
             name: PHP 8.4
             php-version: 8.4
-            database: mariadb:11.7
+            database: mariadb:11.8
           -
             name: Other
             php-version: 8.4
-            database: mariadb:11.7
+            database: mariadb:11.8
             arguments: --full --exclude-phpunit-group=browser,mibs,external-dependencies,os
           -
             name: Other


### PR DESCRIPTION
11.8 is probably a better candidate for testing since it's LTS. Other good candidates (LTS) are 10.11, 11.4 and 12.3.

Also good to know:
- Debian 13 comes with MariaDB 11.8
- Ubuntu 16.04 comes with MariaDB 11.8
- RHEL10 (and derivates) comes with MariaDB 10.11
- Fedora 44 comes with MariaDB 11.8

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
