### PR TITLE
Use sla_nr as part of SLA discovery composite

### DIFF
--- a/app/Models/Sla.php
+++ b/app/Models/Sla.php
@@ -28,6 +28,6 @@ class Sla extends DeviceRelatedModel implements Keyable
 
     public function getCompositeKey(): string
     {
-        return "$this->owner-$this->tag";
+        return "$this->sla_nr-$this->owner-$this->tag";
     }
 }


### PR DESCRIPTION
Please give a short description what your pull request is for

## Summary

Prevent IP SLA discovery collisions by including `sla_nr` in the SLA composite key.

Currently, LibreNMS identifies SLAs using:

```php
return "$this->owner-$this->tag";
```
This can cause multiple SLA operations on the same device to be treated as duplicates when they share identical owner and tag values.
In a Cisco IP SLA environment, multiple HTTP SLA operations can legitimately have same owner and tag values

### Proposed Change
Change the composite key to:
```php
return "$this->sla_nr-$this->owner-$this->tag";
```
Before
```
MariaDB [librenms]> select * from slas where device_id=1909;
+--------+-----------+----------+-------+------------------------------+----------+--------+--------+----------+---------+
| sla_id | device_id | sla_nr   | owner | tag                          | rtt_type | rtt    | status | opstatus | deleted |
+--------+-----------+----------+-------+------------------------------+----------+--------+--------+----------+---------+
|   1704 |      1909 | 10524822 |       | http://gateway2.net/vpntest  | http     |  64.00 |      1 |        0 |       0 |
+--------+-----------+----------+-------+------------------------------+----------+--------+--------+----------+---------+
```

After the change
```
MariaDB [librenms]> select * from slas where device_id=1909;
+--------+-----------+----------+-------+------------------------------+----------+--------+--------+----------+---------+
| sla_id | device_id | sla_nr   | owner | tag                          | rtt_type | rtt    | status | opstatus | deleted |
+--------+-----------+----------+-------+------------------------------+----------+--------+--------+----------+---------+
|  19290 |      1909 | 10524810 |       | http://gateway2.net/vpntest  | http     |   5.00 |      1 |        0 |       0 |
|  19291 |      1909 | 10524811 |       | http://gateway2.net/vpntest  | http     |   5.00 |      1 |        0 |       0 |
|  19292 |      1909 | 10524812 |       | http://gateway2.net/vpntest  | http     |  12.00 |      1 |        0 |       0 |
|  19293 |      1909 | 10524820 |       | http://gateway2.net/vpntest  | http     |  47.00 |      1 |        0 |       0 |
|  19294 |      1909 | 10524821 |       | http://gateway2.net/vpntest  | http     |  70.00 |      1 |        0 |       0 |
|   1704 |      1909 | 10524822 |       | http://gateway2.net/vpntest  | http     |  64.00 |      1 |        0 |       0 |
+--------+-----------+----------+-------+------------------------------+----------+--------+--------+----------+---------+
```


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [ x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
