### PR TITLE
Graph autosizing improvements

### DIFF
--- a/app/View/Components/Graph.php
+++ b/app/View/Components/Graph.php
@@ -10,9 +10,18 @@ use Illuminate\View\Component;
 class Graph extends Component
 {
     const DEFAULT_WIDE_WIDTH = 340;
-    const DEFAULT_WIDE_HEIGHT = 100;
+    const DEFAULT_WIDE_ASPECT_RATIO = 3.4;
     const DEFAULT_NORMAL_WIDTH = 300;
-    const DEFAULT_NORMAL_HEIGHT = 150;
+    const DEFAULT_NORMAL_ASPECT_RATIO = 2.0;
+
+    /** @var array<string, int> */
+    const BREAKPOINTS = [
+        'sm' => 640,
+        'md' => 768,
+        'lg' => 1024,
+        'xl' => 1280,
+        '2xl' => 1536,
+    ];
 
     /**
      * @var array
@@ -54,6 +63,7 @@ class Graph extends Component
      * @param  string  $aspect
      * @param  int|null  $width
      * @param  int|null  $height
+     * @param  array<string, int>  $columns
      * @param  int  $absolute_size
      * @param  Device|int|null  $device
      * @param  Port|int|null  $port
@@ -69,6 +79,7 @@ class Graph extends Component
         string $aspect = 'normal',
         ?int $width = null,
         ?int $height = null,
+        public array $columns = [],
         int $absolute_size = 0,
         private $link = true,
         $popup = false,
@@ -80,8 +91,7 @@ class Graph extends Component
         $this->vars = $vars;
         $this->legend = $legend;
         $this->absolute_size = $absolute_size;
-        $this->width = $width ?: ($aspect == 'wide' ? self::DEFAULT_WIDE_WIDTH : self::DEFAULT_NORMAL_WIDTH);
-        $this->height = $height ?: ($aspect == 'wide' ? self::DEFAULT_WIDE_HEIGHT : self::DEFAULT_NORMAL_HEIGHT);
+        [$this->width, $this->height] = $this->graphDimensions($aspect, $width, $height);
         $this->popup = filter_var($popup, FILTER_VALIDATE_BOOLEAN);
 
         // handle device and port ids/models for convenience could be set in $vars
@@ -147,6 +157,59 @@ class Graph extends Component
             'to' => $this->to,
             ...$this->vars,
         ]);
+    }
+
+    /**
+     * @return array{0: int, 1: int}
+     */
+    private function graphDimensions(string $aspect, ?int $width, ?int $height): array
+    {
+        [$defaultWidth, $aspectRatio] = $this->defaultGraphDimensions($aspect);
+
+        $width = $width ?: $defaultWidth;
+        $height = $height ?: (int) round($width / $aspectRatio);
+
+        return [$width, $height];
+    }
+
+    /**
+     * @return array{0: int, 1: float}
+     */
+    private function defaultGraphDimensions(string $aspect): array
+    {
+        [$defaultWidth, $aspectRatio] = $aspect === 'wide'
+            ? [self::DEFAULT_WIDE_WIDTH, self::DEFAULT_WIDE_ASPECT_RATIO]
+            : [self::DEFAULT_NORMAL_WIDTH, self::DEFAULT_NORMAL_ASPECT_RATIO];
+
+        if ($aspect === 'wide' || $this->columns !== []) {
+            $defaultWidth = $this->responsiveGraphWidth($defaultWidth);
+        }
+
+        return [$defaultWidth, $aspectRatio];
+    }
+
+    private function responsiveGraphWidth(int $defaultWidth): int
+    {
+        $screenWidth = session('screen_width');
+        if (! is_numeric($screenWidth)) {
+            return $defaultWidth;
+        }
+
+        $screenWidth = (int) $screenWidth;
+
+        return intdiv($screenWidth, $this->columnsFor($screenWidth));
+    }
+
+    private function columnsFor(int $screenWidth): int
+    {
+        $columns = 1;
+        foreach (self::BREAKPOINTS as $breakpoint => $minimumWidth) {
+            if ($screenWidth >= $minimumWidth && array_key_exists($breakpoint, $this->columns)) {
+                $columns = max(1, $this->columns[$breakpoint]);
+            }
+        }
+
+        return $columns;
     }
 
     private function getLink(): string

--- a/app/View/Components/Graph.php
+++ b/app/View/Components/Graph.php
@@ -140,7 +140,7 @@ class Graph extends Component
     {
         $aspectRatio = $isWide ? self::DEFAULT_WIDE_ASPECT_RATIO : self::DEFAULT_NORMAL_ASPECT_RATIO;
 
-        return (int) round($width / ($aspectRatio));
+        return (int) round($width / $aspectRatio);
     }
 
     /**

--- a/app/View/Components/Graph.php
+++ b/app/View/Components/Graph.php
@@ -6,6 +6,7 @@ use App\Models\Device;
 use App\Models\Port;
 use Illuminate\Support\Arr;
 use Illuminate\View\Component;
+use Illuminate\View\View;
 
 class Graph extends Component
 {
@@ -16,125 +17,55 @@ class Graph extends Component
 
     /** @var array<string, int> */
     const BREAKPOINTS = [
-        'sm' => 640,
-        'md' => 768,
-        'lg' => 1024,
-        'xl' => 1280,
         '2xl' => 1536,
+        'xl' => 1280,
+        'lg' => 1024,
+        'md' => 768,
+        'sm' => 640,
     ];
 
-    /**
-     * @var array
-     */
-    public $vars;
-    /**
-     * @var int|null
-     */
-    public $width;
-    /**
-     * @var int|null
-     */
-    public $height;
-    /**
-     * @var string
-     */
-    public $type;
-    /**
-     * @var string
-     */
-    public $legend;
-    /**
-     * @var int
-     */
-    public $absolute_size;
-    /**
-     * @var bool
-     */
-    private $popup;
+    public ?int $width;
+    public ?int $height;
+    private bool $popup;
 
-    /**
-     * Create a new component instance.
-     *
-     * @param  string  $type
-     * @param  array  $vars
-     * @param  int|string  $from
-     * @param  int|string  $to
-     * @param  string  $legend
-     * @param  string  $aspect
-     * @param  int|null  $width
-     * @param  int|null  $height
-     * @param  array<string, int>  $columns
-     * @param  int  $absolute_size
-     * @param  Device|int|null  $device
-     * @param  Port|int|null  $port
-     * @param  bool  $link
-     * @param  string  $popupTitle
-     */
     public function __construct(
-        string $type = '',
-        array $vars = [],
-        public $from = '-1d',
-        public $to = null,
-        string $legend = 'no',
+        public string $type = '',
+        public array $vars = [],
+        public int|string $from = '-1d',
+        public int|string|null $to = null,
+        public string $legend = 'no',
         string $aspect = 'normal',
         ?int $width = null,
         ?int $height = null,
         public array $columns = [],
-        int $absolute_size = 0,
-        private $link = true,
-        $popup = false,
+        public int $absolute_size = 0,
+        private readonly bool|string $link = true,
+        bool|string $popup = false,
         public mixed $popupTitle = '',
-        $device = null,
-        $port = null
+        Device|int|null $device = null,
+        Port|int|null $port = null
     ) {
-        $this->type = $type;
-        $this->vars = $vars;
-        $this->legend = $legend;
-        $this->absolute_size = $absolute_size;
-        [$this->width, $this->height] = $this->graphDimensions($aspect, $width, $height);
+        [$this->width, $this->height] = $this->graphDimensions($width, $height, $aspect === 'wide');
         $this->popup = filter_var($popup, FILTER_VALIDATE_BOOLEAN);
-
-        // handle device and port ids/models for convenience could be set in $vars
-        if ($device instanceof Device) {
-            $this->vars['device'] = $device->device_id;
-        } elseif (is_numeric($device)) {
-            $this->vars['device'] = $device;
-        } elseif ($port instanceof Port) {
-            $this->vars['id'] = $port->port_id;
-        } elseif (is_numeric($port)) {
-            $this->vars['id'] = $port;
-        }
+        $this->vars = $this->resolveVars($this->vars, $device, $port);
     }
 
     /**
      * Get the view / contents that represent the component.
-     *
-     * @return \Illuminate\Contracts\View\View|\Closure|string
      */
-    public function render()
+    public function render(): View
     {
         $view = $this->popup ? 'components.graph-popup' : ($this->link === false ? 'components.graph' : 'components.linked-graph');
-        $data = [
+
+        return view($view, [
             'link' => $this->getLink(),
             'src' => $this->getSrc(),
-        ];
-
-        return view($view, $data);
+        ]);
     }
 
-    /**
-     * @param  mixed  $value
-     * @param  int|string  $key
-     * @return bool
-     */
-    public function filterAttributes($value, $key): bool
+    public function filterAttributes(mixed $value, int|string $key): bool
     {
-        $filtered = [
-            'legend',
-            'height',
-            'loading',
-            'img-class',
-        ];
+        $filtered = ['legend', 'height', 'loading', 'img-class'];
 
         // do not add class and style to the image, add them to the outer link
         if ($this->link) {
@@ -143,6 +74,32 @@ class Graph extends Component
         }
 
         return ! in_array($key, $filtered);
+    }
+
+    /**
+     * Fold a device or port reference into the graph vars, preferring device over port.
+     *
+     * @return array<string, mixed>
+     */
+    private function resolveVars(array $vars, Device|int|null $device, Port|int|null $port): array
+    {
+        if ($device instanceof Device) {
+            return [...$vars, 'device' => $device->device_id];
+        }
+
+        if (is_numeric($device)) {
+            return [...$vars, 'device' => $device];
+        }
+
+        if ($port instanceof Port) {
+            return [...$vars, 'id' => $port->port_id];
+        }
+
+        if (is_numeric($port)) {
+            return [...$vars, 'id' => $port];
+        }
+
+        return $vars;
     }
 
     private function getSrc(): string
@@ -162,54 +119,43 @@ class Graph extends Component
     /**
      * @return array{0: int, 1: int}
      */
-    private function graphDimensions(string $aspect, ?int $width, ?int $height): array
+    private function graphDimensions(?int $width, ?int $height, bool $isWide): array
     {
-        [$defaultWidth, $aspectRatio] = $this->defaultGraphDimensions($aspect);
+        $aspectRatio = $isWide ? self::DEFAULT_WIDE_ASPECT_RATIO : self::DEFAULT_NORMAL_ASPECT_RATIO;
 
-        $width = $width ?: $defaultWidth;
+        $width = $width ?: $this->resolveDefaultWidth($isWide);
         $height = $height ?: (int) round($width / $aspectRatio);
 
         return [$width, $height];
     }
 
     /**
-     * @return array{0: int, 1: float}
+     * Base width for this aspect, divided across configured columns when the graph
+     * is in a column grid and the screen width is known.
      */
-    private function defaultGraphDimensions(string $aspect): array
-    {
-        [$defaultWidth, $aspectRatio] = $aspect === 'wide'
-            ? [self::DEFAULT_WIDE_WIDTH, self::DEFAULT_WIDE_ASPECT_RATIO]
-            : [self::DEFAULT_NORMAL_WIDTH, self::DEFAULT_NORMAL_ASPECT_RATIO];
-
-        if ($aspect === 'wide' || $this->columns !== []) {
-            $defaultWidth = $this->responsiveGraphWidth($defaultWidth);
-        }
-
-        return [$defaultWidth, $aspectRatio];
-    }
-
-    private function responsiveGraphWidth(int $defaultWidth): int
+    private function resolveDefaultWidth(bool $isWide): int
     {
         $screenWidth = session('screen_width');
-        if (! is_numeric($screenWidth)) {
-            return $defaultWidth;
+
+        if ($this->columns === [] || ! is_numeric($screenWidth)) {
+            return $isWide ? self::DEFAULT_WIDE_WIDTH : self::DEFAULT_NORMAL_WIDTH;
         }
 
-        $screenWidth = (int) $screenWidth;
-
-        return intdiv($screenWidth, $this->columnsFor($screenWidth));
+        return intdiv((int) $screenWidth, $this->columnsFor((int) $screenWidth));
     }
 
+    /**
+     * Column count for the largest configured breakpoint the screen width satisfies.
+     */
     private function columnsFor(int $screenWidth): int
     {
-        $columns = 1;
         foreach (self::BREAKPOINTS as $breakpoint => $minimumWidth) {
             if ($screenWidth >= $minimumWidth && array_key_exists($breakpoint, $this->columns)) {
-                $columns = max(1, $this->columns[$breakpoint]);
+                return max(1, $this->columns[$breakpoint]);
             }
         }
 
-        return $columns;
+        return 1;
     }
 
     private function getLink(): string

--- a/app/View/Components/Graph.php
+++ b/app/View/Components/Graph.php
@@ -45,7 +45,9 @@ class Graph extends Component
         Device|int|null $device = null,
         Port|int|null $port = null
     ) {
-        [$this->width, $this->height] = $this->graphDimensions($width, $height, $aspect === 'wide');
+        $isWide = $aspect === 'wide';
+        $this->width = $width ?: $this->resolveDefaultWidth($isWide);
+        $this->height = $height ?: $this->calculateDefaultHeight($this->width, $isWide);
         $this->popup = filter_var($popup, FILTER_VALIDATE_BOOLEAN);
         $this->vars = $this->resolveVars($this->vars, $device, $port);
     }
@@ -117,19 +119,6 @@ class Graph extends Component
     }
 
     /**
-     * @return array{0: int, 1: int}
-     */
-    private function graphDimensions(?int $width, ?int $height, bool $isWide): array
-    {
-        $aspectRatio = $isWide ? self::DEFAULT_WIDE_ASPECT_RATIO : self::DEFAULT_NORMAL_ASPECT_RATIO;
-
-        $width = $width ?: $this->resolveDefaultWidth($isWide);
-        $height = $height ?: (int) round($width / $aspectRatio);
-
-        return [$width, $height];
-    }
-
-    /**
      * Base width for this aspect, divided across configured columns when the graph
      * is in a column grid and the screen width is known.
      */
