### PR TITLE
Improve Unit Testing document with background information

### DIFF
--- a/doc/Developing/os/Test-Units.md
+++ b/doc/Developing/os/Test-Units.md
@@ -1,12 +1,31 @@
-# Tests
+# Unit Tests
 
-Tests keep LibreNMS correct, now and in the future. A new OS must
-supply enough test data. Test data for an existing OS is also welcome.
+## Concepts
 
-The saved SNMP data is in `tests/snmpsim/*.snmprec`. The saved database
-data is in `tests/data/*.json`. Read this data for sensitive
-information **before** you submit it. Replace the data in a consistent
-way.
+**Unit testing** is a popular type of software testing. It is used to
+ensure that future **code** modifications don't break past existing
+**behaviors**.
+
+In LibreNMS, one crucial behavior to keep is **result** of polling /
+discovery code over past **input**. **Input** is SNMP data from
+devices, and **result** is database entries generated / updated.
+
+Since none of us have access to *all* physical devices supported by
+LibreNMS, we keep SNMP data collected and database data saved in our
+repository. The collected SNMP data is in
+`tests/snmpsim/*.snmprec`. The saved database is in
+`tests/data/*.json`.
+
+Whenever you submit polling / discovery code modifications, or OS yaml
+definition changes, please add or update these data. Test data for an
+existing OS is also welcome.
+
+> One small note is that providing these data doesn't promise
+> eternally same behavior, though unreasoned change would be
+> prevented.
+
+Read this data for sensitive information **before** you submit
+it. Replace the data in a consistent way.
 
 > We use [snmpsim](http://snmpsim.sourceforge.net/) for the unit tests.
 > For OS discovery, we can mock snmpsim. The other tests need an

--- a/doc/Developing/os/Test-Units.md
+++ b/doc/Developing/os/Test-Units.md
@@ -3,8 +3,7 @@
 ## Concepts
 
 **Unit testing** is a popular type of software testing. It is used to
-ensure that future **code** modifications don't break past existing
-**behaviors**.
+ensure that future **code** modifications don't break past **behaviors**.
 
 In LibreNMS, one crucial behavior to keep is **result** of polling /
 discovery code over past **input**. **Input** is SNMP data from
@@ -19,10 +18,6 @@ repository. The collected SNMP data is in
 Whenever you submit polling / discovery code modifications, or OS yaml
 definition changes, please add or update these data. Test data for an
 existing OS is also welcome.
-
-> One small note is that providing these data doesn't promise
-> eternally same behavior, though unreasoned change would be
-> prevented.
 
 Read this data for sensitive information **before** you submit
 it. Replace the data in a consistent way.


### PR DESCRIPTION
Through my experiences sending several pull requests, I felt **Unit Testing** page needs some background information of **concept**, or more casually *wording*, in LibreNMS project.

The reality of **Unit Testing** page would be that many first-time pull requests are created **before** understanding `snmprec data` and `JSON test data`, and suddenly required to understand them right after pull request creation.

Use of the phrase **Unit Testing** in LibreNMS project may not be perfectly equal to uses in other projects, where the phrase refers to tests of small portion of program codes, usually functions. But modifying all use of the phrase in LibreNMS configurations, documents, commands, etc. to some strictly defined phrase seems impractical. Rather, I try to describe what I have sensed as loosely shared understandings in the project.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
