### PR TITLE
Feature proxmox vminfo

### DIFF
--- a/LibreNMS/OS/Proxmox.php
+++ b/LibreNMS/OS/Proxmox.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * Proxmox.php
+ *
+ * -Description-
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @package    LibreNMS
+ * @link       http://librenms.org
+ */
+
+namespace LibreNMS\OS;
+
+use LibreNMS\Interfaces\Discovery\VminfoDiscovery;
+use LibreNMS\OS\Traits\VminfoProxmox;
+
+class Proxmox extends Shared\Unix implements VminfoDiscovery
+{
+    use VminfoProxmox;
+}

--- a/LibreNMS/OS/Traits/VminfoProxmox.php
+++ b/LibreNMS/OS/Traits/VminfoProxmox.php
@@ -1,0 +1,119 @@
+<?php
+
+/*
+ * VminfoProxmox.php
+ *
+ * -Description-
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @package    LibreNMS
+ * @link       http://librenms.org
+ */
+
+namespace LibreNMS\OS\Traits;
+
+use App\Models\Vminfo;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Log;
+use LibreNMS\Enum\PowerState;
+use LibreNMS\Exceptions\JsonAppExtendErroredException;
+use LibreNMS\Exceptions\JsonAppMissingKeysException;
+use LibreNMS\Exceptions\JsonAppParsingFailedException;
+use LibreNMS\Exceptions\JsonAppWrongVersionException;
+use LibreNMS\Util\Oid;
+use SnmpQuery;
+
+trait VminfoProxmox
+{
+    public function discoverVminfo(): Collection
+    {
+        Log::info('Proxmox VM: ');
+
+        /*
+         * Fetch the guest list from the proxmox extend script. The first line
+         * holds the cluster name for the application module. The json follows.
+         *
+         * {
+         *   "version": 2,
+         *   "error": 0,
+         *   "errorString": "",
+         *   "data": {
+         *     "cluster": "pve01",
+         *     "node": "pve01",
+         *     "vms": [
+         *       {"vmid": 100, "name": "web01", "type": "qemu", "status": "running", "cpus": 4, "mem": 8589934592,
+         *        "ports": [{"dev": "net0", "in": 4298988750, "out": 1207239278}]}
+         *     ]
+         *   }
+         * }
+         */
+
+        $output = SnmpQuery::get('NET-SNMP-EXTEND-MIB::nsExtendOutputFull.' . Oid::encodeString('proxmox'))->value();
+
+        if (empty($output)) {
+            Log::debug('Proxmox: the proxmox extend returned nothing');
+
+            return new Collection;
+        }
+
+        $lines = explode("\n", trim(str_replace('<<<app-proxmox>>>', '', $output)));
+        array_shift($lines); // the cluster name
+        $json = trim(implode("\n", $lines));
+
+        if (! str_starts_with($json, '{')) {
+            Log::info('Proxmox: the proxmox script is too old, update it to report the guests');
+
+            return new Collection;
+        }
+
+        $data = json_decode($json, true);
+
+        if (json_last_error() !== JSON_ERROR_NONE || ! is_array($data)) {
+            throw new JsonAppParsingFailedException('vmwinfo: invalid json', $json);
+        }
+
+        if (! isset($data['version'], $data['error'], $data['errorString'], $data['data'])) {
+            throw new JsonAppMissingKeysException('vmwinfo: missing one or more required keys', $json, $data);
+        }
+
+        if ($data['version'] < 2) {
+            throw new JsonAppWrongVersionException('vmwinfo: version ' . $data['version'] . ' is too old', $json, $data);
+        }
+
+        if ($data['error']) {
+            throw new JsonAppExtendErroredException('vmwinfo: ' . $data['errorString'], $json, $data);
+        }
+
+        return Collection::make($data['data']['vms'] ?? [])
+            ->map(fn (array $vm): Vminfo => new Vminfo([
+                'vm_type' => match ($vm['type'] ?? '') {
+                    'lxc' => 'proxmox-lxc',
+                    default => 'proxmox-qemu',
+                },
+                'vmwVmVMID' => (string) ($vm['vmid'] ?? ''),
+                'vmwVmDisplayName' => $vm['name'] ?? ('VM ' . ($vm['vmid'] ?? '')),
+                'vmwVmGuestOS' => ($vm['type'] ?? '') === 'lxc' ? 'LXC container' : 'QEMU guest',
+                'vmwVmMemSize' => (int) round(($vm['mem'] ?? 0) / 1024 / 1024),
+                'vmwVmCpus' => (int) ($vm['cpus'] ?? 0),
+                'vmwVmState' => match ($vm['status'] ?? '') {
+                    'running' => PowerState::ON,
+                    'stopped' => PowerState::OFF,
+                    'paused', 'suspended' => PowerState::SUSPENDED,
+                    default => PowerState::UNKNOWN,
+                },
+            ]))
+            ->filter(fn (Vminfo $vm): bool => $vm->vmwVmVMID !== '');
+    }
+}

