### PR TITLE
Do not kill a healthy rrdtool during polling

### DIFF
--- a/LibreNMS/Exceptions/RrdTimeoutException.php
+++ b/LibreNMS/Exceptions/RrdTimeoutException.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * RrdTimeoutException.php
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * @link       https://www.librenms.org
+ */
+
+namespace LibreNMS\Exceptions;
+
+use Symfony\Component\Process\Exception\ProcessTimedOutException;
+
+class RrdTimeoutException extends RrdStoreException
+{
+    public static function fromProcessTimeout(ProcessTimedOutException $e, string $command): self
+    {
+        $reason = $e->isIdleTimeout()
+            ? 'rrdtool did not respond within ' . $e->getExceededTimeout() . ' seconds'
+            : 'rrdtool did not respond: the process lifetime of ' . $e->getExceededTimeout() . ' seconds ran out';
+
+        return new self("$reason, running: $command", 0, $e);
+    }
+}

--- a/LibreNMS/RRD/RrdProcess.php
+++ b/LibreNMS/RRD/RrdProcess.php
@@ -7,7 +7,9 @@ use Closure;
 use Illuminate\Support\Str;
 use LibreNMS\Exceptions\RrdException;
 use LibreNMS\Exceptions\RrdExecutableNotFoundException;
+use LibreNMS\Exceptions\RrdTimeoutException;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Process\Exception\ProcessTimedOutException;
 use Symfony\Component\Process\InputStream;
 use Symfony\Component\Process\Process;
 
@@ -118,6 +120,29 @@ class RrdProcess
     {
         $this->runAsync($command);
 
+        try {
+            $this->waitFor($waitFor);
+        } catch (ProcessTimedOutException $e) {
+            throw RrdTimeoutException::fromProcessTimeout($e, $command);
+        }
+
+        $output = $this->process->getOutput();
+
+        if ($waitFor === self::COMMAND_COMPLETE) {
+            $output = substr($output, 0, strrpos($output, $waitFor)); // remove OK line
+        }
+
+        return rtrim($output);
+    }
+
+    /**
+     * The RrdException paths are raised inside the waitUntil() callback, so they are
+     * declared on run() where callers see them rather than repeated here.
+     *
+     * @throws ProcessTimedOutException
+     */
+    private function waitFor(string $waitFor): void
+    {
         $this->process->waitUntil(function ($type, $buffer) use ($waitFor) {
             $this->renewIdleTimeout();
 
@@ -143,14 +168,6 @@ class RrdProcess
 
             return str_contains($buffer, $waitFor);
         });
-
-        $output = $this->process->getOutput();
-
-        if ($waitFor === self::COMMAND_COMPLETE) {
-            $output = substr($output, 0, strrpos($output, $waitFor)); // remove OK line
-        }
-
-        return rtrim($output);
     }
 
     private function runAsync(string $command): void

--- a/LibreNMS/RRD/RrdProcess.php
+++ b/LibreNMS/RRD/RrdProcess.php
@@ -22,7 +22,13 @@ class RrdProcess
     private ?Process $process = null;
     private Closure $processFactory;
 
