### PR TITLE
Allow vrfs.mplsVpnVrfDescription to be null

### DIFF
--- a/database/migrations/2026_07_29_000000_make_mpls_vpn_vrf_description_nullable_in_vrfs_table.php
+++ b/database/migrations/2026_07_29_000000_make_mpls_vpn_vrf_description_nullable_in_vrfs_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('vrfs', function (Blueprint $table) {
+            $table->text('mplsVpnVrfDescription')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('vrfs', function (Blueprint $table) {
+            $table->text('mplsVpnVrfDescription')->nullable(false)->change();
+        });
+    }
+};

--- a/resources/definitions/schema/db_schema.yaml
+++ b/resources/definitions/schema/db_schema.yaml
@@ -2589,7 +2589,7 @@ vrfs:
     - { Field: vrf_name, Type: varchar(128), 'Null': true, Extra: '' }
     - { Field: bgpLocalAs, Type: 'int unsigned', 'Null': true, Extra: '' }
     - { Field: mplsVpnVrfRouteDistinguisher, Type: varchar(128), 'Null': true, Extra: '' }
-    - { Field: mplsVpnVrfDescription, Type: text, 'Null': false, Extra: '' }
+    - { Field: mplsVpnVrfDescription, Type: text, 'Null': true, Extra: '' }
     - { Field: device_id, Type: 'int unsigned', 'Null': false, Extra: '' }
   Indexes:
     PRIMARY: { Name: PRIMARY, Columns: [vrf_id], Unique: true, Type: BTREE }


### PR DESCRIPTION
On devices where the VRF discovery code inserts a `vrfs` row without a description (e.g. Cumulus Linux), discovery fails with:

```
SQLSTATE[HY000]: General error: 1364 Field 'mplsVpnVrfDescription' doesn't have a default value
```

`vrfs.mplsVpnVrfDescription` is a `text NOT NULL` column with no default, but not every code path populates it. This PR makes the column nullable so inserting a VRF without a description works, matching the neighbouring optional columns (`vrf_name`, `mplsVpnVrfRouteDistinguisher`).

Changes:
- Migration to make `vrfs.mplsVpnVrfDescription` nullable.
- Matching update to `resources/definitions/schema/db_schema.yaml`.

Fixes: #18715

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply 20185`.
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
