### PR TITLE
fix(ciscowlc): normalize access point MAC addresses

### DIFF
--- a/LibreNMS/OS/Ciscowlc.php
+++ b/LibreNMS/OS/Ciscowlc.php
@@ -35,6 +35,7 @@ use LibreNMS\Interfaces\Discovery\Sensors\WirelessClientsDiscovery;
 use LibreNMS\Interfaces\Polling\OSPolling;
 use LibreNMS\OS\Shared\Cisco;
 use LibreNMS\RRD\RrdDefinition;
+use LibreNMS\Util\Mac;
 use SnmpQuery;
 
 class Ciscowlc extends Cisco implements
@@ -87,7 +88,7 @@ class Ciscowlc extends Cisco implements
                     'name' => $apNames[$mac]['AIRESPACE-WIRELESS-MIB::bsnAPName'] ?? '',
                     'radio_number' => $slot,
                     'type' => $value['AIRESPACE-WIRELESS-MIB::bsnAPIfType'] ?? '',
-                    'mac_addr' => $mac,
+                    'mac_addr' => Mac::parse($mac)->readable(),
                     'channel' => $channel,
                     'txpow' => $value['AIRESPACE-WIRELESS-MIB::bsnAPIfPhyTxPowerLevel'] ?? 0,
                     'radioutil' => $value['AIRESPACE-WIRELESS-MIB::bsnAPIfLoadChannelUtilization'] ?? 0,


### PR DESCRIPTION
Normalize Cisco WLC access point MAC addresses before storing them in the access_points table.

The MAC address is obtained from the bsnAPIfTable SNMP index. Net-SNMP may render individual octets without leading zeroes, resulting in values such as 0:27:e3:5:33:0 being stored instead of 00:27:e3:05:33:00.

Use the existing LibreNMS\Util\Mac helper to produce the canonical readable format. This is also how access point MAC addresses are handled by the Aruba controller poller. Existing Cisco WLC access point records will be normalized on a subsequent poll.

<img width="1509" height="606" alt="Screenshot From 2026-08-18 16-26-47" src="https://github.com/user-attachments/assets/916b817e-26ef-4197-8317-43ce8fc27884" />

Old and new example (new left).

I reran the unit test but since this is polling the output was the same

DO NOT DELETE THE UNDERLYING TEXT


#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
