### PR TITLE
entity-physical: tell a failed snmp walk apart from an empty one

### DIFF
--- a/LibreNMS/Data/Source/SnmpResponse.php
+++ b/LibreNMS/Data/Source/SnmpResponse.php
@@ -74,6 +74,11 @@ class SnmpResponse implements \Stringable
         return true;
     }
 
+    public function isTimeout(): bool
+    {
+        return (bool) preg_match('/Timeout: No Response from /', $this->stderr);
+    }
+
     /**
      * Get the error message if any
      */

--- a/LibreNMS/Exceptions/EntityPhysicalCollectionException.php
+++ b/LibreNMS/Exceptions/EntityPhysicalCollectionException.php
@@ -36,8 +36,8 @@ class EntityPhysicalCollectionException extends Exception
         public readonly bool $defaultTimeout = true,
     ) {
         parent::__construct('entPhysical collection timed out'
-            .($rowCount > 0 ? " after $rowCount rows" : '')
-            .', keeping existing inventory.'
-            .($defaultTimeout ? ' Raising devices.timeout may help.' : ''));
+            . ($rowCount > 0 ? " after $rowCount rows" : '')
+            . ', keeping existing inventory.'
+            . ($defaultTimeout ? ' Raising devices.timeout may help.' : ''));
     }
 }

--- a/LibreNMS/Exceptions/EntityPhysicalCollectionException.php
+++ b/LibreNMS/Exceptions/EntityPhysicalCollectionException.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * EntityPhysicalCollectionException.php
+ *
+ * Thrown when entity-physical data could not be collected from a device, as
+ * opposed to the device reporting that it has no inventory. The two are not
+ * interchangeable: an empty result is authoritative and should prune stale
+ * rows, a failed collection tells us nothing and must not.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * @link       https://www.librenms.org
+ */
+
+namespace LibreNMS\Exceptions;
+
+use Exception;
+
+class EntityPhysicalCollectionException extends Exception
+{
+}

--- a/LibreNMS/Exceptions/EntityPhysicalCollectionException.php
+++ b/LibreNMS/Exceptions/EntityPhysicalCollectionException.php
@@ -30,4 +30,14 @@ use Exception;
 
 class EntityPhysicalCollectionException extends Exception
 {
+    public function __construct(
+        public readonly string $error,
+        public readonly int $rowCount = 0,
+        public readonly bool $defaultTimeout = true,
+    ) {
+        parent::__construct('entPhysical collection timed out'
+            .($rowCount > 0 ? " after $rowCount rows" : '')
+            .', keeping existing inventory.'
+            .($defaultTimeout ? ' Raising devices.timeout may help.' : ''));
+    }
 }

--- a/LibreNMS/Interfaces/Discovery/EntityPhysicalDiscovery.php
+++ b/LibreNMS/Interfaces/Discovery/EntityPhysicalDiscovery.php
@@ -31,10 +31,15 @@ use Illuminate\Support\Collection;
 interface EntityPhysicalDiscovery
 {
     /**
-     * Discover a Collection of IsIsAdjacency models.
-     * Will be keyed by ifIndex
+     * Discover a Collection of EntPhysical models.
+     *
+     * An empty Collection means the device has no entities, and existing rows will be
+     * pruned. Throw instead if the data could not be collected, so the caller can tell
+     * the two apart.
      *
      * @return \Illuminate\Support\Collection<\App\Models\EntPhysical>
+     *
+     * @throws \LibreNMS\Exceptions\EntityPhysicalCollectionException if the data could not be collected
      */
     public function discoverEntityPhysical(): Collection;
 }

--- a/LibreNMS/Modules/EntityPhysical.php
+++ b/LibreNMS/Modules/EntityPhysical.php
@@ -7,6 +7,7 @@ use App\Models\EntPhysical;
 use App\Observers\ModuleModelObserver;
 use Illuminate\Support\Facades\Log;
 use LibreNMS\DB\SyncsModels;
+use LibreNMS\Exceptions\EntityPhysicalCollectionException;
 use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Module;
 use LibreNMS\OS;
