### PR TITLE
Trim whitespace and add warning for SNMPv3 usernames

### DIFF
--- a/app/Models/Device.php
+++ b/app/Models/Device.php
@@ -527,6 +527,11 @@ class Device extends BaseModel
         $this->attributes['status'] = (int) $status;
     }
 
+    public function setAuthnameAttribute(?string $authname): void
+    {
+        $this->attributes['authname'] = $authname === null ? null : trim($authname);
+    }
+
     public function setSysDescrAttribute(?string $sysDescr): void
     {
         $this->attributes['sysDescr'] = $sysDescr === null ? null : trim($sysDescr, "\\\" \r\n\t\0");

--- a/doc/API/Devices.md
+++ b/doc/API/Devices.md
@@ -1509,7 +1509,7 @@ SNMP v1 or v2c credentials:
 SNMP v3 credentials:
 
 - authlevel: SNMP authlevel (noAuthNoPriv, authNoPriv, authPriv).
-- authname: SNMP Auth username
+- authname: SNMP Auth username (leading and trailing whitespace is automatically trimmed)
 - authpass: SNMP Auth password
 - authalgo: SNMP Auth algorithm (MD5, SHA) (SHA-224, SHA-256, SHA-384, SHA-512 if supported by your server)
 - cryptopass: SNMP Crypto Password

--- a/doc/Support/Configuration.md
+++ b/doc/Support/Configuration.md
@@ -744,7 +744,7 @@ array with `[1]`, `[2]`, and `[3]`.
 
 ```
 authlevel   noAuthNoPriv | authNoPriv | authPriv
-authname    User Name (required even for noAuthNoPriv)
+authname    User Name (required even for noAuthNoPriv; leading and trailing whitespace is automatically trimmed)
 authpass    Auth Passphrase
 authalgo    MD5 | SHA | SHA-224 | SHA-256 | SHA-384 | SHA-512
 cryptopass  Privacy (Encryption) Passphrase

--- a/includes/html/pages/addhost.inc.php
+++ b/includes/html/pages/addhost.inc.php
@@ -223,6 +223,7 @@ foreach (PortAssociationMode::getModes() as $mode) {
             <label for="authname" class="col-sm-3 control-label">Auth User Name</label>
             <div class="col-sm-9">
               <input type="text" name="authname" id="authname" class="form-control input-sm" autocomplete="off">
+              <span id="authname-warning" class="help-block text-warning" style="display: none;"><i class="fa fa-exclamation-triangle"></i> <?php echo __('Warning: Username contains leading or trailing spaces (will be trimmed)'); ?></span>
             </div>
           </div>
           <div class="form-group">
@@ -334,6 +335,18 @@ if (LibrenmsConfig::get('distributed_poller') === true) {
 
     $("[name='snmp']").bootstrapSwitch('offColor','danger');
     $("[name='force_add']").bootstrapSwitch();
+
+    $('#authname').on('input', function() {
+        var val = $(this).val();
+        if (/^\s+|\s+$/.test(val)) {
+            $('#authname-warning').show();
+        } else {
+            $('#authname-warning').hide();
+        }
+    }).on('blur', function() {
+        $(this).val($.trim($(this).val()));
+        $('#authname-warning').hide();
+    });
 
     $(document).ready(function loadPage() { changeForm(); });
 <?php

--- a/includes/html/pages/device/edit/snmp.inc.php
+++ b/includes/html/pages/device/edit/snmp.inc.php
@@ -310,6 +310,7 @@ echo "        </select>
     <label for='authname' class='col-sm-2 control-label'>Auth User Name</label>
     <div class='col-sm-4'>
     <input type='text' id='authname' name='authname' class='form-control' value='" . htmlspecialchars($device->authname ?? '') . "' autocomplete='off'>
+    <span id='authname-warning' class='help-block text-warning' style='display: none;'><i class='fa fa-exclamation-triangle'></i> " . __('Warning: Username contains leading or trailing spaces (will be trimmed)') . "</span>
     </div>
     </div>
     <div class='form-group'>
@@ -442,6 +443,18 @@ var current_os = <?php echo json_encode(['id' => $device->os, 'text' => Librenms
 init_select2('#os', 'os', {}, current_os, 'OS (optional)');
 
 $("[name='snmp']").bootstrapSwitch('offColor','danger');
+
+$('#authname').on('input', function() {
+    var val = $(this).val();
+    if (/^\s+|\s+$/.test(val)) {
+        $('#authname-warning').show();
+    } else {
+        $('#authname-warning').hide();
+    }
+}).on('blur', function() {
+    $(this).val($.trim($(this).val()));
+    $('#authname-warning').hide();
+});
 
 <?php
 if ($device->snmpver == 'v3') {

--- a/resources/js/components/SettingSnmp3auth.vue
+++ b/resources/js/components/SettingSnmp3auth.vue
@@ -56,7 +56,10 @@
                     <div class="form-group">
                         <label for="authname" class="col-sm-3 control-label" v-text="$t('settings.settings.snmp.v3.fields.authname')"></label>
                         <div class="col-sm-9">
-                            <input type="text" class="form-control" id="authname" :value="item.authname" @input="updateItem(id, $event.target.id, $event.target.value)">
+                            <input type="text" class="form-control" id="authname" :value="item.authname" @input="updateItem(id, $event.target.id, $event.target.value)" @blur="trimAuthname(id)">
+                            <span v-if="hasWhitespace(item.authname)" class="help-block text-warning small">
+                                <i class="fa fa-exclamation-triangle"></i> {{ $t('Warning: Username contains leading or trailing spaces (will be trimmed)') }}
+                            </span>
                         </div>
                     </div>
                     <div class="form-group">
@@ -138,6 +141,15 @@ export default {
             updateItem(index, key, value) {
                 this.localList[index][key] = value;
                 this.$emit('input', this.localList);
+            },
+            hasWhitespace(str) {
+                return typeof str === 'string' && /^\s+|\s+$/.test(str);
+            },
+            trimAuthname(index) {
+                if (typeof this.localList[index].authname === 'string') {
+                    this.localList[index].authname = this.localList[index].authname.trim();
+                    this.$emit('input', this.localList);
+                }
             },
             dragged() {
                 this.$emit('input', this.localList);

--- a/tests/Unit/DeviceTest.php
+++ b/tests/Unit/DeviceTest.php
@@ -101,4 +101,16 @@ final class DeviceTest extends DBTestCase
         $this->assertNotNull($found);
         $this->assertEquals($device->device_id, $found->device_id, 'Did not find the correct device');
     }
+
+    public function testAuthnameTrimming(): void
+    {
+        $device = new Device(['authname' => '  librenms  ']);
+        $this->assertEquals('librenms', $device->authname);
+
+        $device->authname = "  another_user \t\n ";
+        $this->assertEquals('another_user', $device->authname);
+
+        $device->authname = null;
+        $this->assertNull($device->authname);
+    }
 }


### PR DESCRIPTION
### Summary                                                                                                                              
                                                                      
When entering or copy-pasting SNMPv3 usernames (e.g. `"librenms "`), trailing or leading spaces could be included in the saved `authname`. This causes SNMPv3 polling and discovery authentication to fail on target devices (unknown username error), which was hard to notice and troubleshoot due to whitespace collapsing in HTML interfaces and logs.                                                                     
                                                                                                                                             
This PR introduces:                                               
1. **Automatic Trimming on Model**: Added a `setAuthnameAttribute` mutator in `Device.php` to automatically trim leading and trailing whitespace whenever `authname` is assigned/filled across the WebUI, API, CLI (`lnms device:add`), and discovery.                                
2. **WebUI Visual Feedback & Auto-Trim**: Added a dynamic warning alert on input and auto-trim on blur in:                               
   - Add Device page (`addhost.inc.php`)                          
   - Edit Device SNMP settings (`snmp.inc.php`)
   - Global SNMPv3 credentials setting (`SettingSnmp3auth.vue`)
3. **Unit Tests**: Added `testAuthnameTrimming` in `DeviceTest.php` to ensure whitespace is trimmed properly on the model.               
4. **Documentation**: Updated `doc/Support/Configuration.md` and `doc/API/Devices.md`.

### Images

<img width="1711" height="789" alt="image" src="https://github.com/user-attachments/assets/6b0b59e3-5e50-40b9-95c6-e22e22b7b26e" />

<img width="1444" height="792" alt="image" src="https://github.com/user-attachments/assets/317aa740-c558-4c46-affa-7782a6fab78e" />


---

#### Please note                                                                                                                         

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)                                                                                                                                                                                 
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.                          
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).                                                                                                                                 
                                                                                                                                                                                                                                                                                          
#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`. If there are schema changes, you can ask on discord how to revert.
