### PR TITLE
World Map Widget: try to zoom to fit on first load

### DIFF
--- a/resources/views/widgets/world-map.blade.php
+++ b/resources/views/widgets/world-map.blade.php
@@ -43,6 +43,7 @@
                     });
 
                     var map = get_map(map_id);
+                    var isFirstLoad = ! map.markerCluster;
                     if (! map.markerCluster) {
                         map.markerCluster = L.markerClusterGroup({
                             maxClusterRadius: group_radius,
@@ -71,6 +72,13 @@
 
                     map.markerCluster.clearLayers();
                     map.markerCluster.addLayers(markers);
+
+                    if (isFirstLoad && markers.length > 0) {
+                        map.fitBounds(map.markerCluster.getBounds(), {
+                            padding: [30, 30],
+                            maxZoom: 12
+                        });
+                    }
                 },
                 error: function(error){
                     toastr.error(error.statusText);


### PR DESCRIPTION
What this does

Currently, the World Map widget always centers on the manually configured default_lat / default_lng / default_zoom, regardless of where devices actually are. This means the widget often opens either too zoomed-in (showing only part of your devices) or too zoomed-out (a mostly empty map), requiring manual panning/zooming every time.

This PR makes the map automatically fit its bounds to the actual device markers the first time the widget loads, using Leaflet's built-in fitBounds(). On subsequent refreshes (e.g. periodic auto-refresh), the user's current map position/zoom is preserved — the auto-fit only happens once, so it doesn't fight with manual panning/zooming during normal use.

This addresses a long-standing request (see #4856) for the map to auto-scale to visible devices instead of requiring a fixed, manually-tuned default view.

How it works
Tracks whether this is the first load of the widget instance (isFirstLoad).
After markers are added to the cluster group, if it's the first load and there's at least one device with a location, calls map.fitBounds() on the cluster group's bounds, with a small padding (30px) and a maxZoom cap (12) so a single device or tightly-clustered devices don't cause an excessive zoom level.
Testing done

Tested on a self-hosted instance with ~25 devices spread across multiple cities. Confirmed:

Widget opens correctly framed around all devices on first load.
Panning/zooming manually and then triggering a refresh does not reset the view.
Works correctly with both a single device and with tightly clustered devices (no runaway zoom).
Backwards compatibility

No config changes required. Existing default_lat/default_lng/default_zoom settings remain functional as the initial map state before markers load; they just no longer determine the final resting view once devices are plotted.

DO NOT DELETE THE UNDERLYING TEXT

Please note
Please read this information carefully. Pull requests may be closed without explanation
due to influx of low quality LLM generated pull requests.
You can run ./lnms dev:check to check your code before submitting.

 Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
 If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
 If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).
Testers
If you would like to test this pull request then please run: ./scripts/github-apply <pr_id>, i.e ./scripts/github-apply 5926
After you are done testing, you can remove the changes with ./scripts/github-remove. If there are schema changes, you can ask on discord how to revert.