### PR TITLE
Fix custom map port down color

### DIFF
--- a/app/Http/Controllers/Maps/CustomMapDataController.php
+++ b/app/Http/Controllers/Maps/CustomMapDataController.php
@@ -112,14 +112,9 @@ class CustomMapDataController extends Controller
                         $edges[$edgeid]['colour_from'] = 'darkred';
                     }
                 } elseif ($edge->port->ifOperStatus != IfOperStatus::Up) {
-                    // If the port is not online, show the same as speed unknown
-                    if ($map->legend_colours) {
-                        $edges[$edgeid]['colour_to'] = $map->legend_colours['-1'];
-                        $edges[$edgeid]['colour_from'] = $map->legend_colours['-1'];
-                    } else {
-                        $edges[$edgeid]['colour_to'] = $this->speedColour(-1.0);
-                        $edges[$edgeid]['colour_from'] = $this->speedColour(-1.0);
-                    }
+                    // If the port is not online, show the same as device down
+                    $edges[$edgeid]['colour_to'] = $map->legend_colours['-2'] ?? '#8b0000';
+                    $edges[$edgeid]['colour_from'] = $map->legend_colours['-2'] ?? '#8b0000';
                 } else {
                     if ($map->legend_colours) {
                         $edges[$edgeid]['colour_to'] = $this->fixedColour($sorted_colours, $edges[$edgeid]['port_topct']);
@@ -333,7 +328,7 @@ class CustomMapDataController extends Controller
         // For the maths below, the 5.1 is worked out as 255 / 50
         // (255 being the max colour value and 50 is the max of the $pct calculation)
         if ($pct <= 0) {
-            // Black if we can't determine the percentage (link down or speed 0), or link speed strictly 0
+            // Black if we can't determine the percentage or link speed strictly 0
             return '#000000';
         } elseif ($pct < 50) {
             // 100% green and slowly increase the red until we get to yellow

--- a/lang/en/map.php
+++ b/lang/en/map.php
@@ -82,7 +82,7 @@ return [
                     'customcolours' => 'Custom Colors',
                     'colour' => 'Color',
                     'colour_lower_pct' => 'Start Percent',
-                    'colour_down' => 'Device Down Color',
+                    'colour_down' => 'Device/Port Down Color',
                     'colour_invalid' => 'Unknown Percent Color',
                     'font_size' => 'Legend Text Size',
                     'steps' => 'Legend Steps',


### PR DESCRIPTION
Custom Map port down show dark red like device down. (customizable)

<img width="706" height="547" alt="image" src="https://github.com/user-attachments/assets/fdb91ce8-b03d-4afc-8c0a-d8902ffc1021" />


#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