-    public function __construct(private readonly LoggerInterface $logger, private readonly int $timeout = 300, ?Closure $processFactory = null)
+    /**
+     * @param  int  $timeout  seconds to wait for rrdtool to answer a single command
+     * @param  int|null  $lifetime  total seconds the process may live, regardless of
+     *                              whether rrdtool is answering. Null means unbounded,
+     *                              which is what a long-running poll needs.
+     */
+    public function __construct(private readonly LoggerInterface $logger, private readonly int $timeout = 300, ?Closure $processFactory = null, private readonly ?int $lifetime = null)
     {
         $this->rrdcached = (string) LibrenmsConfig::get('rrdcached', '');
         $this->rrd_dir = Str::finish(LibrenmsConfig::get('rrd_dir', LibrenmsConfig::get('install_dir') . '/rrd'), '/');
@@ -53,10 +59,47 @@ class RrdProcess
         if ($this->process === null || ! $this->process->isRunning()) {
             $this->process = ($this->processFactory)();
             $this->process->setInput($this->input);
-            $this->process->setTimeout($this->timeout);
+            $this->process->setTimeout($this->lifetime);
             $this->process->setIdleTimeout($this->timeout);
             $this->process->start();
         }
+    }
+
+    /**
+     * Give rrdtool $timeout seconds from now to say something.
+     *
+     * Called twice per command: once when the command is sent, and again each time
+     * rrdtool produces output, so the deadline always sits $timeout seconds ahead
+     * of the last thing that actually happened.
+     *
+     * Symfony compares the idle timeout against the process's *last output*, and
+     * that timestamp is not ours to move. rrdtool only speaks when spoken to, so
+     * between commands "time since last output" is really "time since we last
+     * asked for something" -- which for the poller includes every SNMP walk it
+     * does between writes. Left alone, a device that walks for longer than the
+     * timeout has its perfectly healthy rrdtool killed, and the failure surfaces
+     * at the next write.
+     *
+     * Since the timestamp cannot be moved forward, the allowance is padded by the
+     * time already elapsed against it, which puts the deadline in the same place.
+     * At send time that pad is the caller's think-time; once rrdtool is replying
+     * the elapsed time is ~0 and the allowance is simply $timeout again, so a
+     * command that answers in pieces does not inherit the gap that preceded it.
+     *
+     * An unresponsive rrdtool is still caught either way: nothing extends the
+     * deadline except rrdtool actually speaking.
+     */
+    private function renewIdleTimeout(): void
+    {
+        $lastOutput = $this->process->getLastOutputTime();
+
+        if ($lastOutput === null) {
+            return;
+        }
+
+        $elapsed = max(0, microtime(true) - $lastOutput);
+
+        $this->process->setIdleTimeout($this->timeout + $elapsed);
     }
 
     public function stop(): void
@@ -76,6 +119,8 @@ class RrdProcess
         $this->runAsync($command);
 
         $this->process->waitUntil(function ($type, $buffer) use ($waitFor) {
+            $this->renewIdleTimeout();
+
             if ($type === Process::ERR) {
                 if (str_contains($buffer, 'rrdtool: not found')) {
                     throw new RrdExecutableNotFoundException(trim($buffer));
@@ -119,6 +164,7 @@ class RrdProcess
 
         $this->logger->debug("RRD[%g$command%n]", ['color' => true]);
         $this->process->clearOutput();
+        $this->renewIdleTimeout();
         $this->input->write("$command\n");
     }
 

--- a/LibreNMS/Validations/Rrd/CheckRrdStep.php
+++ b/LibreNMS/Validations/Rrd/CheckRrdStep.php
@@ -4,10 +4,10 @@ namespace LibreNMS\Validations\Rrd;
 
 use App\Facades\LibrenmsConfig;
 use LibreNMS\Exceptions\RrdException;
+use LibreNMS\Exceptions\RrdTimeoutException;
 use LibreNMS\Interfaces\Validation;
 use LibreNMS\RRD\RrdProcess;
 use LibreNMS\ValidationResult;
-use Symfony\Component\Process\Exception\ProcessTimedOutException;
 
 class CheckRrdStep implements Validation
 {
@@ -23,7 +23,7 @@ class CheckRrdStep implements Validation
         $this->rrd_step = (int) LibrenmsConfig::get('rrd.step', self::DEFAULT_RRD_STEP);
 
         // lifetime bounds the whole check so validate cannot grind through a very
-        // large number of files; the ProcessTimedOutException is caught below and
+        // large number of files; the RrdTimeoutException is caught below and
         // reported as "check skipped".
         $this->rrdtool = app(RrdProcess::class, ['timeout' => 120, 'lifetime' => 120]);
     }
@@ -69,7 +69,7 @@ class CheckRrdStep implements Validation
             }
 
             return ValidationResult::ok(__('validation.validations.rrd.CheckRrdStep.ok', ['total' => $total]));
-        } catch (ProcessTimedOutException) {
+        } catch (RrdTimeoutException) {
             return ValidationResult::info(__('validation.validations.rrd.CheckRrdStep.timeout', ['command' => 'lnms maintenance:rrd-step all']));
         }
     }
