### PR TITLE
fix(snmp): preserve blank lines in multi-line values

### DIFF
--- a/LibreNMS/Data/Source/SnmpResponse.php
+++ b/LibreNMS/Data/Source/SnmpResponse.php
@@ -148,11 +148,22 @@ class SnmpResponse implements \Stringable
 
         $this->inferValueEncoding ??= ! StringHelpers::isValidUtf8($this->raw);
         $this->values = [];
-        $line = strtok($this->raw, PHP_EOL);
-        while ($line !== false) {
+        // don't use strtok() here, it collapses consecutive delimiters, dropping blank lines inside multi-line values
+        $lines = explode(PHP_EOL, $this->raw);
+        while ($lines !== [] && trim(end($lines)) === '') {
+            array_pop($lines); // trailing blank lines are never part of a value
+        }
+        $count = count($lines);
+        $index = 0;
+        while ($index < $count) {
+            $line = $lines[$index++];
+
+            if (trim($line) === '') {
+                continue; // blank line where an oid is expected
+            }
+
             if (Str::contains($line, ['at this OID', 'this MIB View', 'End of MIB']) || str_ends_with($line, ' = NULL')) {
                 // these occur when we seek past the end of data, usually the end of the response, but grab the next line and continue
-                $line = strtok(PHP_EOL);
                 continue;
             }
 
@@ -162,10 +173,9 @@ class SnmpResponse implements \Stringable
             }
             [$oid, $value] = $parts;
 
-            $line = strtok(PHP_EOL); // get the next line and concatenate multi-line values
-            while ($line !== false && ! Str::contains($line, self::KEY_VALUE_DELIMITER)) {
-                $value .= PHP_EOL . $line;
-                $line = strtok(PHP_EOL);
+            // consume following lines that aren't a new oid, they are part of a multi-line value
+            while ($index < $count && ! Str::contains($lines[$index], self::KEY_VALUE_DELIMITER)) {
+                $value .= PHP_EOL . $lines[$index++];
             }
 
             // remove extra escapes

--- a/tests/Unit/SnmpResponseTest.php
+++ b/tests/Unit/SnmpResponseTest.php
@@ -187,6 +187,15 @@ final class SnmpResponseTest extends TestCase
         $this->assertEquals(['SNMPv2-MIB::sysDescr' => [1 => "something\n on two lines"]], $response->table());
     }
 
+    public function testMultiLineKeepsBlankLines(): void
+    {
+        // agent scripts (nsExtendOutputFull) commonly separate blocks with blank lines, they must not be dropped
+        $response = new SnmpResponse("NET-SNMP-EXTEND-MIB::nsExtendOutputFull[bird2] = first block\nstill first\n\nsecond block\n\n\nthird block\n");
+
+        $this->assertTrue($response->isValid());
+        $this->assertEquals("first block\nstill first\n\nsecond block\n\n\nthird block", $response->value());
+    }
+
     public function numericTest(): void
     {
         $response = new SnmpResponse(".1.3.6.1.2.1.2.2.1.10.1 = 495813425\n.1.3.6.1.2.1.2.2.1.10.2 = 3495809228\n");


### PR DESCRIPTION
strtok() collapses consecutive delimiters, so SnmpResponse::values() dropped every blank line inside multi-line values. This broke the bird2 poller, which splits on blank lines ("No BGP Peers found", plus deletion of existing bgpPeers rows), and corrupted binary octet strings containing consecutive 0x0A bytes. Regression from #18059

reported on discord, PR so user can test: https://discord.com/channels/327529583601647617/327529583601647617/1537990990009340016

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
