### PR TITLE
API v1: add AlertRule Repository

### DIFF
--- a/app/Exceptions/ErrorReporting.php
+++ b/app/Exceptions/ErrorReporting.php
@@ -27,14 +27,22 @@
 namespace App\Exceptions;
 
 use App\Facades\LibrenmsConfig;
+use App\Http\Middleware\EnforceJsonApi;
+use Binaryk\LaravelRestify\Exceptions\RepositoryNotFoundException;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Auth\AuthenticationException;
 use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Foundation\Configuration\Exceptions;
+use Illuminate\Http\Exceptions\ThrottleRequestsException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
 use LibreNMS\Util\Git;
 use Spatie\LaravelIgnition\Facades\Flare;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 use Throwable;
 
 class ErrorReporting
@@ -95,7 +103,135 @@ class ErrorReporting
             }
         }
 
+        if ($request->is('api/v1/*') || $request->is('api/v1')) {
+            return self::renderApiException($exception);
+        }
+
         return null; // use default rendering
+    }
+
+    /**
+     * Render any exception as a JSON:API errors-array document for v1 API requests.
+     * Public + static so it can be unit-tested without a full HTTP cycle.
+     */
+    public static function renderApiException(Throwable $e): JsonResponse
+    {
+        [$status, $code, $title] = self::classifyException($e);
+
+        if ($e instanceof ValidationException) {
+            $entries = [];
+            foreach ($e->errors() as $field => $messages) {
+                foreach ((array) $messages as $message) {
+                    $entries[] = [
+                        'status' => (string) $status,
+                        'code' => $code,
+                        'title' => $title,
+                        'detail' => $message,
+                        'source' => ['pointer' => '/' . ltrim((string) $field, '/')],
+                    ];
+                }
+            }
+            if ($entries === []) {
+                $entries[] = self::buildSingleErrorEntry($e, $status, $code, $title);
+            }
+        } else {
+            $entries = [self::buildSingleErrorEntry($e, $status, $code, $title)];
+        }
+
+        if ($status >= 500 && config('app.debug')) {
+            $entries[0]['meta'] = [
+                'exception' => $e::class,
+                'file' => $e->getFile(),
+                'line' => $e->getLine(),
+                'trace' => self::formatTrace($e),
+            ];
+        }
+
+        return response()->json(
+            ['errors' => $entries],
+            $status,
+            ['Content-Type' => EnforceJsonApi::CONTENT_TYPE],
+        );
+    }
+
+    /**
+     * @return array{0:int,1:string,2:string} [status, code, title]
+     */
+    private static function classifyException(Throwable $e): array
+    {
+        if ($e instanceof ValidationException) {
+            return [$e->status, 'validation_failed', 'Validation Failed'];
+        }
+        if ($e instanceof AuthenticationException) {
+            return [401, 'unauthenticated', 'Unauthenticated'];
+        }
+        if ($e instanceof AuthorizationException) {
+            return [403, 'forbidden', 'Forbidden'];
+        }
+        if ($e instanceof ModelNotFoundException || $e instanceof RepositoryNotFoundException) {
+            return [404, 'not_found', 'Not Found'];
+        }
+        if ($e instanceof ThrottleRequestsException) {
+            return [429, 'too_many_requests', 'Too Many Requests'];
+        }
+        if ($e instanceof HttpExceptionInterface) {
+            return self::classifyByStatus($e->getStatusCode());
+        }
+
+        return [500, 'server_error', 'Server Error'];
+    }
+
+    /**
+     * @return array{0:int,1:string,2:string}
+     */
+    private static function classifyByStatus(int $status): array
+    {
+        return match ($status) {
+            401 => [401, 'unauthenticated', 'Unauthenticated'],
+            403 => [403, 'forbidden', 'Forbidden'],
+            404 => [404, 'not_found', 'Not Found'],
+            405 => [405, 'method_not_allowed', 'Method Not Allowed'],
+            429 => [429, 'too_many_requests', 'Too Many Requests'],
+            503 => [503, 'service_unavailable', 'Service Unavailable'],
+            default => [
+                $status,
+                'http_' . $status,
+                Response::$statusTexts[$status] ?? 'Error',
+            ],
+        };
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function buildSingleErrorEntry(Throwable $e, int $status, string $code, string $title): array
+    {
+        $detail = $e->getMessage();
+        if ($detail === '' || ($status >= 500 && ! config('app.debug'))) {
+            $detail = $status >= 500 ? 'An unexpected error occurred.' : $title;
+        }
+
+        return [
+            'status' => (string) $status,
+            'code' => $code,
+            'title' => $title,
+            'detail' => $detail,
+        ];
+    }
+
+    /**
+     * @return string[]
+     */
+    private static function formatTrace(Throwable $e): array
+    {
+        $frames = [];
+        foreach (array_slice($e->getTrace(), 0, 10) as $frame) {
+            $location = ($frame['file'] ?? '?') . ':' . ($frame['line'] ?? '?');
+            $call = ($frame['class'] ?? '') . ($frame['type'] ?? '') . ($frame['function'] ?? '');
+            $frames[] = trim($location . ' ' . $call);
+        }
+
+        return $frames;
     }
 
     /**

--- a/app/Exceptions/ErrorReporting.php
+++ b/app/Exceptions/ErrorReporting.php
@@ -27,22 +27,14 @@
 namespace App\Exceptions;
 
 use App\Facades\LibrenmsConfig;
-use App\Http\Middleware\EnforceJsonApi;
-use Binaryk\LaravelRestify\Exceptions\RepositoryNotFoundException;
-use Illuminate\Auth\Access\AuthorizationException;
-use Illuminate\Auth\AuthenticationException;
 use Illuminate\Cache\RateLimiting\Limit;
-use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Foundation\Configuration\Exceptions;
-use Illuminate\Http\Exceptions\ThrottleRequestsException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Str;
-use Illuminate\Validation\ValidationException;
 use LibreNMS\Util\Git;
 use Spatie\LaravelIgnition\Facades\Flare;
-use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 use Throwable;
 
 class ErrorReporting
@@ -104,134 +96,10 @@ class ErrorReporting
         }
 
         if ($request->is('api/v1/*') || $request->is('api/v1')) {
-            return self::renderApiException($exception);
+            return JsonApiErrorRenderer::render($exception);
         }
 
         return null; // use default rendering
-    }
-
-    /**
-     * Render any exception as a JSON:API errors-array document for v1 API requests.
-     * Public + static so it can be unit-tested without a full HTTP cycle.
-     */
-    public static function renderApiException(Throwable $e): JsonResponse
-    {
-        [$status, $code, $title] = self::classifyException($e);
-
-        if ($e instanceof ValidationException) {
-            $entries = [];
-            foreach ($e->errors() as $field => $messages) {
-                foreach ((array) $messages as $message) {
-                    $entries[] = [
-                        'status' => (string) $status,
-                        'code' => $code,
-                        'title' => $title,
-                        'detail' => $message,
-                        'source' => ['pointer' => '/' . ltrim((string) $field, '/')],
-                    ];
-                }
-            }
-            if ($entries === []) {
-                $entries[] = self::buildSingleErrorEntry($e, $status, $code, $title);
-            }
-        } else {
-            $entries = [self::buildSingleErrorEntry($e, $status, $code, $title)];
-        }
-
-        if ($status >= 500 && config('app.debug')) {
-            $entries[0]['meta'] = [
-                'exception' => $e::class,
-                'file' => $e->getFile(),
-                'line' => $e->getLine(),
-                'trace' => self::formatTrace($e),
-            ];
-        }
-
-        return response()->json(
-            ['errors' => $entries],
-            $status,
-            ['Content-Type' => EnforceJsonApi::CONTENT_TYPE],
-        );
-    }
-
-    /**
-     * @return array{0:int,1:string,2:string} [status, code, title]
-     */
-    private static function classifyException(Throwable $e): array
-    {
-        if ($e instanceof ValidationException) {
-            return [$e->status, 'validation_failed', 'Validation Failed'];
-        }
-        if ($e instanceof AuthenticationException) {
-            return [401, 'unauthenticated', 'Unauthenticated'];
-        }
-        if ($e instanceof AuthorizationException) {
-            return [403, 'forbidden', 'Forbidden'];
-        }
-        if ($e instanceof ModelNotFoundException || $e instanceof RepositoryNotFoundException) {
-            return [404, 'not_found', 'Not Found'];
-        }
-        if ($e instanceof ThrottleRequestsException) {
-            return [429, 'too_many_requests', 'Too Many Requests'];
-        }
-        if ($e instanceof HttpExceptionInterface) {
-            return self::classifyByStatus($e->getStatusCode());
-        }
-
-        return [500, 'server_error', 'Server Error'];
-    }
-
-    /**
-     * @return array{0:int,1:string,2:string}
-     */
-    private static function classifyByStatus(int $status): array
-    {
-        return match ($status) {
-            401 => [401, 'unauthenticated', 'Unauthenticated'],
-            403 => [403, 'forbidden', 'Forbidden'],
-            404 => [404, 'not_found', 'Not Found'],
-            405 => [405, 'method_not_allowed', 'Method Not Allowed'],
-            429 => [429, 'too_many_requests', 'Too Many Requests'],
-            503 => [503, 'service_unavailable', 'Service Unavailable'],
-            default => [
-                $status,
-                'http_' . $status,
-                Response::$statusTexts[$status] ?? 'Error',
-            ],
-        };
-    }
-
-    /**
-     * @return array<string, mixed>
-     */
-    private static function buildSingleErrorEntry(Throwable $e, int $status, string $code, string $title): array
-    {
-        $detail = $e->getMessage();
-        if ($detail === '' || ($status >= 500 && ! config('app.debug'))) {
-            $detail = $status >= 500 ? 'An unexpected error occurred.' : $title;
-        }
-
-        return [
-            'status' => (string) $status,
-            'code' => $code,
-            'title' => $title,
-            'detail' => $detail,
-        ];
-    }
-
-    /**
-     * @return string[]
-     */
-    private static function formatTrace(Throwable $e): array
-    {
-        $frames = [];
-        foreach (array_slice($e->getTrace(), 0, 10) as $frame) {
-            $location = ($frame['file'] ?? '?') . ':' . ($frame['line'] ?? '?');
-            $call = ($frame['class'] ?? '') . ($frame['type'] ?? '') . ($frame['function'] ?? '');
-            $frames[] = trim($location . ' ' . $call);
-        }
-
-        return $frames;
     }
 
     /**

--- a/app/Exceptions/JsonApiErrorRenderer.php
+++ b/app/Exceptions/JsonApiErrorRenderer.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace App\Exceptions;
+
+use App\Http\Middleware\EnforceJsonApi;
+use Binaryk\LaravelRestify\Exceptions\RepositoryNotFoundException;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Auth\AuthenticationException;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Http\Exceptions\ThrottleRequestsException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Response;
+use Illuminate\Validation\ValidationException;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
+use Throwable;
+
+/**
+ * Renders exceptions as JSON:API errors-array documents for the v1 API.
+ * The single source of truth for the error document shape.
+ */
+class JsonApiErrorRenderer
+{
+    public static function render(Throwable $e): JsonResponse
+    {
+        [$status, $code, $title] = self::classifyException($e);
+
+        if ($e instanceof ValidationException) {
+            $entries = [];
+            foreach ($e->errors() as $field => $messages) {
+                foreach ((array) $messages as $message) {
+                    $entries[] = [
+                        'status' => (string) $status,
+                        'code' => $code,
+                        'title' => $title,
+                        'detail' => $message,
+                        'source' => ['pointer' => '/' . ltrim((string) $field, '/')],
+                    ];
+                }
+            }
+            if ($entries === []) {
+                $entries[] = self::buildSingleErrorEntry($e, $status, $code, $title);
+            }
+        } else {
+            $entries = [self::buildSingleErrorEntry($e, $status, $code, $title)];
+        }
+
+        if ($status >= 500 && config('app.debug')) {
+            $entries[0]['meta'] = [
+                'exception' => $e::class,
+                'file' => $e->getFile(),
+                'line' => $e->getLine(),
+                'trace' => self::formatTrace($e),
+            ];
+        }
+
+        return response()->json(
+            ['errors' => $entries],
+            $status,
+            ['Content-Type' => EnforceJsonApi::CONTENT_TYPE],
+        );
+    }
+
+    /**
+     * @return array{0:int,1:string,2:string} [status, code, title]
+     */
+    private static function classifyException(Throwable $e): array
+    {
+        if ($e instanceof ValidationException) {
+            return [$e->status, 'validation_failed', 'Validation Failed'];
+        }
+        if ($e instanceof AuthenticationException) {
+            return [401, 'unauthenticated', 'Unauthenticated'];
+        }
+        if ($e instanceof AuthorizationException) {
+            return [403, 'forbidden', 'Forbidden'];
+        }
+        if ($e instanceof ModelNotFoundException || $e instanceof RepositoryNotFoundException) {
+            return [404, 'not_found', 'Not Found'];
+        }
+        if ($e instanceof ThrottleRequestsException) {
+            return [429, 'too_many_requests', 'Too Many Requests'];
+        }
+        if ($e instanceof HttpExceptionInterface) {
+            return self::classifyByStatus($e->getStatusCode());
+        }
+
+        return [500, 'server_error', 'Server Error'];
+    }
+
+    /**
+     * @return array{0:int,1:string,2:string}
+     */
+    private static function classifyByStatus(int $status): array
+    {
+        return match ($status) {
+            401 => [401, 'unauthenticated', 'Unauthenticated'],
+            403 => [403, 'forbidden', 'Forbidden'],
+            404 => [404, 'not_found', 'Not Found'],
+            405 => [405, 'method_not_allowed', 'Method Not Allowed'],
+            429 => [429, 'too_many_requests', 'Too Many Requests'],
+            503 => [503, 'service_unavailable', 'Service Unavailable'],
+            default => [
+                $status,
+                'http_' . $status,
+                Response::$statusTexts[$status] ?? 'Error',
+            ],
+        };
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function buildSingleErrorEntry(Throwable $e, int $status, string $code, string $title): array
+    {
+        $detail = $e->getMessage();
+        if ($detail === '' || ($status >= 500 && ! config('app.debug'))) {
+            $detail = $status >= 500 ? 'An unexpected error occurred.' : $title;
+        }
+
+        return [
+            'status' => (string) $status,
+            'code' => $code,
+            'title' => $title,
+            'detail' => $detail,
+        ];
+    }
+
+    /**
+     * @return string[]
+     */
+    private static function formatTrace(Throwable $e): array
+    {
+        $frames = [];
+        foreach (array_slice($e->getTrace(), 0, 10) as $frame) {
+            $location = ($frame['file'] ?? '?') . ':' . ($frame['line'] ?? '?');
+            $call = ($frame['class'] ?? '') . ($frame['type'] ?? '') . ($frame['function'] ?? '');
+            $frames[] = trim($location . ' ' . $call);
+        }
+
+        return $frames;
+    }
+}

--- a/app/Http/Middleware/FormatJsonApiError.php
+++ b/app/Http/Middleware/FormatJsonApiError.php
@@ -2,16 +2,20 @@
 
 namespace App\Http\Middleware;
 
+use App\Exceptions\ErrorReporting;
 use Closure;
 use Illuminate\Database\QueryException;
 use Illuminate\Http\Request;
 use LibreNMS\Exceptions\DatabaseConnectException;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Exception\HttpException;
-use Throwable;
+use Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException;
 
 /**
- * Ensure errors are formatted correctly for JSON:API.
+ * Convert failures that never reach ErrorReporting::renderApiException()
+ * (which renders all other v1 API errors) into JSON:API 503 documents:
+ * database failures thrown by middleware later in this stack, and server
+ * errors that Laravel's pipeline already rendered into the health
+ * endpoint's response before returning control here.
  */
 class FormatJsonApiError
 {
@@ -20,64 +24,24 @@ class FormatJsonApiError
         try {
             $response = $next($request);
 
-            // Laravel's pipeline may render middleware exceptions before
-            // returning control here instead of allowing them to be caught.
             if ($request->routeIs('api.v1.health') && $response->isServerError()) {
-                return $this->generateJsonApiErrorResponse(503);
+                return $this->serviceUnavailable();
             }
 
-            $errorResponse = $this->generateJsonApiErrorResponse($response->getStatusCode());
-
-            return $errorResponse ?? $response;
-        } catch (HttpException $e) {
-            $errorResponse = $this->generateJsonApiErrorResponse($e->getStatusCode());
-
-            if ($errorResponse) {
-                return $errorResponse;
-            }
-
-            throw $e;
+            return $response;
         } catch (QueryException $e) {
             if (DatabaseConnectException::upgrade($e) !== null) {
-                return $this->generateJsonApiErrorResponse(503);
-            }
-
-            throw $e;
-        } catch (Throwable $e) {
-            if ($request->routeIs('api.v1.health')) {
-                return $this->generateJsonApiErrorResponse(503);
+                return $this->serviceUnavailable();
             }
 
             throw $e;
         }
     }
 
-    protected function generateJsonApiErrorResponse(int $code): ?Response
+    protected function serviceUnavailable(): Response
     {
-        return match ($code) {
-            404 => $this->toJsonApiResponse(404, 'Not Found', 'The requested resource could not be found.'),
-            403 => $this->toJsonApiResponse(403, 'Forbidden', 'You do not have the necessary permissions to access this resource.'),
-            429 => $this->toJsonApiResponse(429, 'Too Many Requests', 'Too many requests. Please try again later.'),
-            503 => $this->toJsonApiResponse(503, 'Service Unavailable', 'A required service is unavailable.'),
-            default => null,
-        };
-    }
-
-    /**
-     * Format the response to adhere strictly to JSON:API specs.
-     */
-    protected function toJsonApiResponse(int $code, string $title, string $detail): Response
-    {
-        return response()->json([
-            'errors' => [
-                [
-                    'status' => "$code", // JSON:API enforces string here
-                    'title' => $title,
-                    'detail' => $detail,
-                ],
-            ],
-        ], $code, [
-            'Content-Type' => 'application/vnd.api+json',
-        ]);
+        return ErrorReporting::renderApiException(
+            new ServiceUnavailableHttpException(null, 'A required service is unavailable.'),
+        );
     }
 }

--- a/app/Http/Middleware/FormatJsonApiError.php
+++ b/app/Http/Middleware/FormatJsonApiError.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Middleware;
 
-use App\Exceptions\ErrorReporting;
+use App\Exceptions\JsonApiErrorRenderer;
 use Closure;
 use Illuminate\Database\QueryException;
 use Illuminate\Http\Request;
@@ -11,7 +11,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException;
 
 /**
- * Convert failures that never reach ErrorReporting::renderApiException()
+ * Convert failures that never reach JsonApiErrorRenderer::render()
  * (which renders all other v1 API errors) into JSON:API 503 documents:
  * database failures thrown by middleware later in this stack, and server
  * errors that Laravel's pipeline already rendered into the health
@@ -40,7 +40,7 @@ class FormatJsonApiError
 
     protected function serviceUnavailable(): Response
     {
-        return ErrorReporting::renderApiException(
+        return JsonApiErrorRenderer::render(
             new ServiceUnavailableHttpException(null, 'A required service is unavailable.'),
         );
     }

--- a/app/Models/AlertRule.php
+++ b/app/Models/AlertRule.php
@@ -80,6 +80,14 @@ class AlertRule extends BaseModel
         'alert_operation_id',
     ];
 
+    // query, builder and extra are NOT NULL without a database default,
+    // so creates must always provide a value
+    protected $attributes = [
+        'query' => '',
+        'builder' => '{}',
+        'extra' => '{}',
+    ];
+
     protected $casts = [
         'builder' => 'array',
         'extra' => 'array',

--- a/app/Restify/AlertRuleRepository.php
+++ b/app/Restify/AlertRuleRepository.php
@@ -68,7 +68,7 @@ class AlertRuleRepository extends Repository
             field('name')->rules('required', 'string', 'max:255'),
             field('severity')->rules('required', 'in:ok,warning,critical'),
             field('isEnabled', fn ($value, $model) => ! $model->disabled)
-                ->fillCallback(function ($request, $model, $attribute) {
+                ->fillCallback(function ($request, $model, $attribute): void {
                     if ($request->exists($attribute)) {
                         $model->disabled = ! $request->boolean($attribute);
                     }
@@ -81,35 +81,35 @@ class AlertRuleRepository extends Repository
             // so they are exposed as first-class attributes instead of a raw blob.
             // recovery and acknowledgement are treated as enabled when absent.
             field('isConditionInverted', fn ($value, $model) => (bool) ($model->extra['invert'] ?? false))
-                ->fillCallback(function ($request, $model, $attribute) {
+                ->fillCallback(function ($request, $model, $attribute): void {
                     if ($request->exists($attribute)) {
                         self::setExtra($model, 'invert', $request->boolean($attribute));
                     }
                 })
                 ->rules('boolean'),
             field('isMuted', fn ($value, $model) => (bool) ($model->extra['mute'] ?? false))
-                ->fillCallback(function ($request, $model, $attribute) {
+                ->fillCallback(function ($request, $model, $attribute): void {
                     if ($request->exists($attribute)) {
                         self::setExtra($model, 'mute', $request->boolean($attribute));
                     }
                 })
                 ->rules('boolean'),
             field('sendsRecoveryAlerts', fn ($value, $model) => (bool) ($model->extra['recovery'] ?? true))
-                ->fillCallback(function ($request, $model, $attribute) {
+                ->fillCallback(function ($request, $model, $attribute): void {
                     if ($request->exists($attribute)) {
                         self::setExtra($model, 'recovery', $request->boolean($attribute));
                     }
                 })
                 ->rules('boolean'),
             field('sendsAcknowledgementAlerts', fn ($value, $model) => (bool) ($model->extra['acknowledgement'] ?? true))
-                ->fillCallback(function ($request, $model, $attribute) {
+                ->fillCallback(function ($request, $model, $attribute): void {
                     if ($request->exists($attribute)) {
                         self::setExtra($model, 'acknowledgement', $request->boolean($attribute));
                     }
                 })
                 ->rules('boolean'),
             field('overridesQuery', fn ($value, $model) => (bool) ($model->extra['options']['override_query'] ?? false))
-                ->fillCallback(function ($request, $model, $attribute) {
+                ->fillCallback(function ($request, $model, $attribute): void {
                     if ($request->exists($attribute)) {
                         $options = $model->extra['options'] ?? [];
                         $options['override_query'] = $request->boolean($attribute);
@@ -118,7 +118,7 @@ class AlertRuleRepository extends Repository
                 })
                 ->rules('boolean'),
             field('procedure', fn ($value, $model) => $model->proc)
-                ->fillCallback(function ($request, $model, $attribute) {
+                ->fillCallback(function ($request, $model, $attribute): void {
                     if ($request->exists($attribute)) {
                         $model->proc = $request->input($attribute);
                     }
@@ -126,14 +126,14 @@ class AlertRuleRepository extends Repository
                 ->rules('nullable', 'string', 'max:80'),
             field('notes')->rules('nullable', 'string'),
             field('isScopeInverted', fn ($value, $model) => (bool) $model->invert_map)
-                ->fillCallback(function ($request, $model, $attribute) {
+                ->fillCallback(function ($request, $model, $attribute): void {
                     if ($request->exists($attribute)) {
                         $model->invert_map = $request->boolean($attribute);
                     }
                 })
                 ->rules('boolean'),
             field('alertOperationId', fn ($value, $model) => $model->alert_operation_id)
-                ->fillCallback(function ($request, $model, $attribute) {
+                ->fillCallback(function ($request, $model, $attribute): void {
                     if ($request->exists($attribute)) {
                         $model->alert_operation_id = $request->input($attribute);
                     }

--- a/app/Restify/AlertRuleRepository.php
+++ b/app/Restify/AlertRuleRepository.php
@@ -18,6 +18,9 @@ class AlertRuleRepository extends Repository
 
     public static string $title = 'name';
 
+    /**
+     * @return array<string, SearchableFilter>
+     */
     public static function searchables(): array
     {
         return [
@@ -25,6 +28,9 @@ class AlertRuleRepository extends Repository
         ];
     }
 
+    /**
+     * @return array<string, MatchFilter>
+     */
     public static function matches(): array
     {
         return [
@@ -39,6 +45,9 @@ class AlertRuleRepository extends Repository
         ];
     }
 
+    /**
+     * @return array<string, SortableFilter>
+     */
     public static function sorts(): array
     {
         return [
@@ -50,6 +59,9 @@ class AlertRuleRepository extends Repository
         ];
     }
 
+    /**
+     * @return array<int, \Binaryk\LaravelRestify\Fields\Field>
+     */
     public function fields(RestifyRequest $request): array
     {
         return [

--- a/app/Restify/AlertRuleRepository.php
+++ b/app/Restify/AlertRuleRepository.php
@@ -34,7 +34,7 @@ class AlertRuleRepository extends Repository
             'query' => MatchFilter::make()->setType('text')->setColumn('query'),
             'procedure' => MatchFilter::make()->setType('text')->setColumn('proc'),
             'notes' => MatchFilter::make()->setType('text')->setColumn('notes'),
-            'isInverted' => MatchFilter::make()->setType('bool')->setColumn('invert_map'),
+            'isScopeInverted' => MatchFilter::make()->setType('bool')->setColumn('invert_map'),
             'alertOperationId' => MatchFilter::make()->setType('integer')->setColumn('alert_operation_id'),
         ];
     }
@@ -45,7 +45,7 @@ class AlertRuleRepository extends Repository
             'name' => SortableFilter::make()->setColumn('name'),
             'severity' => SortableFilter::make()->setColumn('severity'),
             'isEnabled' => SortableFilter::make()->setColumn('disabled'),
-            'isInverted' => SortableFilter::make()->setColumn('invert_map'),
+            'isScopeInverted' => SortableFilter::make()->setColumn('invert_map'),
             'alertOperationId' => SortableFilter::make()->setColumn('alert_operation_id'),
         ];
     }
