### PR TITLE
Fix Arista scoped IPv6 BGP polling

### DIFF
--- a/LibreNMS/Util/IP.php
+++ b/LibreNMS/Util/IP.php
@@ -136,6 +136,40 @@ abstract class IP implements \Stringable
     }
 
     /**
+     * Convert an InetAddress value to its SNMP index representation.
+     *
+     * Scoped addresses use the ipv4z/ipv6z InetAddress types and append the
+     * four-byte zone index to the address bytes.
+     *
+     * @throws InvalidIpException
+     */
+    public static function toSnmpInetAddressIndex(string $address): string
+    {
+        $zone = null;
+        if (str_contains($address, '%')) {
+            [$address, $zone] = explode('%', $address, 2);
+
+            if ($zone === '' || ! ctype_digit($zone) || (int) $zone > 4294967295) {
+                throw new InvalidIpException("Invalid InetAddress zone index: $zone");
+            }
+        }
+
+        $ip = self::parse($address);
+        $isIpv6 = $ip->getFamily() === 'ipv6';
+        $type = $isIpv6 ? 2 : 1;
+        $length = $isIpv6 ? 16 : 4;
+        $index = $ip->toSnmpIndex();
+
+        if ($zone !== null) {
+            $type += 2; // ipv4z(3) or ipv6z(4)
+            $length += 4;
+            $index .= '.' . implode('.', unpack('C*', pack('N', (int) $zone)));
+        }
+
+        return "$type.$length.$index";
+    }
+
+    /**
      * Check if the supplied IP is valid.
      *
      * @param  string  $ip

--- a/includes/polling/bgp-peers.inc.php
+++ b/includes/polling/bgp-peers.inc.php
@@ -128,7 +128,12 @@ if (! empty($peers)) {
         $vrfId = $peer['vrf_id'];
 
         try {
-            $peer_ip = IP::parse($peer['bgpPeerIdentifier']);
+            $peer_address = $peer['bgpPeerIdentifier'];
+            if ($device['os_group'] === 'arista') {
+                // Arista reports link-local BGP peers as ipv6z with a numeric zone index.
+                $peer_address = explode('%', $peer_address, 2)[0];
+            }
+            $peer_ip = IP::parse($peer_address);
 
             d_echo("Checking BGP peer $peer_ip ");
 
@@ -371,7 +376,7 @@ if (! empty($peers)) {
                     }
 
                     if ($device['os_group'] === 'arista') {
-                        $peer_identifier = '1.' . $ip_type . '.' . $ip_len . '.' . $bgp_peer_ident;
+                        $peer_identifier = '1.' . IP::toSnmpInetAddressIndex($peer['bgpPeerIdentifier']);
                         $mib = 'ARISTA-BGP4V2-MIB';
                         $oid_map = [
                             'aristaBgp4V2PeerState' => 'bgpPeerState',

--- a/tests/IpTest.php
+++ b/tests/IpTest.php
@@ -205,4 +205,17 @@ final class IpTest extends TestCase
         $this->assertSame('0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.1', IP::parse('::1')->toSnmpIndex());
         $this->assertSame('32.1.8.120.0.0.224.0.0.130.0.226.0.136.0.161', IP::parse('2001:0878:0000:e000:0082:00e2:0088:00a1')->toSnmpIndex());
     }
+
+    public function testToSnmpInetAddressIndex(): void
+    {
+        $this->assertSame('1.4.192.0.2.1', IP::toSnmpInetAddressIndex('192.0.2.1'));
+        $this->assertSame('2.16.32.1.13.184.0.0.0.0.0.0.0.0.0.0.0.1', IP::toSnmpInetAddressIndex('2001:db8::1'));
+        $this->assertSame('4.20.254.128.0.0.0.0.0.0.42.153.58.255.254.30.176.127.0.0.15.161', IP::toSnmpInetAddressIndex('fe80::2a99:3aff:fe1e:b07f%4001'));
+    }
+
+    public function testToSnmpInetAddressIndexRejectsInvalidZone(): void
+    {
+        $this->expectException(\LibreNMS\Exceptions\InvalidIpException::class);
+        IP::toSnmpInetAddressIndex('fe80::1%Ethernet1');
+    }
 }


### PR DESCRIPTION
## Summary

- encode SNMP `InetAddress` indexes for IPv4, IPv6, and scoped `ipv4z`/`ipv6z` addresses
- allow the Arista BGP poller to parse scoped link-local peer identifiers
- query `ARISTA-BGP4V2-MIB` with the four-byte zone index included

## Root cause

EOS exposes unnumbered BGP peers through `ARISTA-BGP4V2-MIB` as `ipv6z`, for example:

```
aristaBgp4V2PeerState[1][ipv6z]["fe:80:...%4001"] = established(6)
```

Discovery retained the numeric zone suffix, but polling passed the complete value to `IP::parse()`, which rejected it. The existing index builder also represented every IPv6 peer as `ipv6(2)` with a 16-byte address instead of `ipv6z(4)` with a 20-byte address and zone index. As a result, discovered peers remained at the default `stop` / `idle` state even while EOS reported them established.

## Impact

Scoped IPv6 BGP peers on Arista EOS are polled using the correct MIB index, allowing their administrative state, session state, counters, and descriptions to update normally. Existing unscoped IPv4 and IPv6 index output is unchanged.

## Validation

- `vendor/bin/phpunit tests/IpTest.php` (13 tests, 103 assertions)
- `vendor/bin/pint --test LibreNMS/Util/IP.php includes/polling/bgp-peers.inc.php tests/IpTest.php`
- `git diff --check`
