### PR TITLE
Fix rounded corners on overview items

### DIFF
--- a/includes/html/dev-groups-overview-data.inc.php
+++ b/includes/html/dev-groups-overview-data.inc.php
@@ -5,13 +5,13 @@ $device_groups = dbFetchRows('SELECT dg.id, dg.name FROM device_group_device AS 
 if (count($device_groups)) {
     ?>
     <div class='overview-panel tw:mb-5'>
-                <div class='tw:px-4 tw:py-2.5 tw:bg-neutral-100 tw:border-b tw:border-gray-300 tw:text-neutral-700 tw:dark:bg-dark-gray-200 tw:dark:border-zinc-800 tw:dark:text-dark-white-200'>
+                <div class='tw:rounded-t-xl tw:px-4 tw:py-2.5 tw:bg-neutral-100 tw:border-b tw:border-gray-300 tw:text-neutral-700 tw:dark:bg-dark-gray-200 tw:dark:border-zinc-800 tw:dark:text-dark-white-200'>
                     <a href="<?=url('device-groups')?>">
                         <i class="fa fa-th fa-lg icon-theme" aria-hidden="true"></i>
                         <strong>Device Group Membership</strong>
                     </a>
                 </div>
-                <div class="tw:flex tw:flex-col tw:bg-white tw:divide-y tw:divide-gray-300 tw:dark:bg-dark-gray-400 tw:dark:divide-zinc-800">
+                <div class="tw:rounded-b-xl tw:flex tw:flex-col tw:bg-white tw:divide-y tw:divide-gray-300 tw:dark:bg-dark-gray-400 tw:dark:divide-zinc-800">
                     <div class="tw:flex tw:flex-wrap tw:gap-2 tw:p-2">
                         <?php foreach ($device_groups as $group) { ?>
                             <span>

--- a/includes/html/dev-overview-data.inc.php
+++ b/includes/html/dev-overview-data.inc.php
@@ -13,7 +13,7 @@ echo '<script src="js/leaflet.markercluster.js"></script>';
 echo '<script src="js/leaflet.awesome-markers.min.js"></script>';
 
 echo "<div class='overview-panel tw:mb-5'>
-            <div class='tw:px-4 tw:py-2.5 tw:bg-neutral-100 tw:border-b tw:border-gray-300 tw:text-neutral-700 tw:dark:bg-dark-gray-200 tw:dark:border-zinc-800 tw:dark:text-dark-white-200'>";
+            <div class='tw:rounded-t-xl tw:px-4 tw:py-2.5 tw:bg-neutral-100 tw:border-b tw:border-gray-300 tw:text-neutral-700 tw:dark:bg-dark-gray-200 tw:dark:border-zinc-800 tw:dark:text-dark-white-200'>";
 
 if (LibrenmsConfig::get('overview_show_sysDescr')) {
     echo '<i class="fa fa-id-card fa-lg icon-theme" aria-hidden="true"></i> <strong>';
@@ -21,7 +21,7 @@ if (LibrenmsConfig::get('overview_show_sysDescr')) {
     echo '</strong>';
 }
 
-echo '</div><div class="tw:flex tw:flex-col tw:bg-white tw:divide-y tw:divide-gray-300 tw:dark:bg-dark-gray-400 tw:dark:divide-zinc-800">';
+echo '</div><div class="tw:rounded-b-xl tw:flex tw:flex-col tw:bg-white tw:divide-y tw:divide-gray-300 tw:dark:bg-dark-gray-400 tw:dark:divide-zinc-800">';
 
 if ($device['os'] == 'ios' || $device['os'] == 'iosxe') {
     \LibreNMS\Util\Rewrite::ciscoHardware($device, false);

--- a/includes/html/pages/device/overview/availability_bar.inc.php
+++ b/includes/html/pages/device/overview/availability_bar.inc.php
@@ -121,11 +121,11 @@ $total_outage = $outages->reduce(function ($carry, $outage) use ($start_ts, $now
 
 echo <<<'HTML'
 <div class="overview-panel tw:mb-5">
-    <div class="tw:px-4 tw:py-2.5 tw:bg-neutral-100 tw:border-b tw:border-gray-300 tw:text-neutral-700 tw:dark:bg-dark-gray-200 tw:dark:border-zinc-800 tw:dark:text-dark-white-200">
+    <div class="tw:rounded-t-xl tw:px-4 tw:py-2.5 tw:bg-neutral-100 tw:border-b tw:border-gray-300 tw:text-neutral-700 tw:dark:bg-dark-gray-200 tw:dark:border-zinc-800 tw:dark:text-dark-white-200">
         <i class="fa fa-check-circle fa-lg icon-theme" aria-hidden="true"></i>
         <strong> Availability (90 days)</strong>
     </div>
-    <div class="tw:flex tw:min-w-0 tw:flex-col tw:bg-white tw:divide-y tw:divide-gray-300 tw:dark:bg-dark-gray-400 tw:dark:divide-zinc-800">
+    <div class="tw:rounded-b-xl tw:flex tw:min-w-0 tw:flex-col tw:bg-white tw:divide-y tw:divide-gray-300 tw:dark:bg-dark-gray-400 tw:dark:divide-zinc-800">
         <div class="tw:px-4 tw:py-2.5">
             <div class="tw:flex tw:gap-px tw:items-center">
 HTML;

--- a/includes/html/pages/device/overview/eventlog.inc.php
+++ b/includes/html/pages/device/overview/eventlog.inc.php
@@ -4,11 +4,11 @@ use App\Models\Port;
 use LibreNMS\Util\Time;
 
 echo '  <div class="overview-panel tw:mb-5">
-              <div class="tw:px-4 tw:py-2.5 tw:bg-neutral-100 tw:border-b tw:border-gray-300 tw:text-neutral-700 tw:dark:bg-dark-gray-200 tw:dark:border-zinc-800 tw:dark:text-dark-white-200">';
+              <div class="tw:rounded-t-xl tw:px-4 tw:py-2.5 tw:bg-neutral-100 tw:border-b tw:border-gray-300 tw:text-neutral-700 tw:dark:bg-dark-gray-200 tw:dark:border-zinc-800 tw:dark:text-dark-white-200">';
 echo '<a href="' . route('device.eventlog', ['device' => $device['device_id']]) . '">';
 echo '<i class="fa fa-bookmark fa-lg icon-theme" aria-hidden="true"></i> <strong>Recent Events</strong></a>';
 echo '        </div>
-              <div class="tw:flex tw:flex-col tw:bg-white tw:divide-y tw:divide-gray-300 tw:dark:bg-dark-gray-400 tw:dark:divide-zinc-800">';
+              <div class="tw:rounded-b-xl tw:flex tw:flex-col tw:bg-white tw:divide-y tw:divide-gray-300 tw:dark:bg-dark-gray-400 tw:dark:divide-zinc-800">';
 
 $eventlog = dbFetchRows('SELECT * FROM `eventlog` WHERE `device_id` = ? ORDER BY `datetime` DESC LIMIT 0,10', [$device['device_id']]);
 foreach ($eventlog as $entry) {

--- a/includes/html/pages/device/overview/graylog.inc.php
+++ b/includes/html/pages/device/overview/graylog.inc.php
@@ -5,14 +5,14 @@ use App\Facades\LibrenmsConfig;
 if (LibrenmsConfig::get('graylog.server')) {
     echo '
         <div class="overview-panel tw:mb-5" id="graylog-card">
-                    <div class="tw:px-4 tw:py-2.5 tw:bg-neutral-100 tw:border-b tw:border-gray-300 tw:text-neutral-700 tw:dark:bg-dark-gray-200 tw:dark:border-zinc-800 tw:dark:text-dark-white-200">
+                    <div class="tw:rounded-t-xl tw:px-4 tw:py-2.5 tw:bg-neutral-100 tw:border-b tw:border-gray-300 tw:text-neutral-700 tw:dark:bg-dark-gray-200 tw:dark:border-zinc-800 tw:dark:text-dark-white-200">
                         <a href="' . route('device.graylog', ['device' => $device['device_id']]) . '">
                             <i class="fa fa-clone fa-lg icon-theme"
                             aria-hidden="true"></i>
                             <strong>Recent Graylog</strong>
                         </a>
                     </div>
-                    <div class="tw:flex tw:flex-col tw:bg-white tw:divide-y tw:divide-gray-300 tw:dark:bg-dark-gray-400 tw:dark:divide-zinc-800">';
+                    <div class="tw:rounded-b-xl tw:flex tw:flex-col tw:bg-white tw:divide-y tw:divide-gray-300 tw:dark:bg-dark-gray-400 tw:dark:divide-zinc-800">';
 
     $filter_device = $device['device_id'];
     $tmp_output = '

--- a/includes/html/pages/device/overview/mempools.inc.php
+++ b/includes/html/pages/device/overview/mempools.inc.php
@@ -14,13 +14,13 @@ if ($mempools->isNotEmpty()) {
     $mempools_url = url('device') . '/device=' . DeviceCache::getPrimary()->device_id . '/tab=health/metric=mempool/';
     echo '
         <div class="overview-panel tw:mb-5">
-        <div class="tw:px-4 tw:py-2.5 tw:bg-neutral-100 tw:border-b tw:border-gray-300 tw:text-neutral-700 tw:dark:bg-dark-gray-200 tw:dark:border-zinc-800 tw:dark:text-dark-white-200">
+        <div class="tw:rounded-t-xl tw:px-4 tw:py-2.5 tw:bg-neutral-100 tw:border-b tw:border-gray-300 tw:text-neutral-700 tw:dark:bg-dark-gray-200 tw:dark:border-zinc-800 tw:dark:text-dark-white-200">
         ';
     echo '<a href="' . $mempools_url . '">';
     echo '<i class="fas fa-memory fa-lg icon-theme" aria-hidden="true"></i> <strong>Memory</strong></a>';
     echo '
         </div>
-        <div class="tw:flex tw:min-w-0 tw:flex-col tw:bg-white tw:divide-y tw:divide-gray-300 tw:dark:bg-dark-gray-400 tw:dark:divide-zinc-800">
+        <div class="tw:rounded-b-xl tw:flex tw:min-w-0 tw:flex-col tw:bg-white tw:divide-y tw:divide-gray-300 tw:dark:bg-dark-gray-400 tw:dark:divide-zinc-800">
         ';
 
     echo '<div class="tw:grid tw:items-center tw:gap-2.5 tw:px-2 tw:py-2 tw:hover:bg-neutral-100 tw:dark:hover:bg-dark-gray-300">

--- a/includes/html/pages/device/overview/ping.inc.php
+++ b/includes/html/pages/device/overview/ping.inc.php
@@ -4,11 +4,11 @@ if (Rrd::checkRrdExists(Rrd::name(DeviceCache::getPrimary()->hostname, 'icmp-per
     $perf_url = url('device') . '/device=' . DeviceCache::getPrimary()->device_id . '/tab=graphs/group=poller/';
     echo '
         <div class="overview-panel tw:mb-5">
-        <div class="tw:px-4 tw:py-2.5 tw:bg-neutral-100 tw:border-b tw:border-gray-300 tw:text-neutral-700 tw:dark:bg-dark-gray-200 tw:dark:border-zinc-800 tw:dark:text-dark-white-200">
+        <div class="tw:rounded-t-xl tw:px-4 tw:py-2.5 tw:bg-neutral-100 tw:border-b tw:border-gray-300 tw:text-neutral-700 tw:dark:bg-dark-gray-200 tw:dark:border-zinc-800 tw:dark:text-dark-white-200">
         <a href="' . $perf_url . '">
         <i class="fas fa-area-chart fa-lg icon-theme" aria-hidden="true"></i><strong>Ping Response</strong></a>
         </div>
-        <div class="tw:flex tw:flex-col tw:bg-white tw:divide-y tw:divide-gray-300 tw:dark:bg-dark-gray-400 tw:dark:divide-zinc-800">
+        <div class="tw:rounded-b-xl tw:flex tw:flex-col tw:bg-white tw:divide-y tw:divide-gray-300 tw:dark:bg-dark-gray-400 tw:dark:divide-zinc-800">
             <div class="tw:grid tw:items-center tw:gap-2.5 tw:px-2 tw:py-2 tw:hover:bg-neutral-100 tw:dark:hover:bg-dark-gray-300">
             <div>';
 

--- a/includes/html/pages/device/overview/ports.inc.php
+++ b/includes/html/pages/device/overview/ports.inc.php
@@ -5,7 +5,7 @@ use LibreNMS\Util\Rewrite;
 
 if (ObjectCache::portCounts(['total'], $device['device_id'])['total'] > 0) {
     echo '<div class="overview-panel tw:mb-5">
-            <div class="tw:px-4 tw:py-2.5 tw:bg-neutral-100 tw:border-b tw:border-gray-300 tw:text-neutral-700 tw:dark:bg-dark-gray-200 tw:dark:border-zinc-800 tw:dark:text-dark-white-200">
+            <div class="tw:rounded-t-xl tw:px-4 tw:py-2.5 tw:bg-neutral-100 tw:border-b tw:border-gray-300 tw:text-neutral-700 tw:dark:bg-dark-gray-200 tw:dark:border-zinc-800 tw:dark:text-dark-white-200">
               <i class="fa fa-road fa-lg icon-theme" aria-hidden="true"></i><strong> Overall Traffic</strong>
             </div>';
 
@@ -30,7 +30,7 @@ if (ObjectCache::portCounts(['total'], $device['device_id'])['total'] > 0) {
     $graph_array['width'] = '210';
     $overlib_content = generate_overlib_content($graph_array, $device['hostname'] . ' - Device Traffic');
 
-    echo '<div class="tw:flex tw:min-w-0 tw:flex-col tw:bg-white tw:divide-y tw:divide-gray-300 tw:dark:bg-dark-gray-400 tw:dark:divide-zinc-800">';
+    echo '<div class="tw:tw:rounded-b-xl flex tw:min-w-0 tw:flex-col tw:bg-white tw:divide-y tw:divide-gray-300 tw:dark:bg-dark-gray-400 tw:dark:divide-zinc-800">';
     echo '<div class="tw:px-2 tw:py-2">';
     echo \LibreNMS\Util\Url::overlibLink($link, $graph, $overlib_content);
     echo '</div>';
@@ -43,7 +43,7 @@ if (ObjectCache::portCounts(['total'], $device['device_id'])['total'] > 0) {
     <a class="lnms-btn lnms-btn-primary" role="button" href="' . route('device', ['device' => $device['device_id'], 'tab' => 'ports', 'filter' => ['disabled' => ['eq' => '1']]]) . '">Disabled: <span class="lnms-btn-badge">' . $ports['disabled'] . '</span></a>
     </div>';
 
-    echo '<div class="tw:px-4 tw:py-2.5 tw:bg-neutral-100 tw:border-t tw:border-gray-300 tw:dark:bg-dark-gray-200 tw:dark:border-zinc-800">';
+    echo '<div class="tw:rounded-b-xl tw:px-4 tw:py-2.5 tw:bg-neutral-100 tw:border-t tw:border-gray-300 tw:dark:bg-dark-gray-200 tw:dark:border-zinc-800">';
 
     $ifsep = '';
 

--- a/includes/html/pages/device/overview/processors.inc.php
+++ b/includes/html/pages/device/overview/processors.inc.php
@@ -5,12 +5,12 @@ $processors = dbFetchRows('SELECT * FROM `processors` WHERE device_id = ?', [$de
 if (count($processors)) {
     echo '
           <div class="overview-panel tw:mb-5">
-            <div class="tw:px-4 tw:py-2.5 tw:bg-neutral-100 tw:border-b tw:border-gray-300 tw:text-neutral-700 tw:dark:bg-dark-gray-200 tw:dark:border-zinc-800 tw:dark:text-dark-white-200">
+            <div class="tw:rounded-t-xl tw:px-4 tw:py-2.5 tw:bg-neutral-100 tw:border-b tw:border-gray-300 tw:text-neutral-700 tw:dark:bg-dark-gray-200 tw:dark:border-zinc-800 tw:dark:text-dark-white-200">
 ';
     echo '<a href="device/device=' . $device['device_id'] . '/tab=health/metric=processor/">';
     echo '<i class="fa fa-microchip fa-lg icon-theme" aria-hidden="true"></i> <strong>Processors</strong></a>';
     echo '</div>
-        <div class="tw:flex tw:min-w-0 tw:flex-col tw:bg-white tw:divide-y tw:divide-gray-300 tw:dark:bg-dark-gray-400 tw:dark:divide-zinc-800">';
+        <div class="tw:rounded-b-xl tw:flex tw:min-w-0 tw:flex-col tw:bg-white tw:divide-y tw:divide-gray-300 tw:dark:bg-dark-gray-400 tw:dark:divide-zinc-800">';
 
     $graph_array = [];
     $graph_array['to'] = \App\Facades\LibrenmsConfig::get('time.now');

--- a/includes/html/pages/device/overview/puppet_agent.inc.php
+++ b/includes/html/pages/device/overview/puppet_agent.inc.php
@@ -71,13 +71,13 @@ if ($app) {
     $failure_class = $metrics['events_failure'] ? 'tw:text-red-500' : '';
 
     echo '<div class="overview-panel tw:mb-5">
-        <div class="tw:px-4 tw:py-2.5 tw:bg-neutral-100 tw:border-b tw:border-gray-300 tw:text-neutral-700 tw:dark:bg-dark-gray-200 tw:dark:border-zinc-800 tw:dark:text-dark-white-200">
+        <div class="tw:rounded-t-xl tw:px-4 tw:py-2.5 tw:bg-neutral-100 tw:border-b tw:border-gray-300 tw:text-neutral-700 tw:dark:bg-dark-gray-200 tw:dark:border-zinc-800 tw:dark:text-dark-white-200">
             <a href="device/device=' . $device['device_id'] . '/tab=apps/app=puppet-agent/">
                 <i class="fa fa-cogs fa-lg icon-theme" aria-hidden="true"></i>
                 <strong>Puppet Agent</strong>
             </a>
         </div>
-        <div class="tw:flex tw:flex-col tw:bg-white tw:divide-y tw:divide-gray-300 tw:dark:bg-dark-gray-400 tw:dark:divide-zinc-800">
+        <div class="tw:rounded-b-xl tw:flex tw:flex-col tw:bg-white tw:divide-y tw:divide-gray-300 tw:dark:bg-dark-gray-400 tw:dark:divide-zinc-800">
             <div class="' . $row_class . '">
                 <div class="tw:font-medium">Summary</div>
                 <div class="tw:min-w-0">

--- a/includes/html/pages/device/overview/services.inc.php
+++ b/includes/html/pages/device/overview/services.inc.php
@@ -21,7 +21,7 @@ if (ObjectCache::serviceCounts(['total'], $device['device_id'])['total'] > 0) {
 
     $services = ObjectCache::serviceCounts(['total', 'ok', 'warning', 'critical'], $device['device_id']);
     echo '<div class="overview-panel tw:mb-5">
-                    <div class="tw:px-4 tw:py-2.5 tw:bg-neutral-100 tw:border-b tw:border-gray-300 tw:text-neutral-700 tw:dark:bg-dark-gray-200 tw:dark:border-zinc-800 tw:dark:text-dark-white-200">
+                    <div class="tw:rounded-t-xl tw:px-4 tw:py-2.5 tw:bg-neutral-100 tw:border-b tw:border-gray-300 tw:text-neutral-700 tw:dark:bg-dark-gray-200 tw:dark:border-zinc-800 tw:dark:text-dark-white-200">
                         <a href="' . Url::deviceUrl($device['device_id'], ['tab' => 'services']) . '"><i class="fa fa-cogs fa-lg icon-theme" aria-hidden="true"></i> <strong>Services</strong></a>
                     </div>
                     <div class="tw:flex tw:flex-wrap tw:gap-3 tw:p-3">
@@ -30,6 +30,6 @@ if (ObjectCache::serviceCounts(['total'], $device['device_id'])['total'] > 0) {
                         <a class="lnms-btn tw:bg-[#f0ad4e] tw:hover:bg-[#ec971f] tw:text-white!" role="button" href="' . Url::deviceUrl($device['device_id'], ['tab' => 'services']) . '">Warning: <span class="lnms-btn-badge tw:bg-white tw:text-[#f0ad4e]">' . $services['warning'] . '</span></a>
                         <a class="lnms-btn lnms-btn-danger" role="button" href="' . Url::deviceUrl($device['device_id'], ['tab' => 'services']) . '">Critical: <span class="lnms-btn-badge">' . $services['critical'] . '</span></a>
                     </div>
-                    <div class="tw:px-4 tw:py-2.5 tw:bg-neutral-100 tw:border-t tw:border-gray-300 tw:dark:bg-dark-gray-200 tw:dark:border-zinc-800">' . $output . '</div>
+                    <div class="tw:rounded-b-xl tw:px-4 tw:py-2.5 tw:bg-neutral-100 tw:border-t tw:border-gray-300 tw:dark:bg-dark-gray-200 tw:dark:border-zinc-800">' . $output . '</div>
                 </div>';
 }

--- a/includes/html/pages/device/overview/storage.inc.php
+++ b/includes/html/pages/device/overview/storage.inc.php
@@ -10,11 +10,11 @@ $drives = dbFetchRows('SELECT * FROM `storage` WHERE device_id = ? ORDER BY `sto
 if (count($drives)) {
     echo '
               <div class="overview-panel tw:mb-5">
-                <div class="tw:px-4 tw:py-2.5 tw:bg-neutral-100 tw:border-b tw:border-gray-300 tw:text-neutral-700 tw:dark:bg-dark-gray-200 tw:dark:border-zinc-800 tw:dark:text-dark-white-200">';
+                <div class="tw:rounded-t-xl tw:px-4 tw:py-2.5 tw:bg-neutral-100 tw:border-b tw:border-gray-300 tw:text-neutral-700 tw:dark:bg-dark-gray-200 tw:dark:border-zinc-800 tw:dark:text-dark-white-200">';
     echo '<a href="device/device=' . $device['device_id'] . '/tab=health/metric=storage/">';
     echo '<i class="fa fa-database fa-lg icon-theme" aria-hidden="true"></i> <strong>Storage</strong></a>';
     echo '    </div>
-            <div class="tw:flex tw:min-w-0 tw:flex-col tw:bg-white tw:divide-y tw:divide-gray-300 tw:dark:bg-dark-gray-400 tw:dark:divide-zinc-800">';
+            <div class="tw:rounded-b-xl tw:flex tw:min-w-0 tw:flex-col tw:bg-white tw:divide-y tw:divide-gray-300 tw:dark:bg-dark-gray-400 tw:dark:divide-zinc-800">';
 
     foreach ($drives as $drive) {
         $skipdrive = 0;

--- a/includes/html/pages/device/overview/syslog.inc.php
+++ b/includes/html/pages/device/overview/syslog.inc.php
@@ -4,10 +4,10 @@ if (\App\Facades\LibrenmsConfig::get('enable_syslog')) {
     $syslog = dbFetchRows("SELECT *, DATE_FORMAT(timestamp, '" . \App\Facades\LibrenmsConfig::get('dateformat.mysql.compact') . "') AS date from syslog WHERE device_id = ? ORDER BY timestamp DESC LIMIT 20", [$device['device_id']]);
     if (count($syslog)) {
         echo '<div class="overview-panel tw:mb-5">
-              <div class="tw:px-4 tw:py-2.5 tw:bg-neutral-100 tw:border-b tw:border-gray-300 tw:text-neutral-700 tw:dark:bg-dark-gray-200 tw:dark:border-zinc-800 tw:dark:text-dark-white-200">';
+              <div class="tw:rounded-t-xl tw:px-4 tw:py-2.5 tw:bg-neutral-100 tw:border-b tw:border-gray-300 tw:text-neutral-700 tw:dark:bg-dark-gray-200 tw:dark:border-zinc-800 tw:dark:text-dark-white-200">';
         echo '<a href="' . route('device.syslog', ['device' => $device['device_id']]) . '"><i class="fa fa-clone fa-lg icon-theme" aria-hidden="true"></i> <strong>Recent Syslog</strong></a>';
         echo '        </div>
-              <div class="tw:flex tw:flex-col tw:bg-white tw:divide-y tw:divide-gray-300 tw:dark:bg-dark-gray-400 tw:dark:divide-zinc-800">';
+              <div class="tw:rounded-b-xl tw:flex tw:flex-col tw:bg-white tw:divide-y tw:divide-gray-300 tw:dark:bg-dark-gray-400 tw:dark:divide-zinc-800">';
         foreach ($syslog as $entry) {
             if (device_permitted($entry['device_id'])) {
                 echo '<div class="tw:grid tw:items-center tw:gap-2.5 tw:px-2 tw:py-2 tw:hover:bg-neutral-100 tw:dark:hover:bg-dark-gray-300 tw:grid-cols-[auto_1fr]">

--- a/includes/html/pages/device/overview/toner.inc.php
+++ b/includes/html/pages/device/overview/toner.inc.php
@@ -10,12 +10,12 @@ foreach ($supplies as $type => $supply) {
     if (! empty($supply)) {
         echo '
             <div class="overview-panel tw:mb-5">
-              <div class="tw:px-4 tw:py-2.5 tw:bg-neutral-100 tw:border-b tw:border-gray-300 tw:text-neutral-700 tw:dark:bg-dark-gray-200 tw:dark:border-zinc-800 tw:dark:text-dark-white-200">';
+              <div class="tw:rounded-t-xl tw:px-4 tw:py-2.5 tw:bg-neutral-100 tw:border-b tw:border-gray-300 tw:text-neutral-700 tw:dark:bg-dark-gray-200 tw:dark:border-zinc-800 tw:dark:text-dark-white-200">';
         echo '<a href="device/device=' . $device['device_id'] . '/tab=printer/">';
         $title = StringHelpers::camelToTitle($type == 'opc' ? 'organicPhotoConductor' : $type);
         echo '<i class="fa fa-print fa-lg icon-theme" aria-hidden="true"></i> <strong>' . $title . '</strong></a>';
         echo '</div>
-        <div class="tw:flex tw:min-w-0 tw:flex-col tw:bg-white tw:divide-y tw:divide-gray-300 tw:dark:bg-dark-gray-400 tw:dark:divide-zinc-800">';
+        <div class="tw:rounded-b-xl tw:flex tw:min-w-0 tw:flex-col tw:bg-white tw:divide-y tw:divide-gray-300 tw:dark:bg-dark-gray-400 tw:dark:divide-zinc-800">';
 
         foreach ($supply as $toner) {
             $percent = round($toner['supply_current']);


### PR DESCRIPTION
Fix bottom round on the overview pieces on the main device page.

ports needed "tw:rounded-b-xl" in two places.  Changing either one alone led to it not rendering correctly.

syslog and puppet_agent not directly tested, changed to match the others.

original versus fixed
<img width="156" height="132" alt="old" src="https://github.com/user-attachments/assets/5053677e-6621-4648-a252-6b01ce3dfacf" />
<img width="142" height="136" alt="new" src="https://github.com/user-attachments/assets/23b23e1e-7cbb-41cd-aaea-3a3bb7a10835" />


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [N/A ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
