### PR TITLE
improve bird2 poller to collect more of the available data

### DIFF
--- a/LibreNMS/Data/Source/Bird2.php
+++ b/LibreNMS/Data/Source/Bird2.php
@@ -21,7 +21,7 @@
  * @link       https://www.librenms.org
  */
 
-namespace LibreNMS\Util;
+namespace LibreNMS\Data\Source;
 
 class Bird2
 {

--- a/LibreNMS/Util/Bird2.php
+++ b/LibreNMS/Util/Bird2.php
@@ -1,0 +1,136 @@
+<?php
+
+/**
+ * Bird2.php
+ *
+ * Parses `birdc show protocols all` output for the bird2 application.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * @link       https://www.librenms.org
+ */
+
+namespace LibreNMS\Util;
+
+class Bird2
+{
+    /** bird pads this header to a fixed width */
+    public const HEADER = 'Name       Proto      Table      State  Since         Info';
+
+    /**
+     * Parse `birdc show protocols all` into one entry per BGP protocol.
+     *
+     * @return list<array<string, mixed>>
+     */
+    public static function parseProtocols(string $output): array
+    {
+        $protocolsData = [];
+
+        // Remove headers
+        $birdOutput = trim(explode(self::HEADER, $output, 2)[1]);
+        $protocolSegments = explode("\n\n", $birdOutput);
+
+        // Remove the first title
+        unset($protocolSegments[0]);
+
+        foreach ($protocolSegments as $protocolSegment) {
+            // Deal with the title first
+            $protocolSegmentParts = explode("\n", $protocolSegment, 2);
+            $titleParts = preg_split("/\s+/", $protocolSegmentParts[0], 5);
+
+            // make sure we only look at BGP protocols
+            if ($titleParts[1] !== 'BGP') {
+                continue;
+            }
+
+            $protocolData = [
+                'name' => $titleParts[0],
+                'type' => $titleParts[1],
+                'table' => $titleParts[2],
+                'protocol_state' => $titleParts[3],
+                'since' => preg_split("/\s+/", $titleParts[4], 3)[0] . ' ' . preg_split("/\s+/", $titleParts[4], 3)[1],
+            ];
+
+            // Deal with the rest of the body
+            $protocolBodys = preg_split("/^\s{2}([A-Z])/m", $protocolSegmentParts[1]);
+
+            // Loop through all BGP protocols
+            foreach ($protocolBodys as $protocolBody) {
+                // Deal with the BGP block
+                if (str_starts_with($protocolBody, 'GP')) {
+                    foreach (explode("\n", 'B' . $protocolBody) as $protocolBodyLine) {
+                        if (str_contains($protocolBodyLine, ':')) {
+                            $lineParts = explode(':', $protocolBodyLine, 2);
+                            $protocolData[str_replace(' ', '_', strtolower(trim($lineParts[0])))] = trim($lineParts[1]);
+                        }
+                    }
+
+                    // Fix up the error string
+                    if (isset($protocolData['last_error'])) {
+                        // Trim the received
+                        $protocolData['last_error'] = trim(str_ireplace('Received:', '', $protocolData['last_error']));
+                    }
+                }
+
+                // Process the Ip channel (v4/v6)
+                $IpVersion = 4;
+                if (isset($protocolData['neighbor_address']) && filter_var($protocolData['neighbor_address'], FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)) {
+                    $IpVersion = 6;
+                }
+
+                if (str_starts_with($protocolBody, 'hannel ipv' . $IpVersion)) {
+                    foreach (explode("\n", 'C' . $protocolBody) as $protocolBodyLine) {
+                        if (str_contains($protocolBodyLine, ':')) {
+                            $lineParts = explode(':', $protocolBodyLine, 2);
+                            $protocolData[str_replace(' ', '_', strtolower(trim($lineParts[0])))] = trim($lineParts[1]);
+                        }
+                    }
+
+                    // Fix up the ROUTES
+                    if (isset($protocolData['routes'])) {
+                        $routeParts = explode(', ', $protocolData['routes']);
+                        unset($protocolData['routes']);
+                        foreach ($routeParts as $routePart) {
+                            $routeDetail = explode(' ', $routePart);
+                            $protocolData['routes'][$routeDetail[1]] = $routeDetail[0];
+                        }
+                    }
+
+                    // Set the route updates
+                    unset($protocolData['route_change_stats']);
+                    foreach (['import_updates', 'import_withdraws', 'export_updates', 'export_withdraws'] as $key) {
+                        if (! isset($protocolData[$key])) {
+                            continue;
+                        }
+
+                        $routeChange_parts = preg_split("/\s+/", trim($protocolData[$key]));
+
+                        unset($protocolData[$key]);
+                        $protocolData['route_change_stats'][$key] = [
+                            'received' => $routeChange_parts[0],
+                            'rejected' => $routeChange_parts[1],
+                            'filtered' => $routeChange_parts[2],
+                            'ignored' => $routeChange_parts[3],
+                            'accepted' => $routeChange_parts[4],
+                        ];
+                    }
+                }
+            }
+
+            $protocolsData[] = $protocolData;
+        }
+
+        return $protocolsData;
+    }
+}

--- a/LibreNMS/Util/Bird2.php
+++ b/LibreNMS/Util/Bird2.php
@@ -25,8 +25,16 @@ namespace LibreNMS\Util;
 
 class Bird2
 {
-    /** bird pads this header to a fixed width */
     public const HEADER = 'Name       Proto      Table      State  Since         Info';
+
+    /** cbgp rrd datasets, in the order the rrd expects them */
+    public const PREFIX_DATASETS = [
+        'AcceptedPrefixes',
+        'DeniedPrefixes',
+        'AdvertisedPrefixes',
+        'SuppressedPrefixes',
+        'WithdrawnPrefixes',
+    ];
 
     /**
      * Parse `birdc show protocols all` into one entry per BGP protocol.
@@ -37,20 +45,16 @@ class Bird2
     {
         $protocolsData = [];
 
-        // Remove headers
-        $birdOutput = trim(explode(self::HEADER, $output, 2)[1]);
-        $protocolSegments = explode("\n\n", $birdOutput);
+        $parts = explode(self::HEADER, $output, 2);
+        if (! isset($parts[1])) {
+            return $protocolsData;
+        }
 
-        // Remove the first title
-        unset($protocolSegments[0]);
-
-        foreach ($protocolSegments as $protocolSegment) {
-            // Deal with the title first
+        foreach (self::splitProtocols($parts[1]) as $protocolSegment) {
             $protocolSegmentParts = explode("\n", $protocolSegment, 2);
             $titleParts = preg_split("/\s+/", $protocolSegmentParts[0], 5);
 
-            // make sure we only look at BGP protocols
-            if ($titleParts[1] !== 'BGP') {
+            if (($titleParts[1] ?? null) !== 'BGP' || ! isset($protocolSegmentParts[1])) {
                 continue;
             }
 
@@ -62,75 +66,157 @@ class Bird2
                 'since' => preg_split("/\s+/", $titleParts[4], 3)[0] . ' ' . preg_split("/\s+/", $titleParts[4], 3)[1],
             ];
 
-            // Deal with the rest of the body
+            // same indent as the blocks below, so take it before splitting them
+            if (preg_match('/^\s+Description:\s*(.+)$/m', $protocolSegmentParts[1], $descriptionMatch)) {
+                $protocolData['description'] = trim($descriptionMatch[1]);
+            }
+
             $protocolBodys = preg_split("/^\s{2}([A-Z])/m", $protocolSegmentParts[1]);
 
-            // Loop through all BGP protocols
             foreach ($protocolBodys as $protocolBody) {
-                // Deal with the BGP block
                 if (str_starts_with($protocolBody, 'GP')) {
-                    foreach (explode("\n", 'B' . $protocolBody) as $protocolBodyLine) {
-                        if (str_contains($protocolBodyLine, ':')) {
-                            $lineParts = explode(':', $protocolBodyLine, 2);
-                            $protocolData[str_replace(' ', '_', strtolower(trim($lineParts[0])))] = trim($lineParts[1]);
-                        }
-                    }
+                    $protocolData = array_merge($protocolData, self::parseKeyedLines('B' . $protocolBody));
 
-                    // Fix up the error string
                     if (isset($protocolData['last_error'])) {
-                        // Trim the received
                         $protocolData['last_error'] = trim(str_ireplace('Received:', '', $protocolData['last_error']));
                     }
                 }
 
-                // Process the Ip channel (v4/v6)
-                $IpVersion = 4;
-                if (isset($protocolData['neighbor_address']) && filter_var($protocolData['neighbor_address'], FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)) {
-                    $IpVersion = 6;
+                if (! str_starts_with($protocolBody, 'hannel ')) {
+                    continue;
                 }
 
-                if (str_starts_with($protocolBody, 'hannel ipv' . $IpVersion)) {
-                    foreach (explode("\n", 'C' . $protocolBody) as $protocolBodyLine) {
-                        if (str_contains($protocolBodyLine, ':')) {
-                            $lineParts = explode(':', $protocolBodyLine, 2);
-                            $protocolData[str_replace(' ', '_', strtolower(trim($lineParts[0])))] = trim($lineParts[1]);
-                        }
-                    }
-
-                    // Fix up the ROUTES
-                    if (isset($protocolData['routes'])) {
-                        $routeParts = explode(', ', $protocolData['routes']);
-                        unset($protocolData['routes']);
-                        foreach ($routeParts as $routePart) {
-                            $routeDetail = explode(' ', $routePart);
-                            $protocolData['routes'][$routeDetail[1]] = $routeDetail[0];
-                        }
-                    }
-
-                    // Set the route updates
-                    unset($protocolData['route_change_stats']);
-                    foreach (['import_updates', 'import_withdraws', 'export_updates', 'export_withdraws'] as $key) {
-                        if (! isset($protocolData[$key])) {
-                            continue;
-                        }
-
-                        $routeChange_parts = preg_split("/\s+/", trim($protocolData[$key]));
-
-                        unset($protocolData[$key]);
-                        $protocolData['route_change_stats'][$key] = [
-                            'received' => $routeChange_parts[0],
-                            'rejected' => $routeChange_parts[1],
-                            'filtered' => $routeChange_parts[2],
-                            'ignored' => $routeChange_parts[3],
-                            'accepted' => $routeChange_parts[4],
-                        ];
-                    }
-                }
+                $channel = self::parseChannel('C' . $protocolBody);
+                $protocolData['channels'][$channel['afi'] . '.' . $channel['safi']] = $channel;
             }
 
-            $protocolsData[] = $protocolData;
+            // the peer's own family also populates the peer itself
+            $ipVersion = isset($protocolData['neighbor_address'])
+                && filter_var($protocolData['neighbor_address'], FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) ? 6 : 4;
+            $primaryChannel = $protocolData['channels']['ipv' . $ipVersion . '.unicast'] ?? [];
+            unset($primaryChannel['afi'], $primaryChannel['safi']);
+
+            $protocolsData[] = array_merge($protocolData, $primaryChannel);
         }
 
         return $protocolsData;
+    }
+
+    /**
+     * Channel counters mapped onto the bgpPeers_cbgp columns.
+     * Key order must match PREFIX_DATASETS, rrd updates are positional.
+     *
+     * @param  array<string, mixed>  $channel
+     * @return array<string, int>
+     */
+    public static function channelPrefixCounters(array $channel): array
+    {
+        $counters = [
+            'AcceptedPrefixes' => $channel['routes']['imported'] ?? 0,
+            'DeniedPrefixes' => $channel['route_change_stats']['import_updates']['rejected'] ?? 0,
+            'AdvertisedPrefixes' => $channel['routes']['exported'] ?? 0,
+            'SuppressedPrefixes' => $channel['route_change_stats']['import_updates']['filtered'] ?? 0,
+            'WithdrawnPrefixes' => $channel['route_change_stats']['import_withdraws']['accepted'] ?? 0,
+        ];
+
+        return array_map(fn ($value) => (int) Number::cast($value), $counters);
+    }
+
+    /**
+     * Split the protocol table into one block per protocol.
+     * Protocols start at column 0 and their detail is indented, blank lines are not reliable.
+     *
+     * @return list<string>
+     */
+    private static function splitProtocols(string $body): array
+    {
+        $segments = [];
+        $current = null;
+
+        foreach (explode("\n", $body) as $line) {
+            $line = rtrim($line, "\r");
+
+            if (trim($line) === '') {
+                continue;
+            }
+
+            if (ctype_space($line[0])) {
+                $current .= "\n" . $line; // continuation of the current protocol
+                continue;
+            }
+
+            if ($current !== null) {
+                $segments[] = $current;
+            }
+            $current = $line;
+        }
+
+        if ($current !== null) {
+            $segments[] = $current;
+        }
+
+        return $segments;
+    }
+
+    /**
+     * "Field: value" lines into snake_cased keys.
+     *
+     * @return array<string, string>
+     */
+    private static function parseKeyedLines(string $block): array
+    {
+        $data = [];
+
+        foreach (explode("\n", $block) as $line) {
+            if (str_contains($line, ':')) {
+                [$key, $value] = explode(':', $line, 2);
+                $data[str_replace(' ', '_', strtolower(trim($key)))] = trim($value);
+            }
+        }
+
+        return $data;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function parseChannel(string $block): array
+    {
+        // "Channel ipv6" or "Channel ipv4 multicast"
+        $channelParts = preg_split("/\s+/", trim(explode("\n", $block, 2)[0]));
+
+        $channel = array_merge([
+            'afi' => $channelParts[1] ?? '',
+            'safi' => $channelParts[2] ?? 'unicast',
+        ], self::parseKeyedLines($block));
+
+        if (isset($channel['routes'])) {
+            $routeParts = explode(', ', $channel['routes']);
+            unset($channel['routes']);
+            foreach ($routeParts as $routePart) {
+                $routeDetail = explode(' ', $routePart);
+                $channel['routes'][$routeDetail[1]] = $routeDetail[0];
+            }
+        }
+
+        unset($channel['route_change_stats']);
+        foreach (['import_updates', 'import_withdraws', 'export_updates', 'export_withdraws'] as $key) {
+            if (! isset($channel[$key])) {
+                continue;
+            }
+
+            $routeChangeParts = preg_split("/\s+/", trim($channel[$key]));
+
+            unset($channel[$key]);
+            $channel['route_change_stats'][$key] = [
+                'received' => $routeChangeParts[0],
+                'rejected' => $routeChangeParts[1],
+                'filtered' => $routeChangeParts[2],
+                'ignored' => $routeChangeParts[3],
+                'accepted' => $routeChangeParts[4],
+            ];
+        }
+
+        return $channel;
     }
 }

--- a/includes/html/pages/device/routing/bgp.inc.php
+++ b/includes/html/pages/device/routing/bgp.inc.php
@@ -4,10 +4,10 @@ use LibreNMS\Util\IP;
 
 $extra_sql = '';
 $link_array = [
-    'page'   => 'device',
+    'page' => 'device',
     'device' => $device['device_id'],
-    'tab'    => 'routing',
-    'proto'  => 'bgp',
+    'tab' => 'routing',
+    'proto' => 'bgp',
 ];
 
 if (! isset($vars['view'])) {
@@ -195,8 +195,9 @@ foreach (dbFetchRows("SELECT * FROM `bgpPeers` WHERE `device_id` = ? $extra_sql 
         $afi = $afisafi['afi'];
         $safi = $afisafi['safi'];
         $this_afisafi = $afi . $safi;
-        $peer['afi'] = $sep . $afi . '.' . $safi;
-        $sep = '<br />';
+        // several families per session, and the cell is escaped
+        $peer['afi'] = ($peer['afi'] ?? '') . $sep . $afi . '.' . $safi;
+        $sep = ', ';
         $peer['afisafi'][$this_afisafi] = 1;
         // Build a list of valid AFI/SAFI for this peer
     }

--- a/includes/polling/applications/bird2.inc.php
+++ b/includes/polling/applications/bird2.inc.php
@@ -1,7 +1,11 @@
 <?php
 
 use App\Models\BgpPeer;
+use App\Models\BgpPeerCbgp;
 use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
+use LibreNMS\Data\Store\Rrd;
+use LibreNMS\RRD\RrdDefinition;
 use LibreNMS\Util\Bird2;
 use LibreNMS\Util\Oid;
 
@@ -42,6 +46,7 @@ $deviceObj->save();
 
 // Going through all BGP Peers
 $bgpPeerIds = [];
+$peerAfiKeys = [];
 
 foreach ($protocolsData as $protocol) {
     // Skip peers that don't have neighbor_address (incomplete BGP handshakes/errors)
@@ -59,28 +64,29 @@ foreach ($protocolsData as $protocol) {
 
     $bgpPeer->device_id = $device['device_id'];
     $bgpPeer->astext = \LibreNMS\Util\AutonomousSystem::get($protocol['neighbor_as'])->name();
-    $bgpPeer->bgpPeerIdentifier = $protocol['neighbor_id'] ?? '0.0.0.0';
+    // key on the address, not the router id, the routing page filters v4/v6 on it
+    $bgpPeer->bgpPeerIdentifier = $protocol['neighbor_address'];
     $bgpPeer->bgpPeerRemoteAs = $protocol['neighbor_as'];
     $bgpPeer->bgpPeerState = strtolower((string) $protocol['bgp_state']);
     $bgpPeer->bgpPeerAdminStatus = str_replace('up', 'start', strtolower((string) $protocol['protocol_state']));
 
-    if (isset($protocolData['last_error'])) {
+    if (isset($protocol['last_error'])) {
         // Find the subcode if its there and set it
         foreach (trans('bgp.error_subcodes') as $mainCode => $subCodes) {
             foreach ($subCodes as $subCode => $message) {
-                if ($message == $protocolData['last_error']) {
+                if ($message == $protocol['last_error']) {
                     $bgpPeer->bgpPeerLastErrorCode = $mainCode;
                     $bgpPeer->bgpPeerLastErrorSubCode = $subCode;
                 }
             }
         }
 
-        $bgpPeer->bgpPeerLastErrorText = $protocol['neighbor_id'] ?? '0.0.0.0';
+        $bgpPeer->bgpPeerLastErrorText = $protocol['last_error'];
     }
 
     $bgpPeer->bgpLocalAddr = $protocol['source_address'] ?? '0.0.0.0';
     $bgpPeer->bgpPeerRemoteAddr = $protocol['neighbor_address'];
-    $bgpPeer->bgpPeerDescr = $protocol['description'] ?: $protocol['name'];
+    $bgpPeer->bgpPeerDescr = $protocol['description'] ?? $protocol['name'];
     $bgpPeer->bgpPeerInUpdates = intval($protocol['route_change_stats']['import_updates']['accepted'] ?? 0);
     $bgpPeer->bgpPeerOutUpdates = intval($protocol['route_change_stats']['export_updates']['accepted'] ?? 0);
     $bgpPeer->bgpPeerInTotalMessages = intval($protocol['route_change_stats']['import_updates']['received'] ?? 0);
@@ -89,6 +95,66 @@ foreach ($protocolsData as $protocol) {
     $bgpPeer->bgpPeerFsmEstablishedTime = (int) Carbon::parse($protocol['since'])->diffInSeconds(Carbon::now(), true);
     $bgpPeer->bgpPeerInUpdateElapsedTime = (int) Carbon::parse($protocol['since'])->diffInSeconds(Carbon::now(), true);
     $bgpPeer->save();
+
+    // write same graphs as bgp-peers
+    app('Datastore')->put($device, 'bgp', [
+        'bgpPeerIdentifier' => $bgpPeer->bgpPeerIdentifier,
+        'rrd_name' => Rrd::safeName('bgp-' . $bgpPeer->bgpPeerIdentifier),
+        'rrd_def' => RrdDefinition::make()
+            ->addDataset('bgpPeerOutUpdates', 'COUNTER', null, 100000000000)
+            ->addDataset('bgpPeerInUpdates', 'COUNTER', null, 100000000000)
+            ->addDataset('bgpPeerOutTotal', 'COUNTER', null, 100000000000)
+            ->addDataset('bgpPeerInTotal', 'COUNTER', null, 100000000000)
+            ->addDataset('bgpPeerEstablished', 'GAUGE', 0),
+    ], [
+        'bgpPeerOutUpdates' => $bgpPeer->bgpPeerOutUpdates,
+        'bgpPeerInUpdates' => $bgpPeer->bgpPeerInUpdates,
+        'bgpPeerOutTotal' => $bgpPeer->bgpPeerOutTotalMessages,
+        'bgpPeerInTotal' => $bgpPeer->bgpPeerInTotalMessages,
+        'bgpPeerEstablished' => $bgpPeer->bgpPeerFsmEstablishedTime,
+    ]);
+
+    foreach ($protocol['channels'] ?? [] as $channel) {
+        // no id column, match on the composite key
+        $afiKey = [
+            'device_id' => $device['device_id'],
+            'bgpPeerIdentifier' => $bgpPeer->bgpPeerIdentifier,
+            'afi' => $channel['afi'],
+            'safi' => $channel['safi'],
+        ];
+        $existing = BgpPeerCbgp::where($afiKey)->first();
+
+        // bird has no prefix limits, but these are NOT NULL
+        $values = [
+            'PrefixAdminLimit' => (int) ($existing->PrefixAdminLimit ?? 0),
+            'PrefixThreshold' => (int) ($existing->PrefixThreshold ?? 0),
+            'PrefixClearThreshold' => (int) ($existing->PrefixClearThreshold ?? 0),
+        ];
+
+        foreach (Bird2::channelPrefixCounters($channel) as $field => $value) {
+            $previous = (int) ($existing->$field ?? 0);
+
+            $values[$field] = $value;
+            $values[$field . '_prev'] = $previous;
+            $values[$field . '_delta'] = $value - $previous;
+        }
+
+        DB::table('bgpPeers_cbgp')->updateOrInsert($afiKey, $values);
+
+        app('Datastore')->put($device, 'cbgp', [
+            'bgpPeerIdentifier' => $bgpPeer->bgpPeerIdentifier,
+            'afi' => $channel['afi'],
+            'safi' => $channel['safi'],
+            'rrd_name' => Rrd::safeName('cbgp-' . $bgpPeer->bgpPeerIdentifier . '.' . $channel['afi'] . '.' . $channel['safi']),
+            'rrd_def' => array_reduce(
+                Bird2::PREFIX_DATASETS,
+                fn ($def, $ds) => $def->addDataset($ds, 'GAUGE', null, 100000000000),
+                RrdDefinition::make()
+            ),
+        ], Bird2::channelPrefixCounters($channel));
+
+        $peerAfiKeys[] = [$bgpPeer->bgpPeerIdentifier, $channel['afi'], $channel['safi']];
+    }
 
     echo PHP_EOL . $name . ': Processed peer AS' . $bgpPeer->bgpPeerRemoteAs . ' (' . $bgpPeer->astext . ')';
 
@@ -99,3 +165,11 @@ echo PHP_EOL;
 
 // Clean up any bgpPeers that arent on the list for this device
 BgpPeer::where('device_id', $device['device_id'])->whereNotIn('bgpPeer_id', $bgpPeerIds)->delete();
+
+BgpPeerCbgp::where('device_id', $device['device_id'])
+    ->where(function ($query) use ($peerAfiKeys): void {
+        foreach ($peerAfiKeys as [$identifier, $afi, $safi]) {
+            $query->whereNot(fn ($q) => $q->where('bgpPeerIdentifier', $identifier)->where('afi', $afi)->where('safi', $safi));
+        }
+    })
+    ->delete();

--- a/includes/polling/applications/bird2.inc.php
+++ b/includes/polling/applications/bird2.inc.php
@@ -4,9 +4,9 @@ use App\Models\BgpPeer;
 use App\Models\BgpPeerCbgp;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\DB;
+use LibreNMS\Data\Source\Bird2;
 use LibreNMS\Data\Store\Rrd;
 use LibreNMS\RRD\RrdDefinition;
-use LibreNMS\Util\Bird2;
 use LibreNMS\Util\Oid;
 
 $name = 'bird2';

--- a/includes/polling/applications/bird2.inc.php
+++ b/includes/polling/applications/bird2.inc.php
@@ -2,6 +2,7 @@
 
 use App\Models\BgpPeer;
 use Carbon\Carbon;
+use LibreNMS\Util\Bird2;
 use LibreNMS\Util\Oid;
 
 $name = 'bird2';
@@ -17,101 +18,7 @@ if (empty($birdOutput)) {
 
 // ========
 // Process the actual BIRD2 output
-$protocolsData = [];
-
-// Remove headers
-$birdOutput = trim(explode('Name       Proto      Table      State  Since         Info', (string) $birdOutput, 2)[1]);
-$protocolSegments = explode("\n\n", $birdOutput);
-
-// Remove the first title
-unset($protocolSegments[0]);
-
-foreach ($protocolSegments as $protocolSegment) {
-    // Deal with the title first
-    $protocolSegmentParts = explode("\n", $protocolSegment, 2);
-    $titleParts = preg_split("/\s+/", $protocolSegmentParts[0], 5);
-
-    // make sure we only look at BGP protocols
-    if ($titleParts[1] !== 'BGP') {
-        continue;
-    }
-
-    $protocolData = [
-        'name' => $titleParts[0],
-        'type' => $titleParts[1],
-        'table' => $titleParts[2],
-        'protocol_state' => $titleParts[3],
-        'since' => preg_split("/\s+/", $titleParts[4], 3)[0] . ' ' . preg_split("/\s+/", $titleParts[4], 3)[1],
-    ];
-
-    // Deal with the rest of the body
-    $protocolBodys = preg_split("/^\s{2}([A-Z])/m", $protocolSegmentParts[1]);
-
-    // Loop through all BGP protocols
-    foreach ($protocolBodys as $protocolBody) {
-        // Deal with the BGP block
-        if (str_starts_with($protocolBody, 'GP')) {
-            foreach (explode("\n", 'B' . $protocolBody) as $protocolBodyLine) {
-                if (str_contains($protocolBodyLine, ':')) {
-                    $lineParts = explode(':', $protocolBodyLine, 2);
-                    $protocolData[str_replace(' ', '_', strtolower(trim($lineParts[0])))] = trim($lineParts[1]);
-                }
-            }
-
-            // Fix up the error string
-            if (isset($protocolData['last_error'])) {
-                // Trim the received
-                $protocolData['last_error'] = trim(str_ireplace('Received:', '', $protocolData['last_error']));
-            }
-        }
-
-        // Process the Ip channel (v4/v6)
-        $IpVersion = 4;
-        if (isset($protocolData['neighbor_address']) && filter_var($protocolData['neighbor_address'], FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)) {
-            $IpVersion = 6;
-        }
-
-        if (str_starts_with($protocolBody, 'hannel ipv' . $IpVersion)) {
-            foreach (explode("\n", 'C' . $protocolBody) as $protocolBodyLine) {
-                if (str_contains($protocolBodyLine, ':')) {
-                    $lineParts = explode(':', $protocolBodyLine, 2);
-                    $protocolData[str_replace(' ', '_', strtolower(trim($lineParts[0])))] = trim($lineParts[1]);
-                }
-            }
-
-            // Fix up the ROUTES
-            if (isset($protocolData['routes'])) {
-                $routeParts = explode(', ', $protocolData['routes']);
-                unset($protocolData['routes']);
-                foreach ($routeParts as $routePart) {
-                    $routeDetail = explode(' ', $routePart);
-                    $protocolData['routes'][$routeDetail[1]] = $routeDetail[0];
-                }
-            }
-
-            // Set the route updates
-            unset($protocolData['route_change_stats']);
-            foreach (['import_updates', 'import_withdraws', 'export_updates', 'export_withdraws'] as $key) {
-                if (! isset($protocolData[$key])) {
-                    continue;
-                }
-
-                $routeChange_parts = preg_split("/\s+/", trim($protocolData[$key]));
-
-                unset($protocolData[$key]);
-                $protocolData['route_change_stats'][$key] = [
-                    'received' => $routeChange_parts[0],
-                    'rejected' => $routeChange_parts[1],
-                    'filtered' => $routeChange_parts[2],
-                    'ignored' => $routeChange_parts[3],
-                    'accepted' => $routeChange_parts[4],
-                ];
-            }
-        }
-    }
-
-    $protocolsData[] = $protocolData;
-}
+$protocolsData = Bird2::parseProtocols((string) $birdOutput);
 
 // ---
 $deviceObj = DeviceCache::getPrimary();

--- a/tests/Unit/Bird2Test.php
+++ b/tests/Unit/Bird2Test.php
@@ -1,0 +1,211 @@
+<?php
+
+/**
+ * Bird2Test.php
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * @link       https://www.librenms.org
+ */
+
+namespace LibreNMS\Tests\Unit;
+
+use LibreNMS\Data\Source\SnmpResponse;
+use LibreNMS\Tests\TestCase;
+use LibreNMS\Util\Bird2;
+
+/**
+ * Fixtures are verbatim snmpget captures from BIRD 2.17.5 behind net-snmp, using
+ * documentation ranges only (RFC 3849 IPv6, RFC 5737 IPv4, RFC 5398 ASNs).
+ */
+final class Bird2Test extends TestCase
+{
+    public function testSimpleSetup(): void
+    {
+        $peers = $this->parseFixture('simple');
+
+        $this->assertCount(1, $peers);
+        $this->assertSame('uplink', $peers[0]['name']);
+        $this->assertSame('64497', $peers[0]['neighbor_as']);
+        $this->assertSame('2001:db8:0:1::2', $peers[0]['neighbor_address']);
+        $this->assertSame('Established', $peers[0]['bgp_state']);
+        $this->assertSame('up', $peers[0]['protocol_state']);
+
+        $this->assertArrayNotHasKey('description', $peers[0]);
+    }
+
+    public function testNonBgpProtocolsAreIgnored(): void
+    {
+        // the simple fixture also carries Device and Kernel protocols
+        $raw = $this->fixture('simple');
+        $this->assertStringContainsString('Device', $raw);
+        $this->assertStringContainsString('Kernel', $raw);
+
+        foreach ($this->parseFixture('simple') as $peer) {
+            $this->assertSame('BGP', $peer['type']);
+        }
+    }
+
+    public function testIbgpOnlySetup(): void
+    {
+        $peers = $this->parseFixture('ibgp');
+        $this->assertCount(2, $peers);
+
+        $byName = array_column($peers, null, 'name');
+        $this->assertSame(['rr_one', 'rr_two'], array_keys($byName));
+
+        // iBGP: both sides share the local AS
+        foreach ($byName as $peer) {
+            $this->assertSame($peer['local_as'], $peer['neighbor_as'], 'iBGP peers share the AS');
+            $this->assertSame('64496', $peer['neighbor_as']);
+        }
+
+        $this->assertSame('route reflector one', $byName['rr_one']['description']);
+        $this->assertArrayNotHasKey('description', $byName['rr_two']);
+    }
+
+    public function testDescriptionIsOptional(): void
+    {
+        $byName = array_column($this->parseFixture('full'), null, 'name');
+
+        $this->assertSame('documentation transit', $byName['upstream_a']['description']);
+        $this->assertSame('route collector', $byName['collector_c']['description']);
+        $this->assertArrayNotHasKey('description', $byName['peering_b']);
+    }
+
+    public function testSessionCarryingTwoAddressFamilies(): void
+    {
+        $byName = array_column($this->parseFixture('full'), null, 'name');
+
+        $this->assertSame(['ipv4.unicast', 'ipv6.unicast'], array_keys($byName['peering_b']['channels']));
+        $this->assertSame(['ipv6.unicast'], array_keys($byName['upstream_a']['channels']));
+    }
+
+    public function testPrefixCountersPerAddressFamily(): void
+    {
+        $byName = array_column($this->parseFixture('full'), null, 'name');
+
+        $v4 = Bird2::channelPrefixCounters($byName['peering_b']['channels']['ipv4.unicast']);
+        $v6 = Bird2::channelPrefixCounters($byName['peering_b']['channels']['ipv6.unicast']);
+
+        $this->assertSame(18, $v4['AcceptedPrefixes']);
+        $this->assertSame(25, $v6['AcceptedPrefixes']);
+
+        // an export only collector imports nothing but still advertises
+        $collector = Bird2::channelPrefixCounters($byName['collector_c']['channels']['ipv6.unicast']);
+        $this->assertSame(0, $collector['AcceptedPrefixes']);
+        $this->assertGreaterThan(0, $collector['AdvertisedPrefixes']);
+
+        // every counter is an int, bird prints --- where one does not apply
+        foreach ($collector as $value) {
+            $this->assertIsInt($value);
+        }
+    }
+
+    /**
+     * rrd updates are written positionally, so a counter in the wrong slot silently
+     * records itself as a different metric.
+     */
+    public function testPrefixCounterOrderMatchesRrdDatasets(): void
+    {
+        $byName = array_column($this->parseFixture('full'), null, 'name');
+        $counters = Bird2::channelPrefixCounters($byName['peering_b']['channels']['ipv4.unicast']);
+
+        $this->assertSame(Bird2::PREFIX_DATASETS, array_keys($counters));
+    }
+
+    public function testPeerThatNeverEstablished(): void
+    {
+        $byName = array_column($this->parseFixture('down'), null, 'name');
+        $this->assertSame(['working', 'unreachable'], array_keys($byName));
+
+        $this->assertSame('Established', $byName['working']['bgp_state']);
+
+        // still reported, but without the session detail the poller needs
+        $this->assertSame('Connect', $byName['unreachable']['bgp_state']);
+        $this->assertSame('start', $byName['unreachable']['protocol_state']);
+        $this->assertArrayNotHasKey('source_address', $byName['unreachable']);
+    }
+
+    public function testPeerWithLastError(): void
+    {
+        $peers = $this->parseFixture('error');
+        $this->assertCount(1, $peers);
+
+        $this->assertSame('mismatched', $peers[0]['name']);
+        $this->assertSame('Idle', $peers[0]['bgp_state']);
+        $this->assertSame('BGP Error: Bad peer AS', $peers[0]['last_error']);
+        $this->assertSame('as mismatch peer', $peers[0]['description']);
+    }
+
+    /**
+     * bird separates protocols with blank lines, but they are decorative: each protocol
+     * starts at column 0 and its detail is indented. Parsing must not depend on them.
+     */
+    public function testParsingDoesNotDependOnBlankLines(): void
+    {
+        foreach (['simple', 'ibgp', 'full', 'down', 'error'] as $scenario) {
+            // straight from the capture, not via the snmp layer
+            $output = $this->fixture($scenario);
+            $collapsed = preg_replace("/\n{2,}/", "\n", $output);
+
+            $this->assertNotSame($output, $collapsed, "$scenario capture should contain blank lines");
+            $this->assertEquals(
+                Bird2::parseProtocols($output),
+                Bird2::parseProtocols($collapsed),
+                "$scenario must parse the same without blank lines"
+            );
+        }
+    }
+
+    public function testGarbageInputIsNotFatal(): void
+    {
+        $this->assertSame([], Bird2::parseProtocols(''));
+        $this->assertSame([], Bird2::parseProtocols('BIRD 2.17.5 ready.'));
+        $this->assertSame([], Bird2::parseProtocols(Bird2::HEADER));
+        $this->assertSame([], Bird2::parseProtocols(Bird2::HEADER . "\ndevice1    Device     ---        up     2026-01-01 00:00:00\n"));
+    }
+
+    /**
+     * The first protocol in the table must not be dropped, it may be a BGP session.
+     */
+    public function testFirstProtocolIsNotDiscarded(): void
+    {
+        $output = Bird2::HEADER . "\n"
+            . "first_peer BGP        ---        up     2026-01-01 00:00:00  Established\n"
+            . "  BGP state:          Established\n"
+            . "    Neighbor address: 2001:db8:0:1::2\n"
+            . "    Neighbor AS:      64497\n"
+            . "  Channel ipv6\n"
+            . "    Routes:         5 imported, 1 exported, 5 preferred\n";
+
+        $peers = Bird2::parseProtocols($output);
+
+        $this->assertCount(1, $peers);
+        $this->assertSame('first_peer', $peers[0]['name']);
+    }
+
+    private function fixture(string $scenario): string
+    {
+        return file_get_contents(base_path("tests/data/misc/bird2-$scenario.snmpget.txt"));
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function parseFixture(string $scenario): array
+    {
+        return Bird2::parseProtocols((new SnmpResponse($this->fixture($scenario)))->value());
+    }
+}

--- a/tests/Unit/Bird2Test.php
+++ b/tests/Unit/Bird2Test.php
@@ -21,9 +21,9 @@
 
 namespace LibreNMS\Tests\Unit;
 
+use LibreNMS\Data\Source\Bird2;
 use LibreNMS\Data\Source\SnmpResponse;
 use LibreNMS\Tests\TestCase;
-use LibreNMS\Util\Bird2;
 
 /**
  * Fixtures are verbatim snmpget captures from BIRD 2.17.5 behind net-snmp, using

--- a/tests/data/misc/bird2-down.snmpget.txt
+++ b/tests/data/misc/bird2-down.snmpget.txt
@@ -1,0 +1,59 @@
+NET-SNMP-EXTEND-MIB::nsExtendOutputFull[bird2] = BIRD 2.17.5 ready.
+Access restricted
+Name       Proto      Table      State  Since         Info
+device1    Device     ---        up     2026-08-15 13:45:38  
+
+working    BGP        ---        up     2026-08-15 13:45:43  Established   
+  BGP state:          Established
+    Neighbor address: 2001:db8:0:1::2
+    Neighbor AS:      64497
+    Local AS:         64496
+    Neighbor ID:      192.0.2.10
+    Local capabilities
+      Multiprotocol
+        AF announced: ipv6
+      Route refresh
+      Graceful restart
+      4-octet AS numbers
+      Enhanced refresh
+      Long-lived graceful restart
+    Neighbor capabilities
+      Multiprotocol
+        AF announced: ipv6
+      Route refresh
+      Graceful restart
+      4-octet AS numbers
+      Enhanced refresh
+      Long-lived graceful restart
+    Session:          external AS4
+    Source address:   2001:db8:0:1::1
+    Hold timer:       194.713/240
+    Keepalive timer:  64.569/80
+    Send hold timer:  453.563/480
+  Channel ipv6
+    State:          UP
+    Table:          master6
+    Preference:     100
+    Input filter:   ACCEPT
+    Output filter:  ACCEPT
+    Routes:         5 imported, 0 exported, 5 preferred
+    Route change stats:     received   rejected   filtered    ignored   accepted
+      Import updates:              5          0          0          0          5
+      Import withdraws:            0          0        ---          0          0
+      Export updates:              5          5          0        ---          0
+      Export withdraws:            0        ---        ---        ---          0
+    BGP Next hop:   2001:db8:0:1::1 fe80::d4a4:a0ff:fe65:69ba
+
+unreachable BGP        ---        start  2026-08-15 13:45:38  Connect       
+  Description:    peer that never comes up
+  BGP state:          Connect
+    Neighbor address: 2001:db8:0:1::99
+    Neighbor AS:      64500
+    Local AS:         64496
+  Channel ipv6
+    State:          DOWN
+    Table:          master6
+    Preference:     100
+    Input filter:   ACCEPT
+    Output filter:  ACCEPT
+

--- a/tests/data/misc/bird2-error.snmpget.txt
+++ b/tests/data/misc/bird2-error.snmpget.txt
@@ -1,0 +1,20 @@
+NET-SNMP-EXTEND-MIB::nsExtendOutputFull[bird2] = BIRD 2.17.5 ready.
+Access restricted
+Name       Proto      Table      State  Since         Info
+device1    Device     ---        up     2026-08-15 16:49:25  
+
+mismatched BGP        ---        start  2026-08-15 16:49:29  Idle          BGP Error: Bad peer AS
+  Description:    as mismatch peer
+  BGP state:          Idle
+    Neighbor address: 2001:db8:0:1::2
+    Neighbor AS:      64497
+    Local AS:         64496
+    Error wait:       46.342/60
+    Last error:       BGP Error: Bad peer AS
+  Channel ipv6
+    State:          DOWN
+    Table:          master6
+    Preference:     100
+    Input filter:   ACCEPT
+    Output filter:  ACCEPT
+

--- a/tests/data/misc/bird2-full.snmpget.txt
+++ b/tests/data/misc/bird2-full.snmpget.txt
@@ -1,0 +1,186 @@
+NET-SNMP-EXTEND-MIB::nsExtendOutputFull[bird2] = BIRD 2.17.5 ready.
+Access restricted
+Name       Proto      Table      State  Since         Info
+device1    Device     ---        up     2026-08-15 13:45:25  
+
+kernel1    Kernel     master6    up     2026-08-15 13:45:25  
+  Channel ipv6
+    State:          UP
+    Table:          master6
+    Preference:     10
+    Input filter:   ACCEPT
+    Output filter:  ACCEPT
+    Routes:         0 imported, 68 exported, 0 preferred
+    Route change stats:     received   rejected   filtered    ignored   accepted
+      Import updates:              0          0          0          0          0
+      Import withdraws:            0          0        ---          0          0
+      Export updates:             70          0          0        ---         70
+      Export withdraws:            0        ---        ---        ---          0
+
+local_nets Static     master6    up     2026-08-15 13:45:25  
+  Channel ipv6
+    State:          UP
+    Table:          master6
+    Preference:     200
+    Input filter:   ACCEPT
+    Output filter:  REJECT
+    Routes:         2 imported, 0 exported, 2 preferred
+    Route change stats:     received   rejected   filtered    ignored   accepted
+      Import updates:              2          0          0          0          2
+      Import withdraws:            0          0        ---          0          0
+      Export updates:              0          0          0        ---          0
+      Export withdraws:            0        ---        ---        ---          0
+
+internal   OSPF       master6    up     2026-08-15 13:45:25  Alone
+  Channel ipv6
+    State:          UP
+    Table:          master6
+    Preference:     150
+    Input filter:   ACCEPT
+    Output filter:  REJECT
+    Routes:         1 imported, 0 exported, 1 preferred
+    Route change stats:     received   rejected   filtered    ignored   accepted
+      Import updates:              1          0          0          0          1
+      Import withdraws:            0          0        ---          0          0
+      Export updates:             68          1         67        ---          0
+      Export withdraws:            0        ---        ---        ---          0
+
+upstream_a BGP        ---        up     2026-08-15 13:45:30  Established   
+  Description:    documentation transit
+  BGP state:          Established
+    Neighbor address: 2001:db8:0:1::2
+    Neighbor AS:      64497
+    Local AS:         64496
+    Neighbor ID:      192.0.2.10
+    Local capabilities
+      Multiprotocol
+        AF announced: ipv6
+      Route refresh
+      Graceful restart
+      4-octet AS numbers
+      Enhanced refresh
+      Long-lived graceful restart
+    Neighbor capabilities
+      Multiprotocol
+        AF announced: ipv6
+      Route refresh
+      Graceful restart
+      4-octet AS numbers
+      Enhanced refresh
+      Long-lived graceful restart
+    Session:          external AS4
+    Source address:   2001:db8:0:1::1
+    Hold timer:       191.148/240
+    Keepalive timer:  61.171/80
+    Send hold timer:  399.241/480
+  Channel ipv6
+    State:          UP
+    Table:          master6
+    Preference:     100
+    Input filter:   ACCEPT
+    Output filter:  ACCEPT
+    Routes:         40 imported, 28 exported, 40 preferred
+    Route change stats:     received   rejected   filtered    ignored   accepted
+      Import updates:             40          0          0          0         40
+      Import withdraws:            0          0        ---          0          0
+      Export updates:             68         40          0        ---         28
+      Export withdraws:            0        ---        ---        ---          0
+    BGP Next hop:   2001:db8:0:1::1 fe80::a0e8:7dff:fe5f:270c
+
+peering_b  BGP        ---        up     2026-08-15 13:45:29  Established   
+  BGP state:          Established
+    Neighbor address: 192.0.2.2
+    Neighbor AS:      64498
+    Local AS:         64496
+    Neighbor ID:      192.0.2.11
+    Local capabilities
+      Multiprotocol
+        AF announced: ipv4 ipv6
+      Route refresh
+      Graceful restart
+      4-octet AS numbers
+      Enhanced refresh
+      Long-lived graceful restart
+    Neighbor capabilities
+      Multiprotocol
+        AF announced: ipv4 ipv6
+      Route refresh
+      Graceful restart
+      4-octet AS numbers
+      Enhanced refresh
+      Long-lived graceful restart
+    Session:          external AS4
+    Source address:   192.0.2.1
+    Hold timer:       215.712/240
+    Keepalive timer:  71.234/80
+    Send hold timer:  398.142/480
+  Channel ipv4
+    State:          UP
+    Table:          master4
+    Preference:     100
+    Input filter:   ACCEPT
+    Output filter:  ACCEPT
+    Routes:         18 imported, 0 exported, 18 preferred
+    Route change stats:     received   rejected   filtered    ignored   accepted
+      Import updates:             18          0          0          0         18
+      Import withdraws:            0          0        ---          0          0
+      Export updates:             18         18          0        ---          0
+      Export withdraws:            0        ---        ---        ---          0
+    BGP Next hop:   192.0.2.1
+  Channel ipv6
+    State:          UP
+    Table:          master6
+    Preference:     100
+    Input filter:   ACCEPT
+    Output filter:  ACCEPT
+    Routes:         25 imported, 43 exported, 25 preferred
+    Route change stats:     received   rejected   filtered    ignored   accepted
+      Import updates:             25          0          0          0         25
+      Import withdraws:            0          0        ---          0          0
+      Export updates:             68         25          0        ---         43
+      Export withdraws:            0        ---        ---        ---          0
+    BGP Next hop:   2001:db8:0:1::1 fe80::a0e8:7dff:fe5f:270c
+
+collector_c BGP        ---        up     2026-08-15 13:45:29  Established   
+  Description:    route collector
+  BGP state:          Established
+    Neighbor address: 2001:db8:0:1::3
+    Neighbor AS:      64499
+    Local AS:         64496
+    Neighbor ID:      192.0.2.12
+    Local capabilities
+      Multiprotocol
+        AF announced: ipv6
+      Route refresh
+      Graceful restart
+      4-octet AS numbers
+      Enhanced refresh
+      Long-lived graceful restart
+    Neighbor capabilities
+      Multiprotocol
+        AF announced: ipv6
+      Route refresh
+      Graceful restart
+      4-octet AS numbers
+      Enhanced refresh
+      Long-lived graceful restart
+    Session:          external multihop AS4
+    Source address:   2001:db8:0:1::1
+    Hold timer:       202.621/240
+    Keepalive timer:  59.354/80
+    Send hold timer:  366.225/480
+  Channel ipv6
+    State:          UP
+    Table:          master6
+    Preference:     100
+    Input filter:   REJECT
+    Output filter:  ACCEPT
+    Routes:         0 imported, 68 exported, 0 preferred
+    Route change stats:     received   rejected   filtered    ignored   accepted
+      Import updates:              0          0          0          0          0
+      Import withdraws:            0          0        ---          0          0
+      Export updates:             68          0          0        ---         68
+      Export withdraws:            0        ---        ---        ---          0
+    BGP Next hop:   2001:db8:0:1::1
+    IGP IPv6 table: master6
+

--- a/tests/data/misc/bird2-ibgp.snmpget.txt
+++ b/tests/data/misc/bird2-ibgp.snmpget.txt
@@ -1,0 +1,104 @@
+NET-SNMP-EXTEND-MIB::nsExtendOutputFull[bird2] = BIRD 2.17.5 ready.
+Access restricted
+Name       Proto      Table      State  Since         Info
+device1    Device     ---        up     2026-08-15 13:45:12  
+
+internal   Static     master6    up     2026-08-15 13:45:12  
+  Channel ipv6
+    State:          UP
+    Table:          master6
+    Preference:     200
+    Input filter:   ACCEPT
+    Output filter:  REJECT
+    Routes:         1 imported, 0 exported, 1 preferred
+    Route change stats:     received   rejected   filtered    ignored   accepted
+      Import updates:              1          0          0          0          1
+      Import withdraws:            0          0        ---          0          0
+      Export updates:              0          0          0        ---          0
+      Export withdraws:            0        ---        ---        ---          0
+
+rr_one     BGP        ---        up     2026-08-15 13:45:16  Established   
+  Description:    route reflector one
+  BGP state:          Established
+    Neighbor address: 2001:db8:0:1::2
+    Neighbor AS:      64496
+    Local AS:         64496
+    Neighbor ID:      192.0.2.10
+    Local capabilities
+      Multiprotocol
+        AF announced: ipv6
+      Route refresh
+      Graceful restart
+      4-octet AS numbers
+      Enhanced refresh
+      Long-lived graceful restart
+    Neighbor capabilities
+      Multiprotocol
+        AF announced: ipv6
+      Route refresh
+      Graceful restart
+      4-octet AS numbers
+      Enhanced refresh
+      Long-lived graceful restart
+    Session:          internal multihop AS4
+    Source address:   2001:db8:0:1::1
+    Hold timer:       207.795/240
+    Keepalive timer:  65.630/80
+    Send hold timer:  469.975/480
+  Channel ipv6
+    State:          UP
+    Table:          master6
+    Preference:     100
+    Input filter:   ACCEPT
+    Output filter:  ACCEPT
+    Routes:         12 imported, 1 exported, 12 preferred
+    Route change stats:     received   rejected   filtered    ignored   accepted
+      Import updates:             12          0          0          0         12
+      Import withdraws:            0          0        ---          0          0
+      Export updates:             20         19          0        ---          1
+      Export withdraws:            0        ---        ---        ---          0
+    BGP Next hop:   2001:db8:0:1::1
+    IGP IPv6 table: master6
+
+rr_two     BGP        ---        up     2026-08-15 13:45:16  Established   
+  BGP state:          Established
+    Neighbor address: 2001:db8:0:1::3
+    Neighbor AS:      64496
+    Local AS:         64496
+    Neighbor ID:      192.0.2.11
+    Local capabilities
+      Multiprotocol
+        AF announced: ipv6
+      Route refresh
+      Graceful restart
+      4-octet AS numbers
+      Enhanced refresh
+      Long-lived graceful restart
+    Neighbor capabilities
+      Multiprotocol
+        AF announced: ipv6
+      Route refresh
+      Graceful restart
+      4-octet AS numbers
+      Enhanced refresh
+      Long-lived graceful restart
+    Session:          internal multihop AS4
+    Source address:   2001:db8:0:1::1
+    Hold timer:       188.847/240
+    Keepalive timer:  67.784/80
+    Send hold timer:  367.049/480
+  Channel ipv6
+    State:          UP
+    Table:          master6
+    Preference:     100
+    Input filter:   ACCEPT
+    Output filter:  ACCEPT
+    Routes:         7 imported, 1 exported, 7 preferred
+    Route change stats:     received   rejected   filtered    ignored   accepted
+      Import updates:              7          0          0          0          7
+      Import withdraws:            0          0        ---          0          0
+      Export updates:             20         19          0        ---          1
+      Export withdraws:            0        ---        ---        ---          0
+    BGP Next hop:   2001:db8:0:1::1
+    IGP IPv6 table: master6
+

--- a/tests/data/misc/bird2-simple.snmpget.txt
+++ b/tests/data/misc/bird2-simple.snmpget.txt
@@ -1,0 +1,60 @@
+NET-SNMP-EXTEND-MIB::nsExtendOutputFull[bird2] = BIRD 2.17.5 ready.
+Access restricted
+Name       Proto      Table      State  Since         Info
+device1    Device     ---        up     2026-08-15 13:44:59  
+
+kernel1    Kernel     master6    up     2026-08-15 13:44:59  
+  Channel ipv6
+    State:          UP
+    Table:          master6
+    Preference:     10
+    Input filter:   ACCEPT
+    Output filter:  ACCEPT
+    Routes:         0 imported, 30 exported, 0 preferred
+    Route change stats:     received   rejected   filtered    ignored   accepted
+      Import updates:              0          0          0          0          0
+      Import withdraws:            0          0        ---          0          0
+      Export updates:             30          0          0        ---         30
+      Export withdraws:            0        ---        ---        ---          0
+
+uplink     BGP        ---        up     2026-08-15 13:45:03  Established   
+  BGP state:          Established
+    Neighbor address: 2001:db8:0:1::2
+    Neighbor AS:      64497
+    Local AS:         64496
+    Neighbor ID:      192.0.2.10
+    Local capabilities
+      Multiprotocol
+        AF announced: ipv6
+      Route refresh
+      Graceful restart
+      4-octet AS numbers
+      Enhanced refresh
+      Long-lived graceful restart
+    Neighbor capabilities
+      Multiprotocol
+        AF announced: ipv6
+      Route refresh
+      Graceful restart
+      4-octet AS numbers
+      Enhanced refresh
+      Long-lived graceful restart
+    Session:          external AS4
+    Source address:   2001:db8:0:1::1
+    Hold timer:       232.072/240
+    Keepalive timer:  57.941/80
+    Send hold timer:  425.471/480
+  Channel ipv6
+    State:          UP
+    Table:          master6
+    Preference:     100
+    Input filter:   ACCEPT
+    Output filter:  ACCEPT
+    Routes:         30 imported, 0 exported, 30 preferred
+    Route change stats:     received   rejected   filtered    ignored   accepted
+      Import updates:             30          0          0          0         30
+      Import withdraws:            0          0        ---          0          0
+      Export updates:             30         30          0        ---          0
+      Export withdraws:            0        ---        ---        ---          0
+    BGP Next hop:   2001:db8:0:1::1 fe80::bcea:42ff:feab:471e
+


### PR DESCRIPTION
This PR extends the data that's being collected by the bird2 poller module to most of whats available to collect. This enriches the Routing page for the device so we get nearly the same output as for normal SNMP BGP MIB devices.

The bird2 application wrote only a handful of columns to bgpPeers. Most of what the BGP page displays was never collected, so it showed blank, empty, or wrong. birdc show protocols all already reports all of it, we just did not care.

Parsing moved to `LibreNMS\Util\Bird2` which is what makes it testable. The app previously had no coverage at all.

I added different bird configurations that are plausible as fixtures to write the tests. I've tested against 2.0.7, 2.08, 2.0.12, 2.14, 2.17.5 (bullseye/jammy/bookworm/noble/trixie) in case the output changed between versions, it did not.

Also:
- Added Graphs (previously missing)
- Added test suites for common (and more complex) configuration for future proofing from internal testing setup
- adjusted bgp page to show multiple families per session

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
