### PR TITLE
SNMP infer encoding

### DIFF
--- a/LibreNMS/Data/Source/SnmpResponse.php
+++ b/LibreNMS/Data/Source/SnmpResponse.php
@@ -31,6 +31,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use LibreNMS\Util\Oid;
+use LibreNMS\Util\StringHelpers;
 use Log;
 
 class SnmpResponse implements \Stringable
@@ -41,6 +42,7 @@ class SnmpResponse implements \Stringable
 
     private ?string $errorMessage = null;
     private ?array $values = null;
+    private ?bool $inferValueEncoding = null;
 
     /**
      * Create a new response object filling with output from the net-snmp command.
@@ -144,6 +146,7 @@ class SnmpResponse implements \Stringable
             return $this->values;
         }
 
+        $this->inferValueEncoding ??= ! StringHelpers::isValidUtf8($this->raw);
         $this->values = [];
         $line = strtok($this->raw, PHP_EOL);
         while ($line !== false) {
@@ -172,10 +175,14 @@ class SnmpResponse implements \Stringable
 
             if (Str::startsWith($value, '"') && Str::endsWith($value, '"')) {
                 // unformatted string from net-snmp, remove extra escapes
-                $this->values[$oid] = trim(stripslashes($value), "\" \n\r");
+                $value = trim(stripslashes($value), "\" \n\r");
             } else {
-                $this->values[$oid] = trim($value);
+                $value = trim($value);
             }
+
+            $this->values[$oid] = $this->inferValueEncoding
+                ? StringHelpers::inferEncoding($value)
+                : $value;
         }
 
         return $this->values;

--- a/LibreNMS/OS/Traits/YamlOSDiscovery.php
+++ b/LibreNMS/OS/Traits/YamlOSDiscovery.php
@@ -30,8 +30,8 @@ use App\Models\Device;
 use App\Models\Location;
 use App\View\SimpleTemplate;
 use Illuminate\Support\Arr;
-use LibreNMS\Data\Source\SnmpResponse;
 use LibreNMS\Util\Oid;
+use LibreNMS\Util\StringHelpers;
 use Log;
 use SnmpQuery;
 
@@ -72,11 +72,11 @@ trait YamlOSDiscovery
         $oids = Arr::only($os_yaml, $this->osFields);
         $fetch_oids = array_unique(Arr::flatten($oids));
         $numeric = Oid::hasNumeric($fetch_oids);
-        $data = SnmpQuery::numeric($numeric)->get($fetch_oids);
+        $data = $this->fetch($fetch_oids, $numeric);
 
-        Log::debug('Yaml OS data:', $data->values());
+        Log::debug('Yaml OS data:', $data);
 
-        $template_data = array_merge($this->getDevice()->only($this->osFields), $data->values());
+        $template_data = array_merge($this->getDevice()->only($this->osFields), $data);
         foreach ($oids as $field => $oid_list) {
             if ($value = $this->findFirst($data, $oid_list, $numeric)) {
                 // extract via regex if requested
@@ -103,29 +103,33 @@ trait YamlOSDiscovery
 
         $oids = array_filter([$name, $lat, $lng]);
         $numeric = Oid::hasNumeric($oids);
-        $data = SnmpQuery::numeric($numeric)->get($oids);
+        $data = $this->fetch($oids, $numeric);
 
-        Log::debug('Yaml location data:', $data->values());
+        Log::debug('Yaml location data:', $data);
 
-        $location = $this->findFirst($data, $name, $numeric)
-            ?? SnmpQuery::get('SNMPv2-MIB::sysLocation.0')->value();
+        $location = $this->findFirst($data, $name, $numeric) ?? snmp_get($this->getDeviceArray(), 'SNMPv2-MIB::sysLocation.0', '-Oqv');
 
         return new Location([
-            'location' => $location,
+            'location' => StringHelpers::inferEncoding($location),
             'lat' => $this->findFirst($data, $lat, $numeric),
             'lng' => $this->findFirst($data, $lng, $numeric),
         ]);
     }
 
-    private function findFirst(SnmpResponse $data, array|string|null $oids, bool $numeric = false): ?string
+    private function findFirst($data, $oids, $numeric = false)
     {
-        $oids = array_map(
-            fn (string $oid): string => $numeric ? Oid::of($oid)->toNumeric() : $oid,
-            Arr::wrap($oids)
-        );
-        $value = $data->value($oids);
+        foreach (Arr::wrap($oids) as $oid) {
+            // translate all to numeric to make it easier to match
+            if ($numeric) {
+                $oid = Oid::of($oid)->toNumeric();
+            }
 
-        return $value !== '' ? $value : null;
+            if (! empty($data[$oid])) {
+                return $data[$oid];
+            }
+        }
+
+        return null;
     }
 
     private function parseRegex($regexes, $subject)
@@ -141,6 +145,11 @@ trait YamlOSDiscovery
                 }
             }
         }
+    }
+
+    private function fetch(array $oids, $numeric)
+    {
+        return snmp_get_multi_oid($this->getDeviceArray(), $oids, $numeric ? '-OUQn' : '-OUQ');
     }
 
     private function replaceStringsInFields(Device $device, array $os_yaml): void

--- a/LibreNMS/OS/Traits/YamlOSDiscovery.php
+++ b/LibreNMS/OS/Traits/YamlOSDiscovery.php
@@ -30,8 +30,8 @@ use App\Models\Device;
 use App\Models\Location;
 use App\View\SimpleTemplate;
 use Illuminate\Support\Arr;
+use LibreNMS\Data\Source\SnmpResponse;
 use LibreNMS\Util\Oid;
-use LibreNMS\Util\StringHelpers;
 use Log;
 use SnmpQuery;
 
@@ -72,11 +72,11 @@ trait YamlOSDiscovery
         $oids = Arr::only($os_yaml, $this->osFields);
         $fetch_oids = array_unique(Arr::flatten($oids));
         $numeric = Oid::hasNumeric($fetch_oids);
-        $data = $this->fetch($fetch_oids, $numeric);
+        $data = SnmpQuery::numeric($numeric)->get($fetch_oids);
 
-        Log::debug('Yaml OS data:', $data);
+        Log::debug('Yaml OS data:', $data->values());
 
-        $template_data = array_merge($this->getDevice()->only($this->osFields), $data);
+        $template_data = array_merge($this->getDevice()->only($this->osFields), $data->values());
         foreach ($oids as $field => $oid_list) {
             if ($value = $this->findFirst($data, $oid_list, $numeric)) {
                 // extract via regex if requested
@@ -103,33 +103,29 @@ trait YamlOSDiscovery
 
         $oids = array_filter([$name, $lat, $lng]);
         $numeric = Oid::hasNumeric($oids);
-        $data = $this->fetch($oids, $numeric);
+        $data = SnmpQuery::numeric($numeric)->get($oids);
 
-        Log::debug('Yaml location data:', $data);
+        Log::debug('Yaml location data:', $data->values());
 
-        $location = $this->findFirst($data, $name, $numeric) ?? snmp_get($this->getDeviceArray(), 'SNMPv2-MIB::sysLocation.0', '-Oqv');
+        $location = $this->findFirst($data, $name, $numeric)
+            ?? SnmpQuery::get('SNMPv2-MIB::sysLocation.0')->value();
 
         return new Location([
-            'location' => StringHelpers::inferEncoding($location),
+            'location' => $location,
             'lat' => $this->findFirst($data, $lat, $numeric),
             'lng' => $this->findFirst($data, $lng, $numeric),
         ]);
     }
 
-    private function findFirst($data, $oids, $numeric = false)
+    private function findFirst(SnmpResponse $data, array|string|null $oids, bool $numeric = false): ?string
     {
-        foreach (Arr::wrap($oids) as $oid) {
-            // translate all to numeric to make it easier to match
-            if ($numeric) {
-                $oid = Oid::of($oid)->toNumeric();
-            }
+        $oids = array_map(
+            fn (string $oid): string => $numeric ? Oid::of($oid)->toNumeric() : $oid,
+            Arr::wrap($oids)
+        );
+        $value = $data->value($oids);
 
-            if (! empty($data[$oid])) {
-                return $data[$oid];
-            }
-        }
-
-        return null;
+        return $value !== '' ? $value : null;
     }
 
     private function parseRegex($regexes, $subject)
@@ -145,11 +141,6 @@ trait YamlOSDiscovery
                 }
             }
         }
-    }
-
-    private function fetch(array $oids, $numeric)
-    {
-        return snmp_get_multi_oid($this->getDeviceArray(), $oids, $numeric ? '-OUQn' : '-OUQ');
     }
 
     private function replaceStringsInFields(Device $device, array $os_yaml): void

--- a/LibreNMS/Util/StringHelpers.php
+++ b/LibreNMS/Util/StringHelpers.php
@@ -102,7 +102,13 @@ class StringHelpers
      */
     public static function inferEncoding(?string $string): ?string
     {
-        if (empty($string) || self::isValidUtf8($string) || ! function_exists('iconv')) {
+        if (empty($string) || self::isValidUtf8($string)) {
+            return $string;
+        }
+
+        $string = str_replace(chr(218), "\n", $string);
+
+        if (! function_exists('iconv')) {
             return $string;
         }
 

--- a/LibreNMS/Util/StringHelpers.php
+++ b/LibreNMS/Util/StringHelpers.php
@@ -28,6 +28,11 @@ namespace LibreNMS\Util;
 
 class StringHelpers
 {
+    public static function isValidUtf8(string $string): bool
+    {
+        return preg_match('//u', $string) === 1;
+    }
+
     public static function niceCase($string)
     {
         $replacements = [
@@ -97,7 +102,7 @@ class StringHelpers
      */
     public static function inferEncoding(?string $string): ?string
     {
-        if (empty($string) || preg_match('//u', $string) || ! function_exists('iconv')) {
+        if (empty($string) || self::isValidUtf8($string) || ! function_exists('iconv')) {
             return $string;
         }
 

--- a/app/Models/Device.php
+++ b/app/Models/Device.php
@@ -529,7 +529,7 @@ class Device extends BaseModel
 
     public function setSysDescrAttribute(?string $sysDescr): void
     {
-        $this->attributes['sysDescr'] = $sysDescr === null ? null : trim(str_replace(chr(218), "\n", $sysDescr), "\\\" \r\n\t\0");
+        $this->attributes['sysDescr'] = $sysDescr === null ? null : trim($sysDescr, "\\\" \r\n\t\0");
     }
 
     public function setSysNameAttribute(?string $sysName): void

--- a/includes/discovery/ports.inc.php
+++ b/includes/discovery/ports.inc.php
@@ -4,7 +4,6 @@
 use App\Facades\LibrenmsConfig;
 use App\Models\PortGroup;
 use LibreNMS\Enum\PortAssociationMode;
-use LibreNMS\Util\StringHelpers;
 
 $descrSnmpFlags = '-OQUs';
 $typeSnmpFlags = '-OQUs';
@@ -130,10 +129,6 @@ $default_port_group = LibrenmsConfig::get('default_port_group');
 // New interface detection
 foreach ($port_stats as $ifIndex => $snmp_data) {
     $snmp_data['ifIndex'] = $ifIndex; // Store ifIndex in port entry
-    $snmp_data['ifAlias'] = StringHelpers::inferEncoding($snmp_data['ifAlias'] ?? null);
-    $snmp_data['ifName'] = StringHelpers::inferEncoding($snmp_data['ifName'] ?? null);
-    $snmp_data['ifDescr'] = StringHelpers::inferEncoding($snmp_data['ifDescr'] ?? null);
-
     // Get port_id according to port_association_mode used for this device
     $port_id = get_port_id($ports_mapped, $snmp_data, $port_association_mode);
 

--- a/includes/discovery/sensors/rittal-cmc-iii-sensors.inc.php
+++ b/includes/discovery/sensors/rittal-cmc-iii-sensors.inc.php
@@ -25,7 +25,6 @@
  */
 
 use LibreNMS\Util\Number;
-use LibreNMS\Util\StringHelpers;
 
 $cmc_iii_var_table = snmpwalk_cache_oid($device, 'cmcIIIVarTable', [], 'RITTAL-CMC-III-MIB', null);
 $cmc_iii_sensors = [];
@@ -103,7 +102,7 @@ foreach ($cmc_iii_var_table as $index => $entry) {
             }
 
             // encode string to ensure that degree sign may be used properly for unit comparison
-            $unit = StringHelpers::inferEncoding($entry['cmcIIIVarUnit']);
+            $unit = $entry['cmcIIIVarUnit'];
             $type = 'state';
             $temperature_units = ['degree C', 'degree F', '°C', '°F'];
             if ($unit == 'mA') {

--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -8,7 +8,6 @@ use LibreNMS\RRD\RrdDefinition;
 use LibreNMS\Util\Debug;
 use LibreNMS\Util\Mac;
 use LibreNMS\Util\Number;
-use LibreNMS\Util\StringHelpers;
 
 // Build SNMP Cache Array
 $data_oids = [
@@ -587,9 +586,6 @@ foreach ($ports as $port) {
             $this_port['ifName'] = $matches[1];
         }
 
-        $this_port['ifName'] = StringHelpers::inferEncoding($this_port['ifName'] ?? null);
-        $this_port['ifDescr'] = StringHelpers::inferEncoding($this_port['ifDescr'] ?? null);
-
         $polled_period = max($polled - $port['poll_time'], 1);
 
         $port['update'] = [];
@@ -689,7 +685,6 @@ foreach ($ports as $port) {
                 } else {
                     $current_oid = $this_port['ifAlias'];
                 }
-                $current_oid = StringHelpers::inferEncoding($current_oid); // prevent invalid non-utf8 characters
             }
             if ($oid == 'ifSpeed') {
                 $ifSpeed_override = DeviceCache::getPrimary()->getAttrib('ifSpeed:' . $port['ifName']);

--- a/includes/snmp.inc.php
+++ b/includes/snmp.inc.php
@@ -22,6 +22,7 @@ use App\Polling\Measure\Measurement;
 use Illuminate\Support\Str;
 use LibreNMS\Data\Source\SnmpResponse;
 use LibreNMS\Util\Rewrite;
+use LibreNMS\Util\StringHelpers;
 
 /**
  * @deprecated Please use SnmpQuery instead
@@ -424,6 +425,8 @@ function snmpwalk_cache_oid($device, $oid, $array = [], $mib = null, $mibdir = n
         return $array;
     }
 
+    $inferValueEncoding = ! StringHelpers::isValidUtf8($data);
+
     foreach (explode("\n", (string) $data) as $entry) {
         if (! Str::contains($entry, ' =')) {
             if (! empty($entry) && isset($index, $oid)) {
@@ -436,6 +439,9 @@ function snmpwalk_cache_oid($device, $oid, $array = [], $mib = null, $mibdir = n
         [$oid,$value] = explode('=', $entry, 2);
         $oid = trim($oid);
         $value = trim($value, "\" \\\n\r");
+        if ($inferValueEncoding) {
+            $value = StringHelpers::inferEncoding($value);
+        }
         $index = '';
         if (Str::contains($oid, '.')) {
             [$oid, $index] = explode('.', $oid, 2);

--- a/tests/Unit/SnmpResponseTest.php
+++ b/tests/Unit/SnmpResponseTest.php
@@ -32,6 +32,14 @@ use LibreNMS\Tests\TestCase;
 
 final class SnmpResponseTest extends TestCase
 {
+    public function testInfersOutputEncoding(): void
+    {
+        $response = new SnmpResponse("IF-MIB::ifDescr[1] = \xD8verbyvegen\n");
+
+        $this->assertSame('Øverbyvegen', $response->value());
+        $this->assertSame("IF-MIB::ifDescr[1] = \xD8verbyvegen\n", $response->raw);
+    }
+
     public function testSimple(): void
     {
         $response = new SnmpResponse("IF-MIB::ifDescr[1] = lo\nIF-MIB::ifDescr[2] = enp4s0\n");

--- a/tests/Unit/Util/StringHelperTest.php
+++ b/tests/Unit/Util/StringHelperTest.php
@@ -31,6 +31,12 @@ use LibreNMS\Util\StringHelpers;
 
 final class StringHelperTest extends TestCase
 {
+    public function testValidUtf8(): void
+    {
+        $this->assertTrue(StringHelpers::isValidUtf8('Øverbyvegen'));
+        $this->assertFalse(StringHelpers::isValidUtf8("\xD8verbyvegen"));
+    }
+
     /**
      * A basic feature test example.
      *

--- a/tests/Unit/Util/StringHelperTest.php
+++ b/tests/Unit/Util/StringHelperTest.php
@@ -48,6 +48,7 @@ final class StringHelperTest extends TestCase
         $this->assertEquals('', StringHelpers::inferEncoding(''));
         $this->assertEquals('~null', StringHelpers::inferEncoding('~null'));
         $this->assertEquals('Øverbyvegen', StringHelpers::inferEncoding('Øverbyvegen'));
+        $this->assertEquals("first\nsecond", StringHelpers::inferEncoding("first\xDAsecond"));
 
         $this->assertEquals('Øverbyvegen', StringHelpers::inferEncoding(base64_decode('w5h2ZXJieXZlZ2Vu')));
         $this->assertEquals('Øverbyvegen', StringHelpers::inferEncoding(base64_decode('2HZlcmJ5dmVnZW4=')));


### PR DESCRIPTION
Instead of checking each field for invalid character encoding, do it at the snmp level.
Modify `SnmpQuery` and the legacy `snmpwalk_cache_oid`.

This should fix most of the `SQLSTATE[22007]: Invalid datetime format: 1366 Incorrect string value:` errors from incorrectly encoded strings received from snmp devices.

fixes: #16747 #18985 #18294 #19332 #19184

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
