### PR TITLE
Fix DB query statistics being off by a factor of 10

### DIFF
--- a/app/Listeners/QueryMetricListener.php
+++ b/app/Listeners/QueryMetricListener.php
@@ -27,6 +27,6 @@ class QueryMetricListener
     public function handle(QueryExecuted $event): void
     {
         $type = strtolower(substr($event->sql, 0, strpos($event->sql, ' ')));
-        app(MeasurementManager::class)->recordDb(Measurement::make($type, $event->time ? $event->time / 100 : 0));
+        app(MeasurementManager::class)->recordDb(Measurement::make($type, $event->time ? $event->time / 1000 : 0));
     }
 }


### PR DESCRIPTION
milliseconds to seconds conversion is /1000 not /100

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
