### PR TITLE
Add API endpoint to override port speed

### DIFF
--- a/app/Policies/PortPolicy.php
+++ b/app/Policies/PortPolicy.php
@@ -30,6 +30,14 @@ class PortPolicy
     }
 
     /**
+     * Determine whether the user can update any ports.
+     */
+    public function updateAny(User $user): bool
+    {
+        return $this->hasGlobalPermission($user, 'update');
+    }
+
+    /**
      * Determine whether the user can view the port.
      */
     public function view(User $user, Port $port): bool

--- a/doc/API/Ports.md
+++ b/doc/API/Ports.md
@@ -473,3 +473,30 @@ Output:
     "message": "Port description updated."
 }
 ```
+
+### `update_port_speed`
+
+Override the polled interface speed for a given port id. The speed is specified
+in bits per second. Set the speed to `0` to clear the override and allow the
+poller to populate the value again.
+
+Route: `/api/v0/ports/:portid/speed`
+
+Input (JSON):
+
+- speed: Interface speed in bits per second, or `0` to clear the override.
+
+Example:
+
+```curl
+curl -X PATCH -d '{"speed": 1000000000}' -H 'Content-Type: application/json' -H 'X-Auth-Token: YOURAPITOKENHERE' https://foo.example/api/v0/ports/323/speed
+```
+
+Output:
+
+```json
+{
+    "status": "ok",
+    "message": "Port speed updated."
+}
+```

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -1337,6 +1337,54 @@ function update_port_description(Illuminate\Http\Request $request)
     }
 }
 
+function update_port_speed(Illuminate\Http\Request $request): JsonResponse
+{
+    $port_id = $request->route('portid');
+    $port = Port::hasAccess(Auth::user())
+        ->where('port_id', $port_id)
+        ->first();
+
+    if (empty($port)) {
+        return api_error(400, 'Invalid port ID.');
+    }
+
+    $data = json_decode($request->getContent(), true);
+    if (json_last_error() || ! is_array($data)) {
+        return api_error(400, "We couldn't parse the provided json. " . json_last_error_msg());
+    }
+
+    $validator = Validator::make($data, [
+        'speed' => 'required|integer|min:0',
+    ]);
+    if ($validator->fails()) {
+        return api_error(422, $validator->messages());
+    }
+
+    $speed = (int) $data['speed'];
+    $port->ifSpeed = $speed;
+    $port->save();
+
+    $device = DeviceCache::get($port->device_id);
+    if ($speed === 0) {
+        $device->forgetAttrib('ifSpeed:' . $port->ifName);
+        Eventlog::log("$port->ifName Port speed override cleared via API", $port->device_id, 'interface', Severity::Notice, $port->port_id);
+
+        return api_success_noresult(200, 'Port speed override cleared.');
+    }
+
+    $device->setAttrib('ifSpeed:' . $port->ifName, $speed);
+    $port_tune = $device->getAttrib('ifName_tune:' . $port->ifName);
+    $device_tune = $device->getAttrib('override_rrdtool_tune');
+    if ($port_tune == 'true' ||
+        ($device_tune == 'true' && $port_tune != 'false') ||
+        (LibrenmsConfig::get('rrdtool_tune') == 'true' && $port_tune != 'false' && $device_tune != 'false')) {
+        Rrd::tune('port', get_port_rrdfile_path($device->hostname, $port->port_id), $speed);
+    }
+    Eventlog::log("$port->ifName Port speed set via API: $speed", $port->device_id, 'interface', Severity::Notice, $port->port_id);
+
+    return api_success_noresult(200, 'Port speed updated.');
+}
+
 function get_port_description(Illuminate\Http\Request $request)
 {
     $port_id = $request->route('portid');

--- a/routes/api.php
+++ b/routes/api.php
@@ -201,7 +201,7 @@ Route::prefix('v0')->group(function (): void {
             Route::get('', [App\Api\Controllers\LegacyApiController::class, 'get_all_ports'])->name('get_all_ports');
             Route::get('{portid}/description', [App\Api\Controllers\LegacyApiController::class, 'get_port_description'])->name('get_port_description');
         });
-        Route::middleware('can:update,App\Models\Port')->group(function (): void {
+        Route::middleware('can:updateAny,App\Models\Port')->group(function (): void {
             Route::patch('transceiver/metric/{metric}', [App\Api\Controllers\LegacyApiController::class, 'update_transceiver_metric_thresholds'])->name('update_transceiver_metric_thresholds');
             Route::patch('{portid}/description', [App\Api\Controllers\LegacyApiController::class, 'update_port_description'])->name('update_port_description');
             Route::patch('{portid}/speed', [App\Api\Controllers\LegacyApiController::class, 'update_port_speed'])->name('update_port_speed');

--- a/routes/api.php
+++ b/routes/api.php
@@ -204,6 +204,7 @@ Route::prefix('v0')->group(function (): void {
         Route::middleware('can:update,App\Models\Port')->group(function (): void {
             Route::patch('transceiver/metric/{metric}', [App\Api\Controllers\LegacyApiController::class, 'update_transceiver_metric_thresholds'])->name('update_transceiver_metric_thresholds');
             Route::patch('{portid}/description', [App\Api\Controllers\LegacyApiController::class, 'update_port_description'])->name('update_port_description');
+            Route::patch('{portid}/speed', [App\Api\Controllers\LegacyApiController::class, 'update_port_speed'])->name('update_port_speed');
         });
     });
 

--- a/tests/PortApiTest.php
+++ b/tests/PortApiTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace LibreNMS\Tests;
+
+use App\Models\ApiToken;
+use App\Models\Device;
+use App\Models\Port;
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+
+final class PortApiTest extends DBTestCase
+{
+    use DatabaseTransactions;
+
+    public function testUpdatePortSpeed(): void
+    {
+        /** @var User $user */
+        $user = User::factory()->admin()->create();
+        $token = ApiToken::generateToken($user);
+        $device = Device::factory()->create();
+        $port = Port::factory()->for($device)->create([
+            'ifName' => 'ether2',
+            'ifSpeed' => 10000000,
+        ]);
+
+        $this->json('PATCH', "/api/v0/ports/{$port->port_id}/speed", [
+            'speed' => 1000000000,
+        ], ['X-Auth-Token' => $token->token_hash])
+            ->assertStatus(200)
+            ->assertJson([
+                'status' => 'ok',
+                'message' => 'Port speed updated.',
+            ]);
+
+        $this->assertDatabaseHas('ports', [
+            'port_id' => $port->port_id,
+            'ifSpeed' => 1000000000,
+        ]);
+        $this->assertDatabaseHas('devices_attribs', [
+            'device_id' => $device->device_id,
+            'attrib_type' => 'ifSpeed:ether2',
+            'attrib_value' => '1000000000',
+        ]);
+        $this->assertDatabaseHas('eventlog', [
+            'device_id' => $device->device_id,
+            'type' => 'interface',
+            'reference' => $port->port_id,
+            'message' => 'ether2 Port speed set via API: 1000000000',
+        ]);
+    }
+
+    public function testClearPortSpeedOverride(): void
+    {
+        /** @var User $user */
+        $user = User::factory()->admin()->create();
+        $token = ApiToken::generateToken($user);
+        $device = Device::factory()->create();
+        $port = Port::factory()->for($device)->create([
+            'ifName' => 'ether2',
+            'ifSpeed' => 1000000000,
+        ]);
+        $device->setAttrib('ifSpeed:ether2', 1000000000);
+
+        $this->json('PATCH', "/api/v0/ports/{$port->port_id}/speed", [
+            'speed' => 0,
+        ], ['X-Auth-Token' => $token->token_hash])
+            ->assertStatus(200)
+            ->assertJson([
+                'status' => 'ok',
+                'message' => 'Port speed override cleared.',
+            ]);
+
+        $this->assertDatabaseHas('ports', [
+            'port_id' => $port->port_id,
+            'ifSpeed' => 0,
+        ]);
+        $this->assertDatabaseMissing('devices_attribs', [
+            'device_id' => $device->device_id,
+            'attrib_type' => 'ifSpeed:ether2',
+        ]);
+    }
+
+    public function testUpdatePortSpeedValidatesSpeed(): void
+    {
+        /** @var User $user */
+        $user = User::factory()->admin()->create();
+        $token = ApiToken::generateToken($user);
+        $port = Port::factory()->for(Device::factory())->create();
+
+        $this->json('PATCH', "/api/v0/ports/{$port->port_id}/speed", [
+            'speed' => -1,
+        ], ['X-Auth-Token' => $token->token_hash])
+            ->assertStatus(422)
+            ->assertJsonPath('status', 'error');
+    }
+
+    public function testReadOnlyUserCannotUpdatePortSpeed(): void
+    {
+        /** @var User $user */
+        $user = User::factory()->read()->create();
+        $token = ApiToken::generateToken($user);
+        $port = Port::factory()->for(Device::factory())->create();
+
+        $this->json('PATCH', "/api/v0/ports/{$port->port_id}/speed", [
+            'speed' => 1000000000,
+        ], ['X-Auth-Token' => $token->token_hash])
+            ->assertStatus(403);
+    }
+}


### PR DESCRIPTION
## Purpose

Add a write API for managing persistent port speed overrides. This supports interfaces whose reported SNMP `ifSpeed` is nominal or incorrect, while their observed traffic exceeds that value.

## Changes

- Add `PATCH /api/v0/ports/{portid}/speed`
- Accept speed in bits per second; `0` clears the override
- Persist `ifSpeed:<ifName>` so polling keeps the configured value
- Preserve existing RRD tune behavior and event logging
- Document the endpoint and add API coverage for update, clear, validation, and authorization

## Testing

- `./lnms dev:check`: lint, PHPStan, and Pint passed
- `tests/PortApiTest.php`: collected successfully; DB-backed cases skip locally when the LibreNMS test database is unavailable

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://github.com/librenms/librenms/blob/master/doc/Developing/Code-Guidelines.md)
- [ ] Have you attached screenshots of the WebUI for each change made?
- [ ] Have you covered the discovery and polling process with tests?

#### Testers

A LibreNMS test database is required to execute the new API test cases.