### PR TITLE
Add configuration options to control what is included in the global search

### DIFF
--- a/app/Http/Controllers/Ajax/Search/DevicesSearchController.php
+++ b/app/Http/Controllers/Ajax/Search/DevicesSearchController.php
@@ -36,6 +36,10 @@ class DevicesSearchController extends GroupedSearchController
                 ->orWhereRelation('ports.ipv6', 'ipv6_compressed', 'like', $like)
                 ->orWhereRelation('ports', 'ifPhysAddress', 'like', '%' . $mac . '%')
                 ->orWhere('overwrite_ip', 'like', $like);
+
+            if (\LibreNMS\Util\IPv6::isValid($search, false)) {
+                $query->orWhere('ip', '=', inet_pton($search));
+            }
         } elseif (ctype_xdigit($mac)) {
             $query->orWhereRelation('ports', 'ifPhysAddress', 'like', '%' . $mac . '%');
         }

--- a/app/Http/Controllers/Ajax/Search/DevicesSearchController.php
+++ b/app/Http/Controllers/Ajax/Search/DevicesSearchController.php
@@ -36,16 +36,12 @@ class DevicesSearchController extends GroupedSearchController
                 ->orWhereRelation('ports.ipv6', 'ipv6_compressed', 'like', $like)
                 ->orWhereRelation('ports', 'ifPhysAddress', 'like', '%' . $mac . '%')
                 ->orWhere('overwrite_ip', 'like', $like);
-
-            if (\LibreNMS\Util\IPv6::isValid($search, false)) {
-                $query->orWhere('ip', '=', inet_pton($search));
-            }
         } elseif (ctype_xdigit($mac)) {
             $query->orWhereRelation('ports', 'ifPhysAddress', 'like', '%' . $mac . '%');
         }
 
         // A MAC-style search (with or without separators) can also match FDB entries