@@ -64,7 +64,47 @@ class AlertRuleRepository extends Repository
                 ->rules('required', 'boolean'),
             field('query')->rules('nullable', 'string'),
             field('builder')->rules('nullable'),
-            field('extra')->rules('nullable'),
+            // The flags below live in the extra JSON column; only these keys are still
+            // read by the alerting code (notification pacing moved to alert operations),
+            // so they are exposed as first-class attributes instead of a raw blob.
+            // recovery and acknowledgement are treated as enabled when absent.
+            field('isConditionInverted', fn ($value, $model) => (bool) ($model->extra['invert'] ?? false))
+                ->fillCallback(function ($request, $model, $attribute) {
+                    if ($request->exists($attribute)) {
+                        self::setExtra($model, 'invert', $request->boolean($attribute));
+                    }
+                })
+                ->rules('boolean'),
+            field('isMuted', fn ($value, $model) => (bool) ($model->extra['mute'] ?? false))
+                ->fillCallback(function ($request, $model, $attribute) {
+                    if ($request->exists($attribute)) {
+                        self::setExtra($model, 'mute', $request->boolean($attribute));
+                    }
+                })
+                ->rules('boolean'),
+            field('sendsRecoveryAlerts', fn ($value, $model) => (bool) ($model->extra['recovery'] ?? true))
+                ->fillCallback(function ($request, $model, $attribute) {
+                    if ($request->exists($attribute)) {
+                        self::setExtra($model, 'recovery', $request->boolean($attribute));
+                    }
+                })
+                ->rules('boolean'),
+            field('sendsAcknowledgementAlerts', fn ($value, $model) => (bool) ($model->extra['acknowledgement'] ?? true))
+                ->fillCallback(function ($request, $model, $attribute) {
+                    if ($request->exists($attribute)) {
+                        self::setExtra($model, 'acknowledgement', $request->boolean($attribute));
+                    }
+                })
+                ->rules('boolean'),
+            field('overridesQuery', fn ($value, $model) => (bool) ($model->extra['options']['override_query'] ?? false))
+                ->fillCallback(function ($request, $model, $attribute) {
+                    if ($request->exists($attribute)) {
+                        $options = $model->extra['options'] ?? [];
+                        $options['override_query'] = $request->boolean($attribute);
+                        self::setExtra($model, 'options', $options);
+                    }
+                })
+                ->rules('boolean'),
             field('procedure', fn ($value, $model) => $model->proc)
                 ->fillCallback(function ($request, $model, $attribute) {
                     if ($request->exists($attribute)) {
@@ -73,10 +113,10 @@ class AlertRuleRepository extends Repository
                 })
                 ->rules('nullable', 'string', 'max:80'),
             field('notes')->rules('nullable', 'string'),
-            field('isInverted', fn ($value, $model) => $model->invert_map)
+            field('isScopeInverted', fn ($value, $model) => (bool) $model->invert_map)
                 ->fillCallback(function ($request, $model, $attribute) {
                     if ($request->exists($attribute)) {
-                        $model->invert_map = $request->input($attribute);
+                        $model->invert_map = $request->boolean($attribute);
                     }
                 })
                 ->rules('boolean'),
@@ -88,5 +128,16 @@ class AlertRuleRepository extends Repository
                 })
                 ->rules('nullable', 'integer', 'exists:alert_operations,id'),
         ];