@@ -142,6 +131,16 @@ class Graph extends Component
         }
 
         return intdiv((int) $screenWidth, $this->columnsFor((int) $screenWidth));
+    }
+
+    /**
+     * Use the default aspect ratio to calculate the graph height based on the resolved width.
+     */
+    private function calculateDefaultHeight(int $width, bool $isWide): int
+    {
+        $aspectRatio = $isWide ? self::DEFAULT_WIDE_ASPECT_RATIO : self::DEFAULT_NORMAL_ASPECT_RATIO;
+
+        return (int) round($width / ($aspectRatio));
     }
 
     /**

--- a/app/View/Components/Graph.php
+++ b/app/View/Components/Graph.php
@@ -26,7 +26,7 @@ class Graph extends Component
 
     public ?int $width;
     public ?int $height;
-    private bool $popup;
+    private readonly bool $popup;
 
     public function __construct(
         public string $type = '',

--- a/app/View/Components/GraphRow.php
+++ b/app/View/Components/GraphRow.php
@@ -5,11 +5,14 @@ namespace App\View\Components;
 use App\Models\Device;
 use App\Models\Port;
 use Illuminate\View\Component;
+use Illuminate\View\View;
 
 class GraphRow extends Component
 {
     public bool $responsive;
     public ?int $rowWidth;
+    /** @var array<string, int> */
+    public array $graphColumns;
 
     /**
      * Create a new component instance.
@@ -35,14 +38,13 @@ class GraphRow extends Component
     {
         $this->responsive = $columns == 'responsive';
         $this->rowWidth = $this->calculateRowWidth((int) $columns);
+        $this->graphColumns = $this->responsive ? ['sm' => 2, 'lg' => 4] : [];
     }
 
     /**
      * Get the view / contents that represent the component.
-     *
-     * @return \Illuminate\Contracts\View\View|\Closure|string
      */
