### PR TITLE
Device removal: no error on missing rrd dir

### DIFF
--- a/app/Observers/DeviceObserver.php
+++ b/app/Observers/DeviceObserver.php
@@ -125,7 +125,7 @@ class DeviceObserver
             try {
                 $result = File::deleteDirectory($host_dir);
 
-                if (! $result) {
+                if (! $result && File::exists($host_dir)) {
                     Log::debug("Could not delete RRD files for: $device->hostname");
                 }
             } catch (\Exception $e) {


### PR DESCRIPTION
Don't give an error message on deleting the rrd files for a device on removal.
Note: This code doesn't work with rrdcached on remote servers...


#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
