### PR TITLE
flip epair A/B for jails

### DIFF
--- a/includes/html/pages/device/apps/oslv_monitor.inc.php
+++ b/includes/html/pages/device/apps/oslv_monitor.inc.php
@@ -8,6 +8,22 @@ $name = 'oslv_monitor';
 
 $device_obj = DeviceCache::get($device['device_id']);
 
+// FreeBSD epair interfaces are created in pairs, epairNa and epairNb. The end
+// reported here is the guest side, while the host device LibreNMS polls has the
+// opposite end, so on FreeBSD whenever the name is an epairNa/epairNb, flip the
+// a/b suffix and look up that counterpart instead.
+$oslvm_find_port = function ($device_id, $if_name) use ($device) {
+    if ($device['os'] === 'freebsd' && preg_match('/^epair.*[ab]$/', (string) $if_name)) {
+        $if_name = preg_replace_callback(
+            '/[ab]$/',
+            fn ($matches) => $matches[0] === 'a' ? 'b' : 'a',
+            (string) $if_name
+        );
+    }
+
+    return Port::with('device')->firstWhere(['device_id' => $device_id, 'ifName' => $if_name]);
+};
+
 $link_array = [
     'page' => 'device',
     'device' => $device['device_id'],
@@ -439,7 +455,7 @@ if (isset($vars['oslvm']) && isset($app_data['oslvm_data'][$vars['oslvm']])) {
                     if (isset($ip_data['if']) && ! is_null($ip_data['if'])) {
                         $interface = $ip_data['if'];
                         $interface = htmlspecialchars((string) $interface);
-                        $port = Port::with('device')->firstWhere(['device_id' => $app->device_id, 'ifName' => $interface]);
+                        $port = $oslvm_find_port($app->device_id, $interface);
                         if (isset($port)) {
                             $interface_raw = true;
                             $interface = generate_port_link([
@@ -460,7 +476,7 @@ if (isset($vars['oslvm']) && isset($app_data['oslvm_data'][$vars['oslvm']])) {
                     if (isset($ip_data['gw_if']) && ! is_null($ip_data['gw_if'])) {
                         $gw_interface = $ip_data['gw_if'];
                         $gw_interface = htmlspecialchars((string) $gw_interface);
-                        $port = Port::with('device')->firstWhere(['device_id' => $app->device_id, 'ifName' => $gw_interface]);
+                        $port = $oslvm_find_port($app->device_id, $gw_interface);
                         if (isset($port)) {
                             $gw_interface_raw = true;
                             $gw_interface = generate_port_link([


### PR DESCRIPTION
These are created in pairs and are how the host system passes a interface to a jail. Both only have access to one end of it. Thus when querying it in the app page it needs flipped from what ever is being reported in the jail.

https://man.freebsd.org/cgi/man.cgi?epair

Honestly a bit torn between fixing it here and fixing it the extend. The extend reports accurate data, but that data is misleading as to what needs displayed.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
