### PR TITLE
Alert macro for device average CPU utilization

### DIFF
--- a/doc/Alerting/Macros.md
+++ b/doc/Alerting/Macros.md
@@ -95,6 +95,14 @@ Description: Only select devices that aren't deleted, ignored or disabled.
 
 Source: `(devices.disabled = 0 AND devices.ignore = 0)`
 
+#### Device CPU average percentage (Decimal)
+
+Entity: `macros.device_cpu_avg_perc`
+
+Description: Returns the average CPU usage percentage across all processors on the device. Returns `0` when no processor data is available.
+
+Source: `COALESCE((SELECT AVG(p.processor_usage) FROM processors AS p WHERE p.device_id = %devices.device_id), 0)`
+
 #### Device component down [JunOS]
 
 Entity: `macros.device_component_down_junos`

--- a/resources/definitions/macros.json
+++ b/resources/definitions/macros.json
@@ -8,6 +8,7 @@
     "device": "(%devices.disabled = 0 && %devices.ignore = 0)",
     "device_component_down_junos": "%sensors.sensor_class = \"state\" && %sensors.sensor_current != \"6\" && (%sensors.sensor_type = \"jnxFruState\" || %sensors.sensor_type = \"jnxFruTable\") && %sensors.sensor_current != \"2\" && %sensors.sensor_alert = \"1\"",
     "device_component_down_cisco": "%sensors.sensor_current != \"1\" && %sensors.sensor_current != \"5\" && %sensors.sensor_type REGEXP \"^cisco.*State$\" && %sensors.sensor_alert = \"1\"",
+    "device_cpu_avg_perc": "COALESCE((SELECT AVG(p.processor_usage) FROM processors AS p WHERE p.device_id = %devices.device_id), 0)",
     "device_up": "(%devices.status = 1 && %macros.device)",
     "device_down": "(%devices.status = 0 && %macros.device)",
     "now": "NOW()",


### PR DESCRIPTION
macros.device_cpu_avg_perc

Allows you to aggregate all cpus/cores to get the real average.


#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
