### PR TITLE
Restore missing SQL statements from debug output

### DIFF
--- a/app/Http/Controllers/Device/Debug/DebugPollAndDiscoveryController.php
+++ b/app/Http/Controllers/Device/Debug/DebugPollAndDiscoveryController.php
@@ -29,6 +29,7 @@ namespace App\Http\Controllers\Device\Debug;
 use App\Http\Controllers\Controller;
 use App\Http\Controllers\Traits\StreamsOutputToBrowser;
 use App\Models\Device;
+use LibreNMS\Util\Debug;
 use Illuminate\Console\Events\CommandStarting;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Artisan;
@@ -49,6 +50,7 @@ class DebugPollAndDiscoveryController extends Controller
             'type' => ['required', Rule::in(['poller', 'discovery'])],
         ]);
 
+        Debug::enableQueryDebug();
         if ($validated['format'] == 'download') {
             $this->enableDownload($validated['type'] . '-' . $device->hostname . '.txt');
         }

--- a/app/Http/Controllers/Device/Debug/DebugPollAndDiscoveryController.php
+++ b/app/Http/Controllers/Device/Debug/DebugPollAndDiscoveryController.php
@@ -29,12 +29,12 @@ namespace App\Http\Controllers\Device\Debug;
 use App\Http\Controllers\Controller;
 use App\Http\Controllers\Traits\StreamsOutputToBrowser;
 use App\Models\Device;
-use LibreNMS\Util\Debug;
 use Illuminate\Console\Events\CommandStarting;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Validation\Rule;
+use LibreNMS\Util\Debug;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class DebugPollAndDiscoveryController extends Controller


### PR DESCRIPTION
The lnms command line includes SQL statements when -vv is specified.  This PR restores this in the new web based debug output.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
