### PR TITLE
Dxmos SNMP Traps

### DIFF
--- a/LibreNMS/Snmptrap/Handlers/XklAutomaticOTDRTriggered.php
+++ b/LibreNMS/Snmptrap/Handlers/XklAutomaticOTDRTriggered.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * XklAutomaticOTDRTriggered.php
+ *
+ * -Description-
+ * 
+ * XKL Automatic OTDR was run, indicating a disruption in the fiber at
+ * the length provided.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @link       http://librenms.org
+ * @copyright  2026 Heath Barnhart
+ * @author     Heath Barnhart hbarnhart@kanren.net
+ */
+
+namespace LibreNMS\Snmptrap\Handlers;
+
+use App\Models\Device;
+use LibreNMS\Enum\Severity;
+use LibreNMS\Interfaces\SnmptrapHandler;
+use LibreNMS\Snmptrap\Trap;
+
+class XklAutomaticOTDRTriggered implements SnmptrapHandler
+{
+    /**
+     * Handle snmptrap.
+     * Data is pre-parsed and delivered as a Trap.
+     *
+     * @param Device $device
+     * @param Trap $trap
+     * @return void
+     */
+    public function handle(Device $device, Trap $trap)
+    {
+
+        $otdrDescr = $trap->getOidData($trap->findOid('XKL-MIB::xklOTDRLatestMeasurementOSCDescr'));
+        $otdrDistance = $trap->getOidData($trap->findOid('XKL-MIB::xklOTDRLatestMeasurementResults'));
+        $otdrDate = $trap->getOidData($trap->findOid('XKL-MIB::xklOTDRLatestMeasurementDateTime'));
+
+        $message = "Automatic OTDR Event at $otdrDate. Name: $otdrDescr Length: $otdrDistance";
+     
+		$trap->log($message, Severity::Warning);
+
+    }
+}

