### PR TITLE
Fix notifications page showing 0 unread count for users with no read …

### DIFF
--- a/includes/html/pages/notifications.inc.php
+++ b/includes/html/pages/notifications.inc.php
@@ -25,7 +25,7 @@ use App\Models\User;
 use Illuminate\Support\Facades\Gate;
 use LibreNMS\ObjectCache;
 
-$total = Auth::user()->notifications()->count();
+$total = \App\Models\Notification::isUnread(Auth::user())->count();
 
 ?>
 <div class="container">


### PR DESCRIPTION
The page header's unread count uses `Auth::user()->notifications()->count()`, which only returns rows the user has already written a `notifications_attribs` entry for (a read/sticky flag). A user who's never marked anything read gets `0` there regardless of how many notifications are actually unread -- even though the bell badge and the page's own inner list both show the real count correctly.

This same variable also gates whether the "Mark all as Read" button renders at all, so a fresh admin with genuinely unread notifications sees no bulk-clear option and has to click through them one at a time.

Fixed by using the same `Notification::isUnread()` scope the bell badge's own query already relies on -- one shared source of truth instead of two paths that happened to agree everywhere except this one case.

Verified against a real internal instance at the query/logic level: old query returned 0 against 54 real unread notifications, the fix returns 54 matching both the bell badge and the raw table count. Exercised the actual mark-all-read logic end to end and confirmed it correctly clears to 0.

Developed with Claude's assistance; I've reviewed and take responsibility for the change.