### PR TITLE
RouterOS exclude version from hardware platform

### DIFF
--- a/resources/definitions/os_discovery/routeros.yaml
+++ b/resources/definitions/os_discovery/routeros.yaml
@@ -1,6 +1,6 @@
 modules:
     os:
-        sysDescr_regex: '/RouterOS (?<hardware>.*)/'
+        sysDescr_regex: '/RouterOS (?<hardware>\S+)/'
         features: MIKROTIK-MIB::mtxrLicLevel.0
         features_template: 'Level {{ MIKROTIK-MIB::mtxrLicLevel.0 }}'
         serial: MIKROTIK-MIB::mtxrSerialNumber.0


### PR DESCRIPTION
Change regexp to identify Mikrotik platform on witch is running RouterOS. In new versions platfrom contains version number, changing regexp will again catch only platform.

In example:
<img width="1863" height="118" alt="2026-08-29 14_27_00_ Eventlog _ LibreNMS" src="https://github.com/user-attachments/assets/e1831aa5-72bb-4c96-bfd9-9a2e3278d13b" />

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [X] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