+    }
+
+    /**
+     * Write a key into the extra JSON column; the array cast does not allow
+     * in-place mutation of nested values.
+     */
+    private static function setExtra(AlertRule $model, string $key, mixed $value): void
+    {
+        $extra = $model->extra ?? [];
+        $extra[$key] = $value;
+        $model->extra = $extra;
     }
 }

--- a/app/Restify/AlertRuleRepository.php
+++ b/app/Restify/AlertRuleRepository.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Restify;
+
+use App\Models\AlertRule;
+use Binaryk\LaravelRestify\Filters\MatchFilter;
+use Binaryk\LaravelRestify\Filters\SearchableFilter;
+use Binaryk\LaravelRestify\Filters\SortableFilter;
+use Binaryk\LaravelRestify\Http\Requests\RestifyRequest;
+
+class AlertRuleRepository extends Repository
+{
+    // Not device-scoped: alert-rules are visible per alert-rule permission; device
+    // access only matters for the rule's related devices/groups, which are not
+    // exposed through this repository.
+
+    public static string $model = AlertRule::class;
+
+    public static string $title = 'name';
+
+    public static function searchables(): array
+    {
+        return [
+            'name' => SearchableFilter::make()->setColumn('name'),
+        ];
+    }
+
+    public static function matches(): array
+    {
+        return [
+            'name' => MatchFilter::make()->setType('text')->setColumn('name'),
+            'severity' => MatchFilter::make()->setType('text')->setColumn('severity'),
+            'isEnabled' => MatchFilter::make()->setType('bool')->setColumn('disabled'),
+            'query' => MatchFilter::make()->setType('text')->setColumn('query'),
+            'procedure' => MatchFilter::make()->setType('text')->setColumn('proc'),
+            'notes' => MatchFilter::make()->setType('text')->setColumn('notes'),
+            'isInverted' => MatchFilter::make()->setType('bool')->setColumn('invert_map'),
+            'alertOperationId' => MatchFilter::make()->setType('integer')->setColumn('alert_operation_id'),
+        ];
+    }
+
+    public static function sorts(): array
+    {
+        return [
+            'name' => SortableFilter::make()->setColumn('name'),
+            'severity' => SortableFilter::make()->setColumn('severity'),
+            'isEnabled' => SortableFilter::make()->setColumn('disabled'),
+            'isInverted' => SortableFilter::make()->setColumn('invert_map'),
+            'alertOperationId' => SortableFilter::make()->setColumn('alert_operation_id'),
+        ];
+    }
+
+    public function fields(RestifyRequest $request): array
+    {
+        return [
+            field('name')->rules('required', 'string', 'max:255'),
+            field('severity')->rules('required', 'in:ok,warning,critical'),
+            field('isEnabled', fn ($value, $model) => ! $model->disabled)
+                ->fillCallback(function ($request, $model, $attribute) {
+                    if ($request->exists($attribute)) {
+                        $model->disabled = ! $request->boolean($attribute);
+                    }
+                })
+                ->rules('required', 'boolean'),
+            field('query')->rules('nullable', 'string'),
+            field('builder')->rules('nullable'),
+            field('extra')->rules('nullable'),
+            field('procedure', fn ($value, $model) => $model->proc)
+                ->fillCallback(function ($request, $model, $attribute) {
+                    if ($request->exists($attribute)) {
+                        $model->proc = $request->input($attribute);
+                    }
+                })
+                ->rules('nullable', 'string', 'max:80'),
+            field('notes')->rules('nullable', 'string'),
+            field('isInverted', fn ($value, $model) => $model->invert_map)
+                ->fillCallback(function ($request, $model, $attribute) {
+                    if ($request->exists($attribute)) {
+                        $model->invert_map = $request->input($attribute);
+                    }
+                })
+                ->rules('boolean'),
+            field('alertOperationId', fn ($value, $model) => $model->alert_operation_id)
+                ->fillCallback(function ($request, $model, $attribute) {
+                    if ($request->exists($attribute)) {
+                        $model->alert_operation_id = $request->input($attribute);
+                    }
+                })
+                ->rules('nullable', 'integer', 'exists:alert_operations,id'),
+        ];
+    }
+}

