### PR TITLE
Fix undefined stack variable in NTP graphs

### DIFF
--- a/includes/html/graphs/device/ntp_delay.inc.php
+++ b/includes/html/graphs/device/ntp_delay.inc.php
@@ -36,7 +36,7 @@ foreach ($components as $array) {
         $color = \App\Facades\LibrenmsConfig::get("graph_colours.mixed.$count", \App\Facades\LibrenmsConfig::get('graph_colours.oranges.' . ($count - 7)));
 
         $rrd_options[] = 'DEF:DS' . $count . '=' . $rrd_filename . ':delay:AVERAGE';
-        $rrd_options[] = 'LINE1.25:DS' . $count . '#' . $color . ':' . str_pad(substr((string) $array['peer'], 0, 15), 15) . $stack;
+        $rrd_options[] = 'LINE1.25:DS' . $count . '#' . $color . ':' . str_pad(substr((string) $array['peer'], 0, 15), 15);
         $rrd_options[] = 'GPRINT:DS' . $count . ':LAST:%7.2lf';
         $rrd_options[] = 'GPRINT:DS' . $count . ':MIN:%7.2lf';
         $rrd_options[] = 'GPRINT:DS' . $count . ':MAX:%7.2lf\\l';

--- a/includes/html/graphs/device/ntp_dispersion.inc.php
+++ b/includes/html/graphs/device/ntp_dispersion.inc.php
@@ -36,7 +36,7 @@ foreach ($components as $array) {
         $color = \App\Facades\LibrenmsConfig::get("graph_colours.mixed.$count", \App\Facades\LibrenmsConfig::get('graph_colours.oranges.' . ($count - 7)));
 
         $rrd_options[] = 'DEF:DS' . $count . '=' . $rrd_filename . ':dispersion:AVERAGE';
-        $rrd_options[] = 'LINE1.25:DS' . $count . '#' . $color . ':' . str_pad(substr((string) $array['peer'], 0, 15), 15) . $stack;
+        $rrd_options[] = 'LINE1.25:DS' . $count . '#' . $color . ':' . str_pad(substr((string) $array['peer'], 0, 15), 15);
         $rrd_options[] = 'GPRINT:DS' . $count . ':LAST:%7.2lf';
         $rrd_options[] = 'GPRINT:DS' . $count . ':MIN:%7.2lf';
         $rrd_options[] = 'GPRINT:DS' . $count . ':MAX:%7.2lf\\l';

--- a/includes/html/graphs/device/ntp_offset.inc.php
+++ b/includes/html/graphs/device/ntp_offset.inc.php
@@ -35,7 +35,7 @@ foreach ($components as $array) {
         $color = \App\Facades\LibrenmsConfig::get("graph_colours.mixed.$count", \App\Facades\LibrenmsConfig::get('graph_colours.oranges.' . ($count - 7)));
 
         $rrd_options[] = 'DEF:DS' . $count . '=' . $rrd_filename . ':offset:AVERAGE';
-        $rrd_options[] = 'LINE1.25:DS' . $count . '#' . $color . ':' . str_pad(substr((string) $array['peer'], 0, 15), 15) . $stack;
+        $rrd_options[] = 'LINE1.25:DS' . $count . '#' . $color . ':' . str_pad(substr((string) $array['peer'], 0, 15), 15);
         $rrd_options[] = 'GPRINT:DS' . $count . ':LAST:%7.2lf';
         $rrd_options[] = 'GPRINT:DS' . $count . ':MIN:%7.2lf';
         $rrd_options[] = 'GPRINT:DS' . $count . ':MAX:%7.2lf\\l';

--- a/includes/html/graphs/device/ntp_stratum.inc.php
+++ b/includes/html/graphs/device/ntp_stratum.inc.php
@@ -35,7 +35,7 @@ foreach ($components as $array) {
         $color = \App\Facades\LibrenmsConfig::get("graph_colours.mixed.$count", \App\Facades\LibrenmsConfig::get('graph_colours.oranges.' . ($count - 7)));
 
         $rrd_options[] = 'DEF:DS' . $count . '=' . $rrd_filename . ':stratum:AVERAGE';
-        $rrd_options[] = 'LINE1.25:DS' . $count . '#' . $color . ':' . str_pad(substr((string) $array['peer'], 0, 15), 15) . $stack;
+        $rrd_options[] = 'LINE1.25:DS' . $count . '#' . $color . ':' . str_pad(substr((string) $array['peer'], 0, 15), 15);
         $rrd_options[] = 'GPRINT:DS' . $count . ':LAST:%5.0lf';
         $rrd_options[] = 'GPRINT:DS' . $count . ':MIN:%7.0lf';
         $rrd_options[] = 'GPRINT:DS' . $count . ':MAX:%7.0lf\\l';


### PR DESCRIPTION
Remove references to the undefined `$stack` variable from the NTP delay, dispersion, offset, and stratum graph definitions.

These graphs draw an independent line for each NTP peer and do not enable RRD stacking. Concatenating `$stack` therefore has no intended effect, but it emits an undefined-variable warning whenever an NTP graph contains data. In environments that convert warnings to exceptions, it can also prevent the graph from being generated.

The generated RRD `LINE` options otherwise remain unchanged.

Validation performed:

- PHP syntax checks for all four modified graph definitions
- `vendor/bin/pint --test` for all four modified files
- `vendor/bin/rector process --dry-run --debug` for all four modified files
- `git diff --check`

AI helped with summary and tests.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
