### PR TITLE
World Map widget, auto-scale turn on/off toggle in widget settings

### DIFF
--- a/app/Http/Controllers/Widgets/WorldMapController.php
+++ b/app/Http/Controllers/Widgets/WorldMapController.php
@@ -43,6 +43,7 @@ class WorldMapController extends WidgetController
             'init_zoom' => LibrenmsConfig::get('leaflet.default_zoom'),
             'init_layer' => LibrenmsConfig::get('geoloc.layer'),
             'group_radius' => LibrenmsConfig::get('leaflet.group_radius'),
+            'auto_scale' => 1,
             'status' => '0,1',
             'device_group' => null,
         ];

--- a/resources/views/widgets/settings/world-map.blade.php
+++ b/resources/views/widgets/settings/world-map.blade.php
@@ -7,6 +7,17 @@
     </div>
 
     <div class="form-group">
+        <label for="auto_scale-{{ $id }}" class="control-label">{{ __('Auto-scale to devices') }}</label>
+        <div>
+            <input type="hidden" name="auto_scale" value="0">
+            <label class="checkbox-inline">
+                <input type="checkbox" name="auto_scale" id="auto_scale-{{ $id }}" value="1" @if($auto_scale) checked @endif>
+                {{ __('Automatically zoom/pan to fit devices on first load') }}
+            </label>
+        </div>
+    </div>
+
+    <div class="form-group">
         <label for="init_lat-{{ $id }}" class="control-label">{{ __('Initial Latitude') }}</label>
         <input class="form-control" name="init_lat" id="init_lat-{{ $id }}"  type="number" min="-90" max="90" step="any" value="{{ $init_lat }}" placeholder="{{ __('ie. 51.4800 for Greenwich') }}">
     </div>
@@ -56,7 +67,16 @@
 @endsection
 
 @section('javascript')
-    <script type="text/javascript">
-        init_select2('#device_group-{{ $id }}', 'device-group', {});
-    </script>
+	<script type="text/javascript">
+		init_select2('#device_group-{{ $id }}', 'device-group', {});
+
+		function toggleWorldMapInitFields() {
+			var autoScaleOn = $('#auto_scale-{{ $id }}').is(':checked');
+			$('#init_lat-{{ $id }}, #init_lng-{{ $id }}, #init_zoom-{{ $id }}')
+				.prop('readonly', autoScaleOn);
+		}
+
+		toggleWorldMapInitFields();
+		$('#auto_scale-{{ $id }}').on('change', toggleWorldMapInitFields);
+	</script>
 @endsection

--- a/resources/views/widgets/world-map.blade.php
+++ b/resources/views/widgets/world-map.blade.php
@@ -8,6 +8,7 @@
         const disabled_alerts = {{ Js::from($disabled_alerts) }};
         const map_config = {{ Js::from($map_config) }};
         const group_radius = {{ (int) $group_radius }};
+        const auto_scale = {{ (int) $auto_scale }};
 
         function populate_map_markers(map_id, group_radius = 10, status = [0,1], device_group = 0) {
             $.ajax({
@@ -73,7 +74,7 @@
                     map.markerCluster.clearLayers();
                     map.markerCluster.addLayers(markers);
 
-                    if (isFirstLoad && markers.length > 0) {
+                    if (auto_scale && isFirstLoad && markers.length > 0) {
                         map.fitBounds(map.markerCluster.getBounds(), {
                             padding: [30, 30],
                             maxZoom: 12


### PR DESCRIPTION
This adds a toggle to the settings menu of the World Map widget. When enabled the map is auto-scaled. When disabled, it uses the settings Initial Latitude, Initial Longitude and Initial Zoom.

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
