### PR TITLE
Add AdGuard Home application

### DIFF
--- a/LibreNMS/Util/StringHelpers.php
+++ b/LibreNMS/Util/StringHelpers.php
@@ -36,6 +36,7 @@ class StringHelpers
     public static function niceCase($string)
     {
         $replacements = [
+            'adguard' => 'AdGuard Home',
             'bind' => 'BIND',
             'cape' => 'CAPEv2',
             'dbm' => 'dBm',

--- a/doc/Extensions/Applications/AdGuard Home.md
+++ b/doc/Extensions/Applications/AdGuard Home.md
@@ -6,6 +6,10 @@ exports them with SNMP Extend. It graphs DNS queries vs blocked queries,
 the blocked-query breakdown (filters, safe browsing, safe search,
 parental), average processing time, and the running/protection state.
 
+Values are totals over AdGuard's configured statistics interval (24 hours
+by default), not per-second rates. Changing that interval in AdGuard
+will rescale the graphs.
+
 ## SNMP Extend
 
 1. Download the script onto the AdGuard Home host
@@ -32,8 +36,9 @@ parental), average processing time, and the running/protection state.
     }
     ```
 
-    Optional keys: `timeout` (seconds, default 10) and `insecure` (set to
-    `true` to skip TLS certificate verification on https URLs).
+    Optional keys: `timeout` (seconds, default 5) and `insecure` (set to
+    `true` to skip TLS certificate verification on https URLs). The script
+    makes two API calls, so the SNMP timeout must exceed `2 * timeout`.
 
     The file holds credentials, so restrict it to the user snmpd runs
     extend scripts as. On Debian/Ubuntu that is `Debian-snmp`:

--- a/doc/Extensions/Applications/AdGuard Home.md
+++ b/doc/Extensions/Applications/AdGuard Home.md
@@ -36,9 +36,11 @@ will rescale the graphs.
     }
     ```
 
-    Optional keys: `timeout` (seconds, default 5) and `insecure` (set to
-    `true` to skip TLS certificate verification on https URLs). The script
-    makes two API calls, so the SNMP timeout must exceed `2 * timeout`.
+    Optional keys: `timeout` (seconds, default 1) and `insecure` (set to
+    `true` to skip TLS certificate verification on https URLs). LibreNMS
+    defaults to a 1 second SNMP timeout. Local AdGuard answers well inside
+    that. If the API is remote or polls come back empty, cache via cron
+    instead of raising the SNMP timeout (see below).
 
     The file holds credentials, so restrict it to the user snmpd runs
     extend scripts as. On Debian/Ubuntu that is `Debian-snmp`:
@@ -52,6 +54,17 @@ will rescale the graphs.
 
     ```bash
     extend adguard /etc/snmp/adguard
+    ```
+
+    If a live extend times out, run the script from cron and have snmpd
+    cat the cache:
+
+    ```
+    */5 * * * * /etc/snmp/adguard > /var/cache/adguard
+    ```
+
+    ```
+    extend adguard /bin/cat /var/cache/adguard
     ```
 
 5. Restart snmpd service on the host

