### PR TITLE
Added os/php/lnms version info to pollers

### DIFF
--- a/LibreNMS/__init__.py
+++ b/LibreNMS/__init__.py
@@ -181,6 +181,65 @@ def get_config_data(base_dir):
         return None
 
 
+# Poller detail functions ##################################################
+# Collect some information about the host this poller runs on.  This must never
+# interrupt a poller/discovery run, so anything that cannot be determined is
+# simply left out.
+
+# section/entry of `lnms about` holding each detail.  About sections are snake
+# cased in the json output, which turns "LibreNMS" into "libre_n_m_s".
+POLLER_DETAILS = (
+    ("os_version", "environment", "os"),
+    ("php_version", "environment", "php_version"),
+    ("librenms_version", "libre_n_m_s", "version"),
+)
+
+
+def get_poller_details():
+    """
+    Collect details about the environment this poller runs in.
+
+    Uses `lnms about` so the values come from the same code the web ui uses instead
+    of being reimplemented here.  Never raises.
+    :returns dict
+    """
+    details = {}
+
+    try:
+        base_dir = os.path.realpath(os.path.dirname(__file__) + "/..")
+        about_cmd = ["/usr/bin/env", "php", "%s/lnms" % base_dir, "about", "--json"]
+        exit_code, output = command_runner(about_cmd, timeout=300, stderr=False)
+        if exit_code != 0:
+            logger.debug("Command [%s] returned %s", about_cmd, exit_code)
+            return details
+
+        about = json.loads(output)
+
+        for key, section, entry in POLLER_DETAILS:
+            value = about.get(section, {}).get(entry)
+            if value:
+                details[key] = value
+    except Exception:
+        logger.debug("Could not collect poller details", exc_info=True)
+
+    return details
+
+
+def get_poller_details_json():
+    """
+    get_poller_details() encoded as json, or None if nothing could be collected.
+    :returns str | None
+    """
+    try:
+        details = get_poller_details()
+        if details:
+            return json.dumps(details)
+    except Exception:
+        logger.debug("Could not encode poller details", exc_info=True)
+
+    return None
+
+
 def normalize_wait(seconds):
     return ceil(seconds - (time() % seconds))
 

--- a/LibreNMS/service.py
+++ b/LibreNMS/service.py
@@ -39,6 +39,9 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
+# how often to re-collect the poller details reported to poller_cluster (6 hours)
+POLLER_DETAILS_REFRESH = 21600
+
 
 class LogOutput(Enum):
     NONE = "none"
@@ -431,6 +434,8 @@ class Service:
             10, self.systemd_watchdog, "systemd-watchdog"
         )
         self.is_master = False
+        self._poller_details = None
+        self._poller_details_time = 0
 
     def service_age(self):
         return time.time() - self.start_time
@@ -903,6 +908,16 @@ class Service:
                 )
             )
 
+            try:
+                poller_details = self.get_poller_details()
+                if poller_details is not None:
+                    self._db.query(
+                        "UPDATE `poller_cluster` SET `poller_details`=%s WHERE `node_id`=%s",
+                        (poller_details, self.config.node_id),
+                    )
+            except Exception:
+                logger.warning("Could not record poller details", exc_info=True)
+
             # Find our ID
             self._db.query(
                 'SELECT id INTO @parent_poller_id FROM poller_cluster WHERE node_id="{0}"; '.format(
@@ -936,6 +951,14 @@ class Service:
                 "Unable to log performance statistics - is the database still online?",
                 exc_info=True,
             )
+
+    def get_poller_details(self):
+        now = time.time()
+        if now - self._poller_details_time > POLLER_DETAILS_REFRESH:
+            self._poller_details = LibreNMS.get_poller_details_json()
+            self._poller_details_time = now
+
+        return self._poller_details
 
     def systemd_watchdog(self):
         if self.config.health_file:

--- a/LibreNMS/service.py
+++ b/LibreNMS/service.py
@@ -434,7 +434,6 @@ class Service:
             10, self.systemd_watchdog, "systemd-watchdog"
         )
         self.is_master = False
-        self._poller_details = None
         self._poller_details_time = 0
 
     def service_age(self):
@@ -909,7 +908,7 @@ class Service:
             )
 
             try:
-                poller_details = self.get_poller_details()
+                poller_details = self.get_poller_details_due()
                 if poller_details is not None:
                     self._db.query(
                         "UPDATE `poller_cluster` SET `poller_details`=%s WHERE `node_id`=%s",
@@ -952,13 +951,13 @@ class Service:
                 exc_info=True,
             )
 
