### PR TITLE
Add API endpoints for updating sensor thresholds

### DIFF
--- a/app/Api/Controllers/SensorThresholdController.php
+++ b/app/Api/Controllers/SensorThresholdController.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace App\Api\Controllers;
+
+use App\Http\Controllers\Controller;
+use App\Models\Sensor;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
+
+class SensorThresholdController extends Controller
+{
+    private const THRESHOLD_FIELDS = [
+        'sensor_limit_low',
+        'sensor_limit_low_warn',
+        'sensor_limit_warn',
+        'sensor_limit',
+    ];
+
+    public function update(Sensor $sensor, Request $request): JsonResponse
+    {
+        $this->authorize('update', $sensor);
+        abort_if($sensor->sensor_deleted, 404);
+
+        $validated = $this->validateUpdate($request);
+        $this->applyUpdate($sensor, $validated);
+        $sensor->refresh();
+
+        return $this->response(collect([$sensor]));
+    }
+
+    public function bulkUpdate(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'sensor_ids' => 'required|array|min:1|max:500',
+            'sensor_ids.*' => 'required|integer|distinct|min:1',
+        ]);
+        $update = $this->validateUpdate($request);
+        $sensorIds = array_values($validated['sensor_ids']);
+        $sensors = Sensor::query()
+            ->whereIn('sensor_id', $sensorIds)
+            ->where('sensor_deleted', 0)
+            ->get()
+            ->keyBy('sensor_id');
+
+        $missing = array_values(array_diff($sensorIds, $sensors->keys()->all()));
+        if ($missing !== []) {
+            return response()->json([
+                'status' => 'error',
+                'message' => 'One or more sensors do not exist or have been deleted.',
+                'missing_sensor_ids' => $missing,
+            ], 404);
+        }
+
+        foreach ($sensors as $sensor) {
+            $this->authorize('update', $sensor);
+        }
+
+        DB::transaction(function () use ($sensors, $update): void {
+            foreach ($sensors as $sensor) {
+                $this->applyUpdate($sensor, $update);
+            }
+        });
+
+        return $this->response(Sensor::query()->whereIn('sensor_id', $sensorIds)->get());
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function validateUpdate(Request $request): array
+    {
+        $validated = $request->validate([
+            'sensor_limit' => 'sometimes|nullable|numeric',
+            'sensor_limit_warn' => 'sometimes|nullable|numeric',
+            'sensor_limit_low_warn' => 'sometimes|nullable|numeric',
+            'sensor_limit_low' => 'sometimes|nullable|numeric',
+            'sensor_alert' => 'sometimes|boolean',
+            'reset' => 'sometimes|boolean',
+        ]);
+
+        if (! collect(array_keys($validated))->contains(fn (string $key) => in_array($key, [...self::THRESHOLD_FIELDS, 'sensor_alert', 'reset'], true))) {
+            throw ValidationException::withMessages([
+                'thresholds' => ['At least one threshold, sensor_alert, or reset must be supplied.'],
+            ]);
+        }
+
+        if (($validated['reset'] ?? false) && count($validated) > 1) {
+            throw ValidationException::withMessages([
+                'reset' => ['reset cannot be combined with threshold or alert changes.'],
+            ]);
+        }
+
+        return $validated;
+    }
+
+    /**
+     * @param  array<string, mixed>  $update
+     */
+    private function applyUpdate(Sensor $sensor, array $update): void
+    {
+        if ($update['reset'] ?? false) {
+            $sensor->sensor_custom = 'Reset';
+            $sensor->saveQuietly();
+
+            return;
+        }
+
+        $changesThresholds = false;
+        foreach (self::THRESHOLD_FIELDS as $field) {
+            if (array_key_exists($field, $update)) {
+                $sensor->{$field} = $update[$field] === null ? null : (float) $update[$field];
+                $changesThresholds = true;
+            }
+        }
+
+        if (array_key_exists('sensor_alert', $update)) {
+            $sensor->sensor_alert = (bool) $update['sensor_alert'];
+        }
+
+        if ($changesThresholds) {
+            $this->validateOrder($sensor);
+            // SensorObserver converts Saving to Yes and preserves these values
+            // during all subsequent discovery runs.
+            $sensor->sensor_custom = 'Saving';
+        }
+
+        $sensor->save();
+    }
+
+    private function validateOrder(Sensor $sensor): void
+    {
+        $previous = null;
+        foreach (self::THRESHOLD_FIELDS as $field) {
+            $value = $sensor->{$field};
+            if ($value === null) {
+                continue;
+            }
+
+            if ($previous !== null && $value < $previous) {
+                throw ValidationException::withMessages([
+                    $field => ['Thresholds must be ordered: low <= low warning <= high warning <= high.'],
+                ]);
+            }
+            $previous = $value;
+        }
+    }
+
+    /**
+     * @param  Collection<int, Sensor>  $sensors
+     */
+    private function response(Collection $sensors): JsonResponse
+    {
+        return response()->json([
+            'status' => 'ok',
+            'count' => $sensors->count(),
+            'sensors' => $sensors->map(fn (Sensor $sensor) => $sensor->only([
+                'sensor_id',
+                'device_id',
+                'sensor_class',
+                'sensor_descr',
+                'sensor_current',
+                ...self::THRESHOLD_FIELDS,
+                'sensor_alert',
+                'sensor_custom',
+            ]))->values(),
+        ]);
+    }
+}

