### PR TITLE
Include exception class in per-module eventlog messages

### DIFF
--- a/app/Jobs/DiscoverDevice.php
+++ b/app/Jobs/DiscoverDevice.php
@@ -138,7 +138,7 @@ EOH, $this->device->hostname, $os_group ? " ($os_group)" : '', $this->device->de
                 }
 
                 // isolate module exceptions so they don't disrupt the discovery process
-                Eventlog::log("Error discovering $module module. Check log file for more details.", $this->device, 'discovery', Severity::Error);
+                Eventlog::log("Error discovering $module module: " . class_basename($e) . '. Check log file for more details.', $this->device, 'discovery', Severity::Error);
                 report($e);
             }
 

--- a/app/Jobs/PollDevice.php
+++ b/app/Jobs/PollDevice.php
@@ -150,7 +150,7 @@ class PollDevice implements ShouldQueue
                 }
 
                 // isolate module exceptions so they don't disrupt the polling process
-                Eventlog::log("Error polling $module module. Check log file for more details.", $this->device, 'poller', Severity::Error);
+                Eventlog::log("Error polling $module module: " . class_basename($e) . '. Check log file for more details.', $this->device, 'poller', Severity::Error);
                 report($e);
             }
 


### PR DESCRIPTION
PollDevice and DiscoverDevice catch Throwable per module so one bad module cannot abort the whole run. 

The eventlog entry that records it names the module but not the failure, so a timeout, an SNMP error, a DB error and an OS-driver bug all produce the same line.

The class name alone is usually enough to tell those apart at a glance in the device eventlog, without needing shell access to librenms.log.

`  Error polling bgp-peers module: ProcessTimedOutException. Check log file for more details.`

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
