### PR TITLE
Restore the ability for global searches on Cisco MAC address format

### DIFF
--- a/app/Http/Controllers/Ajax/Search/DevicesSearchController.php
+++ b/app/Http/Controllers/Ajax/Search/DevicesSearchController.php
@@ -22,7 +22,7 @@ class DevicesSearchController extends GroupedSearchController
                 ->orWhere('notes', 'like', $like)
                 ->orWhereRelation('location', 'location', 'like', $like);
 
-        $mac = strtolower(str_replace([':', '-'], '', $search));
+        $mac = strtolower(str_replace([':', '-', '.'], '', $search));
 
         if (preg_match('/^[0-9.]+$/', $search) && str_contains($search, '.')) {
             $query->orWhereRelation('ports.ipv4', 'ipv4_address', 'like', $like)


### PR DESCRIPTION
The original global search code stripped the full stop character for MAC address matching so the search would work for MAC addresses in the Cisco format (xxxx.xxxx.xxxx).  This PR restores this functionality.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
