### PR TITLE
Add processor and power supply status definitions

### DIFF
--- a/resources/definitions/os_discovery/drac.yaml
+++ b/resources/definitions/os_discovery/drac.yaml
@@ -286,6 +286,20 @@ modules:
                         - { value: 5, descr: critical, generic: 2 }
                         - { value: 6, descr: nonRecoverable, generic: 2}
                 -
+                    oid: IDRAC-MIB-SMIv2::processorDeviceStatusTable
+                    value: IDRAC-MIB-SMIv2::processorDeviceStatusStatus
+                    num_oid: '.1.3.6.1.4.1.674.10892.5.4.1100.32.1.5.{{ $index }}'
+                    descr: '{{ IDRAC-MIB-SMIv2::processorDeviceStatusLocationName }}'
+                    index: '{{ $index }}'
+                    state_name: processorDeviceStatusStatus
+                    states:
+                        - { value: 1, descr: other, generic: 3 }
+                        - { value: 2, descr: unknown, generic: 3  }
+                        - { value: 3, descr: ok, generic: 0 }
+                        - { value: 4, descr: nonCritical, generic: 1 }
+                        - { value: 5, descr: critical, generic: 2 }
+                        - { value: 6, descr: nonRecoverable, generic: 2}
+                -
                     oid: IDRAC-MIB-SMIv2::processorDeviceTable
                     value: IDRAC-MIB-SMIv2::processorDeviceStatus
                     num_oid: '.1.3.6.1.4.1.674.10892.5.4.1100.30.1.5.{{ $index }}'
@@ -307,6 +321,20 @@ modules:
                     index: '{{ $index }}'
                     group: 'Memory'
                     state_name: memoryDeviceStatus
+                    states:
+                        - { value: 1, descr: other, generic: 3 }
+                        - { value: 2, descr: unknown, generic: 3  }
+                        - { value: 3, descr: ok, generic: 0 }
+                        - { value: 4, descr: nonCritical, generic: 1 }
+                        - { value: 5, descr: critical, generic: 2 }
+                        - { value: 6, descr: nonRecoverable, generic: 2}
+                -
+                    oid: IDRAC-MIB-SMIv2::powerSupplyTable
+                    value: IDRAC-MIB-SMIv2::powerSupplyStatus
+                    num_oid: '.1.3.6.1.4.1.674.10892.5.4.600.12.1.5.{{ $index }}'
+                    descr: '{{ IDRAC-MIB-SMIv2::powerSupplyLocationName }}'
+                    index: '{{ $index }}'
+                    state_name: powerSupplyStatus
                     states:
                         - { value: 1, descr: other, generic: 3 }
                         - { value: 2, descr: unknown, generic: 3  }

--- a/resources/definitions/os_discovery/drac.yaml
+++ b/resources/definitions/os_discovery/drac.yaml
@@ -290,7 +290,7 @@ modules:
                     value: IDRAC-MIB-SMIv2::processorDeviceStatusStatus
                     num_oid: '.1.3.6.1.4.1.674.10892.5.4.1100.32.1.5.{{ $index }}'
                     descr: '{{ IDRAC-MIB-SMIv2::processorDeviceStatusLocationName }}'
-                    index: '{{ $index }}'
+                    index: 'processorDeviceStatusStatus.{{ $index }}'
                     state_name: processorDeviceStatusStatus
                     states:
                         - { value: 1, descr: other, generic: 3 }
@@ -333,7 +333,7 @@ modules:
                     value: IDRAC-MIB-SMIv2::powerSupplyStatus
                     num_oid: '.1.3.6.1.4.1.674.10892.5.4.600.12.1.5.{{ $index }}'
                     descr: '{{ IDRAC-MIB-SMIv2::powerSupplyLocationName }}'
-                    index: '{{ $index }}'
+                    index: 'powerSupplyStatus.{{ $index }}'
                     state_name: powerSupplyStatus
                     states:
                         - { value: 1, descr: other, generic: 3 }


### PR DESCRIPTION
This patch fixes the scenario where the energy supply to the power device is broken. In this case the snmp response does not contain any voltage or current metrics for the broken power supply. Only the global system state and the new added "powerSupplyTable" indicates this specific error.

In addition I added the "processorDeviceStatusTable" which indicates missing cpu's. Means if socket2 is empty, all socket2 related metrics are missing inside the snmp response. Only the "processorDeviceStatusTable" indicates that there is a socket2 with the cpu state "unknown"

Tested on a Dell PowerEdge R730xd with iDRAC 2.70.70.70