--- a/LibreNMS/Snmptrap/Handlers/XklAutomaticOTDRTriggered.php
+++ b/LibreNMS/Snmptrap/Handlers/XklAutomaticOTDRTriggered.php
@@ -46,7 +46,6 @@ class XklAutomaticOTDRTriggered implements SnmptrapHandler
      */
     public function handle(Device $device, Trap $trap)
     {
-
         $otdrDescr = $trap->getOidData($trap->findOid('XKL-MIB::xklOTDRLatestMeasurementOSCDescr'));
         $otdrDistance = $trap->getOidData($trap->findOid('XKL-MIB::xklOTDRLatestMeasurementResults'));
         $otdrDate = $trap->getOidData($trap->findOid('XKL-MIB::xklOTDRLatestMeasurementDateTime'));

--- a/LibreNMS/Snmptrap/Handlers/XklAutomaticOTDRTriggered.php
+++ b/LibreNMS/Snmptrap/Handlers/XklAutomaticOTDRTriggered.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * XklAutomaticOTDRTriggered.php
  *
@@ -46,9 +47,9 @@ class XklAutomaticOTDRTriggered implements SnmptrapHandler
     public function handle(Device $device, Trap $trap)
     {
 
-        $otdrDescr    = $trap->getOidData($trap->findOid('XKL-MIB::xklOTDRLatestMeasurementOSCDescr'));
+        $otdrDescr = $trap->getOidData($trap->findOid('XKL-MIB::xklOTDRLatestMeasurementOSCDescr'));
         $otdrDistance = $trap->getOidData($trap->findOid('XKL-MIB::xklOTDRLatestMeasurementResults'));
-        $otdrDate     = $trap->getOidData($trap->findOid('XKL-MIB::xklOTDRLatestMeasurementDateTime'));
+        $otdrDate = $trap->getOidData($trap->findOid('XKL-MIB::xklOTDRLatestMeasurementDateTime'));
 
         $message = "Automatic OTDR Event at $otdrDate. Name: $otdrDescr Length: $otdrDistance";
 

--- a/LibreNMS/Snmptrap/Handlers/XklAutomaticOTDRTriggered.php
+++ b/LibreNMS/Snmptrap/Handlers/XklAutomaticOTDRTriggered.php
@@ -3,7 +3,7 @@
  * XklAutomaticOTDRTriggered.php
  *
  * -Description-
- * 
+ *
  * XKL Automatic OTDR was run, indicating a disruption in the fiber at
  * the length provided.
  *
@@ -21,6 +21,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  * @link       http://librenms.org
+ *
  * @copyright  2026 Heath Barnhart
  * @author     Heath Barnhart hbarnhart@kanren.net
  */
@@ -38,20 +39,19 @@ class XklAutomaticOTDRTriggered implements SnmptrapHandler
      * Handle snmptrap.
      * Data is pre-parsed and delivered as a Trap.
      *
-     * @param Device $device
-     * @param Trap $trap
+     * @param  Device  $device
+     * @param  Trap  $trap
      * @return void
      */
     public function handle(Device $device, Trap $trap)
     {
 
-        $otdrDescr = $trap->getOidData($trap->findOid('XKL-MIB::xklOTDRLatestMeasurementOSCDescr'));
+        $otdrDescr    = $trap->getOidData($trap->findOid('XKL-MIB::xklOTDRLatestMeasurementOSCDescr'));
         $otdrDistance = $trap->getOidData($trap->findOid('XKL-MIB::xklOTDRLatestMeasurementResults'));
-        $otdrDate = $trap->getOidData($trap->findOid('XKL-MIB::xklOTDRLatestMeasurementDateTime'));
+        $otdrDate     = $trap->getOidData($trap->findOid('XKL-MIB::xklOTDRLatestMeasurementDateTime'));
 
         $message = "Automatic OTDR Event at $otdrDate. Name: $otdrDescr Length: $otdrDistance";
-     
-		$trap->log($message, Severity::Warning);
 
+        $trap->log($message, Severity::Warning);
     }
 }

--- a/LibreNMS/Snmptrap/Handlers/XklEdfaAlarmChange.php
+++ b/LibreNMS/Snmptrap/Handlers/XklEdfaAlarmChange.php
@@ -68,9 +68,6 @@ class XklEdfaAlarmChange implements SnmptrapHandler
         if ($trap->getOidData($trap->findOid('XKL-MIB::xklEDFACaseTemperatureAlarm')) == 'yes') {
             $message = "$edfaName case temperature alarm is active.";
         }
-        if ($trap->getOidData($trap->findOid('XKL-MIB::xklEDFACommonAlarm')) == 'yes') {
-            $message = "$edfaName common alarm is active.";
-        }
         if ($trap->getOidData($trap->findOid('XKL-MIB::xklEDFAPumpTemperatureAlarm')) == 'yes') {
             $message = "$edfaName pump temperature alarm is active.";
         }

--- a/LibreNMS/Snmptrap/Handlers/XklEdfaAlarmChange.php
+++ b/LibreNMS/Snmptrap/Handlers/XklEdfaAlarmChange.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * XklEdfaAlarmChange.php
+ *
+ * -Description-
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @link       http://librenms.org
+ * @copyright  2026 <your name>
+ * @author     <your name> <your email>
+ */
+
+namespace LibreNMS\Snmptrap\Handlers;
+
+use App\Models\Device;
+use LibreNMS\Enum\Severity;
+use LibreNMS\Interfaces\SnmptrapHandler;
+use LibreNMS\Snmptrap\Trap;
+
+class XklEdfaAlarmChange implements SnmptrapHandler
+{
+    /**
+     * Handle snmptrap.
+     * Data is pre-parsed and delivered as a Trap.
+     *
+     * @param Device $device
+     * @param Trap $trap
+     * @return void
+     */
+    public function handle(Device $device, Trap $trap)
+    {
+        /**
+        * Handle snmptrap.
+        * Data is pre-parsed and delivered as a Trap.
+        *
+        * @param  Device  $device
+        * @param  Trap  $trap
+        * @return void
+        */
+
+        $severity = Severity::Warning;
+        $edfaName = $trap->getOidData($trap->findOid('XKL-MIB::xklEDFAName'));
+
+        if ($trap->getOidData($trap->findOid('XKL-MIB::xklEDFAInReset')) == 2) {
+            $message = "$edfaName reset.";
+        } 
+        if ($trap->getOidData($trap->findOid('XKL-MIB::xklEDFADisabled')) == 2) {
+            $message = "$edfaName changed to disabled.";
+        }
+        if ($trap->getOidData($trap->findOid('XKL-MIB::xklEDFAMuted')) == 2) {
+            $message = "$edfaName has become muted.";
+        }
+        if ($trap->getOidData($trap->findOid('XKL-MIB::xklEDFACaseTemperatureAlarm')) == 2) {
+            $message = "$edfaName case temperature alarm is active.";
+        }
+        if ($trap->getOidData($trap->findOid('XKL-MIB::xklEDFACommonAlarm')) == 2) {
+            $message = "$edfaName common alarm is active.";
+        }
+        if ($trap->getOidData($trap->findOid('XKL-MIB::xklEDFAPumpTemperatureAlarm')) == 2) {
+            $message = "$edfaName pump temperature alarm is active.";
+        }
+        if ($trap->getOidData($trap->findOid('XKL-MIB::xklEDFAPumpBiasAlarm')) == 2) {
+            $message = "$edfaName loss of input alarm is active.";
+        }
+        if ($trap->getOidData($trap->findOid('XKL-MIB::xklEDFALossOfInputAlarm')) == 2) {
+            $message = "$edfaName loss of input alarm is active.";
+        }
+        if ($trap->getOidData($trap->findOid('XKL-MIB::xklEDFALossOfOutputAlarm')) == 2) {
+            $message = "$edfaName loss of output alarm is active.";
+        }
+        if ($trap->getOidData($trap->findOid('XKL-MIB::xklEDFALossOfOutputAlarm')) == 2) {
+            $message = "$edfaName loss of output alarm is active.";
+        }
+        if ($trap->getOidData($trap->findOid('XKL-MIB::xklEDFAModuleAlarms')) != "NONE") {
+            $message = "$edfaName module alarm: $trap->getOidData($trap->findOid('XKL-MIB::xklEDFAModuleAlarms'))";
+        }
+
+		$trap->log($message,$severity);
+    }
+}

--- a/LibreNMS/Snmptrap/Handlers/XklEdfaAlarmChange.php
+++ b/LibreNMS/Snmptrap/Handlers/XklEdfaAlarmChange.php
@@ -20,7 +20,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  * @link       http://librenms.org
- * @copyright  2026 Heath Barnhart
+ * @copyright  'yes'0'yes'6 Heath Barnhart
  * @author     Heath Barnhart hbarnhart@kanren.net
  */
 
@@ -54,39 +54,41 @@ class XklEdfaAlarmChange implements SnmptrapHandler
 
         $severity = Severity::Warning;
         $edfaName = $trap->getOidData($trap->findOid('XKL-MIB::xklEDFAName'));
+        $message = "Alarm not found";
 
-        if ($trap->getOidData($trap->findOid('XKL-MIB::xklEDFAInReset')) == 2) {
+        if ($trap->getOidData($trap->findOid('XKL-MIB::xklEDFAInReset')) == 'yes') {
             $message = "$edfaName reset.";
         } 
-        if ($trap->getOidData($trap->findOid('XKL-MIB::xklEDFADisabled')) == 2) {
+        if ($trap->getOidData($trap->findOid('XKL-MIB::xklEDFADisabled')) == 'yes') {
             $message = "$edfaName changed to disabled.";
         }
-        if ($trap->getOidData($trap->findOid('XKL-MIB::xklEDFAMuted')) == 2) {
+        if ($trap->getOidData($trap->findOid('XKL-MIB::xklEDFAMuted')) == 'yes') {
             $message = "$edfaName has become muted.";
         }
-        if ($trap->getOidData($trap->findOid('XKL-MIB::xklEDFACaseTemperatureAlarm')) == 2) {
+        if ($trap->getOidData($trap->findOid('XKL-MIB::xklEDFACaseTemperatureAlarm')) == 'yes') {
             $message = "$edfaName case temperature alarm is active.";
         }
-        if ($trap->getOidData($trap->findOid('XKL-MIB::xklEDFACommonAlarm')) == 2) {
+        if ($trap->getOidData($trap->findOid('XKL-MIB::xklEDFACommonAlarm')) == 'yes') {
             $message = "$edfaName common alarm is active.";
         }
-        if ($trap->getOidData($trap->findOid('XKL-MIB::xklEDFAPumpTemperatureAlarm')) == 2) {
+        if ($trap->getOidData($trap->findOid('XKL-MIB::xklEDFAPumpTemperatureAlarm')) == 'yes') {
             $message = "$edfaName pump temperature alarm is active.";
         }
-        if ($trap->getOidData($trap->findOid('XKL-MIB::xklEDFAPumpBiasAlarm')) == 2) {
+        if ($trap->getOidData($trap->findOid('XKL-MIB::xklEDFAPumpBiasAlarm')) == 'yes') {
             $message = "$edfaName EDFA pump BIAS alarm is active.";
             $severity = Severity::Error;
         }
-        if ($trap->getOidData($trap->findOid('XKL-MIB::xklEDFALossOfInputAlarm')) == 2) {
+        if ($trap->getOidData($trap->findOid('XKL-MIB::xklEDFALossOfInputAlarm')) == 'yes') {
             $message = "$edfaName loss of input alarm is active.";
             $severity = Severity::Error;
         }
-        if ($trap->getOidData($trap->findOid('XKL-MIB::xklEDFALossOfOutputAlarm')) == 2) {
+        if ($trap->getOidData($trap->findOid('XKL-MIB::xklEDFALossOfOutputAlarm')) == 'yes') {
             $message = "$edfaName loss of output alarm is active.";
             $severity = Severity::Error;
         }
         if ($trap->getOidData($trap->findOid('XKL-MIB::xklEDFAModuleAlarms')) != "NONE") {
-            $message = "$edfaName module alarm: $trap->getOidData($trap->findOid('XKL-MIB::xklEDFAModuleAlarms'))";
+            $moduleName = $trap->getOidData($trap->findOid('XKL-MIB::xklEDFAModuleAlarms'));
+            $message = "$edfaName module alarm: $moduleName";
         }
 
 		$trap->log($message,$severity);

--- a/LibreNMS/Snmptrap/Handlers/XklEdfaAlarmChange.php
+++ b/LibreNMS/Snmptrap/Handlers/XklEdfaAlarmChange.php
@@ -4,6 +4,8 @@
  *
  * -Description-
  *
+ * XKL EDFA state alarms.
+ * 
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -18,8 +20,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  * @link       http://librenms.org
- * @copyright  2026 <your name>
- * @author     <your name> <your email>
+ * @copyright  2026 Heath Barnhart
+ * @author     Heath Barnhart hbarnhart@kanren.net
  */
 
 namespace LibreNMS\Snmptrap\Handlers;
@@ -72,16 +74,16 @@ class XklEdfaAlarmChange implements SnmptrapHandler
             $message = "$edfaName pump temperature alarm is active.";
         }
         if ($trap->getOidData($trap->findOid('XKL-MIB::xklEDFAPumpBiasAlarm')) == 2) {
-            $message = "$edfaName loss of input alarm is active.";
+            $message = "$edfaName EDFA pump BIAS alarm is active.";
+            $severity = Severity::Error;
         }
         if ($trap->getOidData($trap->findOid('XKL-MIB::xklEDFALossOfInputAlarm')) == 2) {
             $message = "$edfaName loss of input alarm is active.";
+            $severity = Severity::Error;
         }
         if ($trap->getOidData($trap->findOid('XKL-MIB::xklEDFALossOfOutputAlarm')) == 2) {
             $message = "$edfaName loss of output alarm is active.";
-        }
-        if ($trap->getOidData($trap->findOid('XKL-MIB::xklEDFALossOfOutputAlarm')) == 2) {
-            $message = "$edfaName loss of output alarm is active.";
+            $severity = Severity::Error;
         }
         if ($trap->getOidData($trap->findOid('XKL-MIB::xklEDFAModuleAlarms')) != "NONE") {
             $message = "$edfaName module alarm: $trap->getOidData($trap->findOid('XKL-MIB::xklEDFAModuleAlarms'))";

--- a/LibreNMS/Snmptrap/Handlers/XklEdfaAlarmChange.php
+++ b/LibreNMS/Snmptrap/Handlers/XklEdfaAlarmChange.php
@@ -5,7 +5,7 @@
  * -Description-
  *
  * XKL EDFA state alarms.
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -20,6 +20,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  * @link       http://librenms.org
+ *
  * @copyright  'yes'0'yes'6 Heath Barnhart
  * @author     Heath Barnhart hbarnhart@kanren.net
  */
@@ -37,29 +38,29 @@ class XklEdfaAlarmChange implements SnmptrapHandler
      * Handle snmptrap.
      * Data is pre-parsed and delivered as a Trap.
      *
-     * @param Device $device
-     * @param Trap $trap
+     * @param  Device  $device
+     * @param  Trap  $trap
      * @return void
      */
     public function handle(Device $device, Trap $trap)
     {
         /**
-        * Handle snmptrap.
-        * Data is pre-parsed and delivered as a Trap.
-        *
-        * @param  Device  $device
-        * @param  Trap  $trap
-        * @return void
-        */
+         * Handle snmptrap.
+         * Data is pre-parsed and delivered as a Trap.
+         *
+         * @param  Device  $device
+         * @param  Trap  $trap
+         * @return void
+         */
 
         $severity = Severity::Warning;
         $edfaName = $trap->getOidData($trap->findOid('XKL-MIB::xklEDFAName'));
-        $message = "Alarm not found";
+        $message  = 'Alarm not found';
 
         if ($trap->getOidData($trap->findOid('XKL-MIB::xklEDFAInReset')) == 'yes') {
             $message = "$edfaName reset.";
-        } 
-        if ($trap->getOidData($trap->findOid('XKL-MIB::xklEDFADisabled')) == 'yes') {
+        }
+        if ($trap->getOidData($trap->findOid('XKL-MIB::xklEDFADisabled')) == 'disabled') {
             $message = "$edfaName changed to disabled.";
         }
         if ($trap->getOidData($trap->findOid('XKL-MIB::xklEDFAMuted')) == 'yes') {
@@ -72,22 +73,22 @@ class XklEdfaAlarmChange implements SnmptrapHandler
             $message = "$edfaName pump temperature alarm is active.";
         }
         if ($trap->getOidData($trap->findOid('XKL-MIB::xklEDFAPumpBiasAlarm')) == 'yes') {
-            $message = "$edfaName EDFA pump BIAS alarm is active.";
+            $message  = "$edfaName EDFA pump BIAS alarm is active.";
             $severity = Severity::Error;
         }
         if ($trap->getOidData($trap->findOid('XKL-MIB::xklEDFALossOfInputAlarm')) == 'yes') {
-            $message = "$edfaName loss of input alarm is active.";
+            $message  = "$edfaName loss of input alarm is active.";
             $severity = Severity::Error;
         }
         if ($trap->getOidData($trap->findOid('XKL-MIB::xklEDFALossOfOutputAlarm')) == 'yes') {
-            $message = "$edfaName loss of output alarm is active.";
+            $message  = "$edfaName loss of output alarm is active.";
             $severity = Severity::Error;
         }
-        if ($trap->getOidData($trap->findOid('XKL-MIB::xklEDFAModuleAlarms')) != "NONE") {
+        if ($trap->getOidData($trap->findOid('XKL-MIB::xklEDFAModuleAlarms')) != 'NONE') {
             $moduleName = $trap->getOidData($trap->findOid('XKL-MIB::xklEDFAModuleAlarms'));
-            $message = "$edfaName module alarm: $moduleName";
+            $message    = "$edfaName module alarm: $moduleName";
         }
 
-		$trap->log($message,$severity);
+        $trap->log($message, $severity);
     }
 }

--- a/LibreNMS/Snmptrap/Handlers/XklEdfaAlarmChange.php
+++ b/LibreNMS/Snmptrap/Handlers/XklEdfaAlarmChange.php
@@ -53,10 +53,9 @@ class XklEdfaAlarmChange implements SnmptrapHandler
          * @param  Trap  $trap
          * @return void
          */
-
-        $severity = Severity::Warning;
         $edfaName = $trap->getOidData($trap->findOid('XKL-MIB::xklEDFAName'));
-        $message = 'Alarm not found';
+        $moduleName = $trap->getOidData($trap->findOid('XKL-MIB::xklEDFAModuleAlarms'));
+        $message = "$edfaName module alarm: $moduleName";
 
         if ($trap->getOidData($trap->findOid('XKL-MIB::xklEDFAInReset')) == 'yes') {
             $message = "$edfaName reset.";
@@ -67,27 +66,10 @@ class XklEdfaAlarmChange implements SnmptrapHandler
         if ($trap->getOidData($trap->findOid('XKL-MIB::xklEDFAMuted')) == 'yes') {
             $message = "$edfaName has become muted.";
         }
-        if ($trap->getOidData($trap->findOid('XKL-MIB::xklEDFACaseTemperatureAlarm')) == 'yes') {
-            $message = "$edfaName case temperature alarm is active.";
-        }
-        if ($trap->getOidData($trap->findOid('XKL-MIB::xklEDFAPumpTemperatureAlarm')) == 'yes') {
-            $message = "$edfaName pump temperature alarm is active.";
-        }
-        if ($trap->getOidData($trap->findOid('XKL-MIB::xklEDFAPumpBiasAlarm')) == 'yes') {
-            $message = "$edfaName EDFA pump BIAS alarm is active.";
+
+        $severity = Severity::Warning;
+        if ($trap->getOidData($trap->findOid('XKL-MIB::xklEDFAPumpBiasAlarm')) == 'yes' || $trap->getOidData($trap->findOid('XKL-MIB::xklEDFALossOfInputAlarm')) == 'yes' || $trap->getOidData($trap->findOid('XKL-MIB::xklEDFALossOfOutputAlarm'))) {
             $severity = Severity::Error;
-        }
-        if ($trap->getOidData($trap->findOid('XKL-MIB::xklEDFALossOfInputAlarm')) == 'yes') {
-            $message = "$edfaName loss of input alarm is active.";
-            $severity = Severity::Error;
-        }
-        if ($trap->getOidData($trap->findOid('XKL-MIB::xklEDFALossOfOutputAlarm')) == 'yes') {
-            $message = "$edfaName loss of output alarm is active.";
-            $severity = Severity::Error;
-        }
-        if ($trap->getOidData($trap->findOid('XKL-MIB::xklEDFAModuleAlarms')) != 'NONE') {
-            $moduleName = $trap->getOidData($trap->findOid('XKL-MIB::xklEDFAModuleAlarms'));
-            $message = "$edfaName module alarm: $moduleName";
         }
 
         $trap->log($message, $severity);

--- a/LibreNMS/Snmptrap/Handlers/XklEdfaAlarmChange.php
+++ b/LibreNMS/Snmptrap/Handlers/XklEdfaAlarmChange.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * XklEdfaAlarmChange.php
  *
@@ -55,7 +56,7 @@ class XklEdfaAlarmChange implements SnmptrapHandler
 
         $severity = Severity::Warning;
         $edfaName = $trap->getOidData($trap->findOid('XKL-MIB::xklEDFAName'));
-        $message  = 'Alarm not found';
+        $message = 'Alarm not found';
 
         if ($trap->getOidData($trap->findOid('XKL-MIB::xklEDFAInReset')) == 'yes') {
             $message = "$edfaName reset.";
@@ -73,20 +74,20 @@ class XklEdfaAlarmChange implements SnmptrapHandler
             $message = "$edfaName pump temperature alarm is active.";
         }
         if ($trap->getOidData($trap->findOid('XKL-MIB::xklEDFAPumpBiasAlarm')) == 'yes') {
-            $message  = "$edfaName EDFA pump BIAS alarm is active.";
+            $message = "$edfaName EDFA pump BIAS alarm is active.";
             $severity = Severity::Error;
         }
         if ($trap->getOidData($trap->findOid('XKL-MIB::xklEDFALossOfInputAlarm')) == 'yes') {
-            $message  = "$edfaName loss of input alarm is active.";
+            $message = "$edfaName loss of input alarm is active.";
             $severity = Severity::Error;
         }
         if ($trap->getOidData($trap->findOid('XKL-MIB::xklEDFALossOfOutputAlarm')) == 'yes') {
-            $message  = "$edfaName loss of output alarm is active.";
+            $message = "$edfaName loss of output alarm is active.";
             $severity = Severity::Error;
         }
         if ($trap->getOidData($trap->findOid('XKL-MIB::xklEDFAModuleAlarms')) != 'NONE') {
             $moduleName = $trap->getOidData($trap->findOid('XKL-MIB::xklEDFAModuleAlarms'));
-            $message    = "$edfaName module alarm: $moduleName";
+            $message = "$edfaName module alarm: $moduleName";
         }
 
         $trap->log($message, $severity);

--- a/LibreNMS/Snmptrap/Handlers/XklEdfaLineChange.php
+++ b/LibreNMS/Snmptrap/Handlers/XklEdfaLineChange.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * XklEdfaLineChange.php
+ *
+ * -Description-
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Adva Threshold Exceeded Alarms.
+ *
+ * @link       https://www.librenms.org
+ *
+ * @copyright  2026 KanREN, Inc
+ * @author     Heath Barnhart <hbarnhart@kanren.net>
+ */
+
+namespace LibreNMS\Snmptrap\Handlers;
+
+use App\Models\Device;
+use LibreNMS\Enum\Severity;
+use LibreNMS\Interfaces\SnmptrapHandler;
+use LibreNMS\Snmptrap\Trap;
+
+class XklEdfaLineChange implements SnmptrapHandler {
+    /**
+     * Handle snmptrap.
+     * Data is pre-parsed and delivered as a Trap.
+     *
+     * @param  Device  $device
+     * @param  Trap  $trap
+     * @return void
+     */
+    public function handle(Device $device, Trap $trap): void
+    {
+        $edfaName = $trap->getOidData($trap->findOid('XKL-MIB::xklEDFAName'));
+        $edfaState = $trap->getOidData($trap->findOid('XKL-MIB::xklEDFAAmplificationState'));
+        switch($edfaState) {
+            case 1:
+                $severity = Severity::Ok;
+                break;
+            case 2:
+                $severity = Severity::Info;
+                break;
+            case 4:
+                $severity = Severity::Warning;
+                break;
+            case 7:
+                $severity = Severity::Info;
+                break;
+            default:
+                $severity = Severity::Error;
+                break;
+        }
+
+        $trap->log("$edfaName changed state to $edfaState", $severity);
+    }
+}

--- a/LibreNMS/Snmptrap/Handlers/XklEdfaLineChange.php
+++ b/LibreNMS/Snmptrap/Handlers/XklEdfaLineChange.php
@@ -47,16 +47,16 @@ class XklEdfaLineChange implements SnmptrapHandler {
         $edfaName = $trap->getOidData($trap->findOid('XKL-MIB::xklEDFAName'));
         $edfaState = $trap->getOidData($trap->findOid('XKL-MIB::xklEDFAAmplificationState'));
         switch($edfaState) {
-            case 1:
+            case 'up':
                 $severity = Severity::Ok;
                 break;
-            case 2:
+            case 'unused':
                 $severity = Severity::Info;
                 break;
-            case 4:
+            case 'warning':
                 $severity = Severity::Warning;
                 break;
-            case 7:
+            case 'unknown':
                 $severity = Severity::Info;
                 break;
             default:

--- a/LibreNMS/Snmptrap/Handlers/XklEdfaLineChange.php
+++ b/LibreNMS/Snmptrap/Handlers/XklEdfaLineChange.php
@@ -47,7 +47,7 @@ class XklEdfaLineChange implements SnmptrapHandler
     {
         $edfaName = $trap->getOidData($trap->findOid('XKL-MIB::xklEDFAName'));
         $edfaState = $trap->getOidData($trap->findOid('XKL-MIB::xklEDFAAmplificationState'));
-        $severity  = match ($edfaState) {
+        $severity = match ($edfaState) {
             'up' => Severity::Ok,
             'unused' => Severity::Info,
             'warning' => Severity::Info,

--- a/LibreNMS/Snmptrap/Handlers/XklEdfaLineChange.php
+++ b/LibreNMS/Snmptrap/Handlers/XklEdfaLineChange.php
@@ -33,7 +33,8 @@ use LibreNMS\Enum\Severity;
 use LibreNMS\Interfaces\SnmptrapHandler;
 use LibreNMS\Snmptrap\Trap;
 
-class XklEdfaLineChange implements SnmptrapHandler {
+class XklEdfaLineChange implements SnmptrapHandler
+{
     /**
      * Handle snmptrap.
      * Data is pre-parsed and delivered as a Trap.
@@ -44,14 +45,14 @@ class XklEdfaLineChange implements SnmptrapHandler {
      */
     public function handle(Device $device, Trap $trap): void
     {
-        $edfaName = $trap->getOidData($trap->findOid('XKL-MIB::xklEDFAName'));
+        $edfaName  = $trap->getOidData($trap->findOid('XKL-MIB::xklEDFAName'));
         $edfaState = $trap->getOidData($trap->findOid('XKL-MIB::xklEDFAAmplificationState'));
-        $severity = match($edfaState) {
-            'up' => Severity::Ok,
-            'unused' => Severity::Info,
+        $severity  = match ($edfaState) {
+            'up'      => Severity::Ok,
+            'unused'  => Severity::Info,
             'warning' => Severity::Info,
             'unknown' => Severity::Info,
-            default => Severity::Error,
+            default   => Severity::Error,
         };
 
         $trap->log("$edfaName changed state to $edfaState", $severity);

--- a/LibreNMS/Snmptrap/Handlers/XklEdfaLineChange.php
+++ b/LibreNMS/Snmptrap/Handlers/XklEdfaLineChange.php
@@ -45,14 +45,14 @@ class XklEdfaLineChange implements SnmptrapHandler
      */
     public function handle(Device $device, Trap $trap): void
     {
-        $edfaName  = $trap->getOidData($trap->findOid('XKL-MIB::xklEDFAName'));
+        $edfaName = $trap->getOidData($trap->findOid('XKL-MIB::xklEDFAName'));
         $edfaState = $trap->getOidData($trap->findOid('XKL-MIB::xklEDFAAmplificationState'));
         $severity  = match ($edfaState) {
-            'up'      => Severity::Ok,
-            'unused'  => Severity::Info,
+            'up' => Severity::Ok,
+            'unused' => Severity::Info,
             'warning' => Severity::Info,
             'unknown' => Severity::Info,
-            default   => Severity::Error,
+            default => Severity::Error,
         };
 
         $trap->log("$edfaName changed state to $edfaState", $severity);

--- a/LibreNMS/Snmptrap/Handlers/XklEdfaLineChange.php
+++ b/LibreNMS/Snmptrap/Handlers/XklEdfaLineChange.php
@@ -46,23 +46,13 @@ class XklEdfaLineChange implements SnmptrapHandler {
     {
         $edfaName = $trap->getOidData($trap->findOid('XKL-MIB::xklEDFAName'));
         $edfaState = $trap->getOidData($trap->findOid('XKL-MIB::xklEDFAAmplificationState'));
-        switch($edfaState) {
-            case 'up':
-                $severity = Severity::Ok;
-                break;
-            case 'unused':
-                $severity = Severity::Info;
-                break;
-            case 'warning':
-                $severity = Severity::Warning;
-                break;
-            case 'unknown':
-                $severity = Severity::Info;
-                break;
-            default:
-                $severity = Severity::Error;
-                break;
-        }
+        $severity = match($edfaState) {
+            'up' => Severity::Ok,
+            'unused' => Severity::Info,
+            'warning' => Severity::Info,
+            'unknown' => Severity::Info,
+            default => Severity::Error,
+        };
 
         $trap->log("$edfaName changed state to $edfaState", $severity);
     }

--- a/LibreNMS/Snmptrap/Handlers/XklRxPowerHiAlrm.php
+++ b/LibreNMS/Snmptrap/Handlers/XklRxPowerHiAlrm.php
@@ -1,10 +1,10 @@
 <?php
 /**
- * XklRxPowerLoWarn.php
+ * XklRxPowerHiAlrm.php
  *
  * -Description-
  * 
- * XKL transceiver receive power is below the warning threshold.
+ * XkL transciever has dropped exceeded the its upper recieve threshold.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -31,7 +31,7 @@ use LibreNMS\Enum\Severity;
 use LibreNMS\Interfaces\SnmptrapHandler;
 use LibreNMS\Snmptrap\Trap;
 
-class XklRxPowerLoWarn implements SnmptrapHandler
+class XklRxPowerHiAlrm implements SnmptrapHandler
 {
     /**
      * Handle snmptrap.
@@ -45,12 +45,12 @@ class XklRxPowerLoWarn implements SnmptrapHandler
     {
 
         $rxPower = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportReceivePower'));
-        $rxLoAlarm = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportRxPowerLoWarnThresh'));
+        $rxHiAlarm = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportRxPowerHiAlrmThresh'));
         $xcvrDescr = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportDescr'));
 
-        $message = "Transciever $xcvrDescr is below recieve warning threshold $rxLoAlarm. Current value: $rxPower";
+        $message = "Transciever $xcvrDescr is above recieve alarm threshold $rxHiAlarm. Current value: $rxPower";
         
-		$trap->log($message, Severity::Warning);
+		$trap->log($message, Severity::Error);
 
     }
 }

--- a/LibreNMS/Snmptrap/Handlers/XklRxPowerHiAlrm.php
+++ b/LibreNMS/Snmptrap/Handlers/XklRxPowerHiAlrm.php
@@ -3,7 +3,7 @@
  * XklRxPowerHiAlrm.php
  *
  * -Description-
- * 
+ *
  * XkL transciever has dropped exceeded the its upper recieve threshold.
  *
  * This program is free software: you can redistribute it and/or modify
@@ -20,6 +20,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  * @link       http://librenms.org
+ *
  * @copyright  2026 Heath Barnhart
  * @author     Heath Barnhart hbarnhart@kanren.net
  */
@@ -37,20 +38,18 @@ class XklRxPowerHiAlrm implements SnmptrapHandler
      * Handle snmptrap.
      * Data is pre-parsed and delivered as a Trap.
      *
-     * @param Device $device
-     * @param Trap $trap
+     * @param  Device  $device
+     * @param  Trap  $trap
      * @return void
      */
     public function handle(Device $device, Trap $trap)
     {
-
-        $rxPower = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportReceivePower'));
+        $rxPower   = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportReceivePower'));
         $rxHiAlarm = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportRxPowerHiAlrmThresh'));
         $xcvrDescr = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportDescr'));
 
         $message = "Transciever $xcvrDescr is above recieve alarm threshold $rxHiAlarm. Current value: $rxPower";
-        
-		$trap->log($message, Severity::Error);
 
+        $trap->log($message, Severity::Error);
     }
 }

--- a/LibreNMS/Snmptrap/Handlers/XklRxPowerHiAlrm.php
+++ b/LibreNMS/Snmptrap/Handlers/XklRxPowerHiAlrm.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * XklRxPowerHiAlrm.php
  *
@@ -44,7 +45,7 @@ class XklRxPowerHiAlrm implements SnmptrapHandler
      */
     public function handle(Device $device, Trap $trap)
     {
-        $rxPower   = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportReceivePower'));
+        $rxPower = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportReceivePower'));
         $rxHiAlarm = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportRxPowerHiAlrmThresh'));
         $xcvrDescr = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportDescr'));
 

--- a/LibreNMS/Snmptrap/Handlers/XklRxPowerHiWarn.php
+++ b/LibreNMS/Snmptrap/Handlers/XklRxPowerHiWarn.php
@@ -1,10 +1,10 @@
 <?php
 /**
- * XklRxPowerLoWarn.php
+ * XklRxPowerHiWarn.php
  *
  * -Description-
  * 
- * XKL transceiver receive power is below the warning threshold.
+ * XKL transceiver receive power is above the warning threshold.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -31,7 +31,7 @@ use LibreNMS\Enum\Severity;
 use LibreNMS\Interfaces\SnmptrapHandler;
 use LibreNMS\Snmptrap\Trap;
 
-class XklRxPowerLoWarn implements SnmptrapHandler
+class XklRxPowerHiWarn implements SnmptrapHandler
 {
     /**
      * Handle snmptrap.
@@ -45,10 +45,10 @@ class XklRxPowerLoWarn implements SnmptrapHandler
     {
 
         $rxPower = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportReceivePower'));
-        $rxLoAlarm = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportRxPowerLoWarnThresh'));
+        $rxHiAlarm = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportRxPowerHiWarnThresh'));
         $xcvrDescr = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportDescr'));
 
-        $message = "Transciever $xcvrDescr is below recieve warning threshold $rxLoAlarm. Current value: $rxPower";
+        $message = "Transciever $xcvrDescr is below recieve warning threshold $rxHiAlarm. Current value: $rxPower";
         
 		$trap->log($message, Severity::Warning);
 

--- a/LibreNMS/Snmptrap/Handlers/XklRxPowerHiWarn.php
+++ b/LibreNMS/Snmptrap/Handlers/XklRxPowerHiWarn.php
@@ -48,7 +48,7 @@ class XklRxPowerHiWarn implements SnmptrapHandler
         $rxHiAlarm = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportRxPowerHiWarnThresh'));
         $xcvrDescr = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportDescr'));
 
-        $message = "Transciever $xcvrDescr is below recieve warning threshold $rxHiAlarm. Current value: $rxPower";
+        $message = "Transciever $xcvrDescr is above recieve warning threshold $rxHiAlarm. Current value: $rxPower";
         
 		$trap->log($message, Severity::Warning);
 

--- a/LibreNMS/Snmptrap/Handlers/XklRxPowerHiWarn.php
+++ b/LibreNMS/Snmptrap/Handlers/XklRxPowerHiWarn.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * XklRxPowerHiWarn.php
  *
@@ -44,7 +45,7 @@ class XklRxPowerHiWarn implements SnmptrapHandler
      */
     public function handle(Device $device, Trap $trap)
     {
-        $rxPower   = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportReceivePower'));
+        $rxPower = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportReceivePower'));
         $rxHiAlarm = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportRxPowerHiWarnThresh'));
         $xcvrDescr = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportDescr'));
 

--- a/LibreNMS/Snmptrap/Handlers/XklRxPowerHiWarn.php
+++ b/LibreNMS/Snmptrap/Handlers/XklRxPowerHiWarn.php
@@ -3,7 +3,7 @@
  * XklRxPowerHiWarn.php
  *
  * -Description-
- * 
+ *
  * XKL transceiver receive power is above the warning threshold.
  *
  * This program is free software: you can redistribute it and/or modify
@@ -20,6 +20,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  * @link       http://librenms.org
+ *
  * @copyright  2026 Heath Barnhart
  * @author     Heath Barnhart hbarnhart@kanren.net
  */
@@ -37,20 +38,18 @@ class XklRxPowerHiWarn implements SnmptrapHandler
      * Handle snmptrap.
      * Data is pre-parsed and delivered as a Trap.
      *
-     * @param Device $device
-     * @param Trap $trap
+     * @param  Device  $device
+     * @param  Trap  $trap
      * @return void
      */
     public function handle(Device $device, Trap $trap)
     {
-
-        $rxPower = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportReceivePower'));
+        $rxPower   = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportReceivePower'));
         $rxHiAlarm = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportRxPowerHiWarnThresh'));
         $xcvrDescr = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportDescr'));
 
         $message = "Transciever $xcvrDescr is above recieve warning threshold $rxHiAlarm. Current value: $rxPower";
-        
-		$trap->log($message, Severity::Warning);
 
+        $trap->log($message, Severity::Warning);
     }
 }

--- a/LibreNMS/Snmptrap/Handlers/XklRxPowerLoAlrm.php
+++ b/LibreNMS/Snmptrap/Handlers/XklRxPowerLoAlrm.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * XklRxPowerLoAlrm.php
+ *
+ * -Description-
+ * 
+ * XkL transciever has dropped below the its recieve threshold.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @link       http://librenms.org
+ * @copyright  2026 Heath Barnhart
+ * @author     Heath Barnhart hbarnhart@kanren.net
+ */
+
+namespace LibreNMS\Snmptrap\Handlers;
+
+use App\Models\Device;
+use LibreNMS\Enum\Severity;
+use LibreNMS\Interfaces\SnmptrapHandler;
+use LibreNMS\Snmptrap\Trap;
+
+class XklRxPowerLoAlrm implements SnmptrapHandler
+{
+    /**
+     * Handle snmptrap.
+     * Data is pre-parsed and delivered as a Trap.
+     *
+     * @param Device $device
+     * @param Trap $trap
+     * @return void
+     */
+    public function handle(Device $device, Trap $trap)
+    {
+
+        $rxPower = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportReceivePower'));
+        $rxLoAlarm = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportRxPowerLoAlrmThresh'));
+        $xcvrDescr = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportDescr.33'));
+
+        $message = "Transciever $xcvrDescr is below recieve alarm threshold $rxLoAlarm. Current value: $rxPower";
+        
+		$trap->log($message, Severity::Error);
+
+    }
+}

--- a/LibreNMS/Snmptrap/Handlers/XklRxPowerLoAlrm.php
+++ b/LibreNMS/Snmptrap/Handlers/XklRxPowerLoAlrm.php
@@ -46,7 +46,7 @@ class XklRxPowerLoAlrm implements SnmptrapHandler
 
         $rxPower = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportReceivePower'));
         $rxLoAlarm = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportRxPowerLoAlrmThresh'));
-        $xcvrDescr = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportDescr.33'));
+        $xcvrDescr = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportDescr'));
 
         $message = "Transciever $xcvrDescr is below recieve alarm threshold $rxLoAlarm. Current value: $rxPower";
         

--- a/LibreNMS/Snmptrap/Handlers/XklRxPowerLoAlrm.php
+++ b/LibreNMS/Snmptrap/Handlers/XklRxPowerLoAlrm.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * XklRxPowerLoAlrm.php
  *
@@ -44,7 +45,7 @@ class XklRxPowerLoAlrm implements SnmptrapHandler
      */
     public function handle(Device $device, Trap $trap)
     {
-        $rxPower   = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportReceivePower'));
+        $rxPower = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportReceivePower'));
         $rxLoAlarm = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportRxPowerLoAlrmThresh'));
         $xcvrDescr = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportDescr'));
 

--- a/LibreNMS/Snmptrap/Handlers/XklRxPowerLoAlrm.php
+++ b/LibreNMS/Snmptrap/Handlers/XklRxPowerLoAlrm.php
@@ -3,7 +3,7 @@
  * XklRxPowerLoAlrm.php
  *
  * -Description-
- * 
+ *
  * XkL transciever has dropped below the its recieve threshold.
  *
  * This program is free software: you can redistribute it and/or modify
@@ -20,6 +20,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  * @link       http://librenms.org
+ *
  * @copyright  2026 Heath Barnhart
  * @author     Heath Barnhart hbarnhart@kanren.net
  */
@@ -37,20 +38,18 @@ class XklRxPowerLoAlrm implements SnmptrapHandler
      * Handle snmptrap.
      * Data is pre-parsed and delivered as a Trap.
      *
-     * @param Device $device
-     * @param Trap $trap
+     * @param  Device  $device
+     * @param  Trap  $trap
      * @return void
      */
     public function handle(Device $device, Trap $trap)
     {
-
-        $rxPower = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportReceivePower'));
+        $rxPower   = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportReceivePower'));
         $rxLoAlarm = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportRxPowerLoAlrmThresh'));
         $xcvrDescr = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportDescr'));
 
         $message = "Transciever $xcvrDescr is below recieve alarm threshold $rxLoAlarm. Current value: $rxPower";
-        
-		$trap->log($message, Severity::Error);
 
+        $trap->log($message, Severity::Error);
     }
 }

--- a/LibreNMS/Snmptrap/Handlers/XklRxPowerLoWarn.php
+++ b/LibreNMS/Snmptrap/Handlers/XklRxPowerLoWarn.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * XklRxPowerLoWarn.php
+ *
+ * -Description-
+ * 
+ * XKL transceiver receive power is below the warning threshold.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @link       http://librenms.org
+ * @copyright  2026 Heath Barnhart
+ * @author     Heath Barnhart hbarnhart@kanren.net
+ */
+
+namespace LibreNMS\Snmptrap\Handlers;
+
+use App\Models\Device;
+use LibreNMS\Enum\Severity;
+use LibreNMS\Interfaces\SnmptrapHandler;
+use LibreNMS\Snmptrap\Trap;
+
+class XklRxPowerLoWarn implements SnmptrapHandler
+{
+    /**
+     * Handle snmptrap.
+     * Data is pre-parsed and delivered as a Trap.
+     *
+     * @param Device $device
+     * @param Trap $trap
+     * @return void
+     */
+    public function handle(Device $device, Trap $trap)
+    {
+
+        $rxPower = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportReceivePower'));
+        $rxLoAlarm = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportRxPowerLoWarnThresh'));
+        $xcvrDescr = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportDescr.33'));
+
+        $message = "Transciever $xcvrDescr is below recieve warning threshold $rxLoAlarm. Current value: $rxPower";
+        
+		$trap->log($message, Severity::Warning);
+
+    }
+}

--- a/LibreNMS/Snmptrap/Handlers/XklRxPowerLoWarn.php
+++ b/LibreNMS/Snmptrap/Handlers/XklRxPowerLoWarn.php
@@ -3,7 +3,7 @@
  * XklRxPowerLoWarn.php
  *
  * -Description-
- * 
+ *
  * XKL transceiver receive power is below the warning threshold.
  *
  * This program is free software: you can redistribute it and/or modify
@@ -20,6 +20,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  * @link       http://librenms.org
+ *
  * @copyright  2026 Heath Barnhart
  * @author     Heath Barnhart hbarnhart@kanren.net
  */
@@ -37,20 +38,18 @@ class XklRxPowerLoWarn implements SnmptrapHandler
      * Handle snmptrap.
      * Data is pre-parsed and delivered as a Trap.
      *
-     * @param Device $device
-     * @param Trap $trap
+     * @param  Device  $device
+     * @param  Trap  $trap
      * @return void
      */
     public function handle(Device $device, Trap $trap)
     {
-
-        $rxPower = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportReceivePower'));
+        $rxPower   = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportReceivePower'));
         $rxLoAlarm = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportRxPowerLoWarnThresh'));
         $xcvrDescr = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportDescr'));
 
         $message = "Transciever $xcvrDescr is below recieve warning threshold $rxLoAlarm. Current value: $rxPower";
-        
-		$trap->log($message, Severity::Warning);
 
+        $trap->log($message, Severity::Warning);
     }
 }

--- a/LibreNMS/Snmptrap/Handlers/XklRxPowerLoWarn.php
+++ b/LibreNMS/Snmptrap/Handlers/XklRxPowerLoWarn.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * XklRxPowerLoWarn.php
  *
@@ -44,7 +45,7 @@ class XklRxPowerLoWarn implements SnmptrapHandler
      */
     public function handle(Device $device, Trap $trap)
     {
-        $rxPower   = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportReceivePower'));
+        $rxPower = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportReceivePower'));
         $rxLoAlarm = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportRxPowerLoWarnThresh'));
         $xcvrDescr = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportDescr'));
 

--- a/LibreNMS/Snmptrap/Handlers/XklRxPowerOK.php
+++ b/LibreNMS/Snmptrap/Handlers/XklRxPowerOK.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * XklRxPowerOK.php
+ *
+ * -Description-
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @link       http://librenms.org
+ * @copyright  2026 Heath Barnhart
+ * @author     Heath Barnhart <your email>
+ */
+
+namespace LibreNMS\Snmptrap\Handlers;
+
+use App\Models\Device;
+use LibreNMS\Enum\Severity;
+use LibreNMS\Interfaces\SnmptrapHandler;
+use LibreNMS\Snmptrap\Trap;
+
+class XklRxPowerOK implements SnmptrapHandler
+{
+    /**
+     * Handle snmptrap.
+     * Data is pre-parsed and delivered as a Trap.
+     *
+     * @param Device $device
+     * @param Trap $trap
+     * @return void
+     */
+    public function handle(Device $device, Trap $trap)
+    {
+
+        $rxPower = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportReceivePower'));
+        $xcvrDescr = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportDescr.33'));
+
+        $message = "Transciever $xcvrDescr receive power OK. Current value: $rxPower";
+        
+		$trap->log($message, Severity::Ok);
+
+    }
+}

--- a/LibreNMS/Snmptrap/Handlers/XklRxPowerOK.php
+++ b/LibreNMS/Snmptrap/Handlers/XklRxPowerOK.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * XklRxPowerOK.php
  *
@@ -36,13 +37,13 @@ class XklRxPowerOK implements SnmptrapHandler
      * Handle snmptrap.
      * Data is pre-parsed and delivered as a Trap.
      *
-     * @param Device $device
-     * @param Trap $trap
+     * @param  Device  $device
+     * @param  Trap  $trap
      * @return void
      */
     public function handle(Device $device, Trap $trap)
     {
-        $rxPower   = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportReceivePower'));
+        $rxPower = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportReceivePower'));
         $xcvrDescr = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportDescr.33'));
 
         $message = "Transciever $xcvrDescr receive power OK. Current value: $rxPower";

--- a/LibreNMS/Snmptrap/Handlers/XklRxPowerOK.php
+++ b/LibreNMS/Snmptrap/Handlers/XklRxPowerOK.php
@@ -18,6 +18,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  * @link       http://librenms.org
+ *
  * @copyright  2026 Heath Barnhart
  * @author     Heath Barnhart <your email>
  */
@@ -41,13 +42,11 @@ class XklRxPowerOK implements SnmptrapHandler
      */
     public function handle(Device $device, Trap $trap)
     {
-
-        $rxPower = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportReceivePower'));
+        $rxPower   = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportReceivePower'));
         $xcvrDescr = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportDescr.33'));
 
         $message = "Transciever $xcvrDescr receive power OK. Current value: $rxPower";
-        
-		$trap->log($message, Severity::Ok);
 
+        $trap->log($message, Severity::Ok);
     }
 }

--- a/LibreNMS/Snmptrap/Handlers/XklTransportLinkDown.php
+++ b/LibreNMS/Snmptrap/Handlers/XklTransportLinkDown.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * XklTransportLinkDown.php
+ *
+ * -Description-
+ * 
+ * XKL optical transport service is down.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @link       http://librenms.org
+ * @copyright  2026 Heath Barnhart
+ * @author     Heath Barnhart hbarnhart@kanren.net
+ */
+
+namespace LibreNMS\Snmptrap\Handlers;
+
+use App\Models\Device;
+use LibreNMS\Enum\Severity;
+use LibreNMS\Interfaces\SnmptrapHandler;
+use LibreNMS\Snmptrap\Trap;
+
+class XklTransportLinkDown implements SnmptrapHandler
+{
+    /**
+     * Handle snmptrap.
+     * Data is pre-parsed and delivered as a Trap.
+     *
+     * @param Device $device
+     * @param Trap $trap
+     * @return void
+     */
+    public function handle(Device $device, Trap $trap)
+    {
+
+        $transIndex = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportIndex'));
+        $transTxStatus = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportTxStatus'));
+        $transRxStatus = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportRxStatus'));
+
+        $message = "Transport service $transIndex is down. Transmit status: $transTxStatus Receive status: $transRxStatus";
+        
+		$trap->log($message, Severity::Error);
+
+    }
+}

--- a/LibreNMS/Snmptrap/Handlers/XklTransportLinkDown.php
+++ b/LibreNMS/Snmptrap/Handlers/XklTransportLinkDown.php
@@ -3,7 +3,7 @@
  * XklTransportLinkDown.php
  *
  * -Description-
- * 
+ *
  * XKL optical transport service is down.
  *
  * This program is free software: you can redistribute it and/or modify
@@ -20,6 +20,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  * @link       http://librenms.org
+ *
  * @copyright  2026 Heath Barnhart
  * @author     Heath Barnhart hbarnhart@kanren.net
  */
@@ -37,20 +38,18 @@ class XklTransportLinkDown implements SnmptrapHandler
      * Handle snmptrap.
      * Data is pre-parsed and delivered as a Trap.
      *
-     * @param Device $device
-     * @param Trap $trap
+     * @param  Device  $device
+     * @param  Trap  $trap
      * @return void
      */
     public function handle(Device $device, Trap $trap)
     {
-
-        $transIndex = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportIndex'));
+        $transIndex    = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportIndex'));
         $transTxStatus = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportTxStatus'));
         $transRxStatus = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportRxStatus'));
 
         $message = "Transport service $transIndex is down. Transmit status: $transTxStatus Receive status: $transRxStatus";
-        
-		$trap->log($message, Severity::Error);
 
+        $trap->log($message, Severity::Error);
     }
 }

--- a/LibreNMS/Snmptrap/Handlers/XklTransportLinkDown.php
+++ b/LibreNMS/Snmptrap/Handlers/XklTransportLinkDown.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * XklTransportLinkDown.php
  *
@@ -44,7 +45,7 @@ class XklTransportLinkDown implements SnmptrapHandler
      */
     public function handle(Device $device, Trap $trap)
     {
-        $transIndex    = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportIndex'));
+        $transIndex = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportIndex'));
         $transTxStatus = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportTxStatus'));
         $transRxStatus = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportRxStatus'));
 

--- a/LibreNMS/Snmptrap/Handlers/XklTransportLinkUp.php
+++ b/LibreNMS/Snmptrap/Handlers/XklTransportLinkUp.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * XklTransportLinkUp.php
+ *
+ * -Description-
+ *
+ * XKL optical transport service is now up.
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @link       http://librenms.org
+ * @copyright  2026 Heath Barnhart
+ * @author     Heath Barnhart hbarnhart@kanren.net
+ */
+
+namespace LibreNMS\Snmptrap\Handlers;
+
+use App\Models\Device;
+use LibreNMS\Enum\Severity;
+use LibreNMS\Interfaces\SnmptrapHandler;
+use LibreNMS\Snmptrap\Trap;
+
+class XklTransportLinkUp implements SnmptrapHandler
+{
+    /**
+     * Handle snmptrap.
+     * Data is pre-parsed and delivered as a Trap.
+     *
+     * @param Device $device
+     * @param Trap $trap
+     * @return void
+     */
+    public function handle(Device $device, Trap $trap)
+    {
+
+        $transIndex = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportIndex'));
+
+        $message = "Tranport $transIndex is up.";
+   
+		$trap->log($message, Severity::Ok);
+
+    }
+}

--- a/LibreNMS/Snmptrap/Handlers/XklTransportLinkUp.php
+++ b/LibreNMS/Snmptrap/Handlers/XklTransportLinkUp.php
@@ -50,6 +50,5 @@ class XklTransportLinkUp implements SnmptrapHandler
         $message = "Tranport $transIndex is up.";
 
         $trap->log($message, Severity::Ok);
-
     }
 }

--- a/LibreNMS/Snmptrap/Handlers/XklTransportLinkUp.php
+++ b/LibreNMS/Snmptrap/Handlers/XklTransportLinkUp.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * XklTransportLinkUp.php
  *
@@ -44,7 +45,6 @@ class XklTransportLinkUp implements SnmptrapHandler
      */
     public function handle(Device $device, Trap $trap)
     {
-
         $transIndex = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportIndex'));
 
         $message = "Tranport $transIndex is up.";

--- a/LibreNMS/Snmptrap/Handlers/XklTransportLinkUp.php
+++ b/LibreNMS/Snmptrap/Handlers/XklTransportLinkUp.php
@@ -5,7 +5,7 @@
  * -Description-
  *
  * XKL optical transport service is now up.
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -20,6 +20,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  * @link       http://librenms.org
+ *
  * @copyright  2026 Heath Barnhart
  * @author     Heath Barnhart hbarnhart@kanren.net
  */
@@ -37,8 +38,8 @@ class XklTransportLinkUp implements SnmptrapHandler
      * Handle snmptrap.
      * Data is pre-parsed and delivered as a Trap.
      *
-     * @param Device $device
-     * @param Trap $trap
+     * @param  Device  $device
+     * @param  Trap  $trap
      * @return void
      */
     public function handle(Device $device, Trap $trap)
@@ -47,8 +48,8 @@ class XklTransportLinkUp implements SnmptrapHandler
         $transIndex = $trap->getOidData($trap->findOid('XKL-MIB::xklTransportIndex'));
 
         $message = "Tranport $transIndex is up.";
-   
-		$trap->log($message, Severity::Ok);
+
+        $trap->log($message, Severity::Ok);
 
     }
 }

--- a/config/snmptraps.php
+++ b/config/snmptraps.php
@@ -196,7 +196,10 @@ return [
         'XKL-MIB::xklRxPowerOK' => LibreNMS\Snmptrap\Handlers\XklRxPowerOK::class,
         'XKL-MIB::xklRxPowerLoWarn' => LibreNMS\Snmptrap\Handlers\XklRxPowerLoWarn::class,
         'XKL-MIB::xklRxPowerLoAlrm' => LibreNMS\Snmptrap\Handlers\XklRxPowerLoAlrm::class,
+        'XKL-MIB::xklRxPowerHiWarn' => LibreNMS\Snmptrap\Handlers\XklRxPowerHiWarn::class,
+        'XKL-MIB::xklRxPowerHiAlrm' => LibreNMS\Snmptrap\Handlers\XklRxPowerHiAlrm::class,
         'XKL-MIB::xklAutomaticOTDRTriggered' => LibreNMS\Snmptrap\Handlers\XklAutomaticOTDRTriggered::class,
         'XKL-MIB::xklEDFAAlarmChange' => LibreNMS\Snmptrap\Handlers\XklEdfaAlarmChange::class,
+        'XKL-MIB::xklEDFALineChange' => LibreNMS\Snmptrap\Handlers\XklEdfaLineChange::class,
     ],
 ];

--- a/config/snmptraps.php
+++ b/config/snmptraps.php
@@ -191,5 +191,12 @@ return [
         'EES-POWER-MIB::alarmTrap' => LibreNMS\Snmptrap\Handlers\EesPowerAlarm::class,
         'EES-POWER-MIB::alarmActiveTrap' => LibreNMS\Snmptrap\Handlers\EesPowerAlarm::class,
         'EES-POWER-MIB::alarmCeaseTrap' => LibreNMS\Snmptrap\Handlers\EesPowerAlarm::class,
+        'XKL-MIB::xklTransportLinkUp' => LibreNMS\Snmptrap\Handlers\XklTransportLinkUp::class,
+        'XKL-MIB::xklTransportLinkDown' => LibreNMS\Snmptrap\Handlers\XklTransportLinkDown::class,
+        'XKL-MIB::xklRxPowerOK' => LibreNMS\Snmptrap\Handlers\XklRxPowerOK::class,
+        'XKL-MIB::xklRxPowerLoWarn' => LibreNMS\Snmptrap\Handlers\XklRxPowerLoWarn::class,
+        'XKL-MIB::xklRxPowerLoAlrm' => LibreNMS\Snmptrap\Handlers\XklRxPowerLoAlrm::class,
+        'XKL-MIB::xklAutomaticOTDRTriggered' => LibreNMS\Snmptrap\Handlers\XklAutomaticOTDRTriggered::class,
+        'XKL-MIB::xklEDFAAlarmChange' => LibreNMS\Snmptrap\Handlers\XklEdfaAlarmChange::class,
     ],
 ];

--- a/tests/Feature/SnmpTraps/XklAutomaticOTDRTriggeredTest.php
+++ b/tests/Feature/SnmpTraps/XklAutomaticOTDRTriggeredTest.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * XklAutomaticOTDRTriggeredTest.php
+ *
+ * -Description-
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @link       http://librenms.org
+ * @copyright  2026 Heath Barnhart
+ * @author     Heath Barnhart hbarnhart@kanren.net
+ */
+ 
+ namespace LibreNMS\Tests\Feature\SnmpTraps;
+
+final class XklAutomaticOTDRTriggeredTest extends SnmpTrapTestCase
+{
+    public function testXklAutomaticOTDRTriggered(): void
+    {
+	    $this->assertTrapLogsMessage(<<<'TRAP'
+{{ hostname }}
+UDP: [{{ ip }}]:44298->[192.168.5.5]:162
+DISMAN-EVENT-MIB::sysUpTimeInstance 0:4:53:43.00
+SNMPv2-MIB::snmpTrapOID.0 XKL-MIB::xklAutomaticOTDRTriggered
+XKL-MIB::xklOTDRLatestMeasurementOSCIndex.1 1
+XKL-MIB::xklOTDRLatestMeasurementOSCDescr.1 OSC 0 (N\/A)
+XKL-MIB::xklOTDRLatestMeasurementResults.1 47.91km
+XKL-MIB::xklOTDRLatestMeasurementDateTime.1 06-23-2026 01:25:21
+XKL-MIB::xklOTDRLatestMeasurementOTDRGroupNumber.1 none
+XKL-MIB::xklOTDRLatestMeasurementOTDRGroupName.1 N\/A
+TRAP,
+
+		'Automatic OTDR Event at 06-23-2026 01:25:21. Name: OSC 0 (N\/A) Length: 47.91km',
+		'Failed to handle XklAutomaticOTDRTriggered trap.',
+		);
+	}
+}

--- a/tests/Feature/SnmpTraps/XklAutomaticOTDRTriggeredTest.php
+++ b/tests/Feature/SnmpTraps/XklAutomaticOTDRTriggeredTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * XklAutomaticOTDRTriggeredTest.php
  *
@@ -18,18 +19,20 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  * @link       http://librenms.org
+ *
  * @copyright  2026 Heath Barnhart
  * @author     Heath Barnhart hbarnhart@kanren.net
  */
- 
+
 namespace LibreNMS\Tests\Feature\SnmpTraps;
+
 use LibreNMS\Enum\Severity;
 
 final class XklAutomaticOTDRTriggeredTest extends SnmpTrapTestCase
 {
     public function testXklAutomaticOTDRTriggered(): void
     {
-	    $this->assertTrapLogsMessage(<<<'TRAP'
+        $this->assertTrapLogsMessage(<<<'TRAP'
 {{ hostname }}
 UDP: [{{ ip }}]:44298->[192.168.5.5]:162
 DISMAN-EVENT-MIB::sysUpTimeInstance 0:4:53:43.00
@@ -42,9 +45,9 @@ XKL-MIB::xklOTDRLatestMeasurementOTDRGroupNumber.1 none
 XKL-MIB::xklOTDRLatestMeasurementOTDRGroupName.1 N\/A
 TRAP,
 
-		'Automatic OTDR Event at 06-23-2026 01:25:21. Name: OSC 0 (N\/A) Length: 47.91km',
-		'Failed to handle XklAutomaticOTDRTriggered trap.',
-		[Severity::Warning],
-		);
-	}
+            'Automatic OTDR Event at 06-23-2026 01:25:21. Name: OSC 0 (N\/A) Length: 47.91km',
+            'Failed to handle XklAutomaticOTDRTriggered trap.',
+            [Severity::Warning],
+        );
+    }
 }

--- a/tests/Feature/SnmpTraps/XklAutomaticOTDRTriggeredTest.php
+++ b/tests/Feature/SnmpTraps/XklAutomaticOTDRTriggeredTest.php
@@ -22,7 +22,8 @@
  * @author     Heath Barnhart hbarnhart@kanren.net
  */
  
- namespace LibreNMS\Tests\Feature\SnmpTraps;
+namespace LibreNMS\Tests\Feature\SnmpTraps;
+use LibreNMS\Enum\Severity;
 
 final class XklAutomaticOTDRTriggeredTest extends SnmpTrapTestCase
 {
@@ -43,6 +44,7 @@ TRAP,
 
 		'Automatic OTDR Event at 06-23-2026 01:25:21. Name: OSC 0 (N\/A) Length: 47.91km',
 		'Failed to handle XklAutomaticOTDRTriggered trap.',
+		[Severity::Warning],
 		);
 	}
 }

--- a/tests/Feature/SnmpTraps/XklEdfaAlarmChangeTest.php
+++ b/tests/Feature/SnmpTraps/XklEdfaAlarmChangeTest.php
@@ -1,0 +1,262 @@
+<?php
+/**
+ * XklEdfaAlarmChangeTest.php
+ *
+ * -Description-
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @link       http://librenms.org
+ * @copyright  2026 Heath Barnhart
+ * @author     Heath Barnhart hbarnhart@kanren.net
+ */
+ 
+ namespace LibreNMS\Tests\Feature\SnmpTraps;
+ use LibreNMS\Enum\Severity;
+
+final class XklEdfaAlarmChangeTest extends SnmpTrapTestCase
+{
+    public function testXklEdfaAlarmChangeDisabled(): void
+    {
+	    $this->assertTrapLogsMessage(<<<'TRAP'
+{{ hostname }}
+UDP: [{{ ip }}]:44298->[192.168.5.5]:162
+DISMAN-EVENT-MIB::sysUpTimeInstance 0:4:53:43.00
+SNMPv2-MIB::snmpTrapOID.0 XKL-MIB::xklEDFAAlarmChange
+XKL-MIB::xklEDFAIndex.1 1
+XKL-MIB::xklEDFAInReset.1 no
+XKL-MIB::xklEDFADisabled.1 enabled
+XKL-MIB::xklEDFAMuted.1 no
+XKL-MIB::xklEDFACaseTemperatureAlarm.1 no
+XKL-MIB::xklEDFACommonAlarm.1 yes
+XKL-MIB::xklEDFAPumpTemperatureAlarm.1 no
+XKL-MIB::xklEDFALossOfInputAlarm.1 no
+XKL-MIB::xklEDFALossOfOutputAlarm.1 no
+XKL-MIB::xklEDFAModuleAlarms.1 NONE 
+XKL-MIB::xklEDFAName.1 Output EDFA
+TRAP,
+
+		'Output EDFA changed to disabled.',
+		'Failed to handle XklEdfaAlarmChange EDFA disabled alarm trap.',
+		);
+	}
+
+	public function testXklEdfaAlarmChangeReset(): void
+    {
+	    $this->assertTrapLogsMessage(<<<'TRAP'
+{{ hostname }}
+UDP: [{{ ip }}]:44298->[192.168.5.5]:162
+DISMAN-EVENT-MIB::sysUpTimeInstance 0:4:53:43.00
+SNMPv2-MIB::snmpTrapOID.0 XKL-MIB::xklEDFAAlarmChange
+XKL-MIB::xklEDFAIndex.1 1
+XKL-MIB::xklEDFAInReset.1 yes
+XKL-MIB::xklEDFADisabled.1 disabled
+XKL-MIB::xklEDFAMuted.1 no
+XKL-MIB::xklEDFACaseTemperatureAlarm.1 no
+XKL-MIB::xklEDFACommonAlarm.1 yes
+XKL-MIB::xklEDFAPumpTemperatureAlarm.1 no
+XKL-MIB::xklEDFALossOfInputAlarm.1 no
+XKL-MIB::xklEDFALossOfOutputAlarm.1 no
+XKL-MIB::xklEDFAModuleAlarms.1 NONE 
+XKL-MIB::xklEDFAName.1 Output EDFA
+TRAP,
+
+		'Output EDFA reset.',
+		'Failed to handle XklEdfaAlarmChange EDFA reset alarm trap.',
+		);
+	}
+
+	public function testXklEdfaAlarmChangeMuted(): void
+    {
+	    $this->assertTrapLogsMessage(<<<'TRAP'
+{{ hostname }}
+UDP: [{{ ip }}]:44298->[192.168.5.5]:162
+DISMAN-EVENT-MIB::sysUpTimeInstance 0:4:53:43.00
+SNMPv2-MIB::snmpTrapOID.0 XKL-MIB::xklEDFAAlarmChange
+XKL-MIB::xklEDFAIndex.1 1
+XKL-MIB::xklEDFAInReset.1 no
+XKL-MIB::xklEDFADisabled.1 disabled
+XKL-MIB::xklEDFAMuted.1 yes
+XKL-MIB::xklEDFACaseTemperatureAlarm.1 no
+XKL-MIB::xklEDFACommonAlarm.1 yes
+XKL-MIB::xklEDFAPumpTemperatureAlarm.1 no
+XKL-MIB::xklEDFALossOfInputAlarm.1 no
+XKL-MIB::xklEDFALossOfOutputAlarm.1 no
+XKL-MIB::xklEDFAModuleAlarms.1 NONE 
+XKL-MIB::xklEDFAName.1 Output EDFA
+TRAP,
+
+		'Output EDFA has become muted.',
+		'Failed to handle XklEdfaAlarmChange EDFA muted alarm trap.',
+		);
+	}
+
+	public function testXklEdfaAlarmChangeCaseTemp(): void
+    {
+	    $this->assertTrapLogsMessage(<<<'TRAP'
+{{ hostname }}
+UDP: [{{ ip }}]:44298->[192.168.5.5]:162
+DISMAN-EVENT-MIB::sysUpTimeInstance 0:4:53:43.00
+SNMPv2-MIB::snmpTrapOID.0 XKL-MIB::xklEDFAAlarmChange
+XKL-MIB::xklEDFAIndex.1 1
+XKL-MIB::xklEDFAInReset.1 no
+XKL-MIB::xklEDFADisabled.1 disabled
+XKL-MIB::xklEDFAMuted.1 no
+XKL-MIB::xklEDFACaseTemperatureAlarm.1 yes
+XKL-MIB::xklEDFACommonAlarm.1 yes
+XKL-MIB::xklEDFAPumpTemperatureAlarm.1 no
+XKL-MIB::xklEDFALossOfInputAlarm.1 no
+XKL-MIB::xklEDFALossOfOutputAlarm.1 no
+XKL-MIB::xklEDFAModuleAlarms.1 NONE 
+XKL-MIB::xklEDFAName.1 Output EDFA
+TRAP,
+
+		'Output EDFA case temperature alarm is active.',
+		'Failed to handle XklEdfaAlarmChange case temperature alarm trap.',
+		);
+	}
+
+	public function testXklEdfaAlarmChangePumpTemp(): void
+    {
+	    $this->assertTrapLogsMessage(<<<'TRAP'
+{{ hostname }}
+UDP: [{{ ip }}]:44298->[192.168.5.5]:162
+DISMAN-EVENT-MIB::sysUpTimeInstance 0:4:53:43.00
+SNMPv2-MIB::snmpTrapOID.0 XKL-MIB::xklEDFAAlarmChange
+XKL-MIB::xklEDFAIndex.1 1
+XKL-MIB::xklEDFAInReset.1 no
+XKL-MIB::xklEDFADisabled.1 disabled
+XKL-MIB::xklEDFAMuted.1 no
+XKL-MIB::xklEDFACaseTemperatureAlarm.1 no
+XKL-MIB::xklEDFACommonAlarm.1 yes
+XKL-MIB::xklEDFAPumpTemperatureAlarm.1 yes
+XKL-MIB::xklEDFALossOfInputAlarm.1 no
+XKL-MIB::xklEDFALossOfOutputAlarm.1 no
+XKL-MIB::xklEDFAModuleAlarms.1 NONE 
+XKL-MIB::xklEDFAName.1 Output EDFA
+TRAP,
+
+		'Output EDFA pump temperature alarm is active.',
+		'Failed to handle XklEdfaAlarmChange pump temperature alarm trap.',
+		);
+	}
+
+	public function testXklEdfaAlarmChangePumpBias(): void
+    {
+	    $this->assertTrapLogsMessage(<<<'TRAP'
+{{ hostname }}
+UDP: [{{ ip }}]:44298->[192.168.5.5]:162
+DISMAN-EVENT-MIB::sysUpTimeInstance 0:4:53:43.00
+SNMPv2-MIB::snmpTrapOID.0 XKL-MIB::xklEDFAAlarmChange
+XKL-MIB::xklEDFAIndex.1 1
+XKL-MIB::xklEDFAInReset.1 no
+XKL-MIB::xklEDFADisabled.1 disabled
+XKL-MIB::xklEDFAMuted.1 no
+XKL-MIB::xklEDFACaseTemperatureAlarm.1 no
+XKL-MIB::xklEDFACommonAlarm.1 no
+XKL-MIB::xklEDFAPumpTemperatureAlarm.1 no
+XKL-MIB::xklEDFAPumpBiasAlarm yes
+XKL-MIB::xklEDFALossOfInputAlarm.1 no
+XKL-MIB::xklEDFALossOfOutputAlarm.1 no
+XKL-MIB::xklEDFAModuleAlarms.1 NONE 
+XKL-MIB::xklEDFAName.1 Output EDFA
+TRAP,
+
+		'Output EDFA pump BIAS alarm is active.',
+		'Failed to handle XklEdfaAlarmChange EDFA BIAS alarm trap.',
+		[Severity::Error],
+		);
+	}
+
+	public function testXklEdfaAlarmChangeLossInput(): void
+    {
+	    $this->assertTrapLogsMessage(<<<'TRAP'
+{{ hostname }}
+UDP: [{{ ip }}]:44298->[192.168.5.5]:162
+DISMAN-EVENT-MIB::sysUpTimeInstance 0:4:53:43.00
+SNMPv2-MIB::snmpTrapOID.0 XKL-MIB::xklEDFAAlarmChange
+XKL-MIB::xklEDFAIndex.1 1
+XKL-MIB::xklEDFAInReset.1 no
+XKL-MIB::xklEDFADisabled.1 disabled
+XKL-MIB::xklEDFAMuted.1 no
+XKL-MIB::xklEDFACaseTemperatureAlarm.1 no
+XKL-MIB::xklEDFACommonAlarm.1 no
+XKL-MIB::xklEDFAPumpTemperatureAlarm.1 no
+XKL-MIB::xklEDFAPumpBiasAlarm no
+XKL-MIB::xklEDFALossOfInputAlarm.1 yes
+XKL-MIB::xklEDFALossOfOutputAlarm.1 no
+XKL-MIB::xklEDFAModuleAlarms.1 NONE 
+XKL-MIB::xklEDFAName.1 Output EDFA
+TRAP,
+
+		'Output EDFA loss of input alarm is active.',
+		'Failed to handle XklEdfaAlarmChange loss of input alarm trap.',
+		[Severity::Error],
+		);
+	}
+
+	public function testXklEdfaAlarmChangeLossOutput(): void
+    {
+	    $this->assertTrapLogsMessage(<<<'TRAP'
+{{ hostname }}
+UDP: [{{ ip }}]:44298->[192.168.5.5]:162
+DISMAN-EVENT-MIB::sysUpTimeInstance 0:4:53:43.00
+SNMPv2-MIB::snmpTrapOID.0 XKL-MIB::xklEDFAAlarmChange
+XKL-MIB::xklEDFAIndex.1 1
+XKL-MIB::xklEDFAInReset.1 no
+XKL-MIB::xklEDFADisabled.1 disabled
+XKL-MIB::xklEDFAMuted.1 no
+XKL-MIB::xklEDFACaseTemperatureAlarm.1 no
+XKL-MIB::xklEDFACommonAlarm.1 no
+XKL-MIB::xklEDFAPumpTemperatureAlarm.1 no
+XKL-MIB::xklEDFAPumpBiasAlarm no
+XKL-MIB::xklEDFALossOfInputAlarm.1 no
+XKL-MIB::xklEDFALossOfOutputAlarm.1 yes
+XKL-MIB::xklEDFAModuleAlarms.1 NONE 
+XKL-MIB::xklEDFAName.1 Output EDFA
+TRAP,
+
+		'Output EDFA loss of output alarm is active.',
+		'Failed to handle XklEdfaAlarmChange loss of output alarm trap.',
+		[Severity::Error],
+		);
+	}
+
+	public function testXklEdfaAlarmChangeModule(): void
+    {
+	    $this->assertTrapLogsMessage(<<<'TRAP'
+{{ hostname }}
+UDP: [{{ ip }}]:44298->[192.168.5.5]:162
+DISMAN-EVENT-MIB::sysUpTimeInstance 0:4:53:43.00
+SNMPv2-MIB::snmpTrapOID.0 XKL-MIB::xklEDFAAlarmChange
+XKL-MIB::xklEDFAIndex.1 1
+XKL-MIB::xklEDFAInReset.1 no
+XKL-MIB::xklEDFADisabled.1 disabled
+XKL-MIB::xklEDFAMuted.1 no
+XKL-MIB::xklEDFACaseTemperatureAlarm.1 no
+XKL-MIB::xklEDFACommonAlarm.1 no
+XKL-MIB::xklEDFAPumpTemperatureAlarm.1 no
+XKL-MIB::xklEDFAPumpBiasAlarm no
+XKL-MIB::xklEDFALossOfInputAlarm.1 no
+XKL-MIB::xklEDFALossOfOutputAlarm.1 yes
+XKL-MIB::xklEDFAModuleAlarms.1 OSC 6
+XKL-MIB::xklEDFAName.1 Output EDFA
+TRAP,
+
+		'Output EDFA $ module alarm: OSC 6',
+		'Failed to handle XklEdfaAlarmChange loss of output alarm trap.',
+		[Severity::Error],
+		);
+	}
+}

--- a/tests/Feature/SnmpTraps/XklEdfaAlarmChangeTest.php
+++ b/tests/Feature/SnmpTraps/XklEdfaAlarmChangeTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * XklEdfaAlarmChangeTest.php
  *
@@ -18,18 +19,20 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  * @link       http://librenms.org
+ *
  * @copyright  2026 Heath Barnhart
  * @author     Heath Barnhart hbarnhart@kanren.net
  */
- 
+
 namespace LibreNMS\Tests\Feature\SnmpTraps;
+
 use LibreNMS\Enum\Severity;
 
 final class XklEdfaAlarmChangeTest extends SnmpTrapTestCase
 {
     public function testXklEdfaAlarmChangeDisabled(): void
     {
-	    $this->assertTrapLogsMessage(<<<'TRAP'
+        $this->assertTrapLogsMessage(<<<'TRAP'
 {{ hostname }}
 UDP: [{{ ip }}]:44298->[192.168.5.5]:162
 DISMAN-EVENT-MIB::sysUpTimeInstance 0:4:53:43.00
@@ -43,18 +46,18 @@ XKL-MIB::xklEDFACommonAlarm.1 yes
 XKL-MIB::xklEDFAPumpTemperatureAlarm.1 no
 XKL-MIB::xklEDFALossOfInputAlarm.1 no
 XKL-MIB::xklEDFALossOfOutputAlarm.1 no
-XKL-MIB::xklEDFAModuleAlarms.1 NONE 
+XKL-MIB::xklEDFAModuleAlarms.1 NONE
 XKL-MIB::xklEDFAName.1 Output EDFA
 TRAP,
 
-		'Output EDFA changed to disabled.',
-		'Failed to handle XklEdfaAlarmChange EDFA disabled alarm trap.',
-		);
-	}
+            'Output EDFA changed to disabled.',
+            'Failed to handle XklEdfaAlarmChange EDFA disabled alarm trap.',
+        );
+    }
 
-	public function testXklEdfaAlarmChangeReset(): void
+    public function testXklEdfaAlarmChangeReset(): void
     {
-	    $this->assertTrapLogsMessage(<<<'TRAP'
+        $this->assertTrapLogsMessage(<<<'TRAP'
 {{ hostname }}
 UDP: [{{ ip }}]:44298->[192.168.5.5]:162
 DISMAN-EVENT-MIB::sysUpTimeInstance 0:4:53:43.00
@@ -68,18 +71,18 @@ XKL-MIB::xklEDFACommonAlarm.1 yes
 XKL-MIB::xklEDFAPumpTemperatureAlarm.1 no
 XKL-MIB::xklEDFALossOfInputAlarm.1 no
 XKL-MIB::xklEDFALossOfOutputAlarm.1 no
-XKL-MIB::xklEDFAModuleAlarms.1 NONE 
+XKL-MIB::xklEDFAModuleAlarms.1 NONE
 XKL-MIB::xklEDFAName.1 Output EDFA
 TRAP,
 
-		'Output EDFA reset.',
-		'Failed to handle XklEdfaAlarmChange EDFA reset alarm trap.',
-		);
-	}
+            'Output EDFA reset.',
+            'Failed to handle XklEdfaAlarmChange EDFA reset alarm trap.',
+        );
+    }
 
-	public function testXklEdfaAlarmChangeMuted(): void
+    public function testXklEdfaAlarmChangeMuted(): void
     {
-	    $this->assertTrapLogsMessage(<<<'TRAP'
+        $this->assertTrapLogsMessage(<<<'TRAP'
 {{ hostname }}
 UDP: [{{ ip }}]:44298->[192.168.5.5]:162
 DISMAN-EVENT-MIB::sysUpTimeInstance 0:4:53:43.00
@@ -93,18 +96,18 @@ XKL-MIB::xklEDFACommonAlarm.1 yes
 XKL-MIB::xklEDFAPumpTemperatureAlarm.1 no
 XKL-MIB::xklEDFALossOfInputAlarm.1 no
 XKL-MIB::xklEDFALossOfOutputAlarm.1 no
-XKL-MIB::xklEDFAModuleAlarms.1 NONE 
+XKL-MIB::xklEDFAModuleAlarms.1 NONE
 XKL-MIB::xklEDFAName.1 Output EDFA
 TRAP,
 
-		'Output EDFA has become muted.',
-		'Failed to handle XklEdfaAlarmChange EDFA muted alarm trap.',
-		);
-	}
+            'Output EDFA has become muted.',
+            'Failed to handle XklEdfaAlarmChange EDFA muted alarm trap.',
+        );
+    }
 
-	public function testXklEdfaAlarmChangeCaseTemp(): void
+    public function testXklEdfaAlarmChangeCaseTemp(): void
     {
-	    $this->assertTrapLogsMessage(<<<'TRAP'
+        $this->assertTrapLogsMessage(<<<'TRAP'
 {{ hostname }}
 UDP: [{{ ip }}]:44298->[192.168.5.5]:162
 DISMAN-EVENT-MIB::sysUpTimeInstance 0:4:53:43.00
@@ -118,18 +121,18 @@ XKL-MIB::xklEDFACommonAlarm.1 yes
 XKL-MIB::xklEDFAPumpTemperatureAlarm.1 no
 XKL-MIB::xklEDFALossOfInputAlarm.1 no
 XKL-MIB::xklEDFALossOfOutputAlarm.1 no
-XKL-MIB::xklEDFAModuleAlarms.1 NONE 
+XKL-MIB::xklEDFAModuleAlarms.1 NONE
 XKL-MIB::xklEDFAName.1 Output EDFA
 TRAP,
 
-		'Output EDFA case temperature alarm is active.',
-		'Failed to handle XklEdfaAlarmChange case temperature alarm trap.',
-		);
-	}
+            'Output EDFA case temperature alarm is active.',
+            'Failed to handle XklEdfaAlarmChange case temperature alarm trap.',
+        );
+    }
 
-	public function testXklEdfaAlarmChangePumpTemp(): void
+    public function testXklEdfaAlarmChangePumpTemp(): void
     {
-	    $this->assertTrapLogsMessage(<<<'TRAP'
+        $this->assertTrapLogsMessage(<<<'TRAP'
 {{ hostname }}
 UDP: [{{ ip }}]:44298->[192.168.5.5]:162
 DISMAN-EVENT-MIB::sysUpTimeInstance 0:4:53:43.00
@@ -143,18 +146,18 @@ XKL-MIB::xklEDFACommonAlarm.1 yes
 XKL-MIB::xklEDFAPumpTemperatureAlarm.1 yes
 XKL-MIB::xklEDFALossOfInputAlarm.1 no
 XKL-MIB::xklEDFALossOfOutputAlarm.1 no
-XKL-MIB::xklEDFAModuleAlarms.1 NONE 
+XKL-MIB::xklEDFAModuleAlarms.1 NONE
 XKL-MIB::xklEDFAName.1 Output EDFA
 TRAP,
 
-		'Output EDFA pump temperature alarm is active.',
-		'Failed to handle XklEdfaAlarmChange pump temperature alarm trap.',
-		);
-	}
+            'Output EDFA pump temperature alarm is active.',
+            'Failed to handle XklEdfaAlarmChange pump temperature alarm trap.',
+        );
+    }
 
-	public function testXklEdfaAlarmChangePumpBias(): void
+    public function testXklEdfaAlarmChangePumpBias(): void
     {
-	    $this->assertTrapLogsMessage(<<<'TRAP'
+        $this->assertTrapLogsMessage(<<<'TRAP'
 {{ hostname }}
 UDP: [{{ ip }}]:44298->[192.168.5.5]:162
 DISMAN-EVENT-MIB::sysUpTimeInstance 0:4:53:43.00
@@ -169,19 +172,19 @@ XKL-MIB::xklEDFAPumpTemperatureAlarm.1 no
 XKL-MIB::xklEDFAPumpBiasAlarm yes
 XKL-MIB::xklEDFALossOfInputAlarm.1 no
 XKL-MIB::xklEDFALossOfOutputAlarm.1 no
-XKL-MIB::xklEDFAModuleAlarms.1 NONE 
+XKL-MIB::xklEDFAModuleAlarms.1 NONE
 XKL-MIB::xklEDFAName.1 Output EDFA
 TRAP,
 
-		'Output EDFA pump BIAS alarm is active.',
-		'Failed to handle XklEdfaAlarmChange EDFA BIAS alarm trap.',
-		[Severity::Error],
-		);
-	}
+            'Output EDFA pump BIAS alarm is active.',
+            'Failed to handle XklEdfaAlarmChange EDFA BIAS alarm trap.',
+            [Severity::Error],
+        );
+    }
 
-	public function testXklEdfaAlarmChangeLossInput(): void
+    public function testXklEdfaAlarmChangeLossInput(): void
     {
-	    $this->assertTrapLogsMessage(<<<'TRAP'
+        $this->assertTrapLogsMessage(<<<'TRAP'
 {{ hostname }}
 UDP: [{{ ip }}]:44298->[192.168.5.5]:162
 DISMAN-EVENT-MIB::sysUpTimeInstance 0:4:53:43.00
@@ -196,19 +199,19 @@ XKL-MIB::xklEDFAPumpTemperatureAlarm.1 no
 XKL-MIB::xklEDFAPumpBiasAlarm no
 XKL-MIB::xklEDFALossOfInputAlarm.1 yes
 XKL-MIB::xklEDFALossOfOutputAlarm.1 no
-XKL-MIB::xklEDFAModuleAlarms.1 NONE 
+XKL-MIB::xklEDFAModuleAlarms.1 NONE
 XKL-MIB::xklEDFAName.1 Output EDFA
 TRAP,
 
-		'Output EDFA loss of input alarm is active.',
-		'Failed to handle XklEdfaAlarmChange loss of input alarm trap.',
-		[Severity::Error],
-		);
-	}
+            'Output EDFA loss of input alarm is active.',
+            'Failed to handle XklEdfaAlarmChange loss of input alarm trap.',
+            [Severity::Error],
+        );
+    }
 
-	public function testXklEdfaAlarmChangeLossOutput(): void
+    public function testXklEdfaAlarmChangeLossOutput(): void
     {
-	    $this->assertTrapLogsMessage(<<<'TRAP'
+        $this->assertTrapLogsMessage(<<<'TRAP'
 {{ hostname }}
 UDP: [{{ ip }}]:44298->[192.168.5.5]:162
 DISMAN-EVENT-MIB::sysUpTimeInstance 0:4:53:43.00
@@ -223,19 +226,19 @@ XKL-MIB::xklEDFAPumpTemperatureAlarm.1 no
 XKL-MIB::xklEDFAPumpBiasAlarm no
 XKL-MIB::xklEDFALossOfInputAlarm.1 no
 XKL-MIB::xklEDFALossOfOutputAlarm.1 yes
-XKL-MIB::xklEDFAModuleAlarms.1 NONE 
+XKL-MIB::xklEDFAModuleAlarms.1 NONE
 XKL-MIB::xklEDFAName.1 Output EDFA
 TRAP,
 
-		'Output EDFA loss of output alarm is active.',
-		'Failed to handle XklEdfaAlarmChange loss of output alarm trap.',
-		[Severity::Error],
-		);
-	}
+            'Output EDFA loss of output alarm is active.',
+            'Failed to handle XklEdfaAlarmChange loss of output alarm trap.',
+            [Severity::Error],
+        );
+    }
 
-	public function testXklEdfaAlarmChangeModule(): void
+    public function testXklEdfaAlarmChangeModule(): void
     {
-	    $this->assertTrapLogsMessage(<<<'TRAP'
+        $this->assertTrapLogsMessage(<<<'TRAP'
 {{ hostname }}
 UDP: [{{ ip }}]:44298->[192.168.5.5]:162
 DISMAN-EVENT-MIB::sysUpTimeInstance 0:4:53:43.00
@@ -254,9 +257,9 @@ XKL-MIB::xklEDFAModuleAlarms.1 OSC 6
 XKL-MIB::xklEDFAName.1 Output EDFA
 TRAP,
 
-		'Output EDFA $ module alarm: OSC 6',
-		'Failed to handle XklEdfaAlarmChange loss of output alarm trap.',
-		[Severity::Error],
-		);
-	}
+            'Output EDFA $ module alarm: OSC 6',
+            'Failed to handle XklEdfaAlarmChange loss of output alarm trap.',
+            [Severity::Error],
+        );
+    }
 }

--- a/tests/Feature/SnmpTraps/XklEdfaAlarmChangeTest.php
+++ b/tests/Feature/SnmpTraps/XklEdfaAlarmChangeTest.php
@@ -22,8 +22,8 @@
  * @author     Heath Barnhart hbarnhart@kanren.net
  */
  
- namespace LibreNMS\Tests\Feature\SnmpTraps;
- use LibreNMS\Enum\Severity;
+namespace LibreNMS\Tests\Feature\SnmpTraps;
+use LibreNMS\Enum\Severity;
 
 final class XklEdfaAlarmChangeTest extends SnmpTrapTestCase
 {

--- a/tests/Feature/SnmpTraps/XklEdfaAlarmChangeTest.php
+++ b/tests/Feature/SnmpTraps/XklEdfaAlarmChangeTest.php
@@ -105,7 +105,7 @@ TRAP,
         );
     }
 
-    public function testXklEdfaAlarmChangeCaseTemp(): void
+    public function testXklEdfaAlarmChange(): void
     {
         $this->assertTrapLogsMessage(<<<'TRAP'
 {{ hostname }}
@@ -121,145 +121,12 @@ XKL-MIB::xklEDFACommonAlarm.1 yes
 XKL-MIB::xklEDFAPumpTemperatureAlarm.1 no
 XKL-MIB::xklEDFALossOfInputAlarm.1 no
 XKL-MIB::xklEDFALossOfOutputAlarm.1 no
-XKL-MIB::xklEDFAModuleAlarms.1 NONE
+XKL-MIB::xklEDFAModuleAlarms.1 LOS AOP
 XKL-MIB::xklEDFAName.1 Output EDFA
 TRAP,
 
-            'Output EDFA case temperature alarm is active.',
-            'Failed to handle XklEdfaAlarmChange case temperature alarm trap.',
-        );
-    }
-
-    public function testXklEdfaAlarmChangePumpTemp(): void
-    {
-        $this->assertTrapLogsMessage(<<<'TRAP'
-{{ hostname }}
-UDP: [{{ ip }}]:44298->[192.168.5.5]:162
-DISMAN-EVENT-MIB::sysUpTimeInstance 0:4:53:43.00
-SNMPv2-MIB::snmpTrapOID.0 XKL-MIB::xklEDFAAlarmChange
-XKL-MIB::xklEDFAIndex.1 1
-XKL-MIB::xklEDFAInReset.1 no
-XKL-MIB::xklEDFADisabled.1 disabled
-XKL-MIB::xklEDFAMuted.1 no
-XKL-MIB::xklEDFACaseTemperatureAlarm.1 no
-XKL-MIB::xklEDFACommonAlarm.1 yes
-XKL-MIB::xklEDFAPumpTemperatureAlarm.1 yes
-XKL-MIB::xklEDFALossOfInputAlarm.1 no
-XKL-MIB::xklEDFALossOfOutputAlarm.1 no
-XKL-MIB::xklEDFAModuleAlarms.1 NONE
-XKL-MIB::xklEDFAName.1 Output EDFA
-TRAP,
-
-            'Output EDFA pump temperature alarm is active.',
-            'Failed to handle XklEdfaAlarmChange pump temperature alarm trap.',
-        );
-    }
-
-    public function testXklEdfaAlarmChangePumpBias(): void
-    {
-        $this->assertTrapLogsMessage(<<<'TRAP'
-{{ hostname }}
-UDP: [{{ ip }}]:44298->[192.168.5.5]:162
-DISMAN-EVENT-MIB::sysUpTimeInstance 0:4:53:43.00
-SNMPv2-MIB::snmpTrapOID.0 XKL-MIB::xklEDFAAlarmChange
-XKL-MIB::xklEDFAIndex.1 1
-XKL-MIB::xklEDFAInReset.1 no
-XKL-MIB::xklEDFADisabled.1 disabled
-XKL-MIB::xklEDFAMuted.1 no
-XKL-MIB::xklEDFACaseTemperatureAlarm.1 no
-XKL-MIB::xklEDFACommonAlarm.1 no
-XKL-MIB::xklEDFAPumpTemperatureAlarm.1 no
-XKL-MIB::xklEDFAPumpBiasAlarm yes
-XKL-MIB::xklEDFALossOfInputAlarm.1 no
-XKL-MIB::xklEDFALossOfOutputAlarm.1 no
-XKL-MIB::xklEDFAModuleAlarms.1 NONE
-XKL-MIB::xklEDFAName.1 Output EDFA
-TRAP,
-
-            'Output EDFA pump BIAS alarm is active.',
-            'Failed to handle XklEdfaAlarmChange EDFA BIAS alarm trap.',
-            [Severity::Error],
-        );
-    }
-
-    public function testXklEdfaAlarmChangeLossInput(): void
-    {
-        $this->assertTrapLogsMessage(<<<'TRAP'
-{{ hostname }}
-UDP: [{{ ip }}]:44298->[192.168.5.5]:162
-DISMAN-EVENT-MIB::sysUpTimeInstance 0:4:53:43.00
-SNMPv2-MIB::snmpTrapOID.0 XKL-MIB::xklEDFAAlarmChange
-XKL-MIB::xklEDFAIndex.1 1
-XKL-MIB::xklEDFAInReset.1 no
-XKL-MIB::xklEDFADisabled.1 disabled
-XKL-MIB::xklEDFAMuted.1 no
-XKL-MIB::xklEDFACaseTemperatureAlarm.1 no
-XKL-MIB::xklEDFACommonAlarm.1 no
-XKL-MIB::xklEDFAPumpTemperatureAlarm.1 no
-XKL-MIB::xklEDFAPumpBiasAlarm no
-XKL-MIB::xklEDFALossOfInputAlarm.1 yes
-XKL-MIB::xklEDFALossOfOutputAlarm.1 no
-XKL-MIB::xklEDFAModuleAlarms.1 NONE
-XKL-MIB::xklEDFAName.1 Output EDFA
-TRAP,
-
-            'Output EDFA loss of input alarm is active.',
-            'Failed to handle XklEdfaAlarmChange loss of input alarm trap.',
-            [Severity::Error],
-        );
-    }
-
-    public function testXklEdfaAlarmChangeLossOutput(): void
-    {
-        $this->assertTrapLogsMessage(<<<'TRAP'
-{{ hostname }}
-UDP: [{{ ip }}]:44298->[192.168.5.5]:162
-DISMAN-EVENT-MIB::sysUpTimeInstance 0:4:53:43.00
-SNMPv2-MIB::snmpTrapOID.0 XKL-MIB::xklEDFAAlarmChange
-XKL-MIB::xklEDFAIndex.1 1
-XKL-MIB::xklEDFAInReset.1 no
-XKL-MIB::xklEDFADisabled.1 disabled
-XKL-MIB::xklEDFAMuted.1 no
-XKL-MIB::xklEDFACaseTemperatureAlarm.1 no
-XKL-MIB::xklEDFACommonAlarm.1 no
-XKL-MIB::xklEDFAPumpTemperatureAlarm.1 no
-XKL-MIB::xklEDFAPumpBiasAlarm no
-XKL-MIB::xklEDFALossOfInputAlarm.1 no
-XKL-MIB::xklEDFALossOfOutputAlarm.1 yes
-XKL-MIB::xklEDFAModuleAlarms.1 NONE
-XKL-MIB::xklEDFAName.1 Output EDFA
-TRAP,
-
-            'Output EDFA loss of output alarm is active.',
-            'Failed to handle XklEdfaAlarmChange loss of output alarm trap.',
-            [Severity::Error],
-        );
-    }
-
-    public function testXklEdfaAlarmChangeModule(): void
-    {
-        $this->assertTrapLogsMessage(<<<'TRAP'
-{{ hostname }}
-UDP: [{{ ip }}]:44298->[192.168.5.5]:162
-DISMAN-EVENT-MIB::sysUpTimeInstance 0:4:53:43.00
-SNMPv2-MIB::snmpTrapOID.0 XKL-MIB::xklEDFAAlarmChange
-XKL-MIB::xklEDFAIndex.1 1
-XKL-MIB::xklEDFAInReset.1 no
-XKL-MIB::xklEDFADisabled.1 disabled
-XKL-MIB::xklEDFAMuted.1 no
-XKL-MIB::xklEDFACaseTemperatureAlarm.1 no
-XKL-MIB::xklEDFACommonAlarm.1 no
-XKL-MIB::xklEDFAPumpTemperatureAlarm.1 no
-XKL-MIB::xklEDFAPumpBiasAlarm no
-XKL-MIB::xklEDFALossOfInputAlarm.1 no
-XKL-MIB::xklEDFALossOfOutputAlarm.1 yes
-XKL-MIB::xklEDFAModuleAlarms.1 OSC 6
-XKL-MIB::xklEDFAName.1 Output EDFA
-TRAP,
-
-            'Output EDFA $ module alarm: OSC 6',
-            'Failed to handle XklEdfaAlarmChange loss of output alarm trap.',
-            [Severity::Error],
+            'Output EDFA modules alarms: LOS AOP.',
+            'Failed to handle EDFA module alarms',
         );
     }
 }

--- a/tests/Feature/SnmpTraps/XklEdfaLineChangeTest.php
+++ b/tests/Feature/SnmpTraps/XklEdfaLineChangeTest.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * XklEdfaLineChangeTest.php
+ *
+ * -Description-
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @link       http://librenms.org
+ * @copyright  2026 Heath Barnhart
+ * @author     Heath Barnhart hbarnhart@kanren.net
+ */
+ 
+ namespace LibreNMS\Tests\Feature\SnmpTraps;
+ use LibreNMS\Enum\Severity;
+
+final class XklEdfaLineChangeTest extends SnmpTrapTestCase
+{
+    public function testXklEdfaLineChangeUp(): void
+    {
+	    $this->assertTrapLogsMessage(<<<'TRAP'
+{{ hostname }}
+UDP: [{{ ip }}]:44298->[192.168.5.5]:162
+DISMAN-EVENT-MIB::sysUpTimeInstance 0:4:53:43.00
+SNMPv2-MIB::snmpTrapOID.0 XKL-MIB::xklEDFALineChange
+XKL-MIB::xklEDFAIndex.1 1
+XKL-MIB::xklEDFAAmplificationState.1 up
+XKL-MIB::xklEDFAName.1 Output EDFA
+TRAP,
+
+		'Output EDFA changed state to up',
+		'Failed to handle XklEdfaLineChange up state trap.',
+		[Severity::Ok],
+		);
+	}
+
+	public function testXklEdfaLineChangeUnused(): void
+    {
+	    $this->assertTrapLogsMessage(<<<'TRAP'
+{{ hostname }}
+UDP: [{{ ip }}]:44298->[192.168.5.5]:162
+DISMAN-EVENT-MIB::sysUpTimeInstance 0:4:53:43.00
+SNMPv2-MIB::snmpTrapOID.0 XKL-MIB::xklEDFALineChange
+XKL-MIB::xklEDFAIndex.1 1
+XKL-MIB::xklEDFAAmplificationState.1 unused
+XKL-MIB::xklEDFAName.1 Output EDFA
+TRAP,
+
+		'Output EDFA changed state to unused',
+		'Failed to handle XklEdfaLineChange unused state trap.',
+		[Severity::Info],
+		);
+	}
+
+	public function testXklEdfaLineChangeWarning(): void
+    {
+	    $this->assertTrapLogsMessage(<<<'TRAP'
+{{ hostname }}
+UDP: [{{ ip }}]:44298->[192.168.5.5]:162
+DISMAN-EVENT-MIB::sysUpTimeInstance 0:4:53:43.00
+SNMPv2-MIB::snmpTrapOID.0 XKL-MIB::xklEDFALineChange
+XKL-MIB::xklEDFAIndex.1 1
+XKL-MIB::xklEDFAAmplificationState.1 warning
+XKL-MIB::xklEDFAName.1 Output EDFA
+TRAP,
+
+		'Output EDFA changed state to warning',
+		'Failed to handle XklEdfaLineChange warning state trap.',
+		[Severity::Warning],
+		);
+	}
+
+	public function testXklEdfaLineChangeUnknown(): void
+    {
+	    $this->assertTrapLogsMessage(<<<'TRAP'
+{{ hostname }}
+UDP: [{{ ip }}]:44298->[192.168.5.5]:162
+DISMAN-EVENT-MIB::sysUpTimeInstance 0:4:53:43.00
+SNMPv2-MIB::snmpTrapOID.0 XKL-MIB::xklEDFALineChange
+XKL-MIB::xklEDFAIndex.1 1
+XKL-MIB::xklEDFAAmplificationState.1 unknown
+XKL-MIB::xklEDFAName.1 Output EDFA
+TRAP,
+
+		'Output EDFA changed state to unknown',
+		'Failed to handle XklEdfaLineChange Unknown state trap.',
+		[Severity::Info],
+		);
+	}
+
+	public function testXklEdfaLineChangeDefault(): void
+    {
+	    $this->assertTrapLogsMessage(<<<'TRAP'
+{{ hostname }}
+UDP: [{{ ip }}]:44298->[192.168.5.5]:162
+DISMAN-EVENT-MIB::sysUpTimeInstance 0:4:53:43.00
+SNMPv2-MIB::snmpTrapOID.0 XKL-MIB::xklEDFALineChange
+XKL-MIB::xklEDFAIndex.1 1
+XKL-MIB::xklEDFAAmplificationState.1 alarm
+XKL-MIB::xklEDFAName.1 Output EDFA
+TRAP,
+
+		'Output EDFA changed state to alarm',
+		'Failed to handle XklEdfaLineChange default state trap.',
+		[Severity::Error],
+		);
+	}
+}

--- a/tests/Feature/SnmpTraps/XklEdfaLineChangeTest.php
+++ b/tests/Feature/SnmpTraps/XklEdfaLineChangeTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * XklEdfaLineChangeTest.php
  *
@@ -18,6 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  * @link       http://librenms.org
+ *
  * @copyright  2026 Heath Barnhart
  * @author     Heath Barnhart hbarnhart@kanren.net
  */

--- a/tests/Feature/SnmpTraps/XklEdfaLineChangeTest.php
+++ b/tests/Feature/SnmpTraps/XklEdfaLineChangeTest.php
@@ -21,15 +21,16 @@
  * @copyright  2026 Heath Barnhart
  * @author     Heath Barnhart hbarnhart@kanren.net
  */
- 
+
 namespace LibreNMS\Tests\Feature\SnmpTraps;
+
 use LibreNMS\Enum\Severity;
 
 final class XklEdfaLineChangeTest extends SnmpTrapTestCase
 {
     public function testXklEdfaLineChangeUp(): void
     {
-	    $this->assertTrapLogsMessage(<<<'TRAP'
+        $this->assertTrapLogsMessage(<<<'TRAP'
 {{ hostname }}
 UDP: [{{ ip }}]:44298->[192.168.5.5]:162
 DISMAN-EVENT-MIB::sysUpTimeInstance 0:4:53:43.00
@@ -39,15 +40,15 @@ XKL-MIB::xklEDFAAmplificationState.1 up
 XKL-MIB::xklEDFAName.1 Output EDFA
 TRAP,
 
-		'Output EDFA changed state to up',
-		'Failed to handle XklEdfaLineChange up state trap.',
-		[Severity::Ok],
-		);
-	}
+            'Output EDFA changed state to up',
+            'Failed to handle XklEdfaLineChange up state trap.',
+            [Severity::Ok],
+        );
+    }
 
-	public function testXklEdfaLineChangeUnused(): void
+    public function testXklEdfaLineChangeUnused(): void
     {
-	    $this->assertTrapLogsMessage(<<<'TRAP'
+        $this->assertTrapLogsMessage(<<<'TRAP'
 {{ hostname }}
 UDP: [{{ ip }}]:44298->[192.168.5.5]:162
 DISMAN-EVENT-MIB::sysUpTimeInstance 0:4:53:43.00
@@ -57,15 +58,15 @@ XKL-MIB::xklEDFAAmplificationState.1 unused
 XKL-MIB::xklEDFAName.1 Output EDFA
 TRAP,
 
-		'Output EDFA changed state to unused',
-		'Failed to handle XklEdfaLineChange unused state trap.',
-		[Severity::Info],
-		);
-	}
+            'Output EDFA changed state to unused',
+            'Failed to handle XklEdfaLineChange unused state trap.',
+            [Severity::Info],
+        );
+    }
 
-	public function testXklEdfaLineChangeWarning(): void
+    public function testXklEdfaLineChangeWarning(): void
     {
-	    $this->assertTrapLogsMessage(<<<'TRAP'
+        $this->assertTrapLogsMessage(<<<'TRAP'
 {{ hostname }}
 UDP: [{{ ip }}]:44298->[192.168.5.5]:162
 DISMAN-EVENT-MIB::sysUpTimeInstance 0:4:53:43.00
@@ -75,15 +76,15 @@ XKL-MIB::xklEDFAAmplificationState.1 warning
 XKL-MIB::xklEDFAName.1 Output EDFA
 TRAP,
 
-		'Output EDFA changed state to warning',
-		'Failed to handle XklEdfaLineChange warning state trap.',
-		[Severity::Warning],
-		);
-	}
+            'Output EDFA changed state to warning',
+            'Failed to handle XklEdfaLineChange warning state trap.',
+            [Severity::Warning],
+        );
+    }
 
-	public function testXklEdfaLineChangeUnknown(): void
+    public function testXklEdfaLineChangeUnknown(): void
     {
-	    $this->assertTrapLogsMessage(<<<'TRAP'
+        $this->assertTrapLogsMessage(<<<'TRAP'
 {{ hostname }}
 UDP: [{{ ip }}]:44298->[192.168.5.5]:162
 DISMAN-EVENT-MIB::sysUpTimeInstance 0:4:53:43.00
@@ -93,15 +94,15 @@ XKL-MIB::xklEDFAAmplificationState.1 unknown
 XKL-MIB::xklEDFAName.1 Output EDFA
 TRAP,
 
-		'Output EDFA changed state to unknown',
-		'Failed to handle XklEdfaLineChange Unknown state trap.',
-		[Severity::Info],
-		);
-	}
+            'Output EDFA changed state to unknown',
+            'Failed to handle XklEdfaLineChange Unknown state trap.',
+            [Severity::Info],
+        );
+    }
 
-	public function testXklEdfaLineChangeDefault(): void
+    public function testXklEdfaLineChangeDefault(): void
     {
-	    $this->assertTrapLogsMessage(<<<'TRAP'
+        $this->assertTrapLogsMessage(<<<'TRAP'
 {{ hostname }}
 UDP: [{{ ip }}]:44298->[192.168.5.5]:162
 DISMAN-EVENT-MIB::sysUpTimeInstance 0:4:53:43.00
@@ -111,9 +112,9 @@ XKL-MIB::xklEDFAAmplificationState.1 alarm
 XKL-MIB::xklEDFAName.1 Output EDFA
 TRAP,
 
-		'Output EDFA changed state to alarm',
-		'Failed to handle XklEdfaLineChange default state trap.',
-		[Severity::Error],
-		);
-	}
+            'Output EDFA changed state to alarm',
+            'Failed to handle XklEdfaLineChange default state trap.',
+            [Severity::Error],
+        );
+    }
 }