@@ -46,16 +47,11 @@ class EntityPhysical implements Module
      */
     public function discover(OS $os): void
     {
-        $inventory = $os->discoverEntityPhysical();
-
-        // A failed SNMP walk (e.g. a timeout) yields an empty collection that is
-        // indistinguishable from a device that genuinely has no entPhysical data.
-        // Syncing that empty result would delete all existing inventory rows, so if
-        // the device already has inventory we keep the last-known-good and warn
-        // rather than wipe it on a transient collection failure.
-        if ($inventory->isEmpty() && $os->getDevice()->entityPhysical()->exists()) {
-            Log::warning('entPhysical discovery returned no data for ' . $os->getDevice()->hostname
-                . '; keeping existing inventory (possible SNMP collection failure)');
+        try {
+            $inventory = $os->discoverEntityPhysical();
+        } catch (EntityPhysicalCollectionException $e) {
+            Log::warning('entPhysical collection failed for ' . $os->getDevice()->hostname
+                . ', keeping existing inventory: ' . $e->getMessage());
 
             return;
         }

--- a/LibreNMS/Modules/EntityPhysical.php
+++ b/LibreNMS/Modules/EntityPhysical.php
@@ -4,9 +4,11 @@ namespace LibreNMS\Modules;
 
 use App\Models\Device;
 use App\Models\EntPhysical;
+use App\Models\Eventlog;
 use App\Observers\ModuleModelObserver;
 use Illuminate\Support\Facades\Log;
 use LibreNMS\DB\SyncsModels;
+use LibreNMS\Enum\Severity;
 use LibreNMS\Exceptions\EntityPhysicalCollectionException;
 use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Module;
@@ -50,8 +52,8 @@ class EntityPhysical implements Module
         try {
             $inventory = $os->discoverEntityPhysical();
         } catch (EntityPhysicalCollectionException $e) {
-            Log::warning('entPhysical collection failed for ' . $os->getDevice()->hostname
-                . ', keeping existing inventory: ' . $e->getMessage());
+            Eventlog::log($e->getMessage(), $os->getDevice(), 'discovery', Severity::Warning);
+            Log::debug('entPhysical collection failed: ' . $e->error);
 
             return;
         }

--- a/LibreNMS/Modules/EntityPhysical.php
+++ b/LibreNMS/Modules/EntityPhysical.php
@@ -5,6 +5,7 @@ namespace LibreNMS\Modules;
 use App\Models\Device;
 use App\Models\EntPhysical;
 use App\Observers\ModuleModelObserver;
+use Illuminate\Support\Facades\Log;
 use LibreNMS\DB\SyncsModels;
 use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Module;
@@ -46,6 +47,18 @@ class EntityPhysical implements Module
     public function discover(OS $os): void
     {
         $inventory = $os->discoverEntityPhysical();
+
+        // A failed SNMP walk (e.g. a timeout) yields an empty collection that is
+        // indistinguishable from a device that genuinely has no entPhysical data.
+        // Syncing that empty result would delete all existing inventory rows, so if
+        // the device already has inventory we keep the last-known-good and warn
+        // rather than wipe it on a transient collection failure.
+        if ($inventory->isEmpty() && $os->getDevice()->entityPhysical()->exists()) {
+            Log::warning('entPhysical discovery returned no data for ' . $os->getDevice()->hostname
+                . '; keeping existing inventory (possible SNMP collection failure)');
+
+            return;
+        }
 
         ModuleModelObserver::observe(EntPhysical::class);
         $this->syncModels($os->getDevice(), 'entityPhysical', $inventory);

--- a/LibreNMS/OS/Traits/EntityMib.php
+++ b/LibreNMS/OS/Traits/EntityMib.php
@@ -28,6 +28,7 @@ namespace LibreNMS\OS\Traits;
 
 use App\Models\EntPhysical;
 use Illuminate\Support\Collection;
+use LibreNMS\Exceptions\EntityPhysicalCollectionException;
 
 trait EntityMib
 {
@@ -38,6 +39,10 @@ trait EntityMib
             $snmpQuery = $snmpQuery->mibs([$this->entityVendorTypeMib]);
         }
         $data = $snmpQuery->walk('ENTITY-MIB::entPhysicalTable');
+
+        if ($data->isTimeout()) {
+            throw new EntityPhysicalCollectionException($data->getErrorMessage());
+        }
 
         if (! $data->isValid()) {
             return new Collection;

--- a/LibreNMS/OS/Traits/EntityMib.php
+++ b/LibreNMS/OS/Traits/EntityMib.php
@@ -41,7 +41,11 @@ trait EntityMib
         $data = $snmpQuery->walk('ENTITY-MIB::entPhysicalTable');
 
         if ($data->isTimeout()) {
-            throw new EntityPhysicalCollectionException($data->getErrorMessage());
+            throw new EntityPhysicalCollectionException(
+                $data->getErrorMessage(),
+                count($data->values()),
+                ($this->getDevice()->timeout ?? \LibrenmsConfig::get('snmp.timeout')) == 1,
+            );
         }
 
         if (! $data->isValid()) {

--- a/tests/Feature/EntityPhysicalDiscoveryTest.php
+++ b/tests/Feature/EntityPhysicalDiscoveryTest.php
@@ -4,6 +4,7 @@ namespace LibreNMS\Tests\Feature;
 
 use App\Models\Device;
 use App\Models\EntPhysical;
+use App\Models\Eventlog;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Collection;
 use LibreNMS\Exceptions\EntityPhysicalCollectionException;
@@ -30,7 +31,7 @@ class EntityPhysicalDiscoveryTest extends TestCase
 
         if ($collectionFailed) {
             $os->shouldReceive('discoverEntityPhysical')
-                ->andThrow(new EntityPhysicalCollectionException('Timeout: No Response from udp:127.0.0.1:161'));
+                ->andThrow(new EntityPhysicalCollectionException('Timeout: No Response from udp:127.0.0.1:161', 120, true));
         } else {
             $os->shouldReceive('discoverEntityPhysical')->andReturn($discovered);
         }
@@ -104,6 +105,44 @@ class EntityPhysicalDiscoveryTest extends TestCase
         $this->assertEquals(2, $device->entityPhysical()->count());
         $this->assertEquals('new-chassis',
             $device->entityPhysical()->where('entPhysicalIndex', 1)->first()->entPhysicalDescr);
+    }
+
+    public function testTheExceptionMessageNamesTheRowCountAndTheTimeoutHint(): void
+    {
+        // partial walk on a device still using the default 1s timeout: the operator
+        // needs to know rows arrived (so the agent is alive, just slow) and that the
+        // timeout is theirs to raise.
+        $partial = new EntityPhysicalCollectionException('Timeout: No Response from udp:10.0.0.1:161', 120, true);
+        $this->assertStringContainsString('120 rows', $partial->getMessage());
+        $this->assertStringContainsString('keeping existing inventory', $partial->getMessage());
+        $this->assertStringContainsString('devices.timeout', $partial->getMessage());
+
+        // nothing came back at all: "after 0 rows" is noise, omit it
+        $nothing = new EntityPhysicalCollectionException('Timeout: No Response from udp:10.0.0.1:161', 0, true);
+        $this->assertStringNotContainsString('0 rows', $nothing->getMessage());
+        $this->assertStringContainsString('keeping existing inventory', $nothing->getMessage());
+
+        // the timeout was already raised and it still failed: do not advise raising it
+        $tuned = new EntityPhysicalCollectionException('Timeout: No Response from udp:10.0.0.1:161', 120, false);
+        $this->assertStringContainsString('120 rows', $tuned->getMessage());
+        $this->assertStringNotContainsString('devices.timeout', $tuned->getMessage());
+    }
+
+    public function testFailedCollectionIsRecordedOnTheDeviceEventlog(): void
+    {
+        $device = Device::factory()->create();
+        EntPhysical::factory()->count(5)->create(['device_id' => $device->device_id]);
+
+        $this->runDiscovery($device, new Collection, collectionFailed: true);
+
+        $this->assertDatabaseHas('eventlog', [
+            'device_id' => $device->device_id,
+            'type' => 'discovery',
+        ]);
+        $event = Eventlog::where('device_id', $device->device_id)
+            ->where('type', 'discovery')->first();
+        $this->assertStringContainsString('keeping existing inventory', $event->message,
+            'the operator must be told on the device page, not only in librenms.log');
     }
 
     protected function tearDown(): void

--- a/tests/Feature/EntityPhysicalDiscoveryTest.php
+++ b/tests/Feature/EntityPhysicalDiscoveryTest.php
@@ -6,6 +6,7 @@ use App\Models\Device;
 use App\Models\EntPhysical;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Collection;
+use LibreNMS\Exceptions\EntityPhysicalCollectionException;
 use LibreNMS\Modules\EntityPhysical;
 use LibreNMS\OS;
 use LibreNMS\Tests\TestCase;
@@ -20,27 +21,49 @@ class EntityPhysicalDiscoveryTest extends TestCase
      * returns $discovered, bound to $device.
      *
      * @param  Collection<int, EntPhysical>  $discovered
+     * @param  bool  $collectionFailed  throw as a failed SNMP collection would
      */
-    private function runDiscovery(Device $device, Collection $discovered): void
+    private function runDiscovery(Device $device, Collection $discovered, bool $collectionFailed = false): void
     {
         $os = Mockery::mock(OS::class);
-        $os->shouldReceive('discoverEntityPhysical')->andReturn($discovered);
         $os->shouldReceive('getDevice')->andReturn($device);
+
+        if ($collectionFailed) {
+            $os->shouldReceive('discoverEntityPhysical')
+                ->andThrow(new EntityPhysicalCollectionException('Timeout: No Response from udp:127.0.0.1:161'));
+        } else {
+            $os->shouldReceive('discoverEntityPhysical')->andReturn($discovered);
+        }
 
         (new EntityPhysical)->discover($os);
     }
 
-    public function testEmptyDiscoveryDoesNotWipeExistingInventory(): void
+    public function testFailedCollectionDoesNotWipeExistingInventory(): void
     {
         $device = Device::factory()->create();
         EntPhysical::factory()->count(5)->create(['device_id' => $device->device_id]);
         $this->assertEquals(5, $device->entityPhysical()->count());
 
-        // A failed SNMP walk yields an empty collection — must NOT delete the 5 rows.
-        $this->runDiscovery($device, new Collection);
+        // The walk failed, so we know nothing about the device's inventory.
+        // Syncing that non-result would delete all 5 rows.
+        $this->runDiscovery($device, new Collection, collectionFailed: true);
 
         $this->assertEquals(5, $device->entityPhysical()->count(),
-            'existing entPhysical inventory must be preserved when discovery returns empty');
+            'existing entPhysical inventory must be preserved when collection fails');
+    }
+
+    public function testGenuineEmptyDiscoveryPrunesExistingInventory(): void
+    {
+        $device = Device::factory()->create();
+        EntPhysical::factory()->count(5)->create(['device_id' => $device->device_id]);
+
+        // The device answered and reported no inventory: it really has none now
+        // (stripped, replaced, or the MIB was removed). Those rows must go, or a
+        // stale inventory is kept forever with no way to converge.
+        $this->runDiscovery($device, new Collection, collectionFailed: false);
+
+        $this->assertEquals(0, $device->entityPhysical()->count(),
+            'a device that genuinely reports no inventory must have its stale rows pruned');
     }
 
     public function testGenuineEmptyOnDeviceWithNoInventoryStaysEmpty(): void

--- a/tests/Feature/EntityPhysicalDiscoveryTest.php
+++ b/tests/Feature/EntityPhysicalDiscoveryTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace LibreNMS\Tests\Feature;
+
+use App\Models\Device;
+use App\Models\EntPhysical;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Collection;
+use LibreNMS\Modules\EntityPhysical;
+use LibreNMS\OS;
+use LibreNMS\Tests\TestCase;
+use Mockery;
+
+class EntityPhysicalDiscoveryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Build an EntityPhysical module + a mocked OS whose discoverEntityPhysical()
+     * returns $discovered, bound to $device.
+     *
+     * @param  Collection<int, EntPhysical>  $discovered
+     */
+    private function runDiscovery(Device $device, Collection $discovered): void
+    {
+        $os = Mockery::mock(OS::class);
+        $os->shouldReceive('discoverEntityPhysical')->andReturn($discovered);
+        $os->shouldReceive('getDevice')->andReturn($device);
+
+        (new EntityPhysical)->discover($os);
+    }
+
+    public function testEmptyDiscoveryDoesNotWipeExistingInventory(): void
+    {
+        $device = Device::factory()->create();
+        EntPhysical::factory()->count(5)->create(['device_id' => $device->device_id]);
+        $this->assertEquals(5, $device->entityPhysical()->count());
+
+        // A failed SNMP walk yields an empty collection — must NOT delete the 5 rows.
+        $this->runDiscovery($device, new Collection);
+
+        $this->assertEquals(5, $device->entityPhysical()->count(),
+            'existing entPhysical inventory must be preserved when discovery returns empty');
+    }
+
+    public function testGenuineEmptyOnDeviceWithNoInventoryStaysEmpty(): void
+    {
+        $device = Device::factory()->create();
+        $this->assertEquals(0, $device->entityPhysical()->count());
+
+        // Empty discovery on a device that never had inventory: no-op, no crash.
+        $this->runDiscovery($device, new Collection);
+
+        $this->assertEquals(0, $device->entityPhysical()->count());
+    }
+
+    public function testNonEmptyDiscoverySyncsNormally(): void
+    {
+        $device = Device::factory()->create();
+        EntPhysical::factory()->create([
+            'device_id' => $device->device_id,
+            'entPhysicalIndex' => 1,
+            'entPhysicalDescr' => 'old-chassis',
+        ]);
+
+        // A good walk returns real rows — normal reconcile: index 1 updated, index 2 added.
+        $discovered = new Collection([
+            new EntPhysical([
+                'entPhysicalIndex' => 1,
+                'entPhysicalDescr' => 'new-chassis',
+                'entPhysicalClass' => 'chassis',
+            ]),
+            new EntPhysical([
+                'entPhysicalIndex' => 2,
+                'entPhysicalDescr' => 'linecard',
+                'entPhysicalClass' => 'module',
+            ]),
+        ]);
+        $this->runDiscovery($device, $discovered);
+
+        $this->assertEquals(2, $device->entityPhysical()->count());
+        $this->assertEquals('new-chassis',
+            $device->entityPhysical()->where('entPhysicalIndex', 1)->first()->entPhysicalDescr);
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+}

--- a/tests/Unit/SnmpResponseTest.php
+++ b/tests/Unit/SnmpResponseTest.php
@@ -357,4 +357,38 @@ HOST-RESOURCES-MIB::hrStorageUsed.36 = 127044934
             $this->fail('There should be no data in the array.');
         });
     }
