### PR TITLE
add stale issue action

### DIFF
--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/stale@v10
         with:
-          days-before-issue-stale: 80
+          days-before-issue-stale: 90
           days-before-issue-close: 14
           stale-issue-label: 'Stale'
           stale-issue-message: >

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -1,0 +1,31 @@
+name: Close stale issues
+
+on:
+  schedule:
+    - cron: '30 1 * * *'
+  workflow_dispatch: # dispatch manually
+
+permissions:
+  actions: write
+  issues: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v10
+        with:
+          days-before-issue-stale: 80
+          days-before-issue-close: 14
+          stale-issue-label: 'Stale'
+          stale-issue-message: >
+            This issue has had no activity for 80 days. Add a comment to keep it open.
+            If there is no activity in 14 days, it will be closed.
+          close-issue-message: >
+            This issue was closed because it had no activity for 14 days after the stale warning.
+          close-issue-reason: 'not_planned'
+
+          # do not touch PRs
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          # debug-only: true

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -19,7 +19,7 @@ jobs:
           days-before-issue-close: 14
           stale-issue-label: 'Stale'
           stale-issue-message: >
-            This issue has had no activity for 80 days. Add a comment to keep it open.
+            This issue has had no activity for 90 days. Add a comment to keep it open.
             If there is no activity in 14 days, it will be closed.
           close-issue-message: >
             This issue was closed because it had no activity for 14 days after the stale warning.


### PR DESCRIPTION
github action to mark issues that have had no activity for more than 90 days as stale, adding the "Stale" label. Issues with that label which do not get any update in the next 14 days will be closed automatically after that. 

uses https://github.com/actions/stale

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
