### PR TITLE
Fix null lat/lng in device API response

### DIFF
--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -309,9 +309,10 @@ function get_device(Illuminate\Http\Request $request)
     }
 
     return check_device_permission($device->device_id, function () use ($device) {
-        $device['location'] = $device->location?->location;
-        $device['lat'] = $device->location?->lat;
-        $device['lng'] = $device->location?->lng;
+        $location = $device->location;
+        $device['location'] = $location?->location;
+        $device['lat'] = $location?->lat;
+        $device['lng'] = $location?->lng;
 
         $host_id = get_vm_parent_id($device);
         if (is_numeric($host_id)) {


### PR DESCRIPTION
## Fix null lat/lng in the device API response

### Bug
In `get_device()` (`includes/html/api_functions.inc.php`), assigning `$device['location']` sets the model **attribute** `location` to a string (the location name), which shadows the Eloquent `location` **relation**. The next two lines then evaluate `$device->location` as that string, so `$device->location?->lat` reads `->lat` off a string — `?->` only short-circuits on `null`, not on a non-object.

For any device that **has** a location this means:
1. `GET /api/v0/devices/{id}` logs `Attempt to read property "lat"/"lng" on string in .../api_functions.inc.php`, and
2. the response returns `"lat": null, "lng": null` even though the device has valid coordinates.

### Fix
Capture the relation into a local variable before overwriting the `location` attribute:

```php
$location = $device->location;
$device['location'] = $location?->location;
$device['lat'] = $location?->lat;
$device['lng'] = $location?->lng;
```

### Testing
Tested on 26.8.0 against `GET /api/v0/devices/<id>` for a device that has a location:

| | response `lat`/`lng` | PHP warning |
|---|---|---|
| before | `null` / `null` | logged every call |
| after  | real coordinates | none |

No behaviour change for devices **without** a location — the relation is `null`, so `?->` still short-circuits and `lat`/`lng` stay `null` as before.
