### PR TITLE
fix never ending outages

### DIFF
--- a/app/Actions/Device/CheckDeviceAvailability.php
+++ b/app/Actions/Device/CheckDeviceAvailability.php
@@ -13,7 +13,6 @@ readonly class CheckDeviceAvailability
         private DeviceIsPingable $deviceIsPingable,
         private DeviceIsSnmpable $deviceIsSnmpable,
         private DeviceMtuTest $deviceMtuTest,
-        private UpdateDeviceOutage $updateDeviceOutage,
     ) {
     }
 
@@ -32,7 +31,7 @@ readonly class CheckDeviceAvailability
             $results['snmp'] = $this->deviceIsSnmpable->execute($device);
         }
 
-        $changed = $this->setDeviceAvailability->execute($device, $results);
+        $this->setDeviceAvailability->execute($device, $results);
 
         if ($ping_response->isAlive()) {
             $device->mtu_status = $this->deviceMtuTest->execute($device);
@@ -44,10 +43,6 @@ readonly class CheckDeviceAvailability
             }
 
             $device->save();
-
-            if ($changed) {
-                $this->updateDeviceOutage->execute($device);
-            }
         }
 
         return $device->status;

--- a/app/Jobs/PingCheck.php
+++ b/app/Jobs/PingCheck.php
@@ -29,7 +29,6 @@ namespace App\Jobs;
 use App\Action;
 use App\Actions\Alerts\RunAlertRulesAction;
 use App\Actions\Device\SetDeviceAvailability;
-use App\Actions\Device\UpdateDeviceOutage;
 use App\Models\Device;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -187,9 +186,6 @@ class PingCheck implements ShouldQueue
         // mark up only if snmp is not down too
         $changed = app(SetDeviceAvailability::class)->execute($device, ['icmp' => $response->isAlive()]);
         $device->save();
-        if ($changed) {
-            app(UpdateDeviceOutage::class)->execute($device);
-        }
 
         // mark as processed
         $this->processed->put($device->device_id, true);

--- a/app/Observers/DeviceObserver.php
+++ b/app/Observers/DeviceObserver.php
@@ -2,6 +2,7 @@
 
 namespace App\Observers;
 
+use App\Actions\Device\UpdateDeviceOutage;
 use App\ApiClients\Oxidized;
 use App\Facades\LibrenmsConfig;
 use App\Facades\Rrd;
@@ -47,6 +48,8 @@ class DeviceObserver
             $polled_by = LibrenmsConfig::get('distributed_poller') ? (' by ' . \config('librenms.node_id')) : '';
 
             Eventlog::log(sprintf('Device status changed to %s from %s check%s.', ucfirst($type), $reason, $polled_by), $device, $type);
+
+            app(UpdateDeviceOutage::class)->execute($device);
         }
 
         // key attribute changes

--- a/tests/Unit/UpdateDeviceOutageTest.php
+++ b/tests/Unit/UpdateDeviceOutageTest.php
@@ -106,6 +106,43 @@ final class UpdateDeviceOutageTest extends DBTestCase
         $this->assertCount(0, $device->outages()->get());
     }
 
+    public function testSavingStatusChangeToUpClosesOpenOutage(): void
+    {
+        $device = Device::factory()->create(['status' => 0]);
+        DeviceOutage::factory()->open()->create(['device_id' => $device->device_id]);
+
+        $device->status = 1;
+        $device->save();
+
+        $this->assertNull(
+            $device->outages()->whereNull('up_again')->first(),
+            'Outage must be closed when the device status is saved as up'
+        );
+    }
+
+    public function testSavingStatusChangeToDownOpensOutage(): void
+    {
+        $device = Device::factory()->create(['status' => 1]);
+
+        $device->status = 0;
+        $device->save();
+
+        $this->assertCount(1, $device->outages()->get());
+        $this->assertNull($device->outages()->first()->up_again);
+    }
+
+    public function testSavingWithoutStatusChangeLeavesOutagesAlone(): void
+    {
+        $device = Device::factory()->create(['status' => 0]);
+        DeviceOutage::factory()->open()->create(['device_id' => $device->device_id]);
+
+        $device->sysName = 'unrelated-change';
+        $device->save();
+
+        $this->assertCount(1, $device->outages()->get());
+        $this->assertNull($device->outages()->first()->up_again);
+    }
+
     public function testOpensOutageDuringMaintenanceWhenConsiderMaintenanceDisabled(): void
     {
         LibrenmsConfig::set('graphing.availability_consider_maintenance', false);


### PR DESCRIPTION
closes #20251, related to #20380 

move to observer which already does logging, gated by isDirty flag


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