--- a/app/Restify/Repository.php
+++ b/app/Restify/Repository.php
@@ -5,6 +5,7 @@ namespace App\Restify;
 use Binaryk\LaravelRestify\Http\Requests\RestifyRequest;
 use Binaryk\LaravelRestify\Repositories\Repository as RestifyRepository;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Gate;
@@ -27,6 +28,9 @@ abstract class Repository extends RestifyRepository
     /**
      * Restify does not authorize index requests against the model policy by
      * itself, so gate them on viewAny here.
+     *
+     * @param  Builder<Model>|Relation<Model, Model, mixed>  $query
+     * @return Builder<Model>|Relation<Model, Model, mixed>
      */
     public static function mainQuery(RestifyRequest $request, Builder|Relation $query)
     {

--- a/app/Restify/Repository.php
+++ b/app/Restify/Repository.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Restify;
+
+use Binaryk\LaravelRestify\Http\Requests\RestifyRequest;
+use Binaryk\LaravelRestify\Repositories\Repository as RestifyRepository;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
+
+/**
+ * Base class for all v1 API model repositories.
+ *
+ * Access to any repository requires the global api.access permission;
+ * model-specific policies control what can be done within a repository.
+ */
+abstract class Repository extends RestifyRepository
+{
+    public static function authorizedToUseRepository(Request $request): bool
+    {
+        $user = $request->user();
+
+        return $user !== null && $user->can('api.access');
+    }
+
+    /**
+     * Restify does not authorize index requests against the model policy by
+     * itself, so gate them on viewAny here.
+     */
+    public static function mainQuery(RestifyRequest $request, Builder|Relation $query)
+    {
+        if ($request->isIndexRequest()) {
+            Gate::authorize('viewAny', static::guessModelClassName());
+        }
+
+        return $query;
+    }
+}

--- a/tests/Feature/Api/AlertRuleApiTest.php
+++ b/tests/Feature/Api/AlertRuleApiTest.php
@@ -1,0 +1,383 @@
+<?php
+
+namespace LibreNMS\Tests\Feature\Api;
+
+use App\Facades\LibrenmsConfig;
+use App\Http\Middleware\EnforceJsonApi;
+use App\Models\AlertOperation;
+use App\Models\AlertRule;
+use App\Models\User;
+use Database\Seeders\RolesSeeder;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Testing\TestResponse;
+use Laravel\Sanctum\Sanctum;
+use LibreNMS\Tests\DBTestCase;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+
+class AlertRuleApiTest extends DBTestCase
+{
+    use DatabaseTransactions;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(RolesSeeder::class);
+
+        // Ensure api.access permission exists and is assigned to admin and global-read roles
+        $apiAccess = Permission::findOrCreate('api.access');
+        Role::findOrCreate('admin')->givePermissionTo($apiAccess);
+        Role::findOrCreate('global-read')->givePermissionTo($apiAccess);
+
+        LibrenmsConfig::set('api.v1.enabled', true);
+    }
+
+    /**
+     * Send a JSON:API POST request with the correct Content-Type.
+     *
+     * @param  array<string, mixed>  $data
+     * @param  array<string, string>  $headers
+     */
+    protected function postJsonApi(string $uri, array $data = [], array $headers = []): TestResponse
+    {
+        return $this->json('POST', $uri, $data, array_merge([
+            'Content-Type' => EnforceJsonApi::CONTENT_TYPE,
+            'Accept' => EnforceJsonApi::CONTENT_TYPE,
+        ], $headers));
+    }
+
+    /**
+     * Send a JSON:API PUT request with the correct Content-Type.
+     *
+     * @param  array<string, mixed>  $data
+     * @param  array<string, string>  $headers
+     */
+    protected function putJsonApi(string $uri, array $data = [], array $headers = []): TestResponse
+    {
+        return $this->json('PUT', $uri, $data, array_merge([
+            'Content-Type' => EnforceJsonApi::CONTENT_TYPE,
+            'Accept' => EnforceJsonApi::CONTENT_TYPE,
+        ], $headers));
+    }
+
+    /**
+     * Send a JSON:API DELETE request.
+     *
+     * @param  array<string, string>  $headers
+     */
+    protected function deleteJsonApi(string $uri, array $headers = []): TestResponse
+    {
+        return $this->json('DELETE', $uri, [], array_merge([
+            'Accept' => EnforceJsonApi::CONTENT_TYPE,
+        ], $headers));
+    }
+
+    /**
+     * A user whose role can view alert rules but lacks the api.access permission.
+     */
+    protected function createUserWithoutApiAccess(): User
+    {
+        $role = Role::findOrCreate('alert-rule-reader');
+        $role->givePermissionTo(Permission::findOrCreate('alert-rule.viewAny'));
+        $role->givePermissionTo(Permission::findOrCreate('alert-rule.view'));
+
+        $user = User::factory()->create();
+        $user->assignRole($role);
+
+        return $user;
+    }
+
+    // ── Authentication & authorization ───────────────────────
+
+    public function testUnauthenticatedRequestReturns401(): void
+    {
+        $this->getJson('/api/v1/alert-rules')
+            ->assertStatus(401);
+    }
+
+    public function testDisabledApiReturns404(): void
+    {
+        LibrenmsConfig::set('api.v1.enabled', false);
+
+        $user = User::factory()->admin()->create();
+        Sanctum::actingAs($user);
+
+        $this->getJson('/api/v1/alert-rules')
+            ->assertStatus(404);
+    }
+
+    public function testUserWithoutApiAccessPermissionCannotAccessAlertRules(): void
+    {
+        $user = $this->createUserWithoutApiAccess();
+        AlertRule::factory()->create();
+        Sanctum::actingAs($user);
+
+        $this->getJson('/api/v1/alert-rules')
+            ->assertStatus(403);
+    }
+
+    public function testResponseHasJsonApiContentType(): void
+    {
+        $user = User::factory()->admin()->create();
+        Sanctum::actingAs($user);
+
+        $this->getJson('/api/v1/alert-rules')
+            ->assertStatus(200)
+            ->assertHeader('Content-Type', EnforceJsonApi::CONTENT_TYPE);
+    }
+
+    // ── Read ─────────────────────────────────────────────────
+
+    public function testAdminCanListAlertRules(): void
+    {
+        $user = User::factory()->admin()->create();
+        AlertRule::factory()->count(3)->create();
+        Sanctum::actingAs($user);
+
+        $this->getJson('/api/v1/alert-rules')
+            ->assertStatus(200)
+            ->assertJsonPath('meta.total', 3);
+    }
+
+    public function testGlobalReadCanListAlertRules(): void
+    {
+        $user = User::factory()->read()->create();
+        AlertRule::factory()->count(2)->create();
+        Sanctum::actingAs($user);
+
+        $this->getJson('/api/v1/alert-rules')
+            ->assertStatus(200)
+            ->assertJsonPath('meta.total', 2);
+    }
+
+    public function testAdminCanShowAlertRule(): void
+    {
+        $user = User::factory()->admin()->create();
+        $rule = AlertRule::factory()->create(['name' => 'Device Down']);
+        Sanctum::actingAs($user);
+
+        $this->getJson("/api/v1/alert-rules/{$rule->id}")
+            ->assertStatus(200)
+            ->assertJsonPath('data.attributes.name', 'Device Down');
+    }
+
+    public function testAlertRuleFieldsArePresent(): void
+    {
+        $user = User::factory()->admin()->create();
+        $rule = AlertRule::factory()->create([
+            'name' => 'Port Down',
+            'severity' => 'critical',
+            'disabled' => 0,
+            'notes' => 'Check port status',
+        ]);
+        Sanctum::actingAs($user);
+
+        $this->getJson("/api/v1/alert-rules/{$rule->id}")
+            ->assertStatus(200)
+            ->assertJsonPath('data.attributes.name', 'Port Down')
+            ->assertJsonPath('data.attributes.severity', 'critical')
+            ->assertJsonPath('data.attributes.isEnabled', true)
+            ->assertJsonPath('data.attributes.notes', 'Check port status');
+    }
+
+    public function testAlertRuleSearchByName(): void
+    {
+        $user = User::factory()->admin()->create();
+        AlertRule::factory()->create(['name' => 'Device Down']);
+        AlertRule::factory()->create(['name' => 'Port Errors']);
+        Sanctum::actingAs($user);
+
+        $this->getJson('/api/v1/alert-rules?search=Device')
+            ->assertStatus(200)
+            ->assertJsonPath('meta.total', 1);
+    }
+
+    public function testAlertRuleMatchBySeverity(): void
+    {
+        $user = User::factory()->admin()->create();
+        AlertRule::factory()->create(['severity' => 'critical']);
+        AlertRule::factory()->create(['severity' => 'warning']);
+        AlertRule::factory()->create(['severity' => 'warning']);
+        Sanctum::actingAs($user);
+
+        $this->getJson('/api/v1/alert-rules?severity=warning')
+            ->assertStatus(200)
+            ->assertJsonPath('meta.total', 2);
+    }
+
+    // ── Create ───────────────────────────────────────────────
+
+    public function testAdminCanCreateAlertRule(): void
+    {
+        $user = User::factory()->admin()->create();
+        Sanctum::actingAs($user);
+
+        $builder = [
+            'condition' => 'AND',
+            'rules' => [['id' => 'devices.status', 'operator' => 'equal', 'value' => 0]],
+        ];
+        $extra = ['mute' => false, 'count' => '-1', 'delay' => 300, 'interval' => 300];
+        $query = 'devices.status = 0';
+
+        $response = $this->postJsonApi('/api/v1/alert-rules', [
+            'name' => 'Device Unreachable',
+            'severity' => 'critical',
+            'isEnabled' => true,
+            'procedure' => 'Page on-call',
+            'notes' => 'Triggered when ICMP fails for 5m',
+            'isInverted' => false,
+            'builder' => $builder,
+            'extra' => $extra,
+            'query' => $query,
+        ]);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('data.attributes.name', 'Device Unreachable')
+            ->assertJsonPath('data.attributes.severity', 'critical')
+            ->assertJsonPath('data.attributes.isEnabled', true)
+            ->assertJsonPath('data.attributes.procedure', 'Page on-call')
+            ->assertJsonPath('data.attributes.notes', 'Triggered when ICMP fails for 5m')
+            ->assertJsonPath('data.attributes.isInverted', false)
+            ->assertJsonPath('data.attributes.builder', $builder)
+            ->assertJsonPath('data.attributes.query', $query);
+
+        $created = AlertRule::where('name', 'Device Unreachable')->firstOrFail();
+        $this->assertSame($builder, $created->builder);
+        $this->assertSame($extra, $created->extra);
+        $this->assertSame($query, $created->query);
+        $this->assertSame('Page on-call', $created->proc);
+        $this->assertSame(0, (int) $created->disabled);
+        $this->assertSame(0, (int) $created->invert_map);
+    }
+
+    public function testAlertRuleCreateUsesDefaultsForOptionalFields(): void
+    {
+        $user = User::factory()->admin()->create();
+        Sanctum::actingAs($user);
+
+        $this->postJsonApi('/api/v1/alert-rules', [
+            'name' => 'Bare Minimum Rule',
+            'severity' => 'warning',
+            'isEnabled' => true,
+        ])->assertStatus(201);
+
+        $created = AlertRule::where('name', 'Bare Minimum Rule')->firstOrFail();
+        $this->assertSame([], $created->builder);
+        $this->assertSame([], $created->extra);
+        $this->assertSame('', $created->query);
+    }
+
+    public function testAlertRuleCreateRejectsMissingRequiredFields(): void
+    {
+        $user = User::factory()->admin()->create();
+        Sanctum::actingAs($user);
+
+        $this->postJsonApi('/api/v1/alert-rules', [
+            'notes' => 'no name, no severity',
+        ])->assertStatus(422);
+    }
+
+    public function testAlertRuleCreateRejectsInvalidSeverity(): void
+    {
+        $user = User::factory()->admin()->create();
+        Sanctum::actingAs($user);
+
+        $this->postJsonApi('/api/v1/alert-rules', [
+            'name' => 'Bad Severity',
+            'severity' => 'catastrophic',
+            'isEnabled' => true,
+        ])->assertStatus(422);
+    }
+
+    public function testReadOnlyUserCannotCreateAlertRule(): void
+    {
+        $user = User::factory()->read()->create();
+        Sanctum::actingAs($user);
+
+        $this->postJsonApi('/api/v1/alert-rules', [
+            'name' => 'Should Be Rejected',
+            'severity' => 'warning',
+            'isEnabled' => true,
+        ])->assertStatus(403);
+    }
+
+    // ── Update & delete ──────────────────────────────────────
+
+    public function testAdminCanUpdateAlertRuleSeverity(): void
+    {
+        $user = User::factory()->admin()->create();
+        $rule = AlertRule::factory()->create([
+            'name' => 'Test Rule',
+            'severity' => 'warning',
+            'disabled' => 0,
+        ]);
+        Sanctum::actingAs($user);
+
+        $this->putJsonApi("/api/v1/alert-rules/{$rule->id}", [
+            'name' => 'Test Rule',
+            'severity' => 'critical',
+            'isEnabled' => 0,
+        ])->assertStatus(200)
+            ->assertJsonPath('data.attributes.severity', 'critical');
+    }
+
+    public function testAdminCanDeleteAlertRule(): void
+    {
+        $user = User::factory()->admin()->create();
+        $rule = AlertRule::factory()->create();
+        Sanctum::actingAs($user);
+
+        $this->deleteJsonApi("/api/v1/alert-rules/{$rule->id}")
+            ->assertStatus(204);
+
+        $this->assertDatabaseMissing('alert_rules', ['id' => $rule->id]);
+    }
+
+    public function testReadOnlyUserCannotModifyAlertRule(): void
+    {
+        $user = User::factory()->read()->create();
+        $rule = AlertRule::factory()->create();
+        Sanctum::actingAs($user);
+
+        $this->putJsonApi("/api/v1/alert-rules/{$rule->id}", [
+            'name' => 'Hacked',
+            'severity' => 'ok',
+            'isEnabled' => 0,
+        ])->assertStatus(403);
+    }
+
+    // ── Alert operation reference ────────────────────────────
+
+    public function testAlertRuleCanReferenceAlertOperation(): void
+    {
+        $user = User::factory()->admin()->create();
+        $op = AlertOperation::create(['name' => 'Op']);
+        Sanctum::actingAs($user);
+
+        $response = $this->postJsonApi('/api/v1/alert-rules', [
+            'name' => 'With Operation',
+            'severity' => 'warning',
+            'isEnabled' => true,
+            'alertOperationId' => $op->id,
+        ]);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('data.attributes.alertOperationId', $op->id);
+
+        $rule = AlertRule::where('name', 'With Operation')->firstOrFail();
+        $this->assertSame($op->id, $rule->alert_operation_id);
+    }
+
+    public function testAlertRuleRejectsUnknownAlertOperationId(): void
+    {
+        $user = User::factory()->admin()->create();
+        Sanctum::actingAs($user);
+
+        $this->postJsonApi('/api/v1/alert-rules', [
+            'name' => 'Bad FK',
+            'severity' => 'warning',
+            'isEnabled' => true,
+            'alertOperationId' => 999999,
+        ])->assertStatus(422);
+    }
+}

