### PR TITLE
Escape graph parameter strings

### DIFF
--- a/LibreNMS/Data/Graphing/GraphParameters.php
+++ b/LibreNMS/Data/Graphing/GraphParameters.php
@@ -222,7 +222,7 @@ class GraphParameters implements \Stringable
             array_push($options, '--right-axis', $this->escapeParameter($this->right_axis));
         }
         if ($this->right_axis_label !== null) {
-            array_push($options, '--right-axis-label', $this->escapeParameter( $this->right_axis_label));
+            array_push($options, '--right-axis-label', $this->escapeParameter($this->right_axis_label));
         }
         if ($this->left_axis_format !== null) {
             array_push($options, '--left-axis-format', $this->escapeParameter($this->left_axis_format));

--- a/LibreNMS/Data/Graphing/GraphParameters.php
+++ b/LibreNMS/Data/Graphing/GraphParameters.php
@@ -215,23 +215,23 @@ class GraphParameters implements \Stringable
         }
 
         if ($this->visible('title')) {
-            $options[] = '--title=' . $this->formatTitle();
+            $options[] = '--title=' . $this->escapeParameter($this->formatTitle());
         }
 
         if ($this->right_axis !== null) {
-            array_push($options, '--right-axis', $this->right_axis);
+            array_push($options, '--right-axis', $this->escapeParameter($this->right_axis));
         }
         if ($this->right_axis_label !== null) {
-            array_push($options, '--right-axis-label', $this->right_axis_label);
+            array_push($options, '--right-axis-label', $this->escapeParameter( $this->right_axis_label));
         }
         if ($this->left_axis_format !== null) {
-            array_push($options, '--left-axis-format', $this->left_axis_format);
+            array_push($options, '--left-axis-format', $this->escapeParameter($this->left_axis_format));
         }
         if ($this->units_length !== null) {
             array_push($options, '--units-length', $this->units_length);
         }
         if ($this->vertical_label !== null) {
-            array_push($options, '--vertical-label', $this->vertical_label);
+            array_push($options, '--vertical-label', $this->escapeParameter($this->vertical_label));
         }
 
         return $options;
@@ -292,7 +292,7 @@ class GraphParameters implements \Stringable
 
     private function defaultTitle(): string
     {
-        $title = DeviceCache::getPrimary()->displayName() ?: ucfirst($this->type);
+        $title = DeviceCache::getPrimary()->display ?: ucfirst($this->type);
         $title .= '::';
         $title .= Str::title(str_replace('_', ' ', $this->subtype));
 
@@ -301,7 +301,7 @@ class GraphParameters implements \Stringable
 
     private function formatTitle(): string
     {
-        $title = str_replace("'", '', $this->getTitle());
+        $title = $this->getTitle();
 
         // linear approximation
         $slope = 0.1332;
@@ -320,5 +320,10 @@ class GraphParameters implements \Stringable
         }
 
         return substr($title, 0, max(0, $maxChars - 3)) . '...';
+    }
+
+    private function escapeParameter(string $input): string
+    {
+        return str_replace(["'", '"', "\n", "\r"], '', $input);
     }
 }


### PR DESCRIPTION
When building toRrdOptions array, filter out quotes and line returns when setting string parameters

prevents ability to run arbitrary rrdtool commands, whatever you could do with that.

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
