### PR TITLE
Add Opengear OM-series cellular RSSI and signal quality sensors

### DIFF
--- a/resources/definitions/os_discovery/opengear.yaml
+++ b/resources/definitions/os_discovery/opengear.yaml
@@ -106,6 +106,30 @@ modules:
                     num_oid: '.1.3.6.1.4.1.25049.17.17.1.12.{{ $index }}'
                     descr: 'Cellular 4G Modem RSSI'
                     index: '12.{{ $index }}'
+                -
+                    oid: OG-OMTELEM-MIB::ogOmCellUimTable
+                    value: OG-OMTELEM-MIB::ogOmCellUimRssi
+                    num_oid: '.1.3.6.1.4.1.25049.10.19.6.1.1.10.{{ $index }}'
+                    descr: 'Cellular RSSI'
+                    index: 'ogOmCellUimRssi.{{ $index }}'
+                    skip_values:
+                        -
+                            oid: OG-OMTELEM-MIB::ogOmCellUimRssi
+                            op: '='
+                            value: 0
+        percent:
+            data:
+                -
+                    oid: OG-OMTELEM-MIB::ogOmCellUimTable
+                    value: OG-OMTELEM-MIB::ogOmCellUimSignalQuality
+                    num_oid: '.1.3.6.1.4.1.25049.10.19.6.1.1.9.{{ $index }}'
+                    descr: 'Cellular Signal Quality'
+                    index: 'ogOmCellUimSignalQuality.{{ $index }}'
+                    skip_values:
+                        -
+                            oid: OG-OMTELEM-MIB::ogOmCellUimSignalQuality
+                            op: '='
+                            value: 0
         count:
             data:
                 -

--- a/resources/definitions/os_discovery/opengear.yaml
+++ b/resources/definitions/os_discovery/opengear.yaml
@@ -106,6 +106,7 @@ modules:
                     num_oid: '.1.3.6.1.4.1.25049.17.17.1.12.{{ $index }}'
                     descr: 'Cellular 4G Modem RSSI'
                     index: '12.{{ $index }}'
+
                 -
                     oid: OG-OMTELEM-MIB::ogOmCellUimTable
                     value: OG-OMTELEM-MIB::ogOmCellUimRssi
@@ -117,6 +118,7 @@ modules:
                             oid: OG-OMTELEM-MIB::ogOmCellUimRssi
                             op: '='
                             value: 0
+
         percent:
             data:
                 -
@@ -130,6 +132,7 @@ modules:
                             oid: OG-OMTELEM-MIB::ogOmCellUimSignalQuality
                             op: '='
                             value: 0
+
         count:
             data:
                 -


### PR DESCRIPTION
Adds support for Opengear OM-series cellular telemetry sensors from OG-OMTELEM-MIB.

New sensors:
- ogOmCellUimRssi
- ogOmCellUimSignalQuality

Inactive SIM entries returning zero values are excluded using skip_values.

Tested on:
- Opengear OM1200

Observed values:
- Cellular RSSI: -74 dBm
- Cellular Signal Quality: 63%

Prior to this change LibreNMS discovered OM-series temperature and power sensors from OG-OMTELEM-MIB, but did not discover cellular telemetry sensors.



DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
