### PR TITLE
Fix graph date range URL handling

### DIFF
--- a/app/Http/Requests/GraphsPageRequest.php
+++ b/app/Http/Requests/GraphsPageRequest.php
@@ -27,7 +27,7 @@ class GraphsPageRequest extends FormRequest
 
     protected function prepareForValidation(): void
     {
-        $this->merge(Url::parseLegacyPathVars($this->fullUrl()));
+        $this->mergeIfMissing(Url::parseLegacyPathVars($this->path()));
     }
 
     /**

--- a/app/Http/Requests/GraphsPageRequest.php
+++ b/app/Http/Requests/GraphsPageRequest.php
@@ -27,7 +27,7 @@ class GraphsPageRequest extends FormRequest
 
     protected function prepareForValidation(): void
     {
-        $this->merge(Url::parseLegacyPathVars($this->path()));
+        $this->merge(Url::parseLegacyPathVars($this->fullUrl()));
     }
 
     /**

--- a/tests/Feature/Http/GraphsPageControllerTest.php
+++ b/tests/Feature/Http/GraphsPageControllerTest.php
@@ -68,6 +68,19 @@ class GraphsPageControllerTest extends TestCase
         $this->assertNoPhpWarningOutput($response->getContent());
     }
 
+    public function testDateSelectorQueryRangeOverridesLegacyPathRange(): void
+    {
+        $device = Device::factory()->create();
+
+        $response = $this->actingAs($this->adminUser())
+            ->get("/graphs/to=1700003600/id={$device->device_id}/type=device_poller_perf/from=1700000000/?from=1700007200&to=1700010800");
+
+        $response->assertOk();
+        $response->assertSee('data-start="1700007200"', false);
+        $response->assertSee('data-end="1700010800"', false);
+        $this->assertNoPhpWarningOutput($response->getContent());
+    }
+
     public function testShowCommandUsesGraphVars(): void
     {
         $device = Device::factory()->create(['hostname' => 'port-device.example.com']);


### PR DESCRIPTION
## Summary

Fix graph date-range changes being ignored when the page uses LibreNMS legacy path parameters.

fixes: #20349

## Changes

- Parse the full request URL during graph-page validation so query-string `from` and `to` values override legacy path values.
- Add a regression test covering the mixed legacy-path and query-string URL format.

## Testing

- `git diff --check` passes.
- PHPUnit could not be run locally because PHP is unavailable in the environment (`php: command not found`).