### PR TITLE
Fix date_or_relative validation rejecting mo and s units

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -212,7 +212,7 @@ class AppServiceProvider extends ServiceProvider
                 return true;
             }
 
-            if (is_string($value) && preg_match('/^[+-]?\d+[hdmwy]$/', $value)) {
+            if (is_string($value) && preg_match('/^[+-]?\d+(mo|[smhdwy])$/', $value)) {
                 return true;
             }
 

--- a/tests/Unit/CustomValidatorsTest.php
+++ b/tests/Unit/CustomValidatorsTest.php
@@ -131,9 +131,14 @@ final class CustomValidatorsTest extends TestCase
         $this->assertRulePasses('2h', 'date_or_relative');
         $this->assertRulePasses('-3d', 'date_or_relative');
         $this->assertRulePasses('+4w', 'date_or_relative');
+        $this->assertRulePasses('-1mo', 'date_or_relative');
+        $this->assertRulePasses('-2mo', 'date_or_relative');
+        $this->assertRulePasses('-90s', 'date_or_relative');
         $this->assertRulePasses('2023-05-01', 'date_or_relative');
 
         $this->assertRuleFails('10z', 'date_or_relative');
+        $this->assertRuleFails('-2mon', 'date_or_relative');
+        $this->assertRuleFails('-mo', 'date_or_relative');
         $this->assertRuleFails('12345678901234', 'date_or_relative');
         $this->assertRuleFails('not-a-date', 'date_or_relative');
     }


### PR DESCRIPTION
  ## Summary

  Selecting the "1 month" / "2 months" presets in the graph date-range picker (or manually using `from=-2mo` / `from=-90s`) on `/devices/graph/*`, `/ports/graph/*` or `/outages` silently reverts to the previously selected range.
  The request returns a `302` back to the previous URL with the validation error flashed but never displayed.

  ## Root cause

  The custom `date_or_relative` validation rule in `AppServiceProvider` accepts relative offsets with `/^[+-]?\d+[hdmwy]$/`. The character class cannot match the two-character `mo` unit and omits `s`, so `-2mo` and `-90s` fall
  through to `validateDate()`, whose `strtotime()` cannot parse them either. Because these controllers use `$request->validate()` on GET requests, the resulting `ValidationException` redirects to `url()->previous()`.

  `Time::parseAt()` already accepts `mo` / `w` / `s` since #19835, which is why pages that don't validate `from` (e.g. `/graphs`) work. The validator was never updated to match.

  ## Fix

  Change the unit alternation to `(mo|[smhdwy])`, aligning the validator with `parseAt()`. `mo` is listed first so it is tried before bare `m`. The optional sign and the unsigned form are unchanged.

  ## Testing

  - Extended `CustomValidatorsTest::testDateOrRelativeValidation`: `-1mo`, `-2mo`, `-90s` now pass; `-2mon` and `-mo` still fail. `-2mo` and `-90s` were confirmed to fail against the old regex before the change.
  - `vendor/bin/phpunit tests/Unit/CustomValidatorsTest.php --filter testDateOrRelativeValidation` — OK (1 test, 20 assertions)
  - `lnms dev:check lint` (php lint, PHPStan, PHPStan deprecated) — success
  - `lnms dev:check style` — success

  Fixes #19832 (remaining part; #19835 fixed `parseAt()` only).

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
