### PR TITLE
Only deploy docs when running on upstream repository

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -51,12 +51,13 @@ jobs:
           echo "Problems found:" && (grep -F 'no such' output.log && exit 1 || echo "None, Good job :)")
       -
         name: Check GitHub Pages status
+        if: github.repository == 'librenms/librenms' && github.event_name != 'pull_request' && endsWith(github.ref, github.event.repository.default_branch)
         uses: crazy-max/ghaction-github-status@v5
         with:
           pages_threshold: major_outage
       -
         name: Deploy
-        if: github.event_name != 'pull_request' && endsWith(github.ref, github.event.repository.default_branch)
+        if: github.repository == 'librenms/librenms' && github.event_name != 'pull_request' && endsWith(github.ref, github.event.repository.default_branch)
         uses: crazy-max/ghaction-github-pages@v4
         with:
           repo: librenms/docs.librenms.org


### PR DESCRIPTION
When pushing to the default branch (`master`) on a fork, the `doc.yml` workflow was attempting to execute the `Deploy` step to `librenms/docs.librenms.org`, which fails due to missing secrets/permissions on fork repositories.

This PR adds `github.repository == 'librenms/librenms'` to the **Check GitHub Pages status** and **Deploy** steps in `.github/workflows/doc.yml`. Building and validating docs will still run on all PRs and fork branches.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
