### PR TITLE
Added display for poller environments

### DIFF
--- a/resources/views/poller/details.blade.php
+++ b/resources/views/poller/details.blade.php
@@ -1,0 +1,6 @@
+@php($details = is_array($details ?? null) ? $details : [])
+@foreach(['librenms_version' => 'LibreNMS', 'php_version' => 'PHP', 'os_version' => 'OS'] as $key => $label)
+    @if(! empty($details[$key]))
+        <div class="tw:text-nowrap"><span class="tw:font-bold">{{ $label }}:</span> {{ $details[$key] }}</div>
+    @endif
+@endforeach

--- a/resources/views/poller/poller.blade.php
+++ b/resources/views/poller/poller.blade.php
@@ -12,6 +12,7 @@
         <table class="table table-striped table-bordered table-hover table-condensed">
             <tr>
                 <th>{{ __('Poller Name') }}</th>
+                <th>{{ __('Environment') }}</th>
                 <th>{{ __('Devices Polled') }}</th>
                 <th>{{ __('Total Poll Time') }}</th>
                 <th>{{ __('Last Run') }}</th>
@@ -20,6 +21,7 @@
             @foreach($pollers as $poller)
             <tr class="{{ $poller['row_class'] }}" id="row_{{ $poller['id'] }}">
                 <td>{{ $poller['poller_name'] }}</td>
+                <td>@include('poller.details', ['details' => $poller->poller_details])</td>
                 <td>{{ $poller['devices'] }}</td>
                 <td>{{ $poller['time_taken'] }} Seconds</td>
                 <td>{{ \LibreNMS\Util\Time::format($poller['last_polled'], 'compact') }}</td>
@@ -45,6 +47,7 @@
                 <th>{{ __('Name') }}</th>
                 <th>{{ __('Node ID') }}</th>
                 <th>{{ __('Version') }}</th>
+                <th>{{ __('Environment') }}</th>
                 <th>{{ __('Groups Served') }}</th>
                 <th>{{ __('Last Checkin') }}</th>
                 <th>{{ __('Cluster Master') }}</th>
@@ -62,6 +65,7 @@
                     <td rowspan="{{ $poller->stats->count() }}">{{ $poller->poller_name }}</td>
                     <td rowspan="{{ $poller->stats->count() }}" @if($poller->node_id == '') class="danger" @endif>{{ $poller->node_id }}</td>
                     <td rowspan="{{ $poller->stats->count() }}">{{ $poller->poller_version }}</td>
+                    <td rowspan="{{ $poller->stats->count() }}">@include('poller.details', ['details' => $poller->poller_details])</td>
                     <td rowspan="{{ $poller->stats->count() }}">{{ $poller->poller_groups }}</td>
                     <td rowspan="{{ $poller->stats->count() }}">{{ \LibreNMS\Util\Time::format($poller->last_report, 'compact') }}</td>
                     <td rowspan="{{ $poller->stats->count() }}">{{ __($poller->master ? 'Yes' : 'No') }}</td>


### PR DESCRIPTION
<img width="1409" height="585" alt="image" src="https://github.com/user-attachments/assets/ca934939-2c89-479a-9fff-b62c96085223" />

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