+
+    public function testIsTimeout(): void
+    {
+        // the device did not answer: we learned nothing about it
+        $response = new SnmpResponse('', "Timeout: No Response from udp:127.1.6.1:1161.\n", 1);
+        $this->assertTrue($response->isTimeout());
+
+        // a partial walk that then timed out is still a timeout: the rows we got
+        // are not the whole table, so the result must not be treated as complete
+        $response = new SnmpResponse(
+            "ENTITY-MIB::entPhysicalDescr[1] = Chassis\n",
+            "Timeout: No Response from udp:127.1.6.1:1161.\n",
+            1
+        );
+        $this->assertTrue($response->isTimeout());
+        $this->assertFalse($response->isValid());
+
+        // the agent answered, it just has nothing at that OID — not a timeout
+        $response = new SnmpResponse("ENTITY-MIB::entPhysicalTable = No Such Object available on this agent at this OID\n");
+        $this->assertFalse($response->isTimeout());
+        $this->assertFalse($response->isValid());
+
+        $response = new SnmpResponse("SNMPv2-SMI::enterprises.9.9.661.1.3.2.1.1 = No Such Instance currently exists at this OID.\n");
+        $this->assertFalse($response->isTimeout());
+
+        // other transport-level failures are not timeouts
+        $response = new SnmpResponse('', "snmpget: Authentication failure (incorrect password, community or key)\n", 1);
+        $this->assertFalse($response->isTimeout());
+
+        // a good response is not a timeout
+        $response = new SnmpResponse("ENTITY-MIB::entPhysicalDescr[1] = Chassis\n");
+        $this->assertFalse($response->isTimeout());
+        $this->assertTrue($response->isValid());
+    }
 }


### PR DESCRIPTION
An empty Collection from discoverEntityPhysical() meant both "this device has no entities" and "the walk failed", so a timeout made syncModels() delete every existing row. A later good poll repaints them, so inventory oscillates.

A timeout now throws and discovery keeps what it has. An empty result still prunes, so a stripped or replaced device converges. A partial walk that then times out counts as a timeout — the rows that arrived aren't the whole table.

Seen on Juniper MX960s whose entPhysicalTable walk intermittently times out under RE load.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [✅] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [⎯] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [✅] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
