### PR TITLE
Fix TypeError when optional alert transport config fields are null

### DIFF
--- a/LibreNMS/Alert/Transport.php
+++ b/LibreNMS/Alert/Transport.php
@@ -65,8 +65,9 @@ abstract class Transport implements TransportInterface
      * @param  array  $replacements  for SimpleTemplate if desired
      * @return array
      */
-    protected function parseUserOptions(string $input, array $replacements = []): array
+    protected function parseUserOptions(?string $input, array $replacements = []): array
     {
+        $input ??= '';
         $options = [];
         foreach (preg_split('/\\r\\n|\\r|\\n/', $input, -1, PREG_SPLIT_NO_EMPTY) as $option) {
             if (Str::contains($option, '=')) {

--- a/LibreNMS/Alert/Transport/Api.php
+++ b/LibreNMS/Alert/Transport/Api.php
@@ -51,7 +51,7 @@ class Api extends Transport
         ->withHeaders($request_headers); //get each line of key-values and process the variables for Headers
 
         if ($method !== 'get') {
-            $request_body = SimpleTemplate::parse($this->config['api-body'], $alert_data);
+            $request_body = SimpleTemplate::parse($this->config['api-body'] ?? '', $alert_data);
             if ($as_form == true) {
                 $request_body = $this->parseUserOptions($request_body);
                 $method = 'postform';

--- a/tests/Unit/ApiTransportTest.php
+++ b/tests/Unit/ApiTransportTest.php
@@ -51,4 +51,27 @@ final class ApiTransportTest extends TestCase
             $request->url() == 'https://librenms.org?text=This%20is%20a%20post%20multi-line%0Aalert.' &&
             $request->body() == "bodytext=This is a post multi-line\nalert.");
     }
+
+    public function testNullOptionalConfigFieldsDoNotThrow(): void
+    {
+        /** @var AlertTransport $transport */
+        $transport = AlertTransport::factory()->api('', 'post', '')->make();
+
+        // Optional textarea fields (options, headers, body) are stored as null when left blank
+        // on transports created before these fields existed, or cleared via the API. See #20418.
+        $config = $transport->transport_config;
+        $config['api-options'] = null;
+        $config['api-headers'] = null;
+        $config['api-body'] = null;
+        $transport->transport_config = $config;
+
+        LaravelHttp::fake([
+            '*' => LaravelHttp::response(),
+        ]);
+
+        $result = $transport->instance()->deliverAlert(['msg' => 'test']);
+
+        $this->assertTrue($result);
+        LaravelHttp::assertSentCount(1);
+    }
 }


### PR DESCRIPTION
## Description

`parseUserOptions()` and `Api::deliverAlert()` assume `api-options`, `api-headers`, and `api-body` are always strings. In practice these optional textarea config fields can be `null` (transports created before a field existed, or cleared out via the API), which throws an uncaught `TypeError` during alert delivery and silently breaks that transport.

This widens `parseUserOptions()` to accept `?string` (coalescing to `''`), which covers all 7 call sites across the affected transport classes (Api, Alertmanager, Discord, Hipchat, Pushover, Rocket — Slack already guarded correctly), and null-coalesces the separate `api-body` read in `Api::deliverAlert()` before it reaches `SimpleTemplate::parse()`.

Added a regression test reproducing the null-config crash.

Fixes #20418

## How Has This Been Tested?

- [x] `phpunit` — added `testNullOptionalConfigFieldsDoNotThrow` to `tests/Unit/ApiTransportTest.php`, exercising the exact null-field scenario from #20418
- [x] Confirmed the existing `ApiTransportTest` scenarios are unaffected (multiline GET/POST options still parse correctly)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.