### PR TITLE
Fix snmp overwrite_ip

### DIFF
--- a/LibreNMS/Data/Source/Snmp/NetSnmp.php
+++ b/LibreNMS/Data/Source/Snmp/NetSnmp.php
@@ -34,7 +34,6 @@ use LibreNMS\Exceptions\SnmpException;
 use LibreNMS\Exceptions\SnmpVersionUnsupportedException;
 use LibreNMS\Polling\Method\Config\SnmpConfig;
 use LibreNMS\Util\Oid;
-use LibreNMS\Util\Rewrite;
 use Symfony\Component\Process\Process;
 
 class NetSnmp implements SnmpBackendInterface, SnmpTranslatorInterface
@@ -120,10 +119,7 @@ class NetSnmp implements SnmpBackendInterface, SnmpTranslatorInterface
             array_push($cmd, '-r', (string) $config->retries);
         }
 
-        $hostname = Rewrite::addIpv6Brackets($config->target);
-        $cmd[] = "$config->transport:$hostname:$config->port";
-
-        return [...$cmd, ...$oids];
+        return [...$cmd, $config->formattedTarget(), ...$oids];
     }
 
     /**

--- a/LibreNMS/Polling/Method/Config/SnmpConfig.php
+++ b/LibreNMS/Polling/Method/Config/SnmpConfig.php
@@ -28,6 +28,7 @@ namespace LibreNMS\Polling\Method\Config;
 
 use App\Facades\LibrenmsConfig;
 use App\Models\Device;
+use LibreNMS\Util\Rewrite;
 
 final readonly class SnmpConfig
 {
@@ -56,6 +57,20 @@ final readonly class SnmpConfig
     ) {
     }
 
+    public function formattedTarget(bool $withTransport = true): string
+    {
+        $parts = [];
+
+        if ($withTransport) {
+            $parts[] = $this->transport;
+        }
+
+        $parts[] = Rewrite::addIpv6Brackets($this->target);
+        $parts[] = $this->port;
+
+        return implode(':', $parts);
+    }
+
     public static function fromDevice(Device $device): self
     {
         $timeout = (float) ($device->timeout > 0 ? $device->timeout : LibrenmsConfig::get('snmp.timeout', 1));
@@ -65,7 +80,7 @@ final readonly class SnmpConfig
         $rawBulk = $device->getAttrib('snmp_bulk') ?? LibrenmsConfig::getOsSetting($device->os, 'snmp_bulk', LibrenmsConfig::get('snmp_bulk', true));
 
         return new self(
-            target: $device->hostname,
+            target: $device->overwrite_ip ?: $device->hostname,
             version: $device->snmpver ?? 'v2c',
             community: $device->community,
             authname: $device->authname,


### PR DESCRIPTION
It is deprecated, but not removed yet.  If you are using this, you don't need to. Just set the device to use the IP and set the display name. If you are polling multiple things through the same IP, just use host alias.

fixes #20470 

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
