### PR TITLE
Delete device orphans without locking the devices table

### DIFF
--- a/LibreNMS/Device/Processor.php
+++ b/LibreNMS/Device/Processor.php
@@ -161,7 +161,7 @@ class Processor extends Model implements DiscoveryModule, PollerModule, Discover
             );
         }
 
-        \App\Models\Processor::doesntHave('device')->delete();
+        \App\Models\Processor::deleteOrphans();
 
         echo PHP_EOL;
     }

--- a/app/Models/DeviceRelatedModel.php
+++ b/app/Models/DeviceRelatedModel.php
@@ -27,6 +27,7 @@
 namespace App\Models;
 
 use App\Facades\DeviceCache;
+use App\Models\Traits\DeletesDeviceOrphans;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 /**
@@ -34,6 +35,8 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  */
 class DeviceRelatedModel extends BaseModel
 {
+    use DeletesDeviceOrphans;
+
     // ---- Query Scopes ----
 
     public function scopeHasAccess($query, User $user)

--- a/app/Models/Link.php
+++ b/app/Models/Link.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Facades\Permissions;
+use App\Models\Traits\DeletesDeviceOrphans;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -12,6 +13,7 @@ use Illuminate\Support\Facades\Gate;
 
 class Link extends Model
 {
+    use DeletesDeviceOrphans;
     use HasFactory;
 
     public $timestamps = false;
@@ -30,6 +32,11 @@ class Link extends Model
             ->orWhereIntegerInRaw('links.local_device_id', Permissions::devicesForUser($user)))->where(fn (Builder $query) => $query->where('links.remote_device_id', 0)
             ->orWhereIntegerInRaw('links.remote_port_id', Permissions::portsForUser($user))
             ->orWhereIntegerInRaw('links.remote_device_id', Permissions::devicesForUser($user)));
+    }
+
+    protected static function deviceForeignKey(): string
+    {
+        return 'local_device_id';
     }
 
     // ---- Define Relationships ----

--- a/app/Models/Link.php
+++ b/app/Models/Link.php
@@ -34,11 +34,6 @@ class Link extends Model
             ->orWhereIntegerInRaw('links.remote_device_id', Permissions::devicesForUser($user)));
     }
 
-    protected static function deviceForeignKey(): string
-    {
-        return 'local_device_id';
-    }
-
     // ---- Define Relationships ----
     /**
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo<\App\Models\Device, $this>

--- a/app/Models/Processor.php
+++ b/app/Models/Processor.php
@@ -2,10 +2,12 @@
 
 namespace App\Models;
 
+use App\Models\Traits\DeletesDeviceOrphans;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 
 class Processor extends DeviceRelatedModel
 {
+    use DeletesDeviceOrphans;
     use HasFactory;
 
     public $timestamps = false;

--- a/app/Models/Processor.php
+++ b/app/Models/Processor.php
@@ -2,12 +2,10 @@
 
 namespace App\Models;
 
-use App\Models\Traits\DeletesDeviceOrphans;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 
 class Processor extends DeviceRelatedModel
 {
-    use DeletesDeviceOrphans;
     use HasFactory;
 
     public $timestamps = false;

--- a/app/Models/Traits/DeletesDeviceOrphans.php
+++ b/app/Models/Traits/DeletesDeviceOrphans.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models\Traits;
+
+use App\Models\Device;
+use Illuminate\Database\Eloquent\Collection;
+
+trait DeletesDeviceOrphans
+{
+    /**
+     * Delete rows whose device no longer exists. Selects ids first so the delete
+     * never joins devices: a delete that does takes shared locks across it and
+     * deadlocks against concurrent polls.
+     */
+    public static function deleteOrphans(): int
+    {
+        $key = (new static)->getKeyName();
+        $deleted = 0;
+
+        static::query()
+            ->select($key)
+            ->whereNotIn(static::deviceForeignKey(), Device::query()->select('device_id'))
+            ->chunkById(1000, function (Collection $rows) use ($key, &$deleted): void {
+                $deleted += static::query()->whereIntegerInRaw($key, $rows->pluck($key))->delete();
+            });
+
+        return $deleted;
+    }
+
+    protected static function deviceForeignKey(): string
+    {
+        return 'device_id';
+    }
+}