--- a/tests/Feature/SnmpTraps/XklEdfaLineChangeTest.php
+++ b/tests/Feature/SnmpTraps/XklEdfaLineChangeTest.php
@@ -22,8 +22,8 @@
  * @author     Heath Barnhart hbarnhart@kanren.net
  */
  
- namespace LibreNMS\Tests\Feature\SnmpTraps;
- use LibreNMS\Enum\Severity;
+namespace LibreNMS\Tests\Feature\SnmpTraps;
+use LibreNMS\Enum\Severity;
 
 final class XklEdfaLineChangeTest extends SnmpTrapTestCase
 {

--- a/tests/Feature/SnmpTraps/XklRxPowerTest.php
+++ b/tests/Feature/SnmpTraps/XklRxPowerTest.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * XklRxPowerTest.php
+ *
+ * -Description-
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @link       http://librenms.org
+ * @copyright  2026 Heath Barnhart
+ * @author     Heath Barnhart hbarnhart@kanren.net
+ */
+ 
+ namespace LibreNMS\Tests\Feature\SnmpTraps;
+
+final class XklRxPowerTest extends SnmpTrapTestCase
+{
+    public function testXklRxPowerOK(): void
+    {
+	    $this->assertTrapLogsMessage(<<<'TRAP'
+{{ hostname }}
+UDP: [{{ ip }}]:44298->[192.168.5.5]:162
+DISMAN-EVENT-MIB::sysUpTimeInstance 0:4:53:43.00
+SNMPv2-MIB::snmpTrapOID.0 XKL-MIB::xklRxPowerOK
+XKL-MIB::xklTransportIndex.1 1
+XKL-MIB::xklTransportDescr.1 Client 0\/0 (N\/A)
+XKL-MIB::xklTransportReceivePower.1 16 1\/10 dBm
+TRAP,
+
+		'Transciever Wave 0 (N\/A) receive power OK. Current value: 16 1/10 dBm',
+		'Failed to handle XklRxPowerOK trap.',
+		);
+	}
+
+	public function testXklRxPowerLoWarn(): void
+    {
+	    $this->assertTrapLogsMessage(<<<'TRAP'
+{{ hostname }}
+UDP: [{{ ip }}]:44298->[192.168.5.5]:162
+DISMAN-EVENT-MIB::sysUpTimeInstance 0:4:53:43.00
+SNMPv2-MIB::snmpTrapOID.0 XKL-MIB::xklRxPowerLoWarn
+XKL-MIB::xklTransportIndex.33 33
+XKL-MIB::xklTransportDescr.33 Wave 0 (N\/A)
+XKL-MIB::xklTransportReceivePower.33 -237 1\/10 dBm
+XKL-MIB::xklTransportRxPowerLoWarnThresh.33 -230 1\/10 dBm
+TRAP,
+
+		'Transciever Wave 0 (N\/A) is below recieve warning threshold . Current value: -237 1/10 dBm',
+		'Failed to handle XklRxPowerLoWarn trap.',
+		);
+	}
+
+    public function testXklRxPowerLoAlrm(): void
+    {
+	    $this->assertTrapLogsMessage(<<<'TRAP'
+{{ hostname }}
+UDP: [{{ ip }}]:44298->[192.168.5.5]:162
+DISMAN-EVENT-MIB::sysUpTimeInstance 0:4:53:43.00
+SNMPv2-MIB::snmpTrapOID.0 XKL-MIB::xklRxPowerLoAlrm
+"XKL-MIB::xklTransportIndex.33 33"
+"XKL-MIB::xklTransportDescr.33 Wave 0 (N\/A)"
+"XKL-MIB::xklTransportReceivePower.33 -400 1\/10 dBm"
+"XKL-MIB::xklTransportRxPowerLoAlrmThresh.33 -282 1\/10 dBm"
+TRAP,
+
+		'Transciever Wave 0 (N\/A) is below recieve alarm threshold -282 1/10 dBm. Current value: -400 1/10 dBm',
+		'Failed to handle XklRxPowerLoAlrm trap.',
+		);
+	}
+
+	public function testXklRxPowerHiWarn(): void
+    {
+	    $this->assertTrapLogsMessage(<<<'TRAP'
+{{ hostname }}
+UDP: [{{ ip }}]:44298->[192.168.5.5]:162
+DISMAN-EVENT-MIB::sysUpTimeInstance 0:4:53:43.00
+SNMPv2-MIB::snmpTrapOID.0 XKL-MIB::xklRxPowerHiWan
+"XKL-MIB::xklTransportIndex.33 33"
+"XKL-MIB::xklTransportDescr.33 Wave 0 (N\/A)"
+"XKL-MIB::xklTransportReceivePower.33 -5 1\/10 dBm"
+"XKL-MIB::xklTransportRxPowerLoAlrmThresh.33 -10 1\/10 dBm"
+TRAP,
+
+		'Transciever Wave 0 (N\/A) is below recieve warning threshold -10 1/10 dBm. Current value: -5 1/10 dBm',
+		'Failed to handle XklRxPowerHiWarn trap.',
+		);
+	}
+
+public function testXklRxPowerHiAlrm(): void
+    {
+	    $this->assertTrapLogsMessage(<<<'TRAP'
+{{ hostname }}
+UDP: [{{ ip }}]:44298->[192.168.5.5]:162
+DISMAN-EVENT-MIB::sysUpTimeInstance 0:4:53:43.00
+SNMPv2-MIB::snmpTrapOID.0 XKL-MIB::xklRxPowerHiAlrm
+"XKL-MIB::xklTransportIndex.33 33"
+"XKL-MIB::xklTransportDescr.33 Wave 0 (N\/A)"
+"XKL-MIB::xklTransportReceivePower.33 20 1\/10 dBm"
+"XKL-MIB::xklTransportRxPowerLoAlrmThresh.33 10 1\/10 dBm"
+TRAP,
+
+		'Transciever Wave 0 (N\/A) is above recieve alarm threshold -10 1/10 dBm. Current value: 20 1/10 dBm',
+		'Failed to handle XklRxPowerHiAlrm trap.',
+		);
+	}
+}

--- a/tests/Feature/SnmpTraps/XklRxPowerTest.php
+++ b/tests/Feature/SnmpTraps/XklRxPowerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * XklRxPowerTest.php
  *
@@ -18,6 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  * @link       http://librenms.org
+ *
  * @copyright  2026 Heath Barnhart
  * @author     Heath Barnhart hbarnhart@kanren.net
  */

--- a/tests/Feature/SnmpTraps/XklRxPowerTest.php
+++ b/tests/Feature/SnmpTraps/XklRxPowerTest.php
@@ -22,7 +22,8 @@
  * @author     Heath Barnhart hbarnhart@kanren.net
  */
  
- namespace LibreNMS\Tests\Feature\SnmpTraps;
+namespace LibreNMS\Tests\Feature\SnmpTraps;
+use LibreNMS\Enum\Severity;
 
 final class XklRxPowerTest extends SnmpTrapTestCase
 {
@@ -40,6 +41,7 @@ TRAP,
 
 		'Transciever Wave 0 (N\/A) receive power OK. Current value: 16 1/10 dBm',
 		'Failed to handle XklRxPowerOK trap.',
+		[Severity::Ok],
 		);
 	}
 
