### PR TITLE
Transceiver change event logging

### DIFF
--- a/app/Models/Port.php
+++ b/app/Models/Port.php
@@ -117,7 +117,7 @@ class Port extends DeviceRelatedModel
      *
      * @return string
      */
-    public function getLabel()
+    public function getLabel(): string
     {
         $os = $this->device?->os;
 
@@ -153,7 +153,7 @@ class Port extends DeviceRelatedModel
      */
     public function getShortLabel(?int $length = null): string
     {
-        $name = Rewrite::normalizeIfName($this->ifName ?: $this->ifDescr);
+        $name = Rewrite::normalizeIfName($this->getLabel());
 
         return substr(Rewrite::shortenIfName($name), 0, $length);
     }

--- a/app/Models/Transceiver.php
+++ b/app/Models/Transceiver.php
@@ -2,9 +2,12 @@
 
 namespace App\Models;
 
+use App\Observers\TransceiverObserver;
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use LibreNMS\Interfaces\Models\Keyable;
 
+#[ObservedBy([TransceiverObserver::class])]
 class Transceiver extends PortRelatedModel implements Keyable
 {
     use HasFactory;

--- a/app/Observers/TransceiverObserver.php
+++ b/app/Observers/TransceiverObserver.php
@@ -8,7 +8,7 @@ use LibreNMS\Enum\Severity;
 
 class TransceiverObserver
 {
-    private const IDENTITY_ATTRIBUTES = ['serial', 'vendor', 'model', 'type'];
+    private const IDENTITY_ATTRIBUTES = ['vendor', 'model', 'type', 'serial'];
 
     public function created(Transceiver $transceiver): void
     {

--- a/app/Observers/TransceiverObserver.php
+++ b/app/Observers/TransceiverObserver.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\Eventlog;
+use App\Models\Transceiver;
+use LibreNMS\Enum\Severity;
+
+class TransceiverObserver
+{
+    private const IDENTITY_ATTRIBUTES = ['serial', 'vendor', 'model', 'type'];
+
+    public function created(Transceiver $transceiver): void
+    {
+        $port = $this->portLabel($transceiver);
+        $message = 'Transceiver added' . ($port === null ? '' : " on port $port") . ' (' . $this->identity($transceiver) . ')';
+
+        Eventlog::log($message, $transceiver->device_id, 'interface', Severity::Notice, $transceiver->port_id);
+    }
+
+    public function updated(Transceiver $transceiver): void
+    {
+        if (! $transceiver->isDirty(self::IDENTITY_ATTRIBUTES)) {
+            return;
+        }
+
+        $previous = $this->identity($transceiver, true);
+        $current = $this->identity($transceiver);
+        if ($previous === $current) {
+            return;
+        }
+
+        $port = $this->portLabel($transceiver);
+        $message = 'Transceiver changed' . ($port === null ? '' : " on port $port") . ": ($previous) -> ($current)";
+
+        Eventlog::log($message, $transceiver->device_id, 'interface', Severity::Warning, $transceiver->port_id);
+    }
+
+    public function deleted(Transceiver $transceiver): void
+    {
+        $port = $this->portLabel($transceiver);
+        $message = 'Transceiver removed' . ($port === null ? '' : " from port $port") . ' (' . $this->identity($transceiver) . ')';
+
+        Eventlog::log($message, $transceiver->device_id, 'interface', Severity::Warning, $transceiver->port_id);
+    }
+
+    private function portLabel(Transceiver $transceiver): ?string
+    {
+        if (! $transceiver->port_id) {
+            return null;
+        }
+
+        return $transceiver->port?->getShortLabel() ?: "ID $transceiver->port_id";
+    }
+
+    private function identity(Transceiver $transceiver, bool $original = false): string
+    {
+        $details = [];
+
+        foreach (self::IDENTITY_ATTRIBUTES as $attribute) {
+            $value = trim((string) ($original ? $transceiver->getOriginal($attribute) : $transceiver->$attribute));
+            if ($value !== '') {
+                $details[] = "$attribute: $value";
+            }
+        }
+
+        return implode(', ', $details) ?: 'details unavailable';
+    }
+}


### PR DESCRIPTION
`Transceiver changed on port Et1/1: (vendor: Finisar, model: FTLX, type: SFP+, serial: OLD) -> (vendor: Finisar, model: FTLX, type: SFP+, serial: NEW)`

for example

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