--- a/tests/Feature/Api/AlertRuleApiTest.php
+++ b/tests/Feature/Api/AlertRuleApiTest.php
@@ -5,7 +5,10 @@ namespace LibreNMS\Tests\Feature\Api;
 use App\Facades\LibrenmsConfig;
 use App\Http\Middleware\EnforceJsonApi;
 use App\Models\AlertOperation;
+use App\Models\Alert;
+use App\Models\AlertLog;
 use App\Models\AlertRule;
+use App\Models\Device;
 use App\Models\User;
 use Database\Seeders\RolesSeeder;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
@@ -436,6 +439,37 @@ class AlertRuleApiTest extends DBTestCase
             ->assertStatus(204);
 
         $this->assertDatabaseMissing('alert_rules', ['id' => $rule->id]);
+    }
+
+    public function testDeletingAlertRuleCleansUpRelatedRecords(): void
+    {
+        $user = User::factory()->admin()->create();
+        $rule = AlertRule::factory()->create();
+        $device = Device::factory()->create();
+        $rule->devices()->attach($device->device_id);
+        Alert::factory()->create(['rule_id' => $rule->id, 'device_id' => $device->device_id]);
+        AlertLog::factory()->create(['rule_id' => $rule->id, 'device_id' => $device->device_id]);
+        Sanctum::actingAs($user);
+
+        $this->deleteJsonApi("/api/v1/alert-rules/{$rule->id}")
+            ->assertStatus(204);
+
+        $this->assertDatabaseMissing('alert_rules', ['id' => $rule->id]);
+        $this->assertDatabaseMissing('alerts', ['rule_id' => $rule->id]);
+        $this->assertDatabaseMissing('alert_log', ['rule_id' => $rule->id]);
+        $this->assertDatabaseMissing('alert_device_map', ['rule_id' => $rule->id]);
+    }
+
+    public function testReadOnlyUserCannotDeleteAlertRule(): void
+    {
+        $user = User::factory()->read()->create();
+        $rule = AlertRule::factory()->create();
+        Sanctum::actingAs($user);
+
+        $this->deleteJsonApi("/api/v1/alert-rules/{$rule->id}")
+            ->assertStatus(403);
+
+        $this->assertDatabaseHas('alert_rules', ['id' => $rule->id]);
     }
 
     public function testReadOnlyUserCannotModifyAlertRule(): void

