### PR TITLE
Fix Device Dependency Map ignoring configured vis.js options

### DIFF
--- a/resources/views/map/device-dependency.blade.php
+++ b/resources/views/map/device-dependency.blade.php
@@ -190,7 +190,7 @@
                     network_edges.flush();
 
                     var container = document.getElementById('visualization');
-                    var options = {!! $options !!};
+                    var options = {{ Js::from($options) }}; 
                     network = new vis.Network(container, {nodes: network_nodes, edges: network_edges, stabilize: true}, options);
 
                     network.on('click', function (properties) {


### PR DESCRIPTION
The options config value was echoed as a raw PHP array via resources/views/map/device-dependency.blade.php, which triggers 'Array to string conversion' and silently breaks the JS (renders as 'var options = Array;'). Use Js::from() to properly JSON-encode it, matching the pattern already used in netmap.blade.php.

Before:
<img width="703" height="674" alt="image" src="https://github.com/user-attachments/assets/93492135-0a21-4500-8eb0-93a300b7cd35" />
After:
<img width="791" height="778" alt="image" src="https://github.com/user-attachments/assets/86458869-cbc3-4fbc-900d-beb403005084" />


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.