@@ -58,6 +60,7 @@ TRAP,
 
 		'Transciever Wave 0 (N\/A) is below recieve warning threshold . Current value: -237 1/10 dBm',
 		'Failed to handle XklRxPowerLoWarn trap.',
+		[Severity::Warning],
 		);
 	}
 
@@ -76,6 +79,7 @@ TRAP,
 
 		'Transciever Wave 0 (N\/A) is below recieve alarm threshold -282 1/10 dBm. Current value: -400 1/10 dBm',
 		'Failed to handle XklRxPowerLoAlrm trap.',
+		[Severity::Error],
 		);
 	}
 
@@ -94,10 +98,11 @@ TRAP,
 
 		'Transciever Wave 0 (N\/A) is below recieve warning threshold -10 1/10 dBm. Current value: -5 1/10 dBm',
 		'Failed to handle XklRxPowerHiWarn trap.',
+		[Severity::Warning],
 		);
 	}
 
-public function testXklRxPowerHiAlrm(): void
+	public function testXklRxPowerHiAlrm(): void
     {
 	    $this->assertTrapLogsMessage(<<<'TRAP'
 {{ hostname }}
@@ -112,6 +117,7 @@ TRAP,
 
 		'Transciever Wave 0 (N\/A) is above recieve alarm threshold -10 1/10 dBm. Current value: 20 1/10 dBm',
 		'Failed to handle XklRxPowerHiAlrm trap.',
+		[Severity::Error],
 		);
 	}
 }

