### PR TITLE
Remove $this->authorize(view, $device); check to allow port-only users to view ports.

### DIFF
--- a/app/Http/Controllers/DeviceController.php
+++ b/app/Http/Controllers/DeviceController.php
@@ -29,8 +29,6 @@ class DeviceController
             abort(404);
         }
 
-        $this->authorize('view', $device);
-
         DeviceCache::setPrimary($device_id);
 
         $current_tab = str_replace('tab=', '', $current_tab) ?: 'overview';


### PR DESCRIPTION
#### Please give a short description what your pull request is for

A User who only have access to view specific ports, but not an entire device gets being blocked from viewing the port by a 403.

They can view the list of ports at `/ports` but clicking through to viewing an actual port at `/device/device=287/tab=port/port=1093376/` gives a 403 error.

The gate checks exist for this exact scenario on lines 38-44:
```php
        if ($current_tab == 'port') {
            $vars = Url::parseLegacyPath($request->path());
            $port = $device->ports()->findOrFail($vars->get('port'));
            Gate::authorize('view', $port);
        } else {
            Gate::authorize('view', $device);
        }
```

But line 32 fires first and blocks it:
```php
        $this->authorize('view', $device);
```

This PR removes this check in favour of the gates.

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [X] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 20447`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
