### PR TITLE
fix: resolve composer.plugins.json against the install dir, not the cwd

### DIFF
--- a/LibreNMS/ComposerHelper.php
+++ b/LibreNMS/ComposerHelper.php
@@ -98,8 +98,16 @@ class ComposerHelper
 
     public static function getPlugins(): array
     {
-        $plugins = is_file('composer.plugins.json') ?
-            json_decode(file_get_contents('composer.plugins.json'), true) : [];
+        // Resolved against the install directory, not the working directory:
+        // this is also reached from the web UI (Validations\Updates), where the
+        // working directory is the document root. base_path() is deliberately
+        // not used -- this class is registered as a Composer script handler,
+        // and Composer's script autoloader registers psr-0/psr-4/classmap only,
+        // so Laravel's function helpers do not exist during those events.
+        $file = realpath(__DIR__ . '/..') . '/composer.plugins.json';
+
+        $plugins = is_file($file) && is_readable($file) ?
+            json_decode((string) file_get_contents($file), true) : [];
 
         return $plugins['require'] ?? [];
     }

--- a/LibreNMS/ComposerHelper.php
+++ b/LibreNMS/ComposerHelper.php
@@ -98,12 +98,8 @@ class ComposerHelper
 
     public static function getPlugins(): array
     {
-        // Resolved against the install directory, not the working directory:
-        // this is also reached from the web UI (Validations\Updates), where the
-        // working directory is the document root. base_path() is deliberately
-        // not used -- this class is registered as a Composer script handler,
-        // and Composer's script autoloader registers psr-0/psr-4/classmap only,
-        // so Laravel's function helpers do not exist during those events.
+        // Not cwd-relative: also reached from the web UI, where cwd is the
+        // document root. Not base_path(): this class runs as a composer script.
         $file = realpath(__DIR__ . '/..') . '/composer.plugins.json';
 
         $plugins = is_file($file) && is_readable($file) ?

--- a/LibreNMS/Validations/Updates.php
+++ b/LibreNMS/Validations/Updates.php
@@ -109,7 +109,7 @@ class Updates extends BaseValidation
         // TODO check update channel stable version
 
         // check for modified files
-        $modifiedcmd = 'git diff --name-only --exit-code';
+        $modifiedcmd = 'git -C ' . escapeshellarg($validator->getBaseDir()) . ' diff --name-only --exit-code';
         $validator->execAsUser($modifiedcmd, $cmdoutput, $code);
         if ($code !== 0 && ! empty($cmdoutput)) {
             // Check so it's not only plugins that "pests" the diff

--- a/daily.php
+++ b/daily.php
@@ -25,10 +25,8 @@ $options['f'] = isset($options['f']) ? $options['f'] : '';
 if ($options['f'] === 'composer_get_plugins') {
     $output = [];
 
-    $file = __DIR__ . '/composer.plugins.json';
-
-    $plugins = is_file($file) && is_readable($file) ?
-        json_decode((string) file_get_contents($file)) : [];
+    $plugins = is_file('composer.plugins.json') ?
+        json_decode(file_get_contents('composer.plugins.json')) : [];
 
     foreach ($plugins->require ?? [] as $package => $version) {
         $output[] = "$package:$version";

--- a/daily.php
+++ b/daily.php
@@ -25,8 +25,10 @@ $options['f'] = isset($options['f']) ? $options['f'] : '';
 if ($options['f'] === 'composer_get_plugins') {
     $output = [];
 
-    $plugins = is_file('composer.plugins.json') ?
-        json_decode(file_get_contents('composer.plugins.json')) : [];
+    $file = __DIR__ . '/composer.plugins.json';
+
+    $plugins = is_file($file) && is_readable($file) ?
+        json_decode((string) file_get_contents($file)) : [];
 
     foreach ($plugins->require ?? [] as $package => $version) {
         $output[] = "$package:$version";

--- a/tests/Unit/ComposerHelperTest.php
+++ b/tests/Unit/ComposerHelperTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * ComposerHelperTest.php
+ *
+ * -Description-
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @package    LibreNMS
+ * @link       http://librenms.org
+ * @copyright  2026 Lee Clements
+ * @author     Lee Clements <lee.clements@adaptivedatanetworks.com>
+ */
+
+namespace LibreNMS\Tests\Unit;
+
+use LibreNMS\ComposerHelper;
+use LibreNMS\Tests\TestCase;
+
+final class ComposerHelperTest extends TestCase
+{
+    /**
+     * getPlugins() is reached from Validations\Updates, which runs in the web UI
+     * as well as from validate.php. Only validate.php pins the working directory
+     * (validate.php: chdir(__DIR__)), so a working-directory-relative read
+     * returns nothing under php-fpm -- and the modified-files exemption for
+     * composer.json/composer.lock silently stops applying.
+     */
+    public function testGetPluginsIsIndependentOfTheWorkingDirectory(): void
+    {
+        $previous = getcwd();
+
+        // Establish the expected answer from the install directory itself.
+        chdir(base_path());
+        $expected = ComposerHelper::getPlugins();
+
+        $decoy = sys_get_temp_dir() . '/librenms-composer-plugins-' . getmypid();
+        @mkdir($decoy, 0755, true);
+        file_put_contents(
+            $decoy . '/composer.plugins.json',
+            '{"require":{"decoy/decoy":"^1.0"}}'
+        );
+
+        try {
+            chdir($decoy);
+
+            $this->assertSame(
+                $expected,
+                ComposerHelper::getPlugins(),
+                'getPlugins() must resolve composer.plugins.json against the install directory'
+            );
+            $this->assertArrayNotHasKey(
+                'decoy/decoy',
+                ComposerHelper::getPlugins(),
+                'getPlugins() must not read a composer.plugins.json from the working directory'
+            );
+        } finally {
+            if ($previous !== false) {
+                chdir($previous);
+            }
+            @unlink($decoy . '/composer.plugins.json');
+            @rmdir($decoy);
+        }
+    }
+}


### PR DESCRIPTION
`./validate.php` is clean, but **Settings → Validate in the web UI** reports, permanently, on any install that has a composer plugin:

```
Your local git contains modified files, this could prevent automatic updates.
Modified Files: composer.json, composer.lock
```

Those two files being modified is the expected steady state after `lnms plugin:add` (`ComposerHelper::addPackage()` runs `require --update-no-dev` against the main manifest), and `Validations\Updates` already has an exemption for exactly that case, added in fdebee86 with the comment *"Check so it's not only plugins that 'pests' the diff"*:

```php
if (! ($cmdoutput === ['composer.json', 'composer.lock'] && ComposerHelper::getPlugins())) {
```

The exemption just never fires over php-fpm, because `getPlugins()` resolves its file relative to the working directory:

```php
$plugins = is_file('composer.plugins.json') ?
    json_decode(file_get_contents('composer.plugins.json'), true) : [];
```

`validate.php` does `chdir(__DIR__)` before validating. `ValidateController::runValidation()` does not, and the document root is `<install>/html`, so on the web path `getPlugins()` returns `[]`, the exemption evaluates falsy, and the warning is shown.

### Reproduction

Calling `getPlugins()` through the repo's own autoloader, varying **only** the working directory:

| cwd | before | after |
|---|---|---|
| install root — what `validate.php` uses | `{"vendor/plugin":"^1.0"}` | `{"vendor/plugin":"^1.0"}` |
| `<install>/html` — the document root | `[]` ← exemption fails | `{"vendor/plugin":"^1.0"}` |
| an unrelated dir holding its own `composer.plugins.json` | `{"someone/else":"^9.9"}` ← reads the wrong file | `{"vendor/plugin":"^1.0"}` |

The third row is worth noting on its own: the current code reads whatever `composer.plugins.json` happens to sit in the working directory.

### Changes

**1. `ComposerHelper::getPlugins()`** — anchor the path to the install directory.

`base_path()` is deliberately *not* used here. This class is registered as a Composer script handler (`pre-install-cmd`, `post-install-cmd`, `pre-update-cmd`, `post-root-package-install`), and Composer's script autoloader (`AutoloadGenerator::createLoader`) registers psr-0/psr-4/classmap only — never the `files` autoload that defines Laravel's function helpers. `realpath(__DIR__ . '/..')` matches `Validator::getBaseDir()` and `scripts/composer_wrapper.php`, and is the same idiom already used elsewhere in this file. The read is also guarded, since it can now actually resolve on the web path and an unreadable file would otherwise become an `ErrorException` and 500 the validate page.

**2. `daily.php`** — the identical relative read of the same file, which works today only because `daily.sh` cd's first. It runs before `includes/init.php`, so it stays Laravel-free and anchors on `__DIR__` (the file is at the repo root, not one below it).

**3. `Validations/Updates.php`** — pin the git call to the repo root with `git -C`.

This is the other half of the same defect: `Validator::execAsUser()` passes no working directory, so from outside the repo `git diff --name-only --exit-code` exits 129 with empty stdout, and with `diff.relative=true` it returns no paths and exit 0. Either way `if ($code !== 0 && ! empty($cmdoutput))` skips the entire modified-files check without saying so. Without this, the fix above only helps when php-fpm's cwd happens to be inside the repo. `execAsUser()` itself is left alone — `Validations/Programs.php` shares it — and `escapeshellarg`'s single quotes survive the `su … -c "…"` wrapper.

Happy to split #3 into its own PR if you'd rather keep this to the one bug.

### Tests

`tests/Unit/ComposerHelperTest.php` chdir's to a temp directory holding a decoy `composer.plugins.json` and asserts `getPlugins()` ignores it. It fails on current master (returns `decoy/decoy`) and passes with this change. It writes nothing into the install tree, and restores the working directory in a `finally`.

Checks run locally: `pint` (passed), `phpstan` at the repo level 5 on the modified files (no errors), `phpstan -l 6` on the new file — matching what `test:types-new` does for added files (no errors), and `phpunit` (`+1 test, +2 assertions`, no new failures; `rector --dry-run` reports the same pre-existing `daily.php:17` hit with and without this patch). `./lnms dev:check` itself could not be run in my environment, so those were run individually.

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it. — no UI code is touched; the effect is that one warning row stops appearing on Settings → Validate. The reproduction table above is the deterministic equivalent, and I can add a screenshot if you'd like one.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/). — n/a

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