--- a/tests/Feature/SnmpTraps/XklRxPowerTest.php
+++ b/tests/Feature/SnmpTraps/XklRxPowerTest.php
@@ -21,15 +21,16 @@
  * @copyright  2026 Heath Barnhart
  * @author     Heath Barnhart hbarnhart@kanren.net
  */
- 
+
 namespace LibreNMS\Tests\Feature\SnmpTraps;
+
 use LibreNMS\Enum\Severity;
 
 final class XklRxPowerTest extends SnmpTrapTestCase
 {
     public function testXklRxPowerOK(): void
     {
-	    $this->assertTrapLogsMessage(<<<'TRAP'
+        $this->assertTrapLogsMessage(<<<'TRAP'
 {{ hostname }}
 UDP: [{{ ip }}]:44298->[192.168.5.5]:162
 DISMAN-EVENT-MIB::sysUpTimeInstance 0:4:53:43.00
@@ -39,15 +40,15 @@ XKL-MIB::xklTransportDescr.1 Client 0\/0 (N\/A)
 XKL-MIB::xklTransportReceivePower.1 16 1\/10 dBm
 TRAP,
 
-		'Transciever Wave 0 (N\/A) receive power OK. Current value: 16 1/10 dBm',
-		'Failed to handle XklRxPowerOK trap.',
-		[Severity::Ok],
-		);
-	}
+            'Transciever Wave 0 (N\/A) receive power OK. Current value: 16 1/10 dBm',
+            'Failed to handle XklRxPowerOK trap.',
+            [Severity::Ok],
+        );
+    }
 
