### PR TITLE
Reconnect lost DB connections in dbFacile fetch functions

### DIFF
--- a/includes/dbFacile.php
+++ b/includes/dbFacile.php
@@ -20,9 +20,7 @@
  * @see https://laravel.com/docs/eloquent
  */
 
-use Illuminate\Database\Events\QueryExecuted;
 use Illuminate\Database\QueryException;
-use Illuminate\Support\Facades\Event;
 use LibreNMS\DB\Eloquent;
 use LibreNMS\Util\Laravel;
 
@@ -115,17 +113,11 @@ function dbUpdate($data, $table, $where = null, $parameters = [])
 function dbFetchRows($sql, $parameters = [])
 {
     try {
-        $startTime = microtime(true);
-        $connection = DB::connection();
+        $rows = DB::connection()->select($sql, (array) $parameters, false);
 
-        $query = $connection->getPdo()->prepare($sql);
-        $query->execute((array) $parameters);
-        $all = $query->fetchAll(PDO::FETCH_ASSOC);
-
-        $executionTime = round((microtime(true) - $startTime) * 1000, 2);
-        Event::dispatch(new QueryExecuted($sql, $parameters, $executionTime, $connection));
-
-        return $all;
+        return array_map(fn ($row) => (array) $row, $rows);
+    } catch (QueryException $qe) {
+        dbHandleException($qe);
     } catch (PDOException $pdoe) {
         dbHandleException(new QueryException('dbFacile', $sql, $parameters, $pdoe));
     }
@@ -143,17 +135,11 @@ function dbFetchRows($sql, $parameters = [])
 function dbFetchRow($sql = null, $parameters = []): ?array
 {
     try {
-        $startTime = microtime(true);
-        $connection = DB::connection();
+        $row = DB::connection()->selectOne($sql, (array) $parameters, false);
 
-        $query = $connection->getPdo()->prepare($sql);
-        $query->execute((array) $parameters);
-        $row = $query->fetch(PDO::FETCH_ASSOC);
-
-        $executionTime = round((microtime(true) - $startTime) * 1000, 2);
-        Event::dispatch(new QueryExecuted($sql, $parameters, $executionTime, $connection));
-
-        return $row === false ? null : $row;
+        return $row === null ? null : (array) $row;
+    } catch (QueryException $qe) {
+        dbHandleException($qe);
     } catch (PDOException $pdoe) {
         dbHandleException(new QueryException('dbFacile', $sql, $parameters, $pdoe));
     }
@@ -170,17 +156,12 @@ function dbFetchRow($sql = null, $parameters = []): ?array
 function dbFetchCell($sql, $parameters = [])
 {
     try {
-        $startTime = microtime(true);
-        $connection = DB::connection();
+        // cast to array rather than using scalar(), which rejects multi-column selects
+        $row = (array) DB::connection()->selectOne($sql, (array) $parameters, false);
 
-        $query = $connection->getPdo()->prepare($sql);
-        $query->execute((array) $parameters);
-        $value = $query->fetchColumn();
-
-        $executionTime = round((microtime(true) - $startTime) * 1000, 2);
-        Event::dispatch(new QueryExecuted($sql, $parameters, $executionTime, $connection));
-
-        return $value === false ? null : $value;
+        return $row === [] ? null : reset($row);
+    } catch (QueryException $qe) {
+        dbHandleException($qe);
     } catch (PDOException $pdoe) {
         dbHandleException(new QueryException('dbFacile', $sql, $parameters, $pdoe));
     }

--- a/phpstan-baseline-deprecated.neon
+++ b/phpstan-baseline-deprecated.neon
@@ -7103,6 +7103,33 @@ parameters:
 
 		-
 			message: '''
+				#^Call to deprecated function dbFetchCell\(\)\:
+				Please use Eloquent instead; https\://laravel\.com/docs/eloquent$#
+			'''
+			identifier: function.deprecated
+			count: 2
+			path: tests/DbFacileTest.php
+
+		-
+			message: '''
+				#^Call to deprecated function dbFetchRow\(\)\:
+				Please use Eloquent instead; https\://laravel\.com/docs/eloquent$#
+			'''
+			identifier: function.deprecated
+			count: 1
+			path: tests/DbFacileTest.php
+
+		-
+			message: '''
+				#^Call to deprecated function dbFetchRows\(\)\:
+				Please use Eloquent instead; https\://laravel\.com/docs/eloquent$#
+			'''
+			identifier: function.deprecated
+			count: 1
+			path: tests/DbFacileTest.php
+
+		-
+			message: '''
 				#^Call to deprecated method displayName\(\) of class App\\Models\\Device\:
 				use display field directly$#
 			'''

--- a/tests/DbFacileTest.php
+++ b/tests/DbFacileTest.php
@@ -1,0 +1,112 @@
+<?php
+
+/**
+ * DbFacileTest.php
+ *
+ * Tests that dbFacile recovers from a lost database connection
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * @link       https://www.librenms.org
+ *
+ * @copyright  2026 Jacob Wilkins
+ * @author     Jacob Wilkins <jacob@9.nz>
+ */
+
+namespace LibreNMS\Tests;
+
+use App\Models\Device;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Long lived processes such as syslog.php hold a single connection for their whole
+ * lifetime.  When that connection dies, every subsequent query must still succeed,
+ * or the process silently stops recording data until it is restarted.
+ *
+ * These tests deliberately do not use DatabaseTransactions: Connection::handleQueryException()
+ * rethrows without reconnecting while a transaction is open, so the reconnect path
+ * would be unreachable.  They only read, so there is nothing to roll back.
+ */
+final class DbFacileTest extends DBTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (! in_array(DB::connection()->getDriverName(), ['mysql', 'mariadb'])) {
+            $this->markTestSkipped('Killing a connection from a second session requires MySQL/MariaDB.');
+        }
+    }
+
+    public function testFetchRowsReconnectsAfterLostConnection(): void
+    {
+        $before = $this->killCurrentConnection();
+
+        $this->assertSame([['one' => 1]], dbFetchRows('SELECT 1 AS `one`'));
+        $this->assertNotSame($before, $this->connectionId(), 'Expected a new connection, not the killed one.');
+    }
+
+    public function testFetchRowReconnectsAfterLostConnection(): void
+    {
+        $before = $this->killCurrentConnection();
+
+        $this->assertSame(['one' => 1], dbFetchRow('SELECT 1 AS `one`'));
+        $this->assertNotSame($before, $this->connectionId(), 'Expected a new connection, not the killed one.');
+    }
+
+    public function testFetchCellReconnectsAfterLostConnection(): void
+    {
+        $before = $this->killCurrentConnection();
+
+        $this->assertSame(1, dbFetchCell('SELECT 1 AS `one`'));
+        $this->assertNotSame($before, $this->connectionId(), 'Expected a new connection, not the killed one.');
+    }
+
+    public function testDeviceLookupSurvivesLostConnection(): void
+    {
+        $device = Device::factory()->create(); /** @var Device $device */
+        try {
+            $this->killCurrentConnection();
+
+            // the lookup includes/syslog.php performs for every message it receives
+            $this->assertSame(
+                $device->device_id,
+                dbFetchCell('SELECT `device_id` FROM `devices` WHERE `hostname` = ? OR `sysName` = ?', [$device->hostname, $device->hostname])
+            );
+        } finally {
+            $device->delete();
+        }
+    }
+
+    /**
+     * Kill this connection from a second session, leaving a stale handle behind.
+     * Returns the id of the connection that was killed.
+     */
+    private function killCurrentConnection(): int
+    {
+        $connection = DB::connection();
+        $id = $this->connectionId();
+
+        $killer = app('db.factory')->make($connection->getConfig(), 'dbfacile_test_killer');
+        $killer->unprepared('KILL ' . $id);
+        $killer->disconnect();
+
+        return $id;
+    }
+
+    private function connectionId(): int
+    {
+        return (int) DB::connection()->getPdo()->query('SELECT CONNECTION_ID()')->fetchColumn();
+    }
+}


### PR DESCRIPTION
`dbFetchRows()`, `dbFetchRow()` and `dbFetchCell()` reach past the Laravel connection to the raw PDO handle:

```php
$connection = DB::connection();
$query = $connection->getPdo()->prepare($sql);
$query->execute((array) $parameters);
```

This bypasses `Illuminate\Database\Connection::run()`, which is where `tryAgainIfCausedByLostConnection()` reconnects and retries. Once the server has closed the connection — `wait_timeout`, or a MySQL restart — every subsequent call through these three functions throws `SQLSTATE[HY000] 2006 MySQL server has gone away` and returns `null`/`[]` for the remaining life of the process. `dbHandleException()` only logs (its `exit;` is commented out), so the process neither recovers nor dies.

This mostly affects long-lived processes. `syslog.php` is the clearest case, and is how I found it — a syslog receiver silently dropped every message from one device for two days.

syslog-ng's `program()` destination spawns **one long-lived** `syslog.php`, which opens MySQL once at spawn. The failure is self-sustaining:

1. `process_syslog()` resolves `device_id` via `get_cache()` → `dbFetchCell()` — the broken path.
2. `get_cache()` guards its cache with `isset()`, which is false for `null`, so a failed lookup is never cached and every message re-queries.
3. `device_id` stays `null`, so the block containing `dbInsert()` is never entered — and `dbInsert()` is the one function here that already goes through `Connection::insert()` and *would* have reconnected.

So the receiver keeps accepting messages and discarding all of them, indefinitely.

The permanent form of this needs the connection to die *before* a given host's first
successful lookup — which is what happened here, the receiver was up ~26 h before the
device first sent anything, long enough to pass `wait_timeout`. If the cache is already
warm the `device_id` lookup is served from memory and `dbInsert()` reconnects, so the
damage is bounded. A cold cache is what turns it into an open-ended outage. It is also close to invisible: syslog-ng's `written` counter increments normally (the pipe accepted the bytes), and feeding `syslog.php` by hand works, because a fresh process gets a fresh connection.

This change routes the three fetch functions through `select()`/`selectOne()` so they get the same reconnect handling `dbInsert()` and `dbUpdate()` already have.

Notes on the details:

- `useReadPdo` is passed as `false` to preserve existing behaviour — these functions previously always used `getPdo()`, the write connection. This avoids silently moving ~440 SELECTs onto a possibly-lagging replica.
- The manual `QueryExecuted` dispatch is dropped because `Connection::run()` logs the query itself, so `QueryDebugListener` and `QueryMetricListener` still fire.
- `QueryException` is caught *before* `PDOException`, since `QueryException extends PDOException`; without that ordering the retried exception would be caught and re-wrapped.
- `dbFetchCell()` casts and uses `reset()` rather than `scalar()`, which throws on multi-column selects — `fetchColumn()` did not.

I'm aware dbFacile is `@deprecated` in favour of Eloquent. This isn't new work on it: `dbInsert()`/`dbUpdate()` already route through the connection, so this makes the three fetch functions consistent with their siblings rather than adding surface area. It also covers all ~440 existing call sites at once, which migrating a single caller would not.

### Testing

Rebased onto master at `cbb7203cd1`. `./lnms dev:check` — pint, PHP lint, PHPStan and
PHPStan-deprecated all pass clean.

Added `tests/DbFacileTest.php`: it kills the connection from a second session, then
asserts `dbFetchRows()`, `dbFetchRow()` and `dbFetchCell()` still return data. The last
case repeats the exact device lookup `includes/syslog.php` performs for every message.
All four fail on master and pass with this change:

```
# master
FFFF                                                                4 / 4 (100%)
4) LibreNMS\Tests\DbFacileTest::testDeviceLookupSurvivesLostConnection
Failed asserting that null is identical to 2.
Tests: 4, Assertions: 4, Failures: 4.

# with this change
....                                                                4 / 4 (100%)
OK (4 tests, 7 assertions)
```

The tests deliberately do not use `DatabaseTransactions`: `handleQueryException()`
rethrows without reconnecting while a transaction is open, so the reconnect path would
be unreachable inside one. They only read, so there is nothing to roll back.

Full suite with `--db` against MariaDB 11, master and this branch, each against a
freshly created database. Master: `Tests: 4483, Assertions: 11878, Errors: 121,
Failures: 4, Skipped: 1396, Risky: 2`. This branch: `Tests: 4487, Assertions: 11885`
with every other figure unchanged — exactly the four new tests and their seven
assertions — and an identical set of 125 failing test names on both sides. Those
remaining failures are `SQLSTATE[42S02] Base table or view not found` from my local
schema setup and are unrelated to this change.

I also verified this against the running `librenms/librenms:26.8.1` image and its
production database, where `includes/dbFacile.php` is byte-identical to master.
Killing the connection from a second session, with a cold device cache, then
calling `process_syslog()`:

```
=== cold cache, connection killed (reproduces the outage) ===
SQLSTATE[HY000]: General error: 2006 MySQL server has gone away
  (Connection: dbFacile, SQL: SELECT `device_id` FROM devices WHERE `hostname` = ...)
  #0 includes/syslog.php(15): dbFetchCell()
  #1 includes/syslog.php(60): get_cache()
  #2 process_syslog()
shipped dbFacile -> process_syslog device_id : NULL
would insert      : NO - message discarded

=== same stale connection, patched implementation ===
patched lookup    : 2

=== connection recovered, full syslog path ===
process_syslog device_id : '2'
would insert      : YES
```

The stack trace is the whole bug in three frames: `process_syslog()` →
`get_cache()` → `dbFetchCell()` returns `null`, so `device_id` never resolves,
`dbInsert()` is never reached, and the message is discarded.

Return types are unchanged. `PDOStatement::fetchColumn()`/`fetchAll()` and
`Connection::selectOne()`/`select()` both yield native types on the same PDO
(`ATTR_EMULATE_PREPARES` is `false`), verified side by side: `integer 2` from
both, and `[{"device_id":2}]` from both.

### Disclosure

This pull request was prepared with the help of Claude (Anthropic). I'm aware of the
note below about LLM-generated pull requests, so to be concrete about what that means
here: the diff is 13 added and 32 removed lines in one file, every framework claim in
this description was checked against the vendored Laravel source rather than assumed,
and the failure and the fix were both reproduced against a running 26.8.1 instance.
The regression tests fail on master and pass with the change. I'll respond to review
comments myself.

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
