### PR TITLE
Fix config key name and clean up malformed example JSON in VisJS docs

### DIFF
--- a/doc/Extensions/VisJS-Config.md
+++ b/doc/Extensions/VisJS-Config.md
@@ -96,7 +96,7 @@ An example to override the device dependency map to use a hierarchical layout is
 Note that you can choose to enter the JSON config on one line if you want.
 
 ```bash
-lnms config:set network_map_devicedependency_vis_options '{ layout:{ hierarchical: { enabled: true, direction: "LR", sortMethod: "directed", nodeSpacing: 50, treeSpacing: 50, levelSeparation: 300 } }, "edges": { arrows: { to: { enabled: true, scaleFactor:0.5 }, }, "smooth": { enabled: false }, font: { size: 14, color: "red", face: "sans", background: "white", strokeWidth:3, align: "middle", strokeWidth: 2 } }, "physics": {"enabled": false } }'
+lnms config:set network_map_dependencymap_vis_options '"{\"layout\":{\"hierarchical\":{\"enabled\":true,\"direction\":\"UD\",\"sortMethod\":\"directed\",\"nodeSpacing\":50,\"treeSpacing\":50,\"levelSeparation\":300}},\"edges\":{\"arrows\":{\"to\":{\"enabled\":true,\"scaleFactor\":0.5}},\"smooth\":{\"enabled\":false},\"font\":{\"size\":14,\"color\":\"red\",\"face\":\"sans\",\"background\":\"white\",\"strokeWidth\":2,\"align\":\"middle\"}},\"physics\":{\"enabled\":false}}"'
 ```
 
 ### Configurator Output


### PR DESCRIPTION

## Details
The docs referenced `network_map_devicedependency_vis_options`, but
`app/Http/Controllers/Maps/DeviceDependencyController.php` (line 51)
actually reads a different key:

    'options' => LibrenmsConfig::get('network_map_dependencymap_vis_options') ?? LibrenmsConfig::get('network_map_vis_options'),

Setting the documented (wrong) key silently does nothing, since no code
path reads it.

Notably, `lnms config:set` refuses the wrong key outright with "This
is not a valid setting" unless `--ignore-checks` is passed, since it
isn't registered anywhere in the codebase.

The example JSON also had a few issues: unquoted keys (invalid JSON,
only valid as a JS object literal), a trailing comma, and a duplicate
`strokeWidth` key in the font block with two different values - only
the last would ever actually apply.

A note about double-escaping  has already been added to this page
- this just fixes the key name and example for the hierarchical layout.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
