### PR TITLE
Convert measurement manager to use the Console_Color2 colour library to set colours in output

### DIFF
--- a/app/Polling/Measure/MeasurementManager.php
+++ b/app/Polling/Measure/MeasurementManager.php
@@ -32,11 +32,11 @@ use Log;
 
 class MeasurementManager
 {
-    const FPING_COLOR = "\e[0;35m";
-    const SNMP_COLOR = "\e[0;36m";
-    const DB_COLOR = "\e[1;33m";
-    const DATASTORE_COLOR = "\e[0;32m";
-    const NO_COLOR = "\e[0m";
+    const FPING_COLOR = '%m';
+    const SNMP_COLOR = '%c';
+    const DB_COLOR = '%Y';
+    const DATASTORE_COLOR = '%g';
+    const NO_COLOR = '%n';
 
     /**
      * @var \Illuminate\Support\Collection<string, MeasurementCollection>
@@ -87,7 +87,7 @@ class MeasurementManager
             $this->getCategory('db')->getCountDiff(),
             $this->getCategory('db')->getDurationDiff(),
             $dsStats->implode(' ')
-        ));
+        ), ['color' => true]);
 
         $this->checkpoint();
     }
@@ -160,6 +160,6 @@ class MeasurementManager
             $collection->getTotalCount(),
             $collection->getTotalDuration(),
             $summaries->implode(' ')
-        ));
+        ), ['color' => true]);
     }
 }


### PR DESCRIPTION
The measurement manager manually sets colours in the output instead of using Console_Color2.  I assume we want to standardise on the latter option for better flexibility.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
