### PR TITLE
port/portsecurity hostname search - include sysname and displayname in search

### DIFF
--- a/app/Models/Port.php
+++ b/app/Models/Port.php
@@ -384,6 +384,14 @@ class Port extends DeviceRelatedModel
     }
 
     /**
+     * Custom filter for Hostname to also include sysname and displayname.
+     */
+    public function filterDeviceHostname(Builder $query, mixed $value, array $config): void
+    {
+        $this->applyFilterSearch(['device.hostname', 'device.sysName', 'device.display'], $query, $value, $config);
+    }
+
+    /**
      * Custom filter for ifDuplex to handle "unknown" as both 'unknown' and NULL.
      */
     public function filterIfDuplex(Builder $query, mixed $value, array $config): void

--- a/app/Models/PortSecurity.php
+++ b/app/Models/PortSecurity.php
@@ -160,4 +160,12 @@ class PortSecurity extends DeviceRelatedModel implements Keyable
     {
         $this->applyFilterSearch(['port.ifName', 'port.ifDescr', 'port.ifAlias'], $query, $value, $config);
     }
+
+    /**
+     * Custom filter for Hostname to also include sysname and displayname.
+     */
+    public function filterDeviceHostname(Builder $query, mixed $value, array $config): void
+    {
+        $this->applyFilterSearch(['device.hostname', 'device.sysName', 'device.display'], $query, $value, $config);
+    }
 }


### PR DESCRIPTION
new port and port security search filter for hostnames only filter for the 'hostname'.
It is ignoring sysname and displayname.

For people using IP´s as hostname this prevents getting usefull results.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