--- a/doc/Extensions/Applications/AdGuard Home.md
+++ b/doc/Extensions/Applications/AdGuard Home.md
@@ -1,0 +1,56 @@
+# AdGuard Home
+
+A python script that gets query and blocking statistics from the
+[AdGuard Home](https://github.com/AdguardTeam/AdGuardHome) REST API and
+exports them with SNMP Extend. It graphs DNS queries vs blocked queries,
+the blocked-query breakdown (filters, safe browsing, safe search,
+parental), average processing time, and the running/protection state.
+
+## SNMP Extend
+
+1. Download the script onto the AdGuard Home host
+
+    ```bash
+    wget https://raw.githubusercontent.com/librenms/librenms-agent/master/snmp/adguard -O /etc/snmp/adguard
+    ```
+
+2. Make the script executable.
+
+    ```bash
+    chmod +x /etc/snmp/adguard
+    ```
+
+3. Create the config file `/etc/snmp/adguard` reads, `/etc/snmp/adguard.json`,
+    with the base URL of the AdGuard Home web interface and the credentials of
+    a web UI user:
+
+    ```json
+    {
+        "url": "http://127.0.0.1:3000",
+        "username": "admin",
+        "password": "secret"
+    }
+    ```
+
+    Optional keys: `timeout` (seconds, default 10) and `insecure` (set to
+    `true` to skip TLS certificate verification on https URLs).
+
+    The file holds credentials, so restrict it to the user snmpd runs
+    extend scripts as. On Debian/Ubuntu that is `Debian-snmp`:
+
+    ```bash
+    chown root:Debian-snmp /etc/snmp/adguard.json
+    chmod 640 /etc/snmp/adguard.json
+    ```
+
+4. Edit the snmpd.conf file to include the extend by adding the following line to the end of the config file:
+
+    ```bash
+    extend adguard /etc/snmp/adguard
+    ```
+
+5. Restart snmpd service on the host
+
+    LibreNMS discovers the application automatically. Its statistics then
+    appear on the Apps page of the host. Note: the applications module
+    must be enabled on the host or globally.

--- a/includes/html/graphs/application/adguard_blocked.inc.php
+++ b/includes/html/graphs/application/adguard_blocked.inc.php
@@ -1,0 +1,26 @@
+<?php
+
+require 'includes/html/graphs/common.inc.php';
+
+$colours = 'mixed';
+$nototal = (($width < 224) ? 1 : 0);
+$unit_text = 'Queries';
+$rrd_filename = Rrd::name($device['hostname'], ['app', 'adguard', $app->app_id]);
+$array = [
+    'blocked' => ['descr' => 'Blocked (filters)'],
+    'safebrowsing' => ['descr' => 'Safe browsing'],
+    'safesearch' => ['descr' => 'Safe search'],
+    'parental' => ['descr' => 'Parental'],
+];
+
+$i = 0;
+$rrd_list = [];
+foreach ($array as $ds => $var) {
+    $rrd_list[$i]['filename'] = $rrd_filename;
+    $rrd_list[$i]['descr'] = $var['descr'];
+    $rrd_list[$i]['ds'] = $ds;
+    $rrd_list[$i]['colour'] = \App\Facades\LibrenmsConfig::get("graph_colours.$colours.$i");
+    $i++;
+}
+
+require 'includes/html/graphs/generic_multi_line.inc.php';

--- a/includes/html/graphs/application/adguard_proc_time.inc.php
+++ b/includes/html/graphs/application/adguard_proc_time.inc.php
@@ -1,0 +1,23 @@
+<?php
+
+require 'includes/html/graphs/common.inc.php';
+
+$colours = 'mixed';
+$nototal = (($width < 224) ? 1 : 0);
+$unit_text = 'Seconds';
+$rrd_filename = Rrd::name($device['hostname'], ['app', 'adguard', $app->app_id]);
+$array = [
+    'proc_time' => ['descr' => 'Avg processing time'],
+];
+
+$i = 0;
+$rrd_list = [];
+foreach ($array as $ds => $var) {
+    $rrd_list[$i]['filename'] = $rrd_filename;
+    $rrd_list[$i]['descr'] = $var['descr'];
+    $rrd_list[$i]['ds'] = $ds;
+    $rrd_list[$i]['colour'] = \App\Facades\LibrenmsConfig::get("graph_colours.$colours.$i");
+    $i++;
+}
+
+require 'includes/html/graphs/generic_multi_line.inc.php';

--- a/includes/html/graphs/application/adguard_protection.inc.php
+++ b/includes/html/graphs/application/adguard_protection.inc.php
@@ -1,0 +1,24 @@
+<?php
+
+require 'includes/html/graphs/common.inc.php';
+
+$colours = 'mixed';
+$nototal = (($width < 224) ? 1 : 0);
+$unit_text = 'State';
+$rrd_filename = Rrd::name($device['hostname'], ['app', 'adguard', $app->app_id]);
+$array = [
+    'running' => ['descr' => 'Running'],
+    'protection' => ['descr' => 'Protection enabled'],
+];
+
+$i = 0;
+$rrd_list = [];
+foreach ($array as $ds => $var) {
+    $rrd_list[$i]['filename'] = $rrd_filename;
+    $rrd_list[$i]['descr'] = $var['descr'];
+    $rrd_list[$i]['ds'] = $ds;
+    $rrd_list[$i]['colour'] = \App\Facades\LibrenmsConfig::get("graph_colours.$colours.$i");
+    $i++;
+}
+
+require 'includes/html/graphs/generic_multi_line.inc.php';

--- a/includes/html/graphs/application/adguard_queries.inc.php
+++ b/includes/html/graphs/application/adguard_queries.inc.php
@@ -1,0 +1,24 @@
+<?php
+
+require 'includes/html/graphs/common.inc.php';
+
+$colours = 'mixed';
+$nototal = (($width < 224) ? 1 : 0);
+$unit_text = 'Queries';
+$rrd_filename = Rrd::name($device['hostname'], ['app', 'adguard', $app->app_id]);
+$array = [
+    'queries' => ['descr' => 'DNS queries'],
+    'blocked' => ['descr' => 'Blocked'],
+];
+
+$i = 0;
+$rrd_list = [];
+foreach ($array as $ds => $var) {
+    $rrd_list[$i]['filename'] = $rrd_filename;
+    $rrd_list[$i]['descr'] = $var['descr'];
+    $rrd_list[$i]['ds'] = $ds;
+    $rrd_list[$i]['colour'] = \App\Facades\LibrenmsConfig::get("graph_colours.$colours.$i");
+    $i++;
+}
+
+require 'includes/html/graphs/generic_multi_line.inc.php';

--- a/includes/html/pages/apps.inc.php
+++ b/includes/html/pages/apps.inc.php
@@ -668,7 +668,6 @@ $graphs['adguard'] = [
     'protection',
 ];
 
-
 echo '<div class="panel panel-default">';
 echo '<div class="panel-heading">';
 echo "<span style='font-weight: bold;'>Apps</span> &#187; ";

--- a/includes/html/pages/apps.inc.php
+++ b/includes/html/pages/apps.inc.php
@@ -646,6 +646,12 @@ $graphs['i2pd'] = [
     'peers',
     'total_bytes',
 ];
+$graphs['adguard'] = [
+    'queries',
+    'blocked',
+    'proc_time',
+    'protection',
+];
 
 echo '<div class="panel panel-default">';
 echo '<div class="panel-heading">';

--- a/includes/html/pages/apps.inc.php
+++ b/includes/html/pages/apps.inc.php
@@ -661,6 +661,13 @@ $graphs['syslog-ng'] = [
     'truncated_count',
     'written',
 ];
+$graphs['adguard'] = [
+    'queries',
+    'blocked',
+    'proc_time',
+    'protection',
+];
+
 
 echo '<div class="panel panel-default">';
 echo '<div class="panel-heading">';

--- a/includes/html/pages/device/apps/adguard.inc.php
+++ b/includes/html/pages/device/apps/adguard.inc.php
@@ -1,0 +1,28 @@
+<?php
+
+$graphs = [
+    'adguard_queries' => 'DNS queries vs blocked',
+    'adguard_blocked' => 'Blocked query breakdown',
+    'adguard_proc_time' => 'Average processing time',
+    'adguard_protection' => 'Running / protection state',
+];
+
+foreach ($graphs as $key => $text) {
+    $graph_type = $key;
+    $graph_array['height'] = '100';
+    $graph_array['width'] = '215';
+    $graph_array['to'] = \App\Facades\LibrenmsConfig::get('time.now');
+    $graph_array['id'] = $app['app_id'];
+    $graph_array['type'] = 'application_' . $key;
+
+    echo '<div class="panel panel-default">
+    <div class="panel-heading">
+        <h3 class="panel-title">' . $text . '</h3>
+    </div>
+    <div class="panel-body">
+    <div class="row">';
+    include 'includes/html/print-graphrow.inc.php';
+    echo '</div>';
+    echo '</div>';
+    echo '</div>';
+}

--- a/includes/polling/applications/adguard.inc.php
+++ b/includes/polling/applications/adguard.inc.php
@@ -1,0 +1,54 @@
+<?php
+
+use LibreNMS\Exceptions\JsonAppException;
+use LibreNMS\RRD\RrdDefinition;
+
+$name = 'adguard';
+try {
+    $adguard = json_app_get($device, $name, 1)['data'];
+} catch (JsonAppException $e) {
+    echo PHP_EOL . $name . ':' . $e->getCode() . ':' . $e->getMessage() . PHP_EOL;
+    update_application($app, $e->getCode() . ':' . $e->getMessage(), []); // Set empty metrics and error message
+
+    return;
+}
+
+$rrd_name = ['app', $name, $app->app_id];
+$rrd_def = RrdDefinition::make()
+    ->addDataset('queries', 'GAUGE', 0)
+    ->addDataset('blocked', 'GAUGE', 0)
+    ->addDataset('safebrowsing', 'GAUGE', 0)
+    ->addDataset('safesearch', 'GAUGE', 0)
+    ->addDataset('parental', 'GAUGE', 0)
+    ->addDataset('proc_time', 'GAUGE', 0)
+    ->addDataset('running', 'GAUGE', 0, 1)
+    ->addDataset('protection', 'GAUGE', 0, 1);
+
+$fields = [
+    'queries' => $adguard['num_dns_queries'],
+    'blocked' => $adguard['num_blocked_filtering'],
+    'safebrowsing' => $adguard['num_replaced_safebrowsing'],
+    'safesearch' => $adguard['num_replaced_safesearch'],
+    'parental' => $adguard['num_replaced_parental'],
+    'proc_time' => $adguard['avg_processing_time'],
+    'running' => $adguard['running'],
+    'protection' => $adguard['protection_enabled'],
+];
+
+$metrics = $fields;
+if ($adguard['num_dns_queries'] > 0) {
+    $metrics['block_pct'] = round($adguard['num_blocked_filtering'] / $adguard['num_dns_queries'] * 100, 2);
+}
+
+$tags = ['name' => $name, 'app_id' => $app->app_id, 'rrd_def' => $rrd_def, 'rrd_name' => $rrd_name];
+app('Datastore')->put($device, 'app', $tags, $fields);
+
+$app->data = ['version' => $adguard['version']];
+
+if (! $adguard['running']) {
+    update_application($app, 'ERROR: AdGuard Home is not running', $metrics);
+} elseif (! $adguard['protection_enabled']) {
+    update_application($app, 'OK', $metrics, 'protection is disabled');
+} else {
+    update_application($app, 'OK', $metrics);
+}

--- a/tests/data/linux_adguard.json
+++ b/tests/data/linux_adguard.json
@@ -1,0 +1,88 @@
+{
+    "applications": {
+        "discovery": {
+            "applications": [
+                {
+                    "app_type": "adguard",
+                    "app_state": "UNKNOWN",
+                    "discovered": 1,
+                    "app_state_prev": null,
+                    "app_status": "",
+                    "app_instance": "",
+                    "data": null,
+                    "deleted_at": null
+                }
+            ]
+        },
+        "poller": {
+            "applications": [
+                {
+                    "app_type": "adguard",
+                    "app_state": "OK",
+                    "discovered": 1,
+                    "app_state_prev": "UNKNOWN",
+                    "app_status": "",
+                    "app_instance": "",
+                    "data": "{\"version\":\"v0.107.78\"}",
+                    "deleted_at": null
+                }
+            ],
+            "application_metrics": [
+                {
+                    "metric": "block_pct",
+                    "value": 7.14,
+                    "value_prev": null,
+                    "app_type": "adguard"
+                },
+                {
+                    "metric": "blocked",
+                    "value": 26463,
+                    "value_prev": null,
+                    "app_type": "adguard"
+                },
+                {
+                    "metric": "parental",
+                    "value": 0,
+                    "value_prev": null,
+                    "app_type": "adguard"
+                },
+                {
+                    "metric": "proc_time",
+                    "value": 0.021451,
+                    "value_prev": null,
+                    "app_type": "adguard"
+                },
+                {
+                    "metric": "protection",
+                    "value": 1,
+                    "value_prev": null,
+                    "app_type": "adguard"
+                },
+                {
+                    "metric": "queries",
+                    "value": 370797,
+                    "value_prev": null,
+                    "app_type": "adguard"
+                },
+                {
+                    "metric": "running",
+                    "value": 1,
+                    "value_prev": null,
+                    "app_type": "adguard"
+                },
+                {
+                    "metric": "safebrowsing",
+                    "value": 0,
+                    "value_prev": null,
+                    "app_type": "adguard"
+                },
+                {
+                    "metric": "safesearch",
+                    "value": 0,
+                    "value_prev": null,
+                    "app_type": "adguard"
+                }
+            ]
+        }
+    }
+}

--- a/tests/snmpsim/linux_adguard.snmprec
+++ b/tests/snmpsim/linux_adguard.snmprec
@@ -1,0 +1,8 @@
+1.3.6.1.2.1.1.1.0|4|Linux adguard 6.8.0-1030-raspi #34-Ubuntu SMP PREEMPT_DYNAMIC Sat Jun 21 06:31:59 UTC 2025 aarch64
+1.3.6.1.2.1.1.2.0|6|1.3.6.1.4.1.8072.3.2.10
+1.3.6.1.2.1.1.3.0|67|45899334
+1.3.6.1.2.1.1.4.0|4|<private>
+1.3.6.1.2.1.1.5.0|4|<private>
+1.3.6.1.4.1.8072.1.3.2.2.1.21.7.97.100.103.117.97.114.100|2|1
+1.3.6.1.4.1.8072.1.3.2.3.1.2.7.97.100.103.117.97.114.100|4|{"data": {"version": "v0.107.78", "running": 1, "protection_enabled": 1, "num_dns_queries": 370797, "num_blocked_filtering": 26463, "num_replaced_safebrowsing": 0, "num_replaced_safesearch": 0, "num_replaced_parental": 0, "avg_processing_time": 0.021451}, "error": 0, "errorString": "", "version": 1}
+1.3.6.1.6.3.10.2.1.3.0|2|458993


### PR DESCRIPTION
Adds an application for [AdGuard Home](https://github.com/AdguardTeam/AdGuardHome), fed by the `adguard` snmp extend (librenms-agent PR https://github.com/librenms/librenms-agent/pull/629).

Graphs, over AdGuard's rolling stats window:

- DNS queries vs blocked
- Blocked-query breakdown (filters / safe browsing / safe search / parental)
- Average processing time
- Running / protection state

Also exports a `block_pct` metric. App state goes ERROR if AdGuard is not running; if protection is paused, state stays OK with a status note.

All RRD datasets are GAUGE because AdGuard reports window totals, not counters. Test data is in `tests/data/linux_adguard.json`. I've been running this against AdGuard Home v0.107.78 for a couple of days.

**DNS queries vs blocked**

![queries](https://raw.githubusercontent.com/gthelding/librenms/adguard-pr-screenshots/adguard-queries.png)

**Blocked query breakdown**

![blocked](https://raw.githubusercontent.com/gthelding/librenms/adguard-pr-screenshots/adguard-blocked.png)

**Average processing time**

![proc_time](https://raw.githubusercontent.com/gthelding/librenms/adguard-pr-screenshots/adguard-proc_time.png)

**Running / protection state**

![protection](https://raw.githubusercontent.com/gthelding/librenms/adguard-pr-screenshots/adguard-protection.png)

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
