### PR TITLE
fix(hp): add missing hotSpare state to cpqDaPhyDrvStatus mapping

### DIFF
--- a/includes/discovery/sensors/state/hp.inc.php
+++ b/includes/discovery/sensors/state/hp.inc.php
@@ -38,6 +38,8 @@ $tables = [
         ['value' => 7, 'generic' => 1, 'descr' => 'eraseQueued'],
         ['value' => 8, 'generic' => 2, 'descr' => 'ssdWearOut'],
         ['value' => 9, 'generic' => 3, 'descr' => 'notAuthenticated'],
+        // value 10 (hotSpare) is not in the bundled MIB but is emitted by Gen10 firmware (observed on DL360 Gen10)
+        ['value' => 10, 'generic' => 0, 'descr' => 'hotSpare'],
     ]],
     ['cpqDaPhyDrvSmartStatus', '.1.3.6.1.4.1.232.3.2.5.1.1.57.', 'S.M.A.R.T.', 'CPQIDA-MIB', [
         ['value' => 1, 'generic' => 3, 'descr' => 'other'],

--- a/includes/discovery/sensors/state/hp.inc.php
+++ b/includes/discovery/sensors/state/hp.inc.php
@@ -38,7 +38,6 @@ $tables = [
         ['value' => 7, 'generic' => 1, 'descr' => 'eraseQueued'],
         ['value' => 8, 'generic' => 2, 'descr' => 'ssdWearOut'],
         ['value' => 9, 'generic' => 3, 'descr' => 'notAuthenticated'],
-        // value 10 (hotSpare) is not in the bundled MIB but is emitted by Gen10 firmware (observed on DL360 Gen10)
         ['value' => 10, 'generic' => 0, 'descr' => 'hotSpare'],
     ]],
     ['cpqDaPhyDrvSmartStatus', '.1.3.6.1.4.1.232.3.2.5.1.1.57.', 'S.M.A.R.T.', 'CPQIDA-MIB', [

--- a/tests/Unit/HpSensorStateTest.php
+++ b/tests/Unit/HpSensorStateTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace LibreNMS\Tests\Unit;
+
+use LibreNMS\Tests\TestCase;
+
+class HpSensorStateTest extends TestCase
+{
+    /**
+     * @return array<int, array{0: string, 1: string, 2: string, 3: string, 4: array<int, array{value: int, generic: int, descr: string}>}>
+     */
+    private function loadTables(): array
+    {
+        $file = base_path('includes/discovery/sensors/state/hp.inc.php');
+        $source = file_get_contents($file);
+        $this->assertNotFalse($source, "Could not read $file");
+
+        // Extract just the $tables = [ ... ]; array literal via the real
+        // tokenizer (not a hand-copied literal) -- the rest of the file
+        // walks real SNMP data against a live $device, which this test
+        // has no need to set up.
+        $tokens = token_get_all("<?php\n" . $source);
+
+        $start = null;
+        $depth = 0;
+        $end = null;
+        foreach ($tokens as $i => $token) {
+            if ($start === null) {
+                if (is_array($token) && $token[0] === T_VARIABLE && $token[1] === '$tables') {
+                    $start = $i;
+                }
+
+                continue;
+            }
+
+            $text = is_array($token) ? $token[1] : $token;
+            if ($text === '[') {
+                $depth++;
+            } elseif ($text === ']') {
+                $depth--;
+            } elseif ($text === ';' && $depth === 0) {
+                $end = $i;
+                break;
+            }
+        }
+
+        $this->assertNotNull($start, 'Could not find $tables declaration in hp.inc.php');
+        $this->assertNotNull($end, 'Could not find end of $tables declaration in hp.inc.php');
+
+        $statement = '';
+        for ($i = $start; $i <= $end; $i++) {
+            $statement .= is_array($tokens[$i]) ? $tokens[$i][1] : $tokens[$i];
+        }
+
+        $tmpFile = tempnam(sys_get_temp_dir(), 'hp_tables_');
+        file_put_contents($tmpFile, "<?php\n$statement\nreturn \$tables;\n");
+
+        try {
+            $tables = include $tmpFile;
+        } finally {
+            unlink($tmpFile);
+        }
+
+        $this->assertIsArray($tables);
+
+        return $tables;
+    }
+
+    public function testCpqDaPhyDrvStatusHotSpareMapsToOkGeneric(): void
+    {
+        $tables = $this->loadTables();
+
+        $cpqDaPhyDrvStatus = null;
+        foreach ($tables as $table) {
+            if ($table[0] === 'cpqDaPhyDrvStatus') {
+                $cpqDaPhyDrvStatus = $table[4];
+                break;
+            }
+        }
+        $this->assertNotNull($cpqDaPhyDrvStatus, 'cpqDaPhyDrvStatus table not found in hp.inc.php');
+
+        $hotSpare = null;
+        foreach ($cpqDaPhyDrvStatus as $state) {
+            if ($state['value'] === 10) {
+                $hotSpare = $state;
+                break;
+            }
+        }
+
+        $this->assertNotNull($hotSpare, 'value 10 (hotSpare) not found in cpqDaPhyDrvStatus mapping');
+        $this->assertSame('hotSpare', $hotSpare['descr']);
+        $this->assertSame(0, $hotSpare['generic']);
+    }
+}


### PR DESCRIPTION
Value `10` (`hotSpare`) isn't in the bundled `CPQIDA-MIB` (which stops at `notAuthenticated`=9), but is emitted by Gen10 firmware -- observed directly on a real DL360 Gen10, and independently reported by other users hitting the same gap: [HPE's own community forum](https://community.hpe.com/t5/servers-general/firmware-3-06-and-drive-oids/td-p/7225070) (HPE support confirming the bundled MIB was outdated relative to newer firmware) and the [`check_hp` Icinga plugin's changelog](https://exchange.icinga.com/gunny/check_hp/releases) reporting the same undocumented status independently. Maps to `generic=0` (OK); a standby spare drive is a healthy state, not a fault.

One honest note: I couldn't add a test fixture confirming this specific mapping end-to-end -- found along the way that `cpqDaPhyDrvStatus`/`cpqDaPhyDrvSmartStatus` don't currently produce any discovered sensors against the existing test fixtures at all, real recorded data notwithstanding. That looks like a separate, pre-existing bug in the discovery path unrelated to this change, not something this PR causes or fixes -- happy to dig into that separately if useful, but didn't want to hold up a one-line mapping fix chasing an unrelated issue.

Developed with Claude's assistance; I've reviewed and take responsibility for the change.