### PR TITLE
Prevent Web UI Debug from making changes

### DIFF
--- a/LibreNMS/Util/ModuleTestHelper.php
+++ b/LibreNMS/Util/ModuleTestHelper.php
@@ -299,7 +299,7 @@ class ModuleTestHelper
         ob_start();
         Log::setDefaultDriver('stdout');
 
-        (new DiscoverDevice($device_id, $this->modules))->handle();
+        (new DiscoverDevice($device_id, $this->modules, false))->handle();
 
         $this->discovery_output = ob_get_contents();
         if ($this->quiet) {
@@ -331,7 +331,7 @@ class ModuleTestHelper
         ob_start();
         Log::setDefaultDriver('stdout');
 
-        (new PollDevice($device_id, $this->modules))->handle();
+        (new PollDevice($device_id, $this->modules, false))->handle();
 
         $this->poller_output = ob_get_contents();
         if ($this->quiet) {

--- a/app/Console/Commands/DevCollectSnmprec.php
+++ b/app/Console/Commands/DevCollectSnmprec.php
@@ -221,8 +221,8 @@ class DevCollectSnmprec extends LnmsCommand
 
         try {
             $this->runWithProgress(function () use ($device, $moduleList): void {
-                (new DiscoverDevice($device->device_id, $moduleList))->handle();
-                (new PollDevice($device->device_id, $moduleList))->handle();
+                (new DiscoverDevice($device->device_id, $moduleList, false))->handle();
+                (new PollDevice($device->device_id, $moduleList, false))->handle();
             }, __('commands.dev:collect-snmprec.capturing_data'));
         } finally {
             config(['logging.channels.stdout.level' => $previous_level]);

--- a/app/Console/Commands/DeviceDiscover.php
+++ b/app/Console/Commands/DeviceDiscover.php
@@ -67,7 +67,8 @@ class DeviceDiscover extends LnmsCommand
                 DeviceDiscovered::class,
                 ModuleList::fromUserOverrides($this->option('modules')),
                 $this->option('os'),
-                $this->option('type')
+                $this->option('type'),
+                false
             );
 
             $this->line(__('commands.device:discover.starting'));

--- a/app/Console/Commands/DevicePoll.php
+++ b/app/Console/Commands/DevicePoll.php
@@ -90,7 +90,7 @@ class DevicePoll extends LnmsCommand
         }
 
         foreach ($devices as $device_id) {
-            PollDevice::dispatch($device_id, $modules);
+            PollDevice::dispatch($device_id, $modules, $this->option('no-data') ?? false);
         }
 
         $this->line('Submitted work for ' . $devices->count() . ' devices');

--- a/app/Console/Commands/DevicePoll.php
+++ b/app/Console/Commands/DevicePoll.php
@@ -64,7 +64,8 @@ class DevicePoll extends LnmsCommand
                 DevicePolled::class,
                 ModuleList::fromUserOverrides($this->option('modules')),
                 $this->option('os'),
-                $this->option('type')
+                $this->option('type'),
+                $this->option('no-data') ?? false
             );
 
             $this->line(__('commands.device:poll.starting'));

--- a/app/Http/Controllers/Device/Debug/DebugPollAndDiscoveryController.php
+++ b/app/Http/Controllers/Device/Debug/DebugPollAndDiscoveryController.php
@@ -32,6 +32,7 @@ use App\Models\Device;
 use Illuminate\Console\Events\CommandStarting;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Validation\Rule;
 use Symfony\Component\HttpFoundation\StreamedResponse;
