### PR TITLE
Add ability to skip custom oid tests for distributed pollers

### DIFF
--- a/includes/html/modal/new_customoid.inc.php
+++ b/includes/html/modal/new_customoid.inc.php
@@ -103,13 +103,13 @@
                     </div>
                     <div class="form-group">
                         <div class="col-sm-12 text-center">
-                            <button type="button" class="btn btn-success" id="save-oid-button" name="save-oid-button">
+                            <button type="button" class="lnms-btn lnms-btn-success" id="save-oid-button" name="save-oid-button">
                                 Save OID
                             </button>
-                            <button type="button" class="btn btn-warning" id="save-oid-skip-button" name="save-oid-skip-button">
+                            <button type="button" class="lnms-btn lnms-btn-warning" id="save-oid-skip-button" name="save-oid-skip-button">
                                 Save (Skip test)
                             </button>
-                            <button type="button" class="btn btn-primary" id="test-oid-button" name="test-oid-button">
+                            <button type="button" class="lnms-btn lnms-btn-primary" id="test-oid-button" name="test-oid-button">
                                 Test OID
                             </button>
                         </div>

--- a/includes/html/modal/new_customoid.inc.php
+++ b/includes/html/modal/new_customoid.inc.php
@@ -106,6 +106,9 @@
                             <button type="button" class="btn btn-success" id="save-oid-button" name="save-oid-button">
                                 Save OID
                             </button>
+                            <button type="button" class="btn btn-warning" id="save-oid-skip-button" name="save-oid-skip-button">
+                                Save (Skip test)
+                            </button>
                             <button type="button" class="btn btn-primary" id="test-oid-button" name="test-oid-button">
                                 Test OID
                             </button>
@@ -167,8 +170,7 @@ $('#create-oid-form').on('show.bs.modal', function(e) {
         $('#cpassed').prop('checked', false);
     }
 });
-$('#save-oid-button').on('click', function (e) {
-    e.preventDefault();
+function saveOid() {
     var customoid_id = $('#ccustomoid_id').val();
     var url = customoid_id ? '<?php echo route("customoid.update", ["customoid" => ":customoid"]) ?>'.replace(':customoid', customoid_id) : '<?php echo route("customoid.store") ?>';
     $('#datatype').prop('disabled', false);
@@ -194,6 +196,16 @@ $('#save-oid-button').on('click', function (e) {
             toastr.error('Failed to process OID');
         }
     });
+}
+$('#save-oid-button').on('click', function (e) {
+    e.preventDefault();
+    saveOid();
+});
+$('#save-oid-skip-button').on('click', function (e) {
+    e.preventDefault();
+    $('#passed').val('on');
+    $('#cpassed').prop('checked', true);
+    saveOid();
 });
 $('#test-oid-button').on('click', function (e) {
     e.preventDefault();


### PR DESCRIPTION
When running distributed pollers, the WebUI doesn't always have access to run snmp checks.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
