### PR TITLE
MS Teams Workflows based transport

### DIFF
--- a/LibreNMS/Alert/Transport/Msteamsworkflows.php
+++ b/LibreNMS/Alert/Transport/Msteamsworkflows.php
@@ -1,0 +1,106 @@
+<?php
+
+/*
+ * LibreNMS
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version. Please see LICENSE.txt at the top level of
+ * the source code distribution for details.
+ */
+
+namespace LibreNMS\Alert\Transport;
+
+use LibreNMS\Alert\Transport;
+use LibreNMS\Exceptions\AlertTransportDeliveryException;
+use LibreNMS\Util\Http;
+
+class Msteamsworkflows extends Transport
+{
+    protected string $name = 'Microsoft Teams Workflows';
+
+    public function deliverAlert(array $alert_data): bool
+    {
+        $url = $this->config['msteam-workflows-url'];
+        $client = Http::client();
+
+        $stateSymbol = match ($alert_data['state']) {
+            0 => "🟢",
+            1 => "🔴",
+            2 => "🔵",
+            default => "🔴"
+        };
+
+        $messageCard = [
+            "type" => "message",
+            "attachments" => [
+                [
+                    "contentType" => "application/vnd.microsoft.card.adaptive",
+                    "contentUrl" => null,
+                    "content" => [
+                        "schema" => "http://adaptivecards.io/schemas/adaptive-card.json",
+                        "type" => "AdaptiveCard",
+                        "version" => "1.4",
+                        "msTeams" => [
+                            "width" => "full"
+                        ],
+                        "body" => [
+                            [
+                                "type" => "TextBlock",
+                                "text" => $stateSymbol . "  " . $alert_data['title'],
+                                "size" => "medium",
+                                "weight" => "Bolder",
+                                "style" => "heading",
+                                "wrap" => true
+                            ],
+                            [
+                                "type" => "RichTextBlock",
+                                "inlines" => [
+                                    [
+                                        "type" => "TextRun",
+                                        "text" => strip_tags($alert_data['msg']),
+                                        "fontType" => "monospace",
+                                        "size" => "small"
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ];
+
+        $client->withBody(json_encode($messageCard), 'application/json');
+        $res = $client->post($url, []);
+
+        if ($res->successful()) {
+            return true;
+        }
+
+        throw new AlertTransportDeliveryException(
+            $alert_data,
+            $res->status(),
+            $res->body(),
+            $messageCard['text'] ?? $alert_data['msg'],
+            $messageCard ?? []
+        );
+    }
+
+    public static function configTemplate(): array
+    {
+        return [
+            'config' => [
+                [
+                    'title' => 'Workflows Webhook URL',
+                    'name' => 'msteam-workflows-url',
+                    'descr' => 'Microsoft Teams Workflow Webhook URL',
+                    'type' => 'text',
+                ],
+            ],
+            'validation' => [
+                'msteam-workflows-url' => 'required|url',
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
The existing Teams alert transport has been broken for me for three months or so.  Formatting in Teams was awful.  I'm not sure about anyone else, but Microsoft is forcing Workflows based webhooks now and the use of Adaptive Cards.  I was averse to adding Adaptive Card JSON to every Alert Template I had, so I rewrote the transport optimized for Teams Workflows and Adaptive Cards, while allowing Markdown to still be used in Template.  It even honors leading whitespace idents in Template.  I added this as a completely separate Transport to avoid conflicts with the existing one. 

<img width="567" height="428" alt="Example-alert" src="https://github.com/user-attachments/assets/07c43a8f-c57f-4822-bc8a-bb4352be5570" />
<img width="628" height="437" alt="Example-ack" src="https://github.com/user-attachments/assets/afdd951c-38bb-49b4-9bd4-72103cb17330" />
<img width="633" height="427" alt="Example-clear" src="https://github.com/user-attachments/assets/9eb1170a-3e45-45ea-b541-2984faaf50a6" />

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.