--- a/app/Models/Traits/DeletesDeviceOrphans.php
+++ b/app/Models/Traits/DeletesDeviceOrphans.php
@@ -4,9 +4,15 @@ namespace App\Models\Traits;
 
 use App\Models\Device;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 trait DeletesDeviceOrphans
 {
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo<\App\Models\Device, $this>
+     */
+    abstract public function device(): BelongsTo;
+
     /**
      * Delete rows whose device no longer exists. Selects ids first so the delete
      * never joins devices: a delete that does takes shared locks across it and
@@ -14,21 +20,17 @@ trait DeletesDeviceOrphans
      */
     public static function deleteOrphans(): int
     {
-        $key = (new static)->getKeyName();
+        $model = new static;
+        $key = $model->getKeyName();
         $deleted = 0;
 
         static::query()
             ->select($key)
-            ->whereNotIn(static::deviceForeignKey(), Device::query()->select('device_id'))
+            ->whereNotIn($model->device()->getForeignKeyName(), Device::query()->select('device_id'))
             ->chunkById(1000, function (Collection $rows) use ($key, &$deleted): void {
                 $deleted += static::query()->whereIntegerInRaw($key, $rows->pluck($key))->delete();
             });
 
         return $deleted;
-    }
-
-    protected static function deviceForeignKey(): string
-    {
-        return 'device_id';
     }
 }

--- a/app/Observers/DeviceObserver.php
+++ b/app/Observers/DeviceObserver.php
@@ -179,6 +179,8 @@ class DeviceObserver
         $device->ipv4()->delete();
         $device->ipv6()->delete();
         $device->isisAdjacencies()->delete();
+        $device->links()->delete();
+        $device->remoteLinks()->delete();
         $device->macs()->delete();
         $device->mefInfo()->delete();
         $device->mempools()->delete();

--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -571,7 +571,7 @@ foreach (dbFetchRows($sql, [$device['device_id']]) as $test) {
 }
 
 // remove orphaned links
-$deleted = Link::doesntHave('device')->delete();
+$deleted = Link::deleteOrphans();
 echo str_repeat('-', $deleted);
 d_echo(" $deleted orphaned links deleted\n");
 

--- a/tests/Feature/OrphanCleanupTest.php
+++ b/tests/Feature/OrphanCleanupTest.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace LibreNMS\Tests\Feature;
+
+use App\Models\Device;
+use App\Models\Link;
+use App\Models\Port;
+use App\Models\Processor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use LibreNMS\Tests\TestCase;
+
+class OrphanCleanupTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_deleting_a_device_deletes_its_local_links(): void
+    {
+        $device = Device::factory()->create();
+        $link = Link::factory()->create([
+            'local_device_id' => $device->device_id,
+            'local_port_id' => null,
+            'remote_device_id' => 0,
+        ]);
+
+        $device->delete();
+
+        $this->assertDatabaseMissing('links', ['id' => $link->id]);
+    }
+
+    public function test_deleting_a_device_deletes_links_pointing_at_it(): void
+    {
+        $local = Device::factory()->create();
+        $remote = Device::factory()->create();
+        $link = Link::factory()->create([
+            'local_device_id' => $local->device_id,
+            'local_port_id' => null,
+            'remote_device_id' => $remote->device_id,
+        ]);
+
+        $remote->delete();
+
+        $this->assertDatabaseMissing('links', ['id' => $link->id]);
+    }
+
+    public function test_deleting_a_device_leaves_unrelated_links_alone(): void
+    {
+        $device = Device::factory()->create();
+        $other = Device::factory()->create();
+        $keep = Link::factory()->create([
+            'local_device_id' => $other->device_id,
+            'local_port_id' => null,
+            'remote_device_id' => 0,
+        ]);
+
+        $device->delete();
+
+        $this->assertDatabaseHas('links', ['id' => $keep->id]);
+    }
+
+    public function test_deleting_a_port_still_deletes_its_links(): void
+    {
+        $device = Device::factory()->create();
+        $port = Port::factory()->create(['device_id' => $device->device_id]);
+        $link = Link::factory()->create([
+            'local_device_id' => $device->device_id,
+            'local_port_id' => $port->port_id,
+            'remote_device_id' => 0,
+        ]);
+
+        $port->delete();
+
+        $this->assertDatabaseMissing('links', ['id' => $link->id]);
+    }
+
+    public function test_orphan_cleanup_does_not_read_the_devices_table(): void
+    {
+        Link::factory()->create([
+            'local_device_id' => 99999,
+            'local_port_id' => null,
+            'remote_device_id' => 0,
+        ]);
+
+        $queries = [];
+        DB::listen(function ($query) use (&$queries): void {
+            $queries[] = $query->sql;
+        });
+
+        Link::deleteOrphans();
+
+        $deletes = array_values(array_filter($queries, fn ($sql) => str_starts_with(strtolower(ltrim($sql)), 'delete')));
+
+        $this->assertNotEmpty($deletes, 'expected a delete statement');
+        foreach ($deletes as $sql) {
+            $this->assertStringNotContainsString('devices', $sql, "delete statement must not lock devices: $sql");
+        }
+    }
+
+    public function test_orphan_cleanup_removes_links_whose_device_is_gone(): void
+    {
+        $link = Link::factory()->create([
+            'local_device_id' => 99999,
+            'local_port_id' => null,
+            'remote_device_id' => 0,
+        ]);
+
+        Link::deleteOrphans();
+
+        $this->assertDatabaseMissing('links', ['id' => $link->id]);
+    }
+
+    public function test_orphan_cleanup_keeps_links_whose_device_exists(): void
+    {
+        $device = Device::factory()->create();
+        $link = Link::factory()->create([
+            'local_device_id' => $device->device_id,
+            'local_port_id' => null,
+            'remote_device_id' => 0,
+        ]);
+
+        Link::deleteOrphans();
+
+        $this->assertDatabaseHas('links', ['id' => $link->id]);
+    }
+
+    public function test_processor_orphan_cleanup_does_not_read_the_devices_table(): void
+    {
+        Processor::factory()->create(['device_id' => 99999]);
+
+        $queries = [];
+        DB::listen(function ($query) use (&$queries): void {
+            $queries[] = $query->sql;
+        });
+
+        Processor::deleteOrphans();
+
+        $deletes = array_values(array_filter($queries, fn ($sql) => str_starts_with(strtolower(ltrim($sql)), 'delete')));
+
+        $this->assertNotEmpty($deletes, 'expected a delete statement');
+        foreach ($deletes as $sql) {
+            $this->assertStringNotContainsString('devices', $sql, "delete statement must not lock devices: $sql");
+        }
+    }
+
+    public function test_processor_orphan_cleanup_removes_rows_whose_device_is_gone(): void
+    {
+        $orphan = Processor::factory()->create(['device_id' => 99999]);
+        $kept = Processor::factory()->create();
+
+        Processor::deleteOrphans();
+
+        $this->assertDatabaseMissing('processors', ['processor_id' => $orphan->processor_id]);
+        $this->assertDatabaseHas('processors', ['processor_id' => $kept->processor_id]);
+    }
+}

