### PR TITLE
Fix device display name regeneration repeating the first chunk

### DIFF
--- a/app/Listeners/RegenerateDeviceDisplayNames.php
+++ b/app/Listeners/RegenerateDeviceDisplayNames.php
@@ -14,8 +14,10 @@ class RegenerateDeviceDisplayNames
     public function handle(SettingChanged $event): void
     {
         Device::withoutEvents(function (): void {
-            Device::whereNull('display_template')
-                ->orWhere('display_template', '')
+            Device::where(function ($query): void {
+                $query->whereNull('display_template')
+                    ->orWhere('display_template', '');
+            })
                 ->select(['device_id', 'display_template', 'hostname', 'sysName', 'ip', 'overwrite_ip'])
                 ->chunkById(500, function ($devices): void {
                     foreach ($devices as $device) {


### PR DESCRIPTION
Fixes #20484

`RegenerateDeviceDisplayNames` never gets past its first chunk, so after
`device_display_default` is changed most devices keep their old display name.

`chunkById()` appends `and device_id > ?` to the query for every page. The
`whereNull()` / `orWhere()` pair was not grouped, so `AND` bound tighter than
`OR` and the effective condition became:

```sql
where display_template is null or (display_template = '' and device_id > ?)
```

The first branch ignores the paging cursor, so every page returns the same
lowest rows, the cursor never advances, and the listener keeps reprocessing the
first chunk. Grouping the pair restores the intended condition:

```sql
where (display_template is null or display_template = '') and device_id > ?
```

Measured against Eloquent 12.64 (sqlite) with 1200 devices — 1188 with
`display_template` NULL, 12 with `''` — and the listener's chunk size of 500:

| | pages run | distinct `device_id` processed | ids reached |
|---|---|---|---|
| before | still repeating at page 500, stopped by hand | 505 of 1200 | 1 … 505 |
| after | 3, finished on its own | 1200 of 1200 | 1 … 1200 |

Installs with fewer matching devices than the chunk size are not affected: the
first page comes back short, so `chunkById()` stops after it.

Found on a 5353 device install where 503 devices kept the wrong display name
and the regenerator never reached past `device_id` 655.

This is not a WebUI change and does not touch discovery/polling/yaml, so
checkboxes 2 and 3 below do not apply.

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
