### PR TITLE
Fix device availability grey

### DIFF
--- a/app/View/Components/Device/Overview/Availability.php
+++ b/app/View/Components/Device/Overview/Availability.php
@@ -4,7 +4,6 @@ namespace App\View\Components\Device\Overview;
 
 use App\Facades\LibrenmsConfig;
 use App\Models\Device;
-use Carbon\CarbonInterface;
 use Carbon\CarbonInterval;
 use Closure;
 use Illuminate\Contracts\View\View;
@@ -46,11 +45,7 @@ class Availability extends Component
             ->where(fn ($query) => $query->whereNull('up_again')->orWhere('up_again', '>', $start->timestamp))
             ->orderBy('going_down')
             ->get(['going_down', 'up_again']);
-        $insertedAt = $this->device->getAttribute('inserted');
-        $inserted = ($insertedAt instanceof CarbonInterface ? $insertedAt->timestamp : null) ?? min(array_filter([
-            $now->timestamp - (int) $this->device->uptime,
-            $outages->first()?->going_down,
-        ], fn ($value): bool => $value !== null));
+        $deviceCreated = $this->device->inserted?->timestamp;
         $okThreshold = (float) LibrenmsConfig::get('availablity.threshold_ok', 99.9);
         $warningThreshold = (float) LibrenmsConfig::get('availablity.threshold_warning', 95);
         $currentDay = $start->copy()->startOfDay();
@@ -79,7 +74,7 @@ class Availability extends Component
 
             $period = min(86400, $now->timestamp - $dayStart);
             $availability = $period <= 0 ? 100.0 : max(0, min(100, 100 - ($outageSeconds / $period * 100)));
-            if ($dayStart < $inserted) {
+            if ($deviceCreated !== null && $dayStart < $deviceCreated) {
                 $color = 'tw:bg-gray-300';
                 $outageLines = null;
             } elseif ($availability >= $okThreshold) {


### PR DESCRIPTION
If device inserted was null, the fallback path was not working correctly in some cases because the outages were filtered to 90 days.  The inserted field was added way more than 90 days ago, so we can make the assumption that this device has existed more than 90 days.

There is a small chance that the user updated from a very old version of LibreNMS and this shows extra green bars, but that will resolve itself in 90 days as well. This is better when showing "no data" for a device that has existed for years.


#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