--- a/tests/Feature/Api/AlertRuleApiTest.php
+++ b/tests/Feature/Api/AlertRuleApiTest.php
@@ -4,9 +4,9 @@ namespace LibreNMS\Tests\Feature\Api;
 
 use App\Facades\LibrenmsConfig;
 use App\Http\Middleware\EnforceJsonApi;
-use App\Models\AlertOperation;
 use App\Models\Alert;
 use App\Models\AlertLog;
+use App\Models\AlertOperation;
 use App\Models\AlertRule;
 use App\Models\Device;
 use App\Models\User;

--- a/tests/Feature/Api/AlertRuleApiTest.php
+++ b/tests/Feature/Api/AlertRuleApiTest.php
@@ -40,6 +40,7 @@ class AlertRuleApiTest extends DBTestCase
      *
      * @param  array<string, mixed>  $data
      * @param  array<string, string>  $headers
+     * @return TestResponse<\Symfony\Component\HttpFoundation\Response>
      */
     protected function postJsonApi(string $uri, array $data = [], array $headers = []): TestResponse
     {
@@ -54,6 +55,7 @@ class AlertRuleApiTest extends DBTestCase
      *
      * @param  array<string, mixed>  $data
      * @param  array<string, string>  $headers
+     * @return TestResponse<\Symfony\Component\HttpFoundation\Response>
      */
     protected function putJsonApi(string $uri, array $data = [], array $headers = []): TestResponse
     {
@@ -67,6 +69,7 @@ class AlertRuleApiTest extends DBTestCase
      * Send a JSON:API DELETE request.
      *
      * @param  array<string, string>  $headers
+     * @return TestResponse<\Symfony\Component\HttpFoundation\Response>
      */
     protected function deleteJsonApi(string $uri, array $headers = []): TestResponse
     {

--- a/tests/Feature/Api/AlertRuleApiTest.php
+++ b/tests/Feature/Api/AlertRuleApiTest.php
@@ -92,7 +92,11 @@ class AlertRuleApiTest extends DBTestCase
     public function testUnauthenticatedRequestReturns401(): void
     {
         $this->getJson('/api/v1/alert-rules')
-            ->assertStatus(401);
+            ->assertStatus(401)
+            ->assertHeader('Content-Type', EnforceJsonApi::CONTENT_TYPE)
+            ->assertJsonMissingPath('message')
+            ->assertJsonPath('errors.0.status', '401')
+            ->assertJsonPath('errors.0.code', 'unauthenticated');
     }
 
     public function testDisabledApiReturns404(): void
@@ -103,7 +107,9 @@ class AlertRuleApiTest extends DBTestCase
         Sanctum::actingAs($user);
 
         $this->getJson('/api/v1/alert-rules')
-            ->assertStatus(404);
+            ->assertStatus(404)
+            ->assertJsonPath('errors.0.status', '404')
+            ->assertJsonPath('errors.0.code', 'not_found');
     }
 
     public function testUserWithoutApiAccessPermissionCannotAccessAlertRules(): void
@@ -216,7 +222,6 @@ class AlertRuleApiTest extends DBTestCase
             'condition' => 'AND',
             'rules' => [['id' => 'devices.status', 'operator' => 'equal', 'value' => 0]],
         ];
-        $extra = ['mute' => false, 'count' => '-1', 'delay' => 300, 'interval' => 300];
         $query = 'devices.status = 0';
 
         $response = $this->postJsonApi('/api/v1/alert-rules', [
@@ -225,9 +230,13 @@ class AlertRuleApiTest extends DBTestCase
             'isEnabled' => true,
             'procedure' => 'Page on-call',
             'notes' => 'Triggered when ICMP fails for 5m',
-            'isInverted' => false,
+            'isScopeInverted' => false,
+            'isConditionInverted' => false,
+            'isMuted' => true,
+            'sendsRecoveryAlerts' => false,
+            'sendsAcknowledgementAlerts' => true,
+            'overridesQuery' => true,
             'builder' => $builder,
-            'extra' => $extra,
             'query' => $query,
         ]);
 
@@ -237,13 +246,24 @@ class AlertRuleApiTest extends DBTestCase
             ->assertJsonPath('data.attributes.isEnabled', true)
             ->assertJsonPath('data.attributes.procedure', 'Page on-call')
             ->assertJsonPath('data.attributes.notes', 'Triggered when ICMP fails for 5m')
-            ->assertJsonPath('data.attributes.isInverted', false)
+            ->assertJsonPath('data.attributes.isScopeInverted', false)
+            ->assertJsonPath('data.attributes.isConditionInverted', false)
+            ->assertJsonPath('data.attributes.isMuted', true)
+            ->assertJsonPath('data.attributes.sendsRecoveryAlerts', false)
+            ->assertJsonPath('data.attributes.sendsAcknowledgementAlerts', true)
+            ->assertJsonPath('data.attributes.overridesQuery', true)
             ->assertJsonPath('data.attributes.builder', $builder)
             ->assertJsonPath('data.attributes.query', $query);
 
         $created = AlertRule::where('name', 'Device Unreachable')->firstOrFail();
         $this->assertSame($builder, $created->builder);
-        $this->assertSame($extra, $created->extra);
+        $this->assertEquals([
+            'invert' => false,
+            'mute' => true,
+            'recovery' => false,
+            'acknowledgement' => true,
+            'options' => ['override_query' => true],
+        ], $created->extra);
         $this->assertSame($query, $created->query);
         $this->assertSame('Page on-call', $created->proc);
         $this->assertSame(0, (int) $created->disabled);
@@ -259,7 +279,12 @@ class AlertRuleApiTest extends DBTestCase
             'name' => 'Bare Minimum Rule',
             'severity' => 'warning',
             'isEnabled' => true,
-        ])->assertStatus(201);
+        ])->assertStatus(201)
+            ->assertJsonPath('data.attributes.isMuted', false)
+            ->assertJsonPath('data.attributes.isConditionInverted', false)
+            ->assertJsonPath('data.attributes.sendsRecoveryAlerts', true)
+            ->assertJsonPath('data.attributes.sendsAcknowledgementAlerts', true)
+            ->assertJsonPath('data.attributes.overridesQuery', false);
 
         $created = AlertRule::where('name', 'Bare Minimum Rule')->firstOrFail();
         $this->assertSame([], $created->builder);