-        if (ctype_xdigit($mac)) {
+        if (LibrenmsConfig::get('webui.global_search_device_fdb') && ctype_xdigit($mac)) {
             $query->orWhereRelation('portsFdb', 'mac_address', 'like', '%' . $mac . '%');
         }
 

--- a/app/Http/Controllers/Ajax/Search/HealthSearchController.php
+++ b/app/Http/Controllers/Ajax/Search/HealthSearchController.php
@@ -16,6 +16,10 @@ class HealthSearchController extends GroupedSearchController
 {
     protected function groups(string $search, string $like, int $limit, ?User $user): array
     {
+        if (! LibrenmsConfig::get('webui.global_search_health')) {
+            return [null];
+        }
+
         $sensors = Sensor::hasAccess($user)->with('device')->where('sensor_deleted', 0)
             ->where(fn (Builder $q) => $q->where('sensor_descr', 'like', $like)
                 ->orWhere('sensor_class', 'like', $like)

--- a/app/Http/Controllers/Ajax/Search/LogsSearchController.php
+++ b/app/Http/Controllers/Ajax/Search/LogsSearchController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Ajax\Search;
 
+use App\Facades\LibrenmsConfig;
 use App\Models\Eventlog;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Builder;
@@ -12,6 +13,10 @@ class LogsSearchController extends GroupedSearchController
 {
     protected function groups(string $search, string $like, int $limit, ?User $user): array
     {
+        if (! LibrenmsConfig::get('webui.global_search_eventlogs')) {
+            return [null];
+        }
+
         $eventlog = Eventlog::hasAccess($user)->with('device')
             ->where(fn (Builder $q) => $q->where('message', 'like', $like)
                 ->orWhere('type', 'like', $like)

--- a/app/Http/Controllers/Ajax/Search/PortsSearchController.php
+++ b/app/Http/Controllers/Ajax/Search/PortsSearchController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Ajax\Search;
 
+use App\Facades\LibrenmsConfig;
 use App\Models\Port;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Builder;
@@ -12,6 +13,10 @@ class PortsSearchController extends GroupedSearchController
 {
     protected function groups(string $search, string $like, int $limit, ?User $user): array
     {
+        if (! LibrenmsConfig::get('webui.global_search_ports')) {
+            return [null];
+        }
+
         $ports = Port::hasAccess($user)->with('device')->where('deleted', 0)
             ->where(fn (Builder $q) => $q->where('ifAlias', 'like', $like)
                 ->orWhere('ifDescr', 'like', $like)

--- a/app/Http/Controllers/Ajax/Search/RoutingSearchController.php
+++ b/app/Http/Controllers/Ajax/Search/RoutingSearchController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Ajax\Search;
 
+use App\Facades\LibrenmsConfig;
 use App\Models\BgpPeer;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Builder;
@@ -11,6 +12,10 @@ class RoutingSearchController extends GroupedSearchController
 {
     protected function groups(string $search, string $like, int $limit, ?User $user): array
     {
+        if (! LibrenmsConfig::get('webui.global_search_routing')) {
+            return [null];
+        }
+
         $bgp = BgpPeer::hasAccess($user)->with('device')
             ->where(fn (Builder $q) => $q->where('astext', 'like', $like)
                 ->orWhere('bgpPeerDescr', 'like', $like)

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -2517,6 +2517,26 @@ return [
                 'description' => 'Set the max search result limit',
                 'help' => 'Global search results limit',
             ],
+            'global_search_device_fdb' => [
+                'description' => 'Global search device FDB table',
+                'help' => 'Find devices with matching FDB table entries in the global search results',
+            ],
+            'global_search_eventlogs' => [
+                'description' => 'Global search event logs',
+                'help' => 'Find matching event logs in the global search results',
+            ],
+            'global_search_health' => [
+                'description' => 'Global search health',
+                'help' => 'Find matching health sensors in the global search results',
+            ],
+            'global_search_ports' => [
+                'description' => 'Global search ports',
+                'help' => 'Find matching ports in the global search results',
+            ],
+            'global_search_routing' => [
+                'description' => 'Global search route peers',
+                'help' => 'Find matching routing peers in the global search results',
+            ],
             'graph_stacked' => [
                 'description' => 'Use stacked graphs',
                 'help' => 'Display stacked graphs instead of inverted graphs',

--- a/resources/definitions/config_definitions.json
+++ b/resources/definitions/config_definitions.json
@@ -7522,6 +7522,41 @@
             "order": 0,
             "type": "integer"
         },
+        "webui.global_search_device_fdb": {
+            "default": true,
+            "group": "webui",
+            "section": "search",
+            "order": 1,
+            "type": "boolean"
+        },
+        "webui.global_search_eventlogs": {
+            "default": true,
+            "group": "webui",
+            "section": "search",
+            "order": 2,
+            "type": "boolean"
+        },
+        "webui.global_search_health": {
+            "default": true,
+            "group": "webui",
+            "section": "search",
+            "order": 3,
+            "type": "boolean"
+        },
+        "webui.global_search_ports": {
+            "default": true,
+            "group": "webui",
+            "section": "search",
+            "order": 4,
+            "type": "boolean"
+        },
+        "webui.global_search_routing": {
+            "default": true,
+            "group": "webui",
+            "section": "search",
+            "order": 5,
+            "type": "boolean"
+        },
         "webui.graph_stacked": {
             "default": false,
             "group": "webui",

--- a/resources/views/layouts/menu.blade.php
+++ b/resources/views/layouts/menu.blade.php
@@ -863,9 +863,8 @@
                 route('ajax.search.ports'),
                 route('ajax.search.health'),
                 route('ajax.search.routing'),
-                route('ajax.search.logs'),
             ]),
-            order: ['devices', 'ports', 'sensors', 'wireless', 'storage', 'mempools', 'processors', 'bgp', 'eventlog'],
+            order: ['devices', 'ports', 'sensors', 'wireless', 'storage', 'mempools', 'processors', 'bgp'],
             run() {
                 let q = this.query.trim();
                 if (q === '') { this.reset(); return; }

--- a/resources/views/layouts/menu.blade.php
+++ b/resources/views/layouts/menu.blade.php
@@ -863,8 +863,9 @@
                 route('ajax.search.ports'),
                 route('ajax.search.health'),
                 route('ajax.search.routing'),
+                route('ajax.search.logs'),
             ]),
-            order: ['devices', 'ports', 'sensors', 'wireless', 'storage', 'mempools', 'processors', 'bgp'],
+            order: ['devices', 'ports', 'sensors', 'wireless', 'storage', 'mempools', 'processors', 'bgp', 'eventlog'],
             run() {
                 let q = this.query.trim();
                 if (q === '') { this.reset(); return; }


### PR DESCRIPTION
The event log search is quite slow (5-30 seconds) on systems with a lot of event logs.  This PR has started by proposing removing this functionality since it is new, but other options I can think of are to make it configurable or try to improve the query speed for event log searches.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