--- a/LibreNMS/OS/Traits/VminfoProxmox.php
+++ b/LibreNMS/OS/Traits/VminfoProxmox.php
@@ -37,6 +37,9 @@ use SnmpQuery;
 
 trait VminfoProxmox
 {
+    /**
+     * @return Collection<int, Vminfo>
+     */
     public function discoverVminfo(): Collection
     {
         Log::info('Proxmox VM: ');
@@ -96,14 +99,20 @@ trait VminfoProxmox
             throw new JsonAppExtendErroredException('vmwinfo: ' . $data['errorString'], $json, $data);
         }
 
-        return Collection::make($data['data']['vms'] ?? [])
-            ->map(fn (array $vm): Vminfo => new Vminfo([
+        $vms = [];
+
+        foreach ($data['data']['vms'] ?? [] as $vm) {
+            if (! is_array($vm) || ! isset($vm['vmid'])) {
+                continue;
+            }
+
+            $vms[] = new Vminfo([
                 'vm_type' => match ($vm['type'] ?? '') {
                     'lxc' => 'proxmox-lxc',
                     default => 'proxmox-qemu',
                 },
-                'vmwVmVMID' => (string) ($vm['vmid'] ?? ''),
-                'vmwVmDisplayName' => $vm['name'] ?? ('VM ' . ($vm['vmid'] ?? '')),
+                'vmwVmVMID' => (string) $vm['vmid'],
+                'vmwVmDisplayName' => $vm['name'] ?? ('VM ' . $vm['vmid']),
                 'vmwVmGuestOS' => ($vm['type'] ?? '') === 'lxc' ? 'LXC container' : 'QEMU guest',
                 'vmwVmMemSize' => (int) round(($vm['mem'] ?? 0) / 1024 / 1024),
                 'vmwVmCpus' => (int) ($vm['cpus'] ?? 0),
@@ -113,7 +122,9 @@ trait VminfoProxmox
                     'paused', 'suspended' => PowerState::SUSPENDED,
                     default => PowerState::UNKNOWN,
                 },
-            ]))
-            ->filter(fn (Vminfo $vm): bool => $vm->vmwVmVMID !== '');
+            ]);
+        }
+
+        return new Collection($vms);
     }
 }

--- a/doc/Extensions/Applications/Proxmox.md
+++ b/doc/Extensions/Applications/Proxmox.md
@@ -1,6 +1,5 @@
 # Proxmox
 
-
 ## Install prerequisites
 
 === "Debian/Ubuntu"
@@ -43,3 +42,11 @@
     ```
 
 6. Restart snmpd on your host.
+
+## Virtual Machines
+
+With v2 of the script, LibreNMS shows the guests of the node on the Virtual Machines page. It shows QEMU guests and LXC containers.
+
+The vminfo discovery module reads the guests. LibreNMS enables that module for the proxmox OS. Run the discovery of the device to see the
+
+Install the script on each node of a cluster. Each node reports only its own guests.

--- a/doc/Support/Discovery Support.md
+++ b/doc/Support/Discovery Support.md
@@ -192,7 +192,7 @@ with history data.
 
 `slas`: SLA detection and support.
 
-`vminfo`: detection of the VM guests for VMware ESXi, libvirt, and XCP-NG.
+`vminfo`: detection of the VM guests for VMware ESXi, libvirt, XCP-NG, and Proxmox VE.
 
 `printer-supplies`: toner level support.
 

--- a/resources/definitions/os_detection/proxmox.yaml
+++ b/resources/definitions/os_detection/proxmox.yaml
@@ -17,6 +17,7 @@ discovery_modules:
     applications: true
     bgp-peers: false
     stp: false
+    vminfo: true
 processor_stacked: true
 discovery:
     -


### PR DESCRIPTION
linked to https://github.com/librenms/librenms-agent/pull/637

makes Proxmox VMs appear on the /vminfo page using a v2 of the existing Proxmox application via snmp extend.

I am not too happy with using the application code, but I think the SSH way should be avoided.

<img width="1920" height="718" alt="image" src="https://github.com/user-attachments/assets/eb0702d7-94c4-4d47-a1f2-c71c114e2bcf" />


#### Please note

> Please read this information carefully. Pull requests may be closed without explanation 
> due to influx of low quality LLM generated pull requests.
> You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
