### PR TITLE
chore: Fix port_stack API docs to match the current response

### DIFF
--- a/doc/API/Devices.md
+++ b/doc/API/Devices.md
@@ -908,15 +908,10 @@ Route: `/api/v0/devices/:hostname/port_stack`
 
 - hostname can be either the device hostname or id
 
-Input:
-
-- valid_mappings: Filter the result by only showing valid mappings
-  ("0" values not shown).
-
 Example:
 
 ```curl
-curl -H 'X-Auth-Token: YOURAPITOKENHERE' https://foo.example/api/v0/devices/localhost/port_stack?valid_mappings
+curl -H 'X-Auth-Token: YOURAPITOKENHERE' https://foo.example/api/v0/devices/localhost/port_stack
 ```
 
 Output:
@@ -928,15 +923,21 @@ Output:
     "count": 2,
     "mappings": [
         {
-            "device_id": "3742",
-            "port_id_high": "1001000",
-            "port_id_low": "51001",
+            "id": 2795,
+            "device_id": 3742,
+            "high_ifIndex": 17,
+            "high_port_id": 1001000,
+            "low_ifIndex": 18,
+            "low_port_id": 51001,
             "ifStackStatus": "active"
         },
         {
-            "device_id": "3742",
-            "port_id_high": "1001000",
-            "port_id_low": "52001",
+            "id": 2796,
+            "device_id": 3742,
+            "high_ifIndex": 17,
+            "high_port_id": 1001000,
+            "low_ifIndex": 24,
+            "low_port_id": 52001,
             "ifStackStatus": "active"
         }
     ]


### PR DESCRIPTION
The get_port_stack docs describe the pre-2024 ports_stack schema. The documented port_id_high / port_id_low fields are not in the response.

`database/migrations/2024_07_19_120719_update_ports_stack_table.php` (in #16246, 2024-07-26):

```php
$table->id()->first();
$table->unsignedBigInteger('high_port_id')->nullable()->after('port_id_high');
$table->unsignedBigInteger('low_port_id')->nullable()->after('port_id_low');
$table->renameColumn('port_id_high', 'high_ifIndex');
$table->renameColumn('port_id_low', 'low_ifIndex');
```


```php
// includes/html/api_functions.inc.php
return check_device_permission($device->device_id, fn () => api_success($device->portsStack, 'mappings'));
```

`app/Models/PortStack.php` fillable: `high_ifIndex`, `high_port_id`, `low_ifIndex`, `low_port_id`,
`ifStackStatus`.

#16246 also removed the `valid_mappings` handling; the parameter is no longer referenced anywhere.

Neither updated `doc/API/Devices.md`.


`GET /api/v0/devices/<id>/port_stack` on 26.6.1 returns:

```
['device_id', 'high_ifIndex', 'high_port_id', 'id', 'ifStackStatus', 'low_ifIndex', 'low_port_id']
```

all ints except `ifStackStatus`.



DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
