### PR TITLE
Fix ZXA10 memory units and restore Titan discovery

### DIFF
--- a/LibreNMS/Discovery/Yaml/YamlDiscoveryField.php
+++ b/LibreNMS/Discovery/Yaml/YamlDiscoveryField.php
@@ -71,6 +71,11 @@ class YamlDiscoveryField
             return;
         }
 
+        if ($this->isOid && is_numeric($value)) {
+            $value *= $yaml[$this->key . '_multiplier'] ?? $yaml['multiplier'] ?? 1;
+            $value /= $yaml[$this->key . '_divisor'] ?? $yaml['divisor'] ?? 1;
+        }
+
         $this->setValue($value);
     }
 

--- a/resources/definitions/os_discovery/zxa10.yaml
+++ b/resources/definitions/os_discovery/zxa10.yaml
@@ -1,11 +1,17 @@
 modules:
+    os:
+        sysDescr_regex:
+            - '/^ZXA10 (?<hardware>C\d+), ZTE ZXA10 Software Version: (?<version>\S+)/'
+            - '/^(?<hardware>C\d+) Version (?<version>\S+) Software/'
     mempools:
         additional_oids:
             oids:
                 - ZTE-AN-CHASSIS-MIB::zxAnCardActualType
+                - ZTE-TITAN-SLOT-MIB::zxTitanSlotName
         data:
             -
                 total: ZTE-AN-CHASSIS-MIB::zxAnCardMemSize
+                total_multiplier: 1048576
                 percent_used: ZTE-AN-CHASSIS-MIB::zxAnCardMemUsage
                 descr: 'Card {{ ZTE-AN-CHASSIS-MIB::zxAnCardActualType }}'
                 skip_values:
@@ -13,6 +19,11 @@ modules:
                         oid: ZTE-AN-CHASSIS-MIB::zxAnCardMemUsage
                         op: '='
                         value: 0
+            -
+                total: ZTE-TITAN-SLOT-MIB::zxTitanSlotMemTotal
+                percent_used: ZTE-TITAN-SLOT-MIB::zxTitanSlotMemUsedPercent
+                descr: 'Card {{ ZTE-TITAN-SLOT-MIB::zxTitanSlotName }}'
+                precision: 1048576
     processors:
         data:
             -
@@ -20,6 +31,16 @@ modules:
                 value: ZTE-AN-CHASSIS-MIB::zxAnCardCpuLoad
                 num_oid: '.1.3.6.1.4.1.3902.1082.10.1.2.4.1.9.{{ $index }}'
                 descr: '{{ ZTE-AN-CHASSIS-MIB::zxAnCardActualType }} Processor'
+                skip_values:
+                    -
+                        oid: ZTE-AN-CHASSIS-MIB::zxAnCardMemSize
+                        op: '='
+                        value: 0
+            -
+                oid: ZTE-TITAN-SLOT-MIB::zxTitanSlotPerfTable
+                value: ZTE-TITAN-SLOT-MIB::zxTitanSlotCpuUsedPercent
+                num_oid: '.1.3.6.1.4.1.3902.3.6002.2.1.1.8.{{ $index }}'
+                descr: '{{ ZTE-AN-CHASSIS-MIB::zxAnCardActualType:0-2 }} Processor'
     sensors:
         additional_oids:
             data:
@@ -29,6 +50,33 @@ modules:
                         - ZTE-AN-ENVMON-MIB::zxAnEnvRack
                         - ZTE-AN-ENVMON-MIB::zxAnEnvShelf
                         - ZTE-AN-ENVMON-MIB::zxAnEnvSlot
