### PR TITLE
Refactor SNMP target out of config

### DIFF
--- a/LibreNMS/Data/Source/Snmp/NetSnmp.php
+++ b/LibreNMS/Data/Source/Snmp/NetSnmp.php
@@ -34,6 +34,7 @@ use LibreNMS\Exceptions\SnmpException;
 use LibreNMS\Exceptions\SnmpVersionUnsupportedException;
 use LibreNMS\Polling\Method\Config\SnmpConfig;
 use LibreNMS\Util\Oid;
+use LibreNMS\Util\Rewrite;
 use Symfony\Component\Process\Process;
 
 class NetSnmp implements SnmpBackendInterface, SnmpTranslatorInterface
@@ -41,22 +42,22 @@ class NetSnmp implements SnmpBackendInterface, SnmpTranslatorInterface
     /**
      * @param  string[]  $oids
      */
-    public function get(SnmpConfig $config, array $oids, SnmpQueryOptions $options): SnmpResponse
+    public function get(string $target, array $oids, SnmpConfig $config, SnmpQueryOptions $options): SnmpResponse
     {
-        return $this->runCommand($this->buildCli('snmpget', $config, $oids, $options));
+        return $this->runCommand($this->buildCli('snmpget', $target, $oids, $config, $options));
     }
 
-    public function walk(SnmpConfig $config, string $oid, SnmpQueryOptions $options): SnmpResponse
+    public function walk(string $target, string $oid, SnmpConfig $config, SnmpQueryOptions $options): SnmpResponse
     {
-        return $this->runCommand($this->buildCli('snmpwalk', $config, [$oid], $options));
+        return $this->runCommand($this->buildCli('snmpwalk', $target, [$oid], $config, $options));
     }
 
     /**
      * @param  string[]  $oids
      */
-    public function next(SnmpConfig $config, array $oids, SnmpQueryOptions $options): SnmpResponse
+    public function next(string $target, array $oids, SnmpConfig $config, SnmpQueryOptions $options): SnmpResponse
     {
-        return $this->runCommand($this->buildCli('snmpgetnext', $config, $oids, $options));
+        return $this->runCommand($this->buildCli('snmpgetnext', $target, $oids, $config, $options));
     }
 
     public function translate(string $oid, SnmpQueryOptions $options): string
@@ -89,7 +90,7 @@ class NetSnmp implements SnmpBackendInterface, SnmpTranslatorInterface
      * @param  string[]  $oids
      * @return string[]
      */
-    public function buildCli(string $command, SnmpConfig $config, array $oids, SnmpQueryOptions $options): array
+    public function buildCli(string $command, string $target, array $oids, SnmpConfig $config, SnmpQueryOptions $options): array
     {
         if ($command === 'snmpwalk' && $config->bulk && $options->allowBulk && $config->version !== 'v1') {
             $command = 'snmpbulkwalk';
@@ -119,7 +120,9 @@ class NetSnmp implements SnmpBackendInterface, SnmpTranslatorInterface
             array_push($cmd, '-r', (string) $config->retries);
         }
 
-        return [...$cmd, $config->formattedTarget(), ...$oids];
+        $formattedTarget = sprintf('%s:%s:%s', $config->transport, Rewrite::addIpv6Brackets($target), $config->port);
+
+        return [...$cmd, $formattedTarget, ...$oids];
     }
 
     /**

--- a/LibreNMS/Data/Source/Snmp/SnmpBackendInterface.php
+++ b/LibreNMS/Data/Source/Snmp/SnmpBackendInterface.php
@@ -49,7 +49,7 @@ interface SnmpBackendInterface
      *
      * @param  string[]  $oids
      */
-    public function get(SnmpConfig $config, array $oids, SnmpQueryOptions $options): SnmpResponse;
+    public function get(string $target, array $oids, SnmpConfig $config, SnmpQueryOptions $options): SnmpResponse;
 
     /**
      * snmpwalk (or snmpbulkwalk, per $options) a single OID subtree —
@@ -59,7 +59,7 @@ interface SnmpBackendInterface
      * usefully batch multiple subtrees into a single request, since each
      * subtree ends at a different point and streams back independently.
      */