@@ -92,7 +92,7 @@ class CheckRrdStep implements Validation
      * @return string[]
      *
      * @throws RrdException
-     * @throws ProcessTimedOutException
+     * @throws RrdTimeoutException
      */
     private function listFiles(): array
     {

--- a/LibreNMS/Validations/Rrd/CheckRrdStep.php
+++ b/LibreNMS/Validations/Rrd/CheckRrdStep.php
@@ -22,7 +22,10 @@ class CheckRrdStep implements Validation
     {
         $this->rrd_step = (int) LibrenmsConfig::get('rrd.step', self::DEFAULT_RRD_STEP);
 
-        $this->rrdtool = app(RrdProcess::class, ['timeout' => 120]);
+        // lifetime bounds the whole check so validate cannot grind through a very
+        // large number of files; the ProcessTimedOutException is caught below and
+        // reported as "check skipped".
+        $this->rrdtool = app(RrdProcess::class, ['timeout' => 120, 'lifetime' => 120]);
     }
 
     public function enabled(): bool

--- a/tests/Unit/RRD/RrdProcessTest.php
+++ b/tests/Unit/RRD/RrdProcessTest.php
@@ -33,6 +33,7 @@ class RrdProcessTest extends TestCase
         $this->process->shouldReceive('setInput')->byDefault();
         $this->process->shouldReceive('setTimeout')->byDefault();
         $this->process->shouldReceive('setIdleTimeout')->byDefault();
+        $this->process->shouldReceive('getLastOutputTime')->andReturn(microtime(true))->byDefault();
         $this->process->shouldReceive('start')->byDefault();
         $this->process->shouldReceive('isRunning')->andReturn(false, true)->byDefault();
         $this->process->shouldReceive('clearOutput')->byDefault();
@@ -292,6 +293,7 @@ class RrdProcessTest extends TestCase
         $process->shouldReceive('setInput');
         $process->shouldReceive('setTimeout');
         $process->shouldReceive('setIdleTimeout');
+        $process->shouldReceive('getLastOutputTime')->andReturn(microtime(true));
         $process->shouldReceive('start')->once();
         $process->shouldReceive('isRunning')->andReturn(true);
         $process->shouldReceive('stop');

--- a/tests/Unit/RRD/RrdProcessTimeoutTest.php
+++ b/tests/Unit/RRD/RrdProcessTimeoutTest.php
@@ -1,0 +1,234 @@
+<?php
+
+/**
+ * RrdProcessTimeoutTest.php
+ *
+ * Process lifecycle tests for RrdProcess.
+ *
+ * These drive a real Symfony Process against a shell script standing in for
+ * rrdtool, because the behaviour under test is Symfony's own timeout
+ * bookkeeping. A mocked Process cannot demonstrate it.
+ *
+ * No rrdtool binary and no database are required.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.  Please see LICENSE.txt at the top level of
+ * the source code distribution for details.
+ */
+
+namespace LibreNMS\Tests\Unit\RRD;
+
+use LibreNMS\RRD\RrdProcess;
+use LibreNMS\Tests\TestCase;
+use Mockery;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Process\Exception\ProcessTimedOutException;
+use Symfony\Component\Process\Process;
+
+class RrdProcessTimeoutTest extends TestCase
+{
+    /** answers every command promptly, exactly like a healthy rrdtool */
+    private const HEALTHY = 'while IFS= read -r line; do printf "OK u:0.01 s:0.02 r:0.03\n"; done';
+
+    /** accepts the command and never answers, like a wedged rrdcached */
+    private const UNRESPONSIVE = 'while IFS= read -r line; do sleep 30; done';
+
+    /** answers the first command, then wedges -- rrdcached going bad mid-poll */
+    private const HEALTHY_THEN_WEDGED = 'IFS= read -r line; printf "OK u:0.01 s:0.02 r:0.03\n"; '
+        . 'while IFS= read -r line; do sleep 30; done';
+
+    /**
+     * emits a first line promptly, then stalls before finishing the command --
+     * rrdcached accepting a command and dying partway through the reply.
+     */
+    private const ANSWERS_THEN_STALLS = 'IFS= read -r line; printf "OK u:0.01 s:0.02 r:0.03\n"; '
+        . 'while IFS= read -r line; do printf "partial\n"; sleep 30; done';
+
+    private LoggerInterface $logger;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->logger = Mockery::mock(LoggerInterface::class);
+        $this->logger->shouldReceive('debug')->byDefault();
+        $this->logger->shouldReceive('warning')->byDefault();
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    private function rrdProcess(string $script, int $timeout, ?int $lifetime = null): RrdProcess
+    {
+        return new RrdProcess($this->logger, $timeout, fn () => new Process(['sh', '-c', $script]), $lifetime);
+    }
+
+    /**
+     * The reported defect.
+     *
+     * The poller holds one rrdtool process open for a whole poll and writes to
+     * it between SNMP walks. rrdtool only speaks when spoken to, so "time since
+     * last output" is really "time since the caller last asked for something".
+     * On a device whose port walk takes longer than the timeout, a completely
+     * healthy rrdtool is killed for the caller's slowness.
+     */
+    public function testHealthyRrdtoolSurvivesACallerThatIsSlowBetweenCommands(): void
+    {
+        $rrd = $this->rrdProcess(self::HEALTHY, 1);
+
+        $rrd->run('update first.rrd N:1');
+
+        // stand in for a slow SNMP walk: we ask rrdtool for nothing at all
+        usleep(1_500_000);
+
+        $rrd->run('update second.rrd N:2');
+
+        // reaching here at all is the assertion; the process must still be usable
+        $this->assertSame('', $rrd->run('update third.rrd N:3'));
+    }
+
+    /**
+     * The requirement the guard was added for in #18786: notice when rrdtool
+     * stops answering, rather than losing writes in silence. Whatever the
+     * timeout measures, it must still catch this.
+     */
+    public function testUnresponsiveRrdtoolIsStillKilled(): void
+    {
+        $rrd = $this->rrdProcess(self::UNRESPONSIVE, 1);
+
+        $this->expectException(ProcessTimedOutException::class);
+
+        $rrd->run('update wedged.rrd N:1');
+    }
+
+    /**
+     * The timeout should bound how long we wait for rrdtool to answer the
+     * command we just sent -- so it runs from the send, not from the last time
+     * rrdtool happened to say something.
+     */
+    public function testTheTimeoutRunsFromWhenTheCommandWasSent(): void
+    {
+        $rrd = $this->rrdProcess(self::HEALTHY_THEN_WEDGED, 2);
+
+        // first command answers, so the process is now established and running
+        $rrd->run('update fine.rrd N:1');
+
+        // burn most of the window without asking rrdtool for anything
+        usleep(1_500_000);
+
+        $start = microtime(true);
+
+        try {
+            $rrd->run('update wedged.rrd N:2');
+            $this->fail('expected the unresponsive process to time out');
+        } catch (ProcessTimedOutException) {
+            $elapsed = microtime(true) - $start;
+        }
+
+        // measured from the send this is ~2s; from the last output it is ~0.5s
+        $this->assertGreaterThan(1.5, $elapsed, 'the timeout did not run from the send');
+    }
+
+    /**
+     * Consecutive slow gaps must not accumulate into a shorter and shorter
+     * budget for rrdtool. Each command gets the whole window.
+     */
+    public function testSlowGapsDoNotAccumulateAcrossCommands(): void
+    {
+        $rrd = $this->rrdProcess(self::HEALTHY, 1);
+
+        for ($i = 0; $i < 3; $i++) {
+            usleep(700_000);
+            $rrd->run("update gap$i.rrd N:$i");
+        }
+
+        $this->assertSame('', $rrd->run('update final.rrd N:1'));
+    }
+
+    /**
+     * Regression guard for #18783 (71dc70f2a), which raised CheckRrdStep's
+     * timeout to 120 and catches ProcessTimedOutException to report
+     * "check skipped" rather than grinding through 150k files.
+     *
+     * That fix depends on the process lifetime remaining bounded even when
+     * rrdtool answers every single command promptly, so a read-path consumer
+     * asking for a lifetime must still get one. Without this test, making the
+     * per-command timeout stop firing would silently reintroduce the hang
+     * #18783 was written to prevent -- invisibly, since CheckRrdStep is
+     * disabled unless rrd.step has been changed from its default.
+     */
+    public function testAnExplicitLifetimeStillBoundsAStreamOfFastCommands(): void
+    {
+        $rrd = $this->rrdProcess(self::HEALTHY, timeout: 30, lifetime: 1);
+
+        $caught = null;
+        $completed = 0;
+        $giveUp = microtime(true) + 5;
+
+        try {
+            // a healthy rrdtool answering as fast as it can, for longer than the lifetime.
+            // bounded by wall clock so that a lifetime which never fires fails the test
+            // rather than looping until phpunit is killed.
+            while (microtime(true) < $giveUp) {
+                $rrd->run("info file$completed.rrd");
+                $completed++;
+            }
+        } catch (ProcessTimedOutException $e) {
+            $caught = $e;
+        }
+
+        $this->assertNotNull($caught, 'an explicit lifetime must still be enforced');
+        $this->assertTrue($caught->isGeneralTimeout(), 'the lifetime axis should be what fires here');
+        $this->assertGreaterThan(0, $completed, 'commands should succeed until the lifetime is reached');
+    }
+
+    /**
+     * The pad that protects a command from the caller's think-time must not
+     * outlive the start of rrdtool's reply. Otherwise a command that answers in
+     * pieces and then stalls gets the preceding gap added to its budget, so a
+     * long SNMP walk would buy a wedged rrdcached extra time to hang around in.
+     */
+    public function testTheWideningDoesNotOutliveTheStartOfTheReply(): void
+    {
+        $rrd = $this->rrdProcess(self::ANSWERS_THEN_STALLS, 1);
+
+        $rrd->run('update fine.rrd N:1');
+
+        // a long gap doing no rrd work at all, as the poller does while walking
+        usleep(2_000_000);
+
+        $start = microtime(true);
+
+        try {
+            $rrd->run('update stalls.rrd N:2');
+            $this->fail('expected the stalled command to time out');
+        } catch (ProcessTimedOutException) {
+            $elapsed = microtime(true) - $start;
+        }
+
+        // ~1s: the deadline runs from the send, then is renewed when "partial" arrives.
+        // Without that renewal the 2s pad is still in place, giving ~3s.
+        $this->assertLessThan(2.5, $elapsed, 'the caller gap was still inflating the window after rrdtool replied');
+    }
+
+    /**
+     * The poller holds one process open for an entire poll, which legitimately
+     * runs for many minutes on a high-port-count device. It must not be given a
+     * lifetime bound, or a healthy rrdtool is killed for the poll being long.
+     */
+    public function testNoLifetimeIsAppliedUnlessOneIsAsked(): void
+    {
+        $rrd = $this->rrdProcess(self::HEALTHY, timeout: 1);
+
+        // longer than the per-command timeout, spent entirely outside rrdtool
+        usleep(1_500_000);
+        $rrd->run('update first.rrd N:1');
+        usleep(1_500_000);
+
+        $this->assertSame('', $rrd->run('update second.rrd N:2'));
+    }
+}

--- a/tests/Unit/RRD/RrdProcessTimeoutTest.php
+++ b/tests/Unit/RRD/RrdProcessTimeoutTest.php
@@ -20,6 +20,9 @@
 
 namespace LibreNMS\Tests\Unit\RRD;
 
+use LibreNMS\Exceptions\RrdException;
+use LibreNMS\Exceptions\RrdStoreException;
+use LibreNMS\Exceptions\RrdTimeoutException;
 use LibreNMS\RRD\RrdProcess;
 use LibreNMS\Tests\TestCase;
 use Mockery;
@@ -100,7 +103,7 @@ class RrdProcessTimeoutTest extends TestCase
     {
         $rrd = $this->rrdProcess(self::UNRESPONSIVE, 1);
 
-        $this->expectException(ProcessTimedOutException::class);
+        $this->expectException(RrdTimeoutException::class);
 
         $rrd->run('update wedged.rrd N:1');
     }
@@ -125,7 +128,7 @@ class RrdProcessTimeoutTest extends TestCase
         try {
             $rrd->run('update wedged.rrd N:2');
             $this->fail('expected the unresponsive process to time out');
-        } catch (ProcessTimedOutException) {
+        } catch (RrdTimeoutException) {
             $elapsed = microtime(true) - $start;
         }
 
@@ -177,12 +180,14 @@ class RrdProcessTimeoutTest extends TestCase
                 $rrd->run("info file$completed.rrd");
                 $completed++;
             }