+                        - IF-MIB::ifName
+        dbm:
+            data:
+                -
+                    oid: ZTE-AN-OPTICAL-MODULE-MIB::zxAnOpticalIfTxPwrCurrValue
+                    divisor: 1000
+                    descr: '{{ IF-MIB::ifName }} TX Power'
+                    entPhysicalIndex: '{{ $index }}'
+                    entPhysicalIndex_measured: ports
+                    num_oid: '.1.3.6.1.4.1.3902.1082.30.40.2.4.1.3.{{ $index }}'
+                    skip_values:
+                        -
+                            oid: ZTE-AN-OPTICAL-MODULE-MIB::zxAnOpticalIfTxPwrCurrValue
+                            op: '='
+                            value: 2147483647
+                -
+                    oid: ZTE-AN-OPTICAL-MODULE-MIB::zxAnOpticalIfRxPwrCurrValue
+                    divisor: 1000
+                    descr: '{{ IF-MIB::ifName }} RX Power'
+                    entPhysicalIndex: '{{ $index }}'
+                    entPhysicalIndex_measured: ports
+                    num_oid: '.1.3.6.1.4.1.3902.1082.30.40.2.4.1.2.{{ $index }}'
+                    skip_values:
+                        -
+                            oid: ZTE-AN-OPTICAL-MODULE-MIB::zxAnOpticalIfRxPwrCurrValue
+                            op: '='
+                            value: 2147483647
         temperature:
             data:
                 -

--- a/resources/definitions/schema/discovery_schema.json
+++ b/resources/definitions/schema/discovery_schema.json
@@ -47,6 +47,12 @@
                                             "string"
                                         ]
                                     },
+                                    "total_multiplier": {
+                                        "type": [
+                                            "number",
+                                            "string"
+                                        ]
+                                    },
                                     "type": {
                                         "type": "string"
                                     },

--- a/tests/Unit/YamlDiscoveryTest.php
+++ b/tests/Unit/YamlDiscoveryTest.php
@@ -71,6 +71,9 @@ final class YamlDiscoveryTest extends TestCase
         $field->calculateValue(['oidtest' => 'MIB::oid'], ['2.3' => ['MIB::oid' => '43%']], '2.3', 0);
         $this->assertSame(43, $field->value);
 
+        $field->calculateValue(['oidtest' => 'MIB::oid', 'oidtest_multiplier' => 1048576], ['2.3' => ['MIB::oid' => '512']], '2.3', 0);
+        $this->assertSame(536870912, $field->value);
+
         $field->calculateValue(['oidtest' => 'missing'], ['2.3' => ['MIB::oid' => '41']], '2.3', 0);
         $this->assertNull($field->value);
 


### PR DESCRIPTION
## Summary

- Fix ZXA10 C320 card memory values being displayed with the wrong unit.
- Restore/retain ZXA10 Titan/C620 discovery paths for hardware, memory, CPU, and optical power monitoring.
- Add per-field YAML value conversion support for OID-backed discovery fields.

## Problem

`ZTE-AN-CHASSIS-MIB::zxAnCardMemSize` reports memory in **MB**, while LibreNMS stores mempool totals in bytes. For the tested ZTE C320 device (`10.0.100.11`), SNMP returned values such as `512` and `2048`, which were displayed as `512 B` and `2 KiB` instead of `512 MiB` and `2 GiB`.

The same YAML definition also needs to support the separate ZTE Titan/C620 tables. Copying a C320-only definition over the production file removed those platform-specific branches, so this PR keeps both platform paths in one definition.

## Changes

### YAML discovery conversion

- Add per-field `*_multiplier` and `*_divisor` handling in `YamlDiscoveryField`.
- Add `total_multiplier: 1048576` to the ZXA10 C320 card memory definition.
- Keep the multiplier scoped to `total`, so `percent_used` values remain unchanged.
- Extend the discovery schema to accept `total_multiplier`.

### ZXA10 platform coverage

- Restore `sysDescr_regex` matching for C320 and C6xx/Titan models.
- Retain Titan slot memory discovery.
- Retain Titan CPU discovery and skip the incompatible C320 card CPU branch when appropriate.
- Retain optical TX/RX power sensors with sentinel-value filtering and dBm scaling.

## Validation

- Confirmed live SNMP values from ZTE C320:
  - Memory total: `512 MB` / `2048 MB`
  - Memory usage: `40%`, `39%`, `26%`, `27%`
  - CPU and environmental OIDs return valid values.
- YAML structure validation passed.
- PHP syntax checks passed for changed PHP files.
- `git diff --check` passed.

The focused PHPUnit test could not be run in the local checkout because Composer dependencies/vendor autoload are not installed.

## Testing checklist

- [x] C320 memory total is converted from MB to bytes.
- [x] C320 memory percentage remains unchanged.
- [x] Titan/C620 discovery branches are present.
- [x] Existing unrelated working-tree changes are excluded from this PR.