-	public function testXklRxPowerLoWarn(): void
+    public function testXklRxPowerLoWarn(): void
     {
-	    $this->assertTrapLogsMessage(<<<'TRAP'
+        $this->assertTrapLogsMessage(<<<'TRAP'
 {{ hostname }}
 UDP: [{{ ip }}]:44298->[192.168.5.5]:162
 DISMAN-EVENT-MIB::sysUpTimeInstance 0:4:53:43.00
@@ -58,15 +59,15 @@ XKL-MIB::xklTransportReceivePower.33 -237 1\/10 dBm
 XKL-MIB::xklTransportRxPowerLoWarnThresh.33 -230 1\/10 dBm
 TRAP,
 
-		'Transciever Wave 0 (N\/A) is below recieve warning threshold . Current value: -237 1/10 dBm',
-		'Failed to handle XklRxPowerLoWarn trap.',
-		[Severity::Warning],
-		);
-	}
+            'Transciever Wave 0 (N\/A) is below recieve warning threshold . Current value: -237 1/10 dBm',
+            'Failed to handle XklRxPowerLoWarn trap.',
+            [Severity::Warning],
+        );
+    }
 
     public function testXklRxPowerLoAlrm(): void
     {
-	    $this->assertTrapLogsMessage(<<<'TRAP'
+        $this->assertTrapLogsMessage(<<<'TRAP'
 {{ hostname }}
 UDP: [{{ ip }}]:44298->[192.168.5.5]:162
 DISMAN-EVENT-MIB::sysUpTimeInstance 0:4:53:43.00
@@ -77,15 +78,15 @@ SNMPv2-MIB::snmpTrapOID.0 XKL-MIB::xklRxPowerLoAlrm
 "XKL-MIB::xklTransportRxPowerLoAlrmThresh.33 -282 1\/10 dBm"
 TRAP,
 
-		'Transciever Wave 0 (N\/A) is below recieve alarm threshold -282 1/10 dBm. Current value: -400 1/10 dBm',
-		'Failed to handle XklRxPowerLoAlrm trap.',
-		[Severity::Error],
-		);
-	}
+            'Transciever Wave 0 (N\/A) is below recieve alarm threshold -282 1/10 dBm. Current value: -400 1/10 dBm',
+            'Failed to handle XklRxPowerLoAlrm trap.',
+            [Severity::Error],
+        );
+    }
 
