### PR TITLE
Fix port hover graphs on device overview page

### DIFF
--- a/resources/views/components/device/overview/ports.blade.php
+++ b/resources/views/components/device/overview/ports.blade.php
@@ -1,5 +1,4 @@
 @props(['device', 'ports'])
-
 @if($device->ports_total_count)
     <x-device.overview.panel :title="__('Overall Traffic')" icon="fa fa-road">
         <div class="tw:divide-y tw:divide-gray-300 tw:dark:divide-zinc-800">
@@ -21,7 +20,7 @@
             </div>
             <div class="tw:flex tw:flex-wrap tw:gap-x-1 tw:px-2 tw:py-1 tw:bg-neutral-100 tw:dark:bg-dark-gray-200">
                 @foreach($ports as $port)
-                    <x-port-link :port="$port" basic>{{ strtolower($port->getShortLabel()) }}</x-port-link>@if(! $loop->last),@endif
+                    <x-port-link :port="$port">{{ strtolower($port->getShortLabel()) }}</x-port-link>@if(! $loop->last),@endif
                 @endforeach
             </div>
         </div>


### PR DESCRIPTION
closes #20439 

I've decided to limit the graphs to ports that are actually up.

<img width="878" height="613" alt="image" src="https://github.com/user-attachments/assets/8063125e-7467-4c8a-94f4-1f0b7e1fba27" />



DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