--- a/tests/Feature/OrphanCleanupTest.php
+++ b/tests/Feature/OrphanCleanupTest.php
@@ -4,6 +4,7 @@ namespace LibreNMS\Tests\Feature;
 
 use App\Models\Device;
 use App\Models\Link;
+use App\Models\Mempool;
 use App\Models\Port;
 use App\Models\Processor;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -151,5 +152,35 @@ class OrphanCleanupTest extends TestCase
 
         $this->assertDatabaseMissing('processors', ['processor_id' => $orphan->processor_id]);
         $this->assertDatabaseHas('processors', ['processor_id' => $kept->processor_id]);
+    }
+
+    public function test_a_device_related_model_sweeps_orphans_without_declaring_the_trait(): void
+    {
+        $orphan = Mempool::factory()->create(['device_id' => 99999]);
+        $kept = Mempool::factory()->create();
+
+        Mempool::deleteOrphans();
+
+        $this->assertDatabaseMissing('mempools', ['mempool_id' => $orphan->mempool_id]);
+        $this->assertDatabaseHas('mempools', ['mempool_id' => $kept->mempool_id]);
+    }
+
+    public function test_a_device_related_model_orphan_cleanup_does_not_read_the_devices_table(): void
+    {
+        Mempool::factory()->create(['device_id' => 99999]);
+
+        $queries = [];
+        DB::listen(function ($query) use (&$queries): void {
+            $queries[] = $query->sql;
+        });
+
+        Mempool::deleteOrphans();
+
+        $deletes = array_values(array_filter($queries, fn ($sql) => str_starts_with(strtolower(ltrim($sql)), 'delete')));
+
+        $this->assertNotEmpty($deletes, 'expected a delete statement');
+        foreach ($deletes as $sql) {
+            $this->assertStringNotContainsString('devices', $sql, "delete statement must not lock devices: $sql");
+        }
     }
 }


### PR DESCRIPTION

When tracking down persistent "Error polling core module: QueryException" we identified that the clean up code for removing links without devices locks the device table whilst running for all devices.

doesntHave('device')->delete() compiles to a correlated NOT EXISTS, which takes shared locks on every devices row it examines while deleting from the child table. 

This deadlocks against a poll's single row update of devices.uptime, and the poll always loses: InnoDB rolls back the transaction that did the least work.

The cost does not depend on how many rows are deleted. Measured on a 3000 device, 35000 link fixture with no orphans at all, the delete still took 3007 shared locks on devices. Selecting the ids first and then deleting by primary key takes none, and locks only the rows it actually removes.

Also delete a device's links when it is deleted. 

Ports already clean up their own links, but links with a null local_port_id survived. 

This reduces the orphans, it does not avoid the locking, since links has no foreign key and other paths can leave rows behind.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [✅] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [✅] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
