### PR TITLE
Add filter on the device prefetch in the device group update action to reduce unneeded SQL traffic

### DIFF
--- a/app/Actions/Device/UpdateDeviceGroupsAction.php
+++ b/app/Actions/Device/UpdateDeviceGroupsAction.php
@@ -52,7 +52,7 @@ class UpdateDeviceGroupsAction
 
         $device_group_ids = DeviceGroup::query()
             ->with(['devices' => function ($query): void {
-                $query->select('devices.device_id');
+                $query->where('devices.device_id', $this->device->device_id)->select('devices.device_id');
             }])
             ->get()
             ->filter(function (DeviceGroup $device_group) {


### PR DESCRIPTION
I was looking at the amount of data constantly going from our SQL server to the poller during a polling cycle, and noticed that on our system a lot of data (maybe 300kB for each poll) was coming from the following query:
```
select `devices`.`device_id`, `device_group_device`.`device_group_id` as `pivot_device_group_id`, `device_group_device`.`device_id` as `pivot_device_id` from `devices` inner join `device_group_device` on `devices`.`device_id` = `device_group_device`.`device_id` where `device_group_device`.`device_group_id` in (x, x, x, x, x, x, ....)
```

Running poller in verbose mode showed me that the query was running during the device group update code.  I believe that the pre-load is used to avoid a sub-query for every static group that is checked based on the debug output I could see.

This PR restricts the pre-loading of device IDs to only include the device being evaluated, which reduces the amount of data being returned from 21281 rows for every device down to between 0 and 6 rows per device.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