-	public function testXklRxPowerHiWarn(): void
+    public function testXklRxPowerHiWarn(): void
     {
-	    $this->assertTrapLogsMessage(<<<'TRAP'
+        $this->assertTrapLogsMessage(<<<'TRAP'
 {{ hostname }}
 UDP: [{{ ip }}]:44298->[192.168.5.5]:162
 DISMAN-EVENT-MIB::sysUpTimeInstance 0:4:53:43.00
@@ -96,15 +97,15 @@ SNMPv2-MIB::snmpTrapOID.0 XKL-MIB::xklRxPowerHiWan
 "XKL-MIB::xklTransportRxPowerLoAlrmThresh.33 -10 1\/10 dBm"
 TRAP,
 
-		'Transciever Wave 0 (N\/A) is below recieve warning threshold -10 1/10 dBm. Current value: -5 1/10 dBm',
-		'Failed to handle XklRxPowerHiWarn trap.',
-		[Severity::Warning],
-		);
-	}
+            'Transciever Wave 0 (N\/A) is below recieve warning threshold -10 1/10 dBm. Current value: -5 1/10 dBm',
+            'Failed to handle XklRxPowerHiWarn trap.',
+            [Severity::Warning],
+        );
+    }
 
-	public function testXklRxPowerHiAlrm(): void
+    public function testXklRxPowerHiAlrm(): void
     {
-	    $this->assertTrapLogsMessage(<<<'TRAP'
+        $this->assertTrapLogsMessage(<<<'TRAP'
 {{ hostname }}
 UDP: [{{ ip }}]:44298->[192.168.5.5]:162
 DISMAN-EVENT-MIB::sysUpTimeInstance 0:4:53:43.00
@@ -115,9 +116,9 @@ SNMPv2-MIB::snmpTrapOID.0 XKL-MIB::xklRxPowerHiAlrm
 "XKL-MIB::xklTransportRxPowerLoAlrmThresh.33 10 1\/10 dBm"
 TRAP,
 
-		'Transciever Wave 0 (N\/A) is above recieve alarm threshold -10 1/10 dBm. Current value: 20 1/10 dBm',
-		'Failed to handle XklRxPowerHiAlrm trap.',
-		[Severity::Error],
-		);
-	}
+            'Transciever Wave 0 (N\/A) is above recieve alarm threshold -10 1/10 dBm. Current value: 20 1/10 dBm',
+            'Failed to handle XklRxPowerHiAlrm trap.',
+            [Severity::Error],
+        );
+    }
 }

