### PR TITLE
Resolve issues with slow global device search queries

### DIFF
--- a/app/Http/Controllers/Ajax/Search/DevicesSearchController.php
+++ b/app/Http/Controllers/Ajax/Search/DevicesSearchController.php
@@ -4,9 +4,9 @@ namespace App\Http\Controllers\Ajax\Search;
 
 use App\Facades\LibrenmsConfig;
 use App\Models\Device;
+use App\Models\Location;
 use App\Models\Port;
 use App\Models\PortsFdb;
-use App\Models\Location;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Builder;
 use LibreNMS\Enum\DeviceStatus;

--- a/app/Http/Controllers/Ajax/Search/DevicesSearchController.php
+++ b/app/Http/Controllers/Ajax/Search/DevicesSearchController.php
@@ -4,6 +4,9 @@ namespace App\Http\Controllers\Ajax\Search;
 
 use App\Facades\LibrenmsConfig;
 use App\Models\Device;
+use App\Models\Port;
+use App\Models\PortsFdb;
+use App\Models\Location;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Builder;
 use LibreNMS\Enum\DeviceStatus;
@@ -13,8 +16,8 @@ class DevicesSearchController extends GroupedSearchController
 {
     protected function groups(string $search, string $like, int $limit, ?User $user): array
     {
-        $query = Device::hasAccess($user)->select('devices.*')->distinct();
-        $query->where(function (Builder $q) use ($like, $search, $query): void {
+        $query = Device::hasAccess($user)->select('devices.*');
+        $query->where(function (Builder $q) use ($like, $search): void {
             $q->where('hostname', 'like', $like)
                 ->orWhere('sysName', 'like', $like)
                 ->orWhere('display', 'like', $like)
@@ -23,35 +26,44 @@ class DevicesSearchController extends GroupedSearchController
                 ->orWhere('serial', 'like', $like)
                 ->orWhere('notes', 'like', $like);
 
+            $locationquery = Location::where('location', 'like', $like);
+            $q->orWhereIn('devices.location_id', $locationquery->pluck('id'));
+
             $mac = strtolower(str_replace([':', '-'], '', $search));
 
             if (preg_match('/^[0-9.]+$/', $search) && str_contains($search, '.')) {
-                $query->leftJoin('ports', 'ports.device_id', '=', 'devices.device_id')
-                    ->leftJoin('ipv4_addresses', 'ipv4_addresses.port_id', '=', 'ports.port_id');
-                $q->orWhere('ipv4_addresses.ipv4_address', 'like', $like)
+                $portquery = Port::query()
+                    ->leftJoin('ipv4_addresses', 'ipv4_addresses.port_id', '=', 'ports.port_id')
+                    ->where('ipv4_addresses.ipv4_address', 'like', $like);
+
+                $q->orWhereIn('devices.device_id', $portquery->pluck('ports.device_id'))
                     ->orWhere('overwrite_ip', 'like', $like);
+
                 if (\LibreNMS\Util\IPv4::isValid($search, false)) {
                     $q->orWhere('ip', '=', inet_pton($search));
                 }
             } elseif (preg_match('/^[0-9a-f:]+$/i', $search) && str_contains($search, ':')) {
-                $query->leftJoin('ports', 'ports.device_id', '=', 'devices.device_id')
-                    ->leftJoin('ipv6_addresses', 'ipv6_addresses.port_id', '=', 'ports.port_id');
-                $q->orWhere('ipv6_addresses.ipv6_address', 'like', $like)
+                $portquery = Port::query()
+                    ->leftJoin('ipv6_addresses', 'ipv6_addresses.port_id', '=', 'ports.port_id')
+                    ->where('ipv6_addresses.ipv6_address', 'like', $like)
                     ->orWhere('ipv6_addresses.ipv6_compressed', 'like', $like)
-                    ->orWhere('overwrite_ip', 'like', $like)
                     ->orWhere('ports.ifPhysAddress', 'like', '%' . $mac . '%');
+
+                $q->orWhereIn('devices.device_id', $portquery->pluck('ports.device_id'))
+                    ->orWhere('overwrite_ip', 'like', $like);
+
                 if (\LibreNMS\Util\IPv6::isValid($search, false)) {
                     $q->orWhere('ip', '=', inet_pton($search));
                 }
             } elseif (ctype_xdigit($mac)) {
-                $query->leftJoin('ports', 'ports.device_id', '=', 'devices.device_id');
-                $q->orWhere('ports.ifPhysAddress', 'like', '%' . $mac . '%');
+                $portquery = Port::where('ifPhysAddress', 'like', '%' . $mac . '%');
+                $q->orWhereIn('devices.device_id', $portquery->pluck('ports.device_id'));
             }
 
             // A MAC-style search (with or without separators) can also match FDB entries
             if (ctype_xdigit($mac)) {
-                $query->leftJoin('ports_fdb', 'ports_fdb.device_id', '=', 'devices.device_id');
-                $q->orWhere('ports_fdb.mac_address', 'like', '%' . $mac . '%');
+                $fdbquery = PortsFdb::where('mac_address', 'like', '%' . $mac . '%');
+                $q->orWhereIn('devices.device_id', $fdbquery->pluck('device_id'));
             }
         });
 


### PR DESCRIPTION
The combination of joins and use of distinct() is making the device search queries slow on my system (12+ seconds).  We also noticed that the global search no longer looks at location data for a device.

This PR replaces all the port/ip address/mac address joins to use orWhereIn() sub-queries, and restores the searching on location for devices.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
