### PR TITLE
Add Signalgrid alert transport

### DIFF
--- a/LibreNMS/Alert/Transport/Signalgrid.php
+++ b/LibreNMS/Alert/Transport/Signalgrid.php
@@ -1,0 +1,99 @@
+<?php
+
+/**
+ * LibreNMS Signalgrid alerting transport
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * @link        https://www.librenms.org
+ *
+ * @copyright   2026 Signalgrid
+ * @license     GPL
+ */
+
+namespace LibreNMS\Alert\Transport;
+
+use LibreNMS\Alert\Transport;
+use LibreNMS\Enum\AlertState;
+use LibreNMS\Exceptions\AlertTransportDeliveryException;
+use LibreNMS\Util\Http;
+
+class Signalgrid extends Transport
+{
+    /**
+     * @param  array<string, mixed>  $alert_data
+     */
+    public function deliverAlert(array $alert_data): bool
+    {
+        $type = match (true) {
+            $alert_data['state'] == AlertState::RECOVERED => 'SUCCESS',
+            $alert_data['severity'] === 'critical' => 'CRIT',
+            $alert_data['severity'] === 'warning' => 'WARN',
+            default => 'INFO',
+        };
+
+        $data = [
+            'client_key' => $this->config['signalgrid-client-key'],
+            'channel' => $this->config['signalgrid-channel'],
+            'title' => $alert_data['title'],
+            'body' => $alert_data['msg'],
+            'type' => $type,
+        ];
+
+        $res = Http::client()
+            ->asForm()
+            ->post('https://api.signalgrid.co/v1/push', $data);
+
+        $response = $res->json();
+
+        if ($res->successful() && isset($response['code']) && (string) $response['code'] === '200') {
+            return true;
+        }
+
+        throw new AlertTransportDeliveryException(
+            $alert_data,
+            $res->status(),
+            $response['text'] ?? $res->body(),
+            $alert_data['msg'],
+            $data
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function configTemplate(): array
+    {
+        return [
+            'config' => [
+                [
+                    'title' => 'Client Key',
+                    'name' => 'signalgrid-client-key',
+                    'descr' => 'Signalgrid Client Key',
+                    'type' => 'password',
+                ],
+                [
+                    'title' => 'Channel',
+                    'name' => 'signalgrid-channel',
+                    'descr' => 'Signalgrid Channel',
+                    'type' => 'text',
+                ],
+            ],
+            'validation' => [
+                'signalgrid-client-key' => 'required|string',
+                'signalgrid-channel' => 'required|string',
+            ],
+        ];
+    }
+}

--- a/doc/Alerting/Transports/Signalgrid.md
+++ b/doc/Alerting/Transports/Signalgrid.md
@@ -1,0 +1,31 @@
+# Signalgrid
+
+Signalgrid can be used to send LibreNMS alerts as push notifications to iOS and Android devices.
+
+## Configuration
+
+Create a Signalgrid alert transport in LibreNMS and provide the following values:
+
+| Config | Example |
+| --- | --- |
+| Client Key | `your-client-key` |
+| Channel | `your-channel` |
+
+## Severity mapping
+
+LibreNMS alert severities are mapped to Signalgrid notification types as follows:
+
+| LibreNMS | Signalgrid |
+| --- | --- |
+| Critical | CRIT |
+| Warning | WARN |
+| Recovered | SUCCESS |
+| Other | INFO |
+
+## Signalgrid setup
+
+Create or select a channel in Signalgrid and copy its Client Key and Channel into the LibreNMS transport configuration.
+
+For more information, see the Signalgrid documentation:
+
+<https://docs.signalgrid.co/>

--- a/tests/Unit/Alert/Transports/SignalgridTest.php
+++ b/tests/Unit/Alert/Transports/SignalgridTest.php
@@ -1,0 +1,146 @@
+<?php
+
+/**
+ * SignalgridTest.php
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * @link       https://www.librenms.org
+ *
+ * @copyright  2026 Signalgrid
+ */
+
+namespace LibreNMS\Tests\Unit\Alert\Transports;
+
+use App\Models\AlertTransport;
+use App\Models\Device;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use LibreNMS\Alert\AlertData;
+use LibreNMS\Alert\Transport;
+use LibreNMS\Enum\AlertState;
+use LibreNMS\Exceptions\AlertTransportDeliveryException;
+use LibreNMS\Tests\TestCase;
+
+final class SignalgridTest extends TestCase
+{
+    public function testCriticalDelivery(): void
+    {
+        Http::fake([
+            'api.signalgrid.co/*' => Http::response([
+                'code' => '200',
+            ]),
+        ]);
+
+        $transport = $this->transport();
+
+        /** @var Device $mock_device */
+        $mock_device = Device::factory()->make();
+
+        $transport->deliverAlert(AlertData::testData($mock_device));
+
+        Http::assertSent(fn (Request $request) => $request->url() === 'https://api.signalgrid.co/v1/push'
+            && $request->method() === 'POST'
+            && $request->data() === [
+                'client_key' => 'test-client-key',
+                'channel' => 'test-channel',
+                'title' => 'Testing transport from LibreNMS',
+                'body' => 'This is a test alert',
+                'type' => 'CRIT',
+            ]);
+    }
+
+    public function testWarningDelivery(): void
+    {
+        Http::fake([
+            'api.signalgrid.co/*' => Http::response([
+                'code' => '200',
+            ]),
+        ]);
+
+        $transport = $this->transport();
+
+        /** @var Device $mock_device */
+        $mock_device = Device::factory()->make();
+
+        $alert_data = AlertData::testData($mock_device);
+        $alert_data['severity'] = 'warning';
+
+        $transport->deliverAlert($alert_data);
+
+        Http::assertSent(fn (Request $request) => $request->data() === [
+            'client_key' => 'test-client-key',
+            'channel' => 'test-channel',
+            'title' => 'Testing transport from LibreNMS',
+            'body' => 'This is a test alert',
+            'type' => 'WARN',
+        ]);
+    }
+
+    public function testRecoveredDelivery(): void
+    {
+        Http::fake([
+            'api.signalgrid.co/*' => Http::response([
+                'code' => '200',
+            ]),
+        ]);
+
+        $transport = $this->transport();
+
+        /** @var Device $mock_device */
+        $mock_device = Device::factory()->make();
+
+        $alert_data = AlertData::testData($mock_device);
+        $alert_data['state'] = AlertState::RECOVERED;
+
+        $transport->deliverAlert($alert_data);
+
+        Http::assertSent(fn (Request $request) => $request->data() === [
+            'client_key' => 'test-client-key',
+            'channel' => 'test-channel',
+            'title' => 'Testing transport from LibreNMS',
+            'body' => 'This is a test alert',
+            'type' => 'SUCCESS',
+        ]);
+    }
+
+    public function testApiErrorDelivery(): void
+    {
+        Http::fake([
+            'api.signalgrid.co/*' => Http::response([
+                'text' => 'Parameter error: client_key is invalid',
+                'code' => '400',
+            ], 200),
+        ]);
+
+        $this->expectException(AlertTransportDeliveryException::class);
+
+        $transport = $this->transport();
+
+        /** @var Device $mock_device */
+        $mock_device = Device::factory()->make();
+
+        $transport->deliverAlert(AlertData::testData($mock_device));
+    }
+
+    private function transport(): Transport\Signalgrid
+    {
+        return new Transport\Signalgrid(new AlertTransport([
+            'transport_config' => [
+                'signalgrid-client-key' => 'test-client-key',
+                'signalgrid-channel' => 'test-channel',
+            ],
+        ]));
+    }
+}


### PR DESCRIPTION
Hi everyone!

This PR adds Signalgrid as an alert transport so LibreNMS users can receive push notifications on iOS and Android.

It includes Client Key and Channel configuration, severity mapping for critical, warning and recovered alerts, and handling of Signalgrid API errors. Configuration documentation and four unit tests are included.

All four unit tests passed, along with Pint, Rector, PHPStan level 6 and git diff checks. There are no discovery, polling, YAML or database schema changes.

Screenshot:
<img width="893" height="368" alt="Screenshot 2026-09-11 at 23 36 55" src="https://github.com/user-attachments/assets/72535494-d889-4fa2-ab91-e7e11142f363" />


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [X] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [X] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
