### PR TITLE
Override Restify Policy command to fix upstream issue

### DIFF
--- a/app/Providers/RestifyServiceProvider.php
+++ b/app/Providers/RestifyServiceProvider.php
@@ -2,8 +2,10 @@
 
 namespace App\Providers;
 
+use App\Restify\RestifyPolicyCommand;
 use App\Restify\RoutesBoot as CustomRoutesBoot;
 use Binaryk\LaravelRestify\Bootstrap\RoutesBoot;
+use Binaryk\LaravelRestify\Commands\PolicyCommand;
 use Binaryk\LaravelRestify\RestifyApplicationServiceProvider;
 use Illuminate\Support\ServiceProvider;
 
@@ -12,6 +14,7 @@ class RestifyServiceProvider extends ServiceProvider
     public function register(): void
     {
         $this->app->bind(RoutesBoot::class, CustomRoutesBoot::class);
+        $this->app->bind(PolicyCommand::class, RestifyPolicyCommand::class);
 
         if (class_exists(RestifyApplicationServiceProvider::class)) {
             $this->app->register(RestifyApplicationServiceProvider::class);

--- a/app/Restify/RestifyPolicyCommand.php
+++ b/app/Restify/RestifyPolicyCommand.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Restify;
+
+use Binaryk\LaravelRestify\Commands\PolicyCommand;
+
+/**
+ * Fix deprecation warning
+ */
+class RestifyPolicyCommand extends PolicyCommand
+{
+    protected $type = 'Policy';
+}


### PR DESCRIPTION
Fully hide deprecation message.  It currently triggers every lnms command (aka poll)

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
