### PR TITLE
Fix bill bandwidth day-graph under ONLY_FULL_GROUP_BY

### DIFF
--- a/LibreNMS/Billing.php
+++ b/LibreNMS/Billing.php
@@ -405,7 +405,7 @@ class Billing
         $data = [];
         $average = 0;
         if ($imgtype == 'day') {
-            foreach (dbFetchRows('SELECT DISTINCT UNIX_TIMESTAMP(timestamp) as timestamp, SUM(delta) as traf_total, SUM(in_delta) as traf_in, SUM(out_delta) as traf_out FROM bill_data WHERE `bill_id` = ? AND `timestamp` >= FROM_UNIXTIME(?) AND `timestamp` <= FROM_UNIXTIME(?) GROUP BY DATE(timestamp) ORDER BY timestamp ASC', [$bill_id, $from, $to]) as $data) {
+            foreach (dbFetchRows('SELECT UNIX_TIMESTAMP(MIN(timestamp)) as timestamp, SUM(delta) as traf_total, SUM(in_delta) as traf_in, SUM(out_delta) as traf_out FROM bill_data WHERE `bill_id` = ? AND `timestamp` >= FROM_UNIXTIME(?) AND `timestamp` <= FROM_UNIXTIME(?) GROUP BY DATE(timestamp) ORDER BY DATE(timestamp) ASC', [$bill_id, $from, $to]) as $data) {
                 array_push($ticklabels, date('Y-m-d', $data['timestamp']));
                 array_push($in_data, $data['traf_in'] ?? 0);
                 array_push($out_data, $data['traf_out'] ?? 0);


### PR DESCRIPTION
Billing::getBandwidthGraphData()'s 'day' query selected and ordered by UNIX_TIMESTAMP(timestamp) while grouping by DATE(timestamp). Under ONLY_FULL_GROUP_BY this raises SQLSTATE 1055, so dbFetchRows() returns nothing and the bill transfer / accurate graphs render with no data.

Aggregate the selected timestamp (UNIX_TIMESTAMP(MIN(timestamp))) and order by the grouped expression (DATE(timestamp)); drop the redundant DISTINCT. The per-day date('Y-m-d', ...) labels are unchanged. Complements #20102 which fixed the 95th-percentile query.

Fixes #20150

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
