### PR TITLE
fix(routes): unwrap negative NextHopAS from signed ipCidrRouteTable

### DIFF
--- a/LibreNMS/Modules/Routes.php
+++ b/LibreNMS/Modules/Routes.php
@@ -148,7 +148,8 @@ class Routes implements Module
             $data->inetCidrRouteIfIndex = intval($data->inetCidrRouteIfIndex);
             $data->inetCidrRouteType = intval($data->inetCidrRouteType);
             $data->inetCidrRouteProto = intval($data->inetCidrRouteProto);
-            $data->inetCidrRouteNextHopAS = intval($data->inetCidrRouteNextHopAS);
+            $nextHopAS = intval($data->inetCidrRouteNextHopAS);
+            $data->inetCidrRouteNextHopAS = $nextHopAS < 0 ? $nextHopAS + 4294967296 : $nextHopAS; //32bit ASN wrapped negative by signed Integer32 in RFC2096 ipCidrRouteTable
             $data->inetCidrRouteMetric1 = intval($data->inetCidrRouteMetric1) < 0 ? 0 : intval($data->inetCidrRouteMetric1); //negative val from RFC1213
             $data->inetCidrRouteDestType ??= '';
             $data->inetCidrRouteDest = $dst;

--- a/LibreNMS/Modules/Routes.php
+++ b/LibreNMS/Modules/Routes.php
@@ -44,6 +44,7 @@ use LibreNMS\Polling\ConnectivityHelper;
 use LibreNMS\Polling\ModuleStatus;
 use LibreNMS\Util\IPv4;
 use LibreNMS\Util\IPv6;
+use LibreNMS\Util\Number;
 use SnmpQuery;
 
 class Routes implements Module
@@ -148,8 +149,7 @@ class Routes implements Module
             $data->inetCidrRouteIfIndex = intval($data->inetCidrRouteIfIndex);
             $data->inetCidrRouteType = intval($data->inetCidrRouteType);
             $data->inetCidrRouteProto = intval($data->inetCidrRouteProto);
-            $nextHopAS = intval($data->inetCidrRouteNextHopAS);
-            $data->inetCidrRouteNextHopAS = $nextHopAS < 0 ? $nextHopAS + 4294967296 : $nextHopAS; //32bit ASN wrapped negative by signed Integer32 in RFC2096 ipCidrRouteTable
+            $data->inetCidrRouteNextHopAS = Number::correctIntegerOverflow(intval($data->inetCidrRouteNextHopAS)); //32bit ASN wrapped negative by signed Integer32 in RFC2096 ipCidrRouteTable
             $data->inetCidrRouteMetric1 = intval($data->inetCidrRouteMetric1) < 0 ? 0 : intval($data->inetCidrRouteMetric1); //negative val from RFC1213
             $data->inetCidrRouteDestType ??= '';
             $data->inetCidrRouteDest = $dst;


### PR DESCRIPTION
### Problem
Route discovery aborts with a QueryException on devices that use 32-bit ASNs (RFC 6996 private range 4200000000-4294967294):

  SQLSTATE[22003]: Numeric value out of range: 1264 Out of range value
  for column 'inetCidrRouteNextHopAS' at row 1
  (... values (..., -84967296, ...))

Routes::discover() merges inetCidrRouteTable (RFC 4292) and the deprecated ipCidrRouteTable (RFC 2096). The AS column differs between them:

  inetCidrRouteNextHopAS  InetAutonomousSystemNumber (Unsigned32)
  ipCidrRouteNextHopAS    Integer32 (signed)

An agent that reports a 32-bit ASN through the deprecated table wraps it negative. Observed on Junos 23.4, same route in both tables:

  IP-FORWARD-MIB::inetCidrRouteNextHopAS...100.64.96.0.31...100.64.96.17
      = Gauge32: 4210000000
  IP-FORWARD-MIB::ipCidrRouteNextHopAS.100.64.96.0.255.255.255.254.0.100.64.96.17
      = INTEGER: -84967296

  -84967296 + 2^32 = 4210000000

intval() at the sanitising step passes the negative through unchanged, and `route`.`inetCidrRouteNextHopAS` is `int unsigned NOT NULL`, so the insert fails and the whole module aborts part-way through the sync, leaving the device with a truncated route table.

The adjacent inetCidrRouteMetric1 line already guards against negative values arriving from a legacy table; the AS column had no equivalent.

### Change
Re-interpret a negative NextHopAS as the unsigned 32-bit value it was encoded from. An AS number is unsigned by definition, so any negative value here is a signed-Integer32 wrap and adding 2^32 recovers the original.

### Verification
Observed on a fabric of 10 Junos devices (AS 4200000000 and 4210000000) where every discovery run failed. For every route carried by both tables, the unwrapped value equals what inetCidrRouteTable reports for the same destination and next-hop:

  -84967296 -> 4210000000     -84967294 -> 4210000002
  -84967293 -> 4210000003     -84967292 -> 4210000004

so the recovered number is the device's own unsigned ASN, not an approximation. Removing the negative removes the only value the `int unsigned` column rejects, which is what aborted the module.

Devices reporting 16-bit ASNs are unaffected: those values are never negative, so the expression is a no-op for them.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
