### PR TITLE
Fix duplicate BGP peers on Huawei VRP

### DIFF
--- a/includes/discovery/bgp-peers.inc.php
+++ b/includes/discovery/bgp-peers.inc.php
@@ -12,6 +12,10 @@ if (file_exists(base_path("includes/discovery/bgp-peers/{$device['os']}.inc.php"
     include base_path("includes/discovery/bgp-peers/{$device['os']}.inc.php");
 }
 
+if ($device['os'] === 'vrp') {
+    return;
+}
+
 if (empty($bgpLocalAs)) {
     $bgpLocalAs = \SnmpQuery::get('BGP4-MIB::bgpLocalAs.0')->value();
 }


### PR DESCRIPTION
## Summary
- Skip the generic BGP4-MIB discovery path for Huawei VRP devices.
- Prevent the same VRP peer from being inserted twice when Huawei BGP MIB and BGP4-MIB expose the same neighbor.

## Validation
- `php -l includes/discovery/bgp-peers.inc.php`
- `git diff --check`
- Verified on Huawei NetEngine 8000 / VRP 8.250: Huawei BGP discovery remains functional and LibreNMS no longer displays duplicate peers.