-        } catch (ProcessTimedOutException $e) {
+        } catch (RrdTimeoutException $e) {
             $caught = $e;
         }
 
         $this->assertNotNull($caught, 'an explicit lifetime must still be enforced');
-        $this->assertTrue($caught->isGeneralTimeout(), 'the lifetime axis should be what fires here');
+        $previous = $caught->getPrevious();
+        $this->assertInstanceOf(ProcessTimedOutException::class, $previous, 'the Symfony exception should be kept as the cause');
+        $this->assertTrue($previous->isGeneralTimeout(), 'the lifetime axis should be what fires here');
         $this->assertGreaterThan(0, $completed, 'commands should succeed until the lifetime is reached');
     }
 
@@ -206,13 +211,54 @@ class RrdProcessTimeoutTest extends TestCase
         try {
             $rrd->run('update stalls.rrd N:2');
             $this->fail('expected the stalled command to time out');
-        } catch (ProcessTimedOutException) {
+        } catch (RrdTimeoutException) {
             $elapsed = microtime(true) - $start;
         }
 
         // ~1s: the deadline runs from the send, then is renewed when "partial" arrives.
         // Without that renewal the 2s pad is still in place, giving ~3s.
         $this->assertLessThan(2.5, $elapsed, 'the caller gap was still inflating the window after rrdtool replied');