@@ -272,9 +297,89 @@ class AlertRuleApiTest extends DBTestCase
         $user = User::factory()->admin()->create();
         Sanctum::actingAs($user);
 
-        $this->postJsonApi('/api/v1/alert-rules', [
+        $response = $this->postJsonApi('/api/v1/alert-rules', [
             'notes' => 'no name, no severity',
+        ]);
+
+        // JSON:API error document: errors must be an array of error objects
+        // with source pointers, not Laravel's field-keyed object
+        $response->assertStatus(422)
+            ->assertJsonMissingPath('message')
+            ->assertJsonPath('errors.0.status', '422')
+            ->assertJsonPath('errors.0.code', 'validation_failed');
+
+        $pointers = array_column(array_column($response->json('errors'), 'source'), 'pointer');
+        $this->assertContains('/name', $pointers);
+        $this->assertContains('/severity', $pointers);
+    }
+
+    public function testShowUnknownAlertRuleReturns404(): void
+    {
+        $user = User::factory()->admin()->create();
+        Sanctum::actingAs($user);
+
+        $this->getJson('/api/v1/alert-rules/999999')
+            ->assertStatus(404)
+            ->assertJsonPath('errors.0.status', '404')
+            ->assertJsonPath('errors.0.code', 'not_found');
+    }
+
+    public function testRawExtraAttributeIsIgnored(): void
+    {
+        $user = User::factory()->admin()->create();
+        Sanctum::actingAs($user);
+
+        // extra is not an API field; the legacy pacing keys inside it
+        // (delay/interval/count) were replaced by alert operations
+        $this->postJsonApi('/api/v1/alert-rules', [
+            'name' => 'Raw Extra',
+            'severity' => 'warning',
+            'isEnabled' => true,
+            'extra' => ['mute' => true, 'count' => '-1', 'delay' => 300, 'interval' => 300],
+        ])->assertStatus(201);
+
+        $created = AlertRule::where('name', 'Raw Extra')->firstOrFail();
+        $this->assertSame([], $created->extra);
+    }
+
+    public function testAlertRuleCreateRejectsNonBooleanFlagValues(): void
+    {
+        $user = User::factory()->admin()->create();
+        Sanctum::actingAs($user);
+
+        $this->postJsonApi('/api/v1/alert-rules', [
+            'name' => 'Bad Flag Type',
+            'severity' => 'warning',
+            'isEnabled' => true,
+            'isConditionInverted' => 'yes',
         ])->assertStatus(422);
+    }
+
+    public function testUpdatingFlagPreservesOtherExtraKeys(): void
+    {
+        $user = User::factory()->admin()->create();
+        $rule = AlertRule::factory()->create([
+            'name' => 'Flag Merge',
+            'severity' => 'warning',
+            'extra' => ['invert' => true, 'options' => ['override_query' => true]],
+        ]);
+        Sanctum::actingAs($user);
+
+        $this->putJsonApi("/api/v1/alert-rules/{$rule->id}", [
+            'name' => 'Flag Merge',
+            'severity' => 'warning',
+            'isEnabled' => true,
+            'isMuted' => true,
+        ])->assertStatus(200)
+            ->assertJsonPath('data.attributes.isMuted', true)
+            ->assertJsonPath('data.attributes.isConditionInverted', true)
+            ->assertJsonPath('data.attributes.overridesQuery', true);
+
+        $this->assertEquals([
+            'invert' => true,
+            'options' => ['override_query' => true],
+            'mute' => true,
+        ], $rule->fresh()->extra);
     }
 
     public function testAlertRuleCreateRejectsInvalidSeverity(): void


### PR DESCRIPTION
Please give a short description what your pull request is for

This adds the alert rules as first repository to add/edit/remove using the v1 API.
This can function as an example of future repositories and can be a place of discussion on how the actual api will look

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
