### PR TITLE
fix(webui): restore mono styling on dashboard widget headers

### DIFF
--- a/html/css/blue.css
+++ b/html/css/blue.css
@@ -30,6 +30,11 @@
   color: #0052cccc;
 }
 
+.widget-header {
+  background: #0052cc22;
+  color: #0052cccc;
+}
+
 .pace {
   -webkit-pointer-events: none;
   pointer-events: none;

--- a/html/css/mono.css
+++ b/html/css/mono.css
@@ -11,6 +11,15 @@
   color: white;
 }
 
+.widget-header {
+  background: #222;
+  color: white;
+}
+
+.widget-header i {
+  color: white;
+}
+
 .panel-default>.panel-heading .icon-theme,
 .panel-default>.panel-heading a:visited,
 .panel-default>.panel-heading a:link {

--- a/html/css/styles.css
+++ b/html/css/styles.css
@@ -1790,6 +1790,11 @@ label {
   line-height:34px;
 }
 
+.widget-header {
+  background-color: #e5e7eb;
+  color: #1f2937;
+}
+
 .dashboard-graph, .dashboard-graph img {
   height: 100%;
   width: 100%;

--- a/html/css/tw_dark.css
+++ b/html/css/tw_dark.css
@@ -2,6 +2,11 @@
     color: #bfc0c0
 }
 
+.dark .widget-header {
+    background-color: #3e444c;
+    color: #f9fafb
+}
+
 .dark .icon-theme {
     color: #bfc0c0
 }

--- a/resources/views/layouts/librenmsv1.blade.php
+++ b/resources/views/layouts/librenmsv1.blade.php
@@ -39,10 +39,10 @@
     <link href="{{ asset('css/select2.min.css') }}" rel="stylesheet">
     <link href="{{ asset('css/select2-bootstrap.min.css') }}" rel="stylesheet">
     <link href="{{ asset('css/query-builder.default.min.css') }}" rel="stylesheet">
-    <link href="{{ asset(LibrenmsConfig::get('stylesheet', 'css/styles.css')) }}?ver=05282026" rel="stylesheet">
-    <link href="{{ asset('css/tw_dark.css?ver=19112025') }}" rel="stylesheet">
+    <link href="{{ asset(LibrenmsConfig::get('stylesheet', 'css/styles.css')) }}?ver=13082026" rel="stylesheet">
+    <link href="{{ asset('css/tw_dark.css?ver=13082026') }}" rel="stylesheet">
     @if(!in_array(session('applied_site_style', 'light'), ['light', 'dark']))
-    <link href="{{ asset('css/' . session('applied_site_style') . '.css?ver=732417643') }}" rel="stylesheet">
+    <link href="{{ asset('css/' . session('applied_site_style') . '.css?ver=832417643') }}" rel="stylesheet">
     @endif
     @foreach(LibrenmsConfig::get('webui.custom_css', []) as $custom_css)
         <link href="{{ $custom_css }}" rel="stylesheet">

--- a/resources/views/overview/default.blade.php
+++ b/resources/views/overview/default.blade.php
@@ -513,7 +513,7 @@
     function widget_dom(data) {
         dom = '<div id="'+data.user_widget_id+'" class="grid-stack-item" data-type="'+data.widget+'" data-settings="0" gs-id="'+data.user_widget_id+'">'+
               '<div class="grid-stack-item-content tw:ring tw:ring-gray-200 tw:dark:ring-dark-gray-200 tw:left-0! tw:bottom-0!">'+
-              '<header class="tw:bg-gray-200 tw:dark:bg-dark-gray-200 tw:text-gray-800 tw:dark:text-dark-white-100 tw:p-3 tw:text-center"><span id="widget_title_'+data.user_widget_id+'" class="dashboard-widget-title">'+data.title+
+              '<header class="widget-header tw:p-3 tw:text-center"><span id="widget_title_'+data.user_widget_id+'" class="dashboard-widget-title">'+data.title+
               '</span><span id="widget_title_counter_'+data.user_widget_id+'"></span>'+
               '<span class="fade-edit tw:float-right">'+
 


### PR DESCRIPTION
Restores the mono theme's black/white widget headers, which were silently overridden by hard-coded Tailwind utilities after the dashboard UI rework (#19790).                                                                                                                        
                                                                                                                                                                                                                                                                                          
#### Reasoning                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                     
- Commit `e96e8bfdd` ("Dashboard UI updates #19790") replaced the theme-agnostic `<header class="widget_header">` with fixed Tailwind utilities (`tw:bg-gray-200 tw:dark:bg-dark-gray-200 tw:text-gray-800`).                                                                        
- In the `mono` theme the `dark` variant never activates (`applySiteStyle()` only toggles `.dark` for the dark style), so headers rendered as a fixed light-gray instead of mono's `#222`/white panel style.                                                                         
- `mono.css` could not override it because it only targets `.panel-default > .panel-heading`, which the new markup no longer uses.                                                                                                                                                   
                                                                                                                                                                                                                                                                                     
#### Changes                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                     
- **`resources/views/overview/default.blade.php`** — add a stable `widget-header` class to the widget header so themes can target it (light/dark behavior unchanged).                                                                                                                
- **`html/css/mono.css`** — override `.widget-header` to match the mono panel style (`background: #222; color: white`), including the header action icons.                                                                                                                           
- **`resources/views/layouts/librenmsv1.blade.php`** — bump the theme stylesheet cache-buster from `?ver=732417643` to `?ver=832417643`. This URL had not changed since 2025, so browsers were serving the stale `mono.css` from cache and the fix wasn't visible until a hard refresh.                                                                                                                                 

### Before fix
<img width="2553" height="487" alt="image" src="https://github.com/user-attachments/assets/07ee3fb0-fa93-49fa-b396-e42d1bf8e561" />

### After fix
<img width="2553" height="487" alt="image" src="https://github.com/user-attachments/assets/c78598d2-8c11-4a8f-af00-b55f248806a0" />
                                                                                                    
                                                                                                                                                                                                                                                                                     
#### Please note                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                     
- [x] Have you followed our code guidelines?                                                                                                                                                                                                                                         
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it. *(attached)*                                                                                                                                                         
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated test data.                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                     
#### Testers                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                     
If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`                                                                                                                                                     
After you are done testing, you can remove the changes with `./scripts/github-remove`. If there are schema changes, you can ask on discord how to revert.                                            