--- a/app/Api/Controllers/SensorThresholdController.php
+++ b/app/Api/Controllers/SensorThresholdController.php
@@ -22,7 +22,7 @@ class SensorThresholdController extends Controller
     public function update(Sensor $sensor, Request $request): JsonResponse
     {
         $this->authorize('update', $sensor);
-        abort_if($sensor->sensor_deleted, 404);
+        abort_if($sensor->sensor_deleted !== 0, 404);
 
         $validated = $this->validateUpdate($request);
         $this->applyUpdate($sensor, $validated);
@@ -156,16 +156,34 @@ class SensorThresholdController extends Controller
         return response()->json([
             'status' => 'ok',
             'count' => $sensors->count(),
-            'sensors' => $sensors->map(fn (Sensor $sensor) => $sensor->only([
-                'sensor_id',
-                'device_id',
-                'sensor_class',
-                'sensor_descr',
-                'sensor_current',
-                ...self::THRESHOLD_FIELDS,
-                'sensor_alert',
-                'sensor_custom',
-            ]))->values(),
+            'sensors' => $sensors->map(fn (Sensor $sensor) => $this->sensorData($sensor))->values(),
         ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function sensorData(Sensor $sensor): array
+    {
+        $data = $sensor->only([
+            'sensor_id',
+            'device_id',
+            'sensor_class',
+            'sensor_descr',
+            'sensor_current',
+            ...self::THRESHOLD_FIELDS,
+            'sensor_alert',
+            'sensor_custom',
+        ]);
+
+        $data['sensor_id'] = (int) $data['sensor_id'];
+        $data['device_id'] = (int) $data['device_id'];
+        $data['sensor_alert'] = (bool) $data['sensor_alert'];
+
+        foreach (['sensor_current', ...self::THRESHOLD_FIELDS] as $field) {
+            $data[$field] = $data[$field] === null ? null : (float) $data[$field];
+        }
+
+        return $data;
     }
 }

--- a/doc/API/Devices.md
+++ b/doc/API/Devices.md
@@ -1294,6 +1294,54 @@ Output:
 }
 ```
 
+### `update_sensor_thresholds`
+
+Update the thresholds or alert state for one sensor. Threshold changes are
+stored as custom values and are preserved during subsequent discovery runs.
+
+Route: `PATCH /api/v0/resources/sensors/:sensor_id`
+
+Input (at least one field is required):
+
+- `sensor_limit`: critical high threshold; nullable number
+- `sensor_limit_warn`: warning high threshold; nullable number
+- `sensor_limit_low_warn`: warning low threshold; nullable number
+- `sensor_limit_low`: critical low threshold; nullable number
+- `sensor_alert`: enable or disable alerting for this sensor
+- `reset`: reset all custom thresholds during the next discovery; cannot be combined with other fields
+
+The non-null thresholds must be ordered from low to high.
+
+Example:
+
+```curl
+curl -X PATCH -H 'X-Auth-Token: YOURAPITOKENHERE' \
+  -H 'Content-Type: application/json' \
+  -d '{"sensor_limit_low":5,"sensor_limit_low_warn":10,"sensor_limit_warn":75,"sensor_limit":85}' \
+  https://foo.example/api/v0/resources/sensors/218810
+```
+
+### `bulk_update_sensor_thresholds`
+
+Apply the same threshold or alert changes atomically to up to 500 explicitly
+selected sensors. Every sensor is checked against the API user's device access.
+
+Route: `PATCH /api/v0/resources/sensors`
+
+Input:
+
+- `sensor_ids`: array of unique sensor IDs
+- any update field accepted by `update_sensor_thresholds`
+
+Example:
+
+```curl
+curl -X PATCH -H 'X-Auth-Token: YOURAPITOKENHERE' \
+  -H 'Content-Type: application/json' \
+  -d '{"sensor_ids":[218810,218811],"sensor_limit_warn":75,"sensor_limit":85}' \
+  https://foo.example/api/v0/resources/sensors
+```
+
 ### `list_devices`
 
 Return a list of devices.

--- a/routes/api.php
+++ b/routes/api.php
@@ -255,6 +255,8 @@ Route::prefix('v0')->group(function (): void {
         });
         Route::middleware('can:viewAny,App\Models\Sensor')->group(function (): void {
             Route::get('sensors', [App\Api\Controllers\LegacyApiController::class, 'list_sensors'])->name('list_sensors');
+            Route::patch('sensors', [App\Api\Controllers\SensorThresholdController::class, 'bulkUpdate'])->name('bulk_update_sensor_thresholds');
+            Route::patch('sensors/{sensor}', [App\Api\Controllers\SensorThresholdController::class, 'update'])->name('update_sensor_thresholds');
         });
         Route::middleware('can:viewAny,App\Models\Vlan')->group(function (): void {
             Route::get('vlans', [App\Api\Controllers\LegacyApiController::class, 'list_vlans'])->name('list_vlans');

--- a/tests/BasicApiTest.php
+++ b/tests/BasicApiTest.php
@@ -37,7 +37,7 @@ final class BasicApiTest extends DBTestCase
 {
     use DatabaseTransactions;
 
-    public function testListDevices(): void
+    public function test_list_devices(): void
     {
         /** @var User $user */
         $user = User::factory()->admin()->create();
@@ -53,7 +53,7 @@ final class BasicApiTest extends DBTestCase
             ]);
     }
 
-    public function testDisabledUserTokenCannotAccessApi(): void
+    public function test_disabled_user_token_cannot_access_api(): void
     {
         /** @var User $user */
         $user = User::factory()->admin()->create(['enabled' => false]);
@@ -66,7 +66,7 @@ final class BasicApiTest extends DBTestCase
         $this->assertNull(ApiToken::userFromToken($token->token_hash));
     }
 
-    public function testTokenWithoutUserIsInvalid(): void
+    public function test_token_without_user_is_invalid(): void
     {
         $token = new ApiToken;
         $token->user_id = 999999;
@@ -79,7 +79,7 @@ final class BasicApiTest extends DBTestCase
         $this->assertNull(ApiToken::userFromToken($token->token_hash));
     }
 
-    public function testGetDeviceWirelessSensors(): void
+    public function test_get_device_wireless_sensors(): void
     {
         /** @var User $user */
         $user = User::factory()->admin()->create();
@@ -118,7 +118,7 @@ final class BasicApiTest extends DBTestCase
         $this->assertSame('snr', $response->json('wireless_sensors.1.sensor_class'));
     }
 
-    public function testGetDeviceWirelessSensorsSupportsFilteringAndColumns(): void
+    public function test_get_device_wireless_sensors_supports_filtering_and_columns(): void
     {
         /** @var User $user */
         $user = User::factory()->admin()->create();
@@ -160,7 +160,7 @@ final class BasicApiTest extends DBTestCase
         $this->assertArrayNotHasKey('sensor_type', $row);
     }
 
-    public function testGetDeviceWirelessSensorsRejectsInvalidClass(): void
+    public function test_get_device_wireless_sensors_rejects_invalid_class(): void
     {
         /** @var User $user */
         $user = User::factory()->admin()->create();
@@ -179,7 +179,7 @@ final class BasicApiTest extends DBTestCase
             ]);
     }
 
-    public function testUpdateSensorThresholds(): void
+    public function test_update_sensor_thresholds(): void
     {
         /** @var User $user */
         $user = User::factory()->admin()->create();
@@ -211,7 +211,7 @@ final class BasicApiTest extends DBTestCase
         $this->assertSame('Yes', $sensor->sensor_custom);
     }
 
-    public function testBulkUpdateSensorThresholds(): void
+    public function test_bulk_update_sensor_thresholds(): void
     {
         /** @var User $user */
         $user = User::factory()->admin()->create();
@@ -244,7 +244,7 @@ final class BasicApiTest extends DBTestCase
         }
     }
 
-    public function testSensorThresholdsRejectInvalidOrder(): void
+    public function test_sensor_thresholds_reject_invalid_order(): void
     {
         /** @var User $user */
         $user = User::factory()->admin()->create();
@@ -272,7 +272,7 @@ final class BasicApiTest extends DBTestCase
         $this->assertSame('No', $sensor->sensor_custom);
     }
 
-    public function testReadOnlyUserCannotUpdateSensorThresholds(): void
+    public function test_read_only_user_cannot_update_sensor_thresholds(): void
     {
         /** @var User $user */
         $user = User::factory()->read()->create();

--- a/tests/BasicApiTest.php
+++ b/tests/BasicApiTest.php
@@ -28,6 +28,7 @@ namespace LibreNMS\Tests;
 
 use App\Models\ApiToken;
 use App\Models\Device;
+use App\Models\Sensor;
 use App\Models\User;
 use App\Models\WirelessSensor;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
@@ -176,5 +177,121 @@ final class BasicApiTest extends DBTestCase
                 'status' => 'error',
                 'message' => "Invalid wireless sensor class 'bogus'",
             ]);
+    }
+
+    public function testUpdateSensorThresholds(): void
+    {
+        /** @var User $user */
+        $user = User::factory()->admin()->create();
+        $token = ApiToken::generateToken($user);
+        $device = Device::factory()->create();
+        $sensor = Sensor::factory()->for($device)->create([
+            'sensor_class' => 'temperature',
+            'sensor_limit_low' => 5,
+            'sensor_limit_low_warn' => 10,
+            'sensor_limit_warn' => 70,
+            'sensor_limit' => 80,
+            'sensor_custom' => 'No',
+        ]);
+
+        $this->json('PATCH', "/api/v0/resources/sensors/{$sensor->sensor_id}", [
+            'sensor_limit_warn' => 75,
+            'sensor_limit' => 85,
+        ], ['X-Auth-Token' => $token->token_hash])
+            ->assertStatus(200)
+            ->assertJsonPath('status', 'ok')
+            ->assertJsonPath('count', 1)
+            ->assertJsonPath('sensors.0.sensor_limit_warn', 75)
+            ->assertJsonPath('sensors.0.sensor_limit', 85)
+            ->assertJsonPath('sensors.0.sensor_custom', 'Yes');
+
+        $sensor->refresh();
+        $this->assertEquals(75, $sensor->sensor_limit_warn);
+        $this->assertEquals(85, $sensor->sensor_limit);
+        $this->assertSame('Yes', $sensor->sensor_custom);
+    }
+
+    public function testBulkUpdateSensorThresholds(): void
+    {
+        /** @var User $user */
+        $user = User::factory()->admin()->create();
+        $token = ApiToken::generateToken($user);
+        $device = Device::factory()->create();
+        $sensors = Sensor::factory()->count(2)->for($device)->create([
+            'sensor_class' => 'temperature',
+            'sensor_limit_low' => 5,
+            'sensor_limit_low_warn' => 10,
+            'sensor_limit_warn' => 70,
+            'sensor_limit' => 80,
+            'sensor_custom' => 'No',
+        ]);
+
+        $this->json('PATCH', '/api/v0/resources/sensors', [
+            'sensor_ids' => $sensors->pluck('sensor_id')->all(),
+            'sensor_limit_warn' => 72,
+            'sensor_limit' => 82,
+        ], ['X-Auth-Token' => $token->token_hash])
+            ->assertStatus(200)
+            ->assertJsonPath('status', 'ok')
+            ->assertJsonPath('count', 2)
+            ->assertJsonCount(2, 'sensors');
+
+        foreach ($sensors as $sensor) {
+            $sensor->refresh();
+            $this->assertEquals(72, $sensor->sensor_limit_warn);
+            $this->assertEquals(82, $sensor->sensor_limit);
+            $this->assertSame('Yes', $sensor->sensor_custom);
+        }
+    }
+
+    public function testSensorThresholdsRejectInvalidOrder(): void
+    {
+        /** @var User $user */
+        $user = User::factory()->admin()->create();
+        $token = ApiToken::generateToken($user);
+        $device = Device::factory()->create();
+        $sensor = Sensor::factory()->for($device)->create([
+            'sensor_class' => 'temperature',
+            'sensor_limit_low' => 5,
+            'sensor_limit_low_warn' => 10,
+            'sensor_limit_warn' => 70,
+            'sensor_limit' => 80,
+            'sensor_custom' => 'No',
+        ]);
+
+        $this->json('PATCH', "/api/v0/resources/sensors/{$sensor->sensor_id}", [
+            'sensor_limit_warn' => 90,
+            'sensor_limit' => 85,
+        ], ['X-Auth-Token' => $token->token_hash])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors('sensor_limit');
+
+        $sensor->refresh();
+        $this->assertEquals(70, $sensor->sensor_limit_warn);
+        $this->assertEquals(80, $sensor->sensor_limit);
+        $this->assertSame('No', $sensor->sensor_custom);
+    }
+
+    public function testReadOnlyUserCannotUpdateSensorThresholds(): void
+    {
+        /** @var User $user */
+        $user = User::factory()->read()->create();
+        $token = ApiToken::generateToken($user);
+        $device = Device::factory()->create();
+        $sensor = Sensor::factory()->for($device)->create([
+            'sensor_class' => 'temperature',
+            'sensor_limit_warn' => 70,
+            'sensor_limit' => 80,
+            'sensor_custom' => 'No',
+        ]);
+
+        $this->json('PATCH', "/api/v0/resources/sensors/{$sensor->sensor_id}", [
+            'sensor_limit' => 85,
+        ], ['X-Auth-Token' => $token->token_hash])
+            ->assertStatus(403);
+
+        $sensor->refresh();
+        $this->assertEquals(80, $sensor->sensor_limit);
+        $this->assertSame('No', $sensor->sensor_custom);
     }
 }


### PR DESCRIPTION
The existing API exposes sensor data but does not allow clients to update discovered sensor thresholds or alerting. This adds permission-checked endpoints for native and automation clients to manage those values without direct database access.

This change adds:

- `PATCH /api/v0/resources/sensors/{sensor}` for a single sensor;
- `PATCH /api/v0/resources/sensors` for transactional bulk updates of up to 500 sensor IDs;
- updates for low/high warning and critical thresholds plus `sensor_alert`;
- threshold-order validation and all-or-nothing handling for missing or unauthorized bulk items;
- `reset` support to return threshold ownership to discovery;
- stable JSON scalar types in the response;
- API documentation and DB-backed authorization/validation tests.

Validation performed:

- Pint and parallel PHP syntax checks passed for all changed PHP files.
- PHPStan Deprecated and PHPStan passed with no errors through `lnms dev:check lint`.
- The DB-backed `BasicApiTest` cases are included for CI; the local environment does not have `DBTEST` configured, so they are skipped locally rather than run against a production database.

#### Please note

- [x] Have you followed our code guidelines?
- [x] This does not change the WebUI.
- [x] This does not change discovery or polling behavior.