### PR TITLE
Fix panduit yaml

### DIFF
--- a/resources/definitions/os_discovery/panduit.yaml
+++ b/resources/definitions/os_discovery/panduit.yaml
@@ -3,10 +3,8 @@ modules:
         hardware: PANDUIT-MIB::pdug5PartNumber.1
         serial: PANDUIT-MIB::pdug5SerialNumber.1
         version: PANDUIT-MIB::pdug5FirmwareVersion.1
-        features: RFC1213-MIB::sysDescr.0
-        features_replace:
-          - '/SN:/'
-          - '/PN:Device Model:\S+/'
+        sysDescr_regex: '/SN:(?<features>.*)$/'
+        features_replace: ['/PN:Device Model:\S+/']
     sensors:
         state:
               data:


### PR DESCRIPTION
feature discovery re-fetching sysDescr when it already exists

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