-    public function render()
+    public function render(): View
     {
         return view('components.graph-row');
     }

--- a/pint.json
+++ b/pint.json
@@ -75,17 +75,7 @@
         "no_trailing_comma_in_singleline": true,
         "no_trailing_whitespace": true,
         "no_trailing_whitespace_in_comment": true,
-        "no_unneeded_control_parentheses": {
-            "statements": [
-                "break",
-                "clone",
-                "continue",
-                "echo_print",
-                "return",
-                "switch_case",
-                "yield"
-            ]
-        },
+        "no_unneeded_control_parentheses": true,
         "no_unreachable_default_argument_value": true,
         "no_unused_imports": true,
         "no_useless_return": true,

--- a/resources/views/components/graph-row.blade.php
+++ b/resources/views/components/graph-row.blade.php
@@ -13,7 +13,8 @@
                 :port="$port"
                 :device="$device"
                 :legend="$attributes->get('legend', 'no')"
-                :height="$attributes->get('height', 150)"
+                :height="$attributes->get('height')"
+                :columns="$graphColumns"
                 :vars="array_merge($graph, $attributes->get('vars', []))"
                 :img-class="$responsive ? 'tw:w-full tw:h-auto' : null"
         ></x-graph>

--- a/resources/views/device/tabs/latency.blade.php
+++ b/resources/views/device/tabs/latency.blade.php
@@ -25,7 +25,7 @@
                     </div>
                     <div class="row"><x-graph-row :type="'device_smokeping_' . $direction . '_all'" title="Aggregate" :device="$device" columns="responsive"></x-graph-row>
                         @foreach($data['smokeping']->otherGraphs($direction) as $info)
-                            <x-graph-row :type="$info['graph']" :device="$info['device']" columns="responsive">
+                            <x-graph-row :type="$info['graph']['type']" :device="$info['graph']['device']" columns="responsive">
                                 <x-slot name="title"><x-device-link device="$info['device']" /></x-slot>
                             </x-graph-row>
                         @endforeach


### PR DESCRIPTION
Calculate default graph size more dynamically.  Allow callers to specify columns (taking viewport width into account) to give an approximately correct graph size.

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
