### PR TITLE
Widgets: add table support to health-sensors and sort by value

### DIFF
--- a/app/Http/Controllers/Widgets/HealthSensorsController.php
+++ b/app/Http/Controllers/Widgets/HealthSensorsController.php
@@ -31,10 +31,13 @@ use Illuminate\Database\QueryException;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\View\View;
+use LibreNMS\Util\Validate;
 
 class HealthSensorsController extends WidgetController
 {
     protected string $name = 'health-sensors';
+
+    private const MAX_ENTRIES = 100;
 
     /** @var array<string, mixed> */
     protected $defaults = [
@@ -46,6 +49,8 @@ class HealthSensorsController extends WidgetController
         'rows' => 4,
         'cols' => 3,
         'display_mode' => 'number',
+        'sort_by' => 'descr',
+        'sort_order' => 'asc',
         'sensor_class_regex' => '.*',
         'descr_regex' => '.*',
         'warning' => '',
@@ -87,9 +92,11 @@ class HealthSensorsController extends WidgetController
         $descrBare = trim((string) ($settings['descr_regex'] ?? '.*'));
         $classBare = trim((string) ($settings['sensor_class_regex'] ?? '.*'));
 
-        $userWarning = $settings['warning'] ?? null;
-        $userCritical = $settings['critical'] ?? null;
-        $maxEntries = $this->maxEntries((int) $settings['rows'], (int) $settings['cols']);
+        $userWarning = is_numeric($settings['warning'] ?? null) ? (float) $settings['warning'] : null;
+        $userCritical = is_numeric($settings['critical'] ?? null) ? (float) $settings['critical'] : null;
+        $maxEntries = $this->maxEntries((int) $settings['rows'], (int) $settings['cols'], (string) $settings['display_mode']);
+        $sortColumn = $settings['sort_by'] === 'value' ? 'sensor_current' : 'sensor_descr';
+        $sortOrder = Validate::ascDesc($settings['sort_order'], 'ASC');
 
         try {
             $sensors = Sensor::hasAccess($request->user())
@@ -107,8 +114,9 @@ class HealthSensorsController extends WidgetController
                 })
                 ->when($classBare !== '.*', fn ($q) => $q->whereRaw('sensor_class REGEXP ?', [$classBare]))
                 ->when($descrBare !== '.*', fn ($q) => $q->whereRaw('sensor_descr REGEXP ?', [$descrBare]))
+                ->when($sortColumn === 'sensor_current', fn ($q) => $q->whereNotNull('sensor_current'))
                 ->with('device')
-                ->orderBy('sensor_descr')
+                ->orderBy($sortColumn, $sortOrder)
                 ->limit($maxEntries)
                 ->get()
                 ->map(function (Sensor $sensor) use ($userWarning, $userCritical): array {
@@ -168,8 +176,17 @@ class HealthSensorsController extends WidgetController
         $settings['device_regex'] = trim((string) ($settings['device_regex'] ?? ''));
         $settings['rows'] = isset($settings['rows']) && is_numeric($settings['rows']) ? (int) $settings['rows'] : 4;
         $settings['cols'] = isset($settings['cols']) && is_numeric($settings['cols']) ? (int) $settings['cols'] : 3;
-        $settings['rows'] = max(1, min(48, $settings['rows']));
+        $settings['rows'] = max(1, min(self::MAX_ENTRIES, $settings['rows']));
         $settings['cols'] = max(1, min(12, $settings['cols']));
+
+        $settings['sort_by'] = match ((string) ($settings['sort_by'] ?? 'descr')) {
+            'value' => 'value',
+            default => 'descr',
+        };
+        $settings['sort_order'] = match (strtolower((string) ($settings['sort_order'] ?? 'asc'))) {
+            'desc' => 'desc',
+            default => 'asc',
+        };
 
         $sensorClassRegex = trim((string) ($settings['sensor_class_regex'] ?? ''));
         $settings['sensor_class_regex'] = $sensorClassRegex === '' ? '.*' : $sensorClassRegex;
@@ -190,13 +207,15 @@ class HealthSensorsController extends WidgetController
         return view('widgets.settings.health-sensors', $settings);
     }
 
-    private function maxEntries(int $rows, int $cols): int
+    private function maxEntries(int $rows, int $cols, string $displayMode = 'number'): int
     {
-        $rows = max(1, min(50, $rows));
+        $rows = max(1, min(self::MAX_ENTRIES, $rows));
         $cols = max(1, min(12, $cols));
 
+        $entries = $displayMode === 'table' ? $rows : $rows * $cols;
+
         // safety cap to avoid accidentally rendering huge widgets
-        return max(1, min(48, $rows * $cols));
+        return max(1, min(self::MAX_ENTRIES, $entries));
     }
 
     private function thresholdStatus(?float $value, ?float $lowWarn, ?float $lowCrit, ?float $highWarn, ?float $highCrit): string

--- a/resources/views/widgets/health-sensors.blade.php
+++ b/resources/views/widgets/health-sensors.blade.php
@@ -2,6 +2,39 @@
     <div class="alert alert-danger">{{ $error }}</div>
 @elseif ($sensors->isEmpty())
     <div class="alert alert-info">{{ __('No health sensors matched the current filters.') }}</div>
+@elseif ($display_mode === 'table')
+    <div class="health-sensors-widget tw:overflow-y-auto">
+        <table class="table table-condensed table-hover tw:mb-0">
+            <thead>
+                <tr>
+                    <th class="tw:text-right">#</th>
+                    <th>{{ __('Device') }}</th>
+                    <th>{{ __('Sensor') }}</th>
+                    <th class="tw:text-right">{{ __('Value') }}</th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach ($sensors as $index => $row)
+                    @php($sensor = $row['sensor'])
+                    @php($status = $row['status'] ?? 'unknown')
+                    <tr @class(['danger' => $status === 'critical', 'warning' => $status === 'warning'])>
+                        <td class="tw:text-right tw:text-gray-500">{{ $index + 1 }}</td>
+                        <td>
+                            <a href="{{ route('device', ['device' => $sensor->device_id]) }}" class="tw:text-inherit tw:no-underline hover:tw:underline">
+                                {{ $sensor->device?->displayName() ?? __('Unknown device') }}
+                            </a>
+                        </td>
+                        <td>
+                            <a href="{{ url('graphs/id=' . $sensor->sensor_id . '/type=sensor_' . $sensor->sensor_class . '/') }}" class="tw:text-inherit tw:no-underline hover:tw:underline">
+                                {{ \Str::limit($sensor->sensor_descr, 64) }}
+                            </a>
+                        </td>
+                        <td class="tw:text-right tw:font-semibold tw:whitespace-nowrap">{{ $sensor->formatValue() }}</td>
+                    </tr>
+                @endforeach
+            </tbody>
+        </table>
+    </div>
 @else
     @php($colWidth = max(1, min(12, intdiv(12, max(1, (int) ($cols ?? 3))))))
 

--- a/resources/views/widgets/settings/health-sensors.blade.php
+++ b/resources/views/widgets/settings/health-sensors.blade.php
@@ -58,13 +58,28 @@
             <option value="progress-bar" @if ($display_mode === 'progress-bar') selected @endif>{{ __('Progress Bar') }}</option>
             <option value="gauge" @if ($display_mode === 'gauge') selected @endif>{{ __('Gauges') }}</option>
             <option value="graph" @if ($display_mode === 'graph') selected @endif>{{ __('Graph (24h)') }}</option>
+            <option value="table" @if ($display_mode === 'table') selected @endif>{{ __('Table') }}</option>
+        </select>
+    </div>
+    <div class="form-group">
+        <label for="sort_by-{{ $id }}" class="control-label">{{ __('Sort by') }}</label>
+        <select class="form-control" name="sort_by" id="sort_by-{{ $id }}">
+            <option value="descr" @if ($sort_by === 'descr') selected @endif>{{ __('Description') }}</option>
+            <option value="value" @if ($sort_by === 'value') selected @endif>{{ __('Value') }}</option>
+        </select>
+    </div>
+    <div class="form-group">
+        <label for="sort_order-{{ $id }}" class="control-label">{{ __('Sort order') }}</label>
+        <select class="form-control" name="sort_order" id="sort_order-{{ $id }}">
+            <option value="asc" @if ($sort_order === 'asc') selected @endif>{{ __('Ascending') }}</option>
+            <option value="desc" @if ($sort_order === 'desc') selected @endif>{{ __('Descending') }}</option>
         </select>
     </div>
     <div class="form-group">
         <label for="rows-{{ $id }}" class="control-label">{{ __('Rows') }}</label>
-        <input type="number" step="1" min="1" max="50" class="form-control" name="rows" id="rows-{{ $id }}" value="{{ $rows }}">
+        <input type="number" step="1" min="1" max="100" class="form-control" name="rows" id="rows-{{ $id }}" value="{{ $rows }}">
     </div>
-    <div class="form-group">
+    <div class="form-group" id="health-sensors-cols-{{ $id }}">
         <label for="cols-{{ $id }}" class="control-label">{{ __('Columns') }}</label>
         <input type="number" step="1" min="1" max="12" class="form-control" name="cols" id="cols-{{ $id }}" value="{{ $cols }}">
     </div>
@@ -108,10 +123,17 @@
             healthSensorsApplyNames{{ $id }}(scope);
         }
 
+        function healthSensorsToggleCols{{ $id }}() {
+            $('#health-sensors-cols-{{ $id }}').toggle($('#display_mode-{{ $id }}').val() !== 'table');
+        }
+
         (function () {
             var $form = $('#health-sensors-device-{{ $id }}').closest('form');
             $form.on('change', 'input[name=\"device_scope\"]', healthSensorsToggleDeviceScope{{ $id }});
             healthSensorsToggleDeviceScope{{ $id }}();
+
+            $('#display_mode-{{ $id }}').on('change', healthSensorsToggleCols{{ $id }});
+            healthSensorsToggleCols{{ $id }}();
 
             init_select2('#device-{{ $id }}', 'device', {}, @json($device ? ['id' => $device->device_id, 'text' => $device->displayName()] : ''));
             init_select2(


### PR DESCRIPTION
This makes the health sensors widget support table mode and be able to sort by value. This way a user can get a quick glance of devices that is crossing a certain threshold (without creating alarms).

We also hard-cap max entries to 100 instead of 48. Which in my mind is a sane default for tables.

Image displaying the new feature

<img width="1964" height="1018" alt="image" src="https://github.com/user-attachments/assets/cbd7179c-99a0-4e93-8edd-acb2a22b884e" />


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