-    def get_poller_details(self):
+    def get_poller_details_due(self):
         now = time.time()
         if now - self._poller_details_time > POLLER_DETAILS_REFRESH:
-            self._poller_details = LibreNMS.get_poller_details_json()
             self._poller_details_time = now
+            return LibreNMS.get_poller_details_json()
 
-        return self._poller_details
+        return None
 
     def systemd_watchdog(self):
         if self.config.health_file:

--- a/LibreNMS/wrapper.py
+++ b/LibreNMS/wrapper.py
@@ -579,6 +579,18 @@ def wrapper(
             )
             db_connection.query(query)
 
+    if wrapper_type == "discovery":
+        try:
+            poller_details = LibreNMS.get_poller_details_json()
+            if poller_details is not None:
+                db_connection.query(
+                    "UPDATE pollers SET poller_details=%s WHERE poller_name=%s",
+                    (poller_details, config["distributed_poller_name"]),
+                )
+        except Exception:
+            logger.warning("Could not record poller details")
+            logger.debug("Traceback:", exc_info=True)
+
     db_connection.close()
 
     if total_time > wrappers[wrapper_type]["total_exec_time"]:

--- a/app/Models/Poller.php
+++ b/app/Models/Poller.php
@@ -35,6 +35,16 @@ class Poller extends Model
     protected $primaryKey = 'id';
     protected $fillable = ['poller_name'];
 
+    /**
+     * @return array{poller_details: 'array'}
+     */
+    protected function casts(): array
+    {
+        return [
+            'poller_details' => 'array',
+        ];
+    }
+
     // ---- Scopes ----
 
     protected function scopeIsInactive(Builder $query): Builder

--- a/app/Models/PollerCluster.php
+++ b/app/Models/PollerCluster.php
@@ -42,12 +42,13 @@ class PollerCluster extends Model
     protected $fillable = ['poller_name'];
 
     /**
-     * @return array{last_report: 'datetime'}
+     * @return array{last_report: 'datetime', poller_details: 'array'}
      */
     protected function casts(): array
     {
         return [
             'last_report' => 'datetime',
+            'poller_details' => 'array',
         ];
     }
 

--- a/database/migrations/2026_08_31_171758_add_poller_details.php
+++ b/database/migrations/2026_08_31_171758_add_poller_details.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up(): void
+    {
+        Schema::table('pollers', function (Blueprint $table) {
+            $table->longText('poller_details')->nullable()->after('time_taken');
+        });
+
+        Schema::table('poller_cluster', function (Blueprint $table) {
+            $table->longText('poller_details')->nullable()->after('poller_version');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down(): void
+    {
+        Schema::table('pollers', function (Blueprint $table) {
+            $table->dropColumn('poller_details');
+        });
+
+        Schema::table('poller_cluster', function (Blueprint $table) {
+            $table->dropColumn('poller_details');
+        });
+    }
+};

--- a/resources/definitions/schema/db_schema.yaml
+++ b/resources/definitions/schema/db_schema.yaml
@@ -1682,6 +1682,7 @@ pollers:
     - { Field: last_polled, Type: datetime, 'Null': false, Extra: '' }
     - { Field: devices, Type: 'int unsigned', 'Null': false, Extra: '' }
     - { Field: time_taken, Type: double, 'Null': false, Extra: '' }
+    - { Field: poller_details, Type: longtext, 'Null': true, Extra: '' }
   Indexes:
     PRIMARY: { Name: PRIMARY, Columns: [id], Unique: true, Type: BTREE }
     pollers_poller_name_unique: { Name: pollers_poller_name_unique, Columns: [poller_name], Unique: true, Type: BTREE }
@@ -1691,6 +1692,7 @@ poller_cluster:
     - { Field: node_id, Type: varchar(255), 'Null': false, Extra: '' }
     - { Field: poller_name, Type: varchar(255), 'Null': false, Extra: '' }
     - { Field: poller_version, Type: varchar(255), 'Null': false, Extra: '', Default: '' }
+    - { Field: poller_details, Type: longtext, 'Null': true, Extra: '' }
     - { Field: poller_groups, Type: varchar(255), 'Null': false, Extra: '', Default: '' }
     - { Field: last_report, Type: datetime, 'Null': false, Extra: '' }
     - { Field: master, Type: tinyint, 'Null': false, Extra: '' }


### PR DESCRIPTION
Have discovery-wrapper.py and librenms-service.py collect and store OS, PHP and LibreNMS version info for each poller.

Will do a part 2 PR with WebUI changes.

```
poller_details: {"os_version": "Ubuntu 24.04", "php_version": "8.5.8", "librenms_version": "26.9.1-dev.57+c9ea80f643"}
```

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