--- a/tests/Feature/SnmpTraps/XklTransportLinkTest.php
+++ b/tests/Feature/SnmpTraps/XklTransportLinkTest.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * XklTransportLinkTest.php
+ *
+ * -Description-
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @link       http://librenms.org
+ * @copyright  2026 Heath Barnhart
+ * @author     Heath Barnhart hbarnhart@kanren.net
+ */
+ 
+ namespace LibreNMS\Tests\Feature\SnmpTraps;
+
+final class XklTransportLinkTest extends SnmpTrapTestCase
+{
+    public function testXklTransportLinkUp(): void
+    {
+	    $this->assertTrapLogsMessage(<<<'TRAP'
+{{ hostname }}
+UDP: [{{ ip }}]:44298->[192.168.5.5]:162
+DISMAN-EVENT-MIB::sysUpTimeInstance 0:4:53:43.00
+SNMPv2-MIB::snmpTrapOID.0 XKL-MIB::xklTransportLinkUp
+XKL-MIB::xklTransportIndex.1 1
+XKL-MIB::xklTransportStatus.1 up
+XKL-MIB::xklTransportTxStatus.1 up
+XKL-MIB::xklTransportRxStatus.1 up
+TRAP,
+
+		'Tranport 1 is up.',
+		'Failed to handle XklTransportLinkUp trap',
+		);
+	}
+
+	public function testXklTransportLinkDown(): void
+    {
+	    $this->assertTrapLogsMessage(<<<'TRAP'
+{{ hostname }}
+UDP: [{{ ip }}]:44298->[192.168.5.5]:162
+DISMAN-EVENT-MIB::sysUpTimeInstance 0:4:53:43.00
+SNMPv2-MIB::snmpTrapOID.0 XKL-MIB::xklTransportLinkDown
+XKL-MIB::xklTransportIndex.3 3
+XKL-MIB::xklTransportStatus.3 down
+XKL-MIB::xklTransportTxStatus.3 up
+XKL-MIB::xklTransportRxStatus.3 los
+TRAP,
+
+		'Transport service 3 is down. Transmit status: up Receive status: los',
+		'Failed to handle trap XklTransportLinkDown',
+		);
+	}
+}

--- a/tests/Feature/SnmpTraps/XklTransportLinkTest.php
+++ b/tests/Feature/SnmpTraps/XklTransportLinkTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * XklTransportLinkTest.php
  *
@@ -18,6 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  * @link       http://librenms.org
+ *
  * @copyright  2026 Heath Barnhart
  * @author     Heath Barnhart hbarnhart@kanren.net
  */

--- a/tests/Feature/SnmpTraps/XklTransportLinkTest.php
+++ b/tests/Feature/SnmpTraps/XklTransportLinkTest.php
@@ -22,7 +22,8 @@
  * @author     Heath Barnhart hbarnhart@kanren.net
  */
  
- namespace LibreNMS\Tests\Feature\SnmpTraps;
+namespace LibreNMS\Tests\Feature\SnmpTraps;
+use LibreNMS\Enum\Severity;
 
 final class XklTransportLinkTest extends SnmpTrapTestCase
 {
@@ -41,6 +42,7 @@ TRAP,
 
 		'Tranport 1 is up.',
 		'Failed to handle XklTransportLinkUp trap',
+		[Severity::Ok],
 		);
 	}
 
@@ -59,6 +61,7 @@ TRAP,
 
 		'Transport service 3 is down. Transmit status: up Receive status: los',
 		'Failed to handle trap XklTransportLinkDown',
+		[Severity::Error],
 		);
 	}
 }

--- a/tests/Feature/SnmpTraps/XklTransportLinkTest.php
+++ b/tests/Feature/SnmpTraps/XklTransportLinkTest.php
@@ -21,15 +21,16 @@
  * @copyright  2026 Heath Barnhart
  * @author     Heath Barnhart hbarnhart@kanren.net
  */
- 
+
 namespace LibreNMS\Tests\Feature\SnmpTraps;
+
 use LibreNMS\Enum\Severity;
 
 final class XklTransportLinkTest extends SnmpTrapTestCase
 {
     public function testXklTransportLinkUp(): void
     {
-	    $this->assertTrapLogsMessage(<<<'TRAP'
+        $this->assertTrapLogsMessage(<<<'TRAP'
 {{ hostname }}
 UDP: [{{ ip }}]:44298->[192.168.5.5]:162
 DISMAN-EVENT-MIB::sysUpTimeInstance 0:4:53:43.00
@@ -40,15 +41,15 @@ XKL-MIB::xklTransportTxStatus.1 up
 XKL-MIB::xklTransportRxStatus.1 up
 TRAP,
 
-		'Tranport 1 is up.',
-		'Failed to handle XklTransportLinkUp trap',
-		[Severity::Ok],
-		);
-	}
+            'Tranport 1 is up.',
+            'Failed to handle XklTransportLinkUp trap',
+            [Severity::Ok],
+        );
+    }
 
-	public function testXklTransportLinkDown(): void
+    public function testXklTransportLinkDown(): void
     {
-	    $this->assertTrapLogsMessage(<<<'TRAP'
+        $this->assertTrapLogsMessage(<<<'TRAP'
 {{ hostname }}
 UDP: [{{ ip }}]:44298->[192.168.5.5]:162
 DISMAN-EVENT-MIB::sysUpTimeInstance 0:4:53:43.00
@@ -59,9 +60,9 @@ XKL-MIB::xklTransportTxStatus.3 up
 XKL-MIB::xklTransportRxStatus.3 los
 TRAP,
 
-		'Transport service 3 is down. Transmit status: up Receive status: los',
-		'Failed to handle trap XklTransportLinkDown',
-		[Severity::Error],
-		);
-	}
+            'Transport service 3 is down. Transmit status: up Receive status: los',
+            'Failed to handle trap XklTransportLinkDown',
+            [Severity::Error],
+        );
+    }
 }


### PR DESCRIPTION
Trap handlers for observed SNMP Traps from XKL optical line system hardware. Includes handlers and unit tests for:

- EDFA amplifier alarms
- EDFA amplifier line system changes
- Received light level threshold traps
- Optical transport link up and down

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