+    }
+
+    /**
+     * An unresponsive rrdtool is a datastore fault, and must be reported as one.
+     *
+     * Before this change it escaped as a raw ProcessTimedOutException, which is not
+     * part of the RrdException hierarchy. Rrd::write() catches RrdStoreException and
+     * RrdException and neither matches, so the exception left the datastore
+     * entirely and was caught by the per-module handler in PollDevice -- which logs
+     * "Error polling <module> module", blaming whichever module happened to be
+     * writing when the pipe died. It also never reached the three-strikes counter
+     * that exists to disable a datastore that is not working.
+     */
+    public function testAnUnresponsiveRrdtoolIsReportedAsADatastoreFault(): void
+    {
+        $rrd = $this->rrdProcess(self::UNRESPONSIVE, 1);
+
+        try {
+            $rrd->run('update wedged.rrd N:1');
+            $this->fail('expected the unresponsive process to time out');
+        } catch (RrdException $e) {
+            $this->assertInstanceOf(RrdStoreException::class, $e, 'a timeout must reach the three-strikes counter');
+            $this->assertInstanceOf(ProcessTimedOutException::class, $e->getPrevious(), 'the Symfony exception should be kept as the cause');
+        }
+    }
+
+    /**
+     * The message must say which axis fired, because they mean different things:
+     * the per-command timeout means rrdtool did not answer, the lifetime means a
+     * caller-imposed budget ran out.
+     */
+    public function testTheTimeoutMessageSaysWhatActuallyRanOut(): void
+    {
+        $rrd = $this->rrdProcess(self::UNRESPONSIVE, 1);
+
+        try {
+            $rrd->run('update wedged.rrd N:1');
+            $this->fail('expected the unresponsive process to time out');
+        } catch (RrdException $e) {
+            $this->assertStringContainsString('did not respond', $e->getMessage());
+        }
     }
 
     /**


### PR DESCRIPTION

`ProcessTimedOutException` occurs in modules during polling when wall time exceeds 600 s, because of the Symfony timeout guards applied to the shared `RrdProcess`.

This shows up after a lot of SNMP processing — typically `ports` or `bgp-peers`, both long-running in some cases.

The next time the module writes RRD data, `Process::checkTimeout()` is evaluated, finds the guard has already expired, kills rrdtool and throws before rrdtool is asked anything. 

The module loop catches it:
> Error polling ports module: ProcessTimedOutException. Check log file for more details.

Rrdtool was never unhealthy. 

From a device with 1227 ports:
```
Snmpwalk[28/621.57s]     <- caller busy, no rrd traffic at all
RRD [345/0.15s]          <- rrdtool's total work for the entire poll
#### Unload poller module ports ####  619.15s
```

The guards measure the lifetime of the rrdtool shared process not calls to rrdtool: `setTimeout()` runs from process start and is never reset, so on a shared process it bounds the whole poll; `setIdleTimeout()` runs from last output, and since rrdtool only speaks when spoken to, that is really "time since we last asked it for something".

This change places the guard around the rrd-send → rrd-response pair: the deadline is set to now + 600 s when a command is sent, and renewed when rrdtool responds. 

An unresponsive rrdtool is still caught exactly as before — nothing extends the deadline except rrdtool actually speaking.

Four code paths construct one:

| path | before | after |
|---|---|---|
| `Rrd::write()` — polling | 600 s of poll wall time | **per command** |
| `Rrd::graph()` — web UI | 300 s | unchanged in effect: one command, then `stop()` |
| `CheckRrdStep` — `validate`, only when `rrd.step != 300` | 120 s total | 120 s total, unchanged, now requested explicitly |
| `MaintenanceRrdStep` — `lnms maintenance:rrd-step` | killed 300 s after start, mid-run on a large `all` | runs to completion; 300 s now applies per rrdtool command |

The timeout is now an `RrdTimeoutException extends RrdStoreException`, so it is reported as the datastore fault it is and reaches the three-strikes counter in `Rrd::write()` — previously a Symfony `RuntimeException` matched neither `catch` there, so it escaped the datastore entirely and the counter never incremented.

<img width="2000" height="804" alt="1-reported" src="https://github.com/user-attachments/assets/fdab6376-7485-44eb-8513-425710527068" />

Tests: `tests/Unit/RRD/RrdProcessTimeoutTest.php` — 9 tests driving a real `Symfony\Process` against `sh` stand-ins for rrdtool, since the existing tests mock `Process` wholesale and cannot observe its timeout bookkeeping.

No rrdtool binary or database needed. Includes a guard for \#18783, which depends on `validate` staying bounded while rrdtool answers every command promptly.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
