### PR TITLE
fix(device): use displayName() fallback in modernDeviceLink for empty display column

### DIFF
--- a/LibreNMS/Util/Url.php
+++ b/LibreNMS/Util/Url.php
@@ -60,7 +60,7 @@ class Url
             self::deviceUrl($device),
             $class,
             $device->device_id,
-            e($text ?: $device->display),
+            e($text ?: $device->displayName()),
             $extra ? '<br />' . e($extra) : $extra
         );
     }


### PR DESCRIPTION
Devices with an empty display column show a blank hostname in any list view that uses modernDeviceLink(). The display column is normally populated on device creation by DeviceObserver and kept up to date when relevant fields change, so this is rare. It can occur if a device was created through a path that bypassed the observer, or if the migration in 26.5.0 that regenerated display fields encountered a silent save failure for a specific device.

The fix is to use displayName() instead of accessing the display column directly. displayName() provides the fallback chain the rest of the codebase uses: display, then hostname, so devices with an empty display column still render their hostname correctly in list views.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.