### PR TITLE
fix(snmp-scan): add Outcome.EXCLUDED mapping to fix KeyError

### DIFF
--- a/snmp-scan.py
+++ b/snmp-scan.py
@@ -78,10 +78,11 @@ def get_outcome_symbol(outcome):
         Outcome.UNPINGABLE: ".",
         Outcome.KNOWN: "*",
         Outcome.FAILED: "-",
+        Outcome.EXCLUDED: "x",
         Outcome.TERMINATED: "",
         Outcome.NODNS: "~",
         Outcome.ERROR: "E",
-    }[outcome]
+    }.get(outcome, "?")
 
 
 def handle_result(data):
@@ -322,7 +323,7 @@ Example: 192.168.0.1/32 will be treated as a single host address""",
 
     if args.legend and not VERBOSE_LEVEL:
         print(
-            "Legend:\n+  Added device\n*  Known device\n-  Failed to add device\n.  Ping failed\n~  Skipped due to no Reverse DNS\nE  Error when checking\n"
+            "Legend:\n+  Added device\n*  Known device\n-  Failed to add device\n.  Ping failed\nx  Excluded device\n~  Skipped due to no Reverse DNS\nE  Error when checking\n"
         )
 
     print("Scanning IPs:")


### PR DESCRIPTION
### Summary
Fixes an incomplete `Outcome` enum mapping in `snmp-scan.py`.

`Outcome.EXCLUDED` (value `5`) is defined in the `Outcome` enum class and tracked in `stats`, but was missing from the dictionary mapping in `get_outcome_symbol()`. 

This PR:
1. Adds `Outcome.EXCLUDED: "x"` to `get_outcome_symbol()`.
2. Replaces direct dictionary indexing `[outcome]` with defensive `.get(outcome, "?")` lookup to prevent unhandled `KeyError` exceptions.
3. Updates `--legend` output to include `x  Excluded device`.

### Motivation & Context
In `snmp-scan.py`, `Outcome.EXCLUDED` is tracked in the `stats` dictionary and defined in the `Outcome` class. However, `get_outcome_symbol()` omitted `Outcome.EXCLUDED` from its symbol map. Invoking `get_outcome_symbol(Outcome.EXCLUDED)` raises `KeyError: 5`. Using `.get()`
  provides defensive fallback for any unhandled outcomes.


#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
