### PR TITLE
Smarter loading for plugins

### DIFF
--- a/app/Providers/PluginProvider.php
+++ b/app/Providers/PluginProvider.php
@@ -41,7 +41,9 @@ class PluginProvider extends ServiceProvider implements DeferrableProvider
 
     public function boot(): void
     {
-        $this->loadLocalPlugins($this->app->make(PluginManagerInterface::class));
+        if (! $this->app->runningInConsole() && ! $this->app->runningUnitTests()) {
+            $this->loadLocalPlugins($this->app->make(PluginManagerInterface::class));
+        }
     }
 
     public function provides(): array


### PR DESCRIPTION
currently, all plugin hooks are web-ui hooks.
Don't load LOCAL plugins in cli console

Full package based plugins still provide their own Service Providers and control when they boot.

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
