### PR TITLE
Fix bgpLocalAs showing up as negative for 4-byte ASNs

### DIFF
--- a/includes/discovery/bgp-peers.inc.php
+++ b/includes/discovery/bgp-peers.inc.php
@@ -16,6 +16,10 @@ if (empty($bgpLocalAs)) {
     $bgpLocalAs = \SnmpQuery::get('BGP4-MIB::bgpLocalAs.0')->value();
 }
 
+if (is_numeric($bgpLocalAs) && $bgpLocalAs < 0) {
+    $bgpLocalAs += 4294967296;
+}
+
 if (! empty($bgpLocalAs) && $bgpLocalAs == '23456') { // 4Byte ASN
     if ($device['os_group'] === 'arista') {
         $bgpLocalAs = \SnmpQuery::next('ARISTA-BGP4V2-MIB::aristaBgp4V2PeerLocalAs')->value();

--- a/includes/discovery/bgp-peers.inc.php
+++ b/includes/discovery/bgp-peers.inc.php
@@ -16,8 +16,8 @@ if (empty($bgpLocalAs)) {
     $bgpLocalAs = \SnmpQuery::get('BGP4-MIB::bgpLocalAs.0')->value();
 }
 
-if (is_numeric($bgpLocalAs) && $bgpLocalAs < 0) {
-    $bgpLocalAs += 4294967296;
+if (is_numeric($bgpLocalAs)) {
+    $bgpLocalAs = \LibreNMS\Util\Number::correctIntegerOverflow($bgpLocalAs);
 }
 
 if (! empty($bgpLocalAs) && $bgpLocalAs == '23456') { // 4Byte ASN

--- a/tests/data/pfsense_frr-bgp.json
+++ b/tests/data/pfsense_frr-bgp.json
@@ -43,7 +43,7 @@
                     "bgpPeerFsmEstablishedTime": 0,
                     "bgpPeerInUpdateElapsedTime": 0,
                     "context_name": "",
-                    "bgpLocalAs": 0,
+                    "bgpLocalAs": 4200000002,
                     "vrfLocalAs": null
                 },
                 {
@@ -66,7 +66,7 @@
                     "bgpPeerFsmEstablishedTime": 0,
                     "bgpPeerInUpdateElapsedTime": 0,
                     "context_name": "",
-                    "bgpLocalAs": 0,
+                    "bgpLocalAs": 4200000002,
                     "vrfLocalAs": null
                 }
             ]
@@ -93,7 +93,7 @@
                     "bgpPeerFsmEstablishedTime": 96951,
                     "bgpPeerInUpdateElapsedTime": 96950,
                     "context_name": "",
-                    "bgpLocalAs": 0,
+                    "bgpLocalAs": 4200000002,
                     "vrfLocalAs": null
                 },
                 {
@@ -116,7 +116,7 @@
                     "bgpPeerFsmEstablishedTime": 97193,
                     "bgpPeerInUpdateElapsedTime": 97191,
                     "context_name": "",
-                    "bgpLocalAs": 0,
+                    "bgpLocalAs": 4200000002,
                     "vrfLocalAs": null
                 }
             ]


### PR DESCRIPTION
This PR resolves issue #20398 where LibreNMS displays a negative number for the local ASN when using large 4-byte ASNs. 

Because the `INTEGER` bucket from SNMP defaults to a signed 32-bit integer, values above `2147483647` overflow into the negatives. I noticed that `functions.inc.php` already accounts for this when processing remote ASNs by adding `4294967296` if the number is less than zero. 

I just added that exact same logic to `includes/discovery/bgp-peers.inc.php` right after `bgpLocalAs` is fetched via SNMP, which corrects the overflow.

Closes #20398
