### PR TITLE
fix(sensors): format frequency values with SI prefixes

### DIFF
--- a/app/Models/Sensor.php
+++ b/app/Models/Sensor.php
@@ -115,7 +115,7 @@ class Sensor extends SensorModel implements Keyable
         return match ($this->sensor_class) {
             'temperature' => $user && UserPref::getPref($user, 'temp_units') == 'f' ? Rewrite::celsiusToFahrenheit($value) . ' °F' : round($value, 2) . ' °C',
             'state' => $this->currentTranslation()->state_descr ?? 'Unknown',
-            'current', 'power' => Number::formatSi($value, 3, 0, $this->unit()),
+            'current', 'power', 'frequency' => Number::formatSi($value, 3, 0, $this->unit()),
             'runtime' => Time::formatInterval($value * 60),
             'power_consumed' => trim(Number::formatSi($value * 1000, 5, 5, 'Wh')),
             'dbm' => round($value, 3) . ' ' . $this->unit(),


### PR DESCRIPTION
Frequency sensors fall through to the default branch of `Sensor::formatValue()`
and are rendered raw, so a CPU or GPU clock reads as `2700000000 Hz`.

`WirelessSensor::formatValue()` already applies `Number::formatSi` to frequency;
this brings ordinary sensors in line with it.

```diff
-            'current', 'power' => Number::formatSi($value, 3, 0, $this->unit()),
+            'current', 'power', 'frequency' => Number::formatSi($value, 3, 0, $this->unit()),
```

### Existing sensors are not affected

`formatSi` adds no prefix between 0.1 Hz and 1 kHz, so mains frequency renders
byte for byte as before:

```
50          ->  50 Hz          (unchanged)
59.9        ->  59.9 Hz        (unchanged)
60          ->  60 Hz          (unchanged)
400         ->  400 Hz         (unchanged)
```

Of the sensors in `tests/data`, 47 readings across 14 sensor types are at or
above 1 kHz and gain a prefix — microwave and RF links (tachyon, timos,
tait-infra93, huawei-optixrtn, ecresofm-os, uhp, aaron, zmtel, profline-sfd,
deva-db7001, rs, junos), esphome chip clocks and the Raspberry Pi clocks. All of
them are stored in hertz — the yaml definitions normalise with multiplier and
divisor — so the prefix is correct in each case. The Raspberry Pi clocks, for
example, go from `1500000000 Hz` to `1.5 GHz`.

No sensor in the tree reads below 0.1 Hz, where a milli prefix would appear.

Wireless sensors are untouched: `WirelessSensor` extends `SensorModel`, not
`Sensor`, and handles formatting separately. This matters, because Wi-Fi channel
frequencies are stored in megahertz and would have been mislabelled otherwise.

### Checklist

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/) — no discovery/polling change; display only.

### Note

`includes/html/graphs/sensor/generic.inc.php` derives the graph's left-axis
format from the last character of the SI string, which for a GHz-range sensor
yields `%5.1lfGHz` over raw hertz. That predates this change — the Raspberry Pi
clocks already hit it — and is not addressed here, but it is visible on the same
sensors, so worth naming.