@@ -61,7 +62,9 @@ class DebugPollAndDiscoveryController extends Controller
         return $this->stream(function () use ($cmd, $args): void {
             Event::forget(CommandStarting::class); // prevent normal cli setup and checks
 
+            DB::beginTransaction();
             $exitCode = Artisan::call($cmd, $args, $this->getCliStreamOutput());
+            DB::rollBack();
 
             if ($exitCode) {
                 echo PHP_EOL . 'exit_status:' . $exitCode . PHP_EOL;

--- a/app/Http/Controllers/Device/Debug/DebugPollAndDiscoveryController.php
+++ b/app/Http/Controllers/Device/Debug/DebugPollAndDiscoveryController.php
@@ -32,7 +32,6 @@ use App\Models\Device;
 use Illuminate\Console\Events\CommandStarting;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Artisan;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Validation\Rule;
 use Symfony\Component\HttpFoundation\StreamedResponse;
@@ -62,9 +61,7 @@ class DebugPollAndDiscoveryController extends Controller
         return $this->stream(function () use ($cmd, $args): void {
             Event::forget(CommandStarting::class); // prevent normal cli setup and checks
 
-            DB::beginTransaction();
             $exitCode = Artisan::call($cmd, $args, $this->getCliStreamOutput());
-            DB::rollBack();
 
             if ($exitCode) {
                 echo PHP_EOL . 'exit_status:' . $exitCode . PHP_EOL;

--- a/app/Jobs/DiscoverDevice.php
+++ b/app/Jobs/DiscoverDevice.php
@@ -41,6 +41,7 @@ class DiscoverDevice implements ShouldQueue
     public function __construct(
         public int $device_id,
         public ModuleList $moduleList,
+        public bool $nodata,
     ) {
     }
 

--- a/app/Jobs/PollDevice.php
+++ b/app/Jobs/PollDevice.php
@@ -19,6 +19,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use LibreNMS\Enum\ProcessType;
 use LibreNMS\Enum\Severity;
@@ -48,6 +49,7 @@ class PollDevice implements ShouldQueue
     public function __construct(
         public int $device_id,
         public ModuleList $moduleList,
+        public bool $nodata,
     ) {
     }
 
@@ -66,7 +68,9 @@ class PollDevice implements ShouldQueue
         $measurement->manager()->checkpoint(); // don't count previous stats
 
         // check and save status
+        if($this->nodata) DB::beginTransaction();
         app(CheckDeviceAvailability::class)->execute($this->device, true);
+        if($this->nodata) DB::rollBack();
 
         $this->pollModules($connectivity);
 
@@ -90,7 +94,7 @@ class PollDevice implements ShouldQueue
         }
 
         // finalize the device poll
-        $this->device->save();
+        if(!$this->nodata) $this->device->save();
 
         Log::info(sprintf("\n>>> Polled %s (%s) in %0.3f seconds <<<",
             $this->device->displayName(),
@@ -127,6 +131,7 @@ class PollDevice implements ShouldQueue
         $datastore = app('Datastore');
 
         foreach ($this->moduleList->modulesWithStatus(ProcessType::Poller, $this->device) as $module => $module_status) {
+            if($this->nodata) DB::beginTransaction();
             $should_poll = false;
             $start_memory = memory_get_usage();
             $module_start = microtime(true);
@@ -156,6 +161,7 @@ class PollDevice implements ShouldQueue
                 Eventlog::log("Error polling $module module: " . class_basename($e) . '. Check log file for more details.', $this->device, 'poller', Severity::Error);
                 report($e);
             }
+            if($this->nodata) DB::rollBack();
 
             if ($should_poll) {
                 Log::info('');

--- a/app/Jobs/PollDevice.php
+++ b/app/Jobs/PollDevice.php
@@ -68,9 +68,7 @@ class PollDevice implements ShouldQueue
         $measurement->manager()->checkpoint(); // don't count previous stats
 
         // check and save status
-        if($this->nodata) DB::beginTransaction();
         app(CheckDeviceAvailability::class)->execute($this->device, true);
-        if($this->nodata) DB::rollBack();
 
         $this->pollModules($connectivity);
 

--- a/app/Jobs/PollDevice.php
+++ b/app/Jobs/PollDevice.php
@@ -92,7 +92,9 @@ class PollDevice implements ShouldQueue
         }
 
         // finalize the device poll
-        if(!$this->nodata) $this->device->save();
+        if (! $this->nodata) {
+            $this->device->save();
+        }
 
         Log::info(sprintf("\n>>> Polled %s (%s) in %0.3f seconds <<<",
             $this->device->displayName(),
@@ -129,7 +131,9 @@ class PollDevice implements ShouldQueue
         $datastore = app('Datastore');
 
         foreach ($this->moduleList->modulesWithStatus(ProcessType::Poller, $this->device) as $module => $module_status) {
-            if($this->nodata) DB::beginTransaction();
+            if ($this->nodata) {
+                DB::beginTransaction();
+            }
             $should_poll = false;
             $start_memory = memory_get_usage();
             $module_start = microtime(true);
@@ -159,7 +163,9 @@ class PollDevice implements ShouldQueue
                 Eventlog::log("Error polling $module module: " . class_basename($e) . '. Check log file for more details.', $this->device, 'poller', Severity::Error);
                 report($e);
             }
-            if($this->nodata) DB::rollBack();
+            if ($this->nodata) {
+                DB::rollBack();
+            }
 
             if ($should_poll) {
                 Log::info('');

--- a/app/PerDeviceProcess.php
+++ b/app/PerDeviceProcess.php
@@ -48,6 +48,7 @@ class PerDeviceProcess
         private readonly ModuleList $moduleList,
         private readonly ?string $os = null,
         private readonly ?string $deviceType = null,
+        private readonly bool $nodata = false,
     ) {
         $this->results = new Result;
     }
@@ -75,7 +76,7 @@ class PerDeviceProcess
         foreach ($query->pluck('device_id') as $device_id) {
             $this->current_device_id = $device_id;
             $this->results->markAttempted();
-            $dispatcher->dispatchSync(new $this->job($device_id, $this->moduleList));
+            $dispatcher->dispatchSync(new $this->job($device_id, $this->moduleList, $this->nodata));
         }
 
         return $this->results;


### PR DESCRIPTION
The debug should not have any side effects.  Wrap the entire discovery/poll in a transaction then roll it back.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