-    public function walk(SnmpConfig $config, string $oid, SnmpQueryOptions $options): SnmpResponse;
+    public function walk(string $target, string $oid, SnmpConfig $config, SnmpQueryOptions $options): SnmpResponse;
 
     /**
      * snmpgetnext for one or more OIDs — fetches the first OID after each
@@ -67,5 +67,5 @@ interface SnmpBackendInterface
      *
      * @param  string[]  $oids
      */
-    public function next(SnmpConfig $config, array $oids, SnmpQueryOptions $options): SnmpResponse;
+    public function next(string $target, array $oids, SnmpConfig $config, SnmpQueryOptions $options): SnmpResponse;
 }

--- a/LibreNMS/Data/Source/Snmp/SnmpQuery.php
+++ b/LibreNMS/Data/Source/Snmp/SnmpQuery.php
@@ -235,12 +235,13 @@ class SnmpQuery implements SnmpQueryInterface
     public function get($oid): SnmpResponse
     {
         $config = $this->device->toSnmpConfig();
+        $target = $this->device->pollerTarget();
         $chunks = $this->limitOids($this->parseOid($oid), $config);
         $response = new SnmpResponse('');
 
         foreach ($chunks as $chunk) {
             $options = $this->prepareOptions($chunk);
-            $res = $this->execWithCache('snmpget', $chunk, $options, fn () => $this->backend->get($config, $chunk, $options));
+            $res = $this->execWithCache('snmpget', $chunk, $options, fn () => $this->backend->get($target, $chunk, $config, $options));
             $response = $response->append($res);
 
             // if abort on failure is set, return after first failure
@@ -264,13 +265,14 @@ class SnmpQuery implements SnmpQueryInterface
      */
     public function walk($oid): SnmpResponse
     {
-        $target = $this->device->toSnmpConfig();
+        $config = $this->device->toSnmpConfig();
+        $target = $this->device->pollerTarget();
         $oids = $this->parseOid($oid);
         $response = new SnmpResponse('');
 
         foreach ($oids as $singleOid) {
             $options = $this->prepareOptions([$singleOid], walk: true);
-            $res = $this->execWithCache('snmpwalk', [$singleOid], $options, fn () => $this->backend->walk($target, $singleOid, $options));
+            $res = $this->execWithCache('snmpwalk', [$singleOid], $options, fn () => $this->backend->walk($target, $singleOid, $config, $options));
             $response = $response->append($res);
 
             // if abort on failure is set, return after first failure
@@ -295,12 +297,13 @@ class SnmpQuery implements SnmpQueryInterface
     public function next($oid): SnmpResponse
     {
         $config = $this->device->toSnmpConfig();
+        $target = $this->device->pollerTarget();
         $chunks = $this->limitOids($this->parseOid($oid), $config);
         $response = new SnmpResponse('');
 
         foreach ($chunks as $chunk) {
             $options = $this->prepareOptions($chunk);
-            $res = $this->execWithCache('snmpgetnext', $chunk, $options, fn () => $this->backend->next($config, $chunk, $options));
+            $res = $this->execWithCache('snmpgetnext', $chunk, $options, fn () => $this->backend->next($target, $chunk, $config, $options));
             $response = $response->append($res);
 
             // if abort on failure is set, return after first failure
@@ -330,7 +333,7 @@ class SnmpQuery implements SnmpQueryInterface
         $options = clone $this->options;
         $options->mibDirs = Mib::directories($this->device, $this->options->mibDirs);
 
-        return $this->translateBackend->translate((string) $oid, $options);
+        return $this->translateBackend->translate($oid, $options);
     }
 
     /**

--- a/LibreNMS/Polling/Method/Config/SnmpConfig.php
+++ b/LibreNMS/Polling/Method/Config/SnmpConfig.php
@@ -28,13 +28,10 @@ namespace LibreNMS\Polling\Method\Config;
 
 use App\Facades\LibrenmsConfig;
 use App\Models\Device;
-use LibreNMS\Util\Rewrite;
 
 final readonly class SnmpConfig
 {
     public function __construct(
-        public string $target,
-
         // Secrets
         public string $version = 'v2c',
         public ?string $community = null,
@@ -57,20 +54,6 @@ final readonly class SnmpConfig
     ) {
     }
 
-    public function formattedTarget(bool $withTransport = true): string
-    {
-        $parts = [];
-
-        if ($withTransport) {
-            $parts[] = $this->transport;
-        }
-
-        $parts[] = Rewrite::addIpv6Brackets($this->target);
-        $parts[] = $this->port;
-
-        return implode(':', $parts);
-    }
-
     public static function fromDevice(Device $device): self
     {
         $timeout = (float) ($device->timeout > 0 ? $device->timeout : LibrenmsConfig::get('snmp.timeout', 1));
@@ -80,7 +63,6 @@ final readonly class SnmpConfig
         $rawBulk = $device->getAttrib('snmp_bulk') ?? LibrenmsConfig::getOsSetting($device->os, 'snmp_bulk', LibrenmsConfig::get('snmp_bulk', true));
 
         return new self(
-            target: $device->overwrite_ip ?: $device->hostname,
             version: $device->snmpver ?? 'v2c',
             community: $device->community,
             authname: $device->authname,

--- a/app/Http/Controllers/Device/Debug/DebugSnmpwalkController.php
+++ b/app/Http/Controllers/Device/Debug/DebugSnmpwalkController.php
@@ -72,8 +72,9 @@ class DebugSnmpwalkController extends Controller
     {
         return app(NetSnmp::class)->buildCli(
             'snmpwalk',
-            $device->toSnmpConfig(),
+            $device->pollerTarget(),
             ['.'],
+            $device->toSnmpConfig(),
             new SnmpQueryOptions(
                 numericIndexes: true,
                 oidFormat: SnmpOidOutput::Numeric,

--- a/tests/Unit/NetSnmpTest.php
+++ b/tests/Unit/NetSnmpTest.php
@@ -24,7 +24,6 @@ class NetSnmpTest extends TestCase
     public function testBuildCliV2c(): void
     {
         $config = new SnmpConfig(
-            target: '192.168.1.1',
             version: 'v2c',
             community: 'public',
             transport: 'udp',
@@ -32,7 +31,7 @@ class NetSnmpTest extends TestCase
         );
 
         $options = SnmpQueryOptions::quickPrint();
-        $cli = $this->backend->buildCli('snmpget', $config, ['sysDescr.0'], $options);
+        $cli = $this->backend->buildCli('snmpget', '192.168.1.1', ['sysDescr.0'], $config, $options);
 
         $this->assertStringEndsWith('snmpget', $cli[0]);
         $this->assertContains('-M', $cli);
@@ -48,7 +47,6 @@ class NetSnmpTest extends TestCase
     public function testBuildCliNetSnmpLibraryDefaults(): void
     {
         $config = new SnmpConfig(
-            target: '192.168.1.1',
             version: 'v2c',
             community: 'public',
             transport: 'udp',
@@ -56,7 +54,7 @@ class NetSnmpTest extends TestCase
         );
 
         $options = new SnmpQueryOptions();
-        $cli = $this->backend->buildCli('snmpget', $config, ['sysDescr.0'], $options);
+        $cli = $this->backend->buildCli('snmpget', '192.168.1.1', ['sysDescr.0'], $config, $options);
 
         $this->assertStringEndsWith('snmpget', $cli[0]);
         $this->assertNotContains('-OQXUte', $cli);
@@ -68,7 +66,6 @@ class NetSnmpTest extends TestCase
     public function testBuildCliV1(): void
     {
         $config = new SnmpConfig(
-            target: '10.0.0.1',
             version: 'v1',
             community: 'secret',
             transport: 'udp',
@@ -76,7 +73,7 @@ class NetSnmpTest extends TestCase
         );
 
         $options = new SnmpQueryOptions();
-        $cli = $this->backend->buildCli('snmpget', $config, ['sysUpTime.0'], $options);
+        $cli = $this->backend->buildCli('snmpget', '10.0.0.1', ['sysUpTime.0'], $config, $options);
 
         $this->assertContains('-v1', $cli);
         $this->assertContains('secret', $cli);
@@ -86,13 +83,12 @@ class NetSnmpTest extends TestCase
     public function testBuildCliV2cWithContext(): void
     {
         $config = new SnmpConfig(
-            target: '192.168.1.1',
             version: 'v2c',
             community: 'public',
         );
 
         $options = new SnmpQueryOptions(context: 'vrf1');
-        $cli = $this->backend->buildCli('snmpget', $config, ['sysDescr.0'], $options);
+        $cli = $this->backend->buildCli('snmpget', '192.168.1.1', ['sysDescr.0'], $config, $options);
 
         $this->assertContains('public@vrf1', $cli);
     }
@@ -100,7 +96,6 @@ class NetSnmpTest extends TestCase
     public function testBuildCliV3AuthPriv(): void
     {
         $config = new SnmpConfig(
-            target: '192.168.1.5',
             version: 'v3',
             authname: 'admin',
             authpass: 'auth_pass',
@@ -111,7 +106,7 @@ class NetSnmpTest extends TestCase
         );
 
         $options = new SnmpQueryOptions(context: 'ctx');
-        $cli = $this->backend->buildCli('snmpget', $config, ['sysDescr.0'], $options);
+        $cli = $this->backend->buildCli('snmpget', '192.168.1.5', ['sysDescr.0'], $config, $options);
 
         $this->assertContains('-v3', $cli);
         $this->assertContains('-l', $cli);
@@ -133,7 +128,6 @@ class NetSnmpTest extends TestCase
     public function testBuildCliV3AuthNoPriv(): void
     {
         $config = new SnmpConfig(
-            target: '192.168.1.5',
             version: 'v3',
             authname: 'user1',
             authpass: 'auth_pass',
@@ -142,7 +136,7 @@ class NetSnmpTest extends TestCase
         );
 
         $options = new SnmpQueryOptions();
-        $cli = $this->backend->buildCli('snmpget', $config, ['sysDescr.0'], $options);
+        $cli = $this->backend->buildCli('snmpget', '192.168.1.5', ['sysDescr.0'], $config, $options);
 
         $this->assertContains('-v3', $cli);
         $this->assertContains('-l', $cli);
@@ -160,14 +154,13 @@ class NetSnmpTest extends TestCase
     public function testBuildCliV3NoAuthNoPriv(): void
     {
         $config = new SnmpConfig(
-            target: '192.168.1.5',
             version: 'v3',
             authname: 'guest',
             authlevel: 'noAuthNoPriv',
         );
 
         $options = new SnmpQueryOptions();
-        $cli = $this->backend->buildCli('snmpget', $config, ['sysDescr.0'], $options);
+        $cli = $this->backend->buildCli('snmpget', '192.168.1.5', ['sysDescr.0'], $config, $options);
 
         $this->assertContains('-v3', $cli);
         $this->assertContains('-l', $cli);
@@ -181,14 +174,13 @@ class NetSnmpTest extends TestCase
     public function testBuildCliIpv6Brackets(): void
     {
         $config = new SnmpConfig(
-            target: '2001:db8::1',
             version: 'v2c',
             community: 'public',
             transport: 'udp6',
             port: 161,
         );
 
-        $cli = $this->backend->buildCli('snmpget', $config, ['sysDescr.0'], new SnmpQueryOptions());
+        $cli = $this->backend->buildCli('snmpget', '2001:db8::1', ['sysDescr.0'], $config, new SnmpQueryOptions());
 
         $this->assertContains('udp6:[2001:db8::1]:161', $cli);
     }
@@ -196,14 +188,13 @@ class NetSnmpTest extends TestCase
     public function testBuildCliTimeoutAndRetries(): void
     {
         $config = new SnmpConfig(
-            target: '192.168.1.1',
             version: 'v2c',
             community: 'public',
             timeout: 3,
             retries: 0,
         );
 
-        $cli = $this->backend->buildCli('snmpget', $config, ['sysDescr.0'], new SnmpQueryOptions());
+        $cli = $this->backend->buildCli('snmpget', '192.168.1.1', ['sysDescr.0'], $config, new SnmpQueryOptions());
 
         $this->assertContains('-t', $cli);
         $this->assertContains('3', $cli);
@@ -214,13 +205,12 @@ class NetSnmpTest extends TestCase
     public function testBuildCliFloatTimeout(): void
     {
         $config = new SnmpConfig(
-            target: '192.168.1.1',
             version: 'v2c',
             community: 'public',
             timeout: 0.2,
         );
 
-        $cli = $this->backend->buildCli('snmpget', $config, ['sysDescr.0'], new SnmpQueryOptions());
+        $cli = $this->backend->buildCli('snmpget', '192.168.1.1', ['sysDescr.0'], $config, new SnmpQueryOptions());
 
         $this->assertContains('-t', $cli);
         $this->assertContains('0.2', $cli);
@@ -229,13 +219,12 @@ class NetSnmpTest extends TestCase
     public function testBuildCliZeroOrNegativeTimeoutDoesNotEmitFlag(): void
     {
         $config = new SnmpConfig(
-            target: '192.168.1.1',
             version: 'v2c',
             community: 'public',
             timeout: 0,
         );
 
-        $cli = $this->backend->buildCli('snmpget', $config, ['sysDescr.0'], new SnmpQueryOptions());
+        $cli = $this->backend->buildCli('snmpget', '192.168.1.1', ['sysDescr.0'], $config, new SnmpQueryOptions());
 
         $this->assertNotContains('-t', $cli);
     }
@@ -243,43 +232,39 @@ class NetSnmpTest extends TestCase
     public function testBuildCliDecidesBulk(): void
     {
         $configV2 = new SnmpConfig(
-            target: '192.168.1.1',
             version: 'v2c',
             community: 'public',
         );
         $configV1 = new SnmpConfig(
-            target: '192.168.1.1',
             version: 'v1',
             community: 'public',
         );
 
         // v2c with allowBulk (default) upgrades snmpwalk to snmpbulkwalk
-        $cliBulk = $this->backend->buildCli('snmpwalk', $configV2, ['.'], new SnmpQueryOptions());
+        $cliBulk = $this->backend->buildCli('snmpwalk', '192.168.1.1', ['.'], $configV2, new SnmpQueryOptions());
         $this->assertStringEndsWith('snmpbulkwalk', $cliBulk[0]);
 
         // v2c with allowBulk: false stays snmpwalk
-        $cliNoBulk = $this->backend->buildCli('snmpwalk', $configV2, ['.'], new SnmpQueryOptions(allowBulk: false));
+        $cliNoBulk = $this->backend->buildCli('snmpwalk', '192.168.1.1', ['.'], $configV2, new SnmpQueryOptions(allowBulk: false));
         $this->assertStringEndsWith('snmpwalk', $cliNoBulk[0]);
 
         // v1 with allowBulk: true stays snmpwalk because v1 does not support bulk
-        $cliV1 = $this->backend->buildCli('snmpwalk', $configV1, ['.'], new SnmpQueryOptions(allowBulk: true));
+        $cliV1 = $this->backend->buildCli('snmpwalk', '192.168.1.1', ['.'], $configV1, new SnmpQueryOptions(allowBulk: true));
         $this->assertStringEndsWith('snmpwalk', $cliV1[0]);
 
         // v2c with bulk: false on SnmpConfig stays snmpwalk even with allowBulk: true
         $configNoBulk = new SnmpConfig(
-            target: '192.168.1.1',
             version: 'v2c',
             community: 'public',
             bulk: false,
         );
-        $cliTargetNoBulk = $this->backend->buildCli('snmpwalk', $configNoBulk, ['.'], new SnmpQueryOptions(allowBulk: true));
+        $cliTargetNoBulk = $this->backend->buildCli('snmpwalk', '192.168.1.1', ['.'], $configNoBulk, new SnmpQueryOptions(allowBulk: true));
         $this->assertStringEndsWith('snmpwalk', $cliTargetNoBulk[0]);
     }
 
     public function testBuildCliFormattingOptions(): void
     {
         $config = new SnmpConfig(
-            target: '192.168.1.1',
             version: 'v2c',
             community: 'public',
         );
@@ -290,7 +275,7 @@ class NetSnmpTest extends TestCase
         $options->numericIndexes = true;
         $options->numericEnums = false;
 
-        $cli = $this->backend->buildCli('snmpget', $config, ['sysDescr.0'], $options);
+        $cli = $this->backend->buildCli('snmpget', '192.168.1.1', ['sysDescr.0'], $config, $options);
 
         $this->assertContains('-OQXUtbn', $cli); // numeric suppression of 's', no 'e' because numericEnums = false
         $this->assertContains('-Cc', $cli);
@@ -298,25 +283,24 @@ class NetSnmpTest extends TestCase
         // When oidFormat is Suffix, 's' is emitted
         $optionsSymbolic = SnmpQueryOptions::quickPrint();
         $optionsSymbolic->oidFormat = SnmpOidOutput::Suffix;
-        $cliSymbolic = $this->backend->buildCli('snmpget', $config, ['sysDescr.0'], $optionsSymbolic);
+        $cliSymbolic = $this->backend->buildCli('snmpget', '192.168.1.1', ['sysDescr.0'], $config, $optionsSymbolic);
         $this->assertContains('-OQXUtes', $cliSymbolic);
     }
 
     public function testBuildCliAsciiStrings(): void
     {
         $config = new SnmpConfig(
-            target: '192.168.1.1',
             version: 'v2c',
             community: 'public',
         );
 
         $options = SnmpQueryOptions::quickPrint();
         $options->stringFormat = SnmpStringOutput::Ascii;
-        $cli = $this->backend->buildCli('snmpget', $config, ['sysDescr.0'], $options);
+        $cli = $this->backend->buildCli('snmpget', '192.168.1.1', ['sysDescr.0'], $config, $options);
         $this->assertContains('-OQXUtea', $cli);
 
         $optionsFromCli = (new SnmpQueryOptions)->parseCli(['-OteQUSab', '-Pu', '-Ih']);
-        $cliFromCli = $this->backend->buildCli('snmpwalk', $config, ['.1.3.6.1.4.1.2356.100'], $optionsFromCli);
+        $cliFromCli = $this->backend->buildCli('snmpwalk', '192.168.1.1', ['.1.3.6.1.4.1.2356.100'], $config, $optionsFromCli);
         $this->assertContains('-OQUteba', $cliFromCli);
         $this->assertContains('-Pu', $cliFromCli);
         $this->assertContains('-Ih', $cliFromCli);
@@ -325,18 +309,17 @@ class NetSnmpTest extends TestCase
     public function testBuildCliHexStrings(): void
     {
         $config = new SnmpConfig(
-            target: '192.168.1.1',
             version: 'v2c',
             community: 'public',
         );
 
         $options = SnmpQueryOptions::quickPrint();
         $options->stringFormat = SnmpStringOutput::Hex;
-        $cli = $this->backend->buildCli('snmpget', $config, ['sysDescr.0'], $options);
+        $cli = $this->backend->buildCli('snmpget', '192.168.1.1', ['sysDescr.0'], $config, $options);
         $this->assertContains('-OQXUtex', $cli);
 
         $optionsFromCli = (new SnmpQueryOptions)->parseCli(['-OteQUax', '-Pu']);
-        $cliFromCli = $this->backend->buildCli('snmpwalk', $config, ['.1.3.6.1.4.1.2356.100'], $optionsFromCli);
+        $cliFromCli = $this->backend->buildCli('snmpwalk', '192.168.1.1', ['.1.3.6.1.4.1.2356.100'], $config, $optionsFromCli);
         $this->assertContains('-OQUtex', $cliFromCli);
         $this->assertContains('-Pu', $cliFromCli);
     }
@@ -354,7 +337,6 @@ class NetSnmpTest extends TestCase
 
         $config = SnmpConfig::fromDevice($device);
 
-        $this->assertSame('router1.example.com', $config->target);
         $this->assertSame('v2c', $config->version);
         $this->assertSame('test-comm', $config->community);
         $this->assertSame(1161, $config->port);
@@ -377,8 +359,6 @@ class NetSnmpTest extends TestCase
 
         $this->assertSame('test-comm', $config1->community);
         $this->assertSame('new', $config2->community);
-        $this->assertSame('router1.example.com', $config1->target);
-        $this->assertSame('router1.example.com', $config2->target);
     }
 
     public function testSnmpConfigFromDeviceRespectsSnmpBulkSetting(): void

--- a/tests/Unit/SnmpQueryTest.php
+++ b/tests/Unit/SnmpQueryTest.php
@@ -63,12 +63,12 @@ class SnmpQueryTest extends TestCase
         $mockBackend = $this->mockBackend();
         $mockBackend->shouldReceive('walk')
             ->once()
-            ->withArgs(fn (SnmpConfig $config, string $oid) => $oid === 'ifDescr')
+            ->withArgs(fn (string $target, string $oid) => $oid === 'ifDescr')
             ->andReturn(new SnmpResponse("ifDescr.1 = eth0\n"));
 
         $mockBackend->shouldReceive('walk')
             ->once()
-            ->withArgs(fn (SnmpConfig $config, string $oid) => $oid === 'ifType')
+            ->withArgs(fn (string $target, string $oid) => $oid === 'ifType')
             ->andReturn(new SnmpResponse("ifType.1 = ethernetCsmacd\n"));
 
         $query = (new SnmpQuery($mockBackend))->device($this->device);
@@ -82,7 +82,7 @@ class SnmpQueryTest extends TestCase
         $mockBackend = $this->mockBackend();
         $mockBackend->shouldReceive('next')
             ->once()
-            ->withArgs(fn (SnmpConfig $config, array $oids) => $oids === ['sysDescr.0'])
+            ->withArgs(fn (string $target, array $oids) => $oids === ['sysDescr.0'])
             ->andReturn(new SnmpResponse("sysObjectID.0 = .1.3.6.1.4.1\n"));
 
         $query = (new SnmpQuery($mockBackend))->device($this->device);
@@ -106,12 +106,12 @@ class SnmpQueryTest extends TestCase
         $mockBackend = $this->mockBackend();
         $mockBackend->shouldReceive('get')
             ->once()
-            ->withArgs(fn (SnmpConfig $config, array $oids) => $oids === ['oid1', 'oid2'])
+            ->withArgs(fn (string $target, array $oids) => $oids === ['oid1', 'oid2'])
             ->andReturn(new SnmpResponse("oid1 = 1\noid2 = 2\n"));
 
         $mockBackend->shouldReceive('get')
             ->once()
-            ->withArgs(fn (SnmpConfig $config, array $oids) => $oids === ['oid3'])
+            ->withArgs(fn (string $target, array $oids) => $oids === ['oid3'])
             ->andReturn(new SnmpResponse("oid3 = 3\n"));
 
         $query = (new SnmpQuery($mockBackend))->device($device);
@@ -126,12 +126,12 @@ class SnmpQueryTest extends TestCase
         // First OID fails (exitCode 1)
         $mockBackend->shouldReceive('walk')
             ->once()
-            ->withArgs(fn (SnmpConfig $config, string $oid) => $oid === 'unsupportedOid')
+            ->withArgs(fn (string $target, string $oid) => $oid === 'unsupportedOid')
             ->andReturn(new SnmpResponse('', 'Timeout: No Response', 1));
 
         // Second OID should never be queried because of abortOnFailure
         $mockBackend->shouldNotReceive('walk')
-            ->withArgs(fn (SnmpConfig $config, string $oid) => $oid === 'secondOid');
+            ->withArgs(fn (string $target, string $oid) => $oid === 'secondOid');
 
         $query = (new SnmpQuery($mockBackend))
             ->device($this->device)
@@ -149,7 +149,7 @@ class SnmpQueryTest extends TestCase
         $mockBackend = $this->mockBackend();
         $mockBackend->shouldReceive('get')
             ->once()
-            ->withArgs(fn (SnmpConfig $config, array $oids) => $oids === ['sysDescr.0'])
+            ->withArgs(fn (string $target, array $oids) => $oids === ['sysDescr.0'])
             ->andReturn(new SnmpResponse("sysDescr.0 = CachedLinux\n"));
 
         $query = (new SnmpQuery($mockBackend))
@@ -192,7 +192,7 @@ class SnmpQueryTest extends TestCase
         $mockBackend = $this->mockBackend();
         $mockBackend->shouldReceive('get')
             ->once()
-            ->withArgs(fn (SnmpConfig $config, array $oids, SnmpQueryOptions $options) => $options->context === 'vlan-100')
+            ->withArgs(fn (string $target, array $oids, SnmpConfig $config, SnmpQueryOptions $options) => $options->context === 'vlan-100')
             ->andReturn(new SnmpResponse("val = 1\n"));
 
         $query = (new SnmpQuery($mockBackend))
@@ -207,7 +207,7 @@ class SnmpQueryTest extends TestCase
         $mockBackend = $this->mockBackend();
         $mockBackend->shouldReceive('walk')
             ->once()
-            ->withArgs(fn (SnmpConfig $config, string $oid, SnmpQueryOptions $options) => $options->numericIndexes === true
+            ->withArgs(fn (string $target, string $oid, SnmpConfig $config, SnmpQueryOptions $options) => $options->numericIndexes === true
                 && $options->oidFormat === SnmpOidOutput::Suffix
                 && $options->numericEnums === false
                 && $options->tolerateUnorderedIndexes === true)
@@ -245,7 +245,7 @@ class SnmpQueryTest extends TestCase
         $mockBackend = $this->mockBackend();
         $mockBackend->shouldReceive('get')
             ->once()
-            ->withArgs(fn (SnmpConfig $config, array $oids, SnmpQueryOptions $options) => $options->quickPrint === true
+            ->withArgs(fn (string $target, array $oids, SnmpConfig $config, SnmpQueryOptions $options) => $options->quickPrint === true
                     && $options->extendedIndex === true
                     && $options->printUnits === false
                     && $options->numericEnums === true
@@ -261,7 +261,7 @@ class SnmpQueryTest extends TestCase
         $mockBackend = $this->mockBackend();
         $mockBackend->shouldReceive('get')
             ->once()
-            ->withArgs(fn (SnmpConfig $config, array $oids, SnmpQueryOptions $options) => $options->oidFormat === SnmpOidOutput::Suffix)
+            ->withArgs(fn (string $target, array $oids, SnmpConfig $config, SnmpQueryOptions $options) => $options->oidFormat === SnmpOidOutput::Suffix)
             ->andReturn(new SnmpResponse("sysDescr.0 = Linux\n"));
 
         $query = (new SnmpQuery($mockBackend))->device($this->device)->hideMib();
@@ -276,7 +276,7 @@ class SnmpQueryTest extends TestCase
         $mockBackend = $this->mockBackend();
         $mockBackend->shouldReceive('walk')
             ->once()
-            ->withArgs(fn (SnmpConfig $config, string $oid, SnmpQueryOptions $options) => $options->allowBulk === false)
+            ->withArgs(fn (string $target, string $oid, SnmpConfig $config, SnmpQueryOptions $options) => $options->allowBulk === false)
             ->andReturn(new SnmpResponse("laLoadInt = 1\n"));
 
         $query = (new SnmpQuery($mockBackend))->device($this->device);

--- a/tests/Unit/SnmpQueryTest.php
+++ b/tests/Unit/SnmpQueryTest.php
@@ -42,7 +42,7 @@ class SnmpQueryTest extends TestCase
         $mockBackend = $this->mockBackend();
         $mockBackend->shouldReceive('get')
             ->once()
-            ->withArgs(fn (SnmpConfig $config, array $oids, SnmpQueryOptions $options) => $config->target === '10.1.2.3'
+            ->withArgs(fn (string $target, array $oids, SnmpConfig $config, SnmpQueryOptions $options) => $target === '10.1.2.3'
                 && $config->community === 'test-community'
                 && $oids === ['sysDescr.0']
                 && $options->oidFormat === SnmpOidOutput::Numeric


### PR DESCRIPTION
SNMP target did not belong in the SnmpConfig object and I realized it caused issues. Require it as a separate argument in SnmpBackendInterface. Reorder arguments so they are more consistent.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
