### PR TITLE
Always load full device in AlertRules to respect disable_notify

### DIFF
--- a/LibreNMS/Alert/AlertRules.php
+++ b/LibreNMS/Alert/AlertRules.php
@@ -53,7 +53,7 @@ readonly class AlertRules
     public function __construct(
         Device|int $device
     ) {
-        $this->device = is_int($device) ? DeviceCache::get($device) : $device;
+        $this->device = DeviceCache::get(is_int($device) ? $device : $device->device_id);
     }
 
     /**


### PR DESCRIPTION
Fixes #20367

PingCheck loads devices with a partial SELECT that does not include disable_notify. When a status change triggers alert rules, that partial Device object is passed to AlertRules which was taking it at face value - disable_notify evaluated as null and the check was silently skipped, causing alert rules to run for devices with Disable alerting enabled.

The PollDevice path is unaffected as it loads through DeviceCache which always fetches all columns.

Fix: always resolve through DeviceCache in the AlertRules constructor regardless of whether a Device object or device_id is passed.